### PR TITLE
I-36 Remove dependency to PATH const

### DIFF
--- a/frontend/components/utilities/SecurityClient.js
+++ b/frontend/components/utilities/SecurityClient.js
@@ -1,8 +1,6 @@
-import { PATH } from "~/const";
 import token from "~/pages/api/auth/Token";
 
 export default class SecurityClient {
-  static authOrigins = [PATH];
   static #token = "";
 
   contructor() {}
@@ -13,13 +11,12 @@ export default class SecurityClient {
 
   static async fetchCall(resource, options) {
     let req = new Request(resource, options);
-    const destOrigin = new URL(req.url).origin;
 
     if (this.#token == "") {
       this.setToken(await token());
     }
 
-    if (this.#token && this.authOrigins.includes(destOrigin)) {
+    if (this.#token) {
       req.headers.set("Authorization", "Bearer " + this.#token);
       return fetch(req);
     }

--- a/frontend/const.js
+++ b/frontend/const.js
@@ -1,5 +1,3 @@
-export const PATH = process.env.NEXT_PUBLIC_WEBSITE_URL;
-
 export const publicPaths = [
   `/`,
   // `/integrations`,

--- a/frontend/pages/api/auth/ChangePassword2.js
+++ b/frontend/pages/api/auth/ChangePassword2.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -14,7 +13,7 @@ const changePassword2 = ({
   verifier,
   clientProof,
 }) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/password/change-password", {
+  return SecurityClient.fetchCall("/api/v1/password/change-password", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/CheckAuth.js
+++ b/frontend/pages/api/auth/CheckAuth.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient.js";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient.js";
  * @returns
  */
 const checkAuth = async (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/auth/checkAuth", {
+  return SecurityClient.fetchCall("/api/v1/auth/checkAuth", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/CheckEmailVerificationCode.js
+++ b/frontend/pages/api/auth/CheckEmailVerificationCode.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This route check the verification code from the email that user just recieved
  * @param {*} email
@@ -7,7 +5,7 @@ import { PATH } from "~/const";
  * @returns
  */
 const checkEmailVerificationCode = (email, code) => {
-  return fetch(PATH + "/api/v1/signup/email/verify", {
+  return fetch("/api/v1/signup/email/verify", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/CompleteAccountInformationSignup.js
+++ b/frontend/pages/api/auth/CompleteAccountInformationSignup.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This function is called in the end of the signup process.
  * It sends all the necessary nformation to the server.
@@ -28,7 +26,7 @@ const completeAccountInformationSignup = ({
   verifier,
   token,
 }) => {
-  return fetch(PATH + "/api/v1/signup/complete-account/signup", {
+  return fetch("/api/v1/signup/complete-account/signup", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/CompleteAccountInformationSignupInvite.js
+++ b/frontend/pages/api/auth/CompleteAccountInformationSignupInvite.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This function is called in the end of the signup process.
  * It sends all the necessary nformation to the server.
@@ -26,7 +24,7 @@ const completeAccountInformationSignupInvite = ({
   verifier,
   token,
 }) => {
-  return fetch(PATH + "/api/v1/signup/complete-account/invite", {
+  return fetch("/api/v1/signup/complete-account/invite", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/IssueBackupPrivateKey.js
+++ b/frontend/pages/api/auth/IssueBackupPrivateKey.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -13,7 +12,7 @@ const issueBackupPrivateKey = ({
   clientProof,
 }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/password/backup-private-key",
+    "/api/v1/password/backup-private-key",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/auth/Login1.js
+++ b/frontend/pages/api/auth/Login1.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This is the first step of the login process (pake)
  * @param {*} email
@@ -7,7 +5,7 @@ import { PATH } from "~/const";
  * @returns
  */
 const login1 = (email, clientPublicKey) => {
-  return fetch(PATH + "/api/v1/auth/login1", {
+  return fetch("/api/v1/auth/login1", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/Login2.js
+++ b/frontend/pages/api/auth/Login2.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This is the second step of the login process
  * @param {*} email
@@ -7,7 +5,7 @@ import { PATH } from "~/const";
  * @returns
  */
 const login2 = (email, clientProof) => {
-  return fetch(PATH + "/api/v1/auth/login2", {
+  return fetch("/api/v1/auth/login2", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/Logout.js
+++ b/frontend/pages/api/auth/Logout.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const logout = async (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/auth/logout", {
+  return SecurityClient.fetchCall("/api/v1/auth/logout", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/SRP1.js
+++ b/frontend/pages/api/auth/SRP1.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -7,7 +6,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const SRP1 = ({ clientPublicKey }) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/password/srp1", {
+  return SecurityClient.fetchCall("/api/v1/password/srp1", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/SendVerificationEmail.js
+++ b/frontend/pages/api/auth/SendVerificationEmail.js
@@ -1,11 +1,9 @@
-import { PATH } from "~/const";
-
 /**
  * This route send the verification email to the user's email (contains a 6-digit verification code)
  * @param {*} email
  */
 const sendVerificationEmail = (email) => {
-  fetch(PATH + "/api/v1/signup/email/signup", {
+  fetch("/api/v1/signup/email/signup", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/Token.js
+++ b/frontend/pages/api/auth/Token.js
@@ -1,7 +1,5 @@
-import { PATH } from "~/const";
-
 const token = async (req, res) => {
-  return fetch(PATH + "/api/v1/auth/token", {
+  return fetch("/api/v1/auth/token", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/VerifySignupInvite.js
+++ b/frontend/pages/api/auth/VerifySignupInvite.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This route verifies the signup invite link
  * @param {*} email
@@ -7,7 +5,7 @@ import { PATH } from "~/const";
  * @returns
  */
 const verifySignupInvite = ({ email, code }) => {
-  return fetch(PATH + "/api/v1/invite-org/verify", {
+  return fetch("/api/v1/invite-org/verify", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/auth/publicKeyInfisical.js
+++ b/frontend/pages/api/auth/publicKeyInfisical.js
@@ -1,5 +1,3 @@
-import { PATH } from "~/const";
-
 /**
  * This route lets us get the public key of infisical. Th euser doesn't have to be authenticated since this is just the public key.
  * @param {*} req
@@ -7,7 +5,7 @@ import { PATH } from "~/const";
  * @returns
  */
 const publicKeyInfisical = (req, res) => {
-  return fetch(PATH + "/api/v1/key/publicKey/infisical", {
+  return fetch("/api/v1/key/publicKey/infisical", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/files/GetSecrets.js
+++ b/frontend/pages/api/files/GetSecrets.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient.js";
 
 /**
@@ -9,7 +8,6 @@ import SecurityClient from "~/utilities/SecurityClient.js";
  */
 const getSecrets = async (workspaceId, env) => {
   return SecurityClient.fetchCall(
-    PATH +
       "/api/v1/secret/" +
       workspaceId +
       "?" +

--- a/frontend/pages/api/files/UploadSecrets.js
+++ b/frontend/pages/api/files/UploadSecrets.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const uploadSecrets = async ({ workspaceId, secrets, keys, environment }) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/secret/" + workspaceId, {
+  return SecurityClient.fetchCall("/api/v1/secret/" + workspaceId, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/integrations/ChangeHerokuConfigVars.js
+++ b/frontend/pages/api/integrations/ChangeHerokuConfigVars.js
@@ -1,9 +1,8 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 const changeHerokuConfigVars = ({ integrationId, key, secrets }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration/" + integrationId + "/sync",
+    "/api/v1/integration/" + integrationId + "/sync",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/integrations/DeleteIntegration.js
+++ b/frontend/pages/api/integrations/DeleteIntegration.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const deleteIntegration = ({ integrationId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration/" + integrationId,
+    "/api/v1/integration/" + integrationId,
     {
       method: "DELETE",
       headers: {

--- a/frontend/pages/api/integrations/DeleteIntegrationAuth.js
+++ b/frontend/pages/api/integrations/DeleteIntegrationAuth.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const deleteIntegrationAuth = ({ integrationAuthId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration-auth/" + integrationAuthId,
+    "/api/v1/integration-auth/" + integrationAuthId,
     {
       method: "DELETE",
       headers: {

--- a/frontend/pages/api/integrations/GetIntegrationApps.js
+++ b/frontend/pages/api/integrations/GetIntegrationApps.js
@@ -1,9 +1,8 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 const getIntegrationApps = ({ integrationAuthId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration-auth/" + integrationAuthId + "/apps",
+    "/api/v1/integration-auth/" + integrationAuthId + "/apps",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/integrations/GetIntegrations.js
+++ b/frontend/pages/api/integrations/GetIntegrations.js
@@ -1,8 +1,7 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 const getIntegrations = () => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/integration/integrations", {
+  return SecurityClient.fetchCall("/api/v1/integration/integrations", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/integrations/StartIntegration.js
+++ b/frontend/pages/api/integrations/StartIntegration.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const startIntegration = ({ integrationId, appName, environment }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration/" + integrationId,
+    "/api/v1/integration/" + integrationId,
     {
       method: "PATCH",
       headers: {

--- a/frontend/pages/api/integrations/authorizeIntegration.js
+++ b/frontend/pages/api/integrations/authorizeIntegration.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const AuthorizeIntegration = ({ workspaceId, code, integration }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/integration-auth/oauth-token",
+    "/api/v1/integration-auth/oauth-token",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/integrations/getWorkspaceAuthorizations.js
+++ b/frontend/pages/api/integrations/getWorkspaceAuthorizations.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getWorkspaceAuthorizations = ({ workspaceId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + workspaceId + "/authorizations",
+    "/api/v1/workspace/" + workspaceId + "/authorizations",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/integrations/getWorkspaceIntegrations.js
+++ b/frontend/pages/api/integrations/getWorkspaceIntegrations.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getWorkspaceIntegrations = ({ workspaceId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + workspaceId + "/integrations",
+    "/api/v1/workspace/" + workspaceId + "/integrations",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/GetOrg.js
+++ b/frontend/pages/api/organization/GetOrg.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const getOrganization = (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/organization/" + req.orgId, {
+  return SecurityClient.fetchCall("/api/v1/organization/" + req.orgId, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/organization/GetOrgProjects.js
+++ b/frontend/pages/api/organization/GetOrgProjects.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getOrganizationProjects = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/organization/" + req.orgId + "/workspaces",
+    "/api/organization/" + req.orgId + "/workspaces",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/GetOrgSubscription.js
+++ b/frontend/pages/api/organization/GetOrgSubscription.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getOrganizationSubscriptions = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + req.orgId + "/subscriptions",
+    "/api/v1/organization/" + req.orgId + "/subscriptions",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/GetOrgUserProjects.js
+++ b/frontend/pages/api/organization/GetOrgUserProjects.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getOrganizationUserProjects = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + req.orgId + "/my-workspaces",
+    "/api/v1/organization/" + req.orgId + "/my-workspaces",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/GetOrgUsers.js
+++ b/frontend/pages/api/organization/GetOrgUsers.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getOrganizationUsers = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + req.orgId + "/users",
+    "/api/v1/organization/" + req.orgId + "/users",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/StripeRedirect.js
+++ b/frontend/pages/api/organization/StripeRedirect.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const StripeRedirect = ({ orgId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + orgId + "/customer-portal-session",
+    "/api/v1/organization/" + orgId + "/customer-portal-session",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/organization/addIncidentContact.js
+++ b/frontend/pages/api/organization/addIncidentContact.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const addIncidentContact = (organizationId, email) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + organizationId + "/incidentContactOrg",
+    "/api/v1/organization/" + organizationId + "/incidentContactOrg",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/organization/addUserToOrg.js
+++ b/frontend/pages/api/organization/addUserToOrg.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const addUserToOrg = (email, orgId) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/invite-org/signup", {
+  return SecurityClient.fetchCall("/api/v1/invite-org/signup", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/organization/deleteIncidentContact.js
+++ b/frontend/pages/api/organization/deleteIncidentContact.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const deleteIncidentContact = (organizaionId, email) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + organizaionId + "/incidentContactOrg",
+    "/api/v1/organization/" + organizaionId + "/incidentContactOrg",
     {
       method: "DELETE",
       headers: {

--- a/frontend/pages/api/organization/deleteUserFromOrganization.js
+++ b/frontend/pages/api/organization/deleteUserFromOrganization.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const deleteUserFromOrganization = (membershipId) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/membership-org/" + membershipId,
+    "/api/v1/membership-org/" + membershipId,
     {
       method: "DELETE",
       headers: {

--- a/frontend/pages/api/organization/getIncidentContacts.js
+++ b/frontend/pages/api/organization/getIncidentContacts.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getIncidentContacts = (organizationId) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + organizationId + "/incidentContactOrg",
+    "/api/v1/organization/" + organizationId + "/incidentContactOrg",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/organization/getOrgs.js
+++ b/frontend/pages/api/organization/getOrgs.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const getOrganizations = (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/organization", {
+  return SecurityClient.fetchCall("/api/v1/organization", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/organization/renameOrg.js
+++ b/frontend/pages/api/organization/renameOrg.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const renameOrg = (orgId, newOrgName) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/organization/" + orgId + "/name",
+    "/api/v1/organization/" + orgId + "/name",
     {
       method: "PATCH",
       headers: {

--- a/frontend/pages/api/serviceToken/addServiceToken.js
+++ b/frontend/pages/api/serviceToken/addServiceToken.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -15,7 +14,7 @@ const addServiceToken = ({
   encryptedKey,
   nonce,
 }) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/service-token/", {
+  return SecurityClient.fetchCall("/api/v1/service-token/", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/serviceToken/getServiceTokens.js
+++ b/frontend/pages/api/serviceToken/getServiceTokens.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getServiceTokens = ({ workspaceId }) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + workspaceId + "/service-tokens",
+    "/api/v1/workspace/" + workspaceId + "/service-tokens",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/user/getUser.js
+++ b/frontend/pages/api/user/getUser.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const getUser = (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/user", {
+  return SecurityClient.fetchCall("/api/v1/user", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/userActions/checkUserAction.js
+++ b/frontend/pages/api/userActions/checkUserAction.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,6 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const checkUserAction = ({ action }) => {
   return SecurityClient.fetchCall(
-    PATH +
       "/api/v1/user-action" +
       "?" +
       new URLSearchParams({

--- a/frontend/pages/api/userActions/registerUserAction.js
+++ b/frontend/pages/api/userActions/registerUserAction.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -7,7 +6,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const registerUserAction = ({ action }) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/user-action", {
+  return SecurityClient.fetchCall("/api/v1/user-action", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/workspace/addUserToWorkspace.js
+++ b/frontend/pages/api/workspace/addUserToWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const addUserToWorkspace = (email, workspaceId) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + workspaceId + "/invite-signup",
+    "/api/v1/workspace/" + workspaceId + "/invite-signup",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/workspace/changeUserRoleInWorkspace.js
+++ b/frontend/pages/api/workspace/changeUserRoleInWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const changeUserRoleInWorkspace = (membershipId, role) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/membership/" + membershipId + "/change-role",
+    "/api/v1/membership/" + membershipId + "/change-role",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/workspace/createWorkspace.js
+++ b/frontend/pages/api/workspace/createWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -7,7 +6,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const createWorkspace = (workspaceName, organizationId) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/workspace", {
+  return SecurityClient.fetchCall("/api/v1/workspace", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/workspace/deleteUserFromWorkspace.js
+++ b/frontend/pages/api/workspace/deleteUserFromWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -7,7 +6,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const deleteUserFromWorkspace = (membershipId) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/membership/" + membershipId, {
+  return SecurityClient.fetchCall("/api/v1/membership/" + membershipId, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/workspace/deleteWorkspace.js
+++ b/frontend/pages/api/workspace/deleteWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -7,7 +6,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const deleteWorkspace = (workspaceId) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/workspace/" + workspaceId, {
+  return SecurityClient.fetchCall("/api/v1/workspace/" + workspaceId, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/workspace/getLatestFileKey.js
+++ b/frontend/pages/api/workspace/getLatestFileKey.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getLatestFileKey = (workspaceId) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/key/" + workspaceId + "/latest",
+    "/api/v1/key/" + workspaceId + "/latest",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/workspace/getWorkspaceInfo.js
+++ b/frontend/pages/api/workspace/getWorkspaceInfo.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getWorkspaceInfo = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + req.workspaceId,
+    "/api/v1/workspace/" + req.workspaceId,
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/workspace/getWorkspaceKeys.js
+++ b/frontend/pages/api/workspace/getWorkspaceKeys.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getWorkspaceKeys = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + req.workspaceId + "/keys",
+    "/api/v1/workspace/" + req.workspaceId + "/keys",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/workspace/getWorkspaceUsers.js
+++ b/frontend/pages/api/workspace/getWorkspaceUsers.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const getWorkspaceUsers = (req, res) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + req.workspaceId + "/users",
+    "/api/v1/workspace/" + req.workspaceId + "/users",
     {
       method: "GET",
       headers: {

--- a/frontend/pages/api/workspace/getWorkspaces.js
+++ b/frontend/pages/api/workspace/getWorkspaces.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -8,7 +7,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const getWorkspaces = (req, res) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/workspace", {
+  return SecurityClient.fetchCall("/api/v1/workspace", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/frontend/pages/api/workspace/renameWorkspace.js
+++ b/frontend/pages/api/workspace/renameWorkspace.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -9,7 +8,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  */
 const renameWorkspace = (workspaceId, newWorkspaceName) => {
   return SecurityClient.fetchCall(
-    PATH + "/api/v1/workspace/" + workspaceId + "/name",
+    "/api/v1/workspace/" + workspaceId + "/name",
     {
       method: "POST",
       headers: {

--- a/frontend/pages/api/workspace/uploadKeys.js
+++ b/frontend/pages/api/workspace/uploadKeys.js
@@ -1,4 +1,3 @@
-import { PATH } from "~/const";
 import SecurityClient from "~/utilities/SecurityClient";
 
 /**
@@ -10,7 +9,7 @@ import SecurityClient from "~/utilities/SecurityClient";
  * @returns
  */
 const uploadKeys = (workspaceId, userId, encryptedKey, nonce) => {
-  return SecurityClient.fetchCall(PATH + "/api/v1/key/" + workspaceId, {
+  return SecurityClient.fetchCall("/api/v1/key/" + workspaceId, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
Prerequisites to fulfill Issue https://github.com/Infisical/infisical/issues/36 :

1. Remove usage of `NEXT_PUBLIC_WEBSITE_URL` in `next.config.js` and hard-code `self` value instead - this was already implemented: https://github.com/Infisical/infisical/commit/c3427d110a8fcb11a80cdc014a7ef36572c3c6ac
2. Remove usage of `NEXT_PUBLIC_WEBSITE_URL` as `PATH` constant

This PR deals with item 2.

`SecurityClient` depends on `PATH` constant to make sure to add JWT as `Authorization` header only on trusted domains. This `PATH` constant requires building of frontend image to get the client domain `NEXT_PUBLIC_WEBSITE_URL` from environment variable.

Here, trusted domain is the origin of the script. I understand that we don't want to send JWT to external APIs. I assume that this is the reason we have this check.

But..
1. We don't have to prepend `PATH` to every call to the origin, as the origin is automatically prepended when URL consists only of path (e.g. `/api/v1/..` will automatically be `https://domain.com/api/v1/..`)
2. We can inject the JWT for every request that courses through the `SecurityClient` and remove the check whether the caller is trying to reach origin domain. What then if we need to call external API? Just don't use `SecurityClient` 😉 

If I miss the rationale of this utility `SecurityClient`, please let me know. Maybe we can find a compromise.