### PR TITLE
Add Notification Timeout

### DIFF
--- a/frontend/components/context/Notifications/Notification.tsx
+++ b/frontend/components/context/Notifications/Notification.tsx
@@ -6,7 +6,7 @@ import { Notification as NotificationType } from "./NotificationProvider";
 
 interface NotificationProps {
   notification: NotificationType;
-  clearNotification: (text?: string) => void;
+  clearNotification: (text: string) => void;
 }
 
 const Notification = ({

--- a/frontend/components/context/Notifications/Notification.tsx
+++ b/frontend/components/context/Notifications/Notification.tsx
@@ -6,7 +6,7 @@ import classnames from "classnames";
 import { Notification as NotificationType } from "./NotificationProvider";
 
 interface NotificationProps {
-  notification: NotificationType;
+  notification: Required<NotificationType>;
   clearNotification: (text: string) => void;
 }
 

--- a/frontend/components/context/Notifications/Notification.tsx
+++ b/frontend/components/context/Notifications/Notification.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { faXmarkCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classnames from "classnames";
@@ -13,6 +14,27 @@ const Notification = ({
   notification,
   clearNotification,
 }: NotificationProps) => {
+  const timeout = useRef<number>();
+
+  const handleClearNotification = () => clearNotification(notification.text);
+
+  const setNotifTimeout = () => {
+    timeout.current = window.setTimeout(
+      handleClearNotification,
+      notification.timeoutMs
+    );
+  };
+
+  const cancelNotifTimeout = () => {
+    clearTimeout(timeout.current);
+  };
+
+  useEffect(() => {
+    setNotifTimeout();
+
+    return cancelNotifTimeout;
+  }, []);
+
   return (
     <div
       className={classnames(

--- a/frontend/components/context/Notifications/Notification.tsx
+++ b/frontend/components/context/Notifications/Notification.tsx
@@ -42,6 +42,7 @@ const Notification = ({
         {
           "bg-green-600": notification.type === "success",
           "bg-red-500": notification.type === "error",
+          "bg-blue-500": notification.type === "info",
         }
       )}
       role="alert"

--- a/frontend/components/context/Notifications/NotificationProvider.tsx
+++ b/frontend/components/context/Notifications/NotificationProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, ReactNode, useContext, useState } from "react";
 
 import Notifications from "./Notifications";
 
-type NotificationType = "success" | "error";
+type NotificationType = "success" | "error" | "info";
 
 export type Notification = {
   text: string;

--- a/frontend/components/context/Notifications/NotificationProvider.tsx
+++ b/frontend/components/context/Notifications/NotificationProvider.tsx
@@ -25,7 +25,9 @@ interface NotificationProviderProps {
 }
 
 const NotificationProvider = ({ children }: NotificationProviderProps) => {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [notifications, setNotifications] = useState<Required<Notification>[]>(
+    []
+  );
 
   const clearNotification = (text: string) => {
     return setNotifications((state) =>
@@ -44,7 +46,7 @@ const NotificationProvider = ({ children }: NotificationProviderProps) => {
       return;
     }
 
-    const newNotification: Notification = { text, type, timeoutMs };
+    const newNotification: Required<Notification> = { text, type, timeoutMs };
 
     return setNotifications((state) => [...state, newNotification]);
   };

--- a/frontend/components/context/Notifications/NotificationProvider.tsx
+++ b/frontend/components/context/Notifications/NotificationProvider.tsx
@@ -6,7 +6,7 @@ type NotificationType = "success" | "error";
 
 export type Notification = {
   text: string;
-  type: NotificationType;
+  type?: NotificationType;
   timeoutMs?: number;
 };
 

--- a/frontend/components/context/Notifications/NotificationProvider.tsx
+++ b/frontend/components/context/Notifications/NotificationProvider.tsx
@@ -7,6 +7,7 @@ type NotificationType = "success" | "error";
 export type Notification = {
   text: string;
   type: NotificationType;
+  timeoutMs?: number;
 };
 
 type NotificationContextState = {
@@ -36,14 +37,20 @@ const NotificationProvider = ({ children }: NotificationProviderProps) => {
     return setNotifications([]);
   };
 
-  const createNotification = ({ text, type = "success" }: Notification) => {
+  const createNotification = ({
+    text,
+    type = "success",
+    timeoutMs = 2000,
+  }: Notification) => {
     const doesNotifExist = notifications.some((notif) => notif.text === text);
 
     if (doesNotifExist) {
       return;
     }
 
-    return setNotifications((state) => [...state, { text, type }]);
+    const newNotification: Notification = { text, type, timeoutMs };
+
+    return setNotifications((state) => [...state, newNotification]);
   };
 
   return (

--- a/frontend/components/context/Notifications/NotificationProvider.tsx
+++ b/frontend/components/context/Notifications/NotificationProvider.tsx
@@ -11,7 +11,7 @@ export type Notification = {
 };
 
 type NotificationContextState = {
-  createNotification: ({ text, type }: Notification) => void;
+  createNotification: (newNotification: Notification) => void;
 };
 
 const NotificationContext = createContext<NotificationContextState>({
@@ -27,14 +27,10 @@ interface NotificationProviderProps {
 const NotificationProvider = ({ children }: NotificationProviderProps) => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
-  const clearNotification = (text?: string) => {
-    if (text) {
-      return setNotifications((state) =>
-        state.filter((notif) => notif.text !== text)
-      );
-    }
-
-    return setNotifications([]);
+  const clearNotification = (text: string) => {
+    return setNotifications((state) =>
+      state.filter((notif) => notif.text !== text)
+    );
   };
 
   const createNotification = ({

--- a/frontend/components/context/Notifications/Notifications.tsx
+++ b/frontend/components/context/Notifications/Notifications.tsx
@@ -3,7 +3,7 @@ import { Notification as NotificationType } from "./NotificationProvider";
 
 interface NoticationsProps {
   notifications: NotificationType[];
-  clearNotification: (text?: string) => void;
+  clearNotification: (text: string) => void;
 }
 
 const Notifications = ({

--- a/frontend/components/context/Notifications/Notifications.tsx
+++ b/frontend/components/context/Notifications/Notifications.tsx
@@ -10,6 +10,10 @@ const Notifications = ({
   notifications,
   clearNotification,
 }: NoticationsProps) => {
+  if (!notifications.length) {
+    return null;
+  }
+
   return (
     <div className="hidden fixed z-50 top-1 w-full inset-x-0 pointer-events-none md:flex justify-center">
       <div className="flex flex-col gap-y-2 w-96">

--- a/frontend/components/context/Notifications/Notifications.tsx
+++ b/frontend/components/context/Notifications/Notifications.tsx
@@ -2,7 +2,7 @@ import Notification from "./Notification";
 import { Notification as NotificationType } from "./NotificationProvider";
 
 interface NoticationsProps {
-  notifications: NotificationType[];
+  notifications: Required<NotificationType>[];
   clearNotification: (text: string) => void;
 }
 

--- a/frontend/components/context/Notifications/Notifications.tsx
+++ b/frontend/components/context/Notifications/Notifications.tsx
@@ -15,16 +15,14 @@ const Notifications = ({
   }
 
   return (
-    <div className="hidden fixed z-50 top-1 w-full inset-x-0 pointer-events-none md:flex justify-center">
-      <div className="flex flex-col gap-y-2 w-96">
-        {notifications.map((notif) => (
-          <Notification
-            key={notif.text}
-            notification={notif}
-            clearNotification={clearNotification}
-          />
-        ))}
-      </div>
+    <div className="hidden fixed z-50 md:flex md:flex-col-reverse bottom-1 gap-y-2 w-96 h-full right-1 pointer-events-none">
+      {notifications.map((notif) => (
+        <Notification
+          key={notif.text}
+          notification={notif}
+          clearNotification={clearNotification}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
closes #89 

## List of Changes
- Add `info` type for notifications. It's blue-colored.
- Require `notif.text` for `clearNotification`. It didn't make sense to have `clearNotification` to clear _all_ notifications. 
- `Notification` type within state is now `Required<>`. We need to ensure notifications within the `NotificationProvider` context have a `type` and `timeoutMs`
- Add optional `timeoutMs` to create a new `Notification`
- Add timeout capabilities for notifications to auto-hide after a specified amount of time (using the passed `timeoutMs`)
- Move notifications to bottom right of screen and hide notification wrapper if `!notifications.length`