### PR TITLE
Add PR gate workflows

### DIFF
--- a/.github/workflows/check-be-pull-request.yml
+++ b/.github/workflows/check-be-pull-request.yml
@@ -1,0 +1,41 @@
+name: Check Backend Pull Request
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+    paths:
+      - 'backend/**'
+      - '!backend/README.md'
+      - '!backend/.*'
+      - 'backend/.eslintrc.js'
+
+
+jobs:
+
+  check-be-pr:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: ☁️ Checkout source
+        uses: actions/checkout@v3
+      -
+        name: 🔧 Setup Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      -
+        name: 📦 Install dependencies
+        run: npm ci --only-production --ignore-scripts
+        working-directory: backend
+      # -
+      #   name: 🧪 Run tests
+      #   run: npm run test:ci
+      #   working-directory: backend
+      -
+        name: 🏗️ Run build
+        run: npm run build
+        working-directory: backend

--- a/.github/workflows/check-fe-pull-request.yml
+++ b/.github/workflows/check-fe-pull-request.yml
@@ -1,0 +1,41 @@
+name: Check Frontend Pull Request
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+    paths:
+      - 'frontend/**'
+      - '!frontend/README.md'
+      - '!frontend/.*'
+      - 'frontend/.eslintrc.js'
+
+
+jobs:
+
+  check-fe-pr:
+    name: Check
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: ☁️ Checkout source
+        uses: actions/checkout@v3
+      -
+        name: 🔧 Setup Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      -
+        name: 📦 Install dependencies
+        run: npm ci --only-production --ignore-scripts
+        working-directory: frontend
+      # -
+      #   name: 🧪 Run tests
+      #   run: npm run test:ci
+      #   working-directory: frontend
+      -
+        name: 🏗️ Run build
+        run: npm run build
+        working-directory: frontend

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -86,3 +86,5 @@ jobs:
           context: frontend
           tags: infisical/frontend:latest
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - 
         name: ☁️ Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -36,7 +36,7 @@ jobs:
       #   run: |
       #     docker run --rm infisical/backend:test
       -
-        name: 📦 Build backend and push
+        name: 🏗️ Build backend and push
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -52,7 +52,7 @@ jobs:
     steps:
       - 
         name: ☁️ Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -79,7 +79,7 @@ jobs:
       #   run: |
       #     docker run --rm infisical/frontend:test
       -
-        name: 📦 Build frontend and push
+        name: 🏗️ Build frontend and push
         uses: docker/build-push-action@v3
         with:
           push: true


### PR DESCRIPTION
Two separate workflows that run on creation of pull requests:
* Frontend workflow watches for changes under `frontend` directory
* Backend workflow watches for changes under `backend` directory

For now, only executes `npm run build`. But the step for running tests is already included but commented out.

Also squeezed in a fix on build-arg for frontend image build.