### PR TITLE
Adding automatic linter for checking commit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package.json package-lock.json ./
 
-RUN npm ci --only-production
+RUN npm ci --only-production --ignore-scripts
 
 COPY . .
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
   "version": "1.0.0",
   "main": "src/index.js",
   "scripts": {
+    "prepare": "cd .. && npm install",
     "start": "npm run build && node build/index.js",
     "dev": "nodemon",
     "build": "rimraf ./build && tsc && cp -R ./src/templates ./src/json ./build",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY package.json package-lock.json next.config.js ./
 
 # Install dependencies
-RUN npm ci --only-production
+RUN npm ci --only-production --ignore-scripts
 
 
 # Rebuild the source code only when needed

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -9,7 +9,7 @@ COPY package.json ./
 COPY package-lock.json ./
 
 # Install 
-RUN npm install 
+RUN npm install --ignore-scripts
 
 # Copy over next.js config 
 COPY next.config.js ./next.config.js

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -9,7 +9,7 @@ COPY package.json ./
 COPY package-lock.json ./
 
 # Install 
-RUN npm install 
+RUN npm install --ignore-scripts
 
 # Copy over next.js config
 COPY next.config.js ./next.config.js

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "prepare": "cd .. && npm install",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown",
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Add `--ignore-scripts` option for every `npm ci` and `npm install` command

and only eslint will be worked for checking the commit