### PR TITLE
Fix `JWT_SERVICE_SECRET` not present in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,13 +9,13 @@ ENCRYPTION_KEY=replace_with_lengthy_secure_hex
 JWT_SIGNUP_SECRET=replace_with_lengthy_secure_hex
 JWT_REFRESH_SECRET=replace_with_lengthy_secure_hex
 JWT_AUTH_SECRET=replace_with_lengthy_secure_hex
+JWT_SERVICE_SECRET=replace_with_lengthy_secure_hex
 
 # JWT lifetime
 # Optional lifetimes for JWT tokens expressed in seconds or a string 
 # describing a time span (e.g. 60, "2 days", "10h", "7d")
 JWT_AUTH_LIFETIME=
 JWT_REFRESH_LIFETIME=
-JWT_SERVICE_SECRET=
 JWT_SIGNUP_LIFETIME=
 
 # Optional lifetimes for OTP expressed in seconds

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3761,6 +3761,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4967,6 +4968,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -5616,6 +5618,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.2.0",
         "jest-util": "^29.3.1",
@@ -6406,9 +6409,11 @@
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.11.0.tgz",
       "integrity": "sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==",
       "dependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
         "bson": "^4.7.0",
         "denque": "^2.1.0",
         "mongodb-connection-string-url": "^2.5.4",
+        "saslprep": "^1.0.3",
         "socks": "^2.7.1"
       },
       "engines": {
@@ -6600,9 +6605,6 @@
       },
       "bin": {
         "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/normalize-path": {
@@ -7456,6 +7458,7 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
+        "@colors/colors": "1.5.0",
         "string-width": "^4.2.0"
       },
       "engines": {
@@ -8251,6 +8254,7 @@
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
+        "encoding": "^0.1.13",
         "minipass": "^3.1.6",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"

--- a/docs/contributing/developing.mdx
+++ b/docs/contributing/developing.mdx
@@ -23,7 +23,7 @@ Mandatory variables in the `.env` file:
 
 1. Keys and JWT variables
 
-![image](https://user-images.githubusercontent.com/118568289/206791534-9c9d1431-e83d-49c0-8a54-b373ed0df820.png)
+![image](https://user-images.githubusercontent.com/8071263/208800914-f468c2ad-c6a8-4da7-8ffd-eece5d7f08d2.png)
 
 The `.env.example` has these variables empty, you can self generate the `JWT and ENCRYPTION_KEY` with this [32-byte random hex strings generator](https://www.browserling.com/tools/random-hex).
 


### PR DESCRIPTION

According to issue #142, relocated `JWT_SERVICE_SECRET` and updated example image in `/docs/contributing/developing.mdx` to contain `JWT_SERVICE_SECRET` as well.
