### PR TITLE
Fix typo in quickstart

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -8,7 +8,7 @@ Note that the Infisical CLI is platform-agnostic and can inject environment vari
 
 ## Set up Infisical Cloud
 
-1. Login or create an accout at `app.infisical.com`.
+1. Login or create an account at `app.infisical.com`.
 2. Create a new project.
 3. Populate your environment variables as in the image below.
 


### PR DESCRIPTION
This change just fixes a typo I found in your Quickstart guide.