### PR TITLE
ci: add aur release

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURYPUSHTOKEN }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
       - uses: actions/setup-python@v4
       - run: pip install --upgrade cloudsmith-cli
       - name: Publish to CloudSmith 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,13 +30,13 @@ builds:
       - openbsd
       - windows
     goarch:
-      - 386
+      - "386"
       - amd64
       - arm
       - arm64
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
     ignore:
       - goos: windows
         goarch: "386"
@@ -102,6 +102,22 @@ scoop:
   homepage: "https://infisical.com"
   description: "The official Infisical CLI"
   license: Apache-2.0
+aurs:
+  -
+    name: infisical-bin
+    homepage: "https://infisical.com"
+    description: "The official Infisical CLI"
+    maintainers:
+      - Infisical, Inc <support@infisical.com>
+    license: Apache-2.0
+    private_key: '{{ .Env.AUR_KEY }}'
+    git_url: 'ssh://aur@aur.archlinux.org/infisical-bin.git'
+    package: |-
+      # bin
+      install -Dm755 "./infisical" "${pkgdir}/usr/bin/infisical"
+      # license
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/infisical/LICENSE"
+
 # dockers:
 #   - dockerfile: goreleaser.dockerfile
 #     goos: linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,7 +85,7 @@ nfpms:
   homepage: https://infisical.com/
   maintainer: Infisical, Inc
   description: The offical Infisical CLI
-  license: Apache 2.0
+  license: MIT
   formats:
   - rpm
   - deb
@@ -101,7 +101,7 @@ scoop:
     email: ai@infisical.com
   homepage: "https://infisical.com"
   description: "The official Infisical CLI"
-  license: Apache-2.0
+  license: MIT
 aurs:
   -
     name: infisical-bin
@@ -109,7 +109,7 @@ aurs:
     description: "The official Infisical CLI"
     maintainers:
       - Infisical, Inc <support@infisical.com>
-    license: Apache-2.0
+    license: MIT
     private_key: '{{ .Env.AUR_KEY }}'
     git_url: 'ssh://aur@aur.archlinux.org/infisical-bin.git'
     package: |-


### PR DESCRIPTION
Hi, 
As already mentioned on Slack. You'll need to add a github secret called "AUR_KEY" containing your AUR ssh key for this to work. 

Closes #121 