### PR TITLE
ci: add autocompletion and manpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ node_modules
 .DS_Store
 
 /dist
+/completions/
+/manpages/
 
 # frontend
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,11 @@
 #     - cd cli && go mod tidy
 #     # you may remove this if you don't need go generate
 #     - cd cli && go generate ./...
+before:
+  hooks:
+    - ./cli/scripts/completions.sh
+    - ./cli/scripts/manpages.sh
+
 builds:
   - id: darwin-build
     binary: infisical
@@ -43,6 +48,16 @@ builds:
       - goos: freebsd
         goarch: "386"
     dir: ./cli
+
+archives:
+  - format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README*
+      - LICENSE*
+      - manpages/*
+      - completions/*
 
 release:
   replace_existing_draft: true
@@ -92,6 +107,15 @@ nfpms:
   - apk
   - archlinux
   bindir: /usr/bin
+  contents:
+    - src: ./completions/infisical.bash
+      dst: /etc/bash_completion.d/infisical
+    - src: ./completions/infisical.fish
+      dst: /usr/share/fish/vendor_completions.d/infisical.fish
+    - src: ./completions/infisical.zsh
+      dst: /usr/share/zsh/site-functions/_infisical
+    - src: ./manpages/infisical.1.gz
+      dst: /usr/share/man/man1/infisical.1.gz
 scoop:
   bucket:
     owner: Infisical
@@ -117,7 +141,15 @@ aurs:
       install -Dm755 "./infisical" "${pkgdir}/usr/bin/infisical"
       # license
       install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/infisical/LICENSE"
-
+      # completions
+      mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+      mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+      mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+      install -Dm644 "./completions/infisical.bash" "${pkgdir}/usr/share/bash-completion/completions/infisical"
+      install -Dm644 "./completions/infisical.zsh" "${pkgdir}/usr/share/zsh/site-functions/infisical"
+      install -Dm644 "./completions/infisical.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/infisical.fish"
+      # man pages
+      install -Dm644 "./manpages/infisical.1.gz" "${pkgdir}/usr/share/man/man1/infisical.1.gz"
 # dockers:
 #   - dockerfile: goreleaser.dockerfile
 #     goos: linux

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,6 +4,8 @@ go 1.19
 
 require (
 	github.com/99designs/keyring v1.2.2
+	github.com/muesli/mango-cobra v1.2.0
+	github.com/muesli/roff v0.1.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.3.0
 	golang.org/x/term v0.3.0
@@ -22,6 +24,8 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
+	github.com/muesli/mango v0.1.0 // indirect
+	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.10.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -56,6 +56,14 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
+github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=
+github.com/muesli/mango v0.1.0/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango-cobra v1.2.0 h1:DQvjzAM0PMZr85Iv9LIMaYISpTOliMEg+uMFtNbYvWg=
+github.com/muesli/mango-cobra v1.2.0/go.mod h1:vMJL54QytZAJhCT13LPVDfkvCUJ5/4jNUKF/8NC2UjA=
+github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe7Sg=
+github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
+github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
+github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/cli/packages/cmd/man.go
+++ b/cli/packages/cmd/man.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	mcobra "github.com/muesli/mango-cobra"
+	"github.com/muesli/roff"
+	"github.com/spf13/cobra"
+)
+
+var manCmd = &cobra.Command{
+	Use:                   "man",
+	Short:                 "generates the manpages",
+	SilenceUsage:          true,
+	DisableFlagsInUseLine: true,
+	Hidden:                true,
+	Args:                  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		manPage, err := mcobra.NewManPage(1, rootCmd)
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprint(os.Stdout, manPage.Build(roff.NewDocument()))
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(manCmd)
+}

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -14,7 +14,7 @@ var rootCmd = &cobra.Command{
 	Use:               "infisical",
 	Short:             "Infisical CLI is used to inject environment variables into any process",
 	Long:              `Infisical is a simple, end-to-end encrypted service that enables teams to sync and manage their environment variables across their development life cycle.`,
-	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 	Version:           "0.1.16",
 }
 

--- a/cli/scripts/completions.sh
+++ b/cli/scripts/completions.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+rm -rf completions
+mkdir completions
+cd cli
+for sh in bash zsh fish; do
+	go run . completion "$sh" > "../completions/infisical.$sh"
+done

--- a/cli/scripts/manpages.sh
+++ b/cli/scripts/manpages.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+rm -rf manpages
+mkdir manpages
+cd cli
+go run . man | gzip -c > "../manpages/infisical.1.gz"


### PR DESCRIPTION
This adds support for the automatic generation of shell autocompletion files and linux manpages. 