### PR TITLE
ci: auto build and tag images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🏷️ Meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: infisical/backend
       - name: 📦 Build backend and export to Docker
@@ -74,7 +74,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 🏷️ Meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: infisical/frontend
       - name: 📦 Build frontend and export to Docker

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,6 +54,7 @@ jobs:
           context: backend
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
 
   frontend-image:
     name: Build frontend image
@@ -101,5 +102,6 @@ jobs:
           context: frontend
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,13 @@
 name: Push to Docker Hub
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
 
 jobs:
   backend-image:
@@ -15,10 +22,16 @@ jobs:
       - name: 🔧 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: 🐋 Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🏷️ Meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: infisical/backend
       - name: 📦 Build backend and export to Docker
         uses: docker/build-push-action@v3
         with:
@@ -37,9 +50,9 @@ jobs:
       - name: 🏗️ Build backend and push
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: backend
-          tags: infisical/backend:latest
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
 
   frontend-image:
@@ -54,10 +67,16 @@ jobs:
       - name: 🔧 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: 🐋 Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🏷️ Meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: infisical/frontend
       - name: 📦 Build frontend and export to Docker
         uses: docker/build-push-action@v3
         with:
@@ -78,9 +97,9 @@ jobs:
       - name: 🏗️ Build frontend and push
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           context: frontend
-          tags: infisical/frontend:latest
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}


### PR DESCRIPTION
Currently all docker images are tagged with `latest` and overwritten on new builds. 
This is a bit problematic in production environments since it prevents version control. 

I'd like to propose this build pipeline for the docker images. 

The pipeline will be triggered automatically on a new tag and create images with the according tags. 
Pull requests to `main` will trigger the pipeline but only to test if the image still works. The image wont be pushed to dockerhub. 

The docker image with tag `latest` will always be the latest tag on github. Builds triggered by `workflow_dispatch` will have the tag `main`. 