### PR TITLE
Add API Key auth mode

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,6 +38,7 @@ import {
   secret as v2SecretRouter,
   workspace as v2WorkspaceRouter,
   serviceTokenData as v2ServiceTokenDataRouter,
+  apiKeyData as v2APIKeyDataRouter,
 } from './routes/v2';
 
 import { getLogger } from './utils/logger';
@@ -94,6 +95,7 @@ app.use('/api/v1/integration-auth', v1IntegrationAuthRouter);
 app.use('/api/v2/workspace', v2WorkspaceRouter);
 app.use('/api/v2/secret', v2SecretRouter);
 app.use('/api/v2/service-token-data', v2ServiceTokenDataRouter);
+app.use('/api/v2/api-key-data', v2APIKeyDataRouter);
 
 //* Handle unrouted requests and respond with proper error message as well as status code
 app.use((req, res, next)=>{

--- a/backend/src/controllers/v2/apiKeyDataController.ts
+++ b/backend/src/controllers/v2/apiKeyDataController.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express';
+import * as Sentry from '@sentry/node';
+import crypto from 'crypto';
+import bcrypt from 'bcrypt';
+import {
+    APIKeyData
+} from '../../models';
+import {
+    SALT_ROUNDS
+} from '../../config';
+
+/**
+ * Create new API key for user with id [req.user._id]
+ * @param req 
+ * @param res 
+ */
+export const createAPIKey = async (req: Request, res: Response) => {
+    let apiKey, apiKeyData;
+    try {
+        const { name, expiresIn } = req.body;
+        
+        const secret = crypto.randomBytes(16).toString('hex');
+        const secretHash = await bcrypt.hash(secret, SALT_ROUNDS);
+        
+		const expiresAt = new Date();
+		expiresAt.setSeconds(expiresAt.getSeconds() + expiresIn);
+        
+        apiKeyData = await new APIKeyData({
+            name,
+            expiresAt,
+            user: req.user._id,
+            secretHash
+        });
+        
+        // return api key data without sensitive data
+        apiKeyData = await APIKeyData.findById(apiKeyData._id);
+        
+        if (!apiKeyData) throw new Error('Failed to find API key data');
+        
+        apiKey = `ak.${apiKeyData._id.toString()}.${secret}`;
+            
+    } catch (err) {
+        Sentry.setUser({ email: req.user.email });
+        Sentry.captureException(err);
+        return res.status(400).send({
+            message: 'Failed to create service token data'
+        });
+    }
+    
+    return res.status(200).send({
+        apiKey,
+        apiKeyData
+    });
+}

--- a/backend/src/controllers/v2/apiKeyDataController.ts
+++ b/backend/src/controllers/v2/apiKeyDataController.ts
@@ -10,11 +10,36 @@ import {
 } from '../../config';
 
 /**
- * Create new API key for user with id [req.user._id]
+ * Return API key data for user with id [req.user_id]
+ * @param req
+ * @param res 
+ * @returns 
+ */
+export const getAPIKeyData = async (req: Request, res: Response) => {
+    let apiKeyData;
+    try {
+        apiKeyData = await APIKeyData.find({
+            user: req.user._id
+        });
+    } catch (err) {
+        Sentry.setUser({ email: req.user.email });
+        Sentry.captureException(err);
+        return res.status(400).send({
+            message: 'Failed to get API key data'
+        });
+    }
+    
+    return res.status(200).send({
+        apiKeyData
+    });
+}
+
+/**
+ * Create new API key data for user with id [req.user._id]
  * @param req 
  * @param res 
  */
-export const createAPIKey = async (req: Request, res: Response) => {
+export const createAPIKeyData = async (req: Request, res: Response) => {
     let apiKey, apiKeyData;
     try {
         const { name, expiresIn } = req.body;
@@ -30,7 +55,7 @@ export const createAPIKey = async (req: Request, res: Response) => {
             expiresAt,
             user: req.user._id,
             secretHash
-        });
+        }).save();
         
         // return api key data without sensitive data
         apiKeyData = await APIKeyData.findById(apiKeyData._id);
@@ -40,10 +65,11 @@ export const createAPIKey = async (req: Request, res: Response) => {
         apiKey = `ak.${apiKeyData._id.toString()}.${secret}`;
             
     } catch (err) {
+        console.error(err);
         Sentry.setUser({ email: req.user.email });
         Sentry.captureException(err);
         return res.status(400).send({
-            message: 'Failed to create service token data'
+            message: 'Failed to API key data'
         });
     }
     

--- a/backend/src/controllers/v2/apiKeyDataController.ts
+++ b/backend/src/controllers/v2/apiKeyDataController.ts
@@ -78,3 +78,29 @@ export const createAPIKeyData = async (req: Request, res: Response) => {
         apiKeyData
     });
 }
+
+/**
+ * Delete API key data with id [apiKeyDataId].
+ * @param req 
+ * @param res 
+ * @returns 
+ */
+export const deleteAPIKeyData = async (req: Request, res: Response) => {
+    let apiKeyData;
+    try {
+        const { apiKeyDataId } = req.params;
+
+        apiKeyData = await APIKeyData.findByIdAndDelete(apiKeyDataId);
+        
+    } catch (err) {
+        Sentry.setUser({ email: req.user.email });
+        Sentry.captureException(err);
+        return res.status(400).send({
+            message: 'Failed to delete API key data'
+        });
+    }
+    
+    return res.status(200).send({
+        apiKeyData
+    });
+}

--- a/backend/src/controllers/v2/index.ts
+++ b/backend/src/controllers/v2/index.ts
@@ -1,7 +1,9 @@
 import * as workspaceController from './workspaceController';
 import * as serviceTokenDataController from './serviceTokenDataController';
+import * as apiKeyDataController from './apiKeyDataController';
 
 export { 
     workspaceController,
-    serviceTokenDataController
+    serviceTokenDataController,
+    apiKeyDataController
 }

--- a/backend/src/middleware/requireAuth.ts
+++ b/backend/src/middleware/requireAuth.ts
@@ -4,7 +4,8 @@ import { User, ServiceTokenData } from '../models';
 import {
 	validateAuthMode,
 	getAuthUserPayload,
-	getAuthSTDPayload
+	getAuthSTDPayload,
+	getAuthAPIKeyPayload
 } from '../helpers/auth';
 import { BadRequestError } from '../utils/errors';
 
@@ -50,6 +51,11 @@ const requireAuth  = ({
 		switch (authMode) {
 			case 'serviceToken':
 				req.serviceTokenData = await getAuthSTDPayload({
+					authTokenValue: AUTH_TOKEN_VALUE
+				});
+				break;
+			case 'apiKey':
+				req.user = await getAuthAPIKeyPayload({
 					authTokenValue: AUTH_TOKEN_VALUE
 				});
 				break;

--- a/backend/src/models/apiKeyData.ts
+++ b/backend/src/models/apiKeyData.ts
@@ -1,0 +1,37 @@
+import { Schema, model, Types } from 'mongoose';
+
+export interface IAPIKeyData {
+    name: string;
+    user: Types.ObjectId;
+    expiresAt: Date;
+    secretHash: string;
+}
+
+const apiKeyDataSchema = new Schema<IAPIKeyData>(
+    {
+        name: {
+            type: String,
+            required: true
+        },
+        user: {
+            type: Schema.Types.ObjectId,
+            ref: 'User',
+            required: true
+        },
+        expiresAt: {
+            type: Date
+        },
+        secretHash: {
+            type: String,
+            required: true,
+            select: false
+        }
+    }, 
+    {
+        timestamps: true
+    }
+);
+
+const APIKeyData = model<IAPIKeyData>('APIKeyData', apiKeyDataSchema);
+
+export default APIKeyData;

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -14,7 +14,8 @@ import Token, { IToken } from './token';
 import User, { IUser } from './user';
 import UserAction, { IUserAction } from './userAction';
 import Workspace, { IWorkspace } from './workspace';
-import ServiceTokenData, { IServiceTokenData } from './serviceTokenData ';
+import ServiceTokenData, { IServiceTokenData } from './serviceTokenData';
+import APIKeyData, { IAPIKeyData } from './apiKeyData';
 
 export {
 	BackupPrivateKey,
@@ -50,5 +51,7 @@ export {
 	Workspace,
 	IWorkspace,
 	ServiceTokenData,
-	IServiceTokenData
+	IServiceTokenData,
+	APIKeyData,
+	IAPIKeyData
 };

--- a/backend/src/models/serviceTokenData.ts
+++ b/backend/src/models/serviceTokenData.ts
@@ -1,5 +1,4 @@
 import { Schema, model, Types } from 'mongoose';
-import { ENV_DEV, ENV_TESTING, ENV_STAGING, ENV_PROD } from '../variables';
 
 export interface IServiceTokenData {
     name: string;
@@ -38,7 +37,6 @@ const serviceTokenDataSchema = new Schema<IServiceTokenData>(
         },
         secretHash: {
             type: String,
-            unique: true,
             required: true,
             select: false
         },

--- a/backend/src/routes/v2/apiKeyData.ts
+++ b/backend/src/routes/v2/apiKeyData.ts
@@ -7,6 +7,14 @@ import {
 import { body } from 'express-validator';
 import { apiKeyDataController } from '../../controllers/v2';
 
+router.get(
+    '/',
+    requireAuth({
+        acceptedAuthModes: ['jwt']
+    }),
+    apiKeyDataController.getAPIKeyData
+);
+
 router.post(
     '/',
     requireAuth({
@@ -15,7 +23,7 @@ router.post(
     body('name').exists().trim(),
     body('expiresIn'), // measured in ms
     validateRequest,
-    apiKeyDataController.createAPIKey
+    apiKeyDataController.createAPIKeyData
 );
 
 export default router;

--- a/backend/src/routes/v2/apiKeyData.ts
+++ b/backend/src/routes/v2/apiKeyData.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+const router = express.Router();
+import {
+    requireAuth,
+    validateRequest
+} from '../../middleware';
+import { body } from 'express-validator';
+import { apiKeyDataController } from '../../controllers/v2';
+
+router.post(
+    '/',
+    requireAuth({
+        acceptedAuthModes: ['jwt']
+    }),
+    body('name').exists().trim(),
+    body('expiresIn'), // measured in ms
+    validateRequest,
+    apiKeyDataController.createAPIKey
+);
+
+export default router;

--- a/backend/src/routes/v2/apiKeyData.ts
+++ b/backend/src/routes/v2/apiKeyData.ts
@@ -4,7 +4,7 @@ import {
     requireAuth,
     validateRequest
 } from '../../middleware';
-import { body } from 'express-validator';
+import { param, body } from 'express-validator';
 import { apiKeyDataController } from '../../controllers/v2';
 
 router.get(
@@ -24,6 +24,16 @@ router.post(
     body('expiresIn'), // measured in ms
     validateRequest,
     apiKeyDataController.createAPIKeyData
+);
+
+router.delete(
+    '/:apiKeyDataId',
+    requireAuth({
+        acceptedAuthModes: ['jwt']
+    }),
+    param('apiKeyDataId').exists().trim(),
+    validateRequest,
+    apiKeyDataController.deleteAPIKeyData
 );
 
 export default router;

--- a/backend/src/routes/v2/index.ts
+++ b/backend/src/routes/v2/index.ts
@@ -1,9 +1,11 @@
 import secret from './secret';
 import workspace from './workspace';
 import serviceTokenData from './serviceTokenData';
+import apiKeyData from './apiKeyData';
 
 export {
     secret,
     workspace,
-    serviceTokenData
+    serviceTokenData,
+    apiKeyData
 }

--- a/backend/src/routes/v2/workspace.ts
+++ b/backend/src/routes/v2/workspace.ts
@@ -71,5 +71,4 @@ router.get(
 	workspaceController.getWorkspaceServiceTokenData
 );
 
-
 export default router;

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -16,6 +16,7 @@ declare global {
 			serviceToken: any;
 			accessToken: any;
 			serviceTokenData: any;
+			apiKeyData: any;
 			query?: any;
 		}
 	}

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -143,4 +143,14 @@ export const ServiceTokenDataNotFoundError = (error?: Partial<RequestErrorContex
     stack: error?.stack
 })
 
+//* ----->[API KEY DATA ERRORS]<-----
+export const APIKeyDataNotFoundError = (error?: Partial<RequestErrorContext>) => new RequestError({
+    logLevel: error?.logLevel ?? LogLevel.ERROR,
+    statusCode: error?.statusCode ?? 404,
+    type: error?.type ?? 'service_token_data_not_found_error',
+    message: error?.message ?? 'The requested service token data was not found',
+    context: error?.context,
+    stack: error?.stack
+})
+
 //* ----->[MISC ERRORS]<-----


### PR DESCRIPTION
We will soon be opening up Infisical's API and documenting it so users can make API requests to Infisical.

This update adds backend support for API keys that users can use to authenticate with Infisical instead of JWTs; note that API keys v1 currently have full scope over a user's account and in the future we intend to apply scopes so users may pick what permissions API keys have.

Routes added:
- `GET api/v2/api-key-data`
- `POST api/v2/api-key-data`
- `DELETE api/v2/api-key-data`