### PR TITLE
Default port for NGINX in dev

### DIFF
--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -1,10 +1,10 @@
 server {
-    listen 80;
-    
+    listen 8080;
+
     location /api {
         proxy_set_header X-Real-RIP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        
+
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
 
@@ -13,16 +13,16 @@ server {
 
         proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
     }
-    
+
     location / {
         include /etc/nginx/mime.types;
-        
+
         proxy_set_header X-Real-RIP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        
+
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
-        
+
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 


### PR DESCRIPTION
Noticed that the site URL is posted as `http://localhost:8080` in the `example.env` file, which I reckon is for local development purposes.

The NGINX port should likely match this specifically for the `default.dev.conf` for the local.

There are other lines that show whitespace being taken out, this is done just to match the `default.conf` which had those characters cleaned up.