### PR TITLE
Issue 159 - Docker image tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: ☁️ Checkout source
         uses: actions/checkout@v3
+      - name: Save commit hashes for tag
+        id: commit
+        uses: pr-mpt/actions-commit-hash@v2
       - name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: 🔧 Set up Docker Buildx
@@ -39,7 +42,7 @@ jobs:
         with:
           push: true
           context: backend
-          tags: infisical/backend:latest
+          tags: infisical/backend:${{ steps.commit.outputs.short }}
           platforms: linux/amd64,linux/arm64
 
   frontend-image:
@@ -49,6 +52,9 @@ jobs:
     steps:
       - name: ☁️ Checkout source
         uses: actions/checkout@v3
+      - name: Save commit hashes for tag
+        id: commit
+        uses: pr-mpt/actions-commit-hash@v2
       - name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: 🔧 Set up Docker Buildx
@@ -80,7 +86,7 @@ jobs:
         with:
           push: true
           context: frontend
-          tags: infisical/frontend:latest
+          tags: infisical/frontend:${{ steps.commit.outputs.short }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,7 +42,8 @@ jobs:
         with:
           push: true
           context: backend
-          tags: infisical/backend:${{ steps.commit.outputs.short }}
+          tags: infisical/backend:${{ steps.commit.outputs.short }}, 
+                infisical/backend:latest
           platforms: linux/amd64,linux/arm64
 
   frontend-image:
@@ -86,7 +87,8 @@ jobs:
         with:
           push: true
           context: frontend
-          tags: infisical/frontend:${{ steps.commit.outputs.short }}
+          tags: infisical/frontend:${{ steps.commit.outputs.short }}, 
+                infisical/frontend:latest
           platforms: linux/amd64,linux/arm64
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}


### PR DESCRIPTION
#168 

Added the short commit hash as a Docker tag. Kept the latest tag as well so that old images don't continue to be offered as latest on Docker Hub (there is nothing automatically updating this and Docker just assumes latest is truly latest).