### PR TITLE
fix: readme and translation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,6 @@ Infisical officially launched as v.1.0 on November 21st, 2022. There are a lot o
 
 ## 🌎 Translations
 
-Infisical is currently aviable in English and Korean. Help us translate Infisical to your language! 
+Infisical is currently available in English and Korean. Help us translate Infisical to your language! 
 
 You can find all the info in [this issue](https://github.com/Infisical/infisical/issues/181).

--- a/frontend/public/locales/en/integrations.json
+++ b/frontend/public/locales/en/integrations.json
@@ -4,7 +4,7 @@
   "no-integrations1": "You don't have any integrations set up yet. When you do, they will appear here.",
   "no-integrations2": "To start, click on any of the options below. It takes 5 clicks to set up.",
   "available": "Platform & Cloud Integrations",
-  "available-text1": "Click on the itegration you want to connect. This will let your environment variables flow automatically into selected third-party services.",
+  "available-text1": "Click on the integration you want to connect. This will let your environment variables flow automatically into selected third-party services.",
   "available-text2": "Note: during an integration with Heroku, for security reasons, it is impossible to maintain end-to-end encryption. In theory, this lets Infisical decrypt yor environment variables. In practice, we can assure you that this will never be done, and it allows us to protect your secrets from bad actors online. The core Infisical service will always stay end-to-end encrypted. With any questions, reach out support@infisical.com.",
   "cloud-integrations": "Cloud Integrations",
   "framework-integrations": "Framework Integrations",

--- a/frontend/public/locales/en/settings-members.json
+++ b/frontend/public/locales/en/settings-members.json
@@ -1,4 +1,4 @@
 {
   "title": "Project Members",
-  "description": "This pages shows the members of the selected project."
+  "description": "This page shows the members of the selected project."
 }

--- a/frontend/public/locales/en/signup.json
+++ b/frontend/public/locales/en/signup.json
@@ -1,7 +1,7 @@
 {
   "title": "Sign Up",
   "og-title": "Replace .env files with 1 line of code. Sign Up for Infisical in 3 minutes.",
-  "og-description": "Infisical a simple end-to-end encrypted platform that enables teams to sync and manage API-keys and environemntal variables.  Works with Node.js, Next.js, Gatsby, Nest.js...",
+  "og-description": "Infisical a simple end-to-end encrypted platform that enables teams to sync and manage API-keys and environemntal variables. Works with Node.js, Next.js, Gatsby, Nest.js...",
   "signup": "Sign Up",
   "already-have-account": "Have an account? Log in",
   "forgot-password": "Forgot your password?",

--- a/i18n/README.en.md
+++ b/i18n/README.en.md
@@ -325,6 +325,6 @@ Infisical officially launched as v.1.0 on November 21st, 2022. However, a lot of
 
 ## 🌎 Translations
 
-Infisical is currently aviable in English and Korean. Help us translate Infisical to your language! 
+Infisical is currently available in English and Korean. Help us translate Infisical to your language! 
 
 You can find all the info in [this issue](https://github.com/Infisical/infisical/issues/181).


### PR DESCRIPTION
# Description 📣

Fixing some typos in the `en` translation files and in the english READMEs. I've catched those typos while adding `fr` language support and wanted to split those two PR (not directly related)