### PR TITLE
feat(CLI): adding new export format (dotenv-export)

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -95,7 +95,7 @@ func formatEnvs(envs []models.SingleEnvironmentVariable, format string) (string,
 	case FormatYaml:
 		return formatAsYaml(envs), nil
 	default:
-		return "", fmt.Errorf("invalid format type: %s. Available format types are [%s]", format, []string{FormatDotenv, FormatJson, FormatCSV, FormatYaml})
+		return "", fmt.Errorf("invalid format type: %s. Available format types are [%s]", format, []string{FormatDotenv, FormatJson, FormatCSV, FormatYaml, FormatDotEnvExport})
 	}
 }
 

--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	FormatDotenv string = "dotenv"
-	FormatJson   string = "json"
-	FormatCSV    string = "csv"
-	FormatYaml   string = "yaml"
+	FormatDotenv       string = "dotenv"
+	FormatJson         string = "json"
+	FormatCSV          string = "csv"
+	FormatYaml         string = "yaml"
+	FormatDotEnvExport string = "dotenv-export"
 )
 
 // exportCmd represents the export command
@@ -85,6 +86,8 @@ func formatEnvs(envs []models.SingleEnvironmentVariable, format string) (string,
 	switch strings.ToLower(format) {
 	case FormatDotenv:
 		return formatAsDotEnv(envs), nil
+	case FormatDotEnvExport:
+		return formatAsDotEnvExport(envs), nil
 	case FormatJson:
 		return formatAsJson(envs), nil
 	case FormatCSV:
@@ -113,6 +116,15 @@ func formatAsDotEnv(envs []models.SingleEnvironmentVariable) string {
 	var dotenv string
 	for _, env := range envs {
 		dotenv += fmt.Sprintf("%s='%s'\n", env.Key, env.Value)
+	}
+	return dotenv
+}
+
+// Format environment variables as a dotenv file with export at the beginning
+func formatAsDotEnvExport(envs []models.SingleEnvironmentVariable) string {
+	var dotenv string
+	for _, env := range envs {
+		dotenv += fmt.Sprintf("export %s='%s'\n", env.Key, env.Value)
 	}
 	return dotenv
 }

--- a/docs/cli/commands/export.mdx
+++ b/docs/cli/commands/export.mdx
@@ -12,18 +12,21 @@ Export environment variables from the platform into a file format.
 
 ## Options
 
-| Option        | Description                                                                                                                                  | Default value |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `--env`       | Used to set the environment that secrets are pulled from. Accepted values: `dev`, `staging`, `test`, `prod`                                  | `dev`         |
-| `--projectId` | Only required if injecting via the [service token method](../token). If you are not using service token, the project id will be automatically retrieved from the `.infisical.json` located at the root of your local project.  | `None`        |
-| `--expand`    | Parse shell parameter expansions in your secrets (e.g., `${DOMAIN}`)                                                                         | `true`        |
-| `--format`    | Format of the output file. Accepted values: `dotenv`, `csv` and `json`                                                                       | `dotenv`      |
+| Option        | Description                                                                                                                                                                                                                   | Default value |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `--env`       | Used to set the environment that secrets are pulled from. Accepted values: `dev`, `staging`, `test`, `prod`                                                                                                                   | `dev`         |
+| `--projectId` | Only required if injecting via the [service token method](../token). If you are not using service token, the project id will be automatically retrieved from the `.infisical.json` located at the root of your local project. | `None`        |
+| `--expand`    | Parse shell parameter expansions in your secrets (e.g., `${DOMAIN}`)                                                                                                                                                          | `true`        |
+| `--format`    | Format of the output file. Accepted values: `dotenv`, `dotenv-export`, `csv` and `json`                                                                                                                                       | `dotenv`      |
 
 ## Examples
 
 ```bash
 # Export variables to a .env file
 infisical export > .env
+
+# Export variables to a .env file (with export keyword)
+infisical export --format=dotenv-export > .env
 
 # Export variables to a CSV file
 infisical export --format=csv > secrets.csv
@@ -33,4 +36,5 @@ infisical export --format=json > secrets.json
 
 # Export variables to a YAML file
 infisical export --format=yaml > secrets.yaml
+
 ```


### PR DESCRIPTION
# Why
I want to have a way to export the variables with the word `export ` at the beggning of each variable.

This is helpful to permit use the variables in bash subprocesses

The diference between use or not the `export` is described on [this post](https://stackoverflow.com/questions/1158091/defining-a-variable-with-or-without-export)

# How to use
```
infisical export --format=dotenv-export

export INFISICAL_DEV_INT=1
export INFISICAL_DEV_STRING=some-string
```

