### PR TITLE
docs(README): nit typo - Frence should say French

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,6 @@ Infisical officially launched as v.1.0 on November 21st, 2022. There are a lot o
 
 ## 🌎 Translations
 
-Infisical is currently available in English, Korean, Frence, and Portueguese (Brazil). Help us translate Infisical to your language!
+Infisical is currently available in English, Korean, French, and Portueguese (Brazil). Help us translate Infisical to your language!
 
 You can find all the info in [this issue](https://github.com/Infisical/infisical/issues/181).


### PR DESCRIPTION
Update the translations section to say French instead of Frence.