### PR TITLE
Allow INFISICAL_URL to use domain for self-hosted

### DIFF
--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -6,8 +6,10 @@ package cmd
 import (
 	"os"
 
-	"github.com/Infisical/infisical-merge/packages/config"
 	"github.com/spf13/cobra"
+
+	"github.com/Infisical/infisical-merge/packages/config"
+	"github.com/Infisical/infisical-merge/packages/util"
 )
 
 var rootCmd = &cobra.Command{
@@ -30,7 +32,15 @@ func Execute() {
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&debugLogging, "debug", "d", false, "Enable verbose logging")
-	rootCmd.PersistentFlags().StringVar(&config.INFISICAL_URL, "domain", "https://app.infisical.com/api", "Point the CLI to your own backend")
+	rootCmd.PersistentFlags().StringVar(&config.INFISICAL_URL, "domain", util.INFISICAL_DEFAULT_URL, "Point the CLI to your own backend [ENV: INFISICAL_URL]")
 	// rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 	// }
+
+	// if config.INFISICAL_URL is set to the default value, check if INFISICAL_URL is set in the environment
+	// this is used to allow overrides of the default value
+	if config.INFISICAL_URL == util.INFISICAL_DEFAULT_URL {
+		if envInfisicalURL, ok := os.LookupEnv("INFISICAL_URL"); ok {
+			config.INFISICAL_URL = envInfisicalURL
+		}
+	}
 }

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -38,9 +38,10 @@ func init() {
 
 	// if config.INFISICAL_URL is set to the default value, check if INFISICAL_URL is set in the environment
 	// this is used to allow overrides of the default value
-	if config.INFISICAL_URL == util.INFISICAL_DEFAULT_URL {
+	if !rootCmd.Flag("domain").Changed {
 		if envInfisicalURL, ok := os.LookupEnv("INFISICAL_URL"); ok {
 			config.INFISICAL_URL = envInfisicalURL
 		}
 	}
+	
 }

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -32,16 +32,16 @@ func Execute() {
 func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&debugLogging, "debug", "d", false, "Enable verbose logging")
-	rootCmd.PersistentFlags().StringVar(&config.INFISICAL_URL, "domain", util.INFISICAL_DEFAULT_URL, "Point the CLI to your own backend [ENV: INFISICAL_URL]")
+	rootCmd.PersistentFlags().StringVar(&config.INFISICAL_URL, "domain", util.INFISICAL_DEFAULT_API_URL, "Point the CLI to your own backend [can also set via environment variable name: API_URL]")
 	// rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 	// }
 
 	// if config.INFISICAL_URL is set to the default value, check if INFISICAL_URL is set in the environment
 	// this is used to allow overrides of the default value
 	if !rootCmd.Flag("domain").Changed {
-		if envInfisicalURL, ok := os.LookupEnv("INFISICAL_URL"); ok {
-			config.INFISICAL_URL = envInfisicalURL
+		if envInfisicalBackendUrl, ok := os.LookupEnv("API_URL"); ok {
+			config.INFISICAL_URL = envInfisicalBackendUrl
 		}
 	}
-	
+
 }

--- a/cli/packages/config/config.go
+++ b/cli/packages/config/config.go
@@ -1,3 +1,3 @@
 package config
 
-var INFISICAL_URL = "http://localhost:8080/api"
+var INFISICAL_URL string

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -3,7 +3,7 @@ package util
 const (
 	CONFIG_FILE_NAME                     = "infisical-config.json"
 	CONFIG_FOLDER_NAME                   = ".infisical"
-	INFISICAL_DEFAULT_URL                = "https://app.infisical.com/api"
+	INFISICAL_DEFAULT_API_URL            = "https://app.infisical.com/api"
 	INFISICAL_WORKSPACE_CONFIG_FILE_NAME = ".infisical.json"
 	INFISICAL_TOKEN_NAME                 = "INFISICAL_TOKEN"
 	SECRET_TYPE_PERSONAL                 = "personal"

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -3,6 +3,7 @@ package util
 const (
 	CONFIG_FILE_NAME                     = "infisical-config.json"
 	CONFIG_FOLDER_NAME                   = ".infisical"
+	INFISICAL_DEFAULT_URL                = "https://app.infisical.com/api"
 	INFISICAL_WORKSPACE_CONFIG_FILE_NAME = ".infisical.json"
 	INFISICAL_TOKEN_NAME                 = "INFISICAL_TOKEN"
 	SECRET_TYPE_PERSONAL                 = "personal"

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -104,3 +104,9 @@ The Infisical CLI provides a way to inject environment variables from the platfo
 ```bash
 infisical login
 ```
+
+## Set domain if self-hosted
+
+```bash
+export INFISICAL_URL="https://your-self-hosted-infisical.com/api"
+```

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -16,7 +16,7 @@ The Infisical CLI provides a way to inject environment variables from the platfo
     	brew install infisical/get-cli/infisical
     	```
 
-    	## Updates
+    	### Updates
 
     	```bash
     	brew upgrade infisical
@@ -34,7 +34,7 @@ The Infisical CLI provides a way to inject environment variables from the platfo
     			scoop install infisical
     			```
 
-    		## Updates
+    		### Updates
 
     		```bash
     		scoop update infisical
@@ -99,14 +99,28 @@ The Infisical CLI provides a way to inject environment variables from the platfo
    </Tab>
 </Tabs>
 
-## Log in to the Infisical CLI
+### Log in to the Infisical CLI
 
 ```bash
 infisical login
 ```
 
-## Set domain if self-hosted
+<Accordion title="Optional: point CLI to self-hosted">
+The CLI is set to connect to Infisical Cloud by default, but if you're running your own instance of Infisical, you can direct the CLI to it using one of the methods provided below.
+
+#### Export environment variable 
+You can point the CLI to the self hosted Infisical instance by exporting the environment variable `API_URL` in your terminal.
 
 ```bash
-export INFISICAL_URL="https://your-self-hosted-infisical.com/api"
+# Example
+export API_URL="https://your-self-hosted-infisical.com/api"
 ```
+
+#### Set manually on every command
+Another option to point the CLI to your self hosted Infisical instance is to set it via a flag on every command you run.
+
+```bash 
+# Example
+infisical <any-command> --domain="https://your-self-hosted-infisical.com/api"
+```
+</Accordion>


### PR DESCRIPTION
## Description

Updates the cli to allow for an environment variable named `INFISICAL_URL` this way when a self hosted user is using the CLI they don't need to specify the domain over and over.

The order of respect for domains is as follows
Infisical Cloud Domain -> Environment Variable -> CLI Argument

This way the CLI argument can always override even the environment variable.