### PR TITLE
docs(README): fix typo - Portueguese should be Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,6 @@ Infisical officially launched as v.1.0 on November 21st, 2022. There are a lot o
 
 ## 🌎 Translations
 
-Infisical is currently available in English, Korean, French, and Portueguese (Brazil). Help us translate Infisical to your language!
+Infisical is currently available in English, Korean, French, and Portuguese (Brazil). Help us translate Infisical to your language!
 
 You can find all the info in [this issue](https://github.com/Infisical/infisical/issues/181).


### PR DESCRIPTION
Just a tiny typo contribution to the readme. I will try to help with other Brazilian and European Portuguese topics!

Congrats on this fantastic project!