### PR TITLE
Adjust integration bot authorization sequence

### DIFF
--- a/backend/src/middleware/requireIntegrationAuthorizationAuth.ts
+++ b/backend/src/middleware/requireIntegrationAuthorizationAuth.ts
@@ -25,7 +25,6 @@ const requireIntegrationAuthorizationAuth = ({
 }) => {
 	return async (req: Request, res: Response, next: NextFunction) => {
 		const { integrationAuthId } = req[location];
-
 		const integrationAuth = await IntegrationAuth.findOne({
 			_id: integrationAuthId
 		})

--- a/frontend/src/components/basic/dialog/ActivateBotDialog.tsx
+++ b/frontend/src/components/basic/dialog/ActivateBotDialog.tsx
@@ -19,7 +19,6 @@ type Props = {
   isOpen: boolean;
   closeModal: () => void;
   selectedIntegrationOption: IntegrationOption | null;
-  handleBotActivate: () => Promise<void>;
   integrationOptionPress: (integrationOption: IntegrationOption) => void;
 };
 
@@ -27,20 +26,16 @@ const ActivateBotDialog = ({
   isOpen,
   closeModal,
   selectedIntegrationOption,
-  handleBotActivate,
   integrationOptionPress
 }: Props) => {
   const { t } = useTranslation();
 
   const submit = async () => {
     try {
-      // 1. activate bot
-      await handleBotActivate();
-
       // type check
       if (!selectedIntegrationOption) return;
       
-      // 2. start integration or probe for PAT
+      // start integration or probe for PAT
       integrationOptionPress(selectedIntegrationOption);
       
     } catch (err) {

--- a/frontend/src/components/basic/dialog/IntegrationAccessTokenDialog.tsx
+++ b/frontend/src/components/basic/dialog/IntegrationAccessTokenDialog.tsx
@@ -52,7 +52,6 @@ const IntegrationAccessTokenDialog = ({
         <div>
             <Transition appear show={isOpen} as={Fragment}>
                 <Dialog as="div" className="relative z-10" onClose={() => {
-                    console.log('onClose');
                     closeModal();
                 }}>
                     <Transition.Child

--- a/frontend/src/components/integrations/IntegrationSection.tsx
+++ b/frontend/src/components/integrations/IntegrationSection.tsx
@@ -30,8 +30,8 @@ const ProjectIntegrationSection = ({
   setBot,
   environments = [],
   handleDeleteIntegration
-}: Props) =>
-  integrations.length > 0 ? (
+}: Props) => {
+  return integrations.length > 0 ? (
     <div className="mb-12">
       <div className="flex flex-col justify-between items-start mx-4 mb-4 mt-6 text-xl max-w-5xl px-2">
         <h1 className="font-semibold text-3xl">Current Integrations</h1>
@@ -40,7 +40,6 @@ const ProjectIntegrationSection = ({
         </p>
       </div>
       {integrations.map((integration: Integration) => {
-        console.log('IntegrationSection integration: ', integration);
         return (
           <IntegrationTile
             key={`integration-${integration._id.toString()}`} 
@@ -58,5 +57,6 @@ const ProjectIntegrationSection = ({
   ) : (
     <div />
   );
-
+}
+  
 export default ProjectIntegrationSection;

--- a/frontend/src/pages/integrations/[id].tsx
+++ b/frontend/src/pages/integrations/[id].tsx
@@ -183,6 +183,10 @@ export default function Integrations() {
     accessToken?: string;
   }) => {
     try {
+      if (!bot.isActive) {
+        await handleBotActivate();
+      }
+      
       if (integrationOption.type === 'oauth') {
         // integration is of type OAuth
 
@@ -233,7 +237,7 @@ export default function Integrations() {
         return;
       }
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   };
   
@@ -247,6 +251,7 @@ export default function Integrations() {
    * @returns
    */
   const integrationOptionPress = async (integrationOption: IntegrationOption) => {
+    // consider: don't start integration until at [handleIntegrationOption] step
     try {
       const integrationAuthX = integrationAuths.find((integrationAuth) => integrationAuth.integration === integrationOption.slug);
       
@@ -264,12 +269,15 @@ export default function Integrations() {
         return;
       }
       
+      if (!bot.isActive) {
+        await handleBotActivate();
+      }
+      
       // case: integration has been authorized before
       // -> create new integration
       const integration = await createIntegration({
         integrationAuthId: integrationAuthX._id
       });
-      
       setIntegrations([...integrations, integration]);
     } catch (err) {
       console.error(err);
@@ -350,7 +358,6 @@ export default function Integrations() {
           isOpen={isActivateBotDialogOpen}
           closeModal={() => setIsActivateBotDialogOpen(false)}
           selectedIntegrationOption={selectedIntegrationOption}
-          handleBotActivate={handleBotActivate}
           integrationOptionPress={integrationOptionPress}
         />
         <IntegrationAccessTokenDialog
@@ -358,7 +365,6 @@ export default function Integrations() {
           closeModal={() => setIntegrationAccessTokenDialogOpen(false)}
           selectedIntegrationOption={selectedIntegrationOption}
           handleIntegrationOption={handleIntegrationOption}
-          
         />
         <IntegrationSection 
           integrations={integrations} 


### PR DESCRIPTION
Previously, users could authorize workspace bots without inputting their PATs for PAT-integrations like Render and Fly.io. This PR adjusts the sequence for that case so that bot authorization is only conducted after PATs are submitted.