### PR TITLE
feat(pam): RDP CLI access for new PAM model

### DIFF
--- a/cli/packages/util/check-for-update.go
+++ b/cli/packages/util/check-for-update.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"errors"
 )
 
 func CheckForUpdate() {
@@ -25,7 +26,7 @@ func getLatestTag(repoOwner string, repoName string) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode != 200 {
-		return "", fmt.Sprintf("GitHub API returned status code %d", resp.StatusCode)
+		return "", errors.New(fmt.Sprintf("GitHub API returned status code %d", resp.StatusCode))
 	}
 
 	defer resp.Body.Close()

--- a/cli/packages/util/check-for-update.go
+++ b/cli/packages/util/check-for-update.go
@@ -8,7 +8,7 @@ import (
 )
 
 func CheckForUpdate() {
-	latestVersion, err := getLatestTag("infisical", "infisical")
+	latestVersion, err := getLatestTag("Infisical", "infisical")
 	if err != nil {
 		// do nothing and continue
 		return
@@ -23,6 +23,9 @@ func getLatestTag(repoOwner string, repoName string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Sprintf("GitHub API returned status code %d", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
# Description 📣

Wires Windows RDP access into the new PAM model's CLI `access` command. Reuses the existing `RDPProxyServer` with proper gateway disconnect detection so the CLI exits cleanly on server-side session termination.

## Type ✨

- [x] New feature

# Tests 🛠️

```sh
infisical pam access test/test-windows
# Connect with an RDP client, verify session works
# Terminate from web UI, verify CLI exits
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝