### PR TITLE
feat(ui): removed workspace context redirect and added redirect when ws is deleted

### DIFF
--- a/frontend/src/context/WorkspaceContext/WorkspaceContext.tsx
+++ b/frontend/src/context/WorkspaceContext/WorkspaceContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useContext, useEffect, useMemo } from 'react';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
 import { useRouter } from 'next/router';
 
 import { useGetUserWorkspaces } from '@app/hooks/api';
@@ -29,15 +29,6 @@ export const WorkspaceProvider = ({ children }: Props): JSX.Element => {
       isLoading
     };
   }, [ws, workspaceId, isLoading]);
-
-  useEffect(() => {
-    // not loading and current workspace is empty
-    // ws empty means user has no access to the ws
-    // push to the first workspace
-    if (!isLoading && !value?.currentWorkspace?._id) {
-      router.push(`/dashboard/${value.workspaces?.[0]?._id}`);
-    }
-  }, [value?.currentWorkspace?._id, isLoading, value.workspaces?.[0]?._id, router.pathname]);
 
   return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
 };

--- a/frontend/src/views/Settings/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useRouter } from 'next/router';
 
 import { useNotificationContext } from '@app/components/context/Notifications/NotificationProvider';
 import NavHeader from '@app/components/navigation/NavHeader';
@@ -37,7 +38,8 @@ import {
 
 export const ProjectSettingsPage = () => {
   const { t } = useTranslation();
-  const { currentWorkspace } = useWorkspace();
+  const { currentWorkspace, workspaces } = useWorkspace();
+  const router = useRouter();
   const { data: serviceTokens } = useGetUserWsServiceTokens({
     workspaceID: currentWorkspace?._id || ''
   });
@@ -64,7 +66,6 @@ export const ProjectSettingsPage = () => {
   const host = window.location.origin;
   const isEnvServiceAllowed =
     subscriptionPlan !== plans.starter || host !== 'https://app.infisical.com';
-  
 
   const onRenameWorkspace = async (name: string) => {
     try {
@@ -86,6 +87,9 @@ export const ProjectSettingsPage = () => {
     setIsDeleting.on();
     try {
       await deleteWorkspace.mutateAsync({ workspaceID });
+      // redirect user to first workspace user is part of
+      const ws = workspaces.find(({ _id }) => _id !== workspaceID);
+      router.push(`/dashboard/${ws?._id}`);
       createNotification({
         text: 'Successfully deleted workspace',
         type: 'success'


### PR DESCRIPTION
As discussed with @dangtony98 
1. Removed workspace redirect in context to avoid when missing workspace id in pages like integration
2. Instead we will go for rather an error page with a button to take back to dashboard if api calls fails 