### PR TITLE
Add missing `forgot-password` in pt-BR

### DIFF
--- a/frontend/public/locales/pt-BR/login.json
+++ b/frontend/public/locales/pt-BR/login.json
@@ -4,5 +4,6 @@
   "og-description": "Infisical é uma plataforma simples e criptografada de ponta a ponta que permite que as equipes sincronizem e gerenciem seus arquivos .env.",
   "login": "Entrar",
   "need-account": "Precisa de uma conta Infisical?",
+  "forgot-password": "Esqueceu sua senha?",
   "create-account": "Criar uma conta"
 }


### PR DESCRIPTION
### Description

Updates `frontend/public/locales/pt-BR/login.json`, which had a missing key `forgot-password` #181 

### Screenshots

Before:
![before](https://user-images.githubusercontent.com/55207584/219049874-b7c45186-d278-45e7-bdb3-5b19ab83b907.png)

After:
![image](https://user-images.githubusercontent.com/55207584/219049987-adfc034e-d152-4fe1-99c7-6e965fe5a408.png)
