### PR TITLE
New device (IP and user agent) login detection and alert

### DIFF
--- a/backend/src/controllers/v1/authController.ts
+++ b/backend/src/controllers/v1/authController.ts
@@ -6,6 +6,7 @@ import * as bigintConversion from 'bigint-conversion';
 const jsrp = require('jsrp');
 import { User, LoginSRPDetail } from '../../models';
 import { createToken, issueAuthTokens, clearTokens } from '../../helpers/auth';
+import { checkUserDevice } from '../../helpers/user';
 import {
   ACTION_LOGIN,
   ACTION_LOGOUT
@@ -111,6 +112,13 @@ export const login2 = async (req: Request, res: Response) => {
         // compare server and client shared keys
         if (server.checkClientProof(clientProof)) {
           // issue tokens
+
+          await checkUserDevice({
+            user,
+            ip: req.ip,
+            userAgent: req.headers['user-agent'] ?? ''
+          });
+
           const tokens = await issueAuthTokens({ userId: user._id.toString() });
 
           // store (refresh) token in httpOnly cookie

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -1,6 +1,6 @@
-import { Schema, model, Types } from 'mongoose';
+import { Schema, model, Types, Document } from 'mongoose';
 
-export interface IUser {
+export interface IUser extends Document {
 	_id: Types.ObjectId;
 	email: string;
 	firstName?: string;
@@ -18,7 +18,10 @@ export interface IUser {
 	refreshVersion?: number;
 	isMfaEnabled: boolean;
 	mfaMethods: boolean;
-	seenIps: [string]; // TODO 1: email for unseen IPs, TODO 2: move to a central alerting system
+	devices: {
+		ip: string;
+		userAgent: string;
+	}[];
 }
 
 const userSchema = new Schema<IUser>(
@@ -86,8 +89,11 @@ const userSchema = new Schema<IUser>(
 		mfaMethods: [{
 			type: String
 		}],
-		seenIps: {
-			type: [String],
+		devices: {
+			type: [{
+				ip: String,
+				userAgent: String
+			}],
 			default: []
 		}
 	}, 

--- a/backend/src/routes/v2/users.ts
+++ b/backend/src/routes/v2/users.ts
@@ -4,7 +4,7 @@ import {
     requireAuth,
     validateRequest
 } from '../../middleware';
-import { body, param } from 'express-validator';
+import { body } from 'express-validator';
 import { usersController } from '../../controllers/v2';
 
 router.get(

--- a/backend/src/templates/emailVerification.handlebars
+++ b/backend/src/templates/emailVerification.handlebars
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title></title>
+    <title>Code</title>
 </head>
 
 <body>

--- a/backend/src/templates/newDevice.handlebars
+++ b/backend/src/templates/newDevice.handlebars
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Successful login for {{email}} from new device</title>
+</head>
+
+<body>
+    <h2>Infisical</h2>
+    <p>We're verifying a recent login for {{email}}:</p>
+    <p><strong>Timestamp</strong>: {{timestamp}}</p>
+    <p><strong>IP address</strong>: {{ip}}</p>
+    <p><strong>User agent</strong>: {{userAgent}}</p>
+    <p>If you believe that this login is suspicious, please contact Infisical or reset your password immediately.</p>
+</body>
+
+</html>

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -5,38 +5,40 @@ description: "How to configure your environment variables when self-hosting Infi
 
 Configuring Infisical requires setting some environment variables. There is a file called [`.env.example`](https://github.com/Infisical/infisical/blob/main/.env.example) at the root directory of our main repo that you can use to create a `.env` file before you start the server.
 
-| Variable                     | Description                                                                                                 | Default Value    |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------- |
-| `ENCRYPTION_KEY`             | ❗️ Strong hex encryption key                                                                                | `None`           |
-| `JWT_SIGNUP_SECRET`          | ❗️ JWT token secret                                                                                         | `None`           |
-| `JWT_REFRESH_SECRET`         | ❗️ JWT token secret                                                                                         | `None`           |
-| `JWT_AUTH_SECRET`            | ❗️ JWT token secret                                                                                         | `None`           |
-| `JWT_SERVICE_SECRET`         | ❗️ JWT token secret                                                                                         | `None`           |
-| `JWT_SIGNUP_LIFETIME`        | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `15m`            |
-| `JWT_REFRESH_LIFETIME`       | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `90d`            |
-| `JWT_AUTH_LIFETIME`          | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `10d`            |
-| `EMAIL_TOKEN_LIFETIME`       | Email OTP/magic-link lifetime expressed in seconds                                                          | `86400`          |
-| `MONGO_URL`                  | ❗️ MongoDB instance connection string either to container instance or MongoDB Cloud                         | `None`           |
-| `MONGO_USERNAME`             | MongoDB username if using container                                                                         | `None`           |
-| `MONGO_PASSWORD`             | MongoDB password if using container                                                                         | `None`           |
-| `SITE_URL`                   | ❗️ Site URL - should be an absolute URL including the protocol (e.g. `https://app.infisical.com`)           | `None`           |
-| `SMTP_HOST`                  | ❗️ Hostname to connect to for establishing SMTP connections                                                    | `None` |
-| `SMTP_USERNAME`              | ❗️ Credential to connect to host (e.g. `team@infisical.com`)                                                | `None`           |
-| `SMTP_PASSWORD`              | ❗️ Credential to connect to host                                                                            | `None`           |
-| `SMTP_PORT`                  | Port to connect to for establishing SMTP connections                                                     | `587`            |
-| `SMTP_SECURE`                | If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported                        | `false`          |
-| `SMTP_FROM_ADDRESS`          | ❗️ Email address to be used for sending emails (e.g. `team@infisical.com`)                                  | `None`           |
-| `SMTP_FROM_NAME`             | Name label to be used in From field (e.g. `Team`)                                                           | `Infisical`      |
-| `TELEMETRY_ENABLED`          | `true` or `false`. [More](../overview).                                                                     | `true`           |
-| `LICENSE_KEY`                | License key if using Infisical Enterprise Edition                                                            | `true`           |
-| `CLIENT_ID_HEROKU`           | OAuth2 client ID for Heroku integration                                                                      | `None`           |
-| `CLIENT_ID_VERCEL`           | OAuth2 client ID for Vercel integration                                                                      | `None`           |
-| `CLIENT_ID_NETLIFY`          | OAuth2 client ID for Netlify integration                                                                     | `None`           |
-| `CLIENT_ID_GITHUB`           | OAuth2 client ID for GitHub integration                                                                     | `None`           |
-| `CLIENT_SECRET_HEROKU`       | OAuth2 client secret for Heroku integration                                                                  | `None`           |
-| `CLIENT_SECRET_VERCEL`       | OAuth2 client secret for Vercel integration                                                                  | `None`           |
-| `CLIENT_SECRET_NETLIFY`      | OAuth2 client secret for Netlify integration                                                                 | `None`           |
-| `CLIENT_SECRET_GITHUB`       | OAuth2 client secret for GitHub integration                                                                 | `None`           |
-| `CLIENT_SLUG_VERCEL`         | OAuth2 slug for Netlify integration                                                                         | `None`           |
-| `SENTRY_DSN`                 | DSN for error-monitoring with Sentry                                                                        | `None`           |
-| `INVITE_ONLY_SIGNUP`         | If true, users can only sign up if they are invited                                                         | `false`           |
+| Variable                | Description                                                                                                 | Default Value |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- | ------------- |
+| `ENCRYPTION_KEY`        | ❗️ Strong hex encryption key                                                                               | `None`        |
+| `JWT_SIGNUP_SECRET`     | ❗️ JWT token secret                                                                                        | `None`        |
+| `JWT_REFRESH_SECRET`    | ❗️ JWT token secret                                                                                        | `None`        |
+| `JWT_AUTH_SECRET`       | ❗️ JWT token secret                                                                                        | `None`        |
+| `JWT_MFA_SECRET`        | ❗️ JWT token secret                                                                                        | `None`        |
+| `JWT_SERVICE_SECRET`    | ❗️ JWT token secret                                                                                        | `None`        |
+| `JWT_SIGNUP_LIFETIME`   | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `15m`         |
+| `JWT_REFRESH_LIFETIME`  | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `90d`         |
+| `JWT_AUTH_LIFETIME`     | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `10d`         |
+| `JWT_MFA_LIFETIME`      | JWT token lifetime expressed in seconds or a string describing a time span (e.g. 60, "2 days", "10h", "7d") | `5m`          |
+| `EMAIL_TOKEN_LIFETIME`  | Email OTP/magic-link lifetime expressed in seconds                                                          | `86400`       |
+| `MONGO_URL`             | ❗️ MongoDB instance connection string either to container instance or MongoDB Cloud                        | `None`        |
+| `MONGO_USERNAME`        | MongoDB username if using container                                                                         | `None`        |
+| `MONGO_PASSWORD`        | MongoDB password if using container                                                                         | `None`        |
+| `SITE_URL`              | ❗️ Site URL - should be an absolute URL including the protocol (e.g. `https://app.infisical.com`)          | `None`        |
+| `SMTP_HOST`             | ❗️ Hostname to connect to for establishing SMTP connections                                                | `None`        |
+| `SMTP_USERNAME`         | ❗️ Credential to connect to host (e.g. `team@infisical.com`)                                               | `None`        |
+| `SMTP_PASSWORD`         | ❗️ Credential to connect to host                                                                           | `None`        |
+| `SMTP_PORT`             | Port to connect to for establishing SMTP connections                                                        | `587`         |
+| `SMTP_SECURE`           | If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported               | `false`       |
+| `SMTP_FROM_ADDRESS`     | ❗️ Email address to be used for sending emails (e.g. `team@infisical.com`)                                 | `None`        |
+| `SMTP_FROM_NAME`        | Name label to be used in From field (e.g. `Team`)                                                           | `Infisical`   |
+| `TELEMETRY_ENABLED`     | `true` or `false`. [More](../overview).                                                                     | `true`        |
+| `LICENSE_KEY`           | License key if using Infisical Enterprise Edition                                                           | `true`        |
+| `CLIENT_ID_HEROKU`      | OAuth2 client ID for Heroku integration                                                                     | `None`        |
+| `CLIENT_ID_VERCEL`      | OAuth2 client ID for Vercel integration                                                                     | `None`        |
+| `CLIENT_ID_NETLIFY`     | OAuth2 client ID for Netlify integration                                                                    | `None`        |
+| `CLIENT_ID_GITHUB`      | OAuth2 client ID for GitHub integration                                                                     | `None`        |
+| `CLIENT_SECRET_HEROKU`  | OAuth2 client secret for Heroku integration                                                                 | `None`        |
+| `CLIENT_SECRET_VERCEL`  | OAuth2 client secret for Vercel integration                                                                 | `None`        |
+| `CLIENT_SECRET_NETLIFY` | OAuth2 client secret for Netlify integration                                                                | `None`        |
+| `CLIENT_SECRET_GITHUB`  | OAuth2 client secret for GitHub integration                                                                 | `None`        |
+| `CLIENT_SLUG_VERCEL`    | OAuth2 slug for Netlify integration                                                                         | `None`        |
+| `SENTRY_DSN`            | DSN for error-monitoring with Sentry                                                                        | `None`        |
+| `INVITE_ONLY_SIGNUP`    | If true, users can only sign up if they are invited                                                         | `false`       |


### PR DESCRIPTION
This PR adds an alert for whenever a new device is detected for a login. Under-the-hood:

- We record all device info (consisting of IP and user-agent) that a user uses to login.
- Use that info to detect new device logins and alert users about that.