### PR TITLE
Patch Vercel case where secrets can be of type plain and sensitive

### DIFF
--- a/backend/src/routes/v2/workspace.ts
+++ b/backend/src/routes/v2/workspace.ts
@@ -118,7 +118,6 @@ router.delete( // TODO - rewire dashboard to this route
 	workspaceController.deleteWorkspaceMembership
 );
 
-
 router.patch(
 	'/:workspaceId/auto-capitalization',
 	requireAuth({

--- a/backend/src/services/EventService.ts
+++ b/backend/src/services/EventService.ts
@@ -1,5 +1,3 @@
-import { Bot, IBot } from '../models';
-import * as Sentry from '@sentry/node';
 import { handleEventHelper } from '../helpers/event';
 
 interface Event {

--- a/docs/integrations/cloud/vercel.mdx
+++ b/docs/integrations/cloud/vercel.mdx
@@ -30,3 +30,20 @@ Select which Infisical environment secrets you want to sync to which Vercel app 
 
 ![integrations vercel](../../images/integrations-vercel-create.png)
 ![integrations vercel](../../images/integrations-vercel.png)
+
+<Info>
+  Infisical syncs every envar to Vercel with type `encrypted` unless an existing
+  envar with the same name in Vercel exists with a different type. Note that
+  Infisical will not be able to update Vercel envars with type `sensitive` since
+  they can only be decrypted and modified by Vercel's deployment systems.
+</Info>
+
+<Warning>
+  The following environment variable names are reserved by Vercel and cannot be
+  synced: `AWS_SECRET_KEY`, `AWS_EXECUTION_ENV`, `AWS_LAMBDA_LOG_GROUP_NAME`,
+  `AWS_LAMBDA_LOG_STREAM_NAME`, `AWS_LAMBDA_FUNCTION_NAME`,
+  `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, `AWS_LAMBDA_FUNCTION_VERSION`,
+  `NOW_REGION`, `TZ`, `LAMBDA_TASK_ROOT`, `LAMBDA_RUNTIME_DIR`,
+  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`,
+  `AWS_REGION`, and `AWS_DEFAULT_REGION`.
+</Warning>


### PR DESCRIPTION
# Description 📣

This PR patches some previously-failing edge-cases for syncing envars to Vercel that didn't work for some users:
- New envars synced to Vercel will default to type `encrypted`.
- Existing envars in Vercel that are updated via sync from Infisical to Vercel will default to the type of the existing envar in Vercel.
- Infisical will not update envars in Vercel of type `sensitive` since they can only be modified by Vercel's deployment systems.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝