### PR TITLE
Improve env filter

### DIFF
--- a/cli/packages/cmd/cmd_test.go
+++ b/cli/packages/cmd/cmd_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/Infisical/infisical-merge/packages/models"
+)
+
+func TestEnvFilter(t *testing.T) {
+
+	// some test env vars.
+	// HOME and PATH are reserved key words and should be filtered out
+	// XDG_SESSION_ID and LC_CTYPE are reserved key word prefixes and should be filtered out
+	// The filter function only checks the keys of the env map, so we dont need to set any values
+	env := map[string]models.SingleEnvironmentVariable{
+		"test":           {},
+		"test2":          {},
+		"HOME":           {},
+		"PATH":           {},
+		"XDG_SESSION_ID": {},
+		"LC_CTYPE":       {},
+	}
+
+	// check to see if there are any reserved key words in secrets to inject
+	filterEnvVars(env)
+
+	if len(env) != 2 {
+		t.Errorf("Expected 2 secrets to be returned, got %d", len(env))
+	}
+	if _, ok := env["test"]; !ok {
+		t.Errorf("Expected test to be returned")
+	}
+	if _, ok := env["test2"]; !ok {
+		t.Errorf("Expected test2 to be returned")
+	}
+	if _, ok := env["HOME"]; ok {
+		t.Errorf("Expected HOME to be filtered out")
+	}
+	if _, ok := env["PATH"]; ok {
+		t.Errorf("Expected PATH to be filtered out")
+	}
+	if _, ok := env["XDG_SESSION_ID"]; ok {
+		t.Errorf("Expected XDG_SESSION_ID to be filtered out")
+	}
+	if _, ok := env["LC_CTYPE"]; ok {
+		t.Errorf("Expected LC_CTYPE to be filtered out")
+	}
+
+}

--- a/cli/packages/cmd/cmd_test.go
+++ b/cli/packages/cmd/cmd_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Infisical/infisical-merge/packages/models"
 )
 
-func TestEnvFilter(t *testing.T) {
+func TestFilterReservedEnvVars(t *testing.T) {
 
 	// some test env vars.
 	// HOME and PATH are reserved key words and should be filtered out
@@ -22,7 +22,7 @@ func TestEnvFilter(t *testing.T) {
 	}
 
 	// check to see if there are any reserved key words in secrets to inject
-	filterEnvVars(env)
+	filterReservedEnvVars(env)
 
 	if len(env) != 2 {
 		t.Errorf("Expected 2 secrets to be returned, got %d", len(env))

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -110,7 +110,7 @@ var runCmd = &cobra.Command{
 		}
 
 		// check to see if there are any reserved key words in secrets to inject
-		filterEnvVars(secretsByKey)
+		filterReservedEnvVars(secretsByKey)
 
 		// now add infisical secrets
 		for k, v := range secretsByKey {
@@ -156,7 +156,7 @@ var (
 	}
 )
 
-func filterEnvVars(env map[string]models.SingleEnvironmentVariable) {
+func filterReservedEnvVars(env map[string]models.SingleEnvironmentVariable) {
 	for _, reservedEnvName := range reservedEnvVars {
 		if _, ok := env[reservedEnvName]; ok {
 			delete(env, reservedEnvName)

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -110,13 +110,7 @@ var runCmd = &cobra.Command{
 		}
 
 		// check to see if there are any reserved key words in secrets to inject
-		reservedEnvironmentVariables := []string{"HOME", "PATH", "PS1", "PS2"}
-		for _, reservedEnvName := range reservedEnvironmentVariables {
-			if _, ok := secretsByKey[reservedEnvName]; ok {
-				delete(secretsByKey, reservedEnvName)
-				util.PrintWarning(fmt.Sprintf("Infisical secret named [%v] has been removed because it is a reserved secret name", reservedEnvName))
-			}
-		}
+		filterEnvVars(secretsByKey)
 
 		// now add infisical secrets
 		for k, v := range secretsByKey {
@@ -147,6 +141,37 @@ var runCmd = &cobra.Command{
 			}
 		}
 	},
+}
+
+var (
+	reservedEnvVars = []string{
+		"HOME", "PATH", "PS1", "PS2",
+		"PWD", "EDITOR", "XAUTHORITY", "USER",
+		"TERM", "TERMINFO", "SHELL", "MAIL",
+	}
+
+	reservedEnvVarPrefixes = []string{
+		"XDG_",
+		"LC_",
+	}
+)
+
+func filterEnvVars(env map[string]models.SingleEnvironmentVariable) {
+	for _, reservedEnvName := range reservedEnvVars {
+		if _, ok := env[reservedEnvName]; ok {
+			delete(env, reservedEnvName)
+			util.PrintWarning(fmt.Sprintf("Infisical secret named [%v] has been removed because it is a reserved secret name", reservedEnvName))
+		}
+	}
+
+	for _, reservedEnvPrefix := range reservedEnvVarPrefixes {
+		for envName := range env {
+			if strings.HasPrefix(envName, reservedEnvPrefix) {
+				delete(env, envName)
+				util.PrintWarning(fmt.Sprintf("Infisical secret named [%v] has been removed because it contains a reserved prefix", envName))
+			}
+		}
+	}
 }
 
 func init() {

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -587,7 +587,7 @@ func addHash(input string) string {
 }
 
 func getSecretsByKeys(secrets []models.SingleEnvironmentVariable) map[string]models.SingleEnvironmentVariable {
-	secretMapByName := make(map[string]models.SingleEnvironmentVariable)
+	secretMapByName := make(map[string]models.SingleEnvironmentVariable, len(secrets))
 
 	for _, secret := range secrets {
 		secretMapByName[secret.Key] = secret

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -361,10 +361,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 
 	requestedSecrets := []models.SingleEnvironmentVariable{}
 
-	secretsMap := make(map[string]models.SingleEnvironmentVariable)
-	for _, secret := range secrets {
-		secretsMap[secret.Key] = secret
-	}
+	secretsMap := getSecretsByKeys(secrets)
 
 	for _, secretKeyFromArg := range args {
 		if value, ok := secretsMap[strings.ToUpper(secretKeyFromArg)]; ok {


### PR DESCRIPTION
# Description 📣

This PR adds some more reserved env vars as well as support for reserved prefixes like `XDG_` which shouldn't be overwritten by infisical. 
There are probably more vars that should be reserved but I think the current ones should cover most cases. 

The PR also micro-improves the generation of the secrets map by preallocating its size.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

https://github.com/jon4hz/infisical/blob/4a72d725b1038ea86d1cc9888bf78216658682bc/cli/packages/cmd/cmd_test.go

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝