### PR TITLE
fix: pretty print workspace file

### DIFF
--- a/cli/packages/cmd/init.go
+++ b/cli/packages/cmd/init.go
@@ -91,7 +91,7 @@ func writeWorkspaceFile(selectedWorkspace models.Workspace) error {
 		WorkspaceId: selectedWorkspace.ID,
 	}
 
-	marshalledWorkspaceFile, err := json.Marshal(workspaceFileToSave)
+	marshalledWorkspaceFile, err := json.MarshalIndent(workspaceFileToSave, "", "    ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description 📣

Pretty prints new created workspace files. JSON-Indent is set to 4 spaces. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

None :(


## Before
```json
{"workspaceId":"123456789","defaultEnvironment":"","gitBranchToEnvironmentMapping":null}
```

## After
```json
{
    "workspaceId": "123456789",
    "defaultEnvironment": "",
    "gitBranchToEnvironmentMapping": null
}
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝