### PR TITLE
fix: properly support default environment

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -38,7 +38,7 @@ var exportCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 			if environmentFromWorkspace != "" {
 				environmentName = environmentFromWorkspace
 			}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -56,7 +56,7 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 			if environmentFromWorkspace != "" {
 				environmentName = environmentFromWorkspace
 			}

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -32,7 +32,7 @@ var secretsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 			if environmentFromWorkspace != "" {
 				environmentName = environmentFromWorkspace
 			}
@@ -98,7 +98,7 @@ var secretsSetCmd = &cobra.Command{
 
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 			if environmentFromWorkspace != "" {
 				environmentName = environmentFromWorkspace
 			}
@@ -277,7 +277,7 @@ var secretsDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 			if environmentFromWorkspace != "" {
 				environmentName = environmentFromWorkspace
 			}
@@ -338,7 +338,7 @@ var secretsDeleteCmd = &cobra.Command{
 func getSecretsByNames(cmd *cobra.Command, args []string) {
 	environmentName, _ := cmd.Flags().GetString("env")
 	if !cmd.Flags().Changed("env") {
-		environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+		environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 		if environmentFromWorkspace != "" {
 			environmentName = environmentFromWorkspace
 		}
@@ -384,7 +384,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 func generateExampleEnv(cmd *cobra.Command, args []string) {
 	environmentName, _ := cmd.Flags().GetString("env")
 	if !cmd.Flags().Changed("env") {
-		environmentFromWorkspace := util.GetEnvelopmentBasedOnGitBranch()
+		environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
 		if environmentFromWorkspace != "" {
 			environmentName = environmentFromWorkspace
 		}

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -115,8 +115,20 @@ func GetHashFromStringList(list []string) string {
 	return fmt.Sprintf("%x", sum)
 }
 
+// execCmd is a struct that holds the command and arguments to be executed.
+// By using this struct, we can easily mock the command and arguments.
+type execCmd struct {
+	cmd  string
+	args []string
+}
+
+var getCurrentBranchCmd = execCmd{
+	cmd:  "git",
+	args: []string{"symbolic-ref", "--short", "HEAD"},
+}
+
 func getCurrentBranch() (string, error) {
-	cmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
+	cmd := exec.Command(getCurrentBranchCmd.cmd, getCurrentBranchCmd.args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -482,21 +482,29 @@ func DeleteBackupSecrets() error {
 	return os.RemoveAll(fullPathToSecretsBackupFolder)
 }
 
-func GetEnvelopmentBasedOnGitBranch() string {
+func GetEnvFromWorkspaceFile() string {
+	workspaceFile, err := GetWorkSpaceFromFile()
+	if err != nil {
+		log.Debugf("getEnvFromWorkspaceFile: [err=%s]", err)
+		return ""
+	}
+
+	if env := GetEnvelopmentBasedOnGitBranch(workspaceFile); env != "" {
+		return env
+	}
+
+	return workspaceFile.DefaultEnvironment
+}
+
+func GetEnvelopmentBasedOnGitBranch(workspaceFile models.WorkspaceConfigFile) string {
 	branch, err := getCurrentBranch()
 	if err != nil {
 		log.Debugf("getEnvelopmentBasedOnGitBranch: [err=%s]", err)
 	}
 
-	workspaceFile, err := GetWorkSpaceFromFile()
-	if err != nil {
-		log.Debugf("getEnvelopmentBasedOnGitBranch: [err=%s]", err)
-		return ""
-	}
-
 	envBasedOnGitBranch, ok := workspaceFile.GitBranchToEnvironmentMapping[branch]
 
-	log.Debugf("GetEnvelopmentBasedOnGitBranch: [envBasedOnGitBranch=%s] [ok=%s]", envBasedOnGitBranch, ok)
+	log.Debugf("GetEnvelopmentBasedOnGitBranch: [envBasedOnGitBranch=%s] [ok=%t]", envBasedOnGitBranch, ok)
 
 	if err == nil && ok {
 		return envBasedOnGitBranch

--- a/cli/packages/util/secrets_test.go
+++ b/cli/packages/util/secrets_test.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"io"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/Infisical/infisical-merge/packages/models"
@@ -156,5 +159,100 @@ func Test_SubstituteSecrets_When_No_SubstituteNeeded(t *testing.T) {
 		if expanded.Value != tests[index].ExpectedValue {
 			t.Errorf("Test_SubstituteSecrets_When_ReferenceToSelf: expected [%s] but got [%s] for input [%s]", tests[index].ExpectedValue, expanded.Value, tests[index].Value)
 		}
+	}
+}
+
+func Test_Read_Env_From_File(t *testing.T) {
+	type testCase struct {
+		TestFile    string
+		ExpectedEnv string
+	}
+
+	var cases = []testCase{
+		{
+			TestFile:    "testdata/infisical-default-env.json",
+			ExpectedEnv: "myDefaultEnv",
+		},
+		{
+			TestFile:    "testdata/infisical-branch-env.json",
+			ExpectedEnv: "myMainEnv",
+		},
+		{
+			TestFile:    "testdata/infisical-no-matching-branch-env.json",
+			ExpectedEnv: "myDefaultEnv",
+		},
+	}
+
+	// create a tmp directory for testing
+	testDir, err := os.MkdirTemp(os.TempDir(), "infisical-test")
+	if err != nil {
+		t.Errorf("Test_Read_DefaultEnv_From_File: Failed to create temp directory: %s", err)
+	}
+
+	// safe the current working directory
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Test_Read_DefaultEnv_From_File: Failed to get current working directory: %s", err)
+	}
+
+	// backup the original git command
+	originalGitCmd := getCurrentBranchCmd
+
+	// make sure to clean up after the test
+	t.Cleanup(func() {
+		os.Chdir(originalDir)
+		os.RemoveAll(testDir)
+		getCurrentBranchCmd = originalGitCmd
+	})
+
+	// mock the git command to return "main" as the current branch
+	getCurrentBranchCmd = execCmd{cmd: "echo", args: []string{"main"}}
+
+	for _, c := range cases {
+		// make sure we start in the original directory
+		err = os.Chdir(originalDir)
+		if err != nil {
+			t.Errorf("Test_Read_DefaultEnv_From_File: Failed to change working directory: %s", err)
+		}
+
+		// remove old test file if it exists
+		err = os.Remove(path.Join(testDir, INFISICAL_WORKSPACE_CONFIG_FILE_NAME))
+		if err != nil && !os.IsNotExist(err) {
+			t.Errorf("Test_Read_DefaultEnv_From_File: Failed to remove old test file: %s", err)
+		}
+
+		// deploy the test file
+		copyTestFile(t, c.TestFile, path.Join(testDir, INFISICAL_WORKSPACE_CONFIG_FILE_NAME))
+
+		// change the working directory to the tmp directory
+		err = os.Chdir(testDir)
+		if err != nil {
+			t.Errorf("Test_Read_DefaultEnv_From_File: Failed to change working directory: %s", err)
+		}
+
+		// get env from file
+		env := GetEnvFromWorkspaceFile()
+		if env != c.ExpectedEnv {
+			t.Errorf("Test_Read_DefaultEnv_From_File: Expected env to be %s but got %s", c.ExpectedEnv, env)
+		}
+	}
+}
+
+func copyTestFile(t *testing.T, src, dst string) {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		t.Errorf("Test_Read_Env_From_File_By_Branch: Failed to open source file: %s", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		t.Errorf("Test_Read_Env_From_File_By_Branch: Failed to create destination file: %s", err)
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		t.Errorf("Test_Read_Env_From_File_By_Branch: Failed to copy file: %s", err)
 	}
 }

--- a/cli/packages/util/testdata/infisical-branch-env.json
+++ b/cli/packages/util/testdata/infisical-branch-env.json
@@ -1,0 +1,7 @@
+{
+    "workspaceId": "12345678",
+    "defaultEnvironment": "myDefaultEnv",
+    "gitBranchToEnvironmentMapping": {
+        "main": "myMainEnv"
+    }
+}

--- a/cli/packages/util/testdata/infisical-default-env.json
+++ b/cli/packages/util/testdata/infisical-default-env.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "12345678",
+    "defaultEnvironment": "myDefaultEnv",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/cli/packages/util/testdata/infisical-no-matching-branch-env.json
+++ b/cli/packages/util/testdata/infisical-no-matching-branch-env.json
@@ -1,0 +1,7 @@
+{
+    "workspaceId": "12345678",
+    "defaultEnvironment": "myDefaultEnv",
+    "gitBranchToEnvironmentMapping": {
+        "notmain": "myMainEnv"
+    }
+}

--- a/docs/cli/project-config.mdx
+++ b/docs/cli/project-config.mdx
@@ -7,6 +7,24 @@ To link your local project on your machine with an Infisical project, we suggest
 
 The `.infisical.json` file specifies various parameters, such as the Infisical project to retrieve secrets from, along with other configuration options. Furthermore, you can define additional properties in the file to further tailor your local development experience.
 
+## Set default environment
+If you need to change environments while using the CLI, you can do so by including the `--env` flag in your command. 
+However, this can be inconvenient if you typically work in just one environment. 
+To simplify the process, you can establish a default environment, which will be used for every command unless you specify otherwise.
+
+```json .infisical.json
+{
+  "workspaceId": "63ee5410a45f7a1ed39ba118",
+  "defaultEnvironment": "test",
+  "gitBranchToEnvironmentMapping": null
+}
+```
+
+### How it works
+If both `defaultEnvironment` and `gitBranchToEnvironmentMapping` are configured, `gitBranchToEnvironmentMapping` will take precedence over `defaultEnvironment`. 
+However, if `gitBranchToEnvironmentMapping` is not set and `defaultEnvironment` is, then the `defaultEnvironment` will be used to execute your Infisical CLI commands.
+If you wish to override the `defaultEnvironment`, you can do so by using the `--env` flag explicitly.
+
 ## Set Infisical environment based on GitHub branch 
 When fetching your secrets from Infisical, you can switch between environments by using the `--env` flag. However, in certain cases, you may prefer the environment to be automatically mapped based on the current GitHub branch you are working on. 
 To achieve this, simply add the `gitBranchToEnvironmentMapping` property to your configuration file, as shown below.


### PR DESCRIPTION
# Description 📣

I'm not sure if this is intended but at the moment `infisical` completely ignores the `defaultEnvironment` from the workspace file. This PR adds proper support for this config option. At first, it checks the env-branch mapping and if it can't find anything there, it returns the `defaultEnvironment` instead of an empty string. 

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Added some test cases to cover the changes. 

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝