### PR TITLE
fix: always execute cmd in subshell

### DIFF
--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -161,11 +161,14 @@ func init() {
 
 // Will execute a single command and pass in the given secrets into the process
 func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string) error {
-	command := args[0]
-	argsForCommand := args[1:]
+	shell := subShellCmd()
 	color.Green("Injecting %v Infisical secrets into your application process", secretsCount)
 
-	cmd := exec.Command(command, argsForCommand...)
+	args = append(args[:1], args[0:]...) // shift args to the right
+	args[0] = shell[1]
+
+	cmd := exec.Command(shell[0], args...)
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -175,15 +178,7 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string)
 }
 
 func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []string) error {
-	shell := [2]string{"sh", "-c"}
-	if runtime.GOOS == "windows" {
-		shell = [2]string{"cmd", "/C"}
-	} else {
-		currentShell := os.Getenv("SHELL")
-		if currentShell != "" {
-			shell[0] = currentShell
-		}
-	}
+	shell := subShellCmd()
 
 	cmd := exec.Command(shell[0], shell[1], fullCommand)
 	cmd.Stdin = os.Stdin
@@ -195,6 +190,23 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 	log.Debugf("executing command: %s %s %s \n", shell[0], shell[1], fullCommand)
 
 	return execCmd(cmd)
+}
+
+func subShellCmd() [2]string {
+	// default to sh -c
+	shell := [...]string{"sh", "-c"}
+
+	currentShell := os.Getenv("SHELL")
+	if currentShell != "" {
+		shell[0] = currentShell
+	} else if runtime.GOOS == "windows" {
+		// if the SHELL env var is not set and we're on Windows, use cmd.exe
+		// The SHELL var should always be checked first, in case the user executes
+		// infisical from something like Git Bash.
+		return [...]string{"cmd", "/C"}
+	}
+
+	return shell
 }
 
 // Credit: inspired by AWS Valut


### PR DESCRIPTION
# Description 📣

Currently `infisical` doesn't support executing aliases as single command. 
The following script fails but should not imo:

```bash
alias ll="ls -l"
infisical run -- ll # fails
infisical run --command ll # works
```

The script fails because infisical tries to lookup `ll` in the `$PATH` which is impossible, because it's only an alias. If I executed it using `infisical run --command ll` it would have worked, because `infisical` seems to spawn a subshell when the `--command` arg is used. I think this is a bit intuitive and confusing.

This can be fixed if we always start a subshell to execute the command. Is there any reason that speaks against doing that? 


I also fixed a bug on windows, if you use something like "Git Bash", which sets the `$SHELL`  variable. At the moment `infisical` ignores that, even though it would be perfectly valid. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Can be tested with the script in the description. 

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝