### PR TITLE
feat: search for workspace config in parent dir

### DIFF
--- a/cli/packages/util/config.go
+++ b/cli/packages/util/config.go
@@ -105,6 +105,8 @@ func FindWorkspaceConfigFile() (string, error) {
 		_, err := os.Stat(path)
 		if err == nil {
 			// file found
+			log.Debugf("FindWorkspaceConfigFile: workspace file found at [path=%s]", path)
+
 			return path, nil
 		}
 

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -89,8 +89,8 @@ func RequireServiceToken() {
 }
 
 func RequireLocalWorkspaceFile() {
-	workspaceFileExists := WorkspaceConfigFileExistsInCurrentPath()
-	if !workspaceFileExists {
+	workspaceFilePath, _ := FindWorkspaceConfigFile()
+	if workspaceFilePath == "" {
 		PrintErrorMessageAndExit("It looks you have not yet connected this project to Infisical", "To do so, run [infisical init] then run your command again")
 	}
 


### PR DESCRIPTION
# Description 📣

Currently `infisical` only searches in the current directory for a `.infisical.json` file. This PR adds a simple find function, to search for that config file in all parent directories. This way it doesn't matter if you are in a subdirectory of your repo, you'll still be able to execute `infisical` without any issue. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️


```sh
infisical init
mkdir test
cd test
infisical run -- env
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝