### PR TITLE
Update check

### DIFF
--- a/cli/packages/util/check-for-update.go
+++ b/cli/packages/util/check-for-update.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -55,7 +55,7 @@ func getLatestTag(repoOwner string, repoName string) (string, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +64,9 @@ func getLatestTag(repoOwner string, repoName string) (string, error) {
 		Name string `json:"name"`
 	}
 
-	json.Unmarshal(body, &tags)
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return "", fmt.Errorf("failed to unmarshal github response: %w", err)
+	}
 
 	return tags[0].Name[1:], nil
 }

--- a/cli/packages/util/check-for-update.go
+++ b/cli/packages/util/check-for-update.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ func CheckForUpdate() {
 	}
 	latestVersion, err := getLatestTag("Infisical", "infisical")
 	if err != nil {
+		log.Debug(err)
 		// do nothing and continue
 		return
 	}

--- a/cli/packages/util/check-for-update.go
+++ b/cli/packages/util/check-for-update.go
@@ -14,6 +14,9 @@ import (
 )
 
 func CheckForUpdate() {
+	if checkEnv := os.Getenv("INFISICAL_DISABLE_UPDATE_CHECK"); checkEnv != "" {
+		return
+	}
 	latestVersion, err := getLatestTag("Infisical", "infisical")
 	if err != nil {
 		// do nothing and continue

--- a/docs/cli/commands/export.mdx
+++ b/docs/cli/commands/export.mdx
@@ -35,6 +35,27 @@ Export environment variables from the platform into a file format.
   infisical export --format=yaml > secrets.yaml
   ```
 
+  ### Environment variables
+  <Accordion title="INFISICAL_TOKEN">
+    Used to fetch secrets via a [service token](/getting-started/dashboard/token) apposed to logged in credentials. Simply, export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_TOKEN=st.63e03c4a97cb4a747186c71e.ed5b46a34c078a8f94e8228f4ab0ff97.4f7f38034811995997d72badf44b42ec
+    ```
+  </Accordion>
+
+  <Accordion title="INFISICAL_DISABLE_UPDATE_CHECK">
+    Used to disable the check for new CLI versions. This can improve the time it takes to run this command. Recommended for production environments.
+    
+    To use, simply export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_DISABLE_UPDATE_CHECK=true
+    ```
+  </Accordion>
+
   ### flags 
   <Accordion title="--env">
     Used to set the environment that secrets are pulled from. 

--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -40,7 +40,28 @@ Inject secrets from Infisical into your application process.
   $ infisical run -- npm run dev
   ```
 
-  ### flags 
+  ### Environment variables
+  <Accordion title="INFISICAL_TOKEN">
+    Used to fetch secrets via a [service token](/getting-started/dashboard/token) apposed to logged in credentials. Simply, export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_TOKEN=st.63e03c4a97cb4a747186c71e.ed5b46a34c078a8f94e8228f4ab0ff97.4f7f38034811995997d72badf44b42ec
+    ```
+  </Accordion>
+
+  <Accordion title="INFISICAL_DISABLE_UPDATE_CHECK">
+    Used to disable the check for new CLI versions. This can improve the time it takes to run this command. Recommended for production environments.
+    
+    To use, simply export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_DISABLE_UPDATE_CHECK=true
+    ```
+  </Accordion>
+
+  ### Flags 
   <Accordion title="--command">
     Pass secrets into multiple commands at once
 

--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -18,7 +18,28 @@ This command enables you to perform CRUD (create, read, update, delete) operatio
   $ infisical secrets
   ```
 
-  ### flags 
+  ### Environment variables
+  <Accordion title="INFISICAL_TOKEN">
+    Used to fetch secrets via a [service token](/getting-started/dashboard/token) apposed to logged in credentials. Simply, export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_TOKEN=st.63e03c4a97cb4a747186c71e.ed5b46a34c078a8f94e8228f4ab0ff97.4f7f38034811995997d72badf44b42ec
+    ```
+  </Accordion>
+
+  <Accordion title="INFISICAL_DISABLE_UPDATE_CHECK">
+    Used to disable the check for new CLI versions. This can improve the time it takes to run this command. Recommended for production environments.
+    
+    To use, simply export this variable in the terminal before running this command.
+
+    ```bash
+    # Example 
+    export INFISICAL_DISABLE_UPDATE_CHECK=true
+    ```
+  </Accordion>
+
+  ### Flags 
   <Accordion title="--expand">
     Parse shell parameter expansions in your secrets
 


### PR DESCRIPTION
# Description 📣

Hi, I changed a few things regarding the update check infisical does on each run. 
- Use `io` in favor of `ioutil` because ioutil is deprecated
- Added missing error check and log possible errors to the debug log
- Added an env variable to disable the update check

I think it should be possible to disable the update check completely. If you use `infisical` in an air-gapped environment, that check will never succeed and it slows down the execution, because the cli will wait until it hits a timeout while querying github. 

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Run `infisical` in an air-gapped environment with a self hosted instance. 

```sh
infisical run -- echo # will be extremely slow

export INFISICAL_DISABLE_UPDATE_CHECK=1
infisical run -- echo # will be much faster
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝