### PR TITLE
Remove smtp require for selfhost setup

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -50,6 +50,7 @@ const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY!;
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET!;
 const TELEMETRY_ENABLED = process.env.TELEMETRY_ENABLED! !== 'false' && true;
 const LICENSE_KEY = process.env.LICENSE_KEY!;
+const SMTP_CONFIGURED = SMTP_HOST == '' || SMTP_HOST == undefined ? false : true
 
 export {
   PORT,
@@ -101,5 +102,6 @@ export {
   STRIPE_SECRET_KEY,
   STRIPE_WEBHOOK_SECRET,
   TELEMETRY_ENABLED,
-  LICENSE_KEY
+  LICENSE_KEY,
+  SMTP_CONFIGURED
 };

--- a/backend/src/controllers/v2/authController.ts
+++ b/backend/src/controllers/v2/authController.ts
@@ -13,7 +13,7 @@ import { EELogService } from '../../ee/services';
 import {
   NODE_ENV,
   JWT_MFA_LIFETIME,
-  JWT_MFA_SECRET
+  JWT_MFA_SECRET,
 } from '../../config';
 import { BadRequestError, InternalServerError } from '../../utils/errors';
 import {
@@ -89,7 +89,7 @@ export const login1 = async (req: Request, res: Response) => {
  */
 export const login2 = async (req: Request, res: Response) => {
   try {
-    
+
     if (!req.headers['user-agent']) throw InternalServerError({ message: 'User-Agent header is required' });
 
     const { email, clientProof } = req.body;
@@ -129,12 +129,12 @@ export const login2 = async (req: Request, res: Response) => {
               expiresIn: JWT_MFA_LIFETIME,
               secret: JWT_MFA_SECRET
             });
-          
+
             const code = await TokenService.createToken({
               type: TOKEN_EMAIL_MFA,
               email
             });
-            
+
             // send MFA code [code] to [email]
             await sendMail({
               template: 'emailMfa.handlebars',
@@ -144,13 +144,13 @@ export const login2 = async (req: Request, res: Response) => {
                 code
               }
             });
-            
+
             return res.status(200).send({
               mfaEnabled: true,
               token
             });
           }
-          
+
           await checkUserDevice({
             user,
             ip: req.ip,
@@ -183,7 +183,7 @@ export const login2 = async (req: Request, res: Response) => {
             iv?: string;
             tag?: string;
           }
-          
+
           const response: ResponseData = {
             mfaEnabled: false,
             encryptionVersion: user.encryptionVersion,
@@ -193,7 +193,7 @@ export const login2 = async (req: Request, res: Response) => {
             iv: user.iv,
             tag: user.tag
           }
-          
+
           if (
             user?.protectedKey &&
             user?.protectedKeyIV &&
@@ -208,14 +208,14 @@ export const login2 = async (req: Request, res: Response) => {
             name: ACTION_LOGIN,
             userId: user._id
           });
-          
+
           loginAction && await EELogService.createLog({
             userId: user._id,
             actions: [loginAction],
             channel: getChannelFromUserAgent(req.headers['user-agent']),
             ipAddress: req.ip
           });
-          
+
           return res.status(200).send(response);
         }
 
@@ -246,7 +246,7 @@ export const sendMfaToken = async (req: Request, res: Response) => {
       type: TOKEN_EMAIL_MFA,
       email
     });
-    
+
     // send MFA code [code] to [email]
     await sendMail({
       template: 'emailMfa.handlebars',
@@ -261,9 +261,9 @@ export const sendMfaToken = async (req: Request, res: Response) => {
     Sentry.captureException(err);
     return res.status(400).send({
       message: 'Failed to send MFA code'
-    }); 
+    });
   }
-  
+
   return res.status(200).send({
     message: 'Successfully sent new MFA code'
   });
@@ -276,76 +276,76 @@ export const sendMfaToken = async (req: Request, res: Response) => {
  * @param res 
  */
 export const verifyMfaToken = async (req: Request, res: Response) => {
-    const { email, mfaToken } = req.body;
+  const { email, mfaToken } = req.body;
 
-    await TokenService.validateToken({
-      type: TOKEN_EMAIL_MFA,
-      email,
-      token: mfaToken
-    });
+  await TokenService.validateToken({
+    type: TOKEN_EMAIL_MFA,
+    email,
+    token: mfaToken
+  });
 
-    const user = await User.findOne({
-      email
-    }).select('+salt +verifier +encryptionVersion +protectedKey +protectedKeyIV +protectedKeyTag +publicKey +encryptedPrivateKey +iv +tag');
+  const user = await User.findOne({
+    email
+  }).select('+salt +verifier +encryptionVersion +protectedKey +protectedKeyIV +protectedKeyTag +publicKey +encryptedPrivateKey +iv +tag');
 
-    if (!user) throw new Error('Failed to find user'); 
+  if (!user) throw new Error('Failed to find user');
 
-     await checkUserDevice({
-      user,
-      ip: req.ip,
-      userAgent: req.headers['user-agent'] ?? ''
-    });
+  await checkUserDevice({
+    user,
+    ip: req.ip,
+    userAgent: req.headers['user-agent'] ?? ''
+  });
 
-    // issue tokens
-    const tokens = await issueAuthTokens({ userId: user._id.toString() });
+  // issue tokens
+  const tokens = await issueAuthTokens({ userId: user._id.toString() });
 
-    // store (refresh) token in httpOnly cookie
-    res.cookie('jid', tokens.refreshToken, {
-      httpOnly: true,
-      path: '/',
-      sameSite: 'strict',
-      secure: NODE_ENV === 'production' ? true : false
-    });
-    
-    interface VerifyMfaTokenRes {
-      encryptionVersion: number;
-      protectedKey?: string;
-      protectedKeyIV?: string;
-      protectedKeyTag?: string;
-      token: string;
-      publicKey: string;
-      encryptedPrivateKey: string;
-      iv: string;
-      tag: string;
-    }
+  // store (refresh) token in httpOnly cookie
+  res.cookie('jid', tokens.refreshToken, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    secure: NODE_ENV === 'production' ? true : false
+  });
 
-    const resObj: VerifyMfaTokenRes = {
-      encryptionVersion: user.encryptionVersion,
-      token: tokens.token,
-      publicKey: user.publicKey as string,
-      encryptedPrivateKey: user.encryptedPrivateKey as string,
-      iv: user.iv as string,
-      tag: user.tag as string
-    }
-    
-    if (user?.protectedKey && user?.protectedKeyIV && user?.protectedKeyTag) {
-      resObj.protectedKey = user.protectedKey;
-      resObj.protectedKeyIV = user.protectedKeyIV;
-      resObj.protectedKeyTag = user.protectedKeyTag;
-    }
+  interface VerifyMfaTokenRes {
+    encryptionVersion: number;
+    protectedKey?: string;
+    protectedKeyIV?: string;
+    protectedKeyTag?: string;
+    token: string;
+    publicKey: string;
+    encryptedPrivateKey: string;
+    iv: string;
+    tag: string;
+  }
 
-    const loginAction = await EELogService.createAction({
-      name: ACTION_LOGIN,
-      userId: user._id
-    });
-    
-    loginAction && await EELogService.createLog({
-      userId: user._id,
-      actions: [loginAction],
-      channel: getChannelFromUserAgent(req.headers['user-agent']),
-      ipAddress: req.ip
-    });
+  const resObj: VerifyMfaTokenRes = {
+    encryptionVersion: user.encryptionVersion,
+    token: tokens.token,
+    publicKey: user.publicKey as string,
+    encryptedPrivateKey: user.encryptedPrivateKey as string,
+    iv: user.iv as string,
+    tag: user.tag as string
+  }
 
-    return res.status(200).send(resObj); 
+  if (user?.protectedKey && user?.protectedKeyIV && user?.protectedKeyTag) {
+    resObj.protectedKey = user.protectedKey;
+    resObj.protectedKeyIV = user.protectedKeyIV;
+    resObj.protectedKeyTag = user.protectedKeyTag;
+  }
+
+  const loginAction = await EELogService.createAction({
+    name: ACTION_LOGIN,
+    userId: user._id
+  });
+
+  loginAction && await EELogService.createLog({
+    userId: user._id,
+    actions: [loginAction],
+    channel: getChannelFromUserAgent(req.headers['user-agent']),
+    ipAddress: req.ip
+  });
+
+  return res.status(200).send(resObj);
 }
 

--- a/backend/src/routes/status/status.ts
+++ b/backend/src/routes/status/status.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from 'express';
+import { SMTP_CONFIGURED } from '../../config';
 
 const router = express.Router();
 
@@ -8,6 +9,7 @@ router.get(
     res.status(200).json({
       date: new Date(),
       message: 'Ok',
+      emailConfigured: SMTP_CONFIGURED
     })
   }
 );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "npm-proj-1677883018530-0.7603125731052582NtcmfK",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -66,7 +66,7 @@
         "react-table": "^7.8.0",
         "set-cookie-parser": "^2.5.1",
         "sharp": "^0.31.2",
-        "styled-components": "^5.3.5",
+        "styled-components": "^5.3.7",
         "tailwind-merge": "^1.8.1",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",
@@ -20245,10 +20245,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "hasInstallScript": true,
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.7.tgz",
+      "integrity": "sha512-JL1b4A79OGqav4TxkrNsuuQfy6ZnrpyQx6hBDQ3Hd3JyuR2IQuVNBpF+FCEWFNZpN5hj+fhkaEVWteVJ18f0tw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -37001,9 +37000,9 @@
       }
     },
     "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.7.tgz",
+      "integrity": "sha512-JL1b4A79OGqav4TxkrNsuuQfy6ZnrpyQx6hBDQ3Hd3JyuR2IQuVNBpF+FCEWFNZpN5hj+fhkaEVWteVJ18f0tw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "react-table": "^7.8.0",
     "set-cookie-parser": "^2.5.1",
     "sharp": "^0.31.2",
-    "styled-components": "^5.3.5",
+    "styled-components": "^5.3.7",
     "tailwind-merge": "^1.8.1",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/frontend/src/components/signup/TeamInviteStep.tsx
+++ b/frontend/src/components/signup/TeamInviteStep.tsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 
+import { useFetchServerStatus } from '@app/hooks/api/serverDetails';
+import { usePopUp } from '@app/hooks/usePopUp';
 import addUserToOrg from '@app/pages/api/organization/addUserToOrg';
 import getWorkspaces from '@app/pages/api/workspace/getWorkspaces';
 
 import Button from '../basic/buttons/Button';
+import { EmailServiceSetupModal } from '../v2';
 
 /**
  * This is the last step of the signup flow. People can optionally invite their teammates here.
@@ -14,6 +17,10 @@ export default function TeamInviteStep(): JSX.Element {
   const [emails, setEmails] = useState('');
   const { t } = useTranslation();
   const router = useRouter();
+  const {data: serverDetails } = useFetchServerStatus()
+  const { handlePopUpToggle, popUp, handlePopUpOpen } = usePopUp([
+    'setUpEmail'
+  ] as const);
 
   // Redirect user to the getting started page
   const redirectToHome = async () => {
@@ -62,10 +69,20 @@ export default function TeamInviteStep(): JSX.Element {
         </div>
         <Button
           text={t('signup:step5-send-invites') ?? ''}
-          onButtonPressed={() => inviteUsers({ emails })}
+          onButtonPressed={() => {
+            if(serverDetails?.emailConfigured){
+              inviteUsers({ emails })
+            }else{
+              handlePopUpOpen('setUpEmail');
+            }
+          }}
           size="lg"
         />
       </div>
+      <EmailServiceSetupModal
+        isOpen={popUp.setUpEmail?.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle('setUpEmail', isOpen)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/v2/EmailServiceSetupModal/EmailServiceSetupModal.tsx
+++ b/frontend/src/components/v2/EmailServiceSetupModal/EmailServiceSetupModal.tsx
@@ -1,0 +1,21 @@
+import { Button } from '../Button';
+import { Modal, ModalContent } from '../Modal';
+
+type Props = {
+  isOpen?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+};
+
+export const EmailServiceSetupModal = ({ isOpen, onOpenChange }: Props): JSX.Element => (
+  <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+    <ModalContent title="Email service not configured">
+      <p className="mb-4 text-bunker-300">
+        The administrators of this Infisical instance have not yet set up an email service provider required to perform this action
+      </p>
+      
+      <a href="https://infisical.com/docs/self-hosting/configuration/email">
+        <Button className="mr-4">Learn more</Button>
+      </a>
+    </ModalContent>
+  </Modal>
+);

--- a/frontend/src/components/v2/EmailServiceSetupModal/index.tsx
+++ b/frontend/src/components/v2/EmailServiceSetupModal/index.tsx
@@ -1,0 +1,1 @@
+export { EmailServiceSetupModal } from './EmailServiceSetupModal';

--- a/frontend/src/components/v2/index.tsx
+++ b/frontend/src/components/v2/index.tsx
@@ -3,6 +3,7 @@ export * from './Card';
 export * from './Checkbox';
 export * from './DeleteActionModal';
 export * from './Dropdown';
+export * from './EmailServiceSetupModal'
 export * from './EmptyState';
 export * from './FormControl';
 export * from './IconButton';

--- a/frontend/src/hooks/api/serverDetails/index.ts
+++ b/frontend/src/hooks/api/serverDetails/index.ts
@@ -1,0 +1,1 @@
+export { useFetchServerStatus } from './queries'

--- a/frontend/src/hooks/api/serverDetails/queries.tsx
+++ b/frontend/src/hooks/api/serverDetails/queries.tsx
@@ -1,0 +1,19 @@
+import {useQuery } from '@tanstack/react-query';
+
+import { apiRequest } from '@app/config/request';
+
+import { ServerStatus } from './types';
+
+// cache key
+const serverStatusKeys = {
+  serverStatus: ['serverStatus'] as const
+};
+
+const fetchServerStatus = async () => {
+  const {data} = await apiRequest.get<ServerStatus>('/api/status');
+  return data;
+};
+
+export const useFetchServerStatus= () => {
+  return useQuery({ queryKey: serverStatusKeys.serverStatus, queryFn: fetchServerStatus });
+}

--- a/frontend/src/hooks/api/serverDetails/types.ts
+++ b/frontend/src/hooks/api/serverDetails/types.ts
@@ -1,0 +1,5 @@
+export type ServerStatus = {
+  date: string;
+  message: string;
+  emailConfigured: boolean;
+};

--- a/frontend/src/pages/signup.tsx
+++ b/frontend/src/pages/signup.tsx
@@ -13,6 +13,7 @@ import TeamInviteStep from '@app/components/signup/TeamInviteStep';
 import UserInfoStep from '@app/components/signup/UserInfoStep';
 import SecurityClient from '@app/components/utilities/SecurityClient';
 import { getTranslatedStaticProps } from '@app/components/utilities/withTranslateProps';
+import { useFetchServerStatus } from '@app/hooks/api/serverDetails';
 
 import checkEmailVerificationCode from './api/auth/CheckEmailVerificationCode';
 import getWorkspaces from './api/workspace/getWorkspaces';
@@ -25,10 +26,12 @@ export default function SignUp() {
   const [password, setPassword] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState('123456');
   const [codeError, setCodeError] = useState(false);
   const [step, setStep] = useState(1);
   const router = useRouter();
+  const {data: serverDetails } = useFetchServerStatus()
+
 
   const { t } = useTranslation();
 
@@ -67,6 +70,13 @@ export default function SignUp() {
       }
     }
   };
+
+  // when email service is not configured, skip step 2
+  useEffect(() => {
+    if (!serverDetails?.emailConfigured && step === 2){
+      incrementStep()
+    }
+  }, [step]);
 
   return (
     <div className="bg-bunker-800 h-screen flex flex-col items-center justify-center">

--- a/frontend/src/pages/verify-email.tsx
+++ b/frontend/src/pages/verify-email.tsx
@@ -6,12 +6,19 @@ import Link from 'next/link';
 import Button from '@app/components/basic/buttons/Button';
 import InputField from '@app/components/basic/InputField';
 import { getTranslatedStaticProps } from '@app/components/utilities/withTranslateProps';
+import { EmailServiceSetupModal } from '@app/components/v2';
+import { usePopUp } from '@app/hooks';
+import { useFetchServerStatus } from '@app/hooks/api/serverDetails';
 
 import SendEmailOnPasswordReset from './api/auth/SendEmailOnPasswordReset';
 
 export default function VerifyEmail() {
   const [email, setEmail] = useState('');
   const [step, setStep] = useState(1);
+  const {data: serverDetails } = useFetchServerStatus()
+  const { handlePopUpToggle, popUp, handlePopUpOpen } = usePopUp([
+    'setUpEmail'
+  ] as const);
 
   /**
    * This function sends the verification email and forwards a user to the next step.
@@ -63,7 +70,13 @@ export default function VerifyEmail() {
           </div>
           <div className="flex flex-col items-center justify-center w-full md:p-2 max-h-20 max-w-md mt-4 mx-auto text-sm">
             <div className="text-l mt-6 m-8 px-8 py-3 text-lg">
-              <Button text="Continue" onButtonPressed={sendVerificationEmail} size="lg" />
+              <Button text="Continue" onButtonPressed={()=>{
+                if (serverDetails?.emailConfigured){
+                  sendVerificationEmail()
+                } else {
+                  handlePopUpOpen('setUpEmail');
+                }
+              }} size="lg" />
             </div>
           </div>
         </div>
@@ -80,6 +93,11 @@ export default function VerifyEmail() {
           </div>
         </div>
       )}
+
+      <EmailServiceSetupModal
+        isOpen={popUp.setUpEmail?.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle('setUpEmail', isOpen)}
+      />
     </div>
   );
 }

--- a/frontend/src/views/Settings/OrgSettingsPage/components/OrgIncidentContactsTable/OrgIncidentContactsTable.tsx
+++ b/frontend/src/views/Settings/OrgSettingsPage/components/OrgIncidentContactsTable/OrgIncidentContactsTable.tsx
@@ -13,6 +13,7 @@ import * as yup from 'yup';
 import {
   Button,
   DeleteActionModal,
+  EmailServiceSetupModal,
   EmptyState,
   FormControl,
   IconButton,
@@ -28,6 +29,7 @@ import {
   THead,
   Tr} from '@app/components/v2';
 import { usePopUp } from '@app/hooks';
+import { useFetchServerStatus } from '@app/hooks/api/serverDetails';
 import { IncidentContact } from '@app/hooks/api/types';
 
 type Props = {
@@ -50,9 +52,11 @@ export const OrgIncidentContactsTable = ({
   isLoading
 }: Props) => {
   const [searchContact, setSearchContact] = useState('');
+  const {data: serverDetails } = useFetchServerStatus()
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     'addContact',
-    'removeContact'
+    'removeContact',
+    'setUpEmail'
   ] as const);
 
   const {
@@ -92,7 +96,13 @@ export const OrgIncidentContactsTable = ({
         <div>
           <Button
             leftIcon={<FontAwesomeIcon icon={faPlus} />}
-            onClick={() => handlePopUpOpen('addContact')}
+            onClick={() => {
+              if (serverDetails?.emailConfigured){
+                handlePopUpOpen('addContact');
+              } else {
+                handlePopUpOpen('setUpEmail');
+              }
+            }}
           >
             Add Contact
           </Button>
@@ -179,6 +189,10 @@ export const OrgIncidentContactsTable = ({
         title="Do you want to remove this email from incident contact?"
         onChange={(isOpen) => handlePopUpToggle('removeContact', isOpen)}
         onDeleteApproved={onRemoveIncidentContact}
+      />
+      <EmailServiceSetupModal
+        isOpen={popUp.setUpEmail?.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle('setUpEmail', isOpen)}
       />
     </div>
   );

--- a/frontend/src/views/Settings/OrgSettingsPage/components/OrgMembersTable/OrgMembersTable.tsx
+++ b/frontend/src/views/Settings/OrgSettingsPage/components/OrgMembersTable/OrgMembersTable.tsx
@@ -9,7 +9,7 @@ import * as yup from 'yup';
 import {
   Button,
   DeleteActionModal,
-  EmptyState,
+  EmailServiceSetupModal,  EmptyState,
   FormControl,
   IconButton,
   Input,
@@ -28,6 +28,7 @@ import {
   Tr,
   UpgradePlanModal} from '@app/components/v2';
 import { usePopUp } from '@app/hooks';
+import { useFetchServerStatus } from '@app/hooks/api/serverDetails';
 import { OrgUser, Workspace } from '@app/hooks/api/types';
 
 type Props = {
@@ -64,10 +65,12 @@ export const OrgMembersTable = ({
 }: Props) => {
   const router = useRouter();
   const [searchMemberFilter, setSearchMemberFilter] = useState('');
+  const {data: serverDetails } = useFetchServerStatus()
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     'addMember',
     'removeMember',
-    'upgradePlan'
+    'upgradePlan',
+    'setUpEmail'
   ] as const);
 
   const {
@@ -79,8 +82,8 @@ export const OrgMembersTable = ({
 
   const onAddMember = async ({ email }: TAddMemberForm) => {
     await onInviteMember(email);
-    handlePopUpClose('addMember');
-    reset();
+      handlePopUpClose('addMember');
+      reset(); 
   };
 
   const onRemoveOrgMemberApproved = async () => {
@@ -121,10 +124,14 @@ export const OrgMembersTable = ({
           <Button
             leftIcon={<FontAwesomeIcon icon={faPlus} />}
             onClick={() => {
-              if (isMoreUserNotAllowed) {
-                handlePopUpOpen('upgradePlan');
+              if (serverDetails?.emailConfigured){
+                if (isMoreUserNotAllowed) {
+                  handlePopUpOpen('upgradePlan');
+                } else {
+                  handlePopUpOpen('addMember');
+                }
               } else {
-                handlePopUpOpen('addMember');
+                handlePopUpOpen('setUpEmail');
               }
             }}
           >
@@ -290,6 +297,10 @@ export const OrgMembersTable = ({
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle('upgradePlan', isOpen)}
         text="You can add custom environments if you switch to Infisical's Team plan."
+      />
+      <EmailServiceSetupModal
+        isOpen={popUp.setUpEmail?.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle('setUpEmail', isOpen)}
       />
     </div>
   );


### PR DESCRIPTION
# Description 📣

This PR will remove the need for SMTP for the very first account that gets added to Infisical self-hosted. This improves several areas.
-  Reduce confusion for self-hosters by allowing them to create an account right away
- Allows one click deploys because now you do not need smpt for account creation
- Allows users to quickly play with self hosting without needing to go through the process of adding smtp  

When SMTP is not configured, the user will see a pop notifying them that the action cannot be completed because it requires email service.

<img width="1590" alt="PNG image" src="https://user-images.githubusercontent.com/9300960/225696959-13d1c55e-dd1d-4c6d-b5fc-e3867ac82775.png">

During account creation, if email service is not set up, email confirmation will be skipped. 

## Type ✨


- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

manually tested when email is set up and not setup

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝