### PR TITLE
Fixed broken docs link

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -38,7 +38,7 @@ Self-hosted Infisical allows you to maintain your sensitive information within y
   #### 1. Fill our environment variables
 
   Before you can deploy the Helm chart, you must fill out the required environment variables. To do so, please copy the below file to a `.yaml` file. 
-  Refer to the available [environment variables](../../self-hosting/configuration/envars) to learn more
+  Refer to the available [environment variables](/self-hosting/configuration/envars) to learn more
 
   <Accordion title="values.yaml">
   [View all available Helm chart values parameters](https://github.com/Infisical/infisical/tree/main/helm-charts/infisical)
@@ -178,7 +178,7 @@ Self-hosted Infisical allows you to maintain your sensitive information within y
     mkdir nginx && wget -O ./nginx/default.conf https://raw.githubusercontent.com/Infisical/infisical/main/nginx/default.dev.conf
     ```
 
-    3. Tweak the `.env` according to your preferences. Refer to the available [environment variables](../../self-hosting/configuration/envars)
+    3. Tweak the `.env` according to your preferences. Refer to the available [environment variables](/self-hosting/configuration/envars)
 
     ```bash
     # update environment variables like mongo login


### PR DESCRIPTION
# Description 📣

- [Environment variables doc](https://infisical.com/docs/self-hosting/configuration/envars) link was broken in [Self-hosting Overview doc](https://infisical.com/docs/self-hosting/overview) page.
  - ![image](https://user-images.githubusercontent.com/1592319/226790168-eefb4400-c5d5-4d08-816a-dbe971d86557.png)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

- No need to test.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝