### PR TITLE
[Adjustment][Sheen] removed prompt when deleting secret

### DIFF
--- a/frontend/src/components/dashboard/DeleteActionButton.tsx
+++ b/frontend/src/components/dashboard/DeleteActionButton.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import Button from '../basic/buttons/Button';
-import { DeleteEnvVar } from '../basic/dialog/DeleteEnvVar';
 
 type Props = {
   onSubmit: () => void;
@@ -13,7 +12,6 @@ type Props = {
 
 export const DeleteActionButton = ({ onSubmit, isPlain }: Props) => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false)
 
   return (
     <div className={`${
@@ -25,25 +23,17 @@ export const DeleteActionButton = ({ onSubmit, isPlain }: Props) => {
         onKeyDown={() => null}
         role="button"
         tabIndex={0}
-        onClick={() => setOpen(true)}
+        onClick={onSubmit}
         className="invisible group-hover:visible"
       >
         <FontAwesomeIcon className="text-bunker-300 hover:text-red pl-2 pr-6 text-lg mt-0.5" icon={faXmark} />
       </div>
       : <Button
         text={String(t("Delete"))}
-        // onButtonPressed={onSubmit}
         color="red"
         size="md"
-        onButtonPressed={() => setOpen(true)}
+        onButtonPressed={onSubmit}
       />}
-      <DeleteEnvVar 
-        isOpen={open}
-        onClose={() => {
-          setOpen(false)
-        }}
-        onSubmit={onSubmit}
-      />
     </div>
   )
 }


### PR DESCRIPTION
https://github.com/Infisical/infisical/issues/367

# Description 📣
- This PR removes the "Delete Key" modal when deleting a secret in the dashboard. There is already a "Save changes" button for this one so it is no longer necessary.  This will make deleting multiple secrets faster.
 
![image](https://user-images.githubusercontent.com/65645666/232180579-c5d5534a-8660-4474-90c9-513201309764.png)
![image](https://user-images.githubusercontent.com/65645666/232180638-c842f041-78a8-4ef3-a7cc-420ef46bdcc6.png)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

1. Go to dashboard where all the secrets are listed
2. Click the delete button 

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝