### PR TITLE
Add namespace option for using helm

### DIFF
--- a/helm-charts/infisical/templates/NOTES.txt
+++ b/helm-charts/infisical/templates/NOTES.txt
@@ -60,13 +60,13 @@
 $ kubectl get all -n {{ .Release.Namespace }}
  
 → Get your release status
-$ helm status {{ .Release.Namespace }} {{ .Release.Name }}
+$ helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Get your release resources
-$ helm get all {{ .Release.Namespace }} {{ .Release.Name }}
+$ helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Uninstall your release
-$ helm uninstall {{ .Release.Namespace }} {{ .Release.Name }}
+$ helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Get MongoDB root password
 $ kubectl get secret -n {{ .Release.Namespace }} mongodb


### PR DESCRIPTION
# Description 📣

```bash
$ kubectl get all -n {{ .Release.Namespace }}
```
In this statement, the namespace is specified and output.

When using the helm command below, there is no output because the `-n` namespace option is not given.
```bash
$ helm status {{ .Release.Namespace }} {{ .Release.Name }}
$ helm get all {{ .Release.Namespace }} {{ .Release.Name }}
$ helm uninstall {{ .Release.Namespace }} {{ .Release.Name }}
```

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝