### PR TITLE
Add example in CLI usage docs to show how to utilize secrets in shell aliases

### DIFF
--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -34,10 +34,12 @@ infisical init
 
 ## Inject environment variables
 
-```bash
-# inject environment variables into app
-infisical run -- [your application start command]
-```
+<Accordion title="Injecting environment variables directly" defaultOpen="true">
+  ```bash
+  # inject environment variables into app
+  infisical run -- [your application start command]
+  ```
+</Accordion>
 
 <Accordion title="Injecting environment variables in custom aliases">
   Custom aliases can utilize secrets from Infisical. Suppose there is a custom alias `yd` in `custom.sh` that runs `yarn dev` and needs the secrets provided by Infisical.
@@ -54,10 +56,9 @@ infisical run -- [your application start command]
   ```bash
   infisical run --command="source custom.sh && yd"
   ```
-
-  View all available options for `run` command [here](./commands/run)
 </Accordion>
 
+View all available options for `run` command [here](./commands/run)
 
 ## Examples:
 

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -39,6 +39,22 @@ infisical init
 infisical run -- [your application start command]
 ```
 
+## Injecting environment variables in custom aliases
+Custom aliases can utilize secrets from Infisical. Suppose there is a custom alias `yd` in `custom.sh` that runs `yarn dev` and needs the secrets provided by Infisical.
+```bash
+#!/bin/sh
+
+yd() {
+  yarn dev
+}
+```
+
+To make the secrets available from Infisical to `yd`, you can run the following command:
+
+```bash
+infisical run --command="source custom.sh && yd"
+```
+
 View all available options for `run` command [here](./commands/run)
 
 ## Examples:

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -39,23 +39,25 @@ infisical init
 infisical run -- [your application start command]
 ```
 
-## Injecting environment variables in custom aliases
-Custom aliases can utilize secrets from Infisical. Suppose there is a custom alias `yd` in `custom.sh` that runs `yarn dev` and needs the secrets provided by Infisical.
-```bash
-#!/bin/sh
+<Accordion title="Injecting environment variables in custom aliases">
+  Custom aliases can utilize secrets from Infisical. Suppose there is a custom alias `yd` in `custom.sh` that runs `yarn dev` and needs the secrets provided by Infisical.
+  ```bash
+  #!/bin/sh
 
-yd() {
-  yarn dev
-}
-```
+  yd() {
+    yarn dev
+  }
+  ```
 
-To make the secrets available from Infisical to `yd`, you can run the following command:
+  To make the secrets available from Infisical to `yd`, you can run the following command:
 
-```bash
-infisical run --command="source custom.sh && yd"
-```
+  ```bash
+  infisical run --command="source custom.sh && yd"
+  ```
 
-View all available options for `run` command [here](./commands/run)
+  View all available options for `run` command [here](./commands/run)
+</Accordion>
+
 
 ## Examples:
 


### PR DESCRIPTION
Update CLI usage docs to showcase the ability to inject environment variables in shell aliases

# Description 📣
Added a section in `docs/cli/usage.mdx` to demonstrate how environment variables from Infisical can be injected into custom shell aliases using `infisical run --command` command.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️
N/A

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝