### PR TITLE
fix: docker-compose failing due to missing frontend i18n file

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,7 +49,6 @@ services:
     volumes:
       - ./frontend/src:/app/src/ # mounted whole src to avoid missing reload on new files
       - ./frontend/public:/app/public
-      - ./frontend/next-i18next.config.js:/app/next-i18next.config.js
     env_file: .env
     environment:
       - NEXT_PUBLIC_ENV=development

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-proj-1682714485428-0.1455767275640205qNcC1I",
+  "name": "frontend",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed docker compose dev failing due to missing next-i18n config file. This has been removed due to migration towards react-i18next

## Type ✨

- [x] Bug fix

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝