### PR TITLE
Add support for custom environments in GitLab integration

### DIFF
--- a/frontend/src/components/integrations/Integration.tsx
+++ b/frontend/src/components/integrations/Integration.tsx
@@ -191,6 +191,17 @@ const IntegrationTile = ({
               />
             </div>
           );
+        case 'gitlab':
+          return (
+            <div>
+              <div className="mb-2 text-xs font-semibold text-gray-400">ENVIRONMENT</div>
+              <ListBox
+                data={null}
+                isSelected={integration.targetEnvironment}
+                onChange={setIntegrationTargetEnvironment}
+              />
+            </div>
+          );
         default:
           return <div />;
       }

--- a/frontend/src/pages/integrations/gitlab/create.tsx
+++ b/frontend/src/pages/integrations/gitlab/create.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import queryString from 'query-string';
 
-import { Button, Card, CardTitle, FormControl, Select, SelectItem } from '../../../components/v2';
+import { 
+  Button, 
+  Card, 
+  CardTitle, 
+  FormControl, 
+  Input,
+  Select, 
+  SelectItem
+} from '../../../components/v2';
 import {
   useGetIntegrationAuthApps,
   useGetIntegrationAuthById,
@@ -37,6 +45,7 @@ export default function GitLabCreateIntegrationPage() {
   const [targetEntity, setTargetEntity] = useState(gitLabEntities[0].value);
   const [selectedSourceEnvironment, setSelectedSourceEnvironment] = useState('');
   const [targetAppId, setTargetAppId] = useState('');
+  const [targetEnvironment, setTargetEnvironment] = useState('');
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -86,7 +95,7 @@ export default function GitLabCreateIntegrationPage() {
           )?.name ?? null,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
-        targetEnvironment: null,
+        targetEnvironment: targetEnvironment === '' ? '*' : targetEnvironment,
         targetEnvironmentId: null,
         targetService: null,
         targetServiceId: null,
@@ -188,6 +197,15 @@ export default function GitLabCreateIntegrationPage() {
               </SelectItem>
             )}
           </Select>
+        </FormControl>
+        <FormControl
+          label="GitLab Environment Scope (Optional)"
+        >
+          <Input 
+            placeholder="*" 
+            value={targetEnvironment} 
+            onChange={(e) => setTargetEnvironment(e.target.value)} 
+          />
         </FormControl>
         <Button
           onClick={handleButtonClick}


### PR DESCRIPTION
# Description 📣

Previously the GitLab integration synced environment variables to the default (all) environment in GitLab; this PR adds support for being able to specify a custom environment scope for this integration for folks.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝