### PR TITLE
fix(ui): fixed tags overflow in delete card

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ Please ensure you have Docker and Docker Compose installed for your OS.
 
 - `CD` into the repo
 - run command `docker-compose -f docker-compose.dev.yml up --build --force-recreate`
-- Visit localhost:3000 and the website should be live
+- Visit localhost:8080 and the website should be live
 
 ### Steps to shutdown this Docker compose
 

--- a/frontend/src/components/v2/Card/Card.tsx
+++ b/frontend/src/components/v2/Card/Card.tsx
@@ -10,7 +10,7 @@ export type CardTitleProps = {
 export const CardTitle = ({ children, className, subTitle }: CardTitleProps) => (
   <div
     className={twMerge(
-      'px-6 py-4 mb-5 font-sans text-lg font-normal border-b border-mineshaft-600',
+      'px-6 py-4 mb-5 font-sans text-lg font-normal border-b border-mineshaft-600 break-words',
       className
     )}
   >

--- a/frontend/src/components/v2/DeleteActionModal/DeleteActionModal.tsx
+++ b/frontend/src/components/v2/DeleteActionModal/DeleteActionModal.tsx
@@ -76,7 +76,7 @@ export const DeleteActionModal = ({
         <form>
           <FormControl
             label={
-              <div className="pb-2 text-sm">
+              <div className="pb-2 text-sm break-words">
                 Type <span className="font-bold">{deleteKey}</span> to delete the resource
               </div>
             }


### PR DESCRIPTION
# Description 📣

**Fixes**: https://github.com/Infisical/infisical/issues/594

Delete tag card title was overflowing when a user creates a tag with a long name. I have added `break-words` css class to ensure that content does not flow outside the containing div element.

Along with the above fix, I have also corrected port number the README file for local development setup


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Screenshots 

Before:
![image](https://github.com/Infisical/infisical/assets/12864227/68fdd41b-397d-472e-b120-70e866ce7c75)


After:
![image](https://github.com/Infisical/infisical/assets/12864227/90d3f60f-7f6a-4cbe-97da-c89a4668c696)

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝