### PR TITLE
fix(ui): fixed scroll on project list selection

### DIFF
--- a/frontend/src/components/v2/Select/Select.tsx
+++ b/frontend/src/components/v2/Select/Select.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, ReactNode } from 'react';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { faCaretDown, faCheck, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretUp,faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { twMerge } from 'tailwind-merge';
@@ -63,7 +63,9 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
             style={{ width: 'var(--radix-select-trigger-width)' }}
           >
             <SelectPrimitive.ScrollUpButton>
-              <FontAwesomeIcon icon={faChevronUp} size="sm" />
+              <div className="flex items-center justify-center">
+                <FontAwesomeIcon icon={faCaretUp} size="sm" />
+              </div>
             </SelectPrimitive.ScrollUpButton>
             <SelectPrimitive.Viewport className="p-1">
               {isLoading ? (
@@ -76,7 +78,9 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
               )}
             </SelectPrimitive.Viewport>
             <SelectPrimitive.ScrollDownButton>
-              <FontAwesomeIcon icon={faCaretDown} size="xs" />
+              <div className="flex items-center justify-center">
+                <FontAwesomeIcon icon={faCaretDown} size="sm" />
+              </div>
             </SelectPrimitive.ScrollDownButton>
           </SelectPrimitive.Content>
         </SelectPrimitive.Portal>

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -261,8 +261,22 @@ export const AppLayout = ({ children }: LayoutProps) => {
                         router.push(`/dashboard/${value}`);
                       }}
                       position="popper"
-                      dropdownContainerClassName="text-bunker-200 bg-mineshaft-800 border border-mineshaft-600 z-50 overflow-y-scroll max-h-96 no-scrollbar border-gray-700"
+                      dropdownContainerClassName="text-bunker-200 bg-mineshaft-800 border border-mineshaft-600 z-50 max-h-96 border-gray-700"
                     >
+                      <div className='h-full no-scrollbar no-scrollbar::-webkit-scrollbar'>
+                        {workspaces
+                        .filter((ws) => ws.organization === currentOrg?._id)
+                        .map(({ _id, name }) => (
+                          <SelectItem
+                            key={`ws-layout-list-${_id}`}
+                            value={_id}
+                            className={`${currentWorkspace?._id === _id && 'bg-mineshaft-600'}`}
+                          >
+                            {name}
+                          </SelectItem>
+                        ))}
+                      </div>
+                      <hr className="mt-1 mb-1 h-px border-0 bg-gray-700" />
                       <div className="w-full">
                         <Button
                           className="w-full bg-mineshaft-700 py-2 text-bunker-200"
@@ -280,19 +294,7 @@ export const AppLayout = ({ children }: LayoutProps) => {
                         >
                           Add Project
                         </Button>
-                        <hr className="mt-1 mb-1 h-px border-0 bg-gray-700" />
                       </div>
-                      {workspaces
-                        .filter((ws) => ws.organization === currentOrg?._id)
-                        .map(({ _id, name }) => (
-                          <SelectItem
-                            key={`ws-layout-list-${_id}`}
-                            value={_id}
-                            className={`${currentWorkspace?._id === _id && 'bg-mineshaft-600'}`}
-                          >
-                            {name}
-                          </SelectItem>
-                        ))}
                     </Select>
                   </div>
                 ) : (

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -261,20 +261,8 @@ export const AppLayout = ({ children }: LayoutProps) => {
                         router.push(`/dashboard/${value}`);
                       }}
                       position="popper"
-                      dropdownContainerClassName="text-bunker-200 bg-mineshaft-800 border border-mineshaft-600 z-50"
+                      dropdownContainerClassName="text-bunker-200 bg-mineshaft-800 border border-mineshaft-600 z-50 overflow-y-scroll max-h-96 no-scrollbar border-gray-700"
                     >
-                      {workspaces
-                        .filter((ws) => ws.organization === currentOrg?._id)
-                        .map(({ _id, name }) => (
-                          <SelectItem
-                            key={`ws-layout-list-${_id}`}
-                            value={_id}
-                            className={`${currentWorkspace?._id === _id && 'bg-mineshaft-600'}`}
-                          >
-                            {name}
-                          </SelectItem>
-                        ))}
-                      {/* <hr className="mt-1 mb-1 h-px border-0 bg-gray-700" /> */}
                       <div className="w-full">
                         <Button
                           className="w-full bg-mineshaft-700 py-2 text-bunker-200"
@@ -292,7 +280,19 @@ export const AppLayout = ({ children }: LayoutProps) => {
                         >
                           Add Project
                         </Button>
+                        <hr className="mt-1 mb-1 h-px border-0 bg-gray-700" />
                       </div>
+                      {workspaces
+                        .filter((ws) => ws.organization === currentOrg?._id)
+                        .map(({ _id, name }) => (
+                          <SelectItem
+                            key={`ws-layout-list-${_id}`}
+                            value={_id}
+                            className={`${currentWorkspace?._id === _id && 'bg-mineshaft-600'}`}
+                          >
+                            {name}
+                          </SelectItem>
+                        ))}
                     </Select>
                   </div>
                 ) : (


### PR DESCRIPTION
# Description 📣

**Fixes**: https://github.com/Infisical/infisical/issues/594

The project list dropdown in the main dashboard is not having any scroll as of now. This makes the UI a bit bloated when a user adds more than a few projects. I am now adding a scroll bar to the list to improve the user experience.

Along with this, I have updated the up and down arrow icons in the `Select` dropdown component. It was using a different icon for the up arrow and a different icon for the down arrow. I have made it consistent now
```diff
- faChevronUp
+ faCaretUp
```

> I have also moved the `Add Project` button to the top of the list instead of the bottom otherwise It will not be visible when there are multiple projects. Ideally, this item should be fixed during the dropdown scroll but that change is gonna take me some time to figure out

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Demo 🛠️

**Before Fix:** 
![withoutFix](https://github.com/Infisical/infisical/assets/12864227/cafb052a-ba39-48ea-8fc9-e69f277cee26)

**After Fix:**
![fixedScroll](https://github.com/Infisical/infisical/assets/12864227/19bd40ef-af9d-4396-93c3-9e56fbc369da)



```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝