### PR TITLE
Add migration script for server key re-encryption

### DIFF
--- a/backend/src/utils/setup/index.ts
+++ b/backend/src/utils/setup/index.ts
@@ -59,8 +59,8 @@ export const setup = async () => {
     
     // re-encrypt any data previously encrypted under server hex 128-bit ENCRYPTION_KEY
     // to base64 256-bit ROOT_ENCRYPTION_KEY
-    await reencryptBotPrivateKeys();
-    await reencryptSecretBlindIndexDataSalts();
+    // await reencryptBotPrivateKeys();
+    // await reencryptSecretBlindIndexDataSalts();
 
     // initializing Sentry
     Sentry.init({

--- a/migration/.eslintrc.js
+++ b/migration/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "parserOptions": {
+      "ecmaVersion": 2017
+    },
+    "env": {
+      "es6": true
+    }
+  }

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,0 +1,3 @@
+As Infisical's codebase matures, there are structural things that we need to change.
+
+This folder houses various migration scripts that can be used to upgrade self-hosted installations of Infisical to be compatible with newer versions.

--- a/migration/models/bot.js
+++ b/migration/models/bot.js
@@ -1,0 +1,61 @@
+var mongoose = require('mongoose');
+
+var botSchema = new mongoose.Schema(
+	{
+        name: {
+            type: String,
+            required: true
+        },
+        workspace: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Workspace',
+            required: true
+        },
+        isActive: {
+            type: Boolean,
+            required: true,
+            default: false
+        },
+        publicKey: {
+            type: String,
+            required: true
+        },
+        encryptedPrivateKey: {
+            type: String,
+            required: true,
+            select: false
+        },
+        iv: {
+            type: String,
+            required: true,
+            select: false
+        },
+        tag: {
+            type: String,
+            required: true,
+            select: false
+        },
+        algorithm: { // the encryption algorithm used
+            type: String,
+            enum: ['aes-256-gcm'],
+            required: true,
+            select: false
+        },
+        keyEncoding: {
+            type: String,
+            enum: [
+                'utf8',
+                'base64'
+            ],
+            required: true,
+            select: false
+        }
+	},
+	{
+		timestamps: true
+	}
+);
+
+var Bot = mongoose.model('Bot', botSchema);
+
+module.exports = Bot;

--- a/migration/models/secretBlindIndexData.js
+++ b/migration/models/secretBlindIndexData.js
@@ -1,0 +1,43 @@
+var mongoose = require('mongoose');
+
+var secretBlindIndexDataSchema = new mongoose.Schema(
+    {
+        workspace: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Workspace',
+            required: true
+        },
+        encryptedSaltCiphertext:{
+            type: String,
+            required: true
+        },
+        saltIV: {
+            type: String,
+            required: true
+        },
+        saltTag: {
+            type: String,
+            required: true
+        },
+        algorithm: {
+            type: String,
+            enum: ['aes-256-gcm'],
+            required: true,
+            select: false
+        },
+        keyEncoding: {
+            type: String,
+            enum: [
+                'utf8',
+                'base64'
+            ],
+            required: true,
+            select: false
+        }
+
+    }
+);
+
+var SecretBlindIndexData = mongoose.model('SecretBlindIndexData', secretBlindIndexDataSchema);
+
+module.exports = SecretBlindIndexData;

--- a/migration/models/user.js
+++ b/migration/models/user.js
@@ -1,0 +1,83 @@
+var mongoose = require('mongoose');
+
+var userSchema = new mongoose.Schema(
+	{
+		email: {
+			type: String,
+			required: true
+		},
+		firstName: {
+			type: String
+		},
+		lastName: {
+			type: String
+		},
+		encryptionVersion: {
+			type: Number,
+			select: false,
+			default: 1 // to resolve backward-compatibility issues
+		},
+		protectedKey: { // introduced as part of encryption version 2
+			type: String,
+			select: false
+		},
+		protectedKeyIV: { // introduced as part of encryption version 2
+			type: String,
+			select: false
+		},
+		protectedKeyTag: { // introduced as part of encryption version 2
+			type: String,
+			select: false
+		},
+		publicKey: {
+			type: String,
+			select: false
+		},
+		encryptedPrivateKey: {
+			type: String,
+			select: false
+		},
+		iv: { // iv of [encryptedPrivateKey]
+			type: String,
+			select: false
+		},
+		tag: { // tag of [encryptedPrivateKey]
+			type: String,
+			select: false
+		},
+		salt: {
+			type: String,
+			select: false
+		},
+		verifier: {
+			type: String,
+			select: false
+		},
+		refreshVersion: {
+			type: Number,
+			default: 0,
+			select: false
+		},
+		isMfaEnabled: {
+			type: Boolean,
+			default: false
+		},
+		mfaMethods: [{
+			type: String
+		}],
+		devices: {
+			type: [{
+				ip: String,
+				userAgent: String
+			}],
+			default: []
+		}
+	}, 
+	{
+		timestamps: true
+	}
+);
+
+var User = mongoose.model('User', userSchema);
+
+module.exports = User;

--- a/migration/package-lock.json
+++ b/migration/package-lock.json
@@ -1,0 +1,443 @@
+{
+  "name": "migration",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "migration",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.0.3",
+        "mongoose": "^7.2.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "node_modules/mongodb": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.5.0.tgz",
+      "integrity": "sha512-XgrkUgAAdfnZKQfk5AsYL8j7O99WHd4YXPxYxnh8dZxD+ekYWFRA3JktUsBnfg+455Smf75/+asoU/YLwNGoQQ==",
+      "dependencies": {
+        "bson": "^5.3.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.1.tgz",
+      "integrity": "sha512-c2OOl+ch9NlmPeJw7UjSb2jHNjoOw1XXHyzwygIf4z1GmaBx1OYb8OYqHkYPivvEmfY/vUWZFCgePsDqZgFn2w==",
+      "dependencies": {
+        "bson": "^5.3.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.5.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/node": {
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
+    "kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "mongodb": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.5.0.tgz",
+      "integrity": "sha512-XgrkUgAAdfnZKQfk5AsYL8j7O99WHd4YXPxYxnh8dZxD+ekYWFRA3JktUsBnfg+455Smf75/+asoU/YLwNGoQQ==",
+      "requires": {
+        "bson": "^5.3.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.2.1.tgz",
+      "integrity": "sha512-c2OOl+ch9NlmPeJw7UjSb2jHNjoOw1XXHyzwygIf4z1GmaBx1OYb8OYqHkYPivvEmfY/vUWZFCgePsDqZgFn2w==",
+      "requires": {
+        "bson": "^5.3.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.5.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      }
+    },
+    "mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
+    },
+    "mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "requires": {
+        "debug": "4.x"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
+    }
+  }
+}

--- a/migration/package.json
+++ b/migration/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "migration",
+  "version": "1.0.0",
+  "description": "As Infisical's codebase matures, there are structural things that we need to change.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^16.0.3",
+    "mongoose": "^7.2.1"
+  }
+}

--- a/migration/scripts/reencrypt_under_256_key.js
+++ b/migration/scripts/reencrypt_under_256_key.js
@@ -1,0 +1,191 @@
+require('dotenv').config();
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const Bot = require('../models/bot');
+const SecretBlindIndexData = require('../models/secretBlindIndexData');
+
+const decryptSymmetric = ({
+    ciphertext,
+    iv,
+    tag,
+    key
+}) => {
+    // console.log('decryptSymmetric arguments', {
+    //     ciphertext,
+    //     iv,
+    //     tag,
+    //     key
+    // });
+
+    const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        key,
+        Buffer.from(iv, 'base64')
+    );
+
+    decipher.setAuthTag(Buffer.from(tag, 'base64'));
+
+    let cleartext = decipher.update(ciphertext, 'base64', 'utf8');
+    cleartext += decipher.final('utf8');
+    
+    return cleartext;
+}
+
+const decryptSymmetric2 = ({
+	ciphertext,
+	iv,
+	tag,
+	key
+}) => {
+
+    const secretKey = crypto.createSecretKey(key, 'base64');
+
+    const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        secretKey,
+        Buffer.from(iv, 'base64')
+    );
+
+    decipher.setAuthTag(Buffer.from(tag, 'base64'));
+
+    let cleartext = decipher.update(ciphertext, 'base64', 'utf8');
+    cleartext += decipher.final('utf8');
+
+    return cleartext;
+};
+
+const encryptSymmetric = (
+	plaintext,
+	key
+) => {
+    
+    console.log('encryptSymmetric arguments: ', plaintext, key);
+    const iv = crypto.randomBytes(12);
+
+    const secretKey = crypto.createSecretKey(key, 'base64');
+    const cipher = crypto.createCipheriv('aes-256-gcm', secretKey, iv);
+
+    let ciphertext = cipher.update(plaintext, 'utf8', 'base64');
+    ciphertext += cipher.final('base64');
+
+	return {
+		ciphertext,
+		iv: iv.toString('base64'),
+		tag: cipher.getAuthTag().toString('base64')
+	};
+};
+
+/**
+ * This script re-encrypts relevant database structures from the previous
+ * server ENCRYPTION_KEY to ROOT_ENCRYPTION_KEY
+ */
+const main = async () => {
+    console.log('main');
+
+    const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY; // 128-bit hex encryption key
+    const ROOT_ENCRYPTION_KEY = process.env.ROOT_ENCRYPTION_KEY; // 256-bit base64 encryption key
+    
+    console.log('1: ', ENCRYPTION_KEY);
+    console.log('2: ', ROOT_ENCRYPTION_KEY);
+    
+    let errors = 0;
+    let success = 0;
+
+    mongoose.connect(process.env.MONGO_URI)
+        .then(async () => {
+            console.log('Connected!');
+            
+            if (ENCRYPTION_KEY && ROOT_ENCRYPTION_KEY) {
+                console.log('both ENCRYPTION_KEY and ROOT_ENCRYPTION_KEY are present');
+
+                const bots = await Bot.find({
+                    algorithm: 'aes-256-gcm',
+                    keyEncoding: 'utf8'
+                }).select('+encryptedPrivateKey iv tag algorithm keyEncoding workspace');
+                
+                if (bots.length === 0) return;
+                
+                for await (const bot of bots) {
+                    // console.log('bot: ', bot);
+                    try {
+                        const privateKey = decryptSymmetric({
+                            ciphertext: bot.encryptedPrivateKey,
+                            iv: bot.iv,
+                            tag: bot.tag,
+                            key: ENCRYPTION_KEY
+                        });
+
+                        // console.log('privateKey: ', privateKey);
+                        success += 1;
+                    } catch (err) {
+                        errors +=1;
+                        console.error('failed to decrypt bot A: ', bot._id.toString());
+                        
+                        // console.log('try');
+                        // const privateKey2 = decryptSymmetric({
+                        //     ciphertext: bot.encryptedPrivateKey,
+                        //     iv: bot.iv,
+                        //     tag: bot.tag,
+                        //     key: ENCRYPTION_KEY 
+                        // });
+                        
+                        // console.log('privatekey2', privateKey2);
+                    }
+                }
+
+                console.log('number of bots: ', bots.length);
+                console.log('num succ: ', success);
+                console.log('num errors: ', errors);
+                
+                // console.log('bots: ', bots);
+                // console.log('bots.length: ', bots.length);
+
+                // const operationsBot = await Promise.all(
+                //     bots.map(async (bot) => {
+                        
+                        // const privateKey = decryptSymmetric({
+                        //     ciphertext: bot.encryptedPrivateKey,
+                        //     iv: bot.iv,
+                        //     tag: bot.tag,
+                        //     key: ENCRYPTION_KEY
+                        // });
+
+                //         console.log('privateKey: ', privateKey);
+
+                //         const {
+                //             ciphertext: encryptedPrivateKey,
+                //             iv,
+                //             tag
+                //         } = encryptSymmetric(privateKey, ROOT_ENCRYPTION_KEY);
+
+                //         console.log('re-encrypted PrivateKey: ', encryptedPrivateKey);
+                        
+                //         return ({
+                //             updateOne: {
+                //                 filter: {
+                //                     _id: bot._id
+                //                 },
+                //                 update: {
+                //                     encryptedPrivateKey,
+                //                     iv,
+                //                     tag,
+                //                     algorithm: 'aes-256-gcm',
+                //                     keyEncoding: 'base64'
+                //                 }
+                //             }
+                //         })
+                //     })
+                // );
+                
+                // console.log('operationsBot: ', operationsBot);
+            }
+
+            // const user = await Bot.findOne();
+            // const secretBlindIndexData = await SecretBlindIndexData.findOne();
+            
+            // console.log('user: ', user);
+            // console.log('secretBlindIndexData: ', secretBlindIndexData);
+        });
+}
+
+main();

--- a/migration/scripts/reencrypt_under_256_key.js
+++ b/migration/scripts/reencrypt_under_256_key.js
@@ -10,13 +10,6 @@ const decryptSymmetric = ({
     tag,
     key
 }) => {
-    // console.log('decryptSymmetric arguments', {
-    //     ciphertext,
-    //     iv,
-    //     tag,
-    //     key
-    // });
-
     const decipher = crypto.createDecipheriv(
         'aes-256-gcm',
         key,
@@ -31,35 +24,10 @@ const decryptSymmetric = ({
     return cleartext;
 }
 
-const decryptSymmetric2 = ({
-	ciphertext,
-	iv,
-	tag,
-	key
-}) => {
-
-    const secretKey = crypto.createSecretKey(key, 'base64');
-
-    const decipher = crypto.createDecipheriv(
-        'aes-256-gcm',
-        secretKey,
-        Buffer.from(iv, 'base64')
-    );
-
-    decipher.setAuthTag(Buffer.from(tag, 'base64'));
-
-    let cleartext = decipher.update(ciphertext, 'base64', 'utf8');
-    cleartext += decipher.final('utf8');
-
-    return cleartext;
-};
-
 const encryptSymmetric = (
 	plaintext,
 	key
 ) => {
-    
-    console.log('encryptSymmetric arguments: ', plaintext, key);
     const iv = crypto.randomBytes(12);
 
     const secretKey = crypto.createSecretKey(key, 'base64');
@@ -75,116 +43,106 @@ const encryptSymmetric = (
 	};
 };
 
-/**
- * This script re-encrypts relevant database structures from the previous
- * server ENCRYPTION_KEY to ROOT_ENCRYPTION_KEY
- */
 const main = async () => {
     console.log('main');
 
     const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY; // 128-bit hex encryption key
     const ROOT_ENCRYPTION_KEY = process.env.ROOT_ENCRYPTION_KEY; // 256-bit base64 encryption key
-    
-    console.log('1: ', ENCRYPTION_KEY);
-    console.log('2: ', ROOT_ENCRYPTION_KEY);
-    
-    let errors = 0;
-    let success = 0;
 
     mongoose.connect(process.env.MONGO_URI)
         .then(async () => {
             console.log('Connected!');
             
             if (ENCRYPTION_KEY && ROOT_ENCRYPTION_KEY) {
-                console.log('both ENCRYPTION_KEY and ROOT_ENCRYPTION_KEY are present');
 
+                // re-encrypt bot private keys
                 const bots = await Bot.find({
                     algorithm: 'aes-256-gcm',
                     keyEncoding: 'utf8'
                 }).select('+encryptedPrivateKey iv tag algorithm keyEncoding workspace');
                 
-                if (bots.length === 0) return;
-                
-                for await (const bot of bots) {
-                    // console.log('bot: ', bot);
-                    try {
-                        const privateKey = decryptSymmetric({
-                            ciphertext: bot.encryptedPrivateKey,
-                            iv: bot.iv,
-                            tag: bot.tag,
-                            key: ENCRYPTION_KEY
-                        });
+                if (bots.length > 0) {
+                    const operationsBot = await Promise.all(
+                        bots.map(async (bot) => {
+                            
+                            const privateKey = decryptSymmetric({
+                                ciphertext: bot.encryptedPrivateKey,
+                                iv: bot.iv,
+                                tag: bot.tag,
+                                key: ENCRYPTION_KEY
+                            });
 
-                        // console.log('privateKey: ', privateKey);
-                        success += 1;
-                    } catch (err) {
-                        errors +=1;
-                        console.error('failed to decrypt bot A: ', bot._id.toString());
-                        
-                        // console.log('try');
-                        // const privateKey2 = decryptSymmetric({
-                        //     ciphertext: bot.encryptedPrivateKey,
-                        //     iv: bot.iv,
-                        //     tag: bot.tag,
-                        //     key: ENCRYPTION_KEY 
-                        // });
-                        
-                        // console.log('privatekey2', privateKey2);
-                    }
+                            const {
+                                ciphertext: encryptedPrivateKey,
+                                iv,
+                                tag
+                            } = encryptSymmetric(privateKey, ROOT_ENCRYPTION_KEY);
+                            
+                            return ({
+                                updateOne: {
+                                    filter: {
+                                        _id: bot._id
+                                    },
+                                    update: {
+                                        encryptedPrivateKey,
+                                        iv,
+                                        tag,
+                                        algorithm: 'aes-256-gcm',
+                                        keyEncoding: 'base64'
+                                    }
+                                }
+                            })
+                        })
+                    );
+
+                    const botBulkWriteResult = await Bot.bulkWrite(operationsBot);
+                    console.log('botBulkWriteResult: ', botBulkWriteResult);
                 }
-
-                console.log('number of bots: ', bots.length);
-                console.log('num succ: ', success);
-                console.log('num errors: ', errors);
-                
-                // console.log('bots: ', bots);
-                // console.log('bots.length: ', bots.length);
-
-                // const operationsBot = await Promise.all(
-                //     bots.map(async (bot) => {
-                        
-                        // const privateKey = decryptSymmetric({
-                        //     ciphertext: bot.encryptedPrivateKey,
-                        //     iv: bot.iv,
-                        //     tag: bot.tag,
-                        //     key: ENCRYPTION_KEY
-                        // });
-
-                //         console.log('privateKey: ', privateKey);
-
-                //         const {
-                //             ciphertext: encryptedPrivateKey,
-                //             iv,
-                //             tag
-                //         } = encryptSymmetric(privateKey, ROOT_ENCRYPTION_KEY);
-
-                //         console.log('re-encrypted PrivateKey: ', encryptedPrivateKey);
-                        
-                //         return ({
-                //             updateOne: {
-                //                 filter: {
-                //                     _id: bot._id
-                //                 },
-                //                 update: {
-                //                     encryptedPrivateKey,
-                //                     iv,
-                //                     tag,
-                //                     algorithm: 'aes-256-gcm',
-                //                     keyEncoding: 'base64'
-                //                 }
-                //             }
-                //         })
-                //     })
-                // );
-                
-                // console.log('operationsBot: ', operationsBot);
-            }
-
-            // const user = await Bot.findOne();
-            // const secretBlindIndexData = await SecretBlindIndexData.findOne();
             
-            // console.log('user: ', user);
-            // console.log('secretBlindIndexData: ', secretBlindIndexData);
+                // re-encrypt secret blind index data salts
+                const secretBlindIndexData = await SecretBlindIndexData.find({
+                    algorithm: 'aes-256-gcm',
+                    keyEncoding: 'utf8'
+                }).select('+encryptedSaltCiphertext +saltIV +saltTag +algorithm +keyEncoding');
+                
+                if (secretBlindIndexData.length > 0) {
+                    const operationsSecretBlindIndexData = await Promise.all(
+                        secretBlindIndexData.map(async (secretBlindIndexDatum) => {
+            
+                            const salt = decryptSymmetric({
+                                ciphertext: secretBlindIndexDatum.encryptedSaltCiphertext,
+                                iv: secretBlindIndexDatum.saltIV,
+                                tag: secretBlindIndexDatum.saltTag,
+                                key: ENCRYPTION_KEY
+                            });
+                            
+                            const {
+                                ciphertext: encryptedSaltCiphertext,
+                                iv: saltIV,
+                                tag: saltTag
+                            } = encryptSymmetric(salt, ROOT_ENCRYPTION_KEY);
+            
+                            return ({
+                                updateOne: {
+                                    filter: {
+                                        _id: secretBlindIndexDatum._id
+                                    },
+                                    update: {
+                                        encryptedSaltCiphertext,
+                                        saltIV,
+                                        saltTag,
+                                        algorithm: 'aes-256-gcm',
+                                        keyEncoding: 'base64'
+                                    }
+                                }
+                            })
+                        })
+                    );
+                    
+                    const secretBlindIndexDataBulkWriteResult = await SecretBlindIndexData.bulkWrite(operationsSecretBlindIndexData);
+                    console.log('secretBlindIndexDataBulkWriteResult: ', secretBlindIndexDataBulkWriteResult);
+                }
+            }
         });
 }
 


### PR DESCRIPTION
# Description 📣

As of `v0.3.7`, the current top-level server key (`ENCRYPTION_KEY`) supported by Infisical is `128-bit` (encoded in `hex`).

This PR adds a migration script for folks to migrate the encryption key to a new `256-bit` (encoded in `base64`) key (`ROOT_ENCRYPTION_KEY`).

As discussed internally, we've decided not to release this as an automatic upgrade at boot-up and instead include it as a migration script for better control/consistency.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝