### PR TITLE
Fix domain prompt in cli

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -331,6 +331,7 @@ func askForDomain() error {
 	}
 
 	urlValidation := func(input string) error {
+		input = strings.Replace(input, "Example - ", "", 1)
 		_, err := url.ParseRequestURI(input)
 		if err != nil {
 			return errors.New("this is an invalid url")


### PR DESCRIPTION
# Remove "Example - " from  domain input 📣

If user selects a self-hosted instance, cli asks for a domain url, which contains "Example - ". So the user just starts changing example url instead of typing it from scratch. And it leads to "wrong url" message, which is non-obvoius to understand why does it happen
<img width="467" alt="изображение" src="https://github.com/Infisical/infisical/assets/23433573/df4730c9-6384-4f06-b72e-d996c77fba8f">

So it is easy to fix by just removing the "Example - " substring from the input. 

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝