### PR TITLE
Allow custom environments in self-hosted instances

### DIFF
--- a/frontend/src/views/Settings/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -90,7 +90,7 @@ export const ProjectSettingsPage = () => {
   // get user subscription
   const { subscription } = useSubscription();
   const host = window.location.origin;
-  const isEnvServiceAllowed = ((currentWorkspace?.environments || []).length < (subscription?.envLimit || 3) && host === 'https://app.infisical.com');
+  const isEnvServiceAllowed = ((currentWorkspace?.environments || []).length < (subscription?.envLimit || 3) || host !== 'https://app.infisical.com');
 
   const onRenameWorkspace = async (name: string) => {
     try {


### PR DESCRIPTION
# Description 📣

There was [a commit made a few days ago](https://github.com/Infisical/infisical/commit/2bae6cf084a7044142aa4fc8e24ba45804bb595a#diff-566693723d6f3823491cc7715cfaae938ba0fc1c1af729eb33f1292e0c4d71e3R93) which changed the behavior of the frontend to deny users the ability to add custom environments if they were not using Infisical Cloud (on the [app.infisical.com](https://app.infisical.com) domain)
I believe this to be accidental, since the previous code explicitly allowed this.


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---
I have tested my changes, and they work without issue.

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝