### PR TITLE
Update getPlan to consider the user's current workspace

### DIFF
--- a/backend/src/controllers/v1/membershipOrgController.ts
+++ b/backend/src/controllers/v1/membershipOrgController.ts
@@ -99,7 +99,7 @@ export const inviteUserToOrganization = async (req: Request, res: Response) => {
     throw new Error('Failed to validate organization membership');
   }
   
-  const plan = await EELicenseService.getOrganizationPlan(organizationId);
+  const plan = await EELicenseService.getPlan(organizationId);
   
   if (plan.memberLimit !== null) {
     // case: limit imposed on number of members allowed

--- a/backend/src/controllers/v1/workspaceController.ts
+++ b/backend/src/controllers/v1/workspaceController.ts
@@ -116,7 +116,7 @@ export const createWorkspace = async (req: Request, res: Response) => {
     throw new Error("Failed to validate organization membership");
   }
 
-  const plan = await EELicenseService.getOrganizationPlan(organizationId);
+  const plan = await EELicenseService.getPlan(organizationId);
   
   if (plan.workspaceLimit !== null) {
     // case: limit imposed on number of workspaces allowed

--- a/backend/src/ee/controllers/v1/organizationsController.ts
+++ b/backend/src/ee/controllers/v1/organizationsController.ts
@@ -8,8 +8,9 @@ import { EELicenseService } from '../../services';
  */
 export const getOrganizationPlan = async (req: Request, res: Response) => {
     const { organizationId } = req.params;
+    const workspaceId = req.query.workspaceId as string;
 
-    const plan = await EELicenseService.getOrganizationPlan(organizationId);
+    const plan = await EELicenseService.getPlan(organizationId, workspaceId);
 
     return res.status(200).send({
         plan,

--- a/backend/src/ee/routes/v1/organizations.ts
+++ b/backend/src/ee/routes/v1/organizations.ts
@@ -5,7 +5,7 @@ import {
     requireOrganizationAuth,
     validateRequest
 } from '../../../middleware';
-import { param, body } from 'express-validator';
+import { param, body, query } from 'express-validator';
 import { organizationsController } from '../../controllers/v1';
 import {
     OWNER, ADMIN, MEMBER, ACCEPTED
@@ -21,6 +21,7 @@ router.get(
         acceptedStatuses: [ACCEPTED]
     }),
     param('organizationId').exists().trim(),
+    query('workspaceId').optional().isString(),
     validateRequest,
     organizationsController.getOrganizationPlan
 );

--- a/backend/src/ee/services/EELicenseService.ts
+++ b/backend/src/ee/services/EELicenseService.ts
@@ -104,9 +104,9 @@ class EELicenseService {
         return this.globalFeatureSet;
     }
     
-    public async refreshOrganizationPlan(organizationId: string, workspaceId?: string) {
+    public async refreshPlan(organizationId: string, workspaceId?: string) {
         if (this.instanceType === 'cloud') {
-            this.localFeatureSet.del(organizationId);
+            this.localFeatureSet.del(`${organizationId}-${workspaceId ?? ''}`);
             await this.getPlan(organizationId, workspaceId);
         }
     }

--- a/backend/src/helpers/organization.ts
+++ b/backend/src/helpers/organization.ts
@@ -170,7 +170,7 @@ export const updateSubscriptionOrgQuantity = async ({
     );
   }
 
-  await EELicenseService.refreshOrganizationPlan(organizationId);
+  await EELicenseService.refreshPlan(organizationId);
 
   return stripeSubscription;
 };

--- a/backend/src/helpers/workspace.ts
+++ b/backend/src/helpers/workspace.ts
@@ -41,7 +41,7 @@ export const createWorkspace = async ({
 		workspaceId: workspace._id
 	});
 
-	await EELicenseService.refreshOrganizationPlan(organizationId);
+	await EELicenseService.refreshPlan(organizationId);
 
 	return workspace;
 };


### PR DESCRIPTION
Previously, Infisical only considered feature limitations (paywall) at the organization-level which is insufficient/inconsistent with the actual pricing.

This PR adds support for applying limitations at the workspace-level (e.g. number of environments allowed on a select tier in Infisical Cloud); it works by allowing the frontend to query for an organization's plan and (optionally) a specific workspace in that organization.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝