### PR TITLE
bugfix(docs): remove duplicate api key header from API reference docu…

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -47,8 +47,6 @@ paths:
                     description: Secret versions
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v1/secret/{secretId}/secret-versions/rollback:
     post:
       summary: Roll back secret to a version.
@@ -74,8 +72,6 @@ paths:
                     description: Secret rolled back to
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -138,8 +134,6 @@ paths:
                     description: Project secret snapshots
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v1/workspace/{workspaceId}/secret-snapshots/count:
     get:
       description: ''
@@ -184,8 +178,6 @@ paths:
                     description: Secrets rolled back to
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -255,8 +247,6 @@ paths:
                     description: Project logs
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v1/action/{actionId}:
     get:
       description: ''
@@ -1677,8 +1667,6 @@ paths:
                     description: Current user on request
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/users/me/mfa:
     patch:
       description: ''
@@ -1716,8 +1704,6 @@ paths:
                     description: Organizations that user is part of
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/memberships:
     get:
       summary: Return organization memberships
@@ -1744,8 +1730,6 @@ paths:
                     description: Memberships of organization
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/memberships/{membershipId}:
     patch:
       summary: Update organization membership
@@ -1776,8 +1760,6 @@ paths:
                     description: Updated organization membership
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -1819,8 +1801,6 @@ paths:
                     description: Deleted organization membership
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/workspaces:
     get:
       summary: Return projects in organization that user is part of
@@ -1845,8 +1825,6 @@ paths:
                     items:
                       $ref: '#/components/schemas/Project'
                     description: Projects of organization
-      security:
-        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/service-accounts:
     get:
       description: ''
@@ -2057,8 +2035,6 @@ paths:
                 description: Encrypted project key for the given project
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/service-token-data:
     get:
       description: ''
@@ -2099,8 +2075,6 @@ paths:
                     description: Memberships of project
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/memberships/{membershipId}:
     patch:
       summary: Update project membership
@@ -2131,8 +2105,6 @@ paths:
                     description: Updated membership
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2172,8 +2144,6 @@ paths:
                     description: Deleted membership
         '400':
           description: Bad Request
-      security:
-        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/auto-capitalization:
     patch:
       description: ''
@@ -2407,8 +2377,6 @@ paths:
                     description: >-
                       Newly-created secrets for the given project and
                       environment
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2462,8 +2430,6 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Secrets for the given project and environment
-      security:
-        - apiKeyAuth: []
     patch:
       summary: Update secret(s)
       description: Update secret(s)
@@ -2481,8 +2447,6 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Updated secrets
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2514,8 +2478,6 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Deleted secrets
-      security:
-        - apiKeyAuth: []
       requestBody:
         required: true
         content:


### PR DESCRIPTION
# Description 📣

- Remove duplicate API key header from API Reference as it is already defined as part of  global configuration in mint.json

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation

# Tests 🛠️

![Screenshot 2023-06-15 at 4 46 13 PM](https://github.com/Infisical/infisical/assets/8869096/e9fba78c-bacb-44b3-a6f4-7e3507da8199)

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝****