### PR TITLE
bugfix(docs): remove api key auth spec from mint.json 

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -25,11 +25,7 @@
     "baseUrl": [
       "https://app.infisical.com",
       "http://localhost:8080"
-    ],
-    "auth": {
-      "method": "key",
-      "name": "X-API-KEY"
-    }
+    ]
   },
   "topbarLinks": [
     { "name": "Log In", "url": "https://app.infisical.com/login" }

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -47,6 +47,8 @@ paths:
                     description: Secret versions
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v1/secret/{secretId}/secret-versions/rollback:
     post:
       summary: Roll back secret to a version.
@@ -72,6 +74,8 @@ paths:
                     description: Secret rolled back to
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -134,6 +138,8 @@ paths:
                     description: Project secret snapshots
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v1/workspace/{workspaceId}/secret-snapshots/count:
     get:
       description: ''
@@ -178,6 +184,8 @@ paths:
                     description: Secrets rolled back to
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -247,6 +255,8 @@ paths:
                     description: Project logs
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v1/action/{actionId}:
     get:
       description: ''
@@ -1667,6 +1677,8 @@ paths:
                     description: Current user on request
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/users/me/mfa:
     patch:
       description: ''
@@ -1704,6 +1716,8 @@ paths:
                     description: Organizations that user is part of
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/memberships:
     get:
       summary: Return organization memberships
@@ -1730,6 +1744,8 @@ paths:
                     description: Memberships of organization
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/memberships/{membershipId}:
     patch:
       summary: Update organization membership
@@ -1760,6 +1776,8 @@ paths:
                     description: Updated organization membership
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -1801,6 +1819,8 @@ paths:
                     description: Deleted organization membership
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/workspaces:
     get:
       summary: Return projects in organization that user is part of
@@ -1825,6 +1845,8 @@ paths:
                     items:
                       $ref: '#/components/schemas/Project'
                     description: Projects of organization
+      security:
+        - apiKeyAuth: []
   /api/v2/organizations/{organizationId}/service-accounts:
     get:
       description: ''
@@ -2035,6 +2057,8 @@ paths:
                 description: Encrypted project key for the given project
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/service-token-data:
     get:
       description: ''
@@ -2075,6 +2099,8 @@ paths:
                     description: Memberships of project
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/memberships/{membershipId}:
     patch:
       summary: Update project membership
@@ -2105,6 +2131,8 @@ paths:
                     description: Updated membership
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2144,6 +2172,8 @@ paths:
                     description: Deleted membership
         '400':
           description: Bad Request
+      security:
+        - apiKeyAuth: []
   /api/v2/workspace/{workspaceId}/auto-capitalization:
     patch:
       description: ''
@@ -2377,6 +2407,8 @@ paths:
                     description: >-
                       Newly-created secrets for the given project and
                       environment
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2430,6 +2462,8 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Secrets for the given project and environment
+      security:
+        - apiKeyAuth: []
     patch:
       summary: Update secret(s)
       description: Update secret(s)
@@ -2447,6 +2481,8 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Updated secrets
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -2478,6 +2514,8 @@ paths:
                     items:
                       $ref: '#/components/schemas/Secret'
                     description: Deleted secrets
+      security:
+        - apiKeyAuth: []
       requestBody:
         required: true
         content:


### PR DESCRIPTION
# Description 📣

- Remove api key auth spec from mint.json as its already defined as part of swagger definition
- Put back security definition on `spec.yaml` ( This is to make sure at least one field is shown in documentation page. )

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation

# Tests 🛠️

![Screenshot 2023-06-15 at 5 50 13 PM](https://github.com/Infisical/infisical/assets/8869096/05fdceeb-f5a5-4619-bd38-652e15b66a38)

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝