### PR TITLE
Add paywall for PIT and redirect paywall to contact sales in self-hosted

### DIFF
--- a/backend/src/ee/services/EELicenseService.ts
+++ b/backend/src/ee/services/EELicenseService.ts
@@ -55,7 +55,7 @@ class EELicenseService {
         environmentLimit: null,
         environmentsUsed: 0,
         secretVersioning: true,
-        pitRecovery: true,
+        pitRecovery: false,
         rbac: true,
         customRateLimits: true,
         customAlerts: true,

--- a/frontend/src/components/v2/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/v2/UpgradePlanModal/UpgradePlanModal.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
+
 import { useSubscription } from "@app/context";
+
 import { Button } from "../Button";
 import { Modal, ModalClose, ModalContent } from "../Modal";
 

--- a/frontend/src/components/v2/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/v2/UpgradePlanModal/UpgradePlanModal.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-
+import { useSubscription } from "@app/context";
 import { Button } from "../Button";
 import { Modal, ModalClose, ModalContent } from "../Modal";
 
@@ -9,28 +9,35 @@ type Props = {
   text: string;
 };
 
-export const UpgradePlanModal = ({ text, isOpen, onOpenChange }: Props): JSX.Element => (
-  <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-    <ModalContent
-      title="Unleash Infisical's Full Power"
-      footerContent={[
-        <Link
-          href={`/settings/billing/${localStorage.getItem("projectData.id") as string}`}
-          key="upgrade-plan"
-        >
-          <Button className="mr-4 ml-2 mb-2">Upgrade Plan</Button>
-        </Link>,
-        <ModalClose asChild key="upgrade-plan-cancel">
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
-      ]}
-    >
-      <p className="mb-2 text-bunker-300">{text}</p>
-      <p className="text-bunker-300">
-        Upgrade and get access to this, as well as to other powerful enhancements.
-      </p>
-    </ModalContent>
-  </Modal>
-);
+export const UpgradePlanModal = ({ text, isOpen, onOpenChange }: Props): JSX.Element => {
+  const { subscription } = useSubscription();
+  const link = (subscription && subscription.slug !== null) 
+    ? `/settings/billing/${localStorage.getItem("projectData.id") as string}` 
+    : "https://infisical.com/scheduledemo";
+  
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+      <ModalContent
+        title="Unleash Infisical's Full Power"
+        footerContent={[
+          <Link
+            href={link}
+            key="upgrade-plan"
+          >
+            <Button className="mr-4 ml-2 mb-2">Upgrade Plan</Button>
+          </Link>,
+          <ModalClose asChild key="upgrade-plan-cancel">
+            <Button colorSchema="secondary" variant="plain">
+              Cancel
+            </Button>
+          </ModalClose>
+        ]}
+      >
+        <p className="mb-2 text-bunker-300">{text}</p>
+        <p className="text-bunker-300">
+          Upgrade and get access to this, as well as to other powerful enhancements.
+        </p>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/activity/[id].tsx
+++ b/frontend/src/pages/activity/[id].tsx
@@ -184,11 +184,13 @@ export default function Activity() {
           />
         </div>
       </div>
-      <UpgradePlanModal
-        isOpen={popUp.upgradePlan.isOpen}
-        onOpenChange={() => handlePopUpClose("upgradePlan")}
-        text="You can see more logs if you switch to Infisical's Business/Professional Plan."
-      />
+      {subscription && (
+        <UpgradePlanModal
+          isOpen={popUp.upgradePlan.isOpen}
+          onOpenChange={() => handlePopUpClose("upgradePlan")}
+          text={subscription.slug === null ? "You can see more logs under an Enterprise license" : "You can see more logs if you switch to Infisical's Business/Professional Plan."}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/views/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/views/DashboardPage/DashboardPage.tsx
@@ -36,7 +36,7 @@ import {
   UpgradePlanModal
 } from "@app/components/v2";
 import { leaveConfirmDefaultMessage } from "@app/const";
-import { useWorkspace, useSubscription } from "@app/context";
+import { useSubscription,useWorkspace } from "@app/context";
 import { useLeaveConfirm, usePopUp, useToggle } from "@app/hooks";
 import {
   useBatchSecretsOp,
@@ -99,7 +99,7 @@ const USER_ACTION_PUSH = "first_time_secrets_pushed";
  */
 export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
   const { subscription } = useSubscription();
-  console.log('dashboard sub: ', subscription);
+  console.log("dashboard sub: ", subscription);
   const { t } = useTranslation();
   const router = useRouter();
   const { createNotification } = useNotificationContext();

--- a/frontend/src/views/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/views/DashboardPage/DashboardPage.tsx
@@ -99,7 +99,6 @@ const USER_ACTION_PUSH = "first_time_secrets_pushed";
  */
 export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
   const { subscription } = useSubscription();
-  console.log("dashboard sub: ", subscription);
   const { t } = useTranslation();
   const router = useRouter();
   const { createNotification } = useNotificationContext();

--- a/frontend/src/views/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/views/DashboardPage/DashboardPage.tsx
@@ -32,10 +32,11 @@ import {
   PopoverTrigger,
   TableContainer,
   Tag,
-  Tooltip
+  Tooltip,
+  UpgradePlanModal
 } from "@app/components/v2";
 import { leaveConfirmDefaultMessage } from "@app/const";
-import { useWorkspace } from "@app/context";
+import { useWorkspace, useSubscription } from "@app/context";
 import { useLeaveConfirm, usePopUp, useToggle } from "@app/hooks";
 import {
   useBatchSecretsOp,
@@ -97,6 +98,8 @@ const USER_ACTION_PUSH = "first_time_secrets_pushed";
  * They will get it back
  */
 export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
+  const { subscription } = useSubscription();
+  console.log('dashboard sub: ', subscription);
   const { t } = useTranslation();
   const router = useRouter();
   const { createNotification } = useNotificationContext();
@@ -110,7 +113,8 @@ export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
     "uploadedSecOpts",
     "compareSecrets",
     "folderForm",
-    "deleteFolder"
+    "deleteFolder",
+    "upgradePlan"
   ] as const);
   const [isSecretValueHidden, setIsSecretValueHidden] = useToggle(true);
   const [searchFilter, setSearchFilter] = useState("");
@@ -624,7 +628,14 @@ export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
               <div className="hidden xl:block">
                 <Button
                   variant="outline_bg"
-                  onClick={() => handlePopUpOpen("secretSnapshots")}
+                  onClick={() => {
+                    if (subscription && subscription.pitRecovery) {
+                      handlePopUpOpen("secretSnapshots");
+                      return;
+                    }
+                    
+                    handlePopUpOpen("upgradePlan");
+                  }}
                   leftIcon={<FontAwesomeIcon icon={faCodeCommit} />}
                   isLoading={isLoadingSnapshotCount}
                   isDisabled={!canDoRollback}
@@ -886,6 +897,13 @@ export const DashboardPage = ({ envFromTop }: { envFromTop: string }) => {
           </ModalContent>
         </Modal>
       </FormProvider>
+      {subscription && (
+        <UpgradePlanModal
+          isOpen={popUp.upgradePlan.isOpen}
+          onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+          text={subscription.slug === null ? "You can perform point-in-time recovery under an Enterprise license" : "You can perform point-in-time recovery if you switch to Infisical's Team plan"}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/views/Settings/OrgSettingsPage/OrgSettingsPage.tsx
+++ b/frontend/src/views/Settings/OrgSettingsPage/OrgSettingsPage.tsx
@@ -31,8 +31,6 @@ import {
 } from "./components";
 
 export const OrgSettingsPage = () => {
-  const host = window.location.origin;
-
   const { t } = useTranslation();
   const { currentOrg } = useOrganization();
   const { currentWorkspace } = useWorkspace();


### PR DESCRIPTION
# Description 📣

This adds the formal paywall to the point-in-time recovery feature (PIT) in self-hosted and ensures that the paywall redirects to the contact sales page.

To note, PIT was always under `EE` but not yet paywalled till now.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Code improvement

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝