### PR TITLE
add --path flag to docs

### DIFF
--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -113,4 +113,14 @@ Inject secrets from Infisical into your application process.
     By default, all secrets are fetched
   </Accordion>
 
+  <Accordion title="--path">
+    The `--path` flag indicates which project folder secrets will be injected from.
+
+    ```bash
+    # Example
+    infisical run --path="/nextjs" -- npm run dev
+    ```
+
+  </Accordion>
+
 </Accordion>


### PR DESCRIPTION
# Description 📣

Added the --path flag to the [infisical run](https://infisical.com/docs/cli/commands/run) docs.  It was previously missing.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

I did not run any tests but assume it will be fine as it's just a basic content update to the docs.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝