### PR TITLE
fix(docs): Wrong integration name and missing link

### DIFF
--- a/docs/contributing/overview.mdx
+++ b/docs/contributing/overview.mdx
@@ -30,7 +30,7 @@ If you're ever in doubt about whether or not a proposed feature aligns with Infi
 ## Writing and submitting code
 
 Anyone can contribute code to Infisical. To get started, check out the [local development guide](/contributing/developing), make your changes, and submit a pull request to the main repository
-adhering to the [pull request guide](/).
+adhering to the [pull request guide](/contributing/pull-requests).
 
 
 ## Licensing

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -105,7 +105,7 @@ Other environment variables are listed below to increase the functionality of yo
     </ParamField>
 
     <ParamField query="CLIENT_SLUG_VERCEL" type="string" default="none" optional>
-      OAuth2 slug for Netlify integration
+      OAuth2 slug for Vercel integration
     </ParamField>
   </Tab>
   <Tab title="Auth Integrations">


### PR DESCRIPTION
# Description 📣

Fixed the description of the `CLIENT_SLUG_VERCEL` environment variable (was mentioning Netlify instead of Vercel).\
Added the link to the pull request documentation in the contribution overview.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

Checked the local rendering of the relevant MDX files to make sure the changes where added correctly.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝