### PR TITLE
Implemented feature to remove the trailing slash from the domain url

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -73,7 +73,6 @@ var loginCmd = &cobra.Command{
 				return
 			}
 		}
-
 		//override domain
 		domainQuery := true
 		if config.INFISICAL_URL_MANUAL_OVERRIDE != "" && config.INFISICAL_URL_MANUAL_OVERRIDE != util.INFISICAL_DEFAULT_API_URL {
@@ -322,6 +321,8 @@ func DomainOverridePrompt() (bool, error) {
 	)
 
 	options := []string{PRESET, OVERRIDE}
+	//trim the '/' from the end of the domain url
+	config.INFISICAL_URL_MANUAL_OVERRIDE = strings.TrimRight(config.INFISICAL_URL_MANUAL_OVERRIDE, "/")
 	optionsPrompt := promptui.Select{
 		Label: fmt.Sprintf("Current INFISICAL_API_URL Domain Override: %s", config.INFISICAL_URL_MANUAL_OVERRIDE),
 		Items: options,
@@ -380,7 +381,8 @@ func askForDomain() error {
 	if err != nil {
 		return err
 	}
-
+	//trimmed the '/' from the end of the self hosting url
+	domain = strings.TrimRight(domain, "/")
 	//set api and login url
 	config.INFISICAL_URL = fmt.Sprintf("%s/api", domain)
 	config.INFISICAL_LOGIN_URL = fmt.Sprintf("%s/login", domain)


### PR DESCRIPTION
# Description 📣

Fixes #723
This PR fixes the issue when a trailing slash is added to the domain url in cli entered by the url it throws a login error.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

## Test case 1
1. User logins via cli and provides a domain url example: `infisical login --domain https://app.infisical.com/`
2. User selects "Use domain" to use the entered URL.
3. Traling slash is removed from the url.

## Test case 2
1. User logins via cli with the command `infisical login
2. User decides to change the default domain url by selecting "Change domain" in cli
4. User enters a URL.
5. Trailing slash is removed from the entered URL

Video of the test case: 
For the 2nd test case I added a print statement to show that the trailing slash is removed from the URL which I later removed


https://github.com/Infisical/infisical/assets/47941768/1e22a2f4-bc36-400b-a6f7-93da8a9209b1


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝