### PR TITLE
Fix subscription context get organization from useOrganization

### DIFF
--- a/frontend/src/context/SubscriptionContext/SubscriptionContext.tsx
+++ b/frontend/src/context/SubscriptionContext/SubscriptionContext.tsx
@@ -3,8 +3,7 @@ import { createContext, ReactNode, useContext, useMemo } from "react";
 import { useGetOrgSubscription } from "@app/hooks/api";
 import { SubscriptionPlan } from "@app/hooks/api/types";
 
-import { useWorkspace } from "../WorkspaceContext";
-// import { Subscription } from '@app/hooks/api/workspace/types';
+import { useOrganization } from "../OrganizationContext";
 
 type TSubscriptionContext = {
   subscription?: SubscriptionPlan;
@@ -18,9 +17,10 @@ type Props = {
 };
 
 export const SubscriptionProvider = ({ children }: Props): JSX.Element => {
-  const { currentWorkspace } = useWorkspace();
+  const { currentOrg } = useOrganization();
+
   const { data, isLoading } = useGetOrgSubscription({
-    orgID: currentWorkspace?.organization || ""
+    orgID: currentOrg?._id || ""
   });
 
   // memorize the workspace details for the context

--- a/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
+++ b/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
@@ -69,7 +69,7 @@ export const PreviewSection = () => {
     return (
         <div>
             {subscription && subscription?.slug !== "enterprise" && subscription?.slug !== "pro" && subscription?.slug !== "pro-annual" && (
-                <div className="p-4 bg-mineshaft-900 rounded-lg flex-1 border border-mineshaft-600 mb-6 flex items-center bg-mineshaft-600 max-w-screen-lg">
+                <div className="p-4 bg-mineshaft-900 rounded-lg flex-1 border border-mineshaft-600 mb-6 flex items-center bg-mineshaft-600">
                     <div className="flex-1">
                         <h2 className="text-xl font-semibold text-mineshaft-50">Become Infisical</h2>
                         <p className="text-gray-400 mt-4">Unlimited members, projects, RBAC, smart alerts, and so much more</p>
@@ -84,7 +84,7 @@ export const PreviewSection = () => {
                 </div>
             )}
             {!isLoading && subscription && data && (
-                <div className="flex mb-6 max-w-screen-lg">
+                <div className="flex mb-6">
                     <div className="p-4 bg-mineshaft-900 rounded-lg flex-1 mr-4 border border-mineshaft-600">
                         <p className="mb-2 text-gray-400">Current plan</p>
                         <p className="text-2xl text-mineshaft-50 font-semibold mb-8"> 


### PR DESCRIPTION
# Description 📣

This PR patches the subscription context to get the id of the current organization from `useOrganization` hook instead of `useWorkspace` because the latter is `undefined` when the user is at the organization top-level view.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝