### PR TITLE
Remove individual SDK pages from docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -235,18 +235,6 @@
       "pages": ["sdks/overview"]
     },
     {
-      "group": "SDKs",
-      "pages": [
-        "sdks/languages/node",
-        "sdks/languages/python",
-        "sdks/languages/java",
-        "sdks/languages/ruby",
-        "sdks/languages/go",
-        "sdks/languages/rust",
-        "sdks/languages/php"
-      ]
-    },
-    {
       "group": "Overview",
       "pages": [
         "api-reference/overview/introduction",


### PR DESCRIPTION
# Description 📣

This PR removes each SDK page in the documentation in favor of each SDK's separate `README` on GitHub — it's difficult to maintain documentation across each avenue.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝