### PR TITLE
fix(cli): Missing trailing linebreak in vault commands

### DIFF
--- a/cli/packages/cmd/vault.go
+++ b/cli/packages/cmd/vault.go
@@ -48,7 +48,7 @@ var vaultSetCmd = &cobra.Command{
 				return
 			}
 
-			fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]", currentVaultBackend, wantedVaultTypeName)
+			fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]\n", currentVaultBackend, wantedVaultTypeName)
 
 			Telemetry.CaptureEvent("cli-command:vault set", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("wantedVault", wantedVaultTypeName).Set("version", util.CLI_VERSION))
 		} else {
@@ -81,7 +81,7 @@ func printAvailableVaultBackends() {
 
 	Telemetry.CaptureEvent("cli-command:vault", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("version", util.CLI_VERSION))
 
-	fmt.Printf("\n\nYou are currently using [%s] vault to store your login credentials", string(currentVaultBackend))
+	fmt.Printf("\n\nYou are currently using [%s] vault to store your login credentials\n", string(currentVaultBackend))
 }
 
 // Checks if the vault that the user wants to switch to is a valid available vault


### PR DESCRIPTION
# Description 📣

The CLI `vault` and `vault set` commands were missing trailing `\n`, which isn't very comfortable for users (see the screenshot below, taken in bash):

![CLI screenshot](https://github.com/Infisical/infisical/assets/49811529/9e7d8e9f-ad75-4774-9879-9cfa16ddc692)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Building and launching the CLI locally

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝