### PR TITLE
Update IP allowlist implementation

### DIFF
--- a/backend/src/helpers/workspace.ts
+++ b/backend/src/helpers/workspace.ts
@@ -45,7 +45,7 @@ export const createWorkspace = async ({
 		workspaceId: workspace._id,
 	});
 	
-	// initialize default trusted ip of 0.0.0.0/0
+	// initialize default trusted IPv4 CIDR - 0.0.0.0/0
 	await new TrustedIP({
 		workspace: workspace._id,
 		ipAddress: "0.0.0.0",
@@ -54,6 +54,16 @@ export const createWorkspace = async ({
 		isActive: true,
 		comment: ""
 	}).save()
+	
+	// initialize default trusted IPv6 CIDR - ::/0
+	await new TrustedIP({
+		workspace: workspace._id,
+		ipAddress: "::",
+		type: IPType.IPV6,
+		prefix: 0,
+		isActive: true,
+		comment: ""
+	});
 
 	await EELicenseService.refreshPlan(organizationId);
 

--- a/backend/src/validation/workspace.ts
+++ b/backend/src/validation/workspace.ts
@@ -26,6 +26,7 @@ import {
 } from "../variables";
 import { BotService } from "../services";
 import { AuthData } from "../interfaces/middleware";
+import { extractIPDetails } from "../utils/ip";
 
 /**
  * Validate authenticated clients for workspace with id [workspaceId] based
@@ -135,7 +136,8 @@ export const validateClientForWorkspace = async ({
 					}
 				}
 				
-				const check = blockList.check(authData.authIP);
+				const { type } = extractIPDetails(authData.authIP);
+				const check = blockList.check(authData.authIP, type);
 				
 				if (!check) throw UnauthorizedRequestError({
 					message: "Failed workspace authorization"


### PR DESCRIPTION
# Description 📣

This PR patches the IP allowlisting implementation that was faulty for `IPv6` addresses. More specifically, it:

- Runs blocklist logic against the correct type determined off the IP address (previously, it would run an `IPv6` IP against blocklist logic for the `IPv4` format).
- Backfills workspace trusted IPs to also add default `IPv6 CIDR`.
- Initializes `IPv4 CIDR` and `IPv6 CIDR` upon new workspace creation.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝