### PR TITLE
fix: digital ocean reset settings on sync

### DIFF
--- a/backend/src/integrations/sync.ts
+++ b/backend/src/integrations/sync.ts
@@ -2268,11 +2268,21 @@ const syncSecretsDigitalOceanAppPlatform = async ({
   secrets: any;
   accessToken: string;
 }) => {
+  // get current app settings
+  const appSettings = (
+    await standardRequest.get(`${INTEGRATION_DIGITAL_OCEAN_API_URL}/v2/apps/${integration.appId}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json"
+      }
+    })
+  ).data.app.spec;
+
   await standardRequest.put(
     `${INTEGRATION_DIGITAL_OCEAN_API_URL}/v2/apps/${integration.appId}`,
     {
       spec: {
-        name: integration.app,
+        ...appSettings,
         envs: Object.entries(secrets).map(([key, value]) => ({ key, value }))
       }
     },
@@ -2283,7 +2293,7 @@ const syncSecretsDigitalOceanAppPlatform = async ({
       }
     }
   );
-}
+};
 
 /**
  * Sync/push [secrets] to Windmill with name [integration.app]


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Resolves #794 

### Root cause
What happen is the previous implementation only sends env vars to update the app. This causes the app to reset to the default settings.

### Solution
Fetch the current settings of the app first and include it in the update request.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝