### PR TITLE
fix: Blog Section in Doc API Reference Redirects to 404

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -68,7 +68,7 @@
     {
       "name": "Blog",
       "icon": "newspaper",
-      "url": "https://blog.infisical.com/"
+      "url": "https://infisical.com/blog"
     },
     {
       "name": "Slack",


### PR DESCRIPTION
# Description 📣

Resolved the issue where clicking on the "Blog" section in the Doc API reference was redirecting to a 404: NOT_FOUND page. Now, it correctly displays relevant blog posts related to the platform.

Fix was made on the highlighted Blog tab:
![blog-screenshot](https://github.com/Infisical/infisical/assets/26815113/b669a8ad-54f8-49e3-99df-aba5200e23d1)

Now linking to this Blog page when the Blog tab is clicked on:

![working blog page](https://github.com/Infisical/infisical/assets/26815113/fd2ec983-f5c0-4fc0-9e86-1b538d6ca719)


Changed the link- https://blog.infisical.com/ that is  leading to the  404: NOT_FOUND page 
![link causing page not found](https://github.com/Infisical/infisical/assets/26815113/b603d5cb-70fe-493a-a33e-0e5d549369e1)


To this working link -https://infisical.com/blog

![working link](https://github.com/Infisical/infisical/assets/26815113/b0670f67-314e-4cd3-844c-08be93ecba71)


 Video link performing the described functionality.
https://www.loom.com/share/e01c9662f1504a6ea983d061d082d8b2?sid=5164829b-61f9-4d1b-a253-4761cc53bbac

## Type ✨

- [✓ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

---

- [ ✓] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝