### PR TITLE
fix: added dirty flag to set fn in dropzone paste secret

### DIFF
--- a/frontend/src/views/DashboardPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/views/DashboardPage/components/SecretDropzone/SecretDropzone.tsx
@@ -200,7 +200,8 @@ export const SecretDropzone = ({
     if (secrets?.secrets) {
       setValue(
         "secrets",
-        secrets?.secrets?.reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {})
+        secrets?.secrets?.reduce((prev, curr) => ({ ...prev, [curr.key]: curr.value }), {}),
+        { shouldDirty: true }
       );
     }
   };


### PR DESCRIPTION
# Description 📣

1. A small bug fix when clicking `select all` button copy secret modal in dashboard the form is not getting dirty

## Type ✨

- [x] Bug fix

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝