### PR TITLE
Add audit logs for workspace user role and read/write permission changes

### DIFF
--- a/backend/src/ee/models/auditLog/enums.ts
+++ b/backend/src/ee/models/auditLog/enums.ts
@@ -42,4 +42,6 @@ export enum EventType {
     CREATE_SECRET_IMPORT = "create-secret-import",
     UPDATE_SECRET_IMPORT = "update-secret-import",
     DELETE_SECRET_IMPORT = "delete-secret-import",
+    UPDATE_USER_WORKSPACE_ROLE = "update-user-workspace-role",
+    UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS = "update-user-workspace-denied-permissions"
 }

--- a/backend/src/ee/models/auditLog/types.ts
+++ b/backend/src/ee/models/auditLog/types.ts
@@ -346,6 +346,28 @@ interface DeleteSecretImportEvent {
     }
 }
 
+interface UpdateUserRole {
+    type: EventType.UPDATE_USER_WORKSPACE_ROLE,
+    metadata: {
+        userId: string;
+        email: string;
+        oldRole: string;
+        newRole: string;
+    }
+}
+
+interface UpdateUserDeniedPermissions {
+    type: EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS,
+    metadata: {
+        userId: string;
+        email: string;
+        deniedPermissions: {
+            environmentSlug: string;
+            ability: string;
+        }[]
+    }
+}
+
 export type Event = 
     | GetSecretsEvent
     | GetSecretEvent
@@ -376,4 +398,6 @@ export type Event =
     | GetSecretImportsEvent
     | CreateSecretImportEvent
     | UpdateSecretImportEvent
-    | DeleteSecretImportEvent;
+    | DeleteSecretImportEvent
+    | UpdateUserRole
+    | UpdateUserDeniedPermissions;

--- a/frontend/src/ee/api/memberships/UpdateUserProjectPermission.ts
+++ b/frontend/src/ee/api/memberships/UpdateUserProjectPermission.ts
@@ -26,9 +26,9 @@ const updateUserProjectPermission = async ({
       permissions: denials
     })
   }).then(async (res) => {
-    console.log({
-      permissions: denials
-    }, res)
+    // console.log({
+    //   permissions: denials
+    // }, res)
     if (res && res.status === 200) {
       return res.json();
     }

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -31,7 +31,8 @@ export const eventToNameMap: { [K in EventType]: string } = {
     [EventType.CREATE_SECRET_IMPORT]: "Create secret import",
     [EventType.UPDATE_SECRET_IMPORT]: "Update secret import",
     [EventType.DELETE_SECRET_IMPORT]: "Delete secret import",
-    
+    [EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS]: "Update denied permissions",
+    [EventType.UPDATE_USER_WORKSPACE_ROLE]: "Update user role"
 };
 
 export const userAgentTTypeoNameMap: { [K in UserAgentType]: string } = {

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -40,5 +40,7 @@ export enum EventType {
   GET_SECRET_IMPORTS = "get-secret-imports",
   CREATE_SECRET_IMPORT = "create-secret-import",
   UPDATE_SECRET_IMPORT = "update-secret-import",
-  DELETE_SECRET_IMPORT = "delete-secret-import"
+  DELETE_SECRET_IMPORT = "delete-secret-import",
+  UPDATE_USER_WORKSPACE_ROLE = "update-user-workspace-role",
+  UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS = "update-user-workspace-denied-permissions"
 }

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -348,6 +348,29 @@ interface DeleteSecretImportEvent {
     }
 }
 
+interface UpdateUserRole {
+    type: EventType.UPDATE_USER_WORKSPACE_ROLE,
+    metadata: {
+        userId: string;
+        email: string;
+        oldRole: string;
+        newRole: string;
+    }
+}
+
+interface UpdateUserDeniedPermissions {
+    type: EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS,
+    metadata: {
+        userId: string;
+        email: string;
+        deniedPermissions: {
+            environmentSlug: string;
+            ability: string;
+        }[]
+    }
+}
+
+
 export type Event = 
     | GetSecretsEvent
     | GetSecretEvent
@@ -378,7 +401,9 @@ export type Event =
     | GetSecretImportsEvent
     | CreateSecretImportEvent
     | UpdateSecretImportEvent
-    | DeleteSecretImportEvent;
+    | DeleteSecretImportEvent
+    | UpdateUserRole
+    | UpdateUserDeniedPermissions;
 
 export type AuditLog = {
   _id: string;

--- a/frontend/src/views/Project/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/views/Project/AuditLogsPage/components/LogsTableRow.tsx
@@ -279,6 +279,27 @@ export const LogsTableRow = ({
                         <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
                     </Td>
                 );
+            case EventType.UPDATE_USER_WORKSPACE_ROLE:
+                return (
+                    <Td>
+                        <p>{`Email: ${event.metadata.email}`}</p>
+                        <p>{`Old role: ${event.metadata.oldRole}`}</p>
+                        <p>{`New role: ${event.metadata.newRole}`}</p>
+                    </Td>
+                );
+            case EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS:
+                return (
+                    <Td>
+                        <p>{`Email: ${event.metadata.email}`}</p>
+                        {event.metadata.deniedPermissions.map((permission) => {
+                            return (
+                                <p key={`audit-log-denied-permission-${event.metadata.userId}-${permission.environmentSlug}-${permission.ability}`}>
+                                    {`Denied env-ability: ${permission.environmentSlug}-${permission.ability}`}
+                                </p>
+                            );
+                        })}
+                    </Td>
+                );
             default:
                 return (
                     <Td />


### PR DESCRIPTION
# Description 📣

This PR adds audit logs for two more project-level events:
- Whenever a user's role is updated such as from `member` to `admin`.
- Whenever a user's denied permissions is updated such as being denied access to `dev` environment `write` ability.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝