### PR TITLE
fix: backend image failed to start due to npm cache permission

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,8 @@ FROM node:16-alpine
 
 WORKDIR /app
 
+ENV npm_config_cache /home/node/.npm
+
 COPY package*.json ./
 RUN npm ci --only-production
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Backend image is always failed to start while running on non-root environment (e.g. OpenShift). Previous attempt to add recursive chown to `/app` folder causing way slower build times and it turns out I didn't have to change the ownership and just changed the environment variable for the npm cache folder to the 'node' user home folder.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝