### PR TITLE
fix: frontend image displaying some errors due to sed write permission

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -57,7 +57,8 @@ COPY --chown=nextjs:nodejs --chmod=555 scripts ./scripts
 COPY --from=builder /app/public ./public
 RUN chown nextjs:nodejs ./public/data
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs --chmod=777 /app/.next/static ./.next/static
+RUN chmod -R 777 /app/.next/server
 
 USER nextjs
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Frontend image is always displaying some error logs while running on non-root environment (e.g. OpenShift). Previous attempt to add recursive `chmod` to `/app` folder causing way slower build times and it turns out I didn't have to `chmod` for all files and just `chmod` for files inside `/app/.next/server` and `/app/.next/static` folder that affected by `/app/scripts/replace-variable.sh`.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝