### PR TITLE
Improve tag colors and sorting on dashboard page

### DIFF
--- a/frontend/src/views/DashboardPage/components/SecretInputRow/SecretInputRow.tsx
+++ b/frontend/src/views/DashboardPage/components/SecretInputRow/SecretInputRow.tsx
@@ -110,6 +110,11 @@ export const SecretInputRow = memo(
       append
     } = useFieldArray({ control, name: `secrets.${index}.tags` });
 
+    const colorByTagId = new Map((wsTags || []).map((wsTag, i) => [wsTag._id, tagColors[i % tagColors.length]]))
+
+    // display the tags in alphabetical order
+    secretTags.sort((a, b) => a.name.localeCompare(b.name))
+
     // to get details on a secret
     const overrideAction = useWatch({
       control,
@@ -321,19 +326,22 @@ export const SecretInputRow = memo(
         </td>
         <td className="min-w-sm flex">
           <div className="flex h-8 items-center pl-2">
-            {secretTags.map(({ id, slug }, i) => (
-              <Tag
-                className={cx(
-                  tagColors[i % tagColors.length].bg,
-                  tagColors[i % tagColors.length].text
-                )}
-                isDisabled={isReadOnly || isAddOnly || isRollbackMode}
-                onClose={() => remove(i)}
-                key={id}
-              >
-                {slug}
-              </Tag>
-            ))}
+            {secretTags.map(({ id, _id, slug }, i) => {
+              // This map lookup shouldn't ever fail, but if it does we default to the first color
+              const tagColor = colorByTagId.get(_id) || tagColors[0]
+              return (
+                <Tag
+                  className={cx(
+                    tagColor.bg,
+                    tagColor.text
+                  )}
+                  isDisabled={isReadOnly || isAddOnly || isRollbackMode}
+                  onClose={() => remove(i)}
+                  key={id}
+                >
+                  {slug}
+                </Tag>)
+            })}
             <div className="w-0 overflow-hidden group-hover:w-6">
               <Tooltip content="Copy value">
                 <IconButton
@@ -387,9 +395,9 @@ export const SecretInputRow = memo(
                               className="mr-0 data-[state=checked]:bg-primary"
                               id="autoCapitalization"
                               isChecked={selectedTagIds?.[wsTag.slug]}
-                              onCheckedChange={() => {}}
+                              onCheckedChange={() => { }}
                             >
-                              {}
+                              { }
                             </Checkbox>
                           }
                           key={wsTag._id}

--- a/frontend/src/views/DashboardPage/components/SecretInputRow/SecretInputRow.tsx
+++ b/frontend/src/views/DashboardPage/components/SecretInputRow/SecretInputRow.tsx
@@ -110,7 +110,7 @@ export const SecretInputRow = memo(
       append
     } = useFieldArray({ control, name: `secrets.${index}.tags` });
 
-    const colorByTagId = new Map((wsTags || []).map((wsTag, i) => [wsTag._id, tagColors[i % tagColors.length]]))
+    const tagColorByTagId = new Map((wsTags || []).map((wsTag, i) => [wsTag._id, tagColors[i % tagColors.length]]))
 
     // display the tags in alphabetical order
     secretTags.sort((a, b) => a.name.localeCompare(b.name))
@@ -328,7 +328,7 @@ export const SecretInputRow = memo(
           <div className="flex h-8 items-center pl-2">
             {secretTags.map(({ id, _id, slug }, i) => {
               // This map lookup shouldn't ever fail, but if it does we default to the first color
-              const tagColor = colorByTagId.get(_id) || tagColors[0]
+              const tagColor = tagColorByTagId.get(_id) || tagColors[0]
               return (
                 <Tag
                   className={cx(
@@ -395,9 +395,9 @@ export const SecretInputRow = memo(
                               className="mr-0 data-[state=checked]:bg-primary"
                               id="autoCapitalization"
                               isChecked={selectedTagIds?.[wsTag.slug]}
-                              onCheckedChange={() => { }}
+                              onCheckedChange={() => {}}
                             >
-                              { }
+                              {}
                             </Checkbox>
                           }
                           key={wsTag._id}


### PR DESCRIPTION
# Description 📣
Makes 2 changes to the way tags are displayed on the dashboard page.

1. **Displays tags in alphabetical order** (currently it looks like tags are displayed in the order in which they were added, which doesn't seem like a useful ordering)

3. **Makes sure that each tag has a consistent color across all rows** (currently the first tag on each row has one color, the second another, the third another etc., but this is not a useful coloring)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Ran locally and compared the main branch to this PRs branch

Before this PR:
![Screenshot 2023-08-15 at 6 55 01 PM](https://github.com/Infisical/infisical/assets/16603122/b89e4773-b04f-4fcc-a094-58b691aabef5)

After this PR:
![Screenshot 2023-08-15 at 6 55 24 PM](https://github.com/Infisical/infisical/assets/16603122/b5acf4cf-72fb-48f2-8159-7696985ad01a)

I also checked that the colors and the sorting stayed correct when (a) adding and removing existing tags from secrets and (b) creating new tags and adding and removing the new tags

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝