### PR TITLE
Adds user customizable environment ordering

### DIFF
--- a/backend/src/controllers/v2/environmentController.ts
+++ b/backend/src/controllers/v2/environmentController.ts
@@ -86,6 +86,43 @@ export const createWorkspaceEnvironment = async (
 };
 
 /**
+ * Swaps the ordering of two environments in the database. This is purely for asthetic purposes.
+ * @param req
+ * @param res
+ * @returns
+ */
+export const reorderWorkspaceEnvironments = async (
+  req: Request,
+  res: Response
+) => {
+  const { workspaceId } = req.params;
+  const { environmentSlug, environmentName, otherEnvironmentSlug, otherEnvironmentName } = req.body;
+
+  // atomic update the env to avoid conflict
+  const workspace = await Workspace.findById(workspaceId).exec();
+  if (!workspace) {
+    throw new Error("Failed to create workspace environment");
+  }
+
+  const environmentIndex = workspace.environments.findIndex((env) => env.name === environmentName && env.slug === environmentSlug)
+  const otherEnvironmentIndex = workspace.environments.findIndex((env) => env.name === otherEnvironmentName && env.slug === otherEnvironmentSlug)
+
+  if (environmentIndex === undefined || otherEnvironmentIndex === undefined) {
+    throw new Error("environment or otherEnvironment couldn't be found")
+  }
+
+  // swap the order of the environments
+  [workspace.environments[environmentIndex], workspace.environments[otherEnvironmentIndex]] = [workspace.environments[otherEnvironmentIndex], workspace.environments[environmentIndex]]
+
+  await workspace.save()
+
+  return res.status(200).send({
+    message: "Successfully reordered environments",
+    workspace: workspaceId,
+  });
+};
+
+/**
  * Rename workspace environment with new name and slug of a workspace with [workspaceId]
  * Old slug [oldEnvironmentSlug] must be provided
  * @param req
@@ -124,7 +161,7 @@ export const renameWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
-  
+
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments[envIndex].name = environmentName;
@@ -159,7 +196,7 @@ export const renameWorkspaceEnvironment = async (
     { $set: { "deniedPermissions.$[element].environmentSlug": environmentSlug } },
     { arrayFilters: [{ "element.environmentSlug": oldEnvironmentSlug }] }
   );
-  
+
   await EEAuditLogService.createAuditLog(
     req.authData,
     {
@@ -210,7 +247,7 @@ export const deleteWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
-  
+
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments.splice(envIndex, 1);

--- a/backend/src/controllers/v2/environmentController.ts
+++ b/backend/src/controllers/v2/environmentController.ts
@@ -161,6 +161,7 @@ export const renameWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
+
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments[envIndex].name = environmentName;
@@ -195,6 +196,7 @@ export const renameWorkspaceEnvironment = async (
     { $set: { "deniedPermissions.$[element].environmentSlug": environmentSlug } },
     { arrayFilters: [{ "element.environmentSlug": oldEnvironmentSlug }] }
   );
+
   await EEAuditLogService.createAuditLog(
     req.authData,
     {
@@ -245,6 +247,7 @@ export const deleteWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
+
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments.splice(envIndex, 1);

--- a/backend/src/controllers/v2/environmentController.ts
+++ b/backend/src/controllers/v2/environmentController.ts
@@ -86,7 +86,7 @@ export const createWorkspaceEnvironment = async (
 };
 
 /**
- * Swaps the ordering of two environments in the database. This is purely for asthetic purposes.
+ * Swaps the ordering of two environments in the database. This is purely for aesthetic purposes.
  * @param req
  * @param res
  * @returns

--- a/backend/src/controllers/v2/environmentController.ts
+++ b/backend/src/controllers/v2/environmentController.ts
@@ -101,14 +101,14 @@ export const reorderWorkspaceEnvironments = async (
   // atomic update the env to avoid conflict
   const workspace = await Workspace.findById(workspaceId).exec();
   if (!workspace) {
-    throw new Error("Failed to create workspace environment");
+    throw BadRequestError({message: "Couldn't load workspace"});
   }
 
   const environmentIndex = workspace.environments.findIndex((env) => env.name === environmentName && env.slug === environmentSlug)
   const otherEnvironmentIndex = workspace.environments.findIndex((env) => env.name === otherEnvironmentName && env.slug === otherEnvironmentSlug)
 
-  if (environmentIndex === undefined || otherEnvironmentIndex === undefined) {
-    throw new Error("environment or otherEnvironment couldn't be found")
+  if (environmentIndex === -1 || otherEnvironmentIndex === -1) {
+    throw BadRequestError({message: "environment or otherEnvironment couldn't be found"})
   }
 
   // swap the order of the environments

--- a/backend/src/controllers/v2/environmentController.ts
+++ b/backend/src/controllers/v2/environmentController.ts
@@ -161,7 +161,6 @@ export const renameWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
-
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments[envIndex].name = environmentName;
@@ -196,7 +195,6 @@ export const renameWorkspaceEnvironment = async (
     { $set: { "deniedPermissions.$[element].environmentSlug": environmentSlug } },
     { arrayFilters: [{ "element.environmentSlug": oldEnvironmentSlug }] }
   );
-
   await EEAuditLogService.createAuditLog(
     req.authData,
     {
@@ -247,7 +245,6 @@ export const deleteWorkspaceEnvironment = async (
   if (envIndex === -1) {
     throw new Error("Invalid environment given");
   }
-
   const oldEnvironment = workspace.environments[envIndex];
 
   workspace.environments.splice(envIndex, 1);

--- a/backend/src/routes/v2/environment.ts
+++ b/backend/src/routes/v2/environment.ts
@@ -46,6 +46,24 @@ router.put(
   environmentController.renameWorkspaceEnvironment
 );
 
+router.patch(
+  "/:workspaceId/environments",
+  requireAuth({
+    acceptedAuthModes: [AuthMode.JWT],
+  }),
+  requireWorkspaceAuth({
+    acceptedRoles: [ADMIN, MEMBER],
+    locationWorkspaceId: "params",
+  }),
+  param("workspaceId").exists().trim(),
+  body("environmentSlug").exists().isString().trim(),
+  body("environmentName").exists().isString().trim(),
+  body("otherEnvironmentSlug").exists().isString().trim(),
+  body("otherEnvironmentName").exists().isString().trim(),
+  validateRequest,
+  environmentController.reorderWorkspaceEnvironments
+);
+
 router.delete(
   "/:workspaceId/environments",
   requireAuth({

--- a/frontend/src/hooks/api/workspace/index.tsx
+++ b/frontend/src/hooks/api/workspace/index.tsx
@@ -16,6 +16,7 @@ export {
   useGetWorkspaceUsers,
   useNameWorkspaceSecrets,
   useRenameWorkspace,
+  useReorderWsEnvironment,
   useToggleAutoCapitalization,
   useUpdateUserWorkspaceRole,
   useUpdateWsEnvironment} from "./queries";

--- a/frontend/src/hooks/api/workspace/queries.tsx
+++ b/frontend/src/hooks/api/workspace/queries.tsx
@@ -13,6 +13,7 @@ import {
   GetWsEnvironmentDTO,
   NameWorkspaceSecretsDTO,
   RenameWorkspaceDTO,
+  ReorderEnvironmentsDTO,
   ToggleAutoCapitalizationDTO,
   UpdateEnvironmentDTO,
   Workspace,
@@ -236,6 +237,21 @@ export const useCreateWsEnvironment = () => {
       return apiRequest.post(`/api/v2/workspace/${workspaceID}/environments`, {
         environmentName,
         environmentSlug
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(workspaceKeys.getAllUserWorkspace);
+    }
+  });
+};
+
+export const useReorderWsEnvironment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{}, {}, ReorderEnvironmentsDTO>({
+    mutationFn: ({ workspaceID, environmentSlug, environmentName, otherEnvironmentSlug, otherEnvironmentName}) => {
+      return apiRequest.patch(`/api/v2/workspace/${workspaceID}/environments`, {
+        environmentSlug, environmentName, otherEnvironmentSlug, otherEnvironmentName
       });
     },
     onSuccess: () => {

--- a/frontend/src/hooks/api/workspace/types.ts
+++ b/frontend/src/hooks/api/workspace/types.ts
@@ -46,6 +46,15 @@ export type CreateEnvironmentDTO = {
   environmentName: string;
 };
 
+export type ReorderEnvironmentsDTO = {
+  workspaceID: string;
+  environmentSlug: string;
+  environmentName: string;
+  otherEnvironmentSlug: string;
+  otherEnvironmentName: string;
+
+};
+
 export type UpdateEnvironmentDTO = {
   workspaceID: string;
   oldEnvironmentSlug: string;

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
@@ -38,18 +38,18 @@ export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
   const { createNotification } = useNotificationContext();
   const reorderWsEnvironment = useReorderWsEnvironment();
 
-  const reorderEnvs = async (moveUp: boolean, name: string, slug: string) => {
+  const handleReorderEnv= async (shouldMoveUp: boolean, name: string, slug: string) => {
     try {
       if (!currentWorkspace?._id) return;
 
       const indexOfEnv = currentWorkspace.environments.findIndex((env) => env.name === name && env.slug === slug);
 
       // check that this reordering is possible
-      if (indexOfEnv === 0 && moveUp || indexOfEnv === currentWorkspace.environments.length - 1 && !moveUp) {
+      if (indexOfEnv === 0 && shouldMoveUp || indexOfEnv === currentWorkspace.environments.length - 1 && !shouldMoveUp) {
         return
       }
 
-      const indexToSwap = moveUp ? indexOfEnv - 1 : indexOfEnv + 1
+      const indexToSwap = shouldMoveUp ? indexOfEnv - 1 : indexOfEnv + 1
 
       await reorderWsEnvironment.mutateAsync({
         workspaceID: currentWorkspace._id,
@@ -94,7 +94,7 @@ export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
                   <IconButton
                     className="mr-3 py-2"
                     onClick={() => {
-                      reorderEnvs(false, name, slug)
+                      handleReorderEnv(false, name, slug)
                     }}
                     colorSchema="primary"
                     variant="plain"
@@ -106,7 +106,7 @@ export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
                   <IconButton
                     className="mr-3 py-2"
                     onClick={() => {
-                      reorderEnvs(true, name, slug)
+                      handleReorderEnv(true, name, slug)
                     }}
                     colorSchema="primary"
                     variant="plain"

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
@@ -1,6 +1,7 @@
-import { faPencil, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faArrowDown,faArrowUp, faPencil, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+import { useNotificationContext } from "@app/components/context/Notifications/NotificationProvider";
 import {
   EmptyState,
   IconButton,
@@ -14,6 +15,9 @@ import {
   Tr
 } from "@app/components/v2";
 import { useWorkspace } from "@app/context";
+import {
+  useReorderWsEnvironment
+} from "@app/hooks/api";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 type Props = {
@@ -31,6 +35,43 @@ type Props = {
 
 export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
   const { currentWorkspace, isLoading } = useWorkspace();
+  const { createNotification } = useNotificationContext();
+  const reorderWsEnvironment = useReorderWsEnvironment();
+
+  const reorderEnvs = async (moveUp: boolean, name: string, slug: string) => {
+    try {
+      if (!currentWorkspace?._id) return;
+
+      const indexOfEnv = currentWorkspace.environments.findIndex((env) => env.name === name && env.slug === slug);
+
+      // check that this reordering is possible
+      if (indexOfEnv === 0 && moveUp || indexOfEnv === currentWorkspace.environments.length - 1 && !moveUp) {
+        return
+      }
+
+      const indexToSwap = moveUp ? indexOfEnv - 1 : indexOfEnv + 1
+
+      await reorderWsEnvironment.mutateAsync({
+        workspaceID: currentWorkspace._id,
+        environmentSlug: slug,
+        environmentName: name,
+        otherEnvironmentSlug: currentWorkspace.environments[indexToSwap].slug,
+        otherEnvironmentName: currentWorkspace.environments[indexToSwap].name
+      });
+
+      createNotification({
+        text: "Successfully re-ordered environments",
+        type: "success"
+      });
+    } catch (err) {
+      console.error(err);
+      createNotification({
+        text: "Failed to re-order environments",
+        type: "error"
+      });
+    }
+  };
+
   return (
     <TableContainer>
       <Table>
@@ -45,11 +86,35 @@ export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
           {isLoading && <TableSkeleton columns={3} innerKey="project-envs" />}
           {!isLoading &&
             currentWorkspace &&
-            currentWorkspace.environments.map(({ name, slug }) => (
+            currentWorkspace.environments.map(({ name, slug }, pos) => (
               <Tr key={name}>
                 <Td>{name}</Td>
                 <Td>{slug}</Td>
                 <Td className="flex items-center justify-end">
+                  <IconButton
+                    className="mr-3 py-2"
+                    onClick={() => {
+                      reorderEnvs(false, name, slug)
+                    }}
+                    colorSchema="primary"
+                    variant="plain"
+                    ariaLabel="update"
+                    isDisabled={pos === currentWorkspace.environments.length - 1}
+                  >
+                    <FontAwesomeIcon icon={faArrowDown} />
+                  </IconButton>
+                  <IconButton
+                    className="mr-3 py-2"
+                    onClick={() => {
+                      reorderEnvs(true, name, slug)
+                    }}
+                    colorSchema="primary"
+                    variant="plain"
+                    ariaLabel="update"
+                    isDisabled={pos === 0}
+                  >
+                    <FontAwesomeIcon icon={faArrowUp} />
+                  </IconButton>
                   <IconButton
                     className="mr-3 py-2"
                     onClick={() => {


### PR DESCRIPTION
# Description 📣
Fixes #841 

Allows users to re-order their environments on the project settings page. These changes are then reflected in the ordering of columns on the secrets dashboard and in other places throughout Infisical.

Users can specify their desired ordering using the new up and down arrows on the project settings page

![Screenshot 2023-08-16 at 5 46 38 PM](https://github.com/Infisical/infisical/assets/16603122/8d7af246-cd79-4b23-a742-5d41e43ad559)

The up arrow on the top row, and the down arrow on the bottom row are disabled (and you can't click on them)

This is implemented using a new backend route `PATCH /v2/{workspaceId}/environments` which takes two environments (defined by name and slug) and swaps the order of them in the database.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

https://github.com/Infisical/infisical/assets/16603122/d5966031-b47a-449c-a13d-5767cece2ee9

There is technically a bug with the implementation of this feature where if two users are changing the order of their projects' environments at the same time, then they might get strange behavior (e.g. if there are only two environments, and somebody already swapped them and your webpage is out of date, clicking swap will actually just swap them back to the original position and appear to do nothing). However this seems like not a big deal in reality as the ordering is only for aesthetic purposes, and the "swap" way of implementing it was the simplest

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝