### PR TITLE
Attempt to create an initial admin user

### DIFF
--- a/addAdminUser.ts
+++ b/addAdminUser.ts
@@ -1,0 +1,139 @@
+/************************************************************************************************
+*
+*  Attention: The credentials below are only for development purposes, it should never be used for production  
+*
+************************************************************************************************/
+
+import { Key, Membership, MembershipOrg, Organization, User, Workspace } from "../models";
+import { SecretService } from "../services";
+import { Types } from "mongoose";
+import { getCreateAdminUser, getAdminUserEmail, getAdminPassword } from "../config";
+
+export const adminUserEmail = await getAdminUserEmail()
+export const adminUserPassword = await getAdminPassword()
+export const adminUserId = "63cefa6ec8d3175601cfa980"
+export const adminWorkspaceId = "63cefb15c8d3175601cfa989"
+export const adminOrgId = "63cefb15c8d3175601cfa985"
+export const adminMembershipId = "63cefb159185d9aa3ef0cf35"
+export const adminMembershipOrgId = "63cefb159185d9aa3ef0cf31"
+export const adminWorkspaceKeyId = "63cf48f0225e6955acec5eff"
+export const plainTextWorkspaceKey = "543fef8224813a46230b0a50a46c5fb2"
+
+export const createInitialAdminUser = async () => {
+  if (( await getCreateAdminUser()) === "true") {
+    const adminUser = {
+      _id: adminUserId,
+      email: adminUserEmail,
+      refreshVersion: 0,
+      encryptedPrivateKey: "ITMdDXtLoxib4+53U/qzvIV/T/UalRwimogFCXv/UsulzEoiKM+aK2aqOb0=",
+      firstName: "Admin",
+      iv: "9fp0dZHI+UuHeKkWMDvD6w==",
+      lastName: "Admin",
+      publicKey: "cf44BhkybbBfsE0fZHe2jvqtCj6KLXvSq4hVjV0svzk=",
+      salt: "d8099dc70958090346910fb9639262b83cf526fc9b4555a171b36a9e1bcd0240",
+      tag: "bQ/UTghqcQHRoSMpLQD33g==",
+      verifier: "12271fcd50937ca4512e1e3166adaf9d9fc7a5cd0e4c4cb3eda89f35572ede4d9eef23f64aef9220367abff9437b0b6fa55792c442f177201d87051cf77dadade254ff667170440327355fb7d6ac4745d4db302f4843632c2ed5919ebdcff343287a4cd552255d9e3ce81177edefe089617b7616683901475d393405f554634b9bf9230c041ac85624f37a60401be20b78044932580ae0868323be3749fbf856df1518153ba375fec628275f0c445f237446ea4aa7f12c1aa1d6b5fd74b7f2e88d062845a19819ec63f2d2ed9e9f37c055149649461d997d2ae1482f53b04f9de7493efbb9686fb19b2d559b9aa2b502c22dec83f9fc43290dfea89a1dc6f03580b3642b3824513853e81a441be9a0b2fde2231bac60f3287872617a36884697805eeea673cf1a351697834484ada0f282e4745015c9c2928d61e6d092f1b9c3a27eda8413175d23bb2edae62f82ccaf52bf5a6a90344a766c7e4ebf65dae9ae90b2ad4ae65dbf16e3a6948e429771cc50307ae86d454f71a746939ed061f080dd3ae369c1a0739819aca17af46a085bac1f2a5d936d198e7951a8ac3bb38b893665fe7312835abd3f61811f81efa2a8761af5070085f9b6adcca80bf9b0d81899c3d41487fba90728bb24eceb98bd69770360a232624133700ceb4d153f2ad702e0a5b7dfaf97d20bc8aa71dc8c20024a58c06a8fecdad18cb5a2f89c51eaf7",
+    }
+
+    const adminWorkspaceKey = {
+      _id: new Types.ObjectId(adminWorkspaceKeyId),
+      workspace: adminWorkspaceId,
+      encryptedKey: "96ZIRSU21CjVzIQ4Yp994FGWQvDdyK3gq+z+NCaJLK0ByTlvUePmf+AYGFJjkAdz",
+      nonce: "1jhCGqg9Wx3n0OtVxbDgiYYGq4S3EdgO",
+      sender: "63cefa6ec8d3175601cfa980",
+      receiver: "63cefa6ec8d3175601cfa980",
+    }
+
+    const adminWorkspace = {
+      _id: new Types.ObjectId(adminWorkspaceId),
+      name: "Example Project",
+      organization: adminOrgId,
+      environments: [
+        {
+          _id: "63cefb15c8d3175601cfa98a",
+          name: "Development",
+          slug: "dev",
+        },
+        {
+          _id: "63cefb15c8d3175601cfa98b",
+          name: "admin",
+          slug: "admin",
+        },
+        {
+          _id: "63cefb15c8d3175601cfa98c",
+          name: "Staging",
+          slug: "staging",
+        },
+        {
+          _id: "63cefb15c8d3175601cfa98d",
+          name: "Production",
+          slug: "prod",
+        },
+      ],
+    }
+
+    const adminOrg = {
+      _id: adminOrgId,
+      name: "Default Organization",
+    }
+
+    const adminMembershipOrg = {
+      _id: adminMembershipOrgId,
+      organization: adminOrgId,
+      role: "owner",
+      status: "accepted",
+      user: adminUserId,
+    }
+
+    const adminMembership = {
+      _id: adminMembershipId,
+      role: "admin",
+      user: adminUserId,
+      workspace: adminWorkspaceId,
+    }
+
+    try {
+      // create user if not exist 
+      const userInDB = await User.findById(adminUserId)
+      if (!userInDB) {
+        await User.create(adminUser)
+      }
+
+      // create org if not exist 
+      const orgInDB = await Organization.findById(adminOrgId)
+      if (!orgInDB) {
+        await Organization.create(adminOrg)
+      }
+
+      // create membership org if not exist
+      const membershipOrgInDB = await MembershipOrg.findById(adminMembershipOrgId)
+      if (!membershipOrgInDB) {
+        await MembershipOrg.create(adminMembershipOrg)
+      }
+
+      // create membership
+      const membershipInDB = await Membership.findById(adminMembershipId)
+      if (!membershipInDB) {
+        await Membership.create(adminMembership)
+      }
+
+      // create workspace if not exist 
+      const workspaceInDB = await Workspace.findById(adminWorkspaceId)
+      if (!workspaceInDB) {
+        const workspace = await Workspace.create(adminWorkspace)
+        
+        // initialize blind index salt for workspace
+        await SecretService.createSecretBlindIndexData({
+          workspaceId: workspace._id,
+        });
+      }
+
+      // create workspace key if not exist
+      const workspaceKeyInDB = await Key.findById(adminWorkspaceKeyId)
+      if (!workspaceKeyInDB) {
+        await Key.create(adminWorkspaceKey)
+      }
+
+    }
+  }
+}

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -68,6 +68,10 @@ export const getSecretScanningWebhookSecret = async () => (await client.getSecre
 export const getSecretScanningGitAppId = async () => (await client.getSecret("SECRET_SCANNING_GIT_APP_ID")).secretValue;
 export const getSecretScanningPrivateKey = async () => (await client.getSecret("SECRET_SCANNING_PRIVATE_KEY")).secretValue;
 
+export const getCreateAdminUser = async () => (await client.getSecret("CREATE_ADMIN_USER").secretValue || false;
+export const getAdminUserEmail = async () => (await client.getSecret("ADMIN_USER_EMAIL").secretValue;
+export const getAdminPassword = async () => (await client.getSecret("ADMIN_PASSWORD").secretValue;
+
 export const getLicenseKey = async () => {
   const secretValue = (await client.getSecret("LICENSE_KEY")).secretValue;
   return secretValue === "" ? undefined : secretValue;

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -68,9 +68,9 @@ export const getSecretScanningWebhookSecret = async () => (await client.getSecre
 export const getSecretScanningGitAppId = async () => (await client.getSecret("SECRET_SCANNING_GIT_APP_ID")).secretValue;
 export const getSecretScanningPrivateKey = async () => (await client.getSecret("SECRET_SCANNING_PRIVATE_KEY")).secretValue;
 
-export const getCreateAdminUser = async () => (await client.getSecret("CREATE_ADMIN_USER").secretValue || false;
-export const getAdminEmail = async () => (await client.getSecret("ADMIN_EMAIL").secretValue;
-export const getAdminPassword = async () => (await client.getSecret("ADMIN_PASSWORD").secretValue;
+export const getCreateAdminUser = async () => (await client.getSecret("CREATE_ADMIN_USER")).secretValue || false;
+export const getAdminEmail = async () => (await client.getSecret("ADMIN_EMAIL")).secretValue;
+export const getAdminPassword = async () => (await client.getSecret("ADMIN_PASSWORD")).secretValue;
 
 export const getLicenseKey = async () => {
   const secretValue = (await client.getSecret("LICENSE_KEY")).secretValue;

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -69,7 +69,7 @@ export const getSecretScanningGitAppId = async () => (await client.getSecret("SE
 export const getSecretScanningPrivateKey = async () => (await client.getSecret("SECRET_SCANNING_PRIVATE_KEY")).secretValue;
 
 export const getCreateAdminUser = async () => (await client.getSecret("CREATE_ADMIN_USER").secretValue || false;
-export const getAdminUserEmail = async () => (await client.getSecret("ADMIN_USER_EMAIL").secretValue;
+export const getAdminEmail = async () => (await client.getSecret("ADMIN_EMAIL").secretValue;
 export const getAdminPassword = async () => (await client.getSecret("ADMIN_PASSWORD").secretValue;
 
 export const getLicenseKey = async () => {

--- a/backend/src/utils/addAdminUser.ts
+++ b/backend/src/utils/addAdminUser.ts
@@ -7,9 +7,9 @@
 import { Key, Membership, MembershipOrg, Organization, User, Workspace } from "../models";
 import { SecretService } from "../services";
 import { Types } from "mongoose";
-import { getCreateAdminUser, getAdminUserEmail, getAdminPassword } from "../config";
+import { getCreateAdminUser, getAdminEmail, getAdminPassword } from "../config";
 
-export const adminUserEmail = await getAdminUserEmail()
+export const adminUserEmail = await getAdminEmail()
 export const adminUserPassword = await getAdminPassword()
 export const adminUserId = "63cefa6ec8d3175601cfa980"
 export const adminWorkspaceId = "63cefb15c8d3175601cfa989"

--- a/backend/src/utils/addAdminUser.ts
+++ b/backend/src/utils/addAdminUser.ts
@@ -20,7 +20,7 @@ export const adminWorkspaceKeyId = "63cf48f0225e6955acec5eff"
 export const plainTextWorkspaceKey = "543fef8224813a46230b0a50a46c5fb2"
 
 export const createInitialAdminUser = async () => {
-  if (( await getCreateAdminUser()) === "true") {
+  if (( await getCreateAdminUser()) === "True") {
     const adminUser = {
       _id: adminUserId,
       email: adminUserEmail,

--- a/backend/src/utils/addAdminUser.ts
+++ b/backend/src/utils/addAdminUser.ts
@@ -9,8 +9,8 @@ import { SecretService } from "../services";
 import { Types } from "mongoose";
 import { getCreateAdminUser, getAdminEmail, getAdminPassword } from "../config";
 
-export const adminUserEmail = await getAdminEmail()
-export const adminUserPassword = await getAdminPassword()
+export const adminUserEmail = getAdminEmail();
+export const adminUserPassword = getAdminPassword();
 export const adminUserId = "63cefa6ec8d3175601cfa980"
 export const adminWorkspaceId = "63cefb15c8d3175601cfa989"
 export const adminOrgId = "63cefb15c8d3175601cfa985"
@@ -134,6 +134,10 @@ export const createInitialAdminUser = async () => {
         await Key.create(adminWorkspaceKey)
       }
 
+    } catch (e) {
+      /* eslint-disable no-console */
+      console.error(`Unable to create admin user while booting up [err=${e}]`)
+      /* eslint-enable no-console */
     }
   }
 }

--- a/backend/src/utils/addAdminUser.ts
+++ b/backend/src/utils/addAdminUser.ts
@@ -134,6 +134,10 @@ export const createInitialAdminUser = async () => {
         await Key.create(adminWorkspaceKey)
       }
 
+      /* eslint-disable no-console */
+      console.info(`Success, Admin user has been created.`)
+      /* eslint-enable no-console */
+
     } catch (e) {
       /* eslint-disable no-console */
       console.error(`Unable to create admin user while booting up [err=${e}]`)

--- a/backend/src/utils/setup/index.ts
+++ b/backend/src/utils/setup/index.ts
@@ -4,6 +4,7 @@ import { setTransporter } from "../../helpers/nodemailer";
 import { EELicenseService } from "../../ee/services";
 import { initSmtp } from "../../services/smtp";
 import { createTestUserForDevelopment } from "../addDevelopmentUser";
+import { createInitialAdminUser } from "../addAdminUser";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 import { validateEncryptionKeysConfig } from "./validateConfig";
 import {
@@ -97,4 +98,6 @@ export const setup = async () => {
   });
 
   await createTestUserForDevelopment();
+
+  await createInitialAdminUser();
 };

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -168,6 +168,10 @@ backendEnvironmentVariables:
   ## e.g. "mongodb://<user>:<pass>@<host>:<port>/<database-name>"
   ##
   MONGO_URL: ""
+  ##
+  CREATE_ADMIN_USER: false
+  ADMIN_EMAIL: ""
+  ADMIN_PASSWORD: ""
 
 ## @section MongoDB(&reg;) parameters
 ## Documentation : https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml


### PR DESCRIPTION
# Description 📣

Attempt to create an initial admin user to solve #873. I am not a typescript developer, but I wanted to put some code out there and try to help anyway.

I don't know how to generate the workspace, user, and org IDs, but I would be happy to fix that and properly create them on run.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

here's my .env file:
```env
# Keys
# Required key for platform encryption/decryption ops
ENCRYPTION_KEY=6c1fe4e407b8911c104518103505b218

# JWT
# Required secrets to sign JWT tokens
JWT_SIGNUP_SECRET=3679e04ca949f914c03332aaaeba805a
JWT_REFRESH_SECRET=5f2f3c8f0159068dc2bbb3a652a716ff
JWT_AUTH_SECRET=4be6ba5602e0fa0ac6ac05c3cd4d247f
JWT_SERVICE_SECRET=f32f716d70a42c5703f4656015e76200

# MongoDB
# Backend will connect to the MongoDB instance at connection string MONGO_URL which can either be a ref
# to the MongoDB container instance or Mongo Cloud
# Required
MONGO_URL=mongodb://root:example@mongo:27017/?authSource=admin

# Optional credentials for MongoDB container instance and Mongo-Express
MONGO_USERNAME=root
MONGO_PASSWORD=example

# Website URL
# Required
SITE_URL=http://localhost:8080

# Mail/SMTP
SMTP_HOST='smtp-server'
SMTP_PORT='1025'
SMTP_NAME='local'
SMTP_USERNAME='team@infisical.com'
SMTP_PASSWORD=

# admin user testing
CREATE_ADMIN_USER=True
ADMIN_EMAIL='cooladmin@cooladmins.com'
ADMIN_PASSWORD='coolestAdmin2023'
```

Here's the commands I ran on my branch:

```sh
# Here's some code block to paste some code snippets
source .env
/opt/homebrew/bin/docker-compose -f docker-compose.dev.yml up --build --force-recreate
```

Then I logged in via the infisical interface at http://localhost:8080 as a test user, but I can't get it to work with the admin user :( When I check the logs, it logs that it successfully created the admin user, but when I try to log in as that user, it says user not found in the logs.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝