### PR TITLE
Convert arrow keys to html entities so it'll be visible in the dashboard

### DIFF
--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -7,7 +7,30 @@ import { useToggle } from "@app/hooks";
 
 const REGEX = /\${([^}]+)}/g;
 const stripSpanTags = (str: string) => str.replace(/<\/?span[^>]*>/g, "");
+
+const entitiesToReplace = {
+  '<': '&lt;',
+  '>': '&gt;',
+}
+
+const escapeEntitiesFromString = (htmlString: string) => {
+  for (const [key, value] of Object.entries(entitiesToReplace)) {
+    htmlString = htmlString.replaceAll(key, value)
+  }
+
+  return htmlString;
+}
+
+const convertEscapedEntitiesToHTML = (value: string) => {
+  for (const [key, val] of Object.entries(entitiesToReplace)) {
+    value = value.replaceAll(val, key)
+  }
+
+  return value;
+}
+
 const replaceContentWithDot = (str: string) => {
+  str = convertEscapedEntitiesToHTML(str)
   let finalStr = "";
   let isHtml = false;
   for (let i = 0; i < str.length; i += 1) {
@@ -36,7 +59,7 @@ const syntaxHighlight = (orgContent?: string | null, isVisible?: boolean) => {
       `<span class="ph-no-capture text-yellow">&#36;&#123;<span class="ph-no-capture text-yello-200/80">${b}</span>&#125;</span>`
   );
 
-  return newContent;
+  return escapeEntitiesFromString(content);
 };
 
 const sanitizeConf = {
@@ -60,6 +83,7 @@ export const SecretInput = ({
   ...props
 }: Props) => {
   const [isSecretFocused, setIsSecretFocused] = useToggle();
+  const html = syntaxHighlight(value, isVisible || isSecretFocused)
 
   return (
     <div
@@ -68,7 +92,7 @@ export const SecretInput = ({
     >
       <div
         dangerouslySetInnerHTML={{
-          __html: syntaxHighlight(value, isVisible || isSecretFocused)
+          __html: html,
         }}
         className={`absolute top-0 left-0 z-0 h-full w-full text-ellipsis whitespace-pre-line break-all ${
           !value && value !== "" && "italic text-red-600/70"
@@ -87,7 +111,7 @@ export const SecretInput = ({
           if (onBlur) onBlur(sanitizeHtml(evt.currentTarget.innerHTML || "", sanitizeConf));
           setIsSecretFocused.off();
         }}
-        html={isVisible || isSecretFocused ? value || "" : syntaxHighlight(value, false)}
+        html={html}
         {...props}
       />
     </div>

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -53,7 +53,10 @@ const syntaxHighlight = (orgContent?: string | null, isVisible?: boolean) => {
   if (!orgContent) return "missing";
   if (!isVisible) return replaceContentWithDot(orgContent);
   const content = stripSpanTags(orgContent);
-  const escapedContent = escapeEntitiesFromString(content)
+  const escapedContent = sanitizeHtml(content, {
+    ...sanitizeConf,
+    disallowedTagsMode: 'escape',
+  });
   const newContent = escapedContent.replace(
     REGEX,
     (_a, b) =>

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -59,7 +59,7 @@ const syntaxHighlight = (orgContent?: string | null, isVisible?: boolean) => {
       `<span class="ph-no-capture text-yellow">&#36;&#123;<span class="ph-no-capture text-yello-200/80">${b}</span>&#125;</span>`
   );
 
-  return escapeEntitiesFromString(content);
+  return escapeEntitiesFromString(newContent);
 };
 
 const sanitizeConf = {

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -8,26 +8,18 @@ import { useToggle } from "@app/hooks";
 const REGEX = /\${([^}]+)}/g;
 const stripSpanTags = (str: string) => str.replace(/<\/?span[^>]*>/g, "");
 
-const entitiesToReplace = {
-  '<': '&lt;',
-  '>': '&gt;',
-}
-
-const escapeEntitiesFromString = (htmlString: string) => {
-  for (const [key, value] of Object.entries(entitiesToReplace)) {
-    htmlString = htmlString.replaceAll(key, value)
-  }
-
-  return htmlString;
-}
-
 const convertEscapedEntitiesToHTML = (value: string) => {
+  const entitiesToReplace = {
+    '&lt;': "-",
+    '&gt;': "-",
+  }
   for (const [key, val] of Object.entries(entitiesToReplace)) {
-    value = value.replaceAll(val, key)
+    value = value.replaceAll(key, val)
   }
 
   return value;
 }
+
 
 const replaceContentWithDot = (str: string) => {
   str = convertEscapedEntitiesToHTML(str)

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-danger */
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useMemo } from "react";
 import ContentEditable from "react-contenteditable";
 import sanitizeHtml from "sanitize-html";
 
@@ -53,13 +53,14 @@ const syntaxHighlight = (orgContent?: string | null, isVisible?: boolean) => {
   if (!orgContent) return "missing";
   if (!isVisible) return replaceContentWithDot(orgContent);
   const content = stripSpanTags(orgContent);
-  const newContent = content.replace(
+  const escapedContent = escapeEntitiesFromString(content)
+  const newContent = escapedContent.replace(
     REGEX,
     (_a, b) =>
       `<span class="ph-no-capture text-yellow">&#36;&#123;<span class="ph-no-capture text-yello-200/80">${b}</span>&#125;</span>`
   );
 
-  return escapeEntitiesFromString(newContent);
+  return newContent;
 };
 
 const sanitizeConf = {
@@ -83,7 +84,10 @@ export const SecretInput = ({
   ...props
 }: Props) => {
   const [isSecretFocused, setIsSecretFocused] = useToggle();
-  const html = syntaxHighlight(value, isVisible || isSecretFocused)
+  
+  const hiddenValue = useMemo(() => syntaxHighlight(value, false), [value])
+  const originalValue = useMemo(() => syntaxHighlight(value, true), [value])
+  const html = isVisible || isSecretFocused ? originalValue : hiddenValue
 
   return (
     <div


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Converted the angle brackets with html entities so that the content editable won't escape the characters. I don't know why we need to sanitize html but it's still there in `onBlur`

Fixes #820 and #863

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝