### PR TITLE
Update signup secret distinction/tagging for better telemetry

### DIFF
--- a/backend/src/controllers/v2/secretsController.ts
+++ b/backend/src/controllers/v2/secretsController.ts
@@ -234,6 +234,9 @@ export const batchSecrets = async (req: Request, res: Response) => {
           $inc: {
             version: 1
           },
+          $unset: {
+            'metadata.source': true as true
+          },
           ...u,
           _id: new Types.ObjectId(u._id)
         }
@@ -739,7 +742,6 @@ export const createSecrets = async (req: Request, res: Response) => {
  * @returns
  */
 export const getSecrets = async (req: Request, res: Response) => {
-  console.log("getSecrets");
   /* 
     #swagger.summary = 'Read secrets'
     #swagger.description = 'Read secrets from a project and environment'
@@ -968,12 +970,8 @@ export const getSecrets = async (req: Request, res: Response) => {
 
   const postHogClient = await TelemetryService.getPostHogClient();
   
-  console.log("the fetched secrets: ", secrets);
-  console.log("postHogClient: ", postHogClient);
-  
   if (postHogClient) {
-    console.log("should capture!");
-    const test = postHogClient.capture({
+    postHogClient.capture({
       event: "secrets pulled",
       distinctId: await TelemetryService.getDistinctId({
         authData: req.authData
@@ -987,8 +985,6 @@ export const getSecrets = async (req: Request, res: Response) => {
         userAgent: req.headers?.["user-agent"]
       }
     });
-    
-    console.log("test: ", test);
   }
 
   return res.status(200).send({

--- a/backend/src/controllers/v2/secretsController.ts
+++ b/backend/src/controllers/v2/secretsController.ts
@@ -739,6 +739,7 @@ export const createSecrets = async (req: Request, res: Response) => {
  * @returns
  */
 export const getSecrets = async (req: Request, res: Response) => {
+  console.log("getSecrets");
   /* 
     #swagger.summary = 'Read secrets'
     #swagger.description = 'Read secrets from a project and environment'
@@ -966,8 +967,13 @@ export const getSecrets = async (req: Request, res: Response) => {
   );
 
   const postHogClient = await TelemetryService.getPostHogClient();
+  
+  console.log("the fetched secrets: ", secrets);
+  console.log("postHogClient: ", postHogClient);
+  
   if (postHogClient) {
-    postHogClient.capture({
+    console.log("should capture!");
+    const test = postHogClient.capture({
       event: "secrets pulled",
       distinctId: await TelemetryService.getDistinctId({
         authData: req.authData
@@ -981,6 +987,8 @@ export const getSecrets = async (req: Request, res: Response) => {
         userAgent: req.headers?.["user-agent"]
       }
     });
+    
+    console.log("test: ", test);
   }
 
   return res.status(200).send({

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -28,9 +28,6 @@ export interface ISecretVersion {
   createdAt: string;
   folder?: string;
   tags?: string[];
-  metadata?: {
-    [key: string]: string;
-  }
 }
 
 const secretVersionSchema = new Schema<ISecretVersion>(
@@ -120,9 +117,6 @@ const secretVersionSchema = new Schema<ISecretVersion>(
       ref: "Tag",
       type: [Schema.Types.ObjectId],
       default: [],
-    },
-    metadata: {
-      type: Schema.Types.Mixed
     }
   },
   {

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -28,6 +28,9 @@ export interface ISecretVersion {
   createdAt: string;
   folder?: string;
   tags?: string[];
+  metadata?: {
+    [key: string]: string;
+  }
 }
 
 const secretVersionSchema = new Schema<ISecretVersion>(
@@ -118,6 +121,9 @@ const secretVersionSchema = new Schema<ISecretVersion>(
       type: [Schema.Types.ObjectId],
       default: [],
     },
+    metadata: {
+      type: Schema.Types.Mixed
+    }
   },
   {
     timestamps: true,

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -393,9 +393,10 @@ export const createSecretHelper = async ({
     secretCommentTag,
     folder: folderId,
     algorithm: ALGORITHM_AES_256_GCM,
-    keyEncoding: ENCODING_SCHEME_UTF8
+    keyEncoding: ENCODING_SCHEME_UTF8,
+    metadata
   }).save();
-
+  
   const secretVersion = new SecretVersion({
     secret: secret._id,
     version: secret.version,
@@ -413,9 +414,10 @@ export const createSecretHelper = async ({
     secretValueIV,
     secretValueTag,
     algorithm: ALGORITHM_AES_256_GCM,
-    keyEncoding: ENCODING_SCHEME_UTF8
+    keyEncoding: ENCODING_SCHEME_UTF8,
+    metadata
   });
-
+  
   // (EE) add version for new secret
   await EESecretService.addSecretVersions({
     secretVersions: [secretVersion]

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -414,8 +414,7 @@ export const createSecretHelper = async ({
     secretValueIV,
     secretValueTag,
     algorithm: ALGORITHM_AES_256_GCM,
-    keyEncoding: ENCODING_SCHEME_UTF8,
-    metadata
+    keyEncoding: ENCODING_SCHEME_UTF8
   });
   
   // (EE) add version for new secret

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -568,15 +568,17 @@ export const getSecretsHelper = async ({
   );
 
   const postHogClient = await TelemetryService.getPostHogClient();
+  
+  const numberOfSignupSecrets = (secrets.filter((secret) => secret?.metadata?.source === "signup")).length;
 
-  if (postHogClient) {
+  if (postHogClient && (secrets.length - numberOfSignupSecrets > 0)) {
     postHogClient.capture({
       event: "secrets pulled",
       distinctId: await TelemetryService.getDistinctId({
         authData
       }),
       properties: {
-        numberOfSecrets: secrets.length,
+        numberOfSecrets: secrets.length - numberOfSignupSecrets,
         environment,
         workspaceId,
         folderId,

--- a/backend/src/models/secret.ts
+++ b/backend/src/models/secret.ts
@@ -31,6 +31,9 @@ export interface ISecret {
   keyEncoding: "utf8" | "base64";
   tags?: string[];
   folder?: string;
+  metadata?: {
+    [key: string]: string;
+  }
 }
 
 const secretSchema = new Schema<ISecret>(
@@ -131,6 +134,9 @@ const secretSchema = new Schema<ISecret>(
       type: String,
       default: "root",
     },
+    metadata: {
+      type: Schema.Types.Mixed
+    }
   },
   {
     timestamps: true,

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -38,7 +38,7 @@ const fetchProjectEncryptedSecrets = async (
   folderId?: string,
   secretPath?: string
 ) => {
-  const { data } = await apiRequest.get<{ secrets: EncryptedSecret[] }>("/api/v2/secrets", {
+  const { data } = await apiRequest.get<{ secrets: EncryptedSecret[] }>("/api/v3/secrets", {
     params: {
       environment: env,
       workspaceId,
@@ -46,6 +46,7 @@ const fetchProjectEncryptedSecrets = async (
       secretPath
     }
   });
+  
   return data.secrets;
 };
 


### PR DESCRIPTION
# Description 📣

This PR changes the approach to distinguishing between `signup` and other normal secrets for the purposes of telemetry. More specifically:

- When a new user signs up, then the secrets added to their default project are tagged `metadata.source = "signup"`.
- When a user updates the value of an existing secret via dashboard, then the `metadata.source` is `$unset` as this is no longer considered a `signup` secret.
- When the user fetches secrets back for their dashboard (moved from `GET v2/secrets` to `GET v3/secrets` then (1) if all the secrets are `signup` secrets, then it won't send telemetry; (2) if there is at least 1 non-signup secret, then it will send the number of non-signup secrets to telemetry.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝