### PR TITLE
Expose CRUD Environment Operations to Public REST API

### DIFF
--- a/backend/src/routes/v2/environment.ts
+++ b/backend/src/routes/v2/environment.ts
@@ -16,7 +16,7 @@ import {
 router.post(
   "/:workspaceId/environments",
   requireAuth({
-    acceptedAuthModes: [AuthMode.JWT],
+    acceptedAuthModes: [AuthMode.JWT, AuthMode.API_KEY],
   }),
   requireWorkspaceAuth({
     acceptedRoles: [ADMIN, MEMBER],
@@ -32,7 +32,7 @@ router.post(
 router.put(
   "/:workspaceId/environments",
   requireAuth({
-    acceptedAuthModes: [AuthMode.JWT],
+    acceptedAuthModes: [AuthMode.JWT, AuthMode.API_KEY],
   }),
   requireWorkspaceAuth({
     acceptedRoles: [ADMIN, MEMBER],
@@ -49,7 +49,7 @@ router.put(
 router.patch(
   "/:workspaceId/environments",
   requireAuth({
-    acceptedAuthModes: [AuthMode.JWT],
+    acceptedAuthModes: [AuthMode.JWT, AuthMode.API_KEY],
   }),
   requireWorkspaceAuth({
     acceptedRoles: [ADMIN, MEMBER],
@@ -67,7 +67,7 @@ router.patch(
 router.delete(
   "/:workspaceId/environments",
   requireAuth({
-    acceptedAuthModes: [AuthMode.JWT],
+    acceptedAuthModes: [AuthMode.JWT, AuthMode.API_KEY],
   }),
   requireWorkspaceAuth({
     acceptedRoles: [ADMIN],
@@ -82,7 +82,7 @@ router.delete(
 router.get(
   "/:workspaceId/environments",
   requireAuth({
-    acceptedAuthModes: [AuthMode.JWT],
+    acceptedAuthModes: [AuthMode.JWT, AuthMode.API_KEY],
   }),
   requireWorkspaceAuth({
     acceptedRoles: [MEMBER, ADMIN],

--- a/docs/api-reference/endpoints/environments/create.mdx
+++ b/docs/api-reference/endpoints/environments/create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create"
+openapi: "POST /api/v2/workspace/{workspaceId}/environments"
+---

--- a/docs/api-reference/endpoints/environments/delete.mdx
+++ b/docs/api-reference/endpoints/environments/delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Delete"
+openapi: "DELETE /api/v2/workspace/{workspaceId}/environments"
+---

--- a/docs/api-reference/endpoints/environments/list.mdx
+++ b/docs/api-reference/endpoints/environments/list.mdx
@@ -1,0 +1,4 @@
+---
+title: "List"
+openapi: "GET /api/v2/workspace/{workspaceId}/environments"
+---

--- a/docs/api-reference/endpoints/environments/update.mdx
+++ b/docs/api-reference/endpoints/environments/update.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update"
+openapi: "PUT /api/v2/workspace/{workspaceId}/environments"
+---

--- a/docs/api-reference/endpoints/secrets/list.mdx
+++ b/docs/api-reference/endpoints/secrets/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Retrieve"
-openapi: "GET /api/v3/secrets/{secretName}"
+title: "List"
+openapi: "GET /api/v3/secrets/"
 ---
 
 <Tip>

--- a/docs/api-reference/endpoints/secrets/read.mdx
+++ b/docs/api-reference/endpoints/secrets/read.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Retrieve All"
-openapi: "GET /api/v3/secrets/"
+title: "Retrieve"
+openapi: "GET /api/v3/secrets/{secretName}"
 ---
 
 <Tip>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -322,11 +322,20 @@
           ]
         },
         {
+          "group": "Environments",
+          "pages": [
+            "api-reference/endpoints/environments/list",
+            "api-reference/endpoints/environments/create",
+            "api-reference/endpoints/environments/update",
+            "api-reference/endpoints/environments/delete"
+          ]
+        },
+        {
           "group": "Secrets",
           "pages": [
-            "api-reference/endpoints/secrets/read",
+            "api-reference/endpoints/secrets/list",
             "api-reference/endpoints/secrets/create",
-            "api-reference/endpoints/secrets/read-one",
+            "api-reference/endpoints/secrets/read",
             "api-reference/endpoints/secrets/update",
             "api-reference/endpoints/secrets/delete",
             "api-reference/endpoints/secrets/versions",


### PR DESCRIPTION
# Description 📣

This PR:

- Adds `API_KEY` as a form of authentication for the CRUD environment endpoints.
- Adds the environment endpoints to the REST API documentation.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝