### PR TITLE
Rewire dashboard to pull from v3/secrets with folderId support

### DIFF
--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -23,6 +23,7 @@ export const getSecretsRaw = async (req: Request, res: Response) => {
   let workspaceId = req.query.workspaceId as string;
   let environment = req.query.environment as string;
   let secretPath = req.query.secretPath as string;
+  const folderId = req.query.folderId as string | undefined;
   const includeImports = req.query.include_imports as string;
 
   // if the service token has single scope, it will get all secrets for that scope by default
@@ -47,6 +48,7 @@ export const getSecretsRaw = async (req: Request, res: Response) => {
   const secrets = await SecretService.getSecrets({
     workspaceId: new Types.ObjectId(workspaceId),
     environment,
+    folderId,
     secretPath,
     authData: req.authData
   });
@@ -284,11 +286,13 @@ export const getSecrets = async (req: Request, res: Response) => {
   const workspaceId = req.query.workspaceId as string;
   const environment = req.query.environment as string;
   const secretPath = req.query.secretPath as string;
+  const folderId = req.query.folderId as string | undefined;
   const includeImports = req.query.include_imports as string;
 
   const secrets = await SecretService.getSecrets({
     workspaceId: new Types.ObjectId(workspaceId),
     environment,
+    folderId,
     secretPath,
     authData: req.authData
   });

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -498,6 +498,7 @@ export const getSecretsHelper = async ({
   workspaceId,
   environment,
   authData,
+  folderId,
   secretPath = "/"
 }: GetSecretsParams) => {
   let secrets: ISecret[] = [];
@@ -507,7 +508,10 @@ export const getSecretsHelper = async ({
       throw UnauthorizedRequestError({ message: "Folder Permission Denied" });
     }
   }
-  const folderId = await getFolderIdFromServiceToken(workspaceId, environment, secretPath);
+  
+  if (!folderId) {
+    folderId = await getFolderIdFromServiceToken(workspaceId, environment, secretPath);
+  }
 
   // get personal secrets first
   secrets = await Secret.find({

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -25,6 +25,7 @@ export interface CreateSecretParams {
 export interface GetSecretsParams {
   workspaceId: Types.ObjectId;
   environment: string;
+  folderId?: string;
   secretPath: string;
   authData: AuthData;
 }

--- a/backend/src/routes/v3/secrets.ts
+++ b/backend/src/routes/v3/secrets.ts
@@ -17,6 +17,7 @@ router.get(
   "/raw",
   query("workspaceId").optional().isString().trim(),
   query("environment").optional().isString().trim(),
+  query("folderId").optional().isString().trim(),
   query("secretPath").default("/").isString().trim(),
   query("include_imports").optional().isBoolean().default(false),
   validateRequest,
@@ -144,6 +145,7 @@ router.get(
   "/",
   query("workspaceId").exists().isString().trim(),
   query("environment").exists().isString().trim(),
+  query("folderId").optional().isString().trim(),
   query("secretPath").default("/").isString().trim(),
   validateRequest,
   requireAuth({

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -38,7 +38,7 @@ const fetchProjectEncryptedSecrets = async (
   folderId?: string,
   secretPath?: string
 ) => {
-  const { data } = await apiRequest.get<{ secrets: EncryptedSecret[] }>("/api/v2/secrets", {
+  const { data } = await apiRequest.get<{ secrets: EncryptedSecret[] }>("/api/v3/secrets", {
     params: {
       environment: env,
       workspaceId,


### PR DESCRIPTION
# Description 📣

This PR rewires the dashboard to pull secrets from `v3/secrets` instead of `v2/secrets`.

Previously, `v3/secrets` did not support the `folderId` parameter like `v2/secrets` which led to bugs on the dashboard when attempting the transition; the simple change in this PR is:

- If `folderId` is present, then it is used in the query for secrets.
- If `folderId` is not present, then default to the `secretPath` parameter to obtain the `folderId`; if `secretPath` is not present, then the default path is set to `/`.


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝