### PR TITLE
Patch: correct envar ref for temp MFA JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ JWT_REFRESH_SECRET=5f2f3c8f0159068dc2bbb3a652a716ff
 JWT_AUTH_SECRET=4be6ba5602e0fa0ac6ac05c3cd4d247f
 JWT_SERVICE_SECRET=f32f716d70a42c5703f4656015e76200
 JWT_PROVIDER_AUTH_SECRET=f32f716d70a42c5703f4656015e76201
+JWT_MFA_SECRET=fe9c5461e895b6726be6c7990f718841
 
 # JWT lifetime
 # Optional lifetimes for JWT tokens expressed in seconds or a string 
@@ -18,6 +19,7 @@ JWT_AUTH_LIFETIME=
 JWT_REFRESH_LIFETIME=
 JWT_SIGNUP_LIFETIME=
 JWT_PROVIDER_AUTH_LIFETIME=
+JWT_MFA_LIFETIME=
 
 # MongoDB
 # Backend will connect to the MongoDB instance at connection string MONGO_URL which can either be a ref

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -18,7 +18,7 @@ export const getSaltRounds = async () => parseInt((await client.getSecret("SALT_
 export const getJwtAuthLifetime = async () => (await client.getSecret("JWT_AUTH_LIFETIME")).secretValue || "10d";
 export const getJwtAuthSecret = async () => (await client.getSecret("JWT_AUTH_SECRET")).secretValue;
 export const getJwtMfaLifetime = async () => (await client.getSecret("JWT_MFA_LIFETIME")).secretValue || "5m";
-export const getJwtMfaSecret = async () => (await client.getSecret("JWT_MFA_LIFETIME")).secretValue || "5m";
+export const getJwtMfaSecret = async () => (await client.getSecret("JWT_MFA_SECRET")).secretValue;
 export const getJwtRefreshLifetime = async () => (await client.getSecret("JWT_REFRESH_LIFETIME")).secretValue || "90d";
 export const getJwtRefreshSecret = async () => (await client.getSecret("JWT_REFRESH_SECRET")).secretValue;
 export const getJwtServiceSecret = async () => (await client.getSecret("JWT_SERVICE_SECRET")).secretValue;


### PR DESCRIPTION
# Description 📣

MFA JWT secret references wrong envar. 
Patched to correct envar ref & removed null default.
Added MFA JWT params to .env example.

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Verified works with the two-factor email code.

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝