### PR TITLE
Add support for syncing secrets containing / to AWS parameter store integration

### DIFF
--- a/backend/src/integrations/sync.ts
+++ b/backend/src/integrations/sync.ts
@@ -688,15 +688,17 @@ const syncSecretsAWSParameterStore = async ({
   const parameterList = (await ssm.getParametersByPath(params).promise()).Parameters;
 
   let awsParameterStoreSecretsObj: {
-    [key: string]: any; // TODO: fix type
+    [key: string]: any;
   } = {};
 
   if (parameterList) {
     awsParameterStoreSecretsObj = parameterList.reduce(
-      (obj: any, secret: any) => ({
-        ...obj,
-        [secret.Name.split("/").pop()]: secret
-      }),
+      (obj: any, secret: any) => {
+        return ({
+          ...obj,
+          [secret.Name.substring(integration.path.length)]: secret
+        });
+      },
       {}
     );
   }


### PR DESCRIPTION
# Description 📣

This PR adds support for syncing secrets containing `/ ` to the AWS parameter store integration.

Previously, you could define a path (to prepend) like `/project/name/` to a secret like `test1/test2` to be synced for this integration. Now, doing so syncs the secret under `/project/name/test1/test2` to AWS parameter store.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝