### PR TITLE
Fix null appId argument for creating PAT integration

### DIFF
--- a/frontend/src/hooks/api/integrations/queries.tsx
+++ b/frontend/src/hooks/api/integrations/queries.tsx
@@ -46,8 +46,8 @@ export const useCreateIntegration = () => {
       integrationAuthId: string;
       isActive: boolean;
       secretPath: string;
-      app?: string | null;
-      appId?: string | null;
+      app?: string;
+      appId?: string;
       sourceEnvironment: string;
       targetEnvironment: string | null;
       targetEnvironmentId: string | null;

--- a/frontend/src/pages/integrations/aws-parameter-store/create.tsx
+++ b/frontend/src/pages/integrations/aws-parameter-store/create.tsx
@@ -97,8 +97,6 @@ export default function AWSParameterStoreCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app: null,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/aws-secret-manager/create.tsx
+++ b/frontend/src/pages/integrations/aws-secret-manager/create.tsx
@@ -97,7 +97,6 @@ export default function AWSSecretManagerCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetSecretName.trim(),
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/azure-key-vault/create.tsx
+++ b/frontend/src/pages/integrations/azure-key-vault/create.tsx
@@ -60,7 +60,6 @@ export default function AzureKeyVaultCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: vaultBaseUrl,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/circleci/create.tsx
+++ b/frontend/src/pages/integrations/circleci/create.tsx
@@ -66,9 +66,7 @@ export default function CircleCICreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/cloud-66/create.tsx
+++ b/frontend/src/pages/integrations/cloud-66/create.tsx
@@ -64,9 +64,7 @@ export default function Cloud66CreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/codefresh/create.tsx
+++ b/frontend/src/pages/integrations/codefresh/create.tsx
@@ -64,9 +64,7 @@ export default function CodefreshCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/digital-ocean-app-platform/create.tsx
+++ b/frontend/src/pages/integrations/digital-ocean-app-platform/create.tsx
@@ -64,9 +64,7 @@ export default function DigitalOceanAppPlatformCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/flyio/create.tsx
+++ b/frontend/src/pages/integrations/flyio/create.tsx
@@ -67,7 +67,6 @@ export default function FlyioCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/gcp-secret-manager/create.tsx
+++ b/frontend/src/pages/integrations/gcp-secret-manager/create.tsx
@@ -64,7 +64,7 @@ export default function GCPSecretManagerCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name ?? null,
+        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,

--- a/frontend/src/pages/integrations/gcp-secret-manager/pat/create.tsx
+++ b/frontend/src/pages/integrations/gcp-secret-manager/pat/create.tsx
@@ -60,7 +60,7 @@ export default function GCPSecretManagerCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name ?? null,
+        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,

--- a/frontend/src/pages/integrations/github/create.tsx
+++ b/frontend/src/pages/integrations/github/create.tsx
@@ -71,7 +71,6 @@ export default function GitHubCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp.name,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/gitlab/create.tsx
+++ b/frontend/src/pages/integrations/gitlab/create.tsx
@@ -94,10 +94,7 @@ export default function GitLabCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app:
-          integrationAuthApps?.find(
-            (integrationAuthApp) => integrationAuthApp.appId === targetAppId
-          )?.name ?? null,
+        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: targetEnvironment === "" ? "*" : targetEnvironment,

--- a/frontend/src/pages/integrations/hashicorp-vault/create.tsx
+++ b/frontend/src/pages/integrations/hashicorp-vault/create.tsx
@@ -65,7 +65,6 @@ export default function HashiCorpVaultCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: vaultEnginePath,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/heroku/create.tsx
+++ b/frontend/src/pages/integrations/heroku/create.tsx
@@ -65,7 +65,6 @@ export default function HerokuCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId: null,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/laravel-forge/create.tsx
+++ b/frontend/src/pages/integrations/laravel-forge/create.tsx
@@ -64,9 +64,7 @@ export default function LaravelForgeCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/netlify/create.tsx
+++ b/frontend/src/pages/integrations/netlify/create.tsx
@@ -73,9 +73,7 @@ export default function NetlifyCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/northflank/create.tsx
+++ b/frontend/src/pages/integrations/northflank/create.tsx
@@ -85,9 +85,7 @@ export default function NorthflankCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app: integrationAuthApps?.find(
-            (integrationAuthApp) => integrationAuthApp.appId === targetAppId
-          )?.name ?? null,
+        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,

--- a/frontend/src/pages/integrations/render/create.tsx
+++ b/frontend/src/pages/integrations/render/create.tsx
@@ -64,9 +64,7 @@ export default function RenderCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/supabase/create.tsx
+++ b/frontend/src/pages/integrations/supabase/create.tsx
@@ -65,9 +65,7 @@ export default function SupabaseCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/teamcity/create.tsx
+++ b/frontend/src/pages/integrations/teamcity/create.tsx
@@ -74,7 +74,7 @@ export default function TeamCityCreateIntegrationPage() {
       await mutateAsync({
         integrationAuthId: integrationAuth?._id,
         isActive: true,
-        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name ?? null,
+        app: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.appId === targetAppId)?.name,
         appId: targetAppId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: targetEnvironment ? targetEnvironment.name : null,

--- a/frontend/src/pages/integrations/terraform-cloud/create.tsx
+++ b/frontend/src/pages/integrations/terraform-cloud/create.tsx
@@ -76,9 +76,7 @@ export default function TerraformCloudCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/travisci/create.tsx
+++ b/frontend/src/pages/integrations/travisci/create.tsx
@@ -64,9 +64,7 @@ export default function TravisCICreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,

--- a/frontend/src/pages/integrations/windmill/create.tsx
+++ b/frontend/src/pages/integrations/windmill/create.tsx
@@ -65,9 +65,7 @@ export default function WindmillCreateIntegrationPage() {
         integrationAuthId: integrationAuth?._id,
         isActive: true,
         app: targetApp,
-        appId:
-          integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)
-            ?.appId ?? null,
+        appId: integrationAuthApps?.find((integrationAuthApp) => integrationAuthApp.name === targetApp)?.appId,
         sourceEnvironment: selectedSourceEnvironment,
         targetEnvironment: null,
         targetEnvironmentId: null,


### PR DESCRIPTION
# Description 📣

In a previous PR, we removed support for `null` `appId` and `app` values for the endpoint responsible for creating a PAT integration; this caused issues for integrations that are still sending `null` values over during the creation process.

This PR fixes this issue by not sending any values at all if `appId` and `app` are not relevant.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝