### PR TITLE
Update gcp-secret-manager.mdx

### DIFF
--- a/docs/integrations/cloud/gcp-secret-manager.mdx
+++ b/docs/integrations/cloud/gcp-secret-manager.mdx
@@ -108,7 +108,7 @@ Select which Infisical environment secrets you want to sync to the GCP secret ma
    ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-api-services.png) 
    ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app.png) 
     
-    Create the application. As part of the form, add to **Authorized redirect URIs**: `https://your-domain.com/integrations/gitlab/oauth2/callback`.
+    Create the application. As part of the form, add to **Authorized redirect URIs**: `https://your-domain.com/integrations/gcp-secret-manager/oauth2/callback`.
    
    ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app-form.png) 
    


### PR DESCRIPTION
# Description 📣

I just found out that there is a typo for the redirect URL. I copied and pasted the URL of https://your-domain.com/integrations/gitlab/oauth2/callback, but it didn't work. Then I saw the image above and it was https://your-domain.com/integrations/gcp-secret-manager/oauth2/callback. Just a small typo but it might cause some confusion.


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝