### PR TITLE
Add helper text and tooltip for secret path

### DIFF
--- a/frontend/src/components/v2/FormControl/FormControl.tsx
+++ b/frontend/src/components/v2/FormControl/FormControl.tsx
@@ -8,12 +8,17 @@ export type FormLabelProps = {
   id?: string;
   isRequired?: boolean;
   label?: ReactNode;
+  icon?: ReactNode;
 };
 
-export const FormLabel = ({ id, label, isRequired }: FormLabelProps) => (
-  <Label.Root className="mb-0.5 ml-1 block text-sm font-normal text-mineshaft-400" htmlFor={id}>
+export const FormLabel = ({ id, label, isRequired, icon }: FormLabelProps) => (
+  <Label.Root
+    className="mb-0.5 ml-1 block flex items-center text-sm font-normal text-mineshaft-400"
+    htmlFor={id}
+  >
     {label}
     {isRequired && <span className="ml-1 text-red">*</span>}
+    {icon && <span className="ml-2 cursor-pointer text-white">{icon}</span>}
   </Label.Root>
 );
 
@@ -47,6 +52,7 @@ export type FormControlProps = {
   errorText?: ReactNode;
   children: JSX.Element;
   className?: string;
+  icon?: ReactNode;
 };
 
 export const FormControl = ({
@@ -57,12 +63,13 @@ export const FormControl = ({
   errorText,
   id,
   isError,
+  icon,
   className
 }: FormControlProps): JSX.Element => {
   return (
     <div className={twMerge("mb-4", className)}>
       {typeof label === "string" ? (
-        <FormLabel label={label} isRequired={isRequired} id={id} />
+        <FormLabel label={label} isRequired={isRequired} id={id} icon={icon} />
       ) : (
         label
       )}

--- a/frontend/src/components/v2/FormControl/FormControl.tsx
+++ b/frontend/src/components/v2/FormControl/FormControl.tsx
@@ -18,7 +18,7 @@ export const FormLabel = ({ id, label, isRequired, icon }: FormLabelProps) => (
   >
     {label}
     {isRequired && <span className="ml-1 text-red">*</span>}
-    {icon && <span className="ml-2 cursor-pointer text-white">{icon}</span>}
+    {icon && <span className="ml-2 text-mineshaft-300 hover:text-mineshaft-200 cursor-default">{icon}</span>}
   </Label.Root>
 );
 

--- a/frontend/src/components/v2/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/v2/Tooltip/Tooltip.tsx
@@ -10,6 +10,7 @@ export type TooltipProps = Omit<TooltipPrimitive.TooltipContentProps, "open" | "
   asChild?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   defaultOpen?: boolean;
+  position?: "top" | "bottom" | "left" | "right";
 };
 
 export const Tooltip = ({
@@ -20,6 +21,7 @@ export const Tooltip = ({
   defaultOpen,
   className,
   asChild = true,
+  position = "top",
   ...props
 }: TooltipProps) => (
   <TooltipPrimitive.Root
@@ -30,7 +32,7 @@ export const Tooltip = ({
   >
     <TooltipPrimitive.Trigger asChild={asChild}>{children}</TooltipPrimitive.Trigger>
     <TooltipPrimitive.Content
-      side="top"
+      side={position}
       align="center"
       sideOffset={5}
       {...props}

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -92,7 +92,7 @@ export const AddWebhookForm = ({
               icon={
                 <Tooltip
                   isOpen={showTip}
-                  onOpenChange={() => setShowTip(false)}
+                  onOpenChange={setShowTip}
                   content={
                     <div>
                       <h4 className="mb-2">Here are some examples of glob patterns:</h4>
@@ -115,12 +115,11 @@ export const AddWebhookForm = ({
                   position="right"
                   className="text-xs"
                 >
-                  <div className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[1px] border-white">
-                    <FontAwesomeIcon
-                      icon={faInfo}
-                      onClick={() => setShowTip(true)}
-                      className="h-2 w-2"
-                    />
+                  <div
+                    className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[1px] border-white"
+                    onMouseEnter={() => setShowTip(true)}
+                  >
+                    <FontAwesomeIcon icon={faInfo} className="h-2 w-2" />
                   </div>
                 </Tooltip>
               }

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -1,5 +1,7 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { faInfo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
@@ -11,7 +13,8 @@ import {
   ModalClose,
   ModalContent,
   Select,
-  SelectItem
+  SelectItem,
+  Tooltip
 } from "@app/components/v2";
 
 const formSchema = yup.object({
@@ -45,6 +48,7 @@ export const AddWebhookForm = ({
   } = useForm<TFormSchema>({
     resolver: yupResolver(formSchema)
   });
+  const [showTip, setShowTip] = useState<boolean>(false);
 
   useEffect(() => {
     if (!isOpen) {
@@ -85,11 +89,50 @@ export const AddWebhookForm = ({
             />
             <FormControl
               label="Secret Path"
+              icon={
+                <Tooltip
+                  isOpen={showTip}
+                  onOpenChange={() => setShowTip(false)}
+                  content={
+                    <div>
+                      <h4 className="mb-2">Here are some examples of glob patterns:</h4>
+                      <div className="ol-listStyleType">
+                        <li>
+                          <code className="text-primary">/</code> - Matches all files and
+                          directories in the current directory
+                        </li>
+                        <li>
+                          <code className="text-primary">**/*</code> - Matches all files and
+                          directories in the current directory and its subdirectories
+                        </li>
+                        <li>
+                          <code className="text-primary">{"/{dir1,dir2}"}</code> - Matches all files
+                          and directories in dir1 and dir2
+                        </li>
+                      </div>
+                    </div>
+                  }
+                  position="right"
+                  className="text-xs"
+                >
+                  <div className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[1px] border-white">
+                    <FontAwesomeIcon
+                      icon={faInfo}
+                      onClick={() => setShowTip(true)}
+                      className="h-2 w-2"
+                    />
+                  </div>
+                </Tooltip>
+              }
               isRequired
               isError={Boolean(errors?.secretPath)}
               errorText={errors?.secretPath?.message}
+              helperText="Glob patterns are used to match multiple files or directories"
             >
-              <Input placeholder="/, /**/*" {...register("secretPath")} />
+              <Input
+                placeholder="glob pattern / or /**/* or /{dir1,dir2}"
+                {...register("secretPath")}
+              />
             </FormControl>
             <FormControl
               label="Secret Key"

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -116,7 +116,7 @@ export const AddWebhookForm = ({
                   className="text-xs"
                 >
                   <div
-                    className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[1px] border-white"
+                    className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[1px] border-mineshaft-300"
                     onMouseEnter={() => setShowTip(true)}
                   >
                     <FontAwesomeIcon icon={faInfo} className="h-2 w-2" />


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR updates the placeholder for the secret path to be less confusing and includes a helper text telling users that they can use glob patterns. It also adds a tooltip containing examples of various glob patterns they can use.

Fixes Issue: [#946](https://github.com/Infisical/infisical/issues/946)


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

This screenshot shows the design for the secret path field, The input field shows the updated placeholder wth the helper texts and also an info icon which the user clicks to  show examples of glob patterns

![image](https://github.com/Infisical/infisical/assets/60752117/9a24b156-3fcf-4c7b-9e03-d742168675bf)

![image](https://github.com/Infisical/infisical/assets/60752117/2fc60bd9-4998-4695-8c28-c9b8220fa43e)


## [Preview Demo](https://www.loom.com/share/3599af38affa4532b744e81491d56222?sid=fd3c2950-5af6-461c-aeeb-4ed9b159898a)


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝