### PR TITLE
changing CMD for Dockerfile  to address issue #984

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 ENV npm_config_cache /home/node/.npm
 
 COPY package*.json ./
-RUN npm ci --only-production
+RUN npm ci --only-production && npm cache clean --force
 
 COPY --from=build /app .
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,4 +30,4 @@ HEALTHCHECK --interval=10s --timeout=3s --start-period=10s \
 
 EXPOSE 4000
 
-CMD ["npm", "run", "start"]
+CMD ["node", "build/index.js"]


### PR DESCRIPTION
# Description 📣

This PR fixes the root cause of #984. By calling node, instead of npm to start the backend the following items are addressed:

* issue #984 is no longer an issue becuase npm does not try to modify the npm cache
* solves issue with backend pods taking a long time to terminate
  *  (npm does not pass SIGTERM and can cause issues with the app in k8s)
  * see [Dockerfile Good Practices for Node and NPM](https://adambrodziak.pl/dockerfile-good-practices-for-node-and-npm#use-node-not-npm-to-start-the-server)

See Slack Thread: https://infisical-users.slack.com/archives/C04BSBMQAQ7/p1694706353813279?thread_ts=1694636663.038499&cid=C04BSBMQAQ7 for additional details.

This PR also contains a small tweak to the npm command in the production stage which cuts ~65MB from the final image per the "Dockerfile Good Practices ..." article above.

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I have tested this change locally in my deployment with no issues. A copy of the image used for testing can be found here: quay.io/xphyr/infisical-backend:v0.34.5


---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝