### PR TITLE
Fix no Auto-Capitalization for secrets get/set. Fixes #1003

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/Infisical/infisical-merge
 
-go 1.19
+go 1.21
 
 require (
 	github.com/charmbracelet/lipgloss v0.5.0

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -198,7 +198,7 @@ var secretsSetCmd = &cobra.Command{
 			}
 
 			// Key and value from argument
-			key := strings.ToUpper(splitKeyValueFromArg[0])
+			key := splitKeyValueFromArg[0]
 			value := splitKeyValueFromArg[1]
 
 			hashedKey := fmt.Sprintf("%x", sha256.Sum256([]byte(key)))
@@ -417,7 +417,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 	secretsMap := getSecretsByKeys(secrets)
 
 	for _, secretKeyFromArg := range args {
-		if value, ok := secretsMap[strings.ToUpper(secretKeyFromArg)]; ok {
+		if value, ok := secretsMap[secretKeyFromArg]; ok {
 			requestedSecrets = append(requestedSecrets, value)
 		} else {
 			requestedSecrets = append(requestedSecrets, models.SingleEnvironmentVariable{
@@ -625,7 +625,7 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 func CenterString(s string, numStars int) string {
 	stars := strings.Repeat("*", numStars)
 	padding := (numStars - len(s)) / 2
-	cenetredTextWithStar := stars[:padding] + " " + strings.ToUpper(s) + " " + stars[padding:]
+	cenetredTextWithStar := stars[:padding] + " " + s + " " + stars[padding:]
 
 	hashes := strings.Repeat("#", len(cenetredTextWithStar)+2)
 	return fmt.Sprintf("%s \n# %s \n%s", hashes, cenetredTextWithStar, hashes)


### PR DESCRIPTION
Fixes #1003 
# Description 📣

Removes strings.ToUpper() formatting on the secrets key for get/set.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
[scott@samus infisical]$ ./infisical-merge secrets set foo=bar
┌─────────────┬──────────────┬────────────────┐
│ SECRET NAME │ SECRET VALUE │ STATUS         │
├─────────────┼──────────────┼────────────────┤
│ foo         │ bar          │ SECRET CREATED │
└─────────────┴──────────────┴────────────────┘
[scott@samus infisical]$ ./infisical-merge secrets get foo
┌─────────────┬──────────────┬─────────────┐
│ SECRET NAME │ SECRET VALUE │ SECRET TYPE │
├─────────────┼──────────────┼─────────────┤
│ foo         │ bar          │ shared      │
└─────────────┴──────────────┴─────────────┘
[scott@samus infisical]$ ./infisical-merge secrets get ingress.hosts.0
┌─────────────────┬────────────────────────┬─────────────┐
│ SECRET NAME     │ SECRET VALUE           │ SECRET TYPE │
├─────────────────┼────────────────────────┼─────────────┤
│ ingress.hosts.0 │(REDACTED)              │ shared      │
└─────────────────┴────────────────────────┴─────────────┘
--- with existing actual secrets:
[scott@samus cli]$ ./infisical-merge secrets get ingress.ingressClassName
┌──────────────────────────┬──────────────┬─────────────┐
│ SECRET NAME              │ SECRET VALUE │ SECRET TYPE │
├──────────────────────────┼──────────────┼─────────────┤
│ ingress.ingressClassName │ traefik      │ shared      │
└──────────────────────────┴──────────────┴─────────────┘
[scott@samus cli]$ infisical secrets get ingress.ingressClassName
┌──────────────────────────┬──────────────┬─────────────┐
│ SECRET NAME              │ SECRET VALUE │ SECRET TYPE │
├──────────────────────────┼──────────────┼─────────────┤
│ ingress.ingressClassName │ *not found*  │ *not found* │
└──────────────────────────┴──────────────┴─────────────┘
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝