### PR TITLE
Update cpu default frontend value.  Fixes #1005.

### DIFF
--- a/helm-charts/infisical/Chart.yaml
+++ b/helm-charts/infisical/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -50,7 +50,7 @@ frontend:
     limits:
       memory: 100Mi
     requests:
-      cpu: 150m
+      cpu: 100m
   ## @param frontend.kubeSecretRef Backend secret resource reference name (containing required [frontend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   ##
   kubeSecretRef: ""

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -50,7 +50,7 @@ frontend:
     limits:
       memory: 100Mi
     requests:
-      cpu: 10m
+      cpu: 150m
   ## @param frontend.kubeSecretRef Backend secret resource reference name (containing required [frontend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   ##
   kubeSecretRef: ""


### PR DESCRIPTION
# Description 📣

Updated helm values.yaml to set frontend resource requests to a high enough, but still moderately conservative value (150m) to allow page resources to consistently load.

Fixes #1005.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
Deployed helm chart with frontend.resources.requests.cpu: 150m

2023-09-19T02:12:01.256298054Z ---------------------------------------------------------------------
SUCCESS: helm upgrade --history-max=5 --install=true --namespace=infiscial --timeout=10m0s --values=/home/shell/helm/values-infisical-0.3.3.yaml --version=0.3.3 --wait=true infiscial /home/shell/helm/infisical-0.3.3.tgz
---------------------------------------------------------------------

Verified login and page resources load consistently in browser after deployment.

```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝