### PR TITLE
Patch integrations involving teamId

### DIFF
--- a/backend/src/helpers/integration.ts
+++ b/backend/src/helpers/integration.ts
@@ -160,7 +160,7 @@ export const getIntegrationAuthAccessHelper = async ({
   let accessId;
   let accessToken;
   const integrationAuth = await IntegrationAuth.findById(integrationAuthId).select(
-    "workspace integration +accessCiphertext +accessIV +accessTag +accessExpiresAt +refreshCiphertext +refreshIV +refreshTag +accessIdCiphertext +accessIdIV +accessIdTag metadata"
+    "workspace integration +accessCiphertext +accessIV +accessTag +accessExpiresAt +refreshCiphertext +refreshIV +refreshTag +accessIdCiphertext +accessIdIV +accessIdTag metadata teamId"
   );
 
   if (!integrationAuth)


### PR DESCRIPTION
# Description 📣

For some reason,`teamId` went missing when querying for `integrationAuth`; this affected any integrations that used this field like Vercel.

This PR brings back this field.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝