### PR TITLE
Patch self-hosted gitlab integration

### DIFF
--- a/backend/src/helpers/integration.ts
+++ b/backend/src/helpers/integration.ts
@@ -15,6 +15,7 @@ import { IntegrationAuthMetadata } from "../models/integrationAuth/types";
 interface Update {
   workspace: string;
   integration: string;
+  url?: string;
   teamId?: string;
   accountId?: string;
   metadata?: IntegrationAuthMetadata
@@ -63,6 +64,10 @@ export const handleOAuthExchangeHelper = async ({
     workspace: workspaceId,
     integration
   };
+  
+  if (res.url) {
+    update.url = res.url;
+  }
 
   switch (integration) {
     case INTEGRATION_VERCEL:

--- a/backend/src/integrations/exchange.ts
+++ b/backend/src/integrations/exchange.ts
@@ -423,6 +423,7 @@ const exchangeCodeGitlab = async ({
     accessToken: res.access_token,
     refreshToken: res.refresh_token,
     accessExpiresAt,
+    url
   };
 };
 

--- a/frontend/src/pages/integrations/gitlab/create.tsx
+++ b/frontend/src/pages/integrations/gitlab/create.tsx
@@ -84,6 +84,7 @@ export default function GitLabCreateIntegrationPage() {
   const selectedSourceEnvironment = watch("selectedSourceEnvironment");
   const targetEntity = watch("targetEntity");
   const targetTeamId = watch("targetTeamId");
+  const targetAppIdValue = watch("targetAppId");
 
   const { mutateAsync } = useCreateIntegration();
 
@@ -440,6 +441,7 @@ export default function GitLabCreateIntegrationPage() {
           size="sm"
           type="submit"
           isLoading={isLoading}
+          isDisabled={targetAppIdValue === "none"}
         >
           Create Integration
         </Button>


### PR DESCRIPTION
# Description 📣

Previously, the integration to self-hosted instances of GitLab was broken because Infisical wasn't keeping track of the self-hosted URL after the OAuth `code-token` exchange.

This PR fixes this issue so now it is possible to sync secrets to self-hosted GitLab 😄

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝