### PR TITLE
Patch Vercel integration for custom preview branches

### DIFF
--- a/backend/src/integrations/sync.ts
+++ b/backend/src/integrations/sync.ts
@@ -941,7 +941,11 @@ const syncSecretsVercel = async ({
       ? {
           teamId: integrationAuth.teamId
         }
-      : {})
+      : {}),
+    ...(integration?.path
+      ? {
+        gitBranch: integration?.path
+      } : {})
   };
 
   const vercelSecrets: VercelSecret[] = (
@@ -960,7 +964,7 @@ const syncSecretsVercel = async ({
 
     if (
       integration.targetEnvironment === "preview" &&
-      integration.path &&
+      secret.gitBranch &&
       integration.path !== secret.gitBranch
     ) {
       // case: secret on preview environment does not have same target git branch
@@ -969,7 +973,7 @@ const syncSecretsVercel = async ({
 
     return true;
   });
-
+  
   const res: { [key: string]: VercelSecret } = {};
 
   for await (const vercelSecret of vercelSecrets) {


### PR DESCRIPTION
# Description 📣

Previously, the Vercel integration for custom preview branches was flaky because it had an incorrect filtering condition when comparing secrets pulled from Vercel to those in Infisical during the sync operation.

This PR corrects the condition.

To note, as with other integrations, in the future we will need to optimize integrations a lot.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝