### PR TITLE
fix: resolved dashboard showing text folderName in nesting folders

### DIFF
--- a/frontend/src/components/navigation/NavHeader.tsx
+++ b/frontend/src/components/navigation/NavHeader.tsx
@@ -144,7 +144,7 @@ export default function NavHeader({
                   href={{ pathname: "/project/[id]/secrets/[env]", query }}
                 >
                   <a className="text-sm font-semibold text-primary/80 hover:text-primary">
-                    folderName
+                    {folderName}
                   </a>
                 </Link>
               )}


### PR DESCRIPTION
# Description 📣

Resolved directory in dashboard showing folder name as you nest

Closes #1039 

## Type ✨

- [x] Bug fix


# Tests 🛠️


```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝