### PR TITLE
handle siginit and sigterm

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -225,8 +225,19 @@ const main = async () => {
 
   server.on("close", async () => {
     await DatabaseService.closeDatabase();
-    syncSecretsToThirdPartyServices.close();
-    githubPushEventSecretScan.close();
+    // TODO: prevent queue from trying to reconnect with redis after .close
+    syncSecretsToThirdPartyServices.close()
+    githubPushEventSecretScan.close()
+  });
+
+  process.on("SIGINT", function () {
+    server.close();
+    process.exit(0);
+  });
+
+  process.on("SIGTERM", function () {
+    server.close();
+    process.exit(0);
   });
 
   return server;


### PR DESCRIPTION
# Description 📣

This should properly close out db connections and prevent slow shutdown during kubernetes upgrades

Nit:
The bull queue tries to reconnect even after .close() is called. Couldn't find a fix for it, so we'll come back to this.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Tested localy and the clean up is triggered properly 

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝