### PR TITLE
Add version tags to Docker image & display on frontend

### DIFF
--- a/.github/workflows/build-docker-image-to-prod.yml
+++ b/.github/workflows/build-docker-image-to-prod.yml
@@ -39,7 +39,10 @@ jobs:
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           load: true
           context: backend
-          tags: infisical/backend:test
+          tags: |
+            infisical/backend:${{ steps.extract_version.outputs.version }}
+          labels: |
+            version=${{ steps.extract_version.outputs.version }}
       - name: ⏻ Spawn backend container and dependencies
         run: |
           docker compose -f .github/resources/docker-compose.be-test.yml up --wait --quiet-pull
@@ -58,9 +61,10 @@ jobs:
           context: backend
           tags: |
             infisical/backend:${{ steps.commit.outputs.short }}
-            infisical/backend:latest
             infisical/backend:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
+          labels: |
+            version=${{ steps.extract_version.outputs.version }}
 
   frontend-image:
     name: Build frontend image
@@ -90,9 +94,22 @@ jobs:
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           project: 64mmf0n610
           context: frontend
-          tags: infisical/frontend:test
+          tags: |
+            infisical/frontend:${{ steps.extract_version.outputs.version }}
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}
+          labels: |
+            version=${{ steps.extract_version.outputs.version }}
+      - name: 🛠️ Create or update Infisical version in version.ts file
+        run: |
+          version='${{ steps.extract_version.outputs.version }}'
+          file='frontend/src/version.ts'
+          touch "$file"
+          if grep -q "export const CURRENT_INFISICAL_VERSION = '.*';" "$file"; then
+            sed -i "s/export const CURRENT_INFISICAL_VERSION = '.*';/export const CURRENT_INFISICAL_VERSION = '$version';/" "$file"
+          else
+            echo "export const INFISICAL_VERSION = '$version';" >> "$file"
+          fi
       - name: ⏻ Spawn frontend container
         run: |
           docker run -d --rm --name infisical-frontend-test infisical/frontend:test
@@ -111,8 +128,9 @@ jobs:
           context: frontend
           tags: |
             infisical/frontend:${{ steps.commit.outputs.short }}
-            infisical/frontend:latest
             infisical/frontend:${{ steps.extract_version.outputs.version }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}
+          labels: |
+            version=${{ steps.extract_version.outputs.version }}

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -21,6 +21,7 @@ import {
   faCheck,
   faEnvelope,
   faInfinity,
+  faInfo,
   faMobile,
   faPlus,
   faQuestion
@@ -68,6 +69,7 @@ import {
   useLogoutUser,
   useUploadWsKey
 } from "@app/hooks/api";
+import { CURRENT_INFISICAL_VERSION } from "@app/version"
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -696,6 +698,10 @@ export const AppLayout = ({ children }: LayoutProps) => {
                       </div>
                     </button>
                   )}
+                <div className="mb-2 w-full pl-5 duration-200 hover:text-mineshaft-200">
+                  <FontAwesomeIcon icon={faInfo} className="mr-4 px-[0.1rem]" />
+                  Current version: {CURRENT_INFISICAL_VERSION}
+                </div>
               </div>
             </nav>
           </aside>

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,0 +1,1 @@
+export const CURRENT_INFISICAL_VERSION = "v1.1.1"; // placeholder - dynamically updated on prod build


### PR DESCRIPTION
# Description 📣

Add current Infisical version to the backend & frontend Docker images as tags during the GitHub Actions prod build. Inject that version number into the frontend (and replace it so it's dynamic), then display this on the client at the bottom left of the sidebar.

TODO: update docs, check GHA works to inject the version to Docker image tags

## Type ✨

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Not tested the GitHub Actions workflow as discussed.

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝