### PR TITLE
feat(helm-chart): allow to provide affinity values for the pods

### DIFF
--- a/helm-charts/infisical/Chart.yaml
+++ b/helm-charts/infisical/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical/README.md
+++ b/helm-charts/infisical/README.md
@@ -64,16 +64,17 @@ kubectl get secrets -n <namespace> <secret-name> \
 | Name                                    | Description                                                                                                                                                   | Value                |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `frontend.enabled`                      | Enable frontend                                                                                                                                               | `true`               |
-| `frontend.name`                         | Backend name                                                                                                                                                  | `frontend`           |
-| `frontend.fullnameOverride`             | Backend fullnameOverride                                                                                                                                      | `""`                 |
-| `frontend.podAnnotations`               | Backend pod annotations                                                                                                                                       | `{}`                 |
-| `frontend.deploymentAnnotations`        | Backend deployment annotations                                                                                                                                | `{}`                 |
-| `frontend.replicaCount`                 | Backend replica count                                                                                                                                         | `2`                  |
-| `frontend.image.repository`             | Backend image repository                                                                                                                                      | `infisical/frontend` |
-| `frontend.image.tag`                    | Backend image tag                                                                                                                                             | `latest`             |
-| `frontend.image.pullPolicy`             | Backend image pullPolicy                                                                                                                                      | `IfNotPresent`       |
+| `frontend.name`                         | Frontend name                                                                                                                                                 | `frontend`           |
+| `frontend.fullnameOverride`             | Frontend fullnameOverride                                                                                                                                     | `""`                 |
+| `frontend.podAnnotations`               | Frontend pod annotations                                                                                                                                      | `{}`                 |
+| `frontend.deploymentAnnotations`        | Frontend deployment annotations                                                                                                                               | `{}`                 |
+| `frontend.replicaCount`                 | Frontend replica count                                                                                                                                        | `2`                  |
+| `frontend.image.repository`             | Frontend image repository                                                                                                                                     | `infisical/frontend` |
+| `frontend.image.tag`                    | Frontend image tag                                                                                                                                            | `latest`             |
+| `frontend.image.pullPolicy`             | Frontend image pullPolicy                                                                                                                                     | `IfNotPresent`       |
 | `frontend.resources.limits.memory`      | container memory limit [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)          | `100Mi`              |
-| `frontend.resources.requests.cpu`       | container CPU request [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)           | `10m`                |
+| `frontend.resources.requests.cpu`       | container CPU request [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)           | `100m`               |
+| `frontend.affinity`                     | Frontend pod affinity                                                                                                                                         | `{}`                 |
 | `frontend.kubeSecretRef`                | Backend secret resource reference name (containing required [frontend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars)) | `""`                 |
 | `frontend.service.annotations`          | Backend service annotations                                                                                                                                   | `{}`                 |
 | `frontend.service.type`                 | Backend service type                                                                                                                                          | `ClusterIP`          |
@@ -95,6 +96,7 @@ kubectl get secrets -n <namespace> <secret-name> \
 | `backend.image.pullPolicy`                             | Backend image pullPolicy                                                                                                                                                                                                            | `IfNotPresent`              |
 | `backend.resources.limits.memory`                      | container memory limit [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)                                                                                | `200Mi`                     |
 | `backend.resources.requests.cpu`                       | container CPU request [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)                                                                                 | `150m`                      |
+| `backend.affinity`                                     | Backend pod affinity                                                                                                                                                                                                                | `{}`                        |
 | `backend.kubeSecretRef`                                | Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))                                                                        | `""`                        |
 | `backend.service.annotations`                          | Backend service annotations                                                                                                                                                                                                         | `{}`                        |
 | `backend.service.type`                                 | Backend service type                                                                                                                                                                                                                | `ClusterIP`                 |
@@ -189,6 +191,7 @@ kubectl get secrets -n <namespace> <secret-name> \
 | `mailhog.ingress.hosts[0].host`    | Mailhog host               | `mailhog.infisical.local` |
 
 ### Redis parameters
+
 
 
 

--- a/helm-charts/infisical/templates/backend-deployment.yaml
+++ b/helm-charts/infisical/templates/backend-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- with $backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: {{ template "infisical.name" . }}-{{ $backend.name }}
         image: "{{ $backend.image.repository }}:{{ $backend.image.tag | default "latest" }}"

--- a/helm-charts/infisical/templates/frontend-deployment.yaml
+++ b/helm-charts/infisical/templates/frontend-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- with $frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
       - name: {{ template "infisical.name" . }}-{{ $frontend.name }}
         image: "{{ $frontend.image.repository }}:{{ $frontend.image.tag | default "latest" }}"

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -16,31 +16,31 @@ frontend:
   ## @param frontend.enabled Enable frontend
   ##
   enabled: true
-  ## @param frontend.name Backend name
+  ## @param frontend.name Frontend name
   ##
   name: frontend
-  ## @param frontend.fullnameOverride Backend fullnameOverride
+  ## @param frontend.fullnameOverride Frontend fullnameOverride
   ##
   fullnameOverride: ""
-  ## @param frontend.podAnnotations Backend pod annotations
+  ## @param frontend.podAnnotations Frontend pod annotations
   ##
   podAnnotations: {}
-  ## @param frontend.deploymentAnnotations Backend deployment annotations
+  ## @param frontend.deploymentAnnotations Frontend deployment annotations
   ##
   deploymentAnnotations: {}
-  ## @param frontend.replicaCount Backend replica count
+  ## @param frontend.replicaCount Frontend replica count
   ##
   replicaCount: 2
-  ## Backend image parameters
+  ## Frontend image parameters
   ##
   image:
-    ## @param frontend.image.repository Backend image repository
+    ## @param frontend.image.repository Frontend image repository
     ##
     repository: infisical/frontend
-    ## @param frontend.image.tag Backend image tag
+    ## @param frontend.image.tag Frontend image tag
     ##
     tag: "latest"
-    ## @param frontend.image.pullPolicy Backend image pullPolicy
+    ## @param frontend.image.pullPolicy Frontend image pullPolicy
     ##
     pullPolicy: IfNotPresent
   ## @param frontend.resources.limits.memory container memory limit [check the offical kubernetes documentations](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
@@ -51,6 +51,9 @@ frontend:
       memory: 100Mi
     requests:
       cpu: 100m
+  ## @param frontend.affinity Frontend pod affinity
+  ##
+  affinity: {}
   ## @param frontend.kubeSecretRef Backend secret resource reference name (containing required [frontend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   ##
   kubeSecretRef: ""
@@ -118,6 +121,9 @@ backend:
       memory: 200Mi
     requests:
       cpu: 150m
+  ## @param backend.affinity Backend pod affinity
+  ##
+  affinity: {}
   ## @param backend.kubeSecretRef Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   ##
   kubeSecretRef: ""

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -292,7 +292,7 @@ mongodb:
     ##
     rootPassword: root
 
-    ## @param auth.existingSecret Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)
+    ## @param mongodb.auth.existingSecret Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)
     ## NOTE: When it's set the previous parameters are ignored.
     ##
     existingSecret: ""


### PR DESCRIPTION
# Description 📣

Hello,
I use the helm chart to deploy Infisical in Kubernetes and I require to use affinity to move pods on specific nodes. This PR brings this feature in the helm chart.
Thank you for your work!

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝