### PR TITLE
fix: signup only if the user not logged in #1046

### DIFF
--- a/frontend/src/pages/signupinvite.tsx
+++ b/frontend/src/pages/signupinvite.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import crypto from "crypto";
 
-import { useState } from "react";
+import { useEffect,useState } from "react";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
@@ -56,6 +56,19 @@ export default function SignupInvite() {
   const token = parsedUrl.token as string;
   const organizationId = parsedUrl.organization_id as string;
   const email = (parsedUrl.to as string)?.replace(" ", "+").trim();
+
+  // Check if the user is already logged in!
+  useEffect(() => {
+    const tryAuth = async () => {
+      try {
+        const userOrgs = await fetchOrganizations();
+        router.push(`/org/${userOrgs[0]._id}/overview`);
+      } catch (error) {
+        console.log("User already logged in! Redirecting to /org");
+      }
+    };
+    tryAuth();
+  }, []);
 
   // Verifies if the information that the users entered (name, workspace) is there, and if the password matched the criteria.
   const signupErrorCheck = async () => {


### PR DESCRIPTION
# Description 📣
As the issue #1046 describe. There was error due to multiple different user logged into the application. To avoid the bug that leads to that error. It's better not to let user to signup via invite. If the user is already logged. Used the same code snippet as signup page to redirect the user.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

1. Start the infisical local server
1. LogIn to the website
1. Goto `/signupinvite`
1. User should be redirect to the org page.

> For not logged in user, They can continue with the signup proccess

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝