### PR TITLE
Patch delete user, org, project session impl and account for organizationId in local storage

### DIFF
--- a/backend/src/helpers/organization.ts
+++ b/backend/src/helpers/organization.ts
@@ -1,4 +1,4 @@
-import mongoose, { Types } from "mongoose";
+import mongoose, { Types, mongo } from "mongoose";
 import { 
   Bot, 
   BotKey,
@@ -111,48 +111,78 @@ export const createOrganization = async ({
  * @returns 
  */
 export const deleteOrganization = async ({
-  organizationId
+  organizationId,
+  existingSession
 }: {
   organizationId: Types.ObjectId;
+  existingSession?: mongo.ClientSession;
 }) => {
-  const session = await mongoose.startSession();
-  session.startTransaction();
+
+  let session;
+  
+  if (existingSession) {
+    session = existingSession;
+  } else {
+    session = await mongoose.startSession(); 
+    session.startTransaction();
+  }
 
   try {
-    const organization = await Organization.findByIdAndDelete(organizationId);
+    const organization = await Organization.findByIdAndDelete(
+      organizationId,
+      {
+        session
+      }
+    );
   
     if (!organization) throw ResourceNotFoundError();
     
     await MembershipOrg.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await BotOrg.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await SSOConfig.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await Role.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
 
     await IncidentContactOrg.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await GitRisks.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await GitAppInstallationSession.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await GitAppOrganizationInstallation.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
 
     const workspaceIds = await Workspace.distinct("_id", {
@@ -161,167 +191,230 @@ export const deleteOrganization = async ({
     
     await Workspace.deleteMany({
       organization: organization._id
+    }, {
+      session
     });
     
     await Membership.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Key.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await Bot.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await BotKey.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await SecretBlindIndexData.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await Secret.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await SecretVersion.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await SecretSnapshot.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
-    
     
     await SecretImport.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Folder.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await FolderVersion.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Webhook.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await TrustedIP.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await Tag.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await IntegrationAuth.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Integration.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await ServiceToken.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await ServiceTokenData.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await ServiceTokenDataV3.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
     
     await ServiceTokenDataV3Key.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await AuditLog.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Log.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await Action.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await SecretApprovalPolicy.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
 
     await SecretApprovalRequest.deleteMany({
       workspace: {
         $in: workspaceIds
       }
+    }, {
+      session
     });
+    
+    if (organization.customerId) {
+      // delete from stripe here
+      await licenseServerKeyRequest.delete(
+        `${await getLicenseServerUrl()}/api/license-server/v1/customers/${organization.customerId}`
+      );
+    }
     
     return organization;
   } catch (err) {
-    await session.abortTransaction();
+    if (!existingSession) {
+      await session.abortTransaction();
+    }
     throw InternalServerError({
       message: "Failed to delete organization"
     });
   } finally {
-    session.endSession();
+    if (!existingSession) {
+      await session.commitTransaction();
+      session.endSession();
+    }
   }
 }
 

--- a/frontend/src/hooks/api/users/queries.tsx
+++ b/frontend/src/hooks/api/users/queries.tsx
@@ -51,6 +51,17 @@ export const useDeleteUser = () => {
       return user;
     },
     onSuccess: () => {
+      localStorage.removeItem("protectedKey");
+      localStorage.removeItem("protectedKeyIV");
+      localStorage.removeItem("protectedKeyTag");
+      localStorage.removeItem("publicKey");
+      localStorage.removeItem("encryptedPrivateKey");
+      localStorage.removeItem("iv");
+      localStorage.removeItem("tag");
+      localStorage.removeItem("PRIVATE_KEY");
+      localStorage.removeItem("orgData.id");
+      localStorage.removeItem("projectData.id");
+
       queryClient.clear();
     }
   });

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -34,7 +34,6 @@ import * as yup from "yup";
 
 import { useNotificationContext } from "@app/components/context/Notifications/NotificationProvider";
 import { OrgPermissionCan } from "@app/components/permissions";
-import onboardingCheck from "@app/components/utilities/checks/OnboardingCheck";
 import { tempLocalStorage } from "@app/components/utilities/checks/tempLocalStorage";
 import { encryptAssymmetric } from "@app/components/utilities/cryptography/crypto";
 import {
@@ -214,7 +213,6 @@ export const AppLayout = ({ children }: LayoutProps) => {
       // }
     };
     putUserInOrg();
-    onboardingCheck({});
   }, [router.query.id]);
 
   const onCreateProject = async ({ name, addMembers }: TAddProjectFormData) => {

--- a/frontend/src/views/Login/Login.utils.tsx
+++ b/frontend/src/views/Login/Login.utils.tsx
@@ -12,6 +12,7 @@ export const navigateUserToOrg = async (router: NextRouter) => {
         router.push(`/org/${userOrg}/overview`);
     } else {
         // user is not part of any org
+        localStorage.removeItem("orgData.id");
         router.push("/org/none");
     }
 }

--- a/frontend/src/views/Org/NonePage/NonePage.tsx
+++ b/frontend/src/views/Org/NonePage/NonePage.tsx
@@ -49,6 +49,8 @@ export const NonePage = () => {
             const organization = await mutateAsync({
                 name
             });
+            
+            localStorage.setItem("orgData.id", organization._id);
 
             createNotification({
                 text: "Successfully created organization",

--- a/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
+++ b/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
@@ -71,7 +71,7 @@ export const PreviewSection = () => {
       console.error(err);
     }
   };
-
+  
   return (
     <div>
       {subscription &&

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/SecretTagsSection/SecretTagsSection.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/SecretTagsSection/SecretTagsSection.tsx
@@ -54,9 +54,7 @@ export const SecretTagsSection = (): JSX.Element => {
               colorSchema="secondary"
               leftIcon={<FontAwesomeIcon icon={faPlus} />}
               onClick={() => {
-                console.log("x");
                 handlePopUpOpen("CreateSecretTag");
-                console.log("x2");
               }}
               isDisabled={!isAllowed}
             >


### PR DESCRIPTION
This PR:

- Correctly implements MongoDB transactions for the delete user, organization, and project operations.
- Fixes an issue to do with flaky organization deletion behavior due to not accounting for wiping the `organizationId` off local storage.

# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝