### PR TITLE
[ENG-179] Add suport for --path for the secrets generate-example-env command

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -4,14 +4,13 @@ Copyright (c) 2023 Infisical Inc.
 package cmd
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"regexp"
 	"sort"
 	"strings"
 	"unicode"
-
-	"crypto/sha256"
 
 	"github.com/Infisical/infisical-merge/packages/api"
 	"github.com/Infisical/infisical-merge/packages/crypto"
@@ -441,6 +440,11 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	secretsPath, err := cmd.Flags().GetString("path")
+	if err != nil {
+		util.HandleError(err, "Unable to parse flag")
+	}
+
 	infisicalToken, err := cmd.Flags().GetString("token")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
@@ -451,7 +455,7 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs})
+	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath})
 	if err != nil {
 		util.HandleError(err, "To fetch all secrets")
 	}
@@ -650,8 +654,8 @@ func getSecretsByKeys(secrets []models.SingleEnvironmentVariable) map[string]mod
 }
 
 func init() {
-
 	secretsGenerateExampleEnvCmd.Flags().String("token", "", "Fetch secrets using the Infisical Token")
+	secretsGenerateExampleEnvCmd.Flags().String("path", "/", "store the secret within a folder path")
 	secretsCmd.AddCommand(secretsGenerateExampleEnvCmd)
 
 	secretsGetCmd.Flags().String("token", "", "Fetch secrets using the Infisical Token")

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -655,7 +655,7 @@ func getSecretsByKeys(secrets []models.SingleEnvironmentVariable) map[string]mod
 
 func init() {
 	secretsGenerateExampleEnvCmd.Flags().String("token", "", "Fetch secrets using the Infisical Token")
-	secretsGenerateExampleEnvCmd.Flags().String("path", "/", "store the secret within a folder path")
+	secretsGenerateExampleEnvCmd.Flags().String("path", "/", "Fetch secrets from within a folder path")
 	secretsCmd.AddCommand(secretsGenerateExampleEnvCmd)
 
 	secretsGetCmd.Flags().String("token", "", "Fetch secrets using the Infisical Token")


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/Infisical/infisical/issues/1075 .

Currently trying out the project but I ran into this issue too. Felt like a nice to have to improve experience. 

This PR adds a new `--path` flag to the `secrets generate-example-env` command. As such it can be used like this:

```sh
./infisical secrets generate-example-env --path=users/lanre
```

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
./infisical secrets set PROJECT=oops --path users/lanre
./infisical secrets generate-example-env --path=users/lanre
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝