### PR TITLE
security: use file for backend secrets

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -1,6 +1,7 @@
 import { GITLAB_URL } from "../variables";
 
 import InfisicalClient from "infisical-node";
+import { promises as fs } from 'fs';
 
 export const client = new InfisicalClient({
   token: process.env.INFISICAL_TOKEN!,
@@ -8,8 +9,13 @@ export const client = new InfisicalClient({
 
 export const getPort = async () => (await client.getSecret("PORT")).secretValue || 4000;
 export const getEncryptionKey = async () => {
-  const secretValue = (await client.getSecret("ENCRYPTION_KEY")).secretValue;
-  return secretValue === "" ? undefined : secretValue;
+  const file = (await client.getSecret("ENCRYPTION_KEY_FILE")).secretValue;
+  if (file) {
+    return (await fs.readFile(file, 'utf8')).trim();
+  } else {
+    const secretValue = (await client.getSecret("ENCRYPTION_KEY")).secretValue;
+    return secretValue === "" ? undefined : secretValue;
+  }
 }
 export const getRootEncryptionKey = async () => {
   const secretValue = (await client.getSecret("ROOT_ENCRYPTION_KEY")).secretValue;


### PR DESCRIPTION
# Description 📣

This is an early stab at using files to store secrets for the backend.
I'm not yet sure how the whole deployment works, particularly if it makes sense for the backend to read directly from the file system.
I'm opening this early with a just the implementation for a single secret to get some feedback.

closes #1104 

## Type ✨

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I haven't run any tests as I'm opening this to get more clarity on the actual need of the implementation.

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝