### PR TITLE
fix(frontend): Remove max-width to match other views

### DIFF
--- a/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/WebhooksTab.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/WebhooksTab/WebhooksTab.tsx
@@ -139,7 +139,7 @@ export const WebhooksTab = withProjectPermission(
     };
 
     return (
-      <div className="mb-6 max-w-screen-lg rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
         <div className="flex justify-between">
           <p className="text-xl font-semibold text-mineshaft-100">{t("settings.webhooks.title")}</p>
           <ProjectPermissionCan


### PR DESCRIPTION
# Description 📣

This pull request removes the max-width constraint from the WebhooksTab.tsx component to ensure it aligns with the full-width layout pattern of other views, eliminating unused space on larger screens.

The previous 1024px max-width resulted in an inconsistent layout compared to other views. This change resolves the issue and maintains frontend layout consistency.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

The testing for this fix involved manual verification in a web browser:

1. Opened the application in a web browser.
2. Navigated to a project > Project Settings > Webhooks tab.
3. Verified that the max-width constraint has been removed.
4. Confirmed that the WebhooksTab now aligns with the full-width layout consistency seen in other views. Ensured that there is no unused space on larger screens.

The change has been visually verified and tested successfully in different browser environments.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝