### PR TITLE
fix:resolved overview page add secret not working when folder not exist in one level deep

### DIFF
--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -111,9 +111,18 @@ export const SecretOverviewPage = () => {
     try {
       // create folder if not existing
       if (secretPath !== "/") {
+        // /hello/world -> ["", "hello","world"]
         const path = secretPath.split("/");
-        const directory = path.slice(0, -1).join("/");
-        const folderName = path.at(-1);
+        // if its empty string on join use and OR gate to convert to /
+        // /hello
+        const directory =
+          path
+            .slice(0, -1)
+            .reduce(
+              (prev, curr, index, arr) => prev + (index + 1 === arr.length ? curr : `/${curr}`),
+              ""
+            ) || "/";
+        const folderName = path.at(-1); // world
         if (folderName && directory) {
           await createFolder({
             workspaceId,


### PR DESCRIPTION
# Description 📣

1. Fixed folder in overview not creating automatically when ur one level deep

## Type ✨

- [x] Bug fix


# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝