### PR TITLE
feat(helm-chart): repair usage of resources key

### DIFF
--- a/helm-charts/infisical/Chart.yaml
+++ b/helm-charts/infisical/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical/templates/backend-deployment.yaml
+++ b/helm-charts/infisical/templates/backend-deployment.yaml
@@ -44,9 +44,9 @@ spec:
         envFrom:
         - secretRef:
             name: {{ $backend.kubeSecretRef | default (include "infisical.backend.fullname" .) }}
-        # {{- if  $backend.resources }}
-        # resources: {{- toYaml $backend.resources | nindent 12 }}
-        # {{- end }}
+        {{- if  $backend.resources }}
+        resources: {{- toYaml $backend.resources | nindent 12 }}
+        {{- end }}
 ---
 
 apiVersion: v1


### PR DESCRIPTION
# Description 📣

Hey,

This request fixes an issue introduced with the new rewrite of the helm-chart. The resources part is commented but helm interprets the comment and if you have the key `resources` it computes it as a bad thing.

<img width="526" alt="image" src="https://github.com/Infisical/infisical/assets/9136206/544b78f0-9194-4d95-8e77-5c118b9cd309">

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝