### PR TITLE
Fix bug with copying secret to clipboard with an override

### DIFF
--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretItem.tsx
@@ -172,7 +172,11 @@ export const SecretItem = memo(
 
     const copyTokenToClipboard = () => {
       const [overrideValue, value] = getValues(["value", "valueOverride"]);
-      navigator.clipboard.writeText((overrideValue || value) as string);
+      if (isOverriden) {
+        navigator.clipboard.writeText(value as string);
+      } else {
+        navigator.clipboard.writeText(overrideValue as string);
+      }
       setIsSecValueCopied.on();
     };
 


### PR DESCRIPTION
# Description 📣

On clicking copy secret if an override is enabled, it copies the original value instead of the override value.
Fixes #1137 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝