### PR TITLE
Fix bug with error handling while deleting project

### DIFF
--- a/backend/src/helpers/workspace.ts
+++ b/backend/src/helpers/workspace.ts
@@ -272,6 +272,10 @@ export const deleteWorkspace = async ({
 		}, {
 			session
 		});
+
+		if (!existingSession) {
+			await session.commitTransaction();
+		}
 		
 		return workspace;
 	} catch (err) {
@@ -283,7 +287,6 @@ export const deleteWorkspace = async ({
 		});
 	} finally {
 		if (!existingSession) {
-			await session.commitTransaction();
 			session.endSession();
 		}
 	}

--- a/backend/src/middleware/requestErrorHandler.ts
+++ b/backend/src/middleware/requestErrorHandler.ts
@@ -31,6 +31,8 @@ export const requestErrorHandler: ErrorRequestHandler = async (
   if (error instanceof RequestError) {
     if (error instanceof TokenExpiredError) {
       error = UnauthorizedRequestError({ stack: error.stack, message: "Token expired" });
+    } else {
+      error = InternalServerError({ context: { exception: error.message }, stack: error.stack });
     }
     await logAndCaptureException((<RequestError>error));
   } else {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Related to #1120 

There were 2 issues:

1. If theres an error in the try block in /backend/src/helpers/workspace.ts, the commitTransaction() as being executed after abortTransaction() causing the "Cannot call commitTransaction after calling abortTransaction" error.
2. After fixing the above issue, now the error shown in the API response was generic and missing any message which has also been fixed. Refer to following ss

![Screenshot from 2023-10-31 00-19-58](https://github.com/Infisical/infisical/assets/19776470/c6aaae89-1c74-4de8-8b9d-d9082b0c8f80)


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝