### PR TITLE
Add environment field to trustedIp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 # backend
 node_modules
-.env
-.env.dev
-.env.gamma
-.env.prod
-.env.infisical
 
 *~
 *.swp
@@ -25,8 +20,6 @@ node_modules
 /.pnp
 .pnp.js
 
-.env
-
 # testing
 coverage
 reports
@@ -38,9 +31,6 @@ junit.xml
 
 # production
 /build
-
-# misc
-.DS_Store
 
 # debug
 npm-debug.log*
@@ -54,11 +44,16 @@ yarn-error.log*
 .env.production.local
 .vercel
 .env.infisical
+.env
+.env.dev
+.env.gamma
+.env.prod
 
 # Infisical init
 .infisical.json
 
 # Editor specific
 .vscode/*
+.idea/*
 
 frontend-build

--- a/backend/src/ee/models/auditLog/types.ts
+++ b/backend/src/ee/models/auditLog/types.ts
@@ -176,6 +176,7 @@ interface AddTrustedIPEvent {
   metadata: {
     trustedIpId: string;
     ipAddress: string;
+    environment?: string;
     prefix?: number;
   };
 }
@@ -185,6 +186,7 @@ interface UpdateTrustedIPEvent {
   metadata: {
     trustedIpId: string;
     ipAddress: string;
+    environment?: string;
     prefix?: number;
   };
 }
@@ -194,6 +196,7 @@ interface DeleteTrustedIPEvent {
   metadata: {
     trustedIpId: string;
     ipAddress: string;
+    environment?: string;
     prefix?: number;
   };
 }

--- a/backend/src/ee/models/trustedIp.ts
+++ b/backend/src/ee/models/trustedIp.ts
@@ -8,6 +8,7 @@ export enum IPType {
 export interface ITrustedIP {
     _id: Types.ObjectId;
     workspace: Types.ObjectId;
+    environment?: string;
     ipAddress: string;
     type: "ipv4" | "ipv6", // either IPv4/IPv6 address or network IPv4/IPv6 address
     isActive: boolean;
@@ -21,6 +22,10 @@ const trustedIpSchema = new Schema<ITrustedIP>(
             type: Schema.Types.ObjectId,
             ref: "Workspace",
             required: true
+        },
+        environment: {
+            type: String,
+            required: false
         },
         ipAddress: {
             type: String,

--- a/backend/src/helpers/database.ts
+++ b/backend/src/helpers/database.ts
@@ -21,6 +21,7 @@ export const initDatabaseHelper = async ({
         logger.info("Database connection established");
 
     } catch (err) {
+        // @ts-ignore
         logger.error(err, "Unable to establish database connection");
     }
 
@@ -28,7 +29,7 @@ export const initDatabaseHelper = async ({
 }
 
 /**
- * Close database conection
+ * Close database connection
  */
 export const closeDatabaseHelper = async () => {
     if (mongoose.connection && mongoose.connection.readyState === 1) {

--- a/backend/src/validation/workspace.ts
+++ b/backend/src/validation/workspace.ts
@@ -145,6 +145,7 @@ export const AddWorkspaceTrustedIpV1 = z.object({
   }),
   body: z.object({
     ipAddress: z.string().trim(),
+    environment: z.string().trim().default(""),
     comment: z.string().trim().default(""),
     isActive: z.boolean()
   })
@@ -157,7 +158,8 @@ export const UpdateWorkspaceTrustedIpV1 = z.object({
   }),
   body: z.object({
     ipAddress: z.string().trim(),
-    comment: z.string().trim().default("")
+    comment: z.string().trim().default(""),
+    environment: z.string().trim().default(""),
   })
 });
 

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -1,18 +1,14 @@
-import {
-    ActorType,
-    EventType,
-    UserAgentType
-} from "./enums";
+import { ActorType, EventType, UserAgentType } from "./enums";
 
 enum Permission {
-    READ = "read",
-    READ_WRITE = "readWrite"
+  READ = "read",
+  READ_WRITE = "readWrite"
 }
 
 interface Scope {
-    environment: string;
-    secretPath: string;
-    permission: Permission;
+  environment: string;
+  secretPath: string;
+  permission: Permission;
 }
 
 interface UserActorMetadata {
@@ -36,428 +32,427 @@ export interface ServiceActor {
 }
 
 export interface ServiceActorV3 {
-    type: ActorType.SERVICE_V3;
-    metadata: ServiceActorMetadata;
+  type: ActorType.SERVICE_V3;
+  metadata: ServiceActorMetadata;
 }
 
-export type Actor = 
-    | UserActor
-    | ServiceActor
-    | ServiceActorV3;
+export type Actor = UserActor | ServiceActor | ServiceActorV3;
 
 interface GetSecretsEvent {
-    type: EventType.GET_SECRETS;
-    metadata: {
-        environment: string;
-        secretPath: string;
-        numberOfSecrets: number;
-    };
+  type: EventType.GET_SECRETS;
+  metadata: {
+    environment: string;
+    secretPath: string;
+    numberOfSecrets: number;
+  };
 }
 
 interface GetSecretEvent {
-    type: EventType.GET_SECRET;
-    metadata: {
-        environment: string;
-        secretPath: string;
-        secretId: string;
-        secretKey: string;
-        secretVersion: number;
-    };
+  type: EventType.GET_SECRET;
+  metadata: {
+    environment: string;
+    secretPath: string;
+    secretId: string;
+    secretKey: string;
+    secretVersion: number;
+  };
 }
 
 interface CreateSecretEvent {
-    type: EventType.CREATE_SECRET;
-    metadata: {
-        environment: string;
-        secretPath: string;
-        secretId: string;
-        secretKey: string;
-        secretVersion: number;
-    }
+  type: EventType.CREATE_SECRET;
+  metadata: {
+    environment: string;
+    secretPath: string;
+    secretId: string;
+    secretKey: string;
+    secretVersion: number;
+  };
 }
 
 interface UpdateSecretEvent {
-    type: EventType.UPDATE_SECRET;
-    metadata: {
-        environment: string;
-        secretPath: string;
-        secretId: string;
-        secretKey: string;
-        secretVersion: number;
-    }
+  type: EventType.UPDATE_SECRET;
+  metadata: {
+    environment: string;
+    secretPath: string;
+    secretId: string;
+    secretKey: string;
+    secretVersion: number;
+  };
 }
 
 interface DeleteSecretEvent {
-    type: EventType.DELETE_SECRET;
-    metadata: {
-        environment: string;
-        secretPath: string;
-        secretId: string;
-        secretKey: string;
-        secretVersion: number;
-    }
+  type: EventType.DELETE_SECRET;
+  metadata: {
+    environment: string;
+    secretPath: string;
+    secretId: string;
+    secretKey: string;
+    secretVersion: number;
+  };
 }
 
 interface GetWorkspaceKeyEvent {
-    type: EventType.GET_WORKSPACE_KEY,
-    metadata: {
-        keyId: string;
-    }
+  type: EventType.GET_WORKSPACE_KEY;
+  metadata: {
+    keyId: string;
+  };
 }
 
 interface AuthorizeIntegrationEvent {
-    type: EventType.AUTHORIZE_INTEGRATION;
-    metadata: {
-        integration: string;
-    }
+  type: EventType.AUTHORIZE_INTEGRATION;
+  metadata: {
+    integration: string;
+  };
 }
 
 interface UnauthorizeIntegrationEvent {
-    type: EventType.UNAUTHORIZE_INTEGRATION;
-    metadata: {
-        integration: string;
-    }
+  type: EventType.UNAUTHORIZE_INTEGRATION;
+  metadata: {
+    integration: string;
+  };
 }
 
 interface CreateIntegrationEvent {
-    type: EventType.CREATE_INTEGRATION;
-    metadata: {
-        integrationId: string;
-        integration: string;
-        environment: string;
-        secretPath: string;
-        url?: string;
-        app?: string;
-        appId?: string;
-        targetEnvironment?: string;
-        targetEnvironmentId?: string;
-        targetService?: string;
-        targetServiceId?: string;
-        path?: string;
-        region?: string;
-    }
+  type: EventType.CREATE_INTEGRATION;
+  metadata: {
+    integrationId: string;
+    integration: string;
+    environment: string;
+    secretPath: string;
+    url?: string;
+    app?: string;
+    appId?: string;
+    targetEnvironment?: string;
+    targetEnvironmentId?: string;
+    targetService?: string;
+    targetServiceId?: string;
+    path?: string;
+    region?: string;
+  };
 }
 
 interface DeleteIntegrationEvent {
-    type: EventType.DELETE_INTEGRATION;
-    metadata: {
-        integrationId: string;
-        integration: string;
-        environment: string;
-        secretPath: string;
-        url?: string;
-        app?: string;
-        appId?: string;
-        targetEnvironment?: string;
-        targetEnvironmentId?: string;
-        targetService?: string;
-        targetServiceId?: string;
-        path?: string;
-        region?: string;
-    }
+  type: EventType.DELETE_INTEGRATION;
+  metadata: {
+    integrationId: string;
+    integration: string;
+    environment: string;
+    secretPath: string;
+    url?: string;
+    app?: string;
+    appId?: string;
+    targetEnvironment?: string;
+    targetEnvironmentId?: string;
+    targetService?: string;
+    targetServiceId?: string;
+    path?: string;
+    region?: string;
+  };
 }
 
 interface AddTrustedIPEvent {
-    type: EventType.ADD_TRUSTED_IP;
-    metadata: {
-        trustedIpId: string;
-        ipAddress: string;
-        prefix?: number;
-    }
+  type: EventType.ADD_TRUSTED_IP;
+  metadata: {
+    trustedIpId: string;
+    ipAddress: string;
+    environment: string;
+    prefix?: number;
+  };
 }
 
 interface UpdateTrustedIPEvent {
-    type: EventType.UPDATE_TRUSTED_IP;
-    metadata: {
-        trustedIpId: string;
-        ipAddress: string;
-        prefix?: number;
-    }
+  type: EventType.UPDATE_TRUSTED_IP;
+  metadata: {
+    trustedIpId: string;
+    ipAddress: string;
+    environment: string;
+    prefix?: number;
+  };
 }
 
 interface DeleteTrustedIPEvent {
-    type: EventType.DELETE_TRUSTED_IP;
-    metadata: {
-        trustedIpId: string;
-        ipAddress: string;
-        prefix?: number;
-    }
+  type: EventType.DELETE_TRUSTED_IP;
+  metadata: {
+    trustedIpId: string;
+    ipAddress: string;
+    environment: string;
+    prefix?: number;
+  };
 }
 
 interface CreateServiceTokenEvent {
-    type: EventType.CREATE_SERVICE_TOKEN;
-    metadata: {
-        name: string;
-        scopes: Array<{
-            environment: string;
-            secretPath: string;
-        }>;
-    }
+  type: EventType.CREATE_SERVICE_TOKEN;
+  metadata: {
+    name: string;
+    scopes: Array<{
+      environment: string;
+      secretPath: string;
+    }>;
+  };
 }
 
 interface DeleteServiceTokenEvent {
-    type: EventType.DELETE_SERVICE_TOKEN;
-    metadata: {
-        name: string;
-        scopes: Array<{
-            environment: string;
-            secretPath: string;
-        }>;
-    }
+  type: EventType.DELETE_SERVICE_TOKEN;
+  metadata: {
+    name: string;
+    scopes: Array<{
+      environment: string;
+      secretPath: string;
+    }>;
+  };
 }
 
 interface CreateServiceTokenV3Event {
-    type: EventType.CREATE_SERVICE_TOKEN_V3;
-    metadata: {
-        name: string;
-        isActive: boolean;
-        scopes: Array<Scope>;
-        expiresAt?: Date;
-    }
+  type: EventType.CREATE_SERVICE_TOKEN_V3;
+  metadata: {
+    name: string;
+    isActive: boolean;
+    scopes: Array<Scope>;
+    expiresAt?: Date;
+  };
 }
 
 interface UpdateServiceTokenV3Event {
-    type: EventType.UPDATE_SERVICE_TOKEN_V3;
-    metadata: {
-        name?: string;
-        isActive?: boolean;
-        scopes?: Array<Scope>;
-        expiresAt?: Date;
-    }
+  type: EventType.UPDATE_SERVICE_TOKEN_V3;
+  metadata: {
+    name?: string;
+    isActive?: boolean;
+    scopes?: Array<Scope>;
+    expiresAt?: Date;
+  };
 }
 
 interface DeleteServiceTokenV3Event {
-    type: EventType.DELETE_SERVICE_TOKEN_V3;
-    metadata: {
-        name: string;
-        isActive: boolean;
-        scopes: Array<Scope>;
-        expiresAt?: Date;
-    }
+  type: EventType.DELETE_SERVICE_TOKEN_V3;
+  metadata: {
+    name: string;
+    isActive: boolean;
+    scopes: Array<Scope>;
+    expiresAt?: Date;
+  };
 }
 
 interface CreateEnvironmentEvent {
-    type: EventType.CREATE_ENVIRONMENT;
-    metadata: {
-        name: string;
-        slug: string;
-    }
+  type: EventType.CREATE_ENVIRONMENT;
+  metadata: {
+    name: string;
+    slug: string;
+  };
 }
 
 interface UpdateEnvironmentEvent {
-    type: EventType.UPDATE_ENVIRONMENT;
-    metadata: {
-        oldName: string;
-        newName: string;
-        oldSlug: string;
-        newSlug: string;
-    }
+  type: EventType.UPDATE_ENVIRONMENT;
+  metadata: {
+    oldName: string;
+    newName: string;
+    oldSlug: string;
+    newSlug: string;
+  };
 }
 
 interface DeleteEnvironmentEvent {
-    type: EventType.DELETE_ENVIRONMENT;
-    metadata: {
-        name: string;
-        slug: string;
-    }
+  type: EventType.DELETE_ENVIRONMENT;
+  metadata: {
+    name: string;
+    slug: string;
+  };
 }
 
 interface AddWorkspaceMemberEvent {
-    type: EventType.ADD_WORKSPACE_MEMBER;
-    metadata: {
-        userId: string;
-        email: string;
-    }
+  type: EventType.ADD_WORKSPACE_MEMBER;
+  metadata: {
+    userId: string;
+    email: string;
+  };
 }
 
 interface RemoveWorkspaceMemberEvent {
-    type: EventType.REMOVE_WORKSPACE_MEMBER;
-    metadata: {
-        userId: string;
-        email: string;
-    }
+  type: EventType.REMOVE_WORKSPACE_MEMBER;
+  metadata: {
+    userId: string;
+    email: string;
+  };
 }
 
 interface CreateFolderEvent {
-    type: EventType.CREATE_FOLDER;
-    metadata: {
-        environment: string;
-        folderId: string;
-        folderName: string;
-        folderPath: string;
-    }
+  type: EventType.CREATE_FOLDER;
+  metadata: {
+    environment: string;
+    folderId: string;
+    folderName: string;
+    folderPath: string;
+  };
 }
 
 interface UpdateFolderEvent {
-    type: EventType.UPDATE_FOLDER;
-    metadata: {
-        environment: string;
-        folderId: string;
-        oldFolderName: string;
-        newFolderName: string;
-        folderPath: string;
-    }
+  type: EventType.UPDATE_FOLDER;
+  metadata: {
+    environment: string;
+    folderId: string;
+    oldFolderName: string;
+    newFolderName: string;
+    folderPath: string;
+  };
 }
 
 interface DeleteFolderEvent {
-    type: EventType.DELETE_FOLDER;
-    metadata: {
-        environment: string;
-        folderId: string;
-        folderName: string;
-        folderPath: string;
-    }
+  type: EventType.DELETE_FOLDER;
+  metadata: {
+    environment: string;
+    folderId: string;
+    folderName: string;
+    folderPath: string;
+  };
 }
 
 interface CreateWebhookEvent {
-    type: EventType.CREATE_WEBHOOK,
-    metadata: {
-        webhookId: string;
-        environment: string;
-        secretPath: string;
-        webhookUrl: string;
-        isDisabled: boolean;
-    }
+  type: EventType.CREATE_WEBHOOK;
+  metadata: {
+    webhookId: string;
+    environment: string;
+    secretPath: string;
+    webhookUrl: string;
+    isDisabled: boolean;
+  };
 }
 
 interface UpdateWebhookStatusEvent {
-    type: EventType.UPDATE_WEBHOOK_STATUS,
-    metadata: {
-        webhookId: string;
-        environment: string;
-        secretPath: string;
-        webhookUrl: string;
-        isDisabled: boolean;
-    }
+  type: EventType.UPDATE_WEBHOOK_STATUS;
+  metadata: {
+    webhookId: string;
+    environment: string;
+    secretPath: string;
+    webhookUrl: string;
+    isDisabled: boolean;
+  };
 }
 
 interface DeleteWebhookEvent {
-    type: EventType.DELETE_WEBHOOK,
-    metadata: {
-        webhookId: string;
-        environment: string;
-        secretPath: string;
-        webhookUrl: string;
-        isDisabled: boolean;
-    }
+  type: EventType.DELETE_WEBHOOK;
+  metadata: {
+    webhookId: string;
+    environment: string;
+    secretPath: string;
+    webhookUrl: string;
+    isDisabled: boolean;
+  };
 }
 
 interface GetSecretImportsEvent {
-    type: EventType.GET_SECRET_IMPORTS,
-    metadata: {
-        environment: string;
-        secretImportId: string;
-        folderId: string;
-        numberOfImports: number;
-    }
+  type: EventType.GET_SECRET_IMPORTS;
+  metadata: {
+    environment: string;
+    secretImportId: string;
+    folderId: string;
+    numberOfImports: number;
+  };
 }
 
 interface CreateSecretImportEvent {
-    type: EventType.CREATE_SECRET_IMPORT,
-    metadata: {
-        secretImportId: string;
-        folderId: string;
-        importFromEnvironment: string;
-        importFromSecretPath: string;
-        importToEnvironment: string;
-        importToSecretPath: string;
-    }
+  type: EventType.CREATE_SECRET_IMPORT;
+  metadata: {
+    secretImportId: string;
+    folderId: string;
+    importFromEnvironment: string;
+    importFromSecretPath: string;
+    importToEnvironment: string;
+    importToSecretPath: string;
+  };
 }
 
 interface UpdateSecretImportEvent {
-    type: EventType.UPDATE_SECRET_IMPORT,
-    metadata: {
-        secretImportId: string;
-        folderId: string;
-        importToEnvironment: string;
-        importToSecretPath: string;
-        orderBefore: {
-          environment: string;
-          secretPath: string;
-        }[],
-        orderAfter: {
-          environment: string;
-          secretPath: string;
-        }[]
-    }
+  type: EventType.UPDATE_SECRET_IMPORT;
+  metadata: {
+    secretImportId: string;
+    folderId: string;
+    importToEnvironment: string;
+    importToSecretPath: string;
+    orderBefore: {
+      environment: string;
+      secretPath: string;
+    }[];
+    orderAfter: {
+      environment: string;
+      secretPath: string;
+    }[];
+  };
 }
 
 interface DeleteSecretImportEvent {
-    type: EventType.DELETE_SECRET_IMPORT,
-    metadata: {
-        secretImportId: string;
-        folderId: string;
-        importFromEnvironment: string;
-        importFromSecretPath: string;
-        importToEnvironment: string;
-        importToSecretPath: string;
-    }
+  type: EventType.DELETE_SECRET_IMPORT;
+  metadata: {
+    secretImportId: string;
+    folderId: string;
+    importFromEnvironment: string;
+    importFromSecretPath: string;
+    importToEnvironment: string;
+    importToSecretPath: string;
+  };
 }
 
 interface UpdateUserRole {
-    type: EventType.UPDATE_USER_WORKSPACE_ROLE,
-    metadata: {
-        userId: string;
-        email: string;
-        oldRole: string;
-        newRole: string;
-    }
+  type: EventType.UPDATE_USER_WORKSPACE_ROLE;
+  metadata: {
+    userId: string;
+    email: string;
+    oldRole: string;
+    newRole: string;
+  };
 }
 
 interface UpdateUserDeniedPermissions {
-    type: EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS,
-    metadata: {
-        userId: string;
-        email: string;
-        deniedPermissions: {
-            environmentSlug: string;
-            ability: string;
-        }[]
-    }
+  type: EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS;
+  metadata: {
+    userId: string;
+    email: string;
+    deniedPermissions: {
+      environmentSlug: string;
+      ability: string;
+    }[];
+  };
 }
 
-
-export type Event = 
-    | GetSecretsEvent
-    | GetSecretEvent
-    | CreateSecretEvent
-    | UpdateSecretEvent
-    | DeleteSecretEvent
-    | GetWorkspaceKeyEvent
-    | AuthorizeIntegrationEvent
-    | UnauthorizeIntegrationEvent
-    | CreateIntegrationEvent
-    | DeleteIntegrationEvent
-    | AddTrustedIPEvent
-    | UpdateTrustedIPEvent
-    | DeleteTrustedIPEvent
-    | CreateServiceTokenEvent
-    | DeleteServiceTokenEvent
-    | CreateServiceTokenV3Event
-    | UpdateServiceTokenV3Event
-    | DeleteServiceTokenV3Event
-    | CreateEnvironmentEvent
-    | UpdateEnvironmentEvent
-    | DeleteEnvironmentEvent
-    | AddWorkspaceMemberEvent
-    | RemoveWorkspaceMemberEvent
-    | CreateFolderEvent
-    | UpdateFolderEvent
-    | DeleteFolderEvent
-    | CreateWebhookEvent
-    | UpdateWebhookStatusEvent
-    | DeleteWebhookEvent
-    | GetSecretImportsEvent
-    | CreateSecretImportEvent
-    | UpdateSecretImportEvent
-    | DeleteSecretImportEvent
-    | UpdateUserRole
-    | UpdateUserDeniedPermissions;
+export type Event =
+  | GetSecretsEvent
+  | GetSecretEvent
+  | CreateSecretEvent
+  | UpdateSecretEvent
+  | DeleteSecretEvent
+  | GetWorkspaceKeyEvent
+  | AuthorizeIntegrationEvent
+  | UnauthorizeIntegrationEvent
+  | CreateIntegrationEvent
+  | DeleteIntegrationEvent
+  | AddTrustedIPEvent
+  | UpdateTrustedIPEvent
+  | DeleteTrustedIPEvent
+  | CreateServiceTokenEvent
+  | DeleteServiceTokenEvent
+  | CreateServiceTokenV3Event
+  | UpdateServiceTokenV3Event
+  | DeleteServiceTokenV3Event
+  | CreateEnvironmentEvent
+  | UpdateEnvironmentEvent
+  | DeleteEnvironmentEvent
+  | AddWorkspaceMemberEvent
+  | RemoveWorkspaceMemberEvent
+  | CreateFolderEvent
+  | UpdateFolderEvent
+  | DeleteFolderEvent
+  | CreateWebhookEvent
+  | UpdateWebhookStatusEvent
+  | DeleteWebhookEvent
+  | GetSecretImportsEvent
+  | CreateSecretImportEvent
+  | UpdateSecretImportEvent
+  | DeleteSecretImportEvent
+  | UpdateUserRole
+  | UpdateUserDeniedPermissions;
 
 export type AuditLog = {
   _id: string;
   actor: Actor;
-  organization: string; 
+  organization: string;
   workspace: string;
   ipAddress: string;
   event: Event;
@@ -465,14 +460,14 @@ export type AuditLog = {
   userAgentType: UserAgentType;
   createdAt: string;
   updatedAt: string;
-}
+};
 
 export type AuditLogFilters = {
-    eventType?: EventType;
-    userAgentType?: UserAgentType;
-    actor?: string;
-    offset: number;
-    limit: number;
-    startDate?: Date;
-    endDate?: Date;
-}
+  eventType?: EventType;
+  userAgentType?: UserAgentType;
+  actor?: string;
+  offset: number;
+  limit: number;
+  startDate?: Date;
+  endDate?: Date;
+};

--- a/frontend/src/hooks/api/trustedIps/queries.ts
+++ b/frontend/src/hooks/api/trustedIps/queries.ts
@@ -2,107 +2,110 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
-import {
-    TrustedIp
-} from "./types";
+import { TrustedIp } from "./types";
 
 const trustedIps = {
-    getTrustedIps: (workspaceId: string) => [{ workspaceId }, "trusted-ips"] as const
-}
+  getTrustedIps: (workspaceId: string) => [{ workspaceId }, "trusted-ips"] as const
+};
 
 export const useGetTrustedIps = (workspaceId: string) => {
-    return useQuery({ 
-        queryKey: trustedIps.getTrustedIps(workspaceId), 
-        queryFn: async () => {
-            const { data } = await apiRequest.get<{ trustedIps: TrustedIp[] }>(`/api/v1/workspace/${workspaceId}/trusted-ips`);
+  return useQuery({
+    queryKey: trustedIps.getTrustedIps(workspaceId),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<{ trustedIps: TrustedIp[] }>(
+        `/api/v1/workspace/${workspaceId}/trusted-ips`
+      );
 
-            return data.trustedIps;
-        }
-    });
-}
+      return data.trustedIps;
+    }
+  });
+};
 
 export const useAddTrustedIp = () => {
-    const queryClient = useQueryClient();
-    return useMutation({
-        mutationFn: async ({
-            workspaceId,
-            ipAddress,
-            comment,
-            isActive
-        }: {
-            workspaceId: string;
-            ipAddress: string;
-            comment?: string;
-            isActive: boolean;
-        }) => {
-            const { data } = await apiRequest.post(
-                `/api/v1/workspace/${workspaceId}/trusted-ips`, 
-                {
-                    ipAddress,
-                    ...(comment ? { comment } : {}),
-                    isActive
-                }
-            );
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      workspaceId,
+      ipAddress,
+      comment,
+      environment,
+      isActive
+    }: {
+      workspaceId: string;
+      ipAddress: string;
+      comment?: string;
+      environment?: string;
+      isActive: boolean;
+    }) => {
+      const { data } = await apiRequest.post(`/api/v1/workspace/${workspaceId}/trusted-ips`, {
+        ipAddress,
+        ...(comment ? { comment } : {}),
+        ...(environment ? { environment } : {}),
+        isActive
+      });
 
-            return data;
-        },
-            onSuccess(_, dto) {
-            queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
-        }
-    });
+      return data;
+    },
+    onSuccess(_, dto) {
+      queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
+    }
+  });
 };
 
 export const useUpdateTrustedIp = () => {
-    const queryClient = useQueryClient();
-    return useMutation({
-        mutationFn: async ({
-            workspaceId,
-            trustedIpId,
-            ipAddress,
-            comment,
-            isActive
-        }: {
-            workspaceId: string;
-            trustedIpId: string;
-            ipAddress: string;
-            comment?: string;
-            isActive: boolean;
-        }) => {
-            const { data } = await apiRequest.patch(
-                `/api/v1/workspace/${workspaceId}/trusted-ips/${trustedIpId}`,
-                {
-                    ipAddress,
-                    ...(comment ? { comment } : {}),
-                    isActive
-                }
-            );
-
-            return data;
-        },
-            onSuccess(_, dto) {
-            queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      workspaceId,
+      trustedIpId,
+      ipAddress,
+      comment,
+      environment,
+      isActive
+    }: {
+      workspaceId: string;
+      trustedIpId: string;
+      ipAddress: string;
+      comment?: string;
+      environment?: string;
+      isActive: boolean;
+    }) => {
+      const { data } = await apiRequest.patch(
+        `/api/v1/workspace/${workspaceId}/trusted-ips/${trustedIpId}`,
+        {
+          ipAddress,
+          ...(comment ? { comment } : {}),
+          ...(environment ? { environment } : {}),
+          isActive
         }
-    });
+      );
+
+      return data;
+    },
+    onSuccess(_, dto) {
+      queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
+    }
+  });
 };
 
 export const useDeleteTrustedIp = () => {
-    const queryClient = useQueryClient();
-    return useMutation({
-        mutationFn: async ({
-            workspaceId,
-            trustedIpId,
-        }: {
-            workspaceId: string;
-            trustedIpId: string;
-        }) => {
-            const { data } = await apiRequest.delete(
-                `/api/v1/workspace/${workspaceId}/trusted-ips/${trustedIpId}`
-            );
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      workspaceId,
+      trustedIpId
+    }: {
+      workspaceId: string;
+      trustedIpId: string;
+    }) => {
+      const { data } = await apiRequest.delete(
+        `/api/v1/workspace/${workspaceId}/trusted-ips/${trustedIpId}`
+      );
 
-            return data;
-        },
-            onSuccess(_, dto) {
-            queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
-        }
-    });
+      return data;
+    },
+    onSuccess(_, dto) {
+      queryClient.invalidateQueries(trustedIps.getTrustedIps(dto.workspaceId));
+    }
+  });
 };

--- a/frontend/src/hooks/api/trustedIps/types.ts
+++ b/frontend/src/hooks/api/trustedIps/types.ts
@@ -1,9 +1,10 @@
 export type TrustedIp = {
-    _id: string;
-    workspace: string;
-    ipAddress: string;
-    type: "ipv4" | "ipv6";
-    isActive: boolean;
-    comment: string;
-    prefix?: number;
+  _id: string;
+  workspace: string;
+  ipAddress: string;
+  type: "ipv4" | "ipv6";
+  isActive: boolean;
+  comment: string;
+  environment: string;
+  prefix?: number;
 };

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -298,7 +298,7 @@ export const AppLayout = ({ children }: LayoutProps) => {
                             {currentOrg?.name.charAt(0)}
                           </div>
                           <div
-                            className="pl-2 text-sm text-mineshaft-100 text-ellipsis overflow-hidden"
+                            className="overflow-hidden text-ellipsis pl-2 text-sm text-mineshaft-100"
                             style={{ maxWidth: "140px" }}
                           >
                             {currentOrg?.name}
@@ -541,8 +541,8 @@ export const AppLayout = ({ children }: LayoutProps) => {
                           </MenuItem>
                         </a>
                       </Link>
-                      
-                      {/* <Link href={`/project/${currentWorkspace?._id}/allowlist`} passHref>
+
+                      <Link href={`/project/${currentWorkspace?._id}/allowlist`} passHref>
                         <a>
                           <MenuItem
                             isSelected={
@@ -553,7 +553,7 @@ export const AppLayout = ({ children }: LayoutProps) => {
                             IP Allowlist
                           </MenuItem>
                         </a>
-                      </Link> */}
+                      </Link>
                       <Link href={`/project/${currentWorkspace?._id}/audit-logs`} passHref>
                         <a>
                           <MenuItem

--- a/frontend/src/views/Project/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/views/Project/AuditLogsPage/components/LogsFilter.tsx
@@ -3,13 +3,7 @@ import { Control, Controller, UseFormReset } from "react-hook-form";
 import { faFilterCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import {
-    Button,
-    DatePicker,
-    FormControl,
-    Select,
-    SelectItem
-} from "@app/components/v2";
+import { Button, DatePicker, FormControl, Select, SelectItem } from "@app/components/v2";
 import { useWorkspace } from "@app/context";
 import { useGetAuditLogActorFilterOpts } from "@app/hooks/api";
 import { eventToNameMap, userAgentTTypeoNameMap } from "@app/hooks/api/auditLogs/constants";
@@ -19,201 +13,207 @@ import { Actor } from "@app/hooks/api/auditLogs/types";
 import { AuditLogFilterFormData } from "./types";
 
 const eventTypes = Object.entries(eventToNameMap).map(([value, label]) => ({ label, value }));
-const userAgentTypes = Object.entries(userAgentTTypeoNameMap).map(([value, label]) => ({ label, value }));
+const userAgentTypes = Object.entries(userAgentTTypeoNameMap).map(([value, label]) => ({
+  label,
+  value
+}));
 
 type Props = {
-    control: Control<AuditLogFilterFormData>;
-    reset: UseFormReset<AuditLogFilterFormData>;
-}
+  control: Control<AuditLogFilterFormData>;
+  reset: UseFormReset<AuditLogFilterFormData>;
+};
 
-export const LogsFilter = ({
-    control,
-    reset
-}: Props) => {
-    const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
-    const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
+export const LogsFilter = ({ control, reset }: Props) => {
+  const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
+  const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
 
-    const { currentWorkspace } = useWorkspace();
-    const { data, isLoading } = useGetAuditLogActorFilterOpts(currentWorkspace?._id ?? "");
-    
-    const renderActorSelectItem = (actor: Actor) => {
-        switch (actor.type) {
-            case ActorType.USER:
-                return (
-                    <SelectItem value={`${actor.type}-${actor.metadata.userId}`} key={`user-actor-filter-${actor.metadata.userId}`}>
-                        {actor.metadata.email}
-                    </SelectItem>
-                );
-            case ActorType.SERVICE:
-                return (
-                    <SelectItem value={`${actor.type}-${actor.metadata.serviceId}`} key={`service-actor-filter-${actor.metadata.serviceId}`}>
-                        {actor.metadata.name}
-                    </SelectItem>
-                );
-            case ActorType.SERVICE_V3:
-                return (
-                    <SelectItem value={`${actor.type}-${actor.metadata.serviceId}`} key={`service-actor-v3-filter-${actor.metadata.serviceId}`}>
-                        {actor.metadata.name}
-                    </SelectItem>
-                );
-            default:
-                return (
-                    <SelectItem value="actor-none" key="actor-none">
-                        N/A
-                    </SelectItem>
-                );
-        }
+  const { currentWorkspace } = useWorkspace();
+  const { data, isLoading } = useGetAuditLogActorFilterOpts(currentWorkspace?._id ?? "");
 
+  const renderActorSelectItem = (actor: Actor) => {
+    switch (actor.type) {
+      case ActorType.USER:
+        return (
+          <SelectItem
+            value={`${actor.type}-${actor.metadata.userId}`}
+            key={`user-actor-filter-${actor.metadata.userId}`}
+          >
+            {actor.metadata.email}
+          </SelectItem>
+        );
+      case ActorType.SERVICE:
+        return (
+          <SelectItem
+            value={`${actor.type}-${actor.metadata.serviceId}`}
+            key={`service-actor-filter-${actor.metadata.serviceId}`}
+          >
+            {actor.metadata.name}
+          </SelectItem>
+        );
+      case ActorType.SERVICE_V3:
+        return (
+          <SelectItem
+            value={`${actor.type}-${actor.metadata.serviceId}`}
+            key={`service-actor-v3-filter-${actor.metadata.serviceId}`}
+          >
+            {actor.metadata.name}
+          </SelectItem>
+        );
+      default:
+        return (
+          <SelectItem value="actor-none" key="actor-none">
+            N/A
+          </SelectItem>
+        );
     }
+  };
 
-    return (
-        <div className="flex justify-between items-center">
-            <div className="flex items-center">
-                <Controller
-                    control={control}
-                    name="eventType"
-                    render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                        <FormControl
-                            label="Event"
-                            errorText={error?.message}
-                            isError={Boolean(error)}
-                            className="w-40 mr-4"
-                        >
-                            <Select
-                                {...(field.value ? { value: field.value } : { placeholder: "Select" })}
-                                {...field}
-                                onValueChange={(e) => onChange(e)}
-                                className="w-full bg-mineshaft-700 border border-mineshaft-500 text-mineshaft-100"
-                            >
-                                {eventTypes.map(({ label, value }) => (
-                                    <SelectItem value={String(value || "")} key={label}>
-                                        {label}
-                                    </SelectItem>
-                                ))}
-                            </Select>
-                        </FormControl>
-                    )}
-                />
-                {!isLoading && data && data.length > 0 && (
-                    <Controller
-                        control={control}
-                        name="actor"
-                        render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                            <FormControl
-                                label="Actor"
-                                errorText={error?.message}
-                                isError={Boolean(error)}
-                                className="w-40 mr-4"
-                            >
-                                <Select
-                                    {...(field.value ? { value: field.value } : { placeholder: "Select" })}
-                                    {...field}
-                                    onValueChange={(e) => onChange(e)}
-                                    className="w-full bg-mineshaft-700 border border-mineshaft-500 text-mineshaft-100"
-                                >
-                                    {data.map((actor) => renderActorSelectItem(actor))}
-                                </Select>
-                            </FormControl>
-                        )}
-                    />
-                )}
-                <Controller
-                    control={control}
-                    name="userAgentType"
-                    render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                        <FormControl
-                            label="Source"
-                            errorText={error?.message}
-                            isError={Boolean(error)}
-                            className="w-40 mr-4"
-                        >
-                            <Select
-                                {...(field.value ? { value: field.value } : { placeholder: "Select" })}
-                                {...field}
-                                onValueChange={(e) => onChange(e)}
-                                className="w-full bg-mineshaft-700 border border-mineshaft-500 text-mineshaft-100"
-                            >
-                                {userAgentTypes.map(({ label, value }) => (
-                                    <SelectItem value={String(value || "")} key={label}>
-                                        {label}
-                                    </SelectItem>
-                                ))}
-                            </Select>
-                        </FormControl>
-                    )}
-                />
-                <Controller 
-                    name="startDate"
-                    control={control}
-                    render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-                        return (
-                            <FormControl
-                                label="Start date"
-                                errorText={error?.message}
-                                isError={Boolean(error)}
-                                className="mr-4"
-                            >
-                                <DatePicker 
-                                    value={field.value || undefined}
-                                    onChange={date => {
-                                        onChange(date);
-                                        setIsStartDatePickerOpen(false);
-                                    }}
-                                    popUpProps={{ 
-                                        open: isStartDatePickerOpen,
-                                        onOpenChange: setIsStartDatePickerOpen
-                                    }}
-                                    popUpContentProps={{}}
-                                />
-                            </FormControl>
-                        );
-                    }}
-                />
-                <Controller 
-                    name="endDate"
-                    control={control}
-                    render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-                        return (
-                            <FormControl
-                                label="End date"
-                                errorText={error?.message}
-                                isError={Boolean(error)}
-                            >
-                                <DatePicker 
-                                    value={field.value || undefined}
-                                    onChange={date => {
-                                        onChange(date);
-                                        setIsEndDatePickerOpen(false);
-                                    }}
-                                    popUpProps={{ 
-                                        open: isEndDatePickerOpen,
-                                        onOpenChange: setIsEndDatePickerOpen
-                                    }}
-                                    popUpContentProps={{}}
-                                />
-                            </FormControl>
-                        );
-                    }}
-                />
-            </div>
-            <div>
-                <Button
-                    isLoading={false}
-                    colorSchema="primary"
-                    variant="outline_bg"
-                    type="submit"
-                    leftIcon={<FontAwesomeIcon icon={faFilterCircleXmark} className="mr-2" />}
-                    onClick={() => reset({
-                        eventType: undefined,
-                        actor: undefined,
-                        userAgentType: undefined,
-                        startDate: undefined,
-                        endDate: undefined
-                    })}
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center">
+        <Controller
+          control={control}
+          name="eventType"
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+            <FormControl
+              label="Event"
+              errorText={error?.message}
+              isError={Boolean(error)}
+              className="w-50 mr-4"
+            >
+              <Select
+                {...(field.value ? { value: field.value } : { placeholder: "Select" })}
+                {...field}
+                onValueChange={(e) => onChange(e)}
+                className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
+              >
+                {eventTypes.map(({ label, value }) => (
+                  <SelectItem value={String(value || "")} key={label}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        {!isLoading && data && data.length > 0 && (
+          <Controller
+            control={control}
+            name="actor"
+            render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+              <FormControl
+                label="Actor"
+                errorText={error?.message}
+                isError={Boolean(error)}
+                className="mr-4 w-40"
+              >
+                <Select
+                  {...(field.value ? { value: field.value } : { placeholder: "Select" })}
+                  {...field}
+                  onValueChange={(e) => onChange(e)}
+                  className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
                 >
-                    Clear filters
-                </Button>
-            </div>
-        </div>
-    );
-}
+                  {data.map((actor) => renderActorSelectItem(actor))}
+                </Select>
+              </FormControl>
+            )}
+          />
+        )}
+        <Controller
+          control={control}
+          name="userAgentType"
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+            <FormControl
+              label="Source"
+              errorText={error?.message}
+              isError={Boolean(error)}
+              className="mr-4 w-40"
+            >
+              <Select
+                {...(field.value ? { value: field.value } : { placeholder: "Select" })}
+                {...field}
+                onValueChange={(e) => onChange(e)}
+                className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
+              >
+                {userAgentTypes.map(({ label, value }) => (
+                  <SelectItem value={String(value || "")} key={label}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name="startDate"
+          control={control}
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+            return (
+              <FormControl
+                label="Start date"
+                errorText={error?.message}
+                isError={Boolean(error)}
+                className="mr-4"
+              >
+                <DatePicker
+                  value={field.value || undefined}
+                  onChange={(date) => {
+                    onChange(date);
+                    setIsStartDatePickerOpen(false);
+                  }}
+                  popUpProps={{
+                    open: isStartDatePickerOpen,
+                    onOpenChange: setIsStartDatePickerOpen
+                  }}
+                  popUpContentProps={{}}
+                />
+              </FormControl>
+            );
+          }}
+        />
+        <Controller
+          name="endDate"
+          control={control}
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+            return (
+              <FormControl label="End date" errorText={error?.message} isError={Boolean(error)}>
+                <DatePicker
+                  value={field.value || undefined}
+                  onChange={(date) => {
+                    onChange(date);
+                    setIsEndDatePickerOpen(false);
+                  }}
+                  popUpProps={{
+                    open: isEndDatePickerOpen,
+                    onOpenChange: setIsEndDatePickerOpen
+                  }}
+                  popUpContentProps={{}}
+                />
+              </FormControl>
+            );
+          }}
+        />
+      </div>
+      <div>
+        <Button
+          isLoading={false}
+          colorSchema="primary"
+          variant="outline_bg"
+          type="submit"
+          leftIcon={<FontAwesomeIcon icon={faFilterCircleXmark} className="mr-2" />}
+          onClick={() =>
+            reset({
+              eventType: undefined,
+              actor: undefined,
+              userAgentType: undefined,
+              startDate: undefined,
+              endDate: undefined
+            })
+          }
+        >
+          Clear filters
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/views/Project/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/views/Project/AuditLogsPage/components/LogsSection.tsx
@@ -13,78 +13,65 @@ import { LogsTable } from "./LogsTable";
 import { AuditLogFilterFormData, auditLogFilterFormSchema } from "./types";
 
 export const LogsSection = () => {
-    const { subscription } = useSubscription();
-    const router = useRouter();
-    
-    const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp([
-        "upgradePlan"
-    ] as const);
-    
-    const {
-        control,
-        reset,
-        watch,
-        setValue,
-    } = useForm<AuditLogFilterFormData>({
-        resolver: yupResolver(auditLogFilterFormSchema),
-        defaultValues: {
-            page: 1,
-            perPage: 10
-        }
-    });
-    
-    useEffect(() => {
-        if (subscription && !subscription.auditLogs) {
-            handlePopUpOpen("upgradePlan");
-        }
-    }, [subscription]);
+  const { subscription } = useSubscription();
+  const router = useRouter();
 
-    const eventType = watch("eventType") as EventType | undefined;
-    const userAgentType = watch("userAgentType") as UserAgentType | undefined;
-    const actor = watch("actor");
+  const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
 
-    const startDate = watch("startDate");
-    const endDate = watch("endDate");
+  const defaultPage = 1;
+  const defaultPerPage = 10;
+  const { control, reset, watch, setValue } = useForm<AuditLogFilterFormData>({
+    resolver: yupResolver(auditLogFilterFormSchema),
+    defaultValues: {
+      page: defaultPage,
+      perPage: defaultPerPage
+    }
+  });
 
-    const page = watch("page") as number;
-    const perPage = watch("perPage") as number;
-    
-    return (
-        <div 
-            // className="p-4 bg-mineshaft-900 mb-6 rounded-lg border border-mineshaft-600"
-        >
-            {/* <div className="flex items-center mb-8">
-                <h2 className="text-xl font-semibold flex-1 text-white">
-                    Audit Logs
-                </h2>
-            </div> */}
-            <LogsFilter 
-                control={control} 
-                reset={reset}
-            />
-            <LogsTable
-                eventType={eventType}
-                userAgentType={userAgentType}
-                actor={actor}
-                startDate={startDate}
-                endDate={endDate}
-                page={page}
-                perPage={perPage}
-                setValue={setValue}
-            />
-            <UpgradePlanModal
-                isOpen={popUp.upgradePlan.isOpen}
-                onOpenChange={(isOpen) => {
-                    
-                    if (!isOpen) {
-                        router.back();
-                        return;
-                    }
+  useEffect(() => {
+    if (subscription && !subscription.auditLogs) {
+      handlePopUpOpen("upgradePlan");
+    }
+  }, [subscription]);
 
-                    handlePopUpToggle("upgradePlan", isOpen)
-                }}
-                text="You can use audit logs if you switch to a paid Infisical plan."
-            />
-        </div>
-    );
- }
+  const eventType = watch("eventType") as EventType | undefined;
+  const userAgentType = watch("userAgentType") as UserAgentType | undefined;
+  const actor = watch("actor");
+
+  const startDate = watch("startDate");
+  const endDate = watch("endDate");
+
+  /**
+   * There was a bug where the offset number was Nan and the limit was undefined. So I added a defaultPage and defaultPerPage.
+   */
+  const page = (watch("page") as number) ?? defaultPage;
+  const perPage = (watch("perPage") as number) ?? defaultPerPage;
+
+  return (
+    <>
+      <LogsFilter control={control} reset={reset} />
+      <LogsTable
+        eventType={eventType}
+        userAgentType={userAgentType}
+        actor={actor}
+        startDate={startDate}
+        endDate={endDate}
+        page={page}
+        perPage={perPage}
+        setValue={setValue}
+      />
+      <UpgradePlanModal
+        isOpen={popUp.upgradePlan.isOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            router.back();
+            return;
+          }
+
+          handlePopUpToggle("upgradePlan", isOpen);
+        }}
+        text="You can use audit logs if you switch to a paid Infisical plan."
+      />
+    </>
+  );
+};

--- a/frontend/src/views/Project/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/views/Project/AuditLogsPage/components/LogsTableRow.tsx
@@ -1,365 +1,359 @@
-import {
-    Td,
-    Tr
-} from "@app/components/v2";
+import { Td, Tr } from "@app/components/v2";
 import { eventToNameMap, userAgentTTypeoNameMap } from "@app/hooks/api/auditLogs/constants";
 import { ActorType, EventType } from "@app/hooks/api/auditLogs/enums";
 import { Actor, AuditLog, Event } from "@app/hooks/api/auditLogs/types";
 
 type Props = {
-    auditLog: AuditLog
-}
+  auditLog: AuditLog;
+};
 
-export const LogsTableRow = ({
-    auditLog
-}: Props) => {
-    const renderActor = (actor: Actor) => {
-        switch (actor.type) {
-            case ActorType.USER:
-                return (
-                    <Td>
-                        <p>{actor.metadata.email}</p>
-                        <p>User</p>
-                    </Td>
-                );
-            case ActorType.SERVICE:
-                return (
-                    <Td>
-                        <p>{`${actor.metadata.name}`}</p>
-                        <p>Service token</p>
-                    </Td>
-                ); 
-            case ActorType.SERVICE_V3:
-                    return (
-                        <Td>
-                            <p>{`${actor.metadata.name}`}</p>
-                            <p>Service token V3</p>
-                        </Td>
-                    );
-            default:
-                return (
-                    <Td />
-                );
-        }
+export const LogsTableRow = ({ auditLog }: Props) => {
+  const renderActor = (actor: Actor) => {
+    switch (actor.type) {
+      case ActorType.USER:
+        return (
+          <Td>
+            <p>{actor.metadata.email}</p>
+            <p>User</p>
+          </Td>
+        );
+      case ActorType.SERVICE:
+        return (
+          <Td>
+            <p>{`${actor.metadata.name}`}</p>
+            <p>Service token</p>
+          </Td>
+        );
+      case ActorType.SERVICE_V3:
+        return (
+          <Td>
+            <p>{`${actor.metadata.name}`}</p>
+            <p>Service token V3</p>
+          </Td>
+        );
+      default:
+        return <Td />;
     }
-    
-    const renderMetadata = (event: Event) => {
-        switch (event.type) {
-            case EventType.GET_SECRETS:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        <p>{`# Secrets: ${event.metadata.numberOfSecrets}`}</p>
-                    </Td>
-                );
-            case EventType.GET_SECRET:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Secret: ${event.metadata.secretKey}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_SECRET:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Secret: ${event.metadata.secretKey}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_SECRET:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Secret: ${event.metadata.secretKey}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_SECRET:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Secret: ${event.metadata.secretKey}`}</p>
-                    </Td>
-                );
-            case EventType.AUTHORIZE_INTEGRATION:
-                return (
-                    <Td>
-                        <p>{`Integration: ${event.metadata.integration}`}</p>
-                    </Td>
-                );
-            case EventType.UNAUTHORIZE_INTEGRATION:
-                return (
-                    <Td>
-                        <p>{`Integration: ${event.metadata.integration}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_INTEGRATION:
-                return (
-                    <Td>
-                        <p>{`Integration: ${event.metadata.integration}`}</p>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        {event.metadata.app && (
-                            <p>{`Target app: ${event.metadata.app}`}</p>
-                        )}
-                        {event.metadata.appId && (
-                            <p>{`Target app: ${event.metadata.appId}`}</p>
-                        )}
-                        {event.metadata.targetEnvironment && (
-                            <p>{`Target environment: ${event.metadata.targetEnvironment}`}</p>
-                        )}
-                        {event.metadata.targetEnvironmentId && (
-                            <p>{`Target environment ID: ${event.metadata.targetEnvironmentId}`}</p>
-                        )}
-                    </Td>
-                );
-            case EventType.DELETE_INTEGRATION:
-                return (
-                    <Td>
-                        <p>{`Integration: ${event.metadata.integration}`}</p>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.secretPath}`}</p>
-                        {event.metadata.app && (
-                            <p>{`Target App: ${event.metadata.app}`}</p>
-                        )}
-                        {event.metadata.appId && (
-                            <p>{`Target app: ${event.metadata.appId}`}</p>
-                        )}
-                        {event.metadata.targetEnvironment && (
-                            <p>{`Target environment: ${event.metadata.targetEnvironment}`}</p>
-                        )}
-                        {event.metadata.targetEnvironmentId && (
-                            <p>{`Target environment ID: ${event.metadata.targetEnvironmentId}`}</p>
-                        )}
-                    </Td>
-                );
-            case EventType.ADD_TRUSTED_IP:
-                return (
-                    <Td>
-                        <p>{`IP: ${event.metadata.ipAddress}${event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_TRUSTED_IP:
-                return (
-                    <Td>
-                        <p>{`IP: ${event.metadata.ipAddress}${event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_TRUSTED_IP:
-                return (
-                    <Td>
-                        <p>{`IP: ${event.metadata.ipAddress}${event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_SERVICE_TOKEN:
-                return (
-                    <Td>
-                        <p>{`Name: ${event.metadata.name}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_SERVICE_TOKEN:
-                return (
-                    <Td>
-                        <p>{`Name: ${event.metadata.name}`}</p>
-                    </Td>
-                );
-                case EventType.CREATE_SERVICE_TOKEN_V3:
-                    return (
-                        <Td>
-                            <p>{`Name: ${event.metadata.name}`}</p>
-                        </Td>
-                    );
-                case EventType.UPDATE_SERVICE_TOKEN_V3:
-                    return (
-                        <Td>
-                            <p>{`Name: ${event.metadata.name}`}</p>
-                        </Td>
-                    );
-                case EventType.DELETE_SERVICE_TOKEN_V3:
-                    return (
-                        <Td>
-                            <p>{`Name: ${event.metadata.name}`}</p>
-                        </Td>
-                    );
-            case EventType.CREATE_ENVIRONMENT:
-                return (
-                    <Td>
-                        <p>{`Name: ${event.metadata.name}`}</p>
-                        <p>{`Slug: ${event.metadata.slug}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_ENVIRONMENT:
-                return (
-                    <Td>
-                        <p>{`Old name: ${event.metadata.oldName}`}</p>
-                        <p>{`New name: ${event.metadata.newName}`}</p>
-                        <p>{`Old slug: ${event.metadata.oldSlug}`}</p>
-                        <p>{`New slug: ${event.metadata.newSlug}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_ENVIRONMENT:
-                return (
-                    <Td>
-                        <p>{`Name: ${event.metadata.name}`}</p>
-                        <p>{`Slug: ${event.metadata.slug}`}</p>
-                    </Td>
-                );
-            case EventType.ADD_WORKSPACE_MEMBER:
-                return (
-                    <Td>
-                        <p>{`Email: ${event.metadata.email}`}</p>
-                    </Td>
-                );
-            case EventType.REMOVE_WORKSPACE_MEMBER:
-                return (
-                    <Td>
-                        <p>{`Email: ${event.metadata.email}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_FOLDER:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.folderPath}`}</p>
-                        <p>{`Folder: ${event.metadata.folderName}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_FOLDER:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.folderPath}`}</p>
-                        <p>{`Old folder: ${event.metadata.oldFolderName}`}</p>
-                        <p>{`New folder: ${event.metadata.newFolderName}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_FOLDER:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Path: ${event.metadata.folderPath}`}</p>
-                        <p>{`Folder: ${event.metadata.folderName}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_WEBHOOK:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Secret path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
-                        <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_WEBHOOK_STATUS:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Secret path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
-                        <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_WEBHOOK:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`Secret path: ${event.metadata.secretPath}`}</p>
-                        <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
-                        <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
-                    </Td>
-                );
-            case EventType.GET_SECRET_IMPORTS:
-                return (
-                    <Td>
-                        <p>{`Environment: ${event.metadata.environment}`}</p>
-                        <p>{`# Imported paths: ${event.metadata.numberOfImports}`}</p>
-                    </Td>
-                );
-            case EventType.CREATE_SECRET_IMPORT:
-                return (
-                    <Td>
-                        <p>{`Import from env: ${event.metadata.importFromEnvironment}`}</p>
-                        <p>{`Import from path: ${event.metadata.importFromSecretPath}`}</p>
-                        <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
-                        <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_SECRET_IMPORT:
-                return (
-                    <Td>
-                        <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
-                        <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
-                    </Td>
-                );
-            case EventType.DELETE_SECRET_IMPORT:
-                return (
-                    <Td>
-                        <p>{`Import from env: ${event.metadata.importFromEnvironment}`}</p>
-                        <p>{`Import from path: ${event.metadata.importFromSecretPath}`}</p>
-                        <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
-                        <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_USER_WORKSPACE_ROLE:
-                return (
-                    <Td>
-                        <p>{`Email: ${event.metadata.email}`}</p>
-                        <p>{`Old role: ${event.metadata.oldRole}`}</p>
-                        <p>{`New role: ${event.metadata.newRole}`}</p>
-                    </Td>
-                );
-            case EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS:
-                return (
-                    <Td>
-                        <p>{`Email: ${event.metadata.email}`}</p>
-                        {event.metadata.deniedPermissions.map((permission) => {
-                            return (
-                                <p key={`audit-log-denied-permission-${event.metadata.userId}-${permission.environmentSlug}-${permission.ability}`}>
-                                    {`Denied env-ability: ${permission.environmentSlug}-${permission.ability}`}
-                                </p>
-                            );
-                        })}
-                    </Td>
-                );
-            default:
-                return (
-                    <Td />
-                ); 
-        }
+  };
+
+  const renderMetadata = (event: Event) => {
+    switch (event.type) {
+      case EventType.GET_SECRETS:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            <p>{`# Secrets: ${event.metadata.numberOfSecrets}`}</p>
+          </Td>
+        );
+      case EventType.GET_SECRET:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            <p>{`Secret: ${event.metadata.secretKey}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_SECRET:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            <p>{`Secret: ${event.metadata.secretKey}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_SECRET:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            <p>{`Secret: ${event.metadata.secretKey}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_SECRET:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            <p>{`Secret: ${event.metadata.secretKey}`}</p>
+          </Td>
+        );
+      case EventType.AUTHORIZE_INTEGRATION:
+        return (
+          <Td>
+            <p>{`Integration: ${event.metadata.integration}`}</p>
+          </Td>
+        );
+      case EventType.UNAUTHORIZE_INTEGRATION:
+        return (
+          <Td>
+            <p>{`Integration: ${event.metadata.integration}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_INTEGRATION:
+        return (
+          <Td>
+            <p>{`Integration: ${event.metadata.integration}`}</p>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            {event.metadata.app && <p>{`Target app: ${event.metadata.app}`}</p>}
+            {event.metadata.appId && <p>{`Target app: ${event.metadata.appId}`}</p>}
+            {event.metadata.targetEnvironment && (
+              <p>{`Target environment: ${event.metadata.targetEnvironment}`}</p>
+            )}
+            {event.metadata.targetEnvironmentId && (
+              <p>{`Target environment ID: ${event.metadata.targetEnvironmentId}`}</p>
+            )}
+          </Td>
+        );
+      case EventType.DELETE_INTEGRATION:
+        return (
+          <Td>
+            <p>{`Integration: ${event.metadata.integration}`}</p>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.secretPath}`}</p>
+            {event.metadata.app && <p>{`Target App: ${event.metadata.app}`}</p>}
+            {event.metadata.appId && <p>{`Target app: ${event.metadata.appId}`}</p>}
+            {event.metadata.targetEnvironment && (
+              <p>{`Target environment: ${event.metadata.targetEnvironment}`}</p>
+            )}
+            {event.metadata.targetEnvironmentId && (
+              <p>{`Target environment ID: ${event.metadata.targetEnvironmentId}`}</p>
+            )}
+          </Td>
+        );
+      case EventType.ADD_TRUSTED_IP:
+        return (
+          <Td>
+            <p>{`IP: ${event.metadata.ipAddress}${
+              event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""
+            }`}</p>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_TRUSTED_IP:
+        return (
+          <Td>
+            <p>{`IP: ${event.metadata.ipAddress}${
+              event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""
+            }`}</p>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_TRUSTED_IP:
+        return (
+          <Td>
+            <p>{`IP: ${event.metadata.ipAddress}${
+              event.metadata.prefix !== undefined ? `/${event.metadata.prefix}` : ""
+            }`}</p>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_SERVICE_TOKEN:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_SERVICE_TOKEN:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_SERVICE_TOKEN_V3:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_SERVICE_TOKEN_V3:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_SERVICE_TOKEN_V3:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_ENVIRONMENT:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+            <p>{`Slug: ${event.metadata.slug}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_ENVIRONMENT:
+        return (
+          <Td>
+            <p>{`Old name: ${event.metadata.oldName}`}</p>
+            <p>{`New name: ${event.metadata.newName}`}</p>
+            <p>{`Old slug: ${event.metadata.oldSlug}`}</p>
+            <p>{`New slug: ${event.metadata.newSlug}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_ENVIRONMENT:
+        return (
+          <Td>
+            <p>{`Name: ${event.metadata.name}`}</p>
+            <p>{`Slug: ${event.metadata.slug}`}</p>
+          </Td>
+        );
+      case EventType.ADD_WORKSPACE_MEMBER:
+        return (
+          <Td>
+            <p>{`Email: ${event.metadata.email}`}</p>
+          </Td>
+        );
+      case EventType.REMOVE_WORKSPACE_MEMBER:
+        return (
+          <Td>
+            <p>{`Email: ${event.metadata.email}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_FOLDER:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.folderPath}`}</p>
+            <p>{`Folder: ${event.metadata.folderName}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_FOLDER:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.folderPath}`}</p>
+            <p>{`Old folder: ${event.metadata.oldFolderName}`}</p>
+            <p>{`New folder: ${event.metadata.newFolderName}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_FOLDER:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Path: ${event.metadata.folderPath}`}</p>
+            <p>{`Folder: ${event.metadata.folderName}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_WEBHOOK:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Secret path: ${event.metadata.secretPath}`}</p>
+            <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
+            <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_WEBHOOK_STATUS:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Secret path: ${event.metadata.secretPath}`}</p>
+            <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
+            <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_WEBHOOK:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`Secret path: ${event.metadata.secretPath}`}</p>
+            <p>{`Webhook URL: ${event.metadata.webhookUrl}`}</p>
+            <p>{`Disabled: ${event.metadata.isDisabled}`}</p>
+          </Td>
+        );
+      case EventType.GET_SECRET_IMPORTS:
+        return (
+          <Td>
+            <p>{`Environment: ${event.metadata.environment ?? "all"}`}</p>
+            <p>{`# Imported paths: ${event.metadata.numberOfImports}`}</p>
+          </Td>
+        );
+      case EventType.CREATE_SECRET_IMPORT:
+        return (
+          <Td>
+            <p>{`Import from env: ${event.metadata.importFromEnvironment}`}</p>
+            <p>{`Import from path: ${event.metadata.importFromSecretPath}`}</p>
+            <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
+            <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_SECRET_IMPORT:
+        return (
+          <Td>
+            <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
+            <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
+          </Td>
+        );
+      case EventType.DELETE_SECRET_IMPORT:
+        return (
+          <Td>
+            <p>{`Import from env: ${event.metadata.importFromEnvironment}`}</p>
+            <p>{`Import from path: ${event.metadata.importFromSecretPath}`}</p>
+            <p>{`Import to env: ${event.metadata.importToEnvironment}`}</p>
+            <p>{`Import to path: ${event.metadata.importToSecretPath}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_USER_WORKSPACE_ROLE:
+        return (
+          <Td>
+            <p>{`Email: ${event.metadata.email}`}</p>
+            <p>{`Old role: ${event.metadata.oldRole}`}</p>
+            <p>{`New role: ${event.metadata.newRole}`}</p>
+          </Td>
+        );
+      case EventType.UPDATE_USER_WORKSPACE_DENIED_PERMISSIONS:
+        return (
+          <Td>
+            <p>{`Email: ${event.metadata.email}`}</p>
+            {event.metadata.deniedPermissions.map((permission) => {
+              return (
+                <p
+                  key={`audit-log-denied-permission-${event.metadata.userId}-${permission.environmentSlug}-${permission.ability}`}
+                >
+                  {`Denied env-ability: ${permission.environmentSlug}-${permission.ability}`}
+                </p>
+              );
+            })}
+          </Td>
+        );
+      default:
+        return <Td />;
     }
+  };
 
-    const formatDate = (dateToFormat: string) => {
-        const date = new Date(dateToFormat);
-        const year = date.getFullYear();
-        const month = String(date.getMonth() + 1).padStart(2, "0");
-        const day = String(date.getDate()).padStart(2, "0");
+  const formatDate = (dateToFormat: string) => {
+    const date = new Date(dateToFormat);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
 
-        let hours = date.getHours();
-        const minutes = String(date.getMinutes()).padStart(2, "0");
+    let hours = date.getHours();
+    const minutes = String(date.getMinutes()).padStart(2, "0");
 
-        // convert from 24h to 12h format
-        const period = hours >= 12 ? "PM" : "AM";
-        hours %= 12;
-        hours = hours || 12; // the hour '0' should be '12'
+    // convert from 24h to 12h format
+    const period = hours >= 12 ? "PM" : "AM";
+    hours %= 12;
+    hours = hours || 12; // the hour '0' should be '12'
 
-        const formattedDate = `${day}-${month}-${year} at ${hours}:${minutes} ${period}`;
-        return formattedDate;
-    }
-    
-    return (
-       <Tr className={`log-${auditLog._id} h-10 border-b border-x-0 border-t-0`}>
-            <Td>{formatDate(auditLog.createdAt)}</Td>
-            <Td>{`${eventToNameMap[auditLog.event.type]}`}</Td>
-            {renderActor(auditLog.actor)}
-            <Td>
-                <p>{userAgentTTypeoNameMap[auditLog.userAgentType]}</p>
-                <p>{auditLog.ipAddress}</p>
-            </Td>
-            {renderMetadata(auditLog.event)}
-        </Tr> 
-    );
-}
+    const formattedDate = `${day}-${month}-${year} at ${hours}:${minutes} ${period}`;
+    return formattedDate;
+  };
+
+  return (
+    <Tr className={`log-${auditLog._id} h-10 border-x-0 border-b border-t-0`}>
+      <Td>{formatDate(auditLog.createdAt)}</Td>
+      <Td>{`${eventToNameMap[auditLog.event.type]}`}</Td>
+      {renderActor(auditLog.actor)}
+      <Td>
+        <p>{userAgentTTypeoNameMap[auditLog.userAgentType]}</p>
+        <p>{auditLog.ipAddress}</p>
+      </Td>
+      {renderMetadata(auditLog.event)}
+    </Tr>
+  );
+};

--- a/frontend/src/views/Project/IPAllowListPage/components/IPAllowlistModal.tsx
+++ b/frontend/src/views/Project/IPAllowListPage/components/IPAllowlistModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Controller, useForm } from "react-hook-form"; 
+import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
@@ -9,20 +9,21 @@ import {
   FormControl,
   Input,
   Modal,
-  ModalContent
+  ModalContent,
+  Select,
+  SelectItem
 } from "@app/components/v2";
 import { useWorkspace } from "@app/context";
-import {
-    useAddTrustedIp,
-    useGetMyIp,
-    useUpdateTrustedIp
-} from "@app/hooks/api";
+import { useAddTrustedIp, useGetMyIp, useUpdateTrustedIp } from "@app/hooks/api";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
-const schema = yup.object({
+const schema = yup
+  .object({
     ipAddress: yup.string().required("IP address is required"),
-    comment: yup.string()
-}).required();
+    comment: yup.string(),
+    environment: yup.string()
+  })
+  .required();
 
 export type FormData = yup.InferType<typeof schema>;
 
@@ -32,162 +33,179 @@ type Props = {
   handlePopUpToggle: (popUpName: keyof UsePopUpState<["trustedIp"]>, state?: boolean) => void;
 };
 
-export const IPAllowlistModal = ({
-    popUp,
-    handlePopUpClose,
-    handlePopUpToggle
-}: Props) => {
-    const { createNotification } = useNotificationContext();
-    const { data, isLoading } = useGetMyIp();
-    
-    const { currentWorkspace } = useWorkspace();
-    const addTrustedIp = useAddTrustedIp();
-    const updateTrustedIp = useUpdateTrustedIp();
+export const IPAllowlistModal = ({ popUp, handlePopUpClose, handlePopUpToggle }: Props) => {
+  const { createNotification } = useNotificationContext();
+  const { data, isLoading } = useGetMyIp();
 
-    const {
-        control,
-        setValue,
-        handleSubmit,
-        reset,
-        formState: { isSubmitting }
-    } = useForm<FormData>({
-        resolver: yupResolver(schema)
-    });
-    
-    useEffect(() => {
-        const trustedIpData = popUp?.trustedIp?.data as { 
-            ipAddress: string;
-            comment: string;
-            prefix: number;
-        };
+  const { currentWorkspace } = useWorkspace();
+  const addTrustedIp = useAddTrustedIp();
+  const updateTrustedIp = useUpdateTrustedIp();
 
-        if (popUp?.trustedIp?.data) {
-            reset({
-                ipAddress: `${trustedIpData.ipAddress}${trustedIpData.prefix !== undefined ? `/${trustedIpData.prefix}` : ""}`,
-                comment: trustedIpData.comment
-            });
-        } else {
-           reset({
-                ipAddress: "",
-                comment: ""
-            }); 
-        }
-    
-    }, [popUp?.trustedIp?.data]);
-    
-    const onIPAllowlistModalSubmit = async ({
-        ipAddress,
-        comment
-    }: FormData) => {
-        try {
-            if (!currentWorkspace?._id) return;
-            
-            if (popUp?.trustedIp?.data) {
-                await updateTrustedIp.mutateAsync({
-                    workspaceId: currentWorkspace._id,
-                    trustedIpId: (popUp?.trustedIp?.data as { trustedIpId: string })?.trustedIpId,
-                    ipAddress,
-                    comment,
-                    isActive: true
-                });
-            } else {
-                await addTrustedIp.mutateAsync({
-                    workspaceId: currentWorkspace._id,
-                    ipAddress,
-                    comment,
-                    isActive: true
-                });
-            }
-            
-            createNotification({
-                text: `Successfully ${popUp?.trustedIp?.data ? "updated" : "added"} trusted IP`,
-                type: "success"
-            });
-            
-            reset();
-            handlePopUpClose("trustedIp");
-        } catch (err) {
-            createNotification({
-                text: `Failed to ${popUp?.trustedIp?.data ? "update" : "add"} trusted IP`,
-                type: "error"
-            });
-        }
+  const {
+    control,
+    setValue,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting }
+  } = useForm<FormData>({
+    resolver: yupResolver(schema)
+  });
+
+  useEffect(() => {
+    const trustedIpData = popUp?.trustedIp?.data as {
+      ipAddress: string;
+      comment: string;
+      environment: string;
+      prefix: number;
+    };
+
+    if (popUp?.trustedIp?.data) {
+      reset({
+        ipAddress: `${trustedIpData.ipAddress}${
+          trustedIpData.prefix !== undefined ? `/${trustedIpData.prefix}` : ""
+        }`,
+        comment: trustedIpData.comment,
+        environment: trustedIpData.environment
+      });
+    } else {
+      reset({
+        ipAddress: "",
+        comment: "",
+        environment: "all"
+      });
     }
+  }, [popUp?.trustedIp?.data]);
 
-    return (
-        <Modal
-            isOpen={popUp?.trustedIp?.isOpen}
-            onOpenChange={(isOpen) => {
-                handlePopUpToggle("trustedIp", isOpen);
-                reset();
-            }}
-        >
-            <ModalContent title={popUp?.trustedIp?.data ? "Update IP" : "Add IP"}>
-            <form onSubmit={handleSubmit(onIPAllowlistModalSubmit)}>
-                <Controller
-                    control={control}
-                    defaultValue=""
-                    name="ipAddress"
-                    render={({ field, fieldState: { error } }) => (
-                        <FormControl
-                            label="IPv4/IPv6 Address / CIDR Notation"
-                            isError={Boolean(error)}
-                            errorText={error?.message}
-                        >
-                        <Input 
-                            {...field} 
-                            placeholder="123.456.789.0"
-                        />
-                        </FormControl>
-                    )}
-                />
-                {!isLoading && data && (
-                    <Button
-                        colorSchema="secondary"
-                        type="button"
-                        onClick={() => setValue("ipAddress", data)}
-                        className="mb-8"
-                    >
-                        Add current IP address
-                    </Button>
-                )}
-                <Controller
-                    control={control}
-                    defaultValue=""
-                    name="comment"
-                    render={({ field, fieldState: { error } }) => (
-                        <FormControl
-                            label="Comment"
-                            isError={Boolean(error)}
-                            errorText={error?.message}
-                        >
-                        <Input 
-                            {...field} 
-                            placeholder="My IP address"
-                        />
-                        </FormControl>
-                    )}
-                />
-                <div className="mt-8 flex items-center">
-                <Button
-                    className="mr-4"
-                    size="sm"
-                    type="submit"
-                    isLoading={isSubmitting}
-                    isDisabled={isSubmitting}
+  const onIPAllowlistModalSubmit = async ({ ipAddress, comment, environment }: FormData) => {
+    try {
+      if (!currentWorkspace?._id) return;
+
+      if (popUp?.trustedIp?.data) {
+        await updateTrustedIp.mutateAsync({
+          workspaceId: currentWorkspace._id,
+          trustedIpId: (popUp?.trustedIp?.data as { trustedIpId: string })?.trustedIpId,
+          ipAddress,
+          comment,
+          environment,
+          isActive: true
+        });
+      } else {
+        await addTrustedIp.mutateAsync({
+          workspaceId: currentWorkspace._id,
+          ipAddress,
+          comment,
+          environment,
+          isActive: true
+        });
+      }
+
+      createNotification({
+        text: `Successfully ${popUp?.trustedIp?.data ? "updated" : "added"} trusted IP`,
+        type: "success"
+      });
+
+      reset();
+      handlePopUpClose("trustedIp");
+    } catch (err) {
+      createNotification({
+        text: `Failed to ${popUp?.trustedIp?.data ? "update" : "add"} trusted IP`,
+        type: "error"
+      });
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={popUp?.trustedIp?.isOpen}
+      onOpenChange={(isOpen) => {
+        handlePopUpToggle("trustedIp", isOpen);
+        reset();
+      }}
+    >
+      <ModalContent title={popUp?.trustedIp?.data ? "Update IP" : "Add IP"}>
+        <form onSubmit={handleSubmit(onIPAllowlistModalSubmit)}>
+          <Controller
+            control={control}
+            defaultValue=""
+            name="ipAddress"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl
+                label="IPv4/IPv6 Address / CIDR Notation"
+                isError={Boolean(error)}
+                errorText={error?.message}
+              >
+                <Input {...field} placeholder="123.456.789.0" />
+              </FormControl>
+            )}
+          />
+          {!isLoading && data && (
+            <Button
+              colorSchema="secondary"
+              type="button"
+              onClick={() => setValue("ipAddress", data)}
+              className="mb-8"
+            >
+              Add current IP address
+            </Button>
+          )}
+          <Controller
+            control={control}
+            name="environment"
+            defaultValue="all"
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <FormControl
+                label="Environment"
+                className="mt-4"
+                isError={Boolean(error)}
+                errorText={error?.message}
+              >
+                <Select
+                  value={value}
+                  onValueChange={(val) => onChange(val)}
+                  className="w-full border border-mineshaft-500"
                 >
-                    {popUp?.trustedIp?.data ? "Update" : "Add"}
-                </Button>
-                <Button 
-                    colorSchema="secondary" 
-                    variant="plain"
-                    onClick={() => handlePopUpClose("trustedIp")}
-                >
-                    Cancel
-                </Button>
-                </div>
-            </form>
-            </ModalContent>
-        </Modal> 
-    );
-}
+                  <SelectItem value="all" key="all" defaultChecked>
+                    All
+                  </SelectItem>
+                  {currentWorkspace?.environments.map((sourceEnvironment) => (
+                    <SelectItem value={sourceEnvironment.slug} key={`${sourceEnvironment.slug}`}>
+                      {sourceEnvironment.name}
+                    </SelectItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            defaultValue=""
+            name="comment"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl label="Comment" isError={Boolean(error)} errorText={error?.message}>
+                <Input {...field} placeholder="My IP address" />
+              </FormControl>
+            )}
+          />
+          <div className="mt-8 flex items-center">
+            <Button
+              className="mr-4"
+              size="sm"
+              type="submit"
+              isLoading={isSubmitting}
+              isDisabled={isSubmitting}
+            >
+              {popUp?.trustedIp?.data ? "Update" : "Add"}
+            </Button>
+            <Button
+              colorSchema="secondary"
+              variant="plain"
+              onClick={() => handlePopUpClose("trustedIp")}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/frontend/src/views/Project/IPAllowListPage/components/IPAllowlistTable.tsx
+++ b/frontend/src/views/Project/IPAllowListPage/components/IPAllowlistTable.tsx
@@ -58,6 +58,7 @@ export const IPAllowlistTable = ({ popUp, handlePopUpOpen, handlePopUpToggle }: 
             <Tr>
               <Th className="flex-1">IP Address / Range</Th>
               <Th className="flex-1">Format</Th>
+              <Th className="flex-1">Environment</Th>
               <Th className="flex-1">Comment</Th>
               {/* <Th className="flex-1">Status</Th> */}
               <Th className="w-5" />
@@ -69,11 +70,12 @@ export const IPAllowlistTable = ({ popUp, handlePopUpOpen, handlePopUpToggle }: 
               data?.length > 0 &&
               data
                 .sort((a, b) => a.ipAddress.localeCompare(b.ipAddress))
-                .map(({ _id, ipAddress, comment, type, prefix, isActive }) => {
+                .map(({ _id, ipAddress, comment, environment, type, prefix, isActive }) => {
                   return (
                     <Tr key={`ip-access-range-${_id}`} className="h-10">
                       <Td>{`${ipAddress}${prefix !== undefined ? `/${prefix}` : ""}`}</Td>
                       <Td>{formatType(type, prefix)}</Td>
+                      <Td>{environment}</Td>
                       <Td>{comment}</Td>
                       {/* <Td>
                                         <div className="flex items-center">


### PR DESCRIPTION
# Description 📣

The `environment` field has been added as optional to `TrustedIp` and `AuditLog`. Both schemas now allow for an optional `environment` field and were updated in their related files. This change was needed to allow the system to track the environment from which a trusted IP originated. This will increase the security as IPs are now attached to a specific environment. The front-end code was also adjusted to reflect these changes.
Also, it fixes a problem with the `onIPAllowlistModalSubmit` handler, adding a missing field. the 'environment' field added to it. This will ensure that the correct environment data is sent and received. This change covers most of the parts of the application code that deal with IP addresses.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝