### PR TITLE
Docs: Fixing some typos

### DIFF
--- a/docs/cli/scanning-overview.mdx
+++ b/docs/cli/scanning-overview.mdx
@@ -3,11 +3,11 @@ title: 'Secret scanning'
 description: "Scan and prevent secret leaks in your code base"
 ---
 
-Building upon its core functionality of fetching and injecting secrets into your applications, Infisical now takes a significant step forward in bolstering your code security. 
-We've enhanced our CLI tool to include a powerful scanning feature, capable of identifying more than 140 different types of secret leaks in your codebase. 
-In addition to scanning for past leaks, this new addition also actively aids in preventing future leaks. 
+Building upon its core functionality of fetching and injecting secrets into your applications, Infisical now takes a significant step forward in bolstering your code security.
+We've enhanced our CLI tool to include a powerful scanning feature, capable of identifying more than 140 different types of secret leaks in your codebase.
+In addition to scanning for past leaks, this new addition also actively aids in preventing future leaks.
 
-# Scanning 
+# Scanning
 <Tabs>
   <Tab title="Scanning files, directories and or git history">
 	```bash
@@ -19,18 +19,18 @@ In addition to scanning for past leaks, this new addition also actively aids in 
 
 	The `infisical scan` command serves to scan repositories, directories, and files. It's compatible with both individual developer machines and Continuous Integration (CI) environments.
 
-	When you run `infisical scan` on a Git repository, Infisical will parses the output of a `git log -p` command. This command generates [patches](https://stackoverflow.com/questions/8279602/what-is-a-patch-in-git-version-control) that Infisical uses to identify secrets in your code. 
-	You can configure the range of commits that `git log` will cover using the `--log-opts` flag. 
-	Any options you can use with `git log -p` are valid for `--log-opts`. 
+	When you run `infisical scan` on a Git repository, Infisical will parses the output of a `git log -p` command. This command generates [patches](https://stackoverflow.com/questions/8279602/what-is-a-patch-in-git-version-control) that Infisical uses to identify secrets in your code.
+	You can configure the range of commits that `git log` will cover using the `--log-opts` flag.
+	Any options you can use with `git log -p` are valid for `--log-opts`.
 
 	For instance, to instruct Infisical to scan a specific range of commits, use the following command: `infisical scan --log-opts="--all commitA..commitB"`. For more details, refer to the [Git log documentation](https://git-scm.com/docs/git-log).
 
-	To scan individual files and directories, use the `--no-git` flag. 
+	To scan individual files and directories, use the `--no-git` flag.
 
 	**View [full details for this command](./commands/scan)**
   </Tab>
   <Tab title="Scanning uncommitted files ">
-	```bash 
+	```bash
 	infisical scan git-changes
 
 	# Display the full secret findings
@@ -39,8 +39,8 @@ In addition to scanning for past leaks, this new addition also actively aids in 
 
 	Scanning for secrets before you commit your changes is great way to prevent leaks. Infisical makes this easy with the sub command `git-changes`.
 
-	The `git-changes` scans for uncommitted changes in a Git repository, and is especially designed for use on developer machines, aligning with the ['shift left'](https://cloud.google.com/architecture/devops/devops-tech-shifting-left-on-security) security approach. 
-	When `git-changes` is run on a Git repository, Infisical parses the output from a `git diff` command. 
+	The `git-changes` scans for uncommitted changes in a Git repository, and is especially designed for use on developer machines, aligning with the ['shift left'](https://cloud.google.com/architecture/devops/devops-tech-shifting-left-on-security) security approach.
+	When `git-changes` is run on a Git repository, Infisical parses the output from a `git diff` command.
 
 	To scan changes in commits that have been staged via `git add`, you can add the `--staged` flag to the sub command. This flag is particularly useful when using Infisical CLI as a pre-commit tool.
 
@@ -63,14 +63,14 @@ This hook scans the changes you're about to commit for any exposed secrets. If a
 
 To install this git hook, go into your local git repository and run the following command.
 
-```bash 
+```bash
 infisical scan install --pre-commit-hook
 ```
 
 To disable this hook after installing it, run the command `git config --bool hooks.infisical-scan false`
 
-### Third party hooks management 
-If you would rather handle your pre-commit hook outside of the standard `.git/hooks` directory, you can quickly achieve this by adding the following command into your pre-commit script. 
+### Third party hooks management
+If you would rather handle your pre-commit hook outside of the standard `.git/hooks` directory, you can quickly achieve this by adding the following command into your pre-commit script.
 For instance, if you utilize [Husky](https://typicode.github.io/husky/) for managing your Git hooks, you can insert the command provided below into your `.husky/pre-commit` file.
 
 ```bash
@@ -111,7 +111,7 @@ To customize the scan, such as specifying your own rules or establishing excepti
 title = "Some title"
 
 
-# This configuration is the foundation that can be expanded. If there are any overlapping rules 
+# This configuration is the foundation that can be expanded. If there are any overlapping rules
 # between this base and the expanded configuration, the rules in this base will take priority.
 # Another aspect of extending configurations is the ability to link multiple files, up to a depth of 2.
 # "Allowlist" arrays get appended and may have repeated elements.
@@ -150,12 +150,12 @@ tags = ["tag","another tag"]
 secretGroup = 3
 
 # Float representing the minimum shannon entropy a regex group must have to be considered a secret.
-# Shannon entropy measures how random a data is. Since secrets are usually composed of many random characters, they typically have high entropy 
+# Shannon entropy measures how random a data is. Since secrets are usually composed of many random characters, they typically have high entropy
 entropy = 3.5
 
 # Keywords are used for pre-regex check filtering.
-# If rule has keywords but the text fragment being scanned doesn't have at least one of it's keywords, it will be skipped for processing further. 
-# Ideally these values should either be part of the idenitifer or unique strings specific to the rule's regex
+# If rule has keywords but the text fragment being scanned doesn't have at least one of it's keywords, it will be skipped for processing further.
+# Ideally these values should either be part of the identifier or unique strings specific to the rule's regex
 # (introduced in v8.6.0)
 keywords = [
 	"auth",
@@ -181,7 +181,7 @@ regexes = [
 	'''getenv''',
 ]
 # note: stopwords targets the extracted secret, not the entire regex match
-# if the extracted secret is found in the stopwords list, the finding will be skipped (i.e not included in report) 
+# if the extracted secret is found in the stopwords list, the finding will be skipped (i.e not included in report)
 stopwords = [
 	'''client''',
 	'''endpoint''',
@@ -210,7 +210,7 @@ regexes = [
 	'''(9[0-9]{2}|666)-\d{2}-\d{4}''',
 ]
 # note: stopwords targets the extracted secret, not the entire regex match
-# if the extracted secret is found in the stopwords list, the finding will be skipped (i.e not included in report) 
+# if the extracted secret is found in the stopwords list, the finding will be skipped (i.e not included in report)
 stopwords = [
 	'''client''',
 	'''endpoint''',
@@ -223,18 +223,18 @@ stopwords = [
 # Ignoring Known Secrets
 If you're intentionally committing a test secret that `infisical scan` might flag, you can instruct Infisical to overlook that secret with the methods listed below.
 
-### infisical-scan:ignore 
+### infisical-scan:ignore
 
 To ignore a secret contained in line of code, simply add `infisical-scan:ignore ` at the end of the line as comment in the given programming.
 
 ```js example.js
 function helloWorld() {
-    console.log("8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ"); // infisical-scan:ignore 
+    console.log("8dyfuiRyq=vVc3RRr_edRk-fK__JItpZ"); // infisical-scan:ignore
 }
 ```
 
 ### .infisicalignore
-An alternative method to exclude specific findings involves creating a .infisicalignore file at your repository's root. 
+An alternative method to exclude specific findings involves creating a .infisicalignore file at your repository's root.
 You can then add the fingerprints of the findings you wish to exclude. The Infisical scan report provides a unique Fingerprint for each secret found.
 By incorporating these Fingerprints into the .infisicalignore file, Infisical will skip the corresponding secret findings in subsequent scans.
 

--- a/docs/documentation/platform/audit-logs.mdx
+++ b/docs/documentation/platform/audit-logs.mdx
@@ -11,8 +11,8 @@ description: "See which events are triggered within your Infisical project."
     then you should contact team@infisical.com to purchase an enterprise license to use it.
 </Info>
 
-Infisical provides audit logs for security and compliance teams to monitor information access. 
-With this feature, teams can track 25+ different events; 
+Infisical provides audit logs for security and compliance teams to monitor information access.
+With this feature, teams can track 25+ different events;
 filter audit logs by event, actor, source, date or any combination of these filters;
 and inspect extensive metadata in the event of any suspicious activity or incident review.
 
@@ -22,6 +22,6 @@ Each log contains the following data:
 
 - Event: The underlying action such as create, list, read, update, or delete secret(s).
 - Actor: The entity responsible for performing or causing the event; this can be a user or service.
-- Timestamp: The date and time at which point the event occured.
+- Timestamp: The date and time at which point the event occurred.
 - Source (User agent + IP): The software (user agent) and network address (IP) from which the event was initiated.
 - Metadata: Additional data to provide context for each event. For example, this could be the path at which a secret was fetched from etc.

--- a/docs/documentation/platform/token.mdx
+++ b/docs/documentation/platform/token.mdx
@@ -45,16 +45,16 @@ Also, note that Infisical supports [glob patterns](https://www.malikbrowne.com/b
 ![token add](../../images/project-token-old-permissions.png)
 
 In the above screenshot, you can see that we are creating a token token with `read` access to all subfolders at any depth
-of the `/common` path within the development environment of the project; the token expires in 6 months and can be used from any IP address. 
+of the `/common` path within the development environment of the project; the token expires in 6 months and can be used from any IP address.
 
 **FAQ**
 
 <AccordionGroup>
 <Accordion title="Why is the Infisical API rejecting my service token?">
   There are a few reasons for why this might happen:
-  
+
   - The service token has expired.
-  - The service token is insufficently permissioned to interact with the secrets in the given environment and path.
+  - The service token is insufficiently permissioned to interact with the secrets in the given environment and path.
   - You are attempting to access a `/raw` secrets endpoint that requires your project to disable E2EE.
   - (If using ST V3) The service token has not been activated yet.
   - (If using ST V3) The service token is being used from an untrusted IP.

--- a/docs/integrations/cicd/jenkins.mdx
+++ b/docs/integrations/cicd/jenkins.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Jenkins"
-description: "How to effective and securely manage secrets in Jenkins using Infisical"
+description: "How to effectively and securely manage secrets in Jenkins using Infisical"
 ---
 
 Prerequisites:
 
-- Set up and add secrets to [Infisical](https://app.infisical.com). 
+- Set up and add secrets to [Infisical](https://app.infisical.com).
 - You have a working Jenkins installation with the [credentials plugin](https://plugins.jenkins.io/credentials/) installed.
 - You have the Infisical CLI installed on your Jenkins executor nodes or container images.
 
@@ -15,7 +15,7 @@ After setting up your project in Infisical and adding the Infisical CLI to conta
 
 ![Jenkins step 1](../../images/integrations/jenkins/jenkins_1.png)
 
-Click on the credential store you want to store the Infisical Service Token in. In this case, we're using the default Jenkins global store. 
+Click on the credential store you want to store the Infisical Service Token in. In this case, we're using the default Jenkins global store.
 
 <Info>
   Each of your projects will have a different INFISICAL_SERVICE_TOKEN though.
@@ -90,7 +90,7 @@ Scroll down to the **Pipeline** section, paste the following into the **Script**
 ```
 pipeline {
     agent any
-    
+
     environment {
         INFISICAL_SERVICE_TOKEN = credentials('INFISICAL_SERVICE_TOKEN')
     }
@@ -99,16 +99,16 @@ pipeline {
         stage('Run Infisical') {
             steps {
                 sh("infisical secrets")
-                
+
                 // doesn't work
                 // sh("docker run --rm test-container infisical secrets")
-                
+
                 // works
                 // sh("docker run -e INFISICAL_SERVICE_TOKEN=${INFISICAL_SERVICE_TOKEN} --rm test-container infisical secrets")
-                
+
                 // doesn't work
                 // sh("docker-compose up -d")
-                
+
                 // works
                 // sh("INFISICAL_SERVICE_TOKEN=${INFISICAL_SERVICE_TOKEN} docker-compose up -d")
             }

--- a/docs/internals/overview.mdx
+++ b/docs/internals/overview.mdx
@@ -32,6 +32,6 @@ This section covers the internals of Infisical including its technical underpinn
     icon="ticket"
     color="#3775a9"
   >
-    Learn best practices for utilizing Infisical sevrice tokens
+    Learn best practices for utilizing Infisical service tokens
   </Card>
 </CardGroup>

--- a/docs/internals/security.mdx
+++ b/docs/internals/security.mdx
@@ -56,15 +56,15 @@ Within Infisical, a critical security concern is an attacker gaining access to s
 
 ### JWT / API Key
 
-This token category is used by users and included in requests made from the Infisical Web UI or elsewhere to the Infisical API. 
+This token category is used by users and included in requests made from the Infisical Web UI or elsewhere to the Infisical API.
 
 Each token is authenticated against the API and mapped to an existing user in Infisical. If no existing user is found for the token, the request is rejected by the API. Each token assumes the permission set of the user that it is mapped to. For example, if a user corresponding to a token is not allowed access to a certain organization or project, then the token is also not be valid for any requests concerning those specific resources.
 
-In the event of compromise, an attacker could use the token to impersonate the associated user and perform actions within the permission set of that user. While they could retrieve secrets for a project that the user is part of, they could not, however, decrypt secrets if the project follows Infisical's default zero-knowlege architecture. In any case, it would be critical for the user to invalidate this token and change their password immediately to prevent further unintended actions and consequences.
+In the event of compromise, an attacker could use the token to impersonate the associated user and perform actions within the permission set of that user. While they could retrieve secrets for a project that the user is part of, they could not, however, decrypt secrets if the project follows Infisical's default zero-knowledge architecture. In any case, it would be critical for the user to invalidate this token and change their password immediately to prevent further unintended actions and consequences.
 
 ### Service token
 
-This token category is provisioned by users for applications and infrastructure to perform secret operations against the Infisical API. 
+This token category is provisioned by users for applications and infrastructure to perform secret operations against the Infisical API.
 
 Each token is scoped to a project in Infisical and configurable with an expiration date and permission set (also known as **scopes**) for specific environment(s) and path(s) within them. For example, you may provision an application a service token to authenticate against the Infisical API and retrieve secrets from some `/environment-variables` path in the production environment of a project. If the token is tried for another project, environment, or path outside of its permission set, then it is rejected by the API.
 
@@ -87,7 +87,7 @@ Since these encryption operations occur on the client-side, the Infisical API is
 
 ### High availability
 
-Infisical leverages the robust container orchestration capabilities of Kubernetes and the inherent high availability features of the storage backend (i.e. Bitnami MongoDB) to ensure resilience and fault tolerance. 
+Infisical leverages the robust container orchestration capabilities of Kubernetes and the inherent high availability features of the storage backend (i.e. Bitnami MongoDB) to ensure resilience and fault tolerance.
 
 - Kubernetes: By deploying multiple replicas of Infisical application on Kubernetes, operations continue even if a single instance fails. Kubernetes Services facilitate load balancing, effectively distributing traffic across your application’s instances and ensuring optimal performance.
 - Storage backend: Bitnami MongoDB supports replica sets, which provide data redundancy and automatic failover for the underlying database.
@@ -103,7 +103,7 @@ If using [Infisical Cloud](https://app.infisical.com), snapshots of MongoDB data
 
 ### Offline usage
 
-Many teams and organizations use the [Infisical CLI](https://infisical.com/docs/cli/overview) to fetch and inject secrets back from Infisical into their applications and infrastructure locally; the CLI has offline fallback capabiltiies.
+Many teams and organizations use the [Infisical CLI](https://infisical.com/docs/cli/overview) to fetch and inject secrets back from Infisical into their applications and infrastructure locally; the CLI has offline fallback capabilities.
 
 If you have previously retrieved secrets for a specific project and environment, the `run/secret` command will utilize the saved secrets, even when offline, on subsequent fetch attempts to ensure that you always have access to secrets.
 
@@ -111,7 +111,7 @@ If you have previously retrieved secrets for a specific project and environment,
 
 ### Web application
 
-Infisical utilizes the latest HTTP security headers and employs a strict Content-Security-Policy to mitigate XSS. 
+Infisical utilizes the latest HTTP security headers and employs a strict Content-Security-Policy to mitigate XSS.
 
 JWT tokens are stored in browser memory and appended to outbound requests requiring authentication; refresh tokens are stored in `HttpOnly` cookies and included in future requests to `/api/token` for JWT token renewal.
 
@@ -119,7 +119,7 @@ JWT tokens are stored in browser memory and appended to outbound requests requir
 
 Infisical supports several authentication methods including email/password, Google SSO, GitHub SSO, and SAML 2.0 (Okta, Azure, JumpCloud); Infisical also currently offers email-based 2FA with authenticator app methods coming in Q1 2024.
 
-Infisical uses the [secure remote password protocol](https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol#:~:text=The%20SRP%20protocol%20has%20a,the%20user%20to%20the%20server), commonly found in other zero-knowledge platform architectures, for authentication. 
+Infisical uses the [secure remote password protocol](https://en.wikipedia.org/wiki/Secure_Remote_Password_protocol#:~:text=The%20SRP%20protocol%20has%20a,the%20user%20to%20the%20server), commonly found in other zero-knowledge platform architectures, for authentication.
 Put simply, the protocol enables Infisical to validate a user's knowledge of their password without ever seeing it by constructing a mutual secret; we use this protocol because each user's password is used to seed the generation of a master encryption/decryption key via KDF for that user which the platform
 should not see.
 
@@ -141,7 +141,7 @@ For example, you can define a role provisioning access to secrets in a specific 
 
 ### Audit logging
 
-Infisical's audit logging feature spans 25+ events, tracking everything from permissioning changes to queries and mutations applied to secrets, for security and compliance teams at enterprises to monitor information access in the event of any suspicious activity or incident review. Every event is timestamped and information about actor, source (i.e. IP address, user-agent, etc.), and relevant metadata is included.
+Infisical's audit logging feature spans 25+ events, tracking everything from permission changes to queries and mutations applied to secrets, for security and compliance teams at enterprises to monitor information access in the event of any suspicious activity or incident review. Every event is timestamped and information about actor, source (i.e. IP address, user-agent, etc.), and relevant metadata is included.
 
 ### IP allowlisting
 
@@ -151,7 +151,7 @@ By default, each project is initialized with the `0.0.0.0/0` entry, representing
 
 ## Penetration testing
 
-Infisical hires external third parties to perform regular security assessment and penetration testing of the platform. 
+Infisical hires external third parties to perform regular security assessment and penetration testing of the platform.
 
 Most recently, Infisical commissioned cybersecurity firm [Oneleet](https://www.oneleet.com) to perform a full-coverage, gray box penetration test against the platform's entire attack surface to identify vulnerabilities according to industry standards (OWASP, ASVS, WSTG, TOP-10, etc.).
 
@@ -162,7 +162,7 @@ Please email security@infisical.com to request any reports including a letter of
 Whether or not Infisical or your employees can access data in the Infisical instance and/or storage backend depends on many factors how you use Infisical:
 
 - Infisical Self-Hosted: Self-hosting Infisical is common amongst organizations that prefer to keep data on their own infrastructure usually to adhere to strict regulatory and compliance requirements. In this option, organizations retain full control over their data and therefore govern the data access policy of their Infisical instance and storage backend.
-- Infisical Cloud: Using Infisical's managed service, [Infisical Cloud](https://app.infisical.com) means delegating data oversight and management to Infisical.  Under our policy controls, employees are only granted access to parts of infrastructure according to principle of least privilege; this is especially relevent to customer data can only be accessed currently by executive management of Infisical. Moreover, any changes to sensitive customer data is prohibited without explicit customer approval.
+- Infisical Cloud: Using Infisical's managed service, [Infisical Cloud](https://app.infisical.com) means delegating data oversight and management to Infisical.  Under our policy controls, employees are only granted access to parts of infrastructure according to principle of least privilege; this is especially relevant to customer data can only be accessed currently by executive management of Infisical. Moreover, any changes to sensitive customer data is prohibited without explicit customer approval.
 
 It should be noted that, even on Infisical Cloud, it is physically impossible for employees of Infisical to view the values of secrets if users have not explicitly granted Infisical access to their project (i.e. opted out of zero-knowledge).
 


### PR DESCRIPTION
# Description 📣

Some typos fixed in the documentation
My linter also removed some useless trailing spaces in the process

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝