### PR TITLE
[Kubernetes Operator] Skip TLS verification when retrieving/syncing secrets

### DIFF
--- a/docs/integrations/platforms/kubernetes.mdx
+++ b/docs/integrations/platforms/kubernetes.mdx
@@ -168,6 +168,27 @@ The managed secret be should be created in the same namespace as the deployment 
 
 </Accordion>
 
+<Accordion title="tlsConfig">
+  This block defines the  TLS configuration the operator should use to connect to your Infisical instance
+</Accordion>
+
+<Accordion title="tlsConfig.insecureSkipVerify">
+  If enabled and set to true, the http client would not skip TLS verification when syncing your secrets from your infisical instance
+
+  ## Example
+  ```yaml
+  apiVersion: secrets.infisical.com/v1alpha1
+  kind: InfisicalSecret
+  metadata:
+    name: infisicalsecret-sample-crd
+  spec:
+    tlsConfig:
+      insecureSkipVerify: false
+    ...
+  ```
+</Accordion>
+
+
 ### Apply the Infisical CRD to your cluster 
 Once you have configured the Infisical CRD with the required fields, you can apply it to your cluster. 
 After applying, you should notice that the managed secret has been created in the desired namespace your specified.

--- a/k8-operator/api/v1alpha1/infisicalsecret_types.go
+++ b/k8-operator/api/v1alpha1/infisicalsecret_types.go
@@ -33,6 +33,12 @@ type SecretScopeInWorkspace struct {
 	EnvSlug string `json:"envSlug"`
 }
 
+type TLSConfig struct {
+	// Skip TLS verification
+	// +kubebuilder:validation:Optional
+	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+}
+
 type KubeSecretReference struct {
 	// The name of the Kubernetes Secret
 	// +kubebuilder:validation:Required
@@ -53,6 +59,9 @@ type InfisicalSecretSpec struct {
 
 	// +kubebuilder:validation:Required
 	ManagedSecretReference KubeSecretReference `json:"managedSecretReference"`
+
+	// +kubebuilder:validation:Optional
+	TLSConfig TLSConfig `json:"tlsConfig"`
 
 	// +kubebuilder:default:=60
 	ResyncInterval int `json:"resyncInterval"`

--- a/k8-operator/controllers/infisicalsecret_helper.go
+++ b/k8-operator/controllers/infisicalsecret_helper.go
@@ -15,15 +15,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const SERVICE_ACCOUNT_ACCESS_KEY = "serviceAccountAccessKey"
-const SERVICE_ACCOUNT_PUBLIC_KEY = "serviceAccountPublicKey"
-const SERVICE_ACCOUNT_PRIVATE_KEY = "serviceAccountPrivateKey"
+const (
+	SERVICE_ACCOUNT_ACCESS_KEY  = "serviceAccountAccessKey"
+	SERVICE_ACCOUNT_PUBLIC_KEY  = "serviceAccountPublicKey"
+	SERVICE_ACCOUNT_PRIVATE_KEY = "serviceAccountPrivateKey"
+)
 
-const INFISICAL_TOKEN_SECRET_KEY_NAME = "infisicalToken"
-const SECRET_VERSION_ANNOTATION = "secrets.infisical.com/version" // used to set the version of secrets via Etag
-const OPERATOR_SETTINGS_CONFIGMAP_NAME = "infisical-config"
-const OPERATOR_SETTINGS_CONFIGMAP_NAMESPACE = "infisical-operator-system"
-const INFISICAL_DOMAIN = "https://app.infisical.com/api"
+const (
+	INFISICAL_TOKEN_SECRET_KEY_NAME       = "infisicalToken"
+	SECRET_VERSION_ANNOTATION             = "secrets.infisical.com/version" // used to set the version of secrets via Etag
+	OPERATOR_SETTINGS_CONFIGMAP_NAME      = "infisical-config"
+	OPERATOR_SETTINGS_CONFIGMAP_NAMESPACE = "infisical-operator-system"
+	INFISICAL_DOMAIN                      = "https://app.infisical.com/api"
+)
 
 func (r *InfisicalSecretReconciler) GetInfisicalConfigMap(ctx context.Context) (configMap map[string]string, errToReturn error) {
 	// default key values
@@ -35,7 +39,6 @@ func (r *InfisicalSecretReconciler) GetInfisicalConfigMap(ctx context.Context) (
 		Namespace: OPERATOR_SETTINGS_CONFIGMAP_NAMESPACE,
 		Name:      OPERATOR_SETTINGS_CONFIGMAP_NAME,
 	}, kubeConfigMap)
-
 	if err != nil {
 		if errors.IsNotFound(err) {
 			kubeConfigMap = nil
@@ -211,7 +214,10 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 	var fullEncryptedSecretsResponse api.GetEncryptedSecretsV3Response
 
 	if serviceAccountCreds.AccessKey != "" || serviceAccountCreds.PrivateKey != "" || serviceAccountCreds.PublicKey != "" {
-		plainTextSecretsFromApi, fullEncryptedSecretsResponse, err = util.GetPlainTextSecretsViaServiceAccount(serviceAccountCreds, infisicalSecret.Spec.Authentication.ServiceAccount.ProjectId, infisicalSecret.Spec.Authentication.ServiceAccount.EnvironmentName, secretVersionBasedOnETag)
+		plainTextSecretsFromApi, fullEncryptedSecretsResponse, err = util.GetPlainTextSecretsViaServiceAccount(serviceAccountCreds,
+			infisicalSecret.Spec.Authentication.ServiceAccount.ProjectId,
+			infisicalSecret.Spec.Authentication.ServiceAccount.EnvironmentName, secretVersionBasedOnETag,
+			infisicalSecret.Spec.TLSConfig.InsecureSkipVerify)
 		if err != nil {
 			return fmt.Errorf("\nfailed to get secrets because [err=%v]", err)
 		}
@@ -222,7 +228,8 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 		envSlug := infisicalSecret.Spec.Authentication.ServiceToken.SecretsScope.EnvSlug
 		secretsPath := infisicalSecret.Spec.Authentication.ServiceToken.SecretsScope.SecretsPath
 
-		plainTextSecretsFromApi, fullEncryptedSecretsResponse, err = util.GetPlainTextSecretsViaServiceToken(infisicalToken, secretVersionBasedOnETag, envSlug, secretsPath)
+		plainTextSecretsFromApi, fullEncryptedSecretsResponse, err = util.GetPlainTextSecretsViaServiceToken(infisicalToken, secretVersionBasedOnETag,
+			envSlug, secretsPath, infisicalSecret.Spec.TLSConfig.InsecureSkipVerify)
 		if err != nil {
 			return fmt.Errorf("\nfailed to get secrets because [err=%v]", err)
 		}
@@ -243,5 +250,4 @@ func (r *InfisicalSecretReconciler) ReconcileInfisicalSecret(ctx context.Context
 	} else {
 		return r.UpdateInfisicalManagedKubeSecret(ctx, *managedKubeSecret, plainTextSecretsFromApi, fullEncryptedSecretsResponse)
 	}
-
 }


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/Infisical/infisical/issues/1179

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```yaml
spec:
    tlsConfig:
      insecureSkipVerify: false
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝