### PR TITLE
BUMP kube-rbac-proxy v0.15.0

### DIFF
--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -2,7 +2,7 @@ controllerManager:
   kubeRbacProxy:
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.13.1
+      tag: v0.15.0
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/k8-operator/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/k8-operator/kubectl-install/install-secrets-operator.yaml
+++ b/k8-operator/kubectl-install/install-secrets-operator.yaml
@@ -480,7 +480,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
@maidul98 kube-rbac-proxy uses some older go libraries that have critical vulnerabilities (https://github.com/advisories/GHSA-vvpx-j8f3-3w6h and https://github.com/advisories/GHSA-vvpx-j8f3-3w6hm) which got upgraded in 0.14.1 .

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
Tested on an internal environment
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝