### PR TITLE
fix: "Injecting..." status string can be omitted by log levels

### DIFF
--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -204,7 +204,8 @@ func init() {
 func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string) error {
 	command := args[0]
 	argsForCommand := args[1:]
-	color.Green("Injecting %v Infisical secrets into your application process", secretsCount)
+
+	log.Info().Msgf(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
 
 	cmd := exec.Command(command, argsForCommand...)
 	cmd.Stdin = os.Stdin
@@ -232,7 +233,7 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 	cmd.Stderr = os.Stderr
 	cmd.Env = env
 
-	color.Green("Injecting %v Infisical secrets into your application process", secretsCount)
+	log.Info().Msgf(color.GreenString("Injecting %v Infisical secrets into your application process", secretsCount))
 	log.Debug().Msgf("executing command: %s %s %s \n", shell[0], shell[1], fullCommand)
 
 	return execCmd(cmd)


### PR DESCRIPTION
When using `infisical run`, I am often running another command that needs to be processed or consumed by another; such as:

infisical run -- supabase status -o env

The Injecting string was being printed directly to stdout and stopping such scripting from being successful, without further adding tail -n+2.

This change defaults the output to the INFO logging level, which means the behaviour is the exact same for everything; however those who wish can omit this output with -l error|fatal

Fixes #1091 

# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

<img width="1208" alt="image" src="https://github.com/Infisical/infisical/assets/145816/20540710-5722-46da-ba58-c76488da8c3f">

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝