### PR TITLE
parse bot not found in agent

### DIFF
--- a/backend/src/helpers/bot.ts
+++ b/backend/src/helpers/bot.ts
@@ -13,7 +13,7 @@ import {
   SECRET_SHARED
 } from "../variables";
 import { client, getEncryptionKey, getRootEncryptionKey } from "../config";
-import { InternalServerError } from "../utils/errors";
+import { BotNotFoundError, InternalServerError } from "../utils/errors";
 import { Folder } from "../models";
 import { getFolderByPath } from "../services/FolderService";
 import { getAllImportedSecrets } from "../services/SecretImportService";
@@ -223,7 +223,7 @@ export const getKey = async ({ workspaceId }: { workspaceId: Types.ObjectId }) =
     workspace: workspaceId
   }).populate<{ sender: IUser }>("sender", "publicKey");
 
-  if (!botKey) throw new Error("Failed to find bot key");
+  if (!botKey) throw BotNotFoundError({ message: `getKey: Failed to find bot key for [workspaceId=${workspaceId}]` })
 
   const bot = await Bot.findOne({
     workspace: workspaceId

--- a/cli/packages/api/api.go
+++ b/cli/packages/api/api.go
@@ -481,12 +481,12 @@ func CallGetRawSecretsV3(httpClient *resty.Client, request GetRawSecretsV3Reques
 		return GetRawSecretsV3Response{}, fmt.Errorf("CallGetRawSecretsV3: Unable to complete api request [err=%w]", err)
 	}
 
-	if response.IsError() && strings.Contains(response.String(), "Failed to find bot key") {
+	if response.IsError() && strings.Contains(response.String(), "bot_not_found_error") {
 		return GetRawSecretsV3Response{}, fmt.Errorf("project with id %s is a legacy project type, please navigate to project settings and disable end to end encryption then try again", request.WorkspaceId)
 	}
 
 	if response.IsError() {
-		return GetRawSecretsV3Response{}, fmt.Errorf("CallUniversalAuthLogin: Unsuccessful response [%v %v] [status-code=%v] [response=%v]", response.Request.Method, response.Request.URL, response.StatusCode(), response.String())
+		return GetRawSecretsV3Response{}, fmt.Errorf("CallGetRawSecretsV3: Unsuccessful response [%v %v] [status-code=%v] [response=%v]", response.Request.Method, response.Request.URL, response.StatusCode(), response.String())
 	}
 
 	return getRawSecretsV3Response, nil


### PR DESCRIPTION
# Description 📣

Use RequestError instead of Error class so that error type of `bot_not_found_error` can be parsed from agent side to notify users that e2ee is enabled 

