### PR TITLE
extract base from template source path

### DIFF
--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"sync"
 	"syscall"
@@ -189,7 +190,9 @@ func ProcessTemplate(templatePath string, data interface{}, accessToken string) 
 		"secret": secretFunction,
 	}
 
-	tmpl, err := template.New(templatePath).Funcs(funcs).ParseFiles(templatePath)
+	templateName := path.Base(templatePath)
+
+	tmpl, err := template.New(templateName).Funcs(funcs).ParseFiles(templatePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description 📣

When secret templates have a path other than the root, the name of the template needs to be extracted 
