### PR TITLE
Fix: Vercel integration preview environment client side error

### DIFF
--- a/frontend/src/pages/integrations/vercel/create.tsx
+++ b/frontend/src/pages/integrations/vercel/create.tsx
@@ -56,7 +56,7 @@ export default function VercelCreateIntegrationPage() {
     appId: targetAppId
   });
 
-  const filteredBranches = branches?.filter((branchName) => branchName !== "main").concat("");
+  const filteredBranches = branches?.filter((branchName) => branchName !== "main").concat();
 
   useEffect(() => {
     if (workspace) {
@@ -125,7 +125,7 @@ export default function VercelCreateIntegrationPage() {
           subTitle="Select which environment or folder in Infisical you want to sync to Vercel's environment variables."
         >
           <div className="flex flex-row items-center">
-            <div className="inline flex items-center">
+            <div className="flex items-center">
               <Image
                 src="/images/integrations/Vercel.png"
                 height={30}


### PR DESCRIPTION
# Description 📣

Fixed issue with selecting the preview environment for the Vercel integration. This was happening because we were passing an empty value to the select item for branch name. 

Closes #1271.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝