### PR TITLE
Enable new integration auth credential for each new integration

### DIFF
--- a/backend/src/controllers/v1/integrationAuthController.ts
+++ b/backend/src/controllers/v1/integrationAuthController.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { Types } from "mongoose";
 import { standardRequest } from "../../config/request";
 import { getApps, getTeams, revokeAccess } from "../../integrations";
-import { Bot, IntegrationAuth, Workspace } from "../../models";
+import { Bot, IIntegrationAuth, Integration, IntegrationAuth, Workspace } from "../../models";
 import { EventType } from "../../ee/models";
 import { IntegrationService } from "../../services";
 import { EEAuditLogService } from "../../ee/services";
@@ -130,7 +130,6 @@ export const oAuthExchange = async (req: Request, res: Response) => {
 export const saveIntegrationToken = async (req: Request, res: Response) => {
   // TODO: refactor
   // TODO: check if access token is valid for each integration
-  let integrationAuth;
   const {
     body: { workspaceId, integration, url, accessId, namespace, accessToken, refreshToken }
   } = await validateRequest(reqValidator.SaveIntegrationAccessTokenV1, req);
@@ -152,31 +151,21 @@ export const saveIntegrationToken = async (req: Request, res: Response) => {
 
   if (!bot) throw new Error("Bot must be enabled to save integration access token");
 
-  integrationAuth = await IntegrationAuth.findOneAndUpdate(
-    {
-      workspace: new Types.ObjectId(workspaceId),
-      integration
-    },
-    {
-      workspace: new Types.ObjectId(workspaceId),
-      integration,
-      url,
-      namespace,
-      algorithm: ALGORITHM_AES_256_GCM,
-      keyEncoding: ENCODING_SCHEME_UTF8,
-      ...(integration === INTEGRATION_GCP_SECRET_MANAGER
-        ? {
-            metadata: {
-              authMethod: "serviceAccount"
-            }
+  let integrationAuth = await new IntegrationAuth({
+    workspace: new Types.ObjectId(workspaceId),
+    integration,
+    url,
+    namespace,
+    algorithm: ALGORITHM_AES_256_GCM,
+    keyEncoding: ENCODING_SCHEME_UTF8,
+    ...(integration === INTEGRATION_GCP_SECRET_MANAGER
+      ? {
+          metadata: {
+            authMethod: "serviceAccount"
           }
-        : {})
-    },
-    {
-      new: true,
-      upsert: true
-    }
-  );
+        }
+      : {})
+  }).save();
 
   // encrypt and save integration access details
   if (refreshToken) {
@@ -188,12 +177,12 @@ export const saveIntegrationToken = async (req: Request, res: Response) => {
 
   // encrypt and save integration access details
   if (accessId || accessToken) {
-    integrationAuth = await IntegrationService.setIntegrationAuthAccess({
+    integrationAuth = (await IntegrationService.setIntegrationAuthAccess({
       integrationAuthId: integrationAuth._id.toString(),
       accessId,
       accessToken,
       accessExpiresAt: undefined
-    });
+    })) as IIntegrationAuth;
   }
 
   if (!integrationAuth) throw new Error("Failed to save integration access token");
@@ -1209,12 +1198,63 @@ export const getIntegrationAuthTeamCityBuildConfigs = async (req: Request, res: 
 };
 
 /**
+ * Delete all integration authorizations and integrations for workspace with id [workspaceId]
+ * with integration name [integration]
+ * @param req
+ * @param res
+ * @returns
+ */
+export const deleteIntegrationAuths = async (req: Request, res: Response) => {
+  const {
+    query: { integration, workspaceId }
+  } = await validateRequest(reqValidator.DeleteIntegrationAuthsV1, req);
+
+  const { permission } = await getAuthDataProjectPermissions({
+    authData: req.authData,
+    workspaceId: new Types.ObjectId(workspaceId)
+  });
+  
+  ForbiddenError.from(permission).throwUnlessCan(
+    ProjectPermissionActions.Delete,
+    ProjectPermissionSub.Integrations
+  );
+  
+  const integrationAuths = await IntegrationAuth.deleteMany({
+    integration,
+    workspace: new Types.ObjectId(workspaceId)
+  });
+
+  const integrations = await Integration.deleteMany({
+    integration,
+    workspace: new Types.ObjectId(workspaceId)
+  });
+
+  await EEAuditLogService.createAuditLog(
+    req.authData,
+    {
+      type: EventType.UNAUTHORIZE_INTEGRATION,
+      metadata: {
+        integration
+      }
+    },
+    {
+      workspaceId: new Types.ObjectId(workspaceId)
+    }
+  );
+
+  return res.status(200).send({
+    integrationAuths,
+    integrations
+  });
+}
+
+/**
  * Delete integration authorization with id [integrationAuthId]
  * @param req
  * @param res
  * @returns
  */
-export const deleteIntegrationAuth = async (req: Request, res: Response) => {
+export const deleteIntegrationAuthById = async (req: Request, res: Response) => {
   const {
     params: { integrationAuthId }
   } = await validateRequest(reqValidator.DeleteIntegrationAuthV1, req);

--- a/backend/src/routes/v1/integrationAuth.ts
+++ b/backend/src/routes/v1/integrationAuth.ts
@@ -157,11 +157,19 @@ router.get(
 );
 
 router.delete(
+  "/",
+  requireAuth({
+    acceptedAuthModes: [AuthMode.JWT]
+  }),
+  integrationAuthController.deleteIntegrationAuths
+);
+
+router.delete(
   "/:integrationAuthId",
   requireAuth({
     acceptedAuthModes: [AuthMode.JWT]
   }),
-  integrationAuthController.deleteIntegrationAuth
+  integrationAuthController.deleteIntegrationAuthById
 );
 
 export default router;

--- a/backend/src/validation/integrationAuth.ts
+++ b/backend/src/validation/integrationAuth.ts
@@ -192,6 +192,13 @@ export const GetIntegrationAuthNorthflankSecretGroupsV1 = z.object({
   })
 });
 
+export const DeleteIntegrationAuthsV1 = z.object({
+  query: z.object({
+    integration: z.string().trim(),
+    workspaceId: z.string().trim()
+  })
+});
+
 export const DeleteIntegrationAuthV1 = z.object({
   params: z.object({
     integrationAuthId: z.string().trim()

--- a/frontend/src/hooks/api/integrationAuth/index.tsx
+++ b/frontend/src/hooks/api/integrationAuth/index.tsx
@@ -1,6 +1,7 @@
 export {
   useAuthorizeIntegration,
   useDeleteIntegrationAuth,
+  useDeleteIntegrationAuths,
   useGetIntegrationAuthApps,
   useGetIntegrationAuthBitBucketWorkspaces,
   useGetIntegrationAuthById,

--- a/frontend/src/hooks/api/integrationAuth/queries.tsx
+++ b/frontend/src/hooks/api/integrationAuth/queries.tsx
@@ -699,7 +699,22 @@ export const useSaveIntegrationAccessToken = () => {
   });
 };
 
-export const useDeleteIntegrationAuth = () => {
+export const useDeleteIntegrationAuths = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{}, {}, { integration: string; workspaceId: string }>({
+    mutationFn: ({ integration, workspaceId }) => apiRequest.delete(`/api/v1/integration-auth?${new URLSearchParams({
+      integration,
+      workspaceId
+    })}`),
+    onSuccess: (_, { workspaceId }) => {
+      queryClient.invalidateQueries(workspaceKeys.getWorkspaceAuthorization(workspaceId));
+      queryClient.invalidateQueries(workspaceKeys.getWorkspaceIntegrations(workspaceId));
+    }
+  });
+};
+
+export const useDeleteIntegrationAuth = () => { // not used
   const queryClient = useQueryClient();
 
   return useMutation<{}, {}, { id: string; workspaceId: string }>({

--- a/frontend/src/hooks/api/integrations/queries.tsx
+++ b/frontend/src/hooks/api/integrations/queries.tsx
@@ -96,6 +96,7 @@ export const useDeleteIntegration = () => {
     mutationFn: ({ id }) => apiRequest.delete(`/api/v1/integration/${id}`),
     onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries(workspaceKeys.getWorkspaceIntegrations(workspaceId));
+      queryClient.invalidateQueries(workspaceKeys.getWorkspaceAuthorization(workspaceId));
     }
   });
 };

--- a/frontend/src/hooks/api/workspace/queries.tsx
+++ b/frontend/src/hooks/api/workspace/queries.tsx
@@ -126,6 +126,7 @@ const fetchWorkspaceAuthorization = async (workspaceId: string) => {
   const { data } = await apiRequest.get<{ authorizations: IntegrationAuth[] }>(
     `/api/v1/workspace/${workspaceId}/authorizations`
   );
+
   return data.authorizations;
 };
 


### PR DESCRIPTION
# Description 📣

Previously, every new integration of the same category (e.g. Railway) in a project would use the same integration authentication credentials to create that integration. With this PR, whenever you create a new integration, the user is directed to input a new set of authentication credentials to be used for that integration instead of reusing a past one. Put differently, this allows users to use multiple authentication credentials for each integration category instead of being limited to one.

Highlights:
- When an integration is deleted, if there are no other integrations using the same linked integration authentication credential, then the linked authentication credential is also deleted; this is important for backwards compatibility since currently multiple integrations may be linked to one authentication credential.
- When an integration is created, a new integration authorization credential is also prompted to be inputted for it.
- When "revoking an integration authorization," all integrations and integration authorizations for that integration category are deleted.

This is a current solution that will be overhauled in Integration V2 whenever that is undertaken.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝