### PR TITLE
Add version query param to GET secret raw and regular endpoints

### DIFF
--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -348,7 +348,7 @@ export const getSecretByNameRaw = async (req: Request, res: Response) => {
     }
   */
   const {
-    query: { secretPath, environment, workspaceId, type, include_imports },
+    query: { secretPath, environment, workspaceId, type, include_imports, version },
     params: { secretName }
   } = await validateRequest(reqValidator.GetSecretByNameRawV3, req);
 
@@ -371,7 +371,8 @@ export const getSecretByNameRaw = async (req: Request, res: Response) => {
     type,
     secretPath,
     authData: req.authData,
-    include_imports
+    include_imports,
+    version
   });
 
   const key = await BotService.getWorkspaceKeyWithBot({
@@ -865,7 +866,7 @@ export const getSecrets = async (req: Request, res: Response) => {
  */
 export const getSecretByName = async (req: Request, res: Response) => {
   const {
-    query: { secretPath, environment, workspaceId, type, include_imports },
+    query: { secretPath, environment, workspaceId, type, include_imports, version },
     params: { secretName }
   } = await validateRequest(reqValidator.GetSecretByNameV3, req);
 
@@ -888,7 +889,8 @@ export const getSecretByName = async (req: Request, res: Response) => {
     type,
     secretPath,
     authData: req.authData,
-    include_imports
+    include_imports,
+    version
   });
 
   return res.status(200).send({

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -38,6 +38,7 @@ export interface GetSecretParams {
   type?: "shared" | "personal";
   authData: AuthData;
   include_imports?: boolean;
+  version?: number;
 }
 
 export interface UpdateSecretParams {

--- a/backend/src/validation/secrets.ts
+++ b/backend/src/validation/secrets.ts
@@ -246,7 +246,15 @@ export const GetSecretByNameRawV3 = z.object({
     include_imports: z
       .enum(["true", "false"])
       .default("true")
-      .transform((value) => value === "true")
+      .transform((value) => value === "true"),
+    version: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => value === undefined ? undefined : parseInt(value, 10))
+      .refine((value) => value === undefined || !isNaN(value), {
+        message: "Version must be a number",
+      })
   })
 });
 
@@ -318,7 +326,15 @@ export const GetSecretByNameV3 = z.object({
     include_imports: z
       .enum(["true", "false"])
       .default("true")
-      .transform((value) => value === "true")
+      .transform((value) => value === "true"),
+    version: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => value === undefined ? undefined : parseInt(value, 10))
+      .refine((value) => value === undefined || !isNaN(value), {
+        message: "Version must be a number",
+      })
   }),
   params: z.object({
     secretName: z.string().trim()


### PR DESCRIPTION
# Description 📣

This PR adds an optional query parameter `version` to both `GET` secret raw and regular endpoints to get a secret by its version if specified.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝