### PR TITLE
Add IPv6 consideration to default universal auth IP allowlist

### DIFF
--- a/backend/src/controllers/v1/universalAuthController.ts
+++ b/backend/src/controllers/v1/universalAuthController.ts
@@ -550,7 +550,7 @@ export const attachIdentityUniversalAuth = async (req: Request, res: Response) =
 
     // validate trusted ips
     const reformattedClientSecretTrustedIps = clientSecretTrustedIps.map((clientSecretTrustedIp) => {
-        if (!plan.ipAllowlisting && clientSecretTrustedIp.ipAddress !== "0.0.0.0/0") return res.status(400).send({
+        if (!plan.ipAllowlisting && (clientSecretTrustedIp.ipAddress !== "0.0.0.0/0" && clientSecretTrustedIp.ipAddress !== "::/0")) return res.status(400).send({
             message: "Failed to add IP access range to service token due to plan restriction. Upgrade plan to add IP access range."
         });
 
@@ -564,7 +564,7 @@ export const attachIdentityUniversalAuth = async (req: Request, res: Response) =
     });
 
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps.map((accessTokenTrustedIp) => {
-        if (!plan.ipAllowlisting && accessTokenTrustedIp.ipAddress !== "0.0.0.0/0") return res.status(400).send({
+        if (!plan.ipAllowlisting && (accessTokenTrustedIp.ipAddress !== "0.0.0.0/0" && accessTokenTrustedIp.ipAddress !== "::/0")) return res.status(400).send({
             message: "Failed to add IP access range to service token due to plan restriction. Upgrade plan to add IP access range."
         });
 
@@ -750,7 +750,7 @@ export const updateIdentityUniversalAuth = async (req: Request, res: Response) =
     let reformattedClientSecretTrustedIps;
     if (clientSecretTrustedIps) {
         reformattedClientSecretTrustedIps = clientSecretTrustedIps.map((clientSecretTrustedIp) => {
-            if (!plan.ipAllowlisting && clientSecretTrustedIp.ipAddress !== "0.0.0.0/0") return res.status(400).send({
+            if (!plan.ipAllowlisting && (clientSecretTrustedIp.ipAddress !== "0.0.0.0/0" && clientSecretTrustedIp.ipAddress !== "::/0")) return res.status(400).send({
                 message: "Failed to add IP access range to service token due to plan restriction. Upgrade plan to add IP access range."
             });
 
@@ -767,7 +767,7 @@ export const updateIdentityUniversalAuth = async (req: Request, res: Response) =
     let reformattedAccessTokenTrustedIps;
     if (accessTokenTrustedIps) {
         reformattedAccessTokenTrustedIps = accessTokenTrustedIps.map((accessTokenTrustedIp) => {
-            if (!plan.ipAllowlisting && accessTokenTrustedIp.ipAddress !== "0.0.0.0/0") return res.status(400).send({
+            if (!plan.ipAllowlisting && (accessTokenTrustedIp.ipAddress !== "0.0.0.0/0" && accessTokenTrustedIp.ipAddress !== "::/0")) return res.status(400).send({
                 message: "Failed to add IP access range to service token due to plan restriction. Upgrade plan to add IP access range."
             });
 

--- a/backend/src/validation/auth.ts
+++ b/backend/src/validation/auth.ts
@@ -108,14 +108,14 @@ export const AddUniversalAuthToIdentityV1 = z.object({
       })
       .array()
       .min(1)
-      .default([{ ipAddress: "0.0.0.0/0" }]),
+      .default([{ ipAddress: "0.0.0.0/0" }, { ipAddress: "::/0" }]),
     accessTokenTrustedIps: z
       .object({
         ipAddress: z.string().trim(),
       })
       .array()
       .min(1)
-      .default([{ ipAddress: "0.0.0.0/0" }]),
+      .default([{ ipAddress: "0.0.0.0/0" }, { ipAddress: "::/0" }]),
     accessTokenTTL: z.number().int().min(1).refine(value => value !== 0, {
       message: "accessTokenTTL must have a non zero number",
     }).default(2592000),

--- a/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityUniversalAuthForm.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityUniversalAuthForm.tsx
@@ -91,12 +91,14 @@ export const IdentityUniversalAuthForm = ({
             accessTokenTTL: "2592000",
             accessTokenMaxTTL: "2592000",
             accessTokenNumUsesLimit: "0",
-            clientSecretTrustedIps: [{
-                ipAddress: "0.0.0.0/0"
-            }],
-            accessTokenTrustedIps: [{
-                ipAddress: "0.0.0.0/0"
-            }],
+            clientSecretTrustedIps: [
+                { ipAddress: "0.0.0.0/0" },
+                { ipAddress: "::/0" }
+            ],
+            accessTokenTrustedIps: [
+                { ipAddress: "0.0.0.0/0" },
+                { ipAddress: "::/0" }
+            ],
         }
     });
 
@@ -139,12 +141,14 @@ export const IdentityUniversalAuthForm = ({
                 accessTokenTTL: "2592000",
                 accessTokenMaxTTL: "2592000",
                 accessTokenNumUsesLimit: "0",
-                clientSecretTrustedIps: [{
-                    ipAddress: "0.0.0.0/0"
-                }],
-                accessTokenTrustedIps: [{
-                    ipAddress: "0.0.0.0/0"
-                }]
+                clientSecretTrustedIps: [
+                    { ipAddress: "0.0.0.0/0" },
+                    { ipAddress: "::/0" }
+                ],
+                accessTokenTrustedIps: [
+                    { ipAddress: "0.0.0.0/0" },
+                    { ipAddress: "::/0" }
+                ]
             });
         }
     }, [data]);


### PR DESCRIPTION
# Description 📣

This PR updates the default IP allowlist for universal auth to include consideration for IPv6 addresses via `::/0`; previously it only considered IPv4 addresses with `0.0.0.0/0`.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝