### PR TITLE
[feat] Add alphabetical sorting for exported secrets based on keys

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -7,6 +7,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/models"
@@ -74,7 +75,7 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		sort, err := cmd.Flags().GetBool("sort")
+		sortSecrets, err := cmd.Flags().GetBool("sort")
 		if err != nil {
 			util.HandleError(err, "Unable to parse sort")
 		}
@@ -90,8 +91,10 @@ var exportCmd = &cobra.Command{
 			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
 		}
 
-		if sort {
-			util.SortSecrets(&secrets)
+		if sortSecrets {
+			sort.SliceStable(secrets, func(i, j int) bool {
+				return (secrets)[i].Key < (secrets)[j].Key
+			})
 		}
 
 		var output string

--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -74,6 +74,11 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		sort, err := cmd.Flags().GetBool("sort")
+		if err != nil {
+			util.HandleError(err, "Unable to parse sort")
+		}
+
 		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, WorkspaceId: projectId, SecretsPath: secretsPath})
 		if err != nil {
 			util.HandleError(err, "Unable to fetch secrets")
@@ -83,6 +88,10 @@ var exportCmd = &cobra.Command{
 			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_PERSONAL)
 		} else {
 			secrets = util.OverrideSecrets(secrets, util.SECRET_TYPE_SHARED)
+		}
+
+		if sort {
+			util.SortSecrets(&secrets)
 		}
 
 		var output string
@@ -115,6 +124,7 @@ func init() {
 	exportCmd.Flags().StringP("tags", "t", "", "filter secrets by tag slugs")
 	exportCmd.Flags().String("projectId", "", "manually set the projectId to fetch secrets from")
 	exportCmd.Flags().String("path", "/", "get secrets within a folder path")
+	exportCmd.Flags().Bool("sort", false, "sort exported secrets in alphabetical order")
 }
 
 // Format according to the format flag

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/api"
@@ -764,4 +765,10 @@ func GetPlainTextWorkspaceKey(authenticationToken string, receiverPrivateKey str
 	}
 
 	return crypto.DecryptAsymmetric(encryptedWorkspaceKey, encryptedWorkspaceKeyNonce, encryptedWorkspaceKeySenderPublicKey, currentUsersPrivateKey), nil
+}
+
+func SortSecrets(secrets *[]models.SingleEnvironmentVariable) {
+	sort.SliceStable(*secrets, func(i, j int) bool {
+		return (*secrets)[i].Key < (*secrets)[j].Key
+	})
 }

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/api"
@@ -765,10 +764,4 @@ func GetPlainTextWorkspaceKey(authenticationToken string, receiverPrivateKey str
 	}
 
 	return crypto.DecryptAsymmetric(encryptedWorkspaceKey, encryptedWorkspaceKeyNonce, encryptedWorkspaceKeySenderPublicKey, currentUsersPrivateKey), nil
-}
-
-func SortSecrets(secrets *[]models.SingleEnvironmentVariable) {
-	sort.SliceStable(*secrets, func(i, j int) bool {
-		return (*secrets)[i].Key < (*secrets)[j].Key
-	})
 }

--- a/docs/cli/commands/export.mdx
+++ b/docs/cli/commands/export.mdx
@@ -121,4 +121,15 @@ Export environment variables from the platform into a file format.
     By default, all secrets are fetched
   </Accordion>
 
+  <Accordion title="--sort">
+    Arrange secrets in alphabetical order based on their keys.
+
+    ```bash
+    # Example 
+    infisical export --sort=true 
+    ```
+
+    default value: `false`
+  </Accordion>
+
 </Accordion>


### PR DESCRIPTION
# Description 📣

Introduce alphabetical sorting for exported secrets based on keys. 

Closes #1292 

## Type ✨

- [x] New feature

```sh
infisical export --sort=true
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝