### PR TITLE
(Fix): Secret reminder duplication and deletion

### DIFF
--- a/backend/src/helpers/reminder.ts
+++ b/backend/src/helpers/reminder.ts
@@ -1,9 +1,9 @@
-import { ISecret } from "../models";
 import {
   createRecurringSecretReminder,
   deleteRecurringSecretReminder,
   updateRecurringSecretReminder
 } from "../queues/reminders/sendSecretReminders";
+import type { ISecret } from "../models";
 
 type TPartialSecret = Pick<
   ISecret,
@@ -25,10 +25,12 @@ export const createReminder = async (oldSecret: TPartialSecret, newSecret: TPart
 
   if (oldSecret.secretReminderRepeatDays) {
     // This will first delete the existing recurring job, and then create a new one.
+
     await updateRecurringSecretReminder({
       workspaceId,
       secretId,
-      repeatDays: newSecret.secretReminderRepeatDays,
+      newRepeatDays: newSecret.secretReminderRepeatDays,
+      oldRepeatDays: oldSecret.secretReminderRepeatDays,
       note: newSecret.secretReminderNote
     });
   } else {

--- a/backend/src/queues/reminders/sendSecretReminders.ts
+++ b/backend/src/queues/reminders/sendSecretReminders.ts
@@ -1,5 +1,5 @@
-import Queue, { Job } from "bull";
 import { IUser, Membership, Organization, Workspace } from "../../models";
+import Queue, { Job } from "bull";
 import { Types } from "mongoose";
 import { sendMail } from "../../helpers";
 
@@ -8,6 +8,15 @@ type TSendSecretReminders = {
   secretId: string;
   repeatDays: number;
   note: string | undefined | null;
+};
+
+type TUpdateSecretReminder = {
+  oldRepeatDays: number;
+  newRepeatDays: number;
+
+  note: string | undefined | null;
+  secretId: string;
+  workspaceId: string;
 };
 
 type TDeleteSecretReminder = {
@@ -76,8 +85,16 @@ export const deleteRecurringSecretReminder = (jobDetails: TDeleteSecretReminder)
   });
 };
 
-export const updateRecurringSecretReminder = async (jobDetails: TSendSecretReminders) => {
+export const updateRecurringSecretReminder = async (jobDetails: TUpdateSecretReminder) => {
   // We need to delete the potentially existing reminder job first, or the new one won't be created.
-  await deleteRecurringSecretReminder(jobDetails);
-  await createRecurringSecretReminder(jobDetails);
+  await deleteRecurringSecretReminder({
+    repeatDays: jobDetails.oldRepeatDays,
+    secretId: jobDetails.secretId
+  });
+  await createRecurringSecretReminder({
+    repeatDays: jobDetails.newRepeatDays,
+    secretId: jobDetails.secretId,
+    workspaceId: jobDetails.workspaceId,
+    note: jobDetails.note
+  });
 };


### PR DESCRIPTION
# Description 📣


- As mentioned in #1288 sometimes repeatable jobs would be duplicated instead of updated. When a user would attempt to update a reminder, we would try and find the existing reminder with the **new** data, which it would then fail to find. This resulted in the existing reminder not being updated, and a new reminder being created. This led to "duplicate" reminders for the same secret.
   - The fix for this was to create a new `TUpdateSecretReminder` type, which takes both the new _and_ the old repeat value, so we can probably update the old reminder.

- Additionally I also noticed that we weren't handling reminder deletion properly when a secret gets deleted. That was also fixed in this PR. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝