### PR TITLE
feat: allow directory to path mapping for better mono repositories

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -74,6 +74,13 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		if !cmd.Flags().Changed("path") {
+			workspaceMappedPath := util.GetPathFromWorkspaceFile()
+			if workspaceMappedPath != "" {
+				secretsPath = workspaceMappedPath
+			}
+		}
+
 		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, WorkspaceId: projectId, SecretsPath: secretsPath}, "")
 		if err != nil {
 			util.HandleError(err, "Unable to fetch secrets")

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -92,6 +92,14 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		if !cmd.Flags().Changed("path") {
+			workspaceMappedPath := util.GetPathFromWorkspaceFile()
+			if workspaceMappedPath != "" {
+				secretsPath = workspaceMappedPath
+			}
+		}
+
+
 		includeImports, err := cmd.Flags().GetBool("include-imports")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -48,6 +48,13 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		if !cmd.Flags().Changed("path") {
+			workspaceMappedPath := util.GetPathFromWorkspaceFile()
+			if workspaceMappedPath != "" {
+				secretsPath = workspaceMappedPath
+			}
+		}
+
 		shouldExpandSecrets, err := cmd.Flags().GetBool("expand")
 		if err != nil {
 			util.HandleError(err)
@@ -126,6 +133,13 @@ var secretsSetCmd = &cobra.Command{
 		secretsPath, err := cmd.Flags().GetString("path")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
+		}
+
+		if !cmd.Flags().Changed("path") {
+			workspaceMappedPath := util.GetPathFromWorkspaceFile()
+			if workspaceMappedPath != "" {
+				secretsPath = workspaceMappedPath
+			}
 		}
 
 		workspaceFile, err := util.GetWorkSpaceFromFile()
@@ -338,6 +352,13 @@ var secretsDeleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		if !cmd.Flags().Changed("path") {
+			workspaceMappedPath := util.GetPathFromWorkspaceFile()
+			if workspaceMappedPath != "" {
+				secretsPath = workspaceMappedPath
+			}
+		}
+
 		secretType, err := cmd.Flags().GetString("type")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
@@ -403,7 +424,14 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 
 	secretsPath, err := cmd.Flags().GetString("path")
 	if err != nil {
-		util.HandleError(err, "Unable to parse path flag")
+		util.HandleError(err, "Unable to parse flag")
+	}
+
+	if !cmd.Flags().Changed("path") {
+		workspaceMappedPath := util.GetPathFromWorkspaceFile()
+		if workspaceMappedPath != "" {
+			secretsPath = workspaceMappedPath
+		}
 	}
 
 	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath}, "")
@@ -443,6 +471,13 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 	secretsPath, err := cmd.Flags().GetString("path")
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
+	}
+
+	if !cmd.Flags().Changed("path") {
+		workspaceMappedPath := util.GetPathFromWorkspaceFile()
+		if workspaceMappedPath != "" {
+			secretsPath = workspaceMappedPath
+		}
 	}
 
 	infisicalToken, err := cmd.Flags().GetString("token")

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -51,6 +51,7 @@ type WorkspaceConfigFile struct {
 	WorkspaceId                   string            `json:"workspaceId"`
 	DefaultEnvironment            string            `json:"defaultEnvironment"`
 	GitBranchToEnvironmentMapping map[string]string `json:"gitBranchToEnvironmentMapping"`
+	DirectoryToPathMapping        bool              `json:"directoryFromConfigMapping"`
 }
 
 type SymmetricEncryptionResult struct {

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -710,6 +711,47 @@ func DeleteBackupSecrets() error {
 	fullPathToSecretsBackupFolder := fmt.Sprintf("%s/%s", fullConfigFileDirPath, secrets_backup_folder_name)
 
 	return os.RemoveAll(fullPathToSecretsBackupFolder)
+}
+
+func GetPathFromWorkspaceFile() string {
+	workspaceFile, err := GetWorkSpaceFromFile()
+	if err != nil {
+		log.Debug().Msgf("getPathFromWorkspaceFile(workspaceConfig): [err=%s]", err)
+		return ""
+	}
+
+	if !workspaceFile.DirectoryToPathMapping {
+		return ""
+	}
+
+	// We've confirmed we can load the workspace config
+	// so getting the filepath and containing directory really
+	// shouldn't fail.
+	cfgFile, err := FindWorkspaceConfigFile()
+	if err != nil {
+		log.Debug().Msgf("getPathFromWorkspaceFile(workspaceConfigPath): [err=%s]", err)
+		return ""
+	}
+	workspaceDirectory := filepath.Dir(cfgFile)
+
+	// Get Execution Path
+	localPath, err := os.Getwd()
+	if err != nil {
+		log.Debug().Msgf("getPathFromWorkspaceFile(getExecutionPath): [err=%s]", err)
+		return ""
+	}
+
+	path, err := filepath.Rel(workspaceDirectory, localPath)
+	if err != nil {
+		log.Debug().Msgf("getPathFromWorkspaceFile(getRelativePathFromWorkspace): [err=%s]", err)
+		return ""
+	}
+
+	if path == "." {
+		return ""
+	}
+
+	return path
 }
 
 func GetEnvFromWorkspaceFile() string {


### PR DESCRIPTION
# Description 📣

This change adds a new parameter to `.infisical.json` that allows the user to turn on `directoryFromConfigMapping: true` to allow the `--path` CLI argument to be auto confingured with the relative path from where infisical was executed from the `.infisical.json` config.

The default value is `false` which makes this behaviour backwards compatible.

Related #243 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I couldn't see any relevant tests to add the new  use-case to. So here's some manual testing:

https://asciinema.org/a/41jXyufl6fzYsKwnWd7ImTMYq

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝