### PR TITLE
feat(cli): export env group by tag #1320

### DIFF
--- a/docs/cli/commands/export.mdx
+++ b/docs/cli/commands/export.mdx
@@ -99,6 +99,12 @@ Export environment variables from the platform into a file format.
     Default value: `true`
   </Accordion>
 
+  <Accordion title="--group-by-tags">
+    Exported secrets are grouped by tags, support dotenv format only
+
+    Default value: `false`
+  </Accordion>
+
   <Accordion title="--path">
     The `--path` flag indicates which project folder secrets will be injected from.
 


### PR DESCRIPTION
# Description 📣
Added a new flag to export in Go `--group-by-tags`

This will allow user to add environment tags as a comment in the output file, Currently support only for dotenv format. Would add to other formats in a separate PR if wanted.

Default is set to false for backward compatible

Without flag
```
$ infisical export

TEST NO TAGS='test'
TAG WITH ONE='yes i am a tag'
ANOTHER ONE=''
MULTI_TAGS='yes'
```

With flag
```
$ infisical export --group-by-tags

# Tag,!, Blue tasd
MULTI_TAGS='yes'

# Tag,!
TAG WITH ONE='yes i am a tag'

ANOTHER ONE=''
TEST NO TAGS='test'
```

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Check image for the launch.json


<img width="899" alt="Screenshot 2024-01-27 at 8 02 51 PM" src="https://github.com/Infisical/infisical/assets/40920317/a2c4f077-a0c1-4c86-b9a1-bbd826d80a0c">

<img width="899" alt="Screenshot 2024-01-27 at 8 07 40 PM" src="https://github.com/Infisical/infisical/assets/40920317/e7da3d51-a52f-4d2e-be89-51a89b0d1dbe">

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝