### PR TITLE
Remove async from isSamePath check in integration sync

### DIFF
--- a/backend/src/lib/fn/string.ts
+++ b/backend/src/lib/fn/string.ts
@@ -2,7 +2,7 @@ import path from "path";
 
 // given two paths irrespective of ending with / or not
 // this will return true if its equal
-export const isSamePath = async (from: string, to: string) => !path.relative(from, to);
+export const isSamePath = (from: string, to: string) => !path.relative(from, to);
 
 export const removeTrailingSlash = (str: string) => {
   if (str === "/") return str;


### PR DESCRIPTION
# Description 📣

This PR removes `async` from the path check for integrations.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝