### PR TITLE
Add customer portal redirect and patch free trial endpoint

### DIFF
--- a/backend/src/ee/routes/v1/license-router.ts
+++ b/backend/src/ee/routes/v1/license-router.ts
@@ -79,7 +79,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
-      const data = await server.services.license.startOrgTrail({
+      const data = await server.services.license.startOrgTrial({
         actorId: req.permission.id,
         actor: req.permission.type,
         orgId: req.params.organizationId,

--- a/backend/src/ee/routes/v1/license-router.ts
+++ b/backend/src/ee/routes/v1/license-router.ts
@@ -90,6 +90,26 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
   });
 
   server.route({
+    url: "/:organizationId/customer-portal-session",
+    method: "POST",
+    schema: {
+      params: z.object({ organizationId: z.string().trim() }),
+      response: {
+        200: z.any()
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const data = await server.services.license.createOrganizationPortalSession({
+        actorId: req.permission.id,
+        actor: req.permission.type,
+        orgId: req.params.organizationId
+      });
+      return data;
+    }
+  });
+
+  server.route({
     url: "/:organizationId/plan/billing",
     method: "GET",
     schema: {

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -40,9 +40,11 @@ export type TOrgPlanDTO = {
   projectId?: string;
 } & TOrgPermission;
 
-export type TStartOrgTrailDTO = {
+export type TStartOrgTrialDTO = {
   success_url: string;
 } & TOrgPermission;
+
+export type TCreateOrgPortalSession = TOrgPermission;
 
 export type TGetOrgBillInfoDTO = TOrgPermission;
 

--- a/frontend/src/hooks/api/organization/queries.tsx
+++ b/frontend/src/hooks/api/organization/queries.tsx
@@ -328,7 +328,7 @@ export const useCreateCustomerPortalSession = () => {
   return useMutation({
     mutationFn: async (organizationId: string) => {
       const { data } = await apiRequest.post(
-        `/api/v1/organization/${organizationId}/customer-portal-session`
+        `/api/v1/organizations/${organizationId}/customer-portal-session`
       );
       return data;
     }


### PR DESCRIPTION
# Description 📣

This PR includes two updates having to do with the license server / customer portal logic:
- It adds back the redirect endpoint + logic to direct customers to manage their billing/plan information.
- It fixes the free trial endpoint so customers can start free trials in Infisical Cloud

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝