### PR TITLE
(Fix): Add ID to list workspaces endpoint

### DIFF
--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -49,6 +49,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         200: z.object({
           workspaces: z
             .object({
+              id: z.string(),
               name: z.string(),
               organization: z.string(),
               environments: z


### PR DESCRIPTION
# Description 📣

In the old backend we were returning ID's of workspaces, contrary to what the documentation documentation states. This PR re-adds the missing workspace ID field.  

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->