### PR TITLE
doc(cli): HISTIGNORE recommendation

### DIFF
--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -135,3 +135,38 @@ Another option to point the CLI to your self hosted Infisical instance is to set
 infisical <any-command> --domain="https://your-self-hosted-infisical.com/api"
 ```
 </Accordion>
+
+## History
+
+Your terminal keeps a history with the commands you run. When you create Infisical secrets directly from your terminal, they'll stay there for a while.
+
+For security and privacy concerns, we recommend you to configure your terminal to ignore those specific Infisical commands.
+
+<Accordion title="Ignore commands">
+
+<Tabs>
+   <Tab title="Unix/Linux">
+      <Tip>
+        `$HOME/.profile` is pretty common but, you could place it under `$HOME/.profile.d/infisical.sh` or any profile file run at login 
+      </Tip>
+
+      ```bash
+      cat <<EOF >> $HOME/.profile && source $HOME/.profile
+
+      # Ignoring specific Infisical CLI commands
+      DEFAULT_HISTIGNORE=$HISTIGNORE
+      export HISTIGNORE="*infisical secrets set*:$DEFAULT_HISTIGNORE"
+      EOF
+      ```
+
+   </Tab>
+   <Tab title="Windows">
+      If you're on WSL, then you can use the Unix/Linux method.
+
+      <Tip>
+        Here's some [documentation](https://superuser.com/a/1658331) about how to clear the terminal history, in PowerShell and CMD
+      </Tip>
+
+   </Tab>
+</Tabs>
+</Accordion>


### PR DESCRIPTION
# Description 📣

When the user use the CLI to set secrets through the terminal, it keeps the command in the terminal's history and memory.

This recommendation explains how to avoid this behaviour on a given set of Infisical commands, to improve local security and privacy.

## Type ✨

- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# launch the doc (https://infisical.com/docs/contributing/platform/developing#starting-infisical-docs-locally)
cd ./docs && mintlify dev;
```

### CLI - Quick usage

![history](https://github.com/Infisical/infisical/assets/72856427/3d05b4b4-788c-4356-bbd1-3f20275c714d)

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->