### PR TITLE
Patch identity access token + client secret TTL

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -35,12 +35,12 @@ export const identityAccessTokenServiceFactory = ({
     }
 
     // ttl check
-    if (accessTokenTTL > 0) {
+    if (Number(accessTokenTTL) > 0) {
       const currentDate = new Date();
       if (accessTokenLastRenewedAt) {
         // access token has been renewed
         const accessTokenRenewed = new Date(accessTokenLastRenewedAt);
-        const ttlInMilliseconds = accessTokenTTL * 1000;
+        const ttlInMilliseconds = Number(accessTokenTTL) * 1000;
         const expirationDate = new Date(accessTokenRenewed.getTime() + ttlInMilliseconds);
 
         if (currentDate > expirationDate)
@@ -50,7 +50,7 @@ export const identityAccessTokenServiceFactory = ({
       } else {
         // access token has never been renewed
         const accessTokenCreated = new Date(accessTokenCreatedAt);
-        const ttlInMilliseconds = accessTokenTTL * 1000;
+        const ttlInMilliseconds = Number(accessTokenTTL) * 1000;
         const expirationDate = new Date(accessTokenCreated.getTime() + ttlInMilliseconds);
 
         if (currentDate > expirationDate)
@@ -61,9 +61,9 @@ export const identityAccessTokenServiceFactory = ({
     }
 
     // max ttl checks
-    if (accessTokenMaxTTL > 0) {
+    if (Number(accessTokenMaxTTL) > 0) {
       const accessTokenCreated = new Date(accessTokenCreatedAt);
-      const ttlInMilliseconds = accessTokenMaxTTL * 1000;
+      const ttlInMilliseconds = Number(accessTokenMaxTTL) * 1000;
       const currentDate = new Date();
       const expirationDate = new Date(accessTokenCreated.getTime() + ttlInMilliseconds);
 
@@ -72,7 +72,7 @@ export const identityAccessTokenServiceFactory = ({
           message: "Failed to renew MI access token due to Max TTL expiration"
         });
 
-      const extendToDate = new Date(currentDate.getTime() + accessTokenTTL);
+      const extendToDate = new Date(currentDate.getTime() + Number(accessTokenTTL));
       if (extendToDate > expirationDate)
         throw new UnauthorizedError({
           message: "Failed to renew MI access token past its Max TTL expiration"

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -69,9 +69,9 @@ export const identityUaServiceFactory = ({
     if (!validClientSecretInfo) throw new UnauthorizedError();
 
     const { clientSecretTTL, clientSecretNumUses, clientSecretNumUsesLimit } = validClientSecretInfo;
-    if (clientSecretTTL > 0) {
+    if (Number(clientSecretTTL) > 0) {
       const clientSecretCreated = new Date(validClientSecretInfo.createdAt);
-      const ttlInMilliseconds = clientSecretTTL * 1000;
+      const ttlInMilliseconds = Number(clientSecretTTL) * 1000;
       const currentDate = new Date();
       const expirationTime = new Date(clientSecretCreated.getTime() + ttlInMilliseconds);
 
@@ -124,7 +124,10 @@ export const identityUaServiceFactory = ({
       } as TIdentityAccessTokenJwtPayload,
       appCfg.AUTH_SECRET,
       {
-        expiresIn: identityAccessToken.accessTokenMaxTTL === 0 ? undefined : identityAccessToken.accessTokenMaxTTL
+        expiresIn:
+          Number(identityAccessToken.accessTokenMaxTTL) === 0
+            ? undefined
+            : Number(identityAccessToken.accessTokenMaxTTL)
       }
     );
 


### PR DESCRIPTION
# Description 📣

This PR converts expiry TTLs to `Number` that was incorrect mapped as a side-effect of the Postgres migration initiative

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [ x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->