### PR TITLE
fix: resolved secret import secrets failing when folder has empty secrets

### DIFF
--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -41,13 +41,12 @@ export const fnSecretsFromImports = async ({
     environment: importEnv.slug,
     environmentInfo: importEnv,
     folderId: importedFolders?.[i]?.id,
-    secrets: importedFolders?.[i]?.id
-      ? importedSecsGroupByFolderId[importedFolders?.[i]?.id as string].map((item) => ({
-          ...item,
-          environment: importEnv.slug,
-          workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
-          _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
-        }))
-      : []
+    // this will ensure for cases when secrets are empty. Could be due to missing folder for a path or when emtpy secrets inside a given path
+    secrets: (importedSecsGroupByFolderId?.[importedFolders?.[i]?.id as string] || []).map((item) => ({
+      ...item,
+      environment: importEnv.slug,
+      workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
+      _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
+    }))
   }));
 };


### PR DESCRIPTION
# Description 📣

1. Resolution to a bug reported by couple of users that secret import is throwing 500 error. The root cause was valid folders with empty secrets

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->