### PR TITLE
fix(signup): set send verification email button loading state

### DIFF
--- a/frontend/src/components/signup/EnterEmailStep.tsx
+++ b/frontend/src/components/signup/EnterEmailStep.tsx
@@ -28,7 +28,7 @@ export default function EnterEmailStep({
   incrementStep
 }: DownloadBackupPDFStepProps): JSX.Element {
   const { createNotification } = useNotificationContext();
-  const { mutateAsync } = useSendVerificationEmail();
+  const { mutateAsync, isLoading } = useSendVerificationEmail();
   const [emailError, setEmailError] = useState(false);
   const { t } = useTranslation();
 
@@ -91,6 +91,8 @@ export default function EnterEmailStep({
               className='h-14'
               colorSchema="primary"
               variant="outline_bg"
+              isLoading={isLoading}
+              isDisabled={isLoading}
             > {String(t("signup.step1-submit"))} </Button>
           </div>
         </div>


### PR DESCRIPTION
Set loading state for button based on send verification email mutation state

fix #1422

# Description 📣

Use mutation loading state to show loading for send verification email button.

https://github.com/Infisical/infisical/assets/10532751/0c423494-3e42-4c57-b942-68e4f64eddc1

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

No new tests are required for this change.
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->