### PR TITLE
Wait for db service to be healthy before kicking off db-migration and backend services

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,8 @@ services:
   db-migration:
     container_name: infisical-db-migration
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     image: infisical/infisical:latest-postgres
     env_file: .env
     command: npm run migration:latest
@@ -16,7 +17,7 @@ services:
     restart: unless-stopped
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_started
       db-migration:
@@ -52,6 +53,11 @@ services:
       - pg_data:/data/db
     networks:
       - infisical
+    healthcheck:
+      test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
 volumes:
   pg_data:


### PR DESCRIPTION
Wait for db service to be healthy before kicking off db-migration and backend services

# Description 📣

Fix for Issue #1448 : (Clean install ends in db-migration service completing unsuccessfully)

- Added healthcheck for db service to help other services determine readiness.
- Modified db-migration and backend service definitions to wait on db service to be healthy before proceeding with deployment.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

- Ran deployments on my local linux systems (physical and VMs) with different RAM configurations, and on a raspberry pi as well to verify that the deployments are successful, without the mentioned error.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
