### PR TITLE
feat(admin): disable sso authentication method 

### DIFF
--- a/backend/src/db/migrations/20240227141616_disable-auth.ts
+++ b/backend/src/db/migrations/20240227141616_disable-auth.ts
@@ -1,0 +1,17 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.SuperAdmin, (t) => {
+    t.specificType("disabledAuthMethods", "text[]");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.SuperAdmin, "disableAuthMethods")) {
+    await knex.schema.alterTable(TableName.SuperAdmin, (t) => {
+      t.dropColumn("disabledAuthMethods");
+    });
+  }
+}

--- a/backend/src/db/schemas/super-admin.ts
+++ b/backend/src/db/schemas/super-admin.ts
@@ -13,7 +13,8 @@ export const SuperAdminSchema = z.object({
   allowSignUp: z.boolean().default(true).nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
-  allowedSignUpDomain: z.string().nullable().optional()
+  allowedSignUpDomain: z.string().nullable().optional(),
+  disabledAuthMethods: z.string().array().nullable().optional()
 });
 
 export type TSuperAdmin = z.infer<typeof SuperAdminSchema>;

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -32,6 +32,7 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
     schema: {
       body: z.object({
         allowSignUp: z.boolean().optional(),
+        disabledAuthMethods: z.array(z.string()).optional(),
         allowedSignUpDomain: z.string().optional().nullable()
       }),
       response: {

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -34,6 +34,12 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
         });
       }
 
+      if (serverCfg.disabledAuthMethods?.includes("email")) {
+        throw new BadRequestError({
+          message: "Email Authentication method is disabled"
+        });
+      }
+
       if (serverCfg?.allowedSignUpDomain) {
         const domain = email.split("@")[1];
         const allowedDomains = serverCfg.allowedSignUpDomain.split(",").map((e) => e.trim());
@@ -72,6 +78,12 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
       if (!serverCfg.allowSignUp) {
         throw new BadRequestError({
           message: "Sign up is disabled"
+        });
+      }
+
+      if (serverCfg.disabledAuthMethods?.includes("email")) {
+        throw new BadRequestError({
+          message: "Email Authentication method is disabled"
         });
       }
 
@@ -121,6 +133,12 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
       if (!serverCfg.allowSignUp) {
         throw new BadRequestError({
           message: "Sign up is disabled"
+        });
+      }
+
+      if (serverCfg.disabledAuthMethods?.includes("email")) {
+        throw new BadRequestError({
+          message: "Email Authentication method is disabled"
         });
       }
 

--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -268,6 +268,16 @@ export const authLoginServiceFactory = ({ userDAL, tokenService, smtpService }: 
 
     const appCfg = getConfig();
 
+    if (
+      serverCfg.disabledAuthMethods?.includes(authMethod) ||
+      (serverCfg.disabledAuthMethods?.includes("saml") && authMethod.endsWith("-saml"))
+    ) {
+      throw new BadRequestError({
+        message: `Authentication method is disabled`,
+        name: "Oauth 2 login"
+      });
+    }
+
     if (!user) {
       // Create a new user based on oAuth
       if (!serverCfg?.allowSignUp) throw new BadRequestError({ message: "Sign up disabled", name: "Oauth 2 login" });

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -1,6 +1,16 @@
+
+export enum AuthMethod {
+  EMAIL = "email",
+  GOOGLE = "google",
+  GITHUB = "github",
+  GITLAB = "gitlab",
+  SAML = "saml"
+}
+
 export type TServerConfig = {
   initialized: boolean;
   allowSignUp: boolean;
+  disabledAuthMethods: AuthMethod[];
   allowedSignUpDomain?: string | null;
   isMigrationModeOn?: boolean;
 };

--- a/frontend/src/views/admin/DashboardPage/AuthMethodSection.tsx
+++ b/frontend/src/views/admin/DashboardPage/AuthMethodSection.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { faGithub, faGitlab, faGoogle, IconDefinition } from "@fortawesome/free-brands-svg-icons";
+import { faEnvelope } from "@fortawesome/free-regular-svg-icons";
+import { faLock } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { useNotificationContext } from "@app/components/context/Notifications/NotificationProvider";
+import { Switch } from "@app/components/v2";
+import { useServerConfig } from "@app/context";
+import { useUpdateServerConfig } from "@app/hooks/api";
+import { AuthMethod } from "@app/hooks/api/admin/types";
+
+interface AuthMethodOption {
+  label: string;
+  value: AuthMethod;
+  icon: IconDefinition;
+}
+
+const authMethodOpts: AuthMethodOption[] = [
+  { label: "Email", value: AuthMethod.EMAIL, icon: faEnvelope },
+  { label: "Google", value: AuthMethod.GOOGLE, icon: faGoogle },
+  { label: "GitHub", value: AuthMethod.GITHUB, icon: faGithub },
+  { label: "GitLab", value: AuthMethod.GITLAB, icon: faGitlab },
+  { label: "SAML", value: AuthMethod.SAML, icon: faLock }
+];
+
+const schema = z.object({
+  disabledAuthMethods: z.array(z.nativeEnum(AuthMethod))
+});
+
+export type FormData = z.infer<typeof schema>;
+
+export const AuthMethodSection = () => {
+  const { createNotification } = useNotificationContext();
+  const { config } = useServerConfig();
+  const { mutateAsync } = useUpdateServerConfig();
+
+  const { reset, setValue, watch } = useForm<FormData>({
+    defaultValues: {
+      disabledAuthMethods: config.disabledAuthMethods || []
+    },
+    resolver: zodResolver(schema)
+  });
+
+  const disabledAuthMethods = watch("disabledAuthMethods");
+
+  useEffect(() => {
+    if (config) {
+      reset({
+        disabledAuthMethods: config.disabledAuthMethods || []
+      });
+    }
+  }, [config]);
+
+  const onAuthMethodToggle = async (value: boolean, authMethodOpt: AuthMethodOption) => {
+    const newDisabledAuthMethods = value
+      ? disabledAuthMethods.filter((auth) => auth !== authMethodOpt.value)
+      : [...disabledAuthMethods, authMethodOpt.value];
+
+    if (value) {
+      const newUser = await mutateAsync({
+        disabledAuthMethods: newDisabledAuthMethods
+      });
+
+      setValue("disabledAuthMethods", newUser.disabledAuthMethods);
+      createNotification({
+        text: "Successfully enabled authentication method",
+        type: "success"
+      });
+      return;
+    }
+
+    if (newDisabledAuthMethods.length === authMethodOpts.length) {
+      createNotification({
+        text: "You must keep at least 1 authentication method enabled",
+        type: "error"
+      });
+      return;
+    }
+
+    const newConfig = await mutateAsync({
+      disabledAuthMethods: newDisabledAuthMethods
+    });
+
+    setValue("disabledAuthMethods", newConfig.disabledAuthMethods);
+    createNotification({
+      text: "Successfully disabled authentication method",
+      type: "success"
+    });
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+      <h2 className="mb-8 flex-1 text-xl font-semibold text-mineshaft-100">
+        Authentication methods
+      </h2>
+      <p className="mb-4 text-gray-400">
+        Toggle the Authentication method to restrict/grant user access for logging in or registering
+        on Infisical. This action take effect across all Infisical organizations.
+      </p>
+      <div className="mb-4">
+        {config &&
+          authMethodOpts.map((authMethodOpt) => {
+            return (
+              <div className="flex items-center p-4" key={`auth-method-${authMethodOpt.value}`}>
+                <div className="flex items-center">
+                  <FontAwesomeIcon icon={authMethodOpt.icon} className="mr-4" />
+                </div>
+                <Switch
+                  id={`enable-${authMethodOpt.value}-auth`}
+                  onCheckedChange={(value) => onAuthMethodToggle(value, authMethodOpt)}
+                  isChecked={!disabledAuthMethods?.includes(authMethodOpt.value) ?? true}
+                >
+                  <p className="mr-4 w-12">{authMethodOpt.label}</p>
+                </Switch>
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/views/admin/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/views/admin/DashboardPage/DashboardPage.tsx
@@ -22,6 +22,8 @@ import {
 import { useOrganization, useServerConfig, useUser } from "@app/context";
 import { useUpdateServerConfig } from "@app/hooks/api";
 
+import { AuthMethodSection } from "./AuthMethodSection";
+
 enum TabSections {
   Settings = "settings"
 }
@@ -181,6 +183,7 @@ export const AdminDashboardPage = () => {
                   Save
                 </Button>
               </form>
+              <AuthMethodSection />  
             </TabPanel>
           </Tabs>
         </div>


### PR DESCRIPTION
# Description 📣
This add ability for super admin to disable any SSO / email authentication methods available in Infisical across organizations. Even though this methods only work, if the authentication ENV is setup properly. I was thinking we can hide the button in the frontend for the user and also add some checks to protect login/register route. So, for a large organization this can be handy.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

![Admin Dashboard _ Infisical · 1 13am · 02-28](https://github.com/Infisical/infisical/assets/40920317/4956e5c4-8023-4fc6-8194-0ceeae56abcb)

## Test
1. Checkout PR
2. goto Admin panel
3. disable email
4. logout the current user
5. login the user via email. Should throw an error


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->