### PR TITLE
Fix: Invite all members to project when there are no members to invite

### DIFF
--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -238,6 +238,8 @@ export const projectMembershipServiceFactory = ({
 
     if (orgMembers.length !== emails.length) throw new BadRequestError({ message: "Some users are not part of org" });
 
+    if (!orgMembers.length) return [];
+
     const existingMembers = await projectMembershipDAL.find({
       projectId,
       $in: { userId: orgMembers.map(({ user }) => user.id).filter(Boolean) }


### PR DESCRIPTION
# Description 📣

Fixed a 500 status server error occurring when attempting to invite members to a project, when there's only 1 member in the organization. The issue was happening due to our mailing service. When we try to send emails, and the recipients array is empty, it will throw a `No recipients defined` error. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝