### PR TITLE
fix postgresql volume path on docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,7 +52,7 @@ services:
     restart: always
     env_file: .env
     volumes:
-      - pg_data:/data/db
+      - pg_data:/var/lib/postgresql/data
     networks:
       - infisical
     healthcheck:


### PR DESCRIPTION
/data/db doesn't seems to exist, would never persist data otherwise

# Description 📣

The default location of postgresql data is /var/lib/postgresql/data, /data/db doesn't exists

## Type ✨

- [ x ] Bug fix

## Results

Now it persists data