### PR TITLE
fix(helm-charts): standalone chart rbac fix for jobs

### DIFF
--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-standalone-postgres/templates/jobs-rbac.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/jobs-rbac.yaml
@@ -13,7 +13,8 @@ metadata:
   name: default
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Namespace }}
+    name: default 
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: k8s-wait-for-infisical-schema-migration


### PR DESCRIPTION
# Description 📣

The standalone helm chart has an RBAC binding that maps to a non-existent service account, this causes the schema migration init container to fail, resulting in nothing working. 

The message in the init container is:

```
Error from server (Forbidden): jobs.batch "infisical-schema-migration-10" is forbidden: User "system:serviceaccount:infisical:default" cannot get resource "jobs" in API group "batch" in the namespace "infisical"
Error from server (Forbidden): jobs.batch "infisical-schema-migration-10" is forbidden: User "system:serviceaccount:infisical:default" cannot get resource "jobs" in API group "batch" in the namespace "infisical"
Error from server (Forbidden): jobs.batch "infisical-schema-migration-10" is forbidden: User "system:serviceaccount:infisical:default" cannot get resource "jobs" in API group "batch" in the namespace "infisical"
```

With this fix it does not do this anymore, and works as expected.

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Deployed helm chart on a bare cluster, it worked. 

---

- [ X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->