### PR TITLE
fix(server): duplicate secret deletion made possible

### DIFF
--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -202,12 +202,13 @@ export const secretServiceFactory = ({
     return deletedSecrets;
   };
 
-  // this is a utility function for secret modification
-  // this will check given secret name blind index exist or not
-  // if its a created secret set isNew to true
-  // thus if these blindindex exist it will throw an error
-  // vice versa when u need to check for updated secret
-  // this will also return the blind index grouped by secretName
+  /**
+   * Checks and handles secrets using a blind index method.
+   * The function generates mappings between secret names and their blind indexes, validates user IDs for personal secrets, and retrieves secrets from the database based on their blind indexes.
+   * For new secrets (isNew = true), it ensures they don't already exist in the database.
+   * For existing secrets, it verifies their presence in the database.
+   * If discrepancies are found, errors are thrown. The function returns mappings and the fetched secrets.
+   */
   const fnSecretBlindIndexCheck = async ({
     inputSecrets,
     folderId,


### PR DESCRIPTION
# Description 📣

1. Before duplicate secret delete would fail due to this validation check. Updated the check to allow deleting secret even if there are dup keys

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->