### PR TITLE
patch super user migration

### DIFF
--- a/backend/src/db/migrations/20240226094411_instance-id.ts
+++ b/backend/src/db/migrations/20240226094411_instance-id.ts
@@ -11,7 +11,11 @@ export async function up(knex: Knex): Promise<void> {
   // this is updated to avoid race condition on replication
   // eslint-disable-next-line
   // @ts-ignore
-  await knex(TableName.SuperAdmin).update({ id: ADMIN_CONFIG_UUID }).whereNotNull("id").limit(1);
+  await knex(TableName.SuperAdmin)
+    .update({ id: ADMIN_CONFIG_UUID })
+    .whereNotNull("id")
+    .andWhere("id", "<>", ADMIN_CONFIG_UUID)
+    .limit(1);
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/backend/src/db/migrations/20240226094411_instance-id.ts
+++ b/backend/src/db/migrations/20240226094411_instance-id.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-nocheck
 import { Knex } from "knex";
 
 import { TableName } from "../schemas";

--- a/backend/src/db/migrations/20240226094411_instance-id.ts
+++ b/backend/src/db/migrations/20240226094411_instance-id.ts
@@ -8,11 +8,11 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable(TableName.SuperAdmin, (t) => {
     t.uuid("instanceId").notNullable().defaultTo(knex.fn.uuid());
   });
+
   // this is updated to avoid race condition on replication
   // eslint-disable-next-line
   // @ts-ignore
-  await knex(TableName.SuperAdmin)
-    .update({ id: ADMIN_CONFIG_UUID })
+  await knex(TableName.SuperAdmin).update({ id: ADMIN_CONFIG_UUID })
     .whereNotNull("id")
     .andWhere("id", "<>", ADMIN_CONFIG_UUID)
     .limit(1);

--- a/backend/src/db/migrations/20240226094411_instance-id.ts
+++ b/backend/src/db/migrations/20240226094411_instance-id.ts
@@ -10,12 +10,13 @@ export async function up(knex: Knex): Promise<void> {
   });
 
   // this is updated to avoid race condition on replication
-  // eslint-disable-next-line
-  // @ts-ignore
-  await knex(TableName.SuperAdmin).update({ id: ADMIN_CONFIG_UUID })
+  /* eslint-disable */
+  await knex(TableName.SuperAdmin)
+    .update({ id: ADMIN_CONFIG_UUID })
     .whereNotNull("id")
     .andWhere("id", "<>", ADMIN_CONFIG_UUID)
     .limit(1);
+  /* eslint-enable */
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/backend/src/db/migrations/20240226094411_instance-id.ts
+++ b/backend/src/db/migrations/20240226094411_instance-id.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import { Knex } from "knex";
 
 import { TableName } from "../schemas";
@@ -8,15 +10,12 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.alterTable(TableName.SuperAdmin, (t) => {
     t.uuid("instanceId").notNullable().defaultTo(knex.fn.uuid());
   });
-
-  // this is updated to avoid race condition on replication
-  /* eslint-disable */
+  // eslint-disable-next-line
   await knex(TableName.SuperAdmin)
     .update({ id: ADMIN_CONFIG_UUID })
     .whereNotNull("id")
     .andWhere("id", "<>", ADMIN_CONFIG_UUID)
     .limit(1);
-  /* eslint-enable */
 }
 
 export async function down(knex: Knex): Promise<void> {


### PR DESCRIPTION
When multiple super admin configs already exist and at least one has a value equal to `ADMIN_CONFIG_UUID` then this migration will fail because it will try to update one of the configs also to ADMIN_CONFIG_UUID. Since two ids cant be the same we get the following error during migration run in helm:

```
migration file "20240226094411_instance-id.ts" failed
migration failed with error: update "super_admin" set "id" = $1 where "id" is not null - duplicate key value violates unique constraint "super_admin_pkey"
update "super_admin" set "id" = $1 where "id" is not null - duplicate key value violates unique constraint "super_admin_pkey"
Key (id)=(00000000-0000-0000-0000-000000000000) already exists.
error: update "super_admin" set "id" = $1 where "id" is not null - duplicate key value violates unique constraint "super_admin_pkey"
```