### PR TITLE
Feat: Agent exec and custom polling interval

### DIFF
--- a/cli/agent-config.yaml
+++ b/cli/agent-config.yaml
@@ -1,5 +1,5 @@
 infisical:
-  address: "http://localhost:8080"
+  address: "https://app.infisical.com/"
 auth:
   type: "universal-auth"
   config:
@@ -13,3 +13,12 @@ sinks:
 templates:
   - source-path: my-dot-ev-secret-template
     destination-path: my-dot-env.env
+    config:
+      polling-interval: 60s
+      execute:
+        command: docker-compose -f docker-compose.prod.yml down && docker-compose -f docker-compose.prod.yml up -d
+  - source-path: my-dot-ev-secret-template1
+    destination-path: my-dot-env-1.env
+    config:
+      exec:
+        command: mkdir hello-world1

--- a/cli/packages/api/api.go
+++ b/cli/packages/api/api.go
@@ -490,5 +490,7 @@ func CallGetRawSecretsV3(httpClient *resty.Client, request GetRawSecretsV3Reques
 		return GetRawSecretsV3Response{}, fmt.Errorf("CallGetRawSecretsV3: Unsuccessful response [%v %v] [status-code=%v] [response=%v]", response.Request.Method, response.Request.URL, response.StatusCode(), response.String())
 	}
 
+	getRawSecretsV3Response.ETag = response.Header().Get(("etag"))
+
 	return getRawSecretsV3Response, nil
 }

--- a/cli/packages/api/model.go
+++ b/cli/packages/api/model.go
@@ -505,4 +505,5 @@ type GetRawSecretsV3Response struct {
 		SecretComment string `json:"secretComment"`
 	} `json:"secrets"`
 	Imports []any `json:"imports"`
+	ETag		string
 }

--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -485,8 +485,6 @@ func (tm *TokenManager) MonitorSecretChanges(secretTemplate Template, sigChan ch
 	execTimeout := secretTemplate.Config.Exec.Timeout
 	execCommand := secretTemplate.Config.Exec.Command
 
-	// Now you can use the `command` variable, which is guaranteed to be a string
-
 	for {
 		token := tm.GetToken()
 

--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -488,7 +488,6 @@ func (tm *TokenManager) MonitorSecretChanges(secretTemplate Template, sigChan ch
 	// Now you can use the `command` variable, which is guaranteed to be a string
 
 	for {
-		log.Info().Msg("polling")
 		token := tm.GetToken()
 
 		if token != "" {

--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -521,9 +521,12 @@ func (tm *TokenManager) MonitorSecretChanges(secretTemplate Template, sigChan ch
 					}
 				}
 			}
+			time.Sleep(pollingInterval)
+		} else {
+			// It fails to get the access token. So we will re-try in 3 seconds. We do this because if we don't, the user will have to wait for the next polling interval to get the first secret render.
+			time.Sleep(3 * time.Second)
 		}
 
-		time.Sleep(pollingInterval)
 	}
 }
 

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -4,6 +4,7 @@ Copyright (c) 2023 Infisical Inc.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/Infisical/infisical-merge/packages/models"
 	"github.com/Infisical/infisical-merge/packages/util"
@@ -269,4 +271,37 @@ func execCmd(cmd *exec.Cmd) error {
 	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	os.Exit(waitStatus.ExitStatus())
 	return nil
+}
+
+func ExecuteCommandWithTimeout(command string, timeout int64) error {
+
+	shell := [2]string{"sh", "-c"}
+	if runtime.GOOS == "windows" {
+		shell = [2]string{"cmd", "/C"}
+	} else {
+		currentShell := os.Getenv("SHELL")
+		if currentShell != "" {
+			shell[0] = currentShell
+		}
+	}
+
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, shell[0], shell[1], command)
+
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok { // type assertion
+			if exitError.ProcessState.ExitCode() == -1 {
+				return fmt.Errorf("command timed out")
+			}
+		}
+		return err
+	} else {
+		return nil
+	}
 }

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -293,6 +293,9 @@ func ExecuteCommandWithTimeout(command string, timeout int64) error {
 	}
 
 	cmd := exec.CommandContext(ctx, shell[0], shell[1], command)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok { // type assertion

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -20,6 +20,7 @@ type LoggedInUser struct {
 	Domain string `json:"domain"`
 }
 
+
 type SingleEnvironmentVariable struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -32,6 +33,11 @@ type SingleEnvironmentVariable struct {
 		Workspace string `json:"workspace"`
 	} `json:"tags"`
 	Comment string `json:"comment"`
+}
+
+type PlaintextSecretResult struct {
+	Secrets []SingleEnvironmentVariable
+	Hash		string
 }
 
 type SingleFolder struct {

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -20,7 +20,6 @@ type LoggedInUser struct {
 	Domain string `json:"domain"`
 }
 
-
 type SingleEnvironmentVariable struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -37,7 +36,7 @@ type SingleEnvironmentVariable struct {
 
 type PlaintextSecretResult struct {
 	Secrets []SingleEnvironmentVariable
-	Hash		string
+	Etag    string
 }
 
 type SingleFolder struct {

--- a/cli/packages/util/agent.go
+++ b/cli/packages/util/agent.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ConvertPollingIntervalToTime converts a string representation of a polling interval to a time.Duration
+func ConvertPollingIntervalToTime(pollingInterval string) (time.Duration, error) {
+	length := len(pollingInterval)
+	if length < 2 {
+		return 0, fmt.Errorf("invalid format")
+	}
+
+	unit := pollingInterval[length-1:]
+	numberPart := pollingInterval[:length-1]
+
+	number, err := strconv.Atoi(numberPart)
+	if err != nil {
+		return 0, err
+	}
+
+	switch unit {
+	case "s":
+		if number < 60 {
+			return 0, fmt.Errorf("polling interval should be at least 60 seconds")
+		}
+		return time.Duration(number) * time.Second, nil
+	case "m":
+		return time.Duration(number) * time.Minute, nil
+	case "h":
+		return time.Duration(number) * time.Hour, nil
+	case "d":
+		return time.Duration(number) * 24 * time.Hour, nil
+	case "w":
+		return time.Duration(number) * 7 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("invalid time unit")
+	}
+}

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -152,7 +152,7 @@ func GetPlainTextSecretsViaJTW(JTWToken string, receiversPrivateKey string, work
 	return plainTextSecrets, nil
 }
 
-func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId string, environmentName string, secretsPath string, includeImports bool) ([]models.SingleEnvironmentVariable, error) {
+func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId string, environmentName string, secretsPath string, includeImports bool) (models.PlaintextSecretResult, error) {
 	httpClient := resty.New()
 	httpClient.SetAuthToken(accessToken).
 		SetHeader("Accept", "application/json")
@@ -170,12 +170,12 @@ func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId strin
 
 	rawSecrets, err := api.CallGetRawSecretsV3(httpClient, api.GetRawSecretsV3Request{WorkspaceId: workspaceId, SecretPath: secretsPath, Environment: environmentName})
 	if err != nil {
-		return nil, err
+		return models.PlaintextSecretResult{}, err
 	}
 
 	plainTextSecrets := []models.SingleEnvironmentVariable{}
 	if err != nil {
-		return nil, fmt.Errorf("unable to decrypt your secrets [err=%v]", err)
+		return models.PlaintextSecretResult{}, fmt.Errorf("unable to decrypt your secrets [err=%v]", err)
 	}
 
 	for _, secret := range rawSecrets.Secrets {
@@ -189,7 +189,10 @@ func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId strin
 	// 	}
 	// }
 
-	return plainTextSecrets, nil
+	return models.PlaintextSecretResult{
+		Secrets: plainTextSecrets,
+		Hash:    rawSecrets.ETag,
+	}, nil
 }
 
 func InjectImportedSecret(plainTextWorkspaceKey []byte, secrets []models.SingleEnvironmentVariable, importedSecrets []api.ImportedSecretV3) ([]models.SingleEnvironmentVariable, error) {


### PR DESCRIPTION
# Description 📣

This PR introduces custom polling intervals and exec commands. Additionally, now instead of re-rendering the secrets every 5 minutes, we only re-render the secrets when a change has actually happened. When a secret change is detected, 2 things will happen:
   1. Secrets are re-rendered. 
   2. The exec command (if any) will be executed.

The polling interval will default to 5 minutes if not defined, and if it's defined the minimum value is 60 seconds.

The exec command has support for a custom timeout. This means that if a command fails to execute with X amount of seconds, the execution flow will fail and print an error to the terminal. If no timeout is provided, it will default to 30 seconds.

Both the exec command and polling interval is defined on a template-level. 


### New example agent config file
```
infisical:
    address: "http://localhost:8080"
auth:
    type: "universal-auth"
    config:
        client-id: "./agent-test/client-id"
        client-secret: "./agent-test/client-secret"
        remove_client_secret_on_read: false
sinks:
    - type: "file"
      config:
          path: "./agent-test/access-token-sink"
templates:
    - source-path: "./agent-test/dot-env-secret-template"
      destination-path: "./agent-test/.target-env"
      config:
          polling-interval: 60s
          exec:
              timeout: 60
              command: docker compose --help
```


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝