### PR TITLE
Fixed mistype from Hash to Etag to fix the cli issue

### DIFF
--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -191,7 +191,7 @@ func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId strin
 
 	return models.PlaintextSecretResult{
 		Secrets: plainTextSecrets,
-		Hash:    rawSecrets.ETag,
+		Etag:    rawSecrets.ETag,
 	}, nil
 }
 


### PR DESCRIPTION
# Description 📣
With the recent commit, infisical cli secrets command started to break due to some type changes. This PR fixes the value which was forgotten to be changed.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
cli/main.go file now compiles and runs successfully
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->