### PR TITLE
chore: made db connection uri in example to get value from POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 ENCRYPTION_KEY=6c1fe4e407b8911c104518103505b218
 
 # Required
-DB_CONNECTION_URI=postgres://infisical:infisical@db:5432/infisical
+DB_CONNECTION_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
 
 # JWT
 # Required secrets to sign JWT tokens


### PR DESCRIPTION
# Description 📣

Some users have reported migration error or some auth failure when running in docker compose. Most of the time it seems inside .env.example users edit the `POSTGRES_` creds but forgot to update the `DB_CONNECTION_URI`

This resolves it by changing the .env.example `DB_CONNECTION_URI` to interpolate from the `POSTGRES_*` creds

#1511 

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->