### PR TITLE
Feature to get only value of specific secret in `secrets get` command

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -406,7 +406,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse path flag")
 	}
 
-	showOnlyValue, err := cmd.Flags().GetBool("value")
+	showOnlyValue, err := cmd.Flags().GetBool("raw-value")
 	if err != nil {
 		util.HandleError(err, "Unable to parse path flag")
 	}
@@ -433,7 +433,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 	}
 
 	if showOnlyValue && len(requestedSecrets) > 1 {
-		util.PrintErrorMessageAndExit("--value only works with one secret.")
+		util.PrintErrorMessageAndExit("--raw-value only works with one secret.")
 	}
 
 	if showOnlyValue {
@@ -674,7 +674,7 @@ func init() {
 	secretsGetCmd.Flags().String("token", "", "Fetch secrets using the Infisical Token")
 	secretsCmd.AddCommand(secretsGetCmd)
 	secretsGetCmd.Flags().String("path", "/", "get secrets within a folder path")
-	secretsGetCmd.Flags().Bool("value", false, "Returns only the value of secret, only works with one secret")
+	secretsGetCmd.Flags().Bool("raw-value", false, "Returns only the value of secret, only works with one secret")
 
 	secretsCmd.Flags().Bool("secret-overriding", true, "Prioritizes personal secrets, if any, with the same name over shared secrets")
 	secretsCmd.AddCommand(secretsSetCmd)

--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -8,24 +8,28 @@ infisical secrets
 ```
 
 ## Description
+
 This command enables you to perform CRUD (create, read, update, delete) operations on secrets within your Infisical project. With it, you can view, create, update, and delete secrets in your environment.
 
-### Sub-commands 
+### Sub-commands
+
 <Accordion title="infisical secrets" defaultOpen="true">
   Use this command to print out all of the secrets in your project
 
-  ```bash
-  $ infisical secrets
-  ```
+```bash
+$ infisical secrets
+```
 
-  ### Environment variables
+### Environment variables
+
   <Accordion title="INFISICAL_TOKEN">
     Used to fetch secrets via a [service token](/documentation/platform/token) apposed to logged in credentials. Simply, export this variable in the terminal before running this command.
 
     ```bash
-    # Example 
+    # Example
     export INFISICAL_TOKEN=st.63e03c4a97cb4a747186c71e.ed5b46a34c078a8f94e8228f4ab0ff97.4f7f38034811995997d72badf44b42ec
     ```
+
   </Accordion>
 
   <Accordion title="INFISICAL_DISABLE_UPDATE_CHECK">
@@ -34,22 +38,26 @@ This command enables you to perform CRUD (create, read, update, delete) operatio
     To use, simply export this variable in the terminal before running this command.
 
     ```bash
-    # Example 
+    # Example
     export INFISICAL_DISABLE_UPDATE_CHECK=true
     ```
+
   </Accordion>
 
-  ### Flags 
+### Flags
+
   <Accordion title="--expand">
     Parse shell parameter expansions in your secrets
 
     Default value: `true`
+
   </Accordion>
 
   <Accordion title="--env">
     Used to select the environment name on which actions should be taken on
 
     Default value: `dev`
+
   </Accordion>
   <Accordion title="--path">
     The `--path` flag indicates which project folder secrets will be injected from.
@@ -58,6 +66,7 @@ This command enables you to perform CRUD (create, read, update, delete) operatio
     # Example
     infisical secrets --path="/" --env=dev
     ```
+
   </Accordion>
 
 </Accordion>
@@ -65,38 +74,56 @@ This command enables you to perform CRUD (create, read, update, delete) operatio
 <Accordion title="infisical secrets get">
   This command allows you selectively print the requested secrets by name
 
-  ```bash 
-  $ infisical secrets get <secret-name-a> <secret-name-b> ...
+```bash
+$ infisical secrets get <secret-name-a> <secret-name-b> ...
 
-  # Example
-  $ infisical secrets get DOMAIN
+# Example
+$ infisical secrets get DOMAIN
 
-  ```
+```
 
-  ### Flags 
+### Flags
+
   <Accordion title="--env">
     Used to select the environment name on which actions should be taken on
 
     Default value: `dev`
+
+  </Accordion>
+
+  <Accordion title="--value">
+    Used to get just the value of that secret. But this only works with one secret.
+
+    Default value: `false`
+
+    Example: `infisical secrets get DOMAIN --value`
+
+    ```sh
+    # Suggested: When running in CI/CD Environments, or in a script, set INFISICAL_DISABLE_UPDATE_CHECK env to true, to hide cli update messages.
+    INFISICAL_DISABLE_UPDATE_CHECK=true infisical secrets get DOMAIN --value
+    ```
+
   </Accordion>
 </Accordion>
 
 <Accordion title="infisical secrets set">
-This command allows you to set or update secrets in your environment. If the secret key provided already exists, its value will be updated with the new value. 
+This command allows you to set or update secrets in your environment. If the secret key provided already exists, its value will be updated with the new value.
 If the secret key does not exist, a new secret will be created using both the key and value provided.
 
 ```bash
 $ infisical secrets set <key1=value1> <key2=value2>...
 
-## Example 
+## Example
 $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jebhfbwe
 ```
 
-  ### Flags 
+### Flags
+
   <Accordion title="--env">
     Used to select the environment name on which actions should be taken on
 
     Default value: `dev`
+
   </Accordion>
   <Accordion title="--path">
     Used to select the project folder in which the secrets will be set. This is useful when creating new secrets under a particular path.
@@ -105,43 +132,48 @@ $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jeb
     # Example
     infisical secrets set DOMAIN=example.com --path="common/backend"
     ```
+
   </Accordion>
 </Accordion>
 
 <Accordion title="infisical secrets delete">
   This command allows you to delete secrets by their name(s).
 
-  ```bash
-  $ infisical secrets delete <keyName1> <keyName2>...
+```bash
+$ infisical secrets delete <keyName1> <keyName2>...
 
-  ## Example 
-  $ infisical secrets delete STRIPE_API_KEY DOMAIN HASH
-  ```
+## Example
+$ infisical secrets delete STRIPE_API_KEY DOMAIN HASH
+```
 
-  ### Flags 
+### Flags
+
   <Accordion title="--env">
     Used to select the environment name on which actions should be taken on
 
     Default value: `dev`
+
   </Accordion>
   <Accordion title="--path">
-    The `--path` flag indicates which project folder secrets will be injected from. 
+    The `--path` flag indicates which project folder secrets will be injected from.
 
     ```bash
     # Example
     infisical secrets delete <keyName1> <keyName2>... --path="/"
     ```
+
   </Accordion>
 </Accordion>
 
 <Accordion title="infisical secrets folders">
   This command allows you to fetch, create and delete folders from within a path from a given project.
 
-  ```bash
-  $ infisical secrets folders
-  ```
+```bash
+$ infisical secrets folders
+```
 
-  ### sub commands 
+### sub commands
+
   <Accordion title="get">
     Used to fetch all folders within a path in a given project
     ```
@@ -179,6 +211,7 @@ $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jeb
 
       Default value: ``
     </Accordion>
+
   </Accordion>
 
   <Accordion title="delete">
@@ -194,10 +227,11 @@ $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jeb
     </Accordion>
 
     <Accordion title="--name">
-      Name of the folder to be deleted within selected `--path` 
+      Name of the folder to be deleted within selected `--path`
 
       Default value: ``
     </Accordion>
+
   </Accordion>  
 </Accordion>
 
@@ -210,14 +244,16 @@ To place default values in your example .env file, you can simply include the sy
 ```bash
 $ infisical secrets generate-example-env
 
-## Example 
+## Example
 $ infisical secrets generate-example-env > .example-env
 ```
 
-  ### Flags 
+### Flags
+
   <Accordion title="--env">
     Used to select the environment name on which actions should be taken on
 
     Default value: `dev`
+
   </Accordion>
 </Accordion>

--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -12,13 +12,12 @@ infisical secrets
 This command enables you to perform CRUD (create, read, update, delete) operations on secrets within your Infisical project. With it, you can view, create, update, and delete secrets in your environment.
 
 ### Sub-commands
-
 <Accordion title="infisical secrets" defaultOpen="true">
   Use this command to print out all of the secrets in your project
 
-```bash
-$ infisical secrets
-```
+  ```bash
+  $ infisical secrets
+  ```
 
 ### Environment variables
 
@@ -91,17 +90,16 @@ $ infisical secrets get DOMAIN
 
   </Accordion>
 
-  <Accordion title="--value">
-    Used to get just the value of that secret. But this only works with one secret.
+  <Accordion title="--raw-value">
+    Used to print the plain value of a single requested secret without any table style.
 
     Default value: `false`
 
     Example: `infisical secrets get DOMAIN --value`
 
-    ```sh
-    # Suggested: When running in CI/CD Environments, or in a script, set INFISICAL_DISABLE_UPDATE_CHECK env to true, to hide cli update messages.
-    INFISICAL_DISABLE_UPDATE_CHECK=true infisical secrets get DOMAIN --value
-    ```
+    <Tip>
+      When running in CI/CD environments or in a script, set `INFISICAL_DISABLE_UPDATE_CHECK` env to `true`. This will help hide any CLI update messages and only show the secret value.
+    </Tip>
 
   </Accordion>
 </Accordion>


### PR DESCRIPTION
# Description 📣

Closes #845 . This feature adds  a flag `--value` to `infisical secrets get` command which only prints the value of requested secret. 
Note: this flag only works with one secret request.

This will be very helpful for automation scripts and ci/cd pipelines to exactly get what they want
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
INFISICAL_DISABLE_UPDATE_CHECK=true go run main.go secrets get SOME_SECRET --path=/A --value
```
<img width="1720" alt="Screenshot 2024-03-05 at 4 19 01 PM" src="https://github.com/Infisical/infisical/assets/47269183/b2f7f0d6-488c-4133-9563-12b1673f09f9">

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->