### PR TITLE
Fix: Edge case causing project upgrade to fail

### DIFF
--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -102,8 +102,11 @@ export const projectQueueFactory = ({
 
       const oldProjectKey = await projectKeyDAL.findLatestProjectKey(data.startedByUserId, data.projectId);
 
-      if (!project || !oldProjectKey) {
-        throw new Error("Project or project key not found");
+      if (!project) {
+        throw new Error("Project not found");
+      }
+      if (!oldProjectKey) {
+        throw new Error("Old project key not found");
       }
 
       if (project.upgradeStatus !== ProjectUpgradeStatus.Failed && project.upgradeStatus !== null) {
@@ -267,8 +270,19 @@ export const projectQueueFactory = ({
           const user = await userDAL.findUserEncKeyByUserId(key.receiverId);
           const [orgMembership] = await orgDAL.findMembership({ userId: key.receiverId, orgId: project.orgId });
 
-          if (!user || !orgMembership) {
-            throw new Error(`User with ID ${key.receiverId} was not found during upgrade, or user is not in org.`);
+          if (!user) {
+            throw new Error(`User with ID ${key.receiverId} was not found during upgrade.`);
+          }
+
+          if (!orgMembership) {
+            // This can happen. Since we don't remove project memberships and project keys when a user is removed from an org, this is a valid case.
+            logger.info("User is not in organization", {
+              userId: key.receiverId,
+              orgId: project.orgId,
+              projectId: project.id
+            });
+            // eslint-disable-next-line no-continue
+            continue;
           }
 
           const [newMember] = assignWorkspaceKeysToMembers({
@@ -515,6 +529,8 @@ export const projectQueueFactory = ({
           throw new Error("Parts of the upgrade failed. Some secrets were not updated");
         }
 
+        throw new Error("It worked! (This is a test error message)");
+
         await projectDAL.setProjectUpgradeStatus(data.projectId, null, tx);
 
         //  await new Promise((resolve) => setTimeout(resolve, 15_000));
@@ -532,7 +548,12 @@ export const projectQueueFactory = ({
         logger.error("Failed to upgrade project, because no project was found", data);
       } else {
         await projectDAL.setProjectUpgradeStatus(data.projectId, ProjectUpgradeStatus.Failed);
-        logger.error(err, "Failed to upgrade project");
+        logger.error("Failed to upgrade project", err, {
+          extra: {
+            project,
+            jobData: data
+          }
+        });
       }
 
       throw err;

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -529,8 +529,6 @@ export const projectQueueFactory = ({
           throw new Error("Parts of the upgrade failed. Some secrets were not updated");
         }
 
-        throw new Error("It worked! (This is a test error message)");
-
         await projectDAL.setProjectUpgradeStatus(data.projectId, null, tx);
 
         //  await new Promise((resolve) => setTimeout(resolve, 15_000));


### PR DESCRIPTION
# Description 📣

- There's an edge case where project upgrades may fail. This happens when a user in a project no longer has an organization membership. The root cause of this is because we don't remove project memberships and project keys when an organization membership is deleted. I have raised a PR to fix the project memberships/keys, #1536.
- I've also added better logging to the project queue, so we'll be able to better identity what's going wrong through CloudWatch.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝