### PR TITLE
Fix: Remove project keys & memberships when organization membership is deleted

### DIFF
--- a/backend/src/db/seeds/1-user.ts
+++ b/backend/src/db/seeds/1-user.ts
@@ -9,7 +9,12 @@ export async function seed(knex: Knex): Promise<void> {
   await knex(TableName.Users).del();
   await knex(TableName.UserEncryptionKey).del();
   await knex(TableName.SuperAdmin).del();
-  await knex(TableName.SuperAdmin).insert([{ initialized: true, allowSignUp: true }]);
+
+  await knex(TableName.SuperAdmin).insert([
+    // eslint-disable-next-line
+    // @ts-ignore
+    { id: "00000000-0000-0000-0000-000000000000", initialized: true, allowSignUp: true }
+  ]);
   // Inserts seed entries
   const [user] = await knex(TableName.Users)
     .insert([

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -263,6 +263,8 @@ export const registerRoutes = async (
     incidentContactDAL,
     tokenService,
     projectDAL,
+    projectMembershipDAL,
+    projectKeyDAL,
     smtpService,
     userDAL,
     orgBotDAL

--- a/backend/src/services/project-membership/project-membership-dal.ts
+++ b/backend/src/services/project-membership/project-membership-dal.ts
@@ -82,5 +82,25 @@ export const projectMembershipDALFactory = (db: TDbClient) => {
     }
   };
 
-  return { ...projectMemberOrm, findAllProjectMembers, findProjectGhostUser, findMembershipsByEmail };
+  const findProjectMembershipsByUserId = async (orgId: string, userId: string) => {
+    try {
+      const memberships = await db(TableName.ProjectMembership)
+        .where({ userId })
+        .join(TableName.Project, `${TableName.ProjectMembership}.projectId`, `${TableName.Project}.id`)
+        .where({ [`${TableName.Project}.orgId` as "orgId"]: orgId })
+        .select(selectAllTableCols(TableName.ProjectMembership));
+
+      return memberships;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find project memberships by user id" });
+    }
+  };
+
+  return {
+    ...projectMemberOrm,
+    findAllProjectMembers,
+    findProjectGhostUser,
+    findMembershipsByEmail,
+    findProjectMembershipsByUserId
+  };
 };


### PR DESCRIPTION
# Description 📣

- We currently aren't removing project memberships & keys when organization memberships are removed, this PR aims to fix that. This was causing an edge case in the project upgrade, so I thought it would make sense to also fix the root cause while also fixing the project upgrade edge-case. #1535 
- Fixed super admin database seeding. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝