### PR TITLE
Update Railway integration get services query, make services optional

### DIFF
--- a/backend/src/services/integration-auth/integration-auth-service.ts
+++ b/backend/src/services/integration-auth/integration-auth-service.ts
@@ -649,33 +649,21 @@ export const integrationAuthServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Integrations);
     const botKey = await projectBotService.getBotKey(integrationAuth.projectId);
     const { accessToken } = await getIntegrationAccessToken(integrationAuth, botKey);
-    if (appId) {
+
+    if (appId && appId !== "") {
       const query = `
-     query project($id: String!) {
-        project(id: $id) {
-          createdAt
-          deletedAt
-          id
-          description
-          expiredAt
-          isPublic
-          isTempProject
-          isUpdatable
-          name
-          prDeploys
-          teamId
-          updatedAt
-          upstreamUrl
-		  services {
-			edges {
-				node {
-					id
-					name
-				}
-			}
-		  }
+        query project($id: String!) {
+          project(id: $id) {
+            services {
+                edges {
+                    node {
+                        id
+                        name
+                    }
+                }
+            }
+          }
         }
-      }
       `;
 
       const variables = {
@@ -711,6 +699,7 @@ export const integrationAuthServiceFactory = ({
       );
       return edges.map(({ node: { name, id: serviceId } }) => ({ name, serviceId }));
     }
+
     return [];
   };
 

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -1204,21 +1204,21 @@ const syncSecretsRailway = async ({
     }
   `;
 
-  const input = {
-    projectId: integration.appId,
-    environmentId: integration.targetEnvironmentId,
-    ...(integration.targetServiceId ? { serviceId: integration.targetServiceId } : {}),
-    replace: true,
-    variables: getSecretKeyValuePair(secrets)
+  const variables = {
+    input: {
+      projectId: integration.appId,
+      environmentId: integration.targetEnvironmentId,
+      ...(integration.targetServiceId ? { serviceId: integration.targetServiceId } : {}),
+      replace: true,
+      variables: getSecretKeyValuePair(secrets)
+    }
   };
 
   await request.post(
     IntegrationUrls.RAILWAY_API_URL,
     {
       query,
-      variables: {
-        input
-      }
+      variables
     },
     {
       headers: {

--- a/frontend/src/pages/integrations/railway/create.tsx
+++ b/frontend/src/pages/integrations/railway/create.tsx
@@ -74,16 +74,6 @@ export default function RailwayCreateIntegrationPage() {
     }
   }, [targetEnvironments]);
 
-  useEffect(() => {
-    if (targetServices) {
-      if (targetServices.length > 0) {
-        setTargetServiceId(targetServices[0].serviceId);
-      } else {
-        setTargetServiceId("none");
-      }
-    }
-  }, [targetServices]);
-
   const handleButtonClick = async () => {
     try {
       setIsLoading(true);
@@ -124,11 +114,14 @@ export default function RailwayCreateIntegrationPage() {
     }
   };
 
+  const filteredTargetServices = targetServices ? [ { name: "", serviceId: "none" }, ...targetServices ] : [ { name: "", serviceId: "none" } ];
+
   return workspace &&
     selectedSourceEnvironment &&
     integrationAuthApps &&
     targetEnvironments &&
-    targetServices ? (
+    targetServices &&
+    filteredTargetServices ? (
     <div className="flex h-full w-full items-center justify-center">
       <Card className="max-w-md rounded-md p-8">
         <CardTitle className="text-center">Railway Integration</CardTitle>
@@ -208,20 +201,14 @@ export default function RailwayCreateIntegrationPage() {
             className="w-full border border-mineshaft-500"
             isDisabled={targetServices.length === 0}
           >
-            {targetServices.length > 0 ? (
-              targetServices.map((targetService) => (
+              {filteredTargetServices.map((targetService) => (
                 <SelectItem
                   value={targetService.serviceId as string}
                   key={`target-service-${targetService.serviceId as string}`}
                 >
                   {targetService.name}
                 </SelectItem>
-              ))
-            ) : (
-              <SelectItem value="none" key="target-service-none">
-                No services found
-              </SelectItem>
-            )}
+              ))}
           </Select>
         </FormControl>
         <Button


### PR DESCRIPTION
# Description 📣

This PR patches/updates the Railway integration so that:

- The create integration page doesn't break due to incorrect query structure for fetching Railway services.
- Specifying a Railway service is now optional; hence, not selecting a service syncs variables to the Railway application's shared variables.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝