### PR TITLE
Fixed typo in `secrets get` docs

### DIFF
--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -12,12 +12,13 @@ infisical secrets
 This command enables you to perform CRUD (create, read, update, delete) operations on secrets within your Infisical project. With it, you can view, create, update, and delete secrets in your environment.
 
 ### Sub-commands
+
 <Accordion title="infisical secrets" defaultOpen="true">
   Use this command to print out all of the secrets in your project
 
-  ```bash
-  $ infisical secrets
-  ```
+```bash
+$ infisical secrets
+```
 
 ### Environment variables
 
@@ -95,7 +96,7 @@ $ infisical secrets get DOMAIN
 
     Default value: `false`
 
-    Example: `infisical secrets get DOMAIN --value`
+    Example: `infisical secrets get DOMAIN --raw-value`
 
     <Tip>
       When running in CI/CD environments or in a script, set `INFISICAL_DISABLE_UPDATE_CHECK` env to `true`. This will help hide any CLI update messages and only show the secret value.


### PR DESCRIPTION
# Description 📣
Changed `--value` to `--raw-value` in `secrets get` docs. Related to #1532 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->