### PR TITLE
chore: allow cross-architecture image for migration init container

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -32,7 +32,7 @@ spec:
     {{- if $infisicalValues.autoDatabaseSchemaMigration }}
       initContainers:
       - name: "migration-init"
-        image: "groundnuty/k8s-wait-for:1.3"
+        image: {{ $infisicalValues.waitHelperImage | quote }}
         imagePullPolicy: {{ $infisicalValues.image.pullPolicy }}
         args: 
         - "job"

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -15,6 +15,8 @@ infisical:
     tag: "v0.46.3-postgres"
     pullPolicy: IfNotPresent
 
+  waitHelperImage: ghcr.io/groundnuty/k8s-wait-for:no-root-v2.0
+
   affinity: {}
   kubeSecretRef: "infisical-secrets"
   service:


### PR DESCRIPTION
# Description 📣

Hey,
This improvement use a more recent version of the migration init controller. It allows:
- Deploy on amd64 **and** arm64 (it is not possible currently)
- Use a non-root container

Have a nice day!

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Improvement

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->