### PR TITLE
Redirecting to overview page if environment doesn't exists in secrets main page

### DIFF
--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -67,7 +67,6 @@ export const SecretMainPage = () => {
   // env slug
   const environment = router.query.env as string;
   const workspaceId = currentWorkspace?.id || "";
-  console.log("currentWorkspace", currentWorkspace, environment);
   const secretPath = (router.query.secretPath as string) || "/";
   const canReadSecret = permission.can(
     ProjectPermissionActions.Read,

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -2,15 +2,15 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
 import { subject } from "@casl/ability";
+import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
 import {
   faAngleDown,
   faArrowDown,
   faArrowUp,
   faFolderBlank,
-  faList,
   faFolderPlus,
+  faList,
   faMagnifyingGlass,
   faPlus
 } from "@fortawesome/free-solid-svg-icons";
@@ -207,10 +207,10 @@ export const SecretOverviewPage = () => {
   };
 
   const handleEnvSelect = (envId: string) => {
-    if (visibleEnvs.map(env => env.id).includes(envId)) {
-      setVisisbleEnvs(visibleEnvs.filter(env => env.id !== envId))
+    if (visibleEnvs.map((env) => env.id).includes(envId)) {
+      setVisisbleEnvs(visibleEnvs.filter((env) => env.id !== envId));
     } else {
-      setVisisbleEnvs(visibleEnvs.concat(userAvailableEnvs.filter(env => env.id === envId)))
+      setVisisbleEnvs(visibleEnvs.concat(userAvailableEnvs.filter((env) => env.id === envId)));
     }
   };
 
@@ -396,7 +396,7 @@ export const SecretOverviewPage = () => {
                     ariaLabel="Environments"
                     variant="plain"
                     size="sm"
-                    className="flex justify-center items-center overflow-hidden p-0 w-11 bg-mineshaft-800 hover:bg-primary/10 hover:border-primary/60 border border-mineshaft-600 mr-2"
+                    className="mr-2 flex w-11 items-center justify-center overflow-hidden border border-mineshaft-600 bg-mineshaft-800 p-0 hover:border-primary/60 hover:bg-primary/10"
                   >
                     <Tooltip content="Choose visible environments" className="mb-2">
                       <FontAwesomeIcon icon={faList} />
@@ -408,17 +408,19 @@ export const SecretOverviewPage = () => {
                   {userAvailableEnvs.map((avaiableEnv) => {
                     const { id: envId, name } = avaiableEnv;
 
-                    const isEnvSelected = visibleEnvs.map(env => env.id).includes(envId);
+                    const isEnvSelected = visibleEnvs.map((env) => env.id).includes(envId);
                     return (
                       <DropdownMenuItem
                         onClick={() => handleEnvSelect(envId)}
                         key={envId}
-                        icon={isEnvSelected && <FontAwesomeIcon className="text-primary" icon={faCheckCircle} />}
+                        icon={
+                          isEnvSelected && (
+                            <FontAwesomeIcon className="text-primary" icon={faCheckCircle} />
+                          )
+                        }
                         iconPos="left"
                       >
-                        <div className="flex items-center">
-                          {name}
-                        </div>
+                        <div className="flex items-center">{name}</div>
                       </DropdownMenuItem>
                     );
                   })}


### PR DESCRIPTION
# Description 📣

If user tries to visit a secrets page like `/project/<project-id>/secrets/some-env`, he is shown the secrets page and option to add secrets/folder. But in case the `some-env` doesn't exists, user is still shown that page, and errors occur.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This PR redirects the users to overview page and inform them that the env they are trying to accees doesn't exists

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Attached video for reference
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

https://github.com/Infisical/infisical/assets/47269183/b5dfcf99-918e-4e54-8b11-ffcf58529463



---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->