### PR TITLE
Fix: CLI Service Tokens

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -59,7 +59,8 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		infisicalToken, err := cmd.Flags().GetString("token")
+		infisicalToken, err := util.GetInfisicalServiceToken(cmd)
+
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/folder.go
+++ b/cli/packages/cmd/folder.go
@@ -36,7 +36,8 @@ var getCmd = &cobra.Command{
 			}
 		}
 
-		infisicalToken, err := cmd.Flags().GetString("token")
+		infisicalToken, err := util.GetInfisicalServiceToken(cmd)
+
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -62,7 +62,8 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		infisicalToken, err := cmd.Flags().GetString("token")
+		infisicalToken, err := util.GetInfisicalServiceToken(cmd)
+
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -39,10 +38,10 @@ var secretsCmd = &cobra.Command{
 			}
 		}
 
-		infisicalToken, err := cmd.Flags().GetString("token")
+		infisicalToken, err := util.GetInfisicalServiceToken(cmd)
 
-		if infisicalToken == "" {
-			infisicalToken = os.Getenv(util.INFISICAL_TOKEN_NAME)
+		if err != nil {
+			util.HandleError(err, "Unable to parse flag")
 		}
 
 		if err != nil {
@@ -399,7 +398,8 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	infisicalToken, err := cmd.Flags().GetString("token")
+	infisicalToken, err := util.GetInfisicalServiceToken(cmd)
+
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -466,7 +466,8 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	infisicalToken, err := cmd.Flags().GetString("token")
+	infisicalToken, err := util.GetInfisicalServiceToken(cmd)
+
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/models"
+	"github.com/spf13/cobra"
 )
 
 type DecodedSymmetricEncryptionDetails = struct {
@@ -61,6 +62,20 @@ func IsSecretTypeValid(s string) bool {
 		return true
 	}
 	return false
+}
+
+func GetInfisicalServiceToken(cmd *cobra.Command) (serviceToken string, err error) {
+	infisicalToken, err := cmd.Flags().GetString("token")
+
+	if infisicalToken == "" {
+		infisicalToken = os.Getenv(INFISICAL_TOKEN_NAME)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return infisicalToken, nil
 }
 
 // Checks if the passed in email already exists in the users slice


### PR DESCRIPTION
# Description 📣

There appears to be an issue with using the CLI with the service token environment variable (setting `INFISICAL_TOKEN`). We haven't been able to reproduce the issue on our end, but by stepping through the code, I'm as certain as can be, that this will resolve all issues related to service token environment variable.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->