### PR TITLE
doc: helm charts documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+---
+
+repos:
+  # https://github.com/norwoodj/helm-docs#pre-commit-hook
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.13.1
+    hooks:
+      # Will automatically generate the corresponding charts documentation
+      - id: helm-docs
+        files: (README\.md\.gotmpl|_templates\.gotmpl|(Chart|requirements|values)\.yaml)$
+        args:
+          # Make the tool search for charts only given directory
+          - --chart-search-root=helm-charts
+
+          # The `./` makes it relative to the chart-search-root set above
+          - --template-files=./_templates.gotmpl
+
+          # Repeating the flag adds this to the list, now [./_templates.gotmpl, README.md.gotmpl]
+          # A base filename makes it relative to each chart directory found
+          - --template-files=README.md.gotmpl
+          
+          - --sort-values-order=file
+  # https://github.com/dadav/helm-schema#pre-commit-hook
+  - repo: https://github.com/dadav/helm-schema
+    rev: 0.10.0
+    hooks:
+      - id: helm-schema
+        args:
+          # Make the tool search for charts only given directory
+          - --chart-search-root=helm-charts
+          # Don't analyze dependencies
+          - --no-dependencies
+          # Skip default unwanted extra fields (fail-safe)
+          - --skip-auto-generation=required,default,additionalProperties

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,17 @@ repos:
         files: (README\.md\.gotmpl|_templates\.gotmpl|(Chart|requirements|values)\.yaml)$
         args:
           # Make the tool search for charts only given directory
-          - --chart-search-root=helm-charts
+          - "--chart-search-root=helm-charts"
 
           # The `./` makes it relative to the chart-search-root set above
-          - --template-files=./_templates.gotmpl
+          - "--template-files=./_templates.gotmpl"
 
           # Repeating the flag adds this to the list, now [./_templates.gotmpl, README.md.gotmpl]
           # A base filename makes it relative to each chart directory found
-          - --template-files=README.md.gotmpl
-          
-          - --sort-values-order=file
+          - "--template-files=README.md.gotmpl"
+
+          # Sort the list as it is in the values.yaml file
+          - "--sort-values-order=file"
   # https://github.com/dadav/helm-schema#pre-commit-hook
   - repo: https://github.com/dadav/helm-schema
     rev: 0.10.0
@@ -30,8 +31,8 @@ repos:
       - id: helm-schema
         args:
           # Make the tool search for charts only given directory
-          - --chart-search-root=helm-charts
+          - "--chart-search-root=helm-charts"
           # Don't analyze dependencies
-          - --no-dependencies
+          - "--no-dependencies"
           # Skip default unwanted extra fields (fail-safe)
-          - --skip-auto-generation=required,default,additionalProperties
+          - "--skip-auto-generation=required,additionalProperties"

--- a/docs/self-hosting/deployment-options/kubernetes-helm.mdx
+++ b/docs/self-hosting/deployment-options/kubernetes-helm.mdx
@@ -1,8 +1,10 @@
 ---
 title: "Kubernetes via Helm Chart"
 description: "Use Helm chart to install Infisical on your Kubernetes cluster"
---- 
+---
+
 **Prerequisites**
+
 - You have extensive understanding of [Kubernetes](https://kubernetes.io/)
 - Installed [Helm package manager](https://helm.sh/) version v3.11.3 or greater
 - You have [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/) installed and connected to your kubernetes cluster
@@ -18,23 +20,24 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
   </Step>
   <Step title="Add Helm values">
     Create a `values.yaml` file. This will be used to configure settings for the Infisical Helm chart.
-    To explore all configurable properties for your values file, [visit this page](https://raw.githubusercontent.com/Infisical/infisical/main/helm-charts/infisical-standalone-postgres/values.yaml).
+    To explore all configurable properties for your values file, [visit this page](https://github.com/Infisical/infisical/tree/main/helm-charts/infisical-standalone-postgres/README.md#parameters).
   </Step>
   <Step title="Select Infisical version">
     By default, the Infisical version set in your helm chart will likely be outdated. 
     Choose the latest Infisical docker image tag from here [here](https://hub.docker.com/r/infisical/infisical/tags).
-    
+
 
     ```yaml values.yaml
     infisical:
       image:
         repository: infisical/infisical
-        tag: "v0.46.2-postgres" #<-- update
+        tag: "v0.46.2-postgres" # <-- update
         pullPolicy: IfNotPresent
     ```
     <Warning>
       Do you not use the latest docker image tag in production deployments as they can introduce unexpected changes
     </Warning>
+
   </Step>
 
   <Step title="Configure environment variables">
@@ -47,7 +50,7 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
     <Tabs>
       <Tab title="Proof of concept deployment">
         For test or proof-of-concept purposes, you may omit `DB_CONNECTION_URI` and `REDIS_URL` from `infisical-secrets`. This is because the Helm chart will automatically provision and connect to the in-cluster instances of Postgres and Redis by default.
-        ```yaml simple-values-example.yaml 
+        ```yaml simple-values-example.yaml
         apiVersion: v1
         kind: Secret
         metadata:
@@ -60,7 +63,7 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
       </Tab>
       <Tab title="Production deployment">
         For production environments, we recommend using Cloud-based Platform as a Service (PaaS) solutions for PostgreSQL and Redis to ensure high availability. In on-premise setups, it's recommended to configure Redis and Postgres for high availability, either by using Bitnami charts or a custom configuration.
-        ```yaml simple-values-example.yaml 
+        ```yaml simple-values-example.yaml
         apiVersion: v1
         kind: Secret
         metadata:
@@ -74,6 +77,7 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
         ```
       </Tab>
     </Tabs>
+
   </Step>
 
   <Step title="Database schema migration ">
@@ -86,16 +90,18 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
       If you are using in-cluster Postgres, you may notice the migration job failing initially.
       This is expected as it is waiting for the database to be in ready state.
     </Info>
+
   </Step>
 
   <Step title="Routing traffic to Infisical">
     By default, this chart uses Nginx as its Ingress controller to direct traffic to Infisical services.
 
-    ```yaml values.yaml 
+    ```yaml values.yaml
     ingress:
       nginx:
-        enabled: true 
+        enabled: true
     ```
+
   </Step>
 
   <Step title="Install the Helm chart ">
@@ -168,6 +174,7 @@ description: "Use Helm chart to install Infisical on your Kubernetes cluster"
         architecture: standalone
       ```
       </Accordion>
+
   </Step>
 
   <Step title="Access Infisical">

--- a/helm-charts/.gitignore
+++ b/helm-charts/.gitignore
@@ -1,0 +1,3 @@
+charts/
+tmpcharts/
+*.bak

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -2,38 +2,89 @@
 
 Welcome to Infisical Helm Charts repository! Find instructions below to setup and install our charts.
 
-## Installation
-
-```sh
-# Add the Infisical repository
-helm repo add infisical 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/' && helm repo update
-
-# Install Infisical (default values)
-helm upgrade --install --atomic \
-  -n infisical --create-namespace \
-  infisical infisical/infisical
-  
-# Install Infisical Secrets Operator (default values)
-helm upgrade --install --atomic \
-  -n infisical --create-namespace \
-  infisical-secrets-operator infisical/secrets-operator
-```
-
 ## Charts
 
-Here's the link to our charts corresponding documentation :
+Here's the link to our charts corresponding installation instructions:
 
-- [**`infisical`**](./infisical/README.md)
-- [**`secrets-operator`**](./secrets-operator/README.md)
+- [**`infisical-standalone`**](./infisical-standalone-postgres/README.md#installation--upgrade) (recommended, postgres version)
+  - Official Infisical standalone version
+  - https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
+  - [`infisical`](./infisical/README.md#installation--upgrade) (deprecated)
+- [**`secrets-operator`**](./secrets-operator/README.md#installation--upgrade)
+  - Official Infisical Secrets Operator version
+  - https://infisical.com/docs/integrations/platforms/kubernetes#install-operator
+
+## Validation
+
+Take advantage of our YAML schema validation and auto-completion in your IDE and through Helm commands.
+
+1. Choose and install any plugin which supports the `yaml-language-server` annotation (e.g. [VSCode - YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml))
+2. Automatically validate your configuration
+   1. Either using the chart's default `values.yaml` already configured
+   2. Or create your custom `values.yaml` file and place the following at the top of it
+      1. `yaml-language-server: $schema=<path-or-url-to-the-schema>`
+      2. e.g. for the latest `infisical-standalone` chart, you'll use `https://raw.githubusercontent.com/Infisical/infisical/main/helm-charts/infisical-standalone-postgres/Chart.yaml`
+
+```yml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Infisical/infisical/main/helm-charts/infisical-standalone-postgres/values.schema.json
+
+foo: bar
+...
+```
 
 ## Documentation
 
-We're trying to follow a documentation convention across our charts, allowing us to auto-generate markdown documentation thanks to [this tool](https://github.com/bitnami-labs/readme-generator-for-helm)
+We're trying to follow a documentation convention across our charts, allowing us to auto-generate markdown documentation thanks to [`helm-docs`](https://github.com/norwoodj/helm-docs) and [helm-schema](https://github.com/dadav/helm-schema) to generate the YAML validation file (`values.schema.json`)
 
-Steps to update the documentation :
-1. `cd helm-charts/<chart>`
-1. `git clone https://github.com/bitnami-labs/readme-generator-for-helm`
-1. `npm install ./readme-generator-for-helm`
-1. `npm exec readme-generator -- --readme README.md --values values.yaml`
-   - It'll insert the table below the `## Parameters` title
-   - It'll output errors if some of the path aren't documented
+You'll need to install these two tools:
+
+- [`helm-docs`](https://github.com/norwoodj/helm-docs#installation)
+  - `brew install norwoodj/tap/helm-docs` (unix)
+  - `scoop install helm-docs` (windows)
+  - `go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest` (binary)
+- [`helm-schema`](https://github.com/dadav/helm-schema#installation)
+  - `go install github.com/dadav/helm-schema/cmd/helm-schema@latest` (binary)
+
+> [!NOTE]
+> Go text templating is used to generate the documentation, please find more details [here](https://pkg.go.dev/text/template) (syntax, functions).
+
+### Manually
+
+To run the update once and don't want to setup the pre-commit hooks, you can just run both binaries and you'll get the same results:
+
+```sh
+cd helm-charts/
+
+# generate the docs
+helm-docs -t ./_templates.gotmpl -t README.md.gotmpl -s file
+
+# generate the schemas
+helm-schema -n -k required,default,additionalProperties
+```
+
+### Pre-commit
+
+Using `pre-commit` (recommended) to automatically generate the docs without having to think about it, now and for your future contributions. Will update the docs if your commit contains any of the matching files. Here's how to setup the `pre-commit` hooks:
+
+1. Install [`pre-commit`](https://pre-commit.com/#install)
+   1. `brew install pre-commit` (unix)
+   2. `pip install pre-commit` (python)
+2. Execute the below commands
+
+```sh
+# update current pre-commit repos (optional)
+pre-commit autoupdate
+
+# install the requirements defined in '.pre-commit-config.yaml'
+pre-commit install
+
+# setup the hooks in '.git/hooks'
+pre-commit install-hooks
+```
+
+For further details about their respective pre-commit configuration:
+- https://github.com/norwoodj/helm-docs#pre-commit-hook
+- https://github.com/dadav/helm-schema#pre-commit-hook
+
+> [!NOTE]
+> You can type `pre-commit run -all` to run the hooks manually

--- a/helm-charts/_templates.gotmpl
+++ b/helm-charts/_templates.gotmpl
@@ -1,0 +1,104 @@
+{{ define "infisical.description" -}}
+| Name | Chart | Application |
+| - | - | - |
+| [{{ template "chart.name" . }}]({{ template "chart.homepage" . }}) | [![Latest version of '{{ template "chart.name" . }}' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/{{ template "chart.name" . }}/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/{{ template "chart.name" . }}/latest/) | `{{ template "chart.appVersion" . }}` |
+
+{{ template "chart.description" . }}
+
+{{- end }}
+
+{{ define "infisical.installation.repo" -}}
+## Installation & upgrade
+
+To install or upgrade the `{{ template "chart.name" . }}` chart, run the following:
+
+```sh
+# add the Infisical Helm repository
+helm repo add infisical 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/' && helm repo update
+```
+{{- end }}
+
+{{ define "infisical.installation.secrets" -}}
+```sh
+# create the required configuration secret (auto-generated secrets)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infisical-dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: infisical-dev
+  name: infisical-secrets
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: "$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+  AUTH_SECRET: "$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]' | base64)"
+EOF
+```
+{{- end }}
+
+{{ define "infisical.installation.chart" -}}
+```sh
+# with default values
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  {{ template "chart.name" . }} infisical/{{ template "chart.name" . }}
+
+# with custom inline values (replace with your own values)
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  --set ingress.hostName=custom.example.org \
+  {{ template "chart.name" . }} infisical/{{ template "chart.name" . }}
+
+# with custom values file (replace with your own values file)
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  -f custom-values.yaml \
+  {{ template "chart.name" . }} infisical/{{ template "chart.name" . }}
+```
+
+Documentation is also available here : https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
+
+> [!IMPORTANT]
+> If you change the configuration variables in the `infisical-secrets` resource, you might have to restart the infisical deployment to take effect
+{{- end }}
+
+{{ define "infisical.encryptionKeys" -}}
+### Encryption keys
+
+If you did not explicitly set required environment variables, the local setup ([./examples](./examples)) auto-generated them by default. It's recommended to save these credentials somewhere safe. Run the following command in your cluster where Infisical chart is installed. 
+  
+> [!NOTE]
+> Requires [`jq`](https://stedolan.github.io/jq/download/)
+
+```sh
+# export secrets to a given file
+kubectl get secrets -n infisical-dev infisical-secrets \
+  -o json | jq '.data | map_values(@base64d)' > \
+  infisical-secrets.$(date +%s).bak
+```
+{{- end }}
+
+{{ define "infisical.upgrading" -}}
+### Upgrading
+
+Find the chart upgrade instructions below. When upgrading from your version to one of the listed below, please follow every instructions in between to correctly migrate all your data and avoid loss and unexpected issues. 
+
+#### Instructions
+
+1. Make sure **you have all the required environment variables** defined in the value file (`values.yaml` or inline `--set`) you'll provide to `helm`
+   1. e.g. All the above mentioned variables
+1. **Backup your existing secrets** (before the upgrade, for safety precaution)
+   1. e.g. `kubectl get secret infisical-secrets --namespace infisical-dev -o json | jq '{name: .metadata.name,data: .data|map_values(@base64d)}'`
+2. **Upgrade the chart**, with the [instructions](#upgrading)
+3. You're all set!
+{{- end }}
+
+{{ define "infisical.yamlValidation" -}}
+## Validation
+
+You can automatically validate your custom `values.yaml` schema and get YAML auto-completion in your IDE, refer to this [section](../README.md#validation)
+{{- end }}

--- a/helm-charts/infisical-standalone-postgres/.helmignore
+++ b/helm-charts/infisical-standalone-postgres/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -1,20 +1,45 @@
 apiVersion: v2
 name: infisical-standalone
-description: A helm chart for a full Infisical application
+description: Standalone Infisical instance (postgres). An open-source secret management platform.
+home: https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
 
+# A chart can be either an 'application' or a 'library' chart.
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+# https://hub.docker.com/r/infisical/infisical/tags
+appVersion: "v0.46.16"
 
+# A URL to an SVG or PNG image to be used as an icon (optional).
+icon: https://raw.githubusercontent.com/Infisical/infisical/main/img/logotransparent.png
+
+# A list of keywords about this project (optional)
+keywords:
+- secretops
+- keyvalue
+- security
+- inject
+
+# Maintainers list (name required, optional email/url)
+maintainers:
+- name: Infisical
+  url: https://infisical.com/
+  email: team@infisical.com
+
+# Chart's dependencies
 dependencies:
   - name: ingress-nginx
     version: 4.0.13
@@ -28,3 +53,6 @@ dependencies:
     version: 18.14.0
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
+
+# Deprecation notice (https://helm.sh/docs/topics/charts/#deprecating-charts)
+deprecated: false

--- a/helm-charts/infisical-standalone-postgres/LICENSE
+++ b/helm-charts/infisical-standalone-postgres/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2022 Infisical Inc.
+
+Portions of this software are licensed as follows:
+
+- All content that resides under any "ee/" directory of this repository, if such directories exists, are licensed under the license defined in "ee/LICENSE".
+- All third party components incorporated into the Infisical Software are licensed under the original license provided by the owner of the applicable component.
+- Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -103,8 +103,8 @@ Find the chart upgrade instructions below. When upgrading from your version to o
 <summary>
 
 ### **`0.0.1`** (`v0.44.0`)
-MongoDB to PostgreSQL migration
-</summary>
+<details open>
+<summary><strong>Click for details</strong> (MongoDB to PostgreSQL migration)</summary>
 
 Since the new `infisical-standalone-postgres` chart, Infisical moved away from MongoDB to PostgreSQL.
 

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -114,9 +114,9 @@ Here's the migration instructions : https://infisical.com/docs/self-hosting/guid
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Override release name |
 | fullnameOverride | string | `""` | Override release fullname |
-| infisical.enabled | bool | `true` | Enable backend |
+| infisical.enabled | bool | `true` | Enable Infisical |
 | infisical.name | string | `"infisical"` | Backend deployment name |
-| infisical.autoDatabaseSchemaMigration | bool | `true` | Automatically migrate database |
+| infisical.autoDatabaseSchemaMigration | bool | `true` | Automatically apply database schema migration |
 | infisical.fullnameOverride | string | `""` | Backend deployment fullname override |
 | infisical.podAnnotations | object | `{}` | Backend pod annotations |
 | infisical.deploymentAnnotations | object | `{}` | Backend deployment annotations |
@@ -148,7 +148,7 @@ Here's the migration instructions : https://infisical.com/docs/self-hosting/guid
 | postgresql.persistence.existingClaim | string | `""` | Name of an existing PVC to use |
 | postgresql.persistence.mountPath | string | `"/bitnami/postgresql"` | The path the volume will be mounted at. Useful when using custom PostgreSQL images |
 | postgresql.persistence.storageClass | string | `""` | PVC Storage Class for PostgreSQL Primary data volume. If defined, `storageClassName: <storageClass>` If set to `"-"`, `storageClassName: ""`, which disables dynamic provisioning Default is undefined/null, no `storageClassName` spec is set. Using default provisioner |
-| postgresql.persistence.accessModes | list | `["ReadWriteOnce"]` | PVC Access Mode for PostgreSQL volume |
+| postgresql.persistence.accessModes | list | `["ReadWriteOnce"]` | PVC [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for PostgreSQL volume |
 | postgresql.persistence.size | string | `"8Gi"` | PVC Storage Request for PostgreSQL volume |
 | postgresql.persistence.annotations | object | `{}` | Annotations for the PVC |
 | postgresql.persistence.labels | object | `{}` | Labels for the PVC |
@@ -158,6 +158,8 @@ Here's the migration instructions : https://infisical.com/docs/self-hosting/guid
 | redis.name | string | `"redis"` | Redis deployment name |
 | redis.fullnameOverride | string | `"redis"` | Redis deployment fullname override |
 | redis.auth.enabled | bool | `true` | Enable Redis password authentication |
+| redis.auth.existingSecret | string | `""` | The name of an existing secret with Redis&reg; credentials. |
+| redis.auth.existingSecretPasswordKey | string | `""` | Password key to be retrieved from existing secret (ignored unless `existingSecret` parameter is set). |
 | redis.auth.password | string | `"mysecretpassword"` | Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set). Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true |
 | redis.architecture | string | `"standalone"` | Redis architecture. Allowed values: `standalone` or `replication` |
 

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -4,9 +4,9 @@
 
 | Name | Chart | Application |
 | - | - | - |
-| [infisical-standalone]() | [![Latest version of 'infisical-standalone' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/infisical-standalone/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/infisical-standalone/latest/) | `1.0.0` |
+| [infisical-standalone](https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm) | [![Latest version of 'infisical-standalone' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/infisical-standalone/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/infisical-standalone/latest/) | `v0.46.16` |
 
-A helm chart for a full Infisical application
+Standalone Infisical instance (postgres). An open-source secret management platform.
 
 ## Services
 
@@ -116,44 +116,54 @@ Here's the migration instructions : https://infisical.com/docs/self-hosting/guid
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| nameOverride | string | `""` |  |
-| fullnameOverride | string | `""` |  |
-| infisical.enabled | bool | `true` |  |
-| infisical.name | string | `"infisical"` |  |
-| infisical.autoDatabaseSchemaMigration | bool | `true` |  |
-| infisical.fullnameOverride | string | `""` |  |
-| infisical.podAnnotations | object | `{}` |  |
-| infisical.deploymentAnnotations | object | `{}` |  |
-| infisical.replicaCount | int | `2` |  |
-| infisical.image.repository | string | `"infisical/infisical"` |  |
-| infisical.image.tag | string | `"v0.46.3-postgres"` |  |
-| infisical.image.pullPolicy | string | `"IfNotPresent"` |  |
-| infisical.affinity | object | `{}` |  |
-| infisical.kubeSecretRef | string | `"infisical-secrets"` |  |
-| infisical.service.annotations | object | `{}` |  |
-| infisical.service.type | string | `"ClusterIP"` |  |
-| infisical.service.nodePort | string | `""` |  |
-| infisical.resources.limits.memory | string | `"350Mi"` |  |
-| infisical.resources.requests.cpu | string | `"350m"` |  |
-| ingress.enabled | bool | `true` |  |
-| ingress.hostName | string | `""` |  |
-| ingress.ingressClassName | string | `"nginx"` |  |
-| ingress.nginx.enabled | bool | `true` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.tls | list | `[]` |  |
-| postgresql.enabled | bool | `true` |  |
-| postgresql.name | string | `"postgresql"` |  |
-| postgresql.fullnameOverride | string | `"postgresql"` |  |
-| postgresql.auth.username | string | `"infisical"` |  |
-| postgresql.auth.password | string | `"root"` |  |
-| postgresql.auth.database | string | `"infisicalDB"` |  |
-| redis.enabled | bool | `true` |  |
-| redis.name | string | `"redis"` |  |
-| redis.fullnameOverride | string | `"redis"` |  |
-| redis.cluster.enabled | bool | `false` |  |
-| redis.usePassword | bool | `true` |  |
-| redis.auth.password | string | `"mysecretpassword"` |  |
-| redis.architecture | string | `"standalone"` |  |
+| nameOverride | string | `""` | Override release name |
+| fullnameOverride | string | `""` | Override release fullname |
+| infisical.enabled | bool | `true` | Enable backend |
+| infisical.name | string | `"infisical"` | Backend deployment name |
+| infisical.autoDatabaseSchemaMigration | bool | `true` | Automatically migrate database |
+| infisical.fullnameOverride | string | `""` | Backend deployment fullname override |
+| infisical.podAnnotations | object | `{}` | Backend pod annotations |
+| infisical.deploymentAnnotations | object | `{}` | Backend deployment annotations |
+| infisical.replicaCount | int | `2` | Backend replicas count |
+| infisical.image.repository | string | `"infisical/infisical"` | Backend image repository |
+| infisical.image.tag | string | `"v0.46.3-postgres"` | Backend image [tag](https://hub.docker.com/r/infisical/infisical/tags) |
+| infisical.image.pullPolicy | string | `"IfNotPresent"` | Backend image pullPolicy |
+| infisical.affinity | object | `{}` | Backend pod affinity |
+| infisical.kubeSecretRef | string | `"infisical-secrets"` | Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars)) |
+| infisical.config | object | `{}` | Backend [configuration variables](https://infisical.com/docs/self-hosting/configuration/envars) (inline, e.g. for gitops mechanism). Those variables take precedence over `infisical.kubeSecretRef` |
+| infisical.service.annotations | object | `{}` | Backend service annotations |
+| infisical.service.type | string | `"ClusterIP"` | Backend service type |
+| infisical.service.nodePort | int | `0` | Backend service nodePort (used if above type is `NodePort`) |
+| infisical.resources.limits.memory | string | `"350Mi"` | Memory resource limit |
+| infisical.resources.requests.cpu | string | `"350m"` | CPU resource request |
+| ingress.enabled | bool | `true` | Enable ingress |
+| ingress.hostName | string | `""` | Your instance's hostname (e.g. `infisical.example.org`). Replace with your own domain |
+| ingress.ingressClassName | string | `"nginx"` | Ingress class name |
+| ingress.nginx.enabled | bool | `true` | Enable and install NginX ingress controller |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.tls | list | `[]` | Ingress TLS hosts (matching above `ingress.hostName`). Replace with your own domain |
+| postgresql.enabled | bool | `true` | Enable PostgreSQL |
+| postgresql.name | string | `"postgresql"` | PostgreSQL deployment name |
+| postgresql.fullnameOverride | string | `"postgresql"` | PostgreSQL deployment fullname override |
+| postgresql.auth.username | string | `"infisical"` | PostgreSQL database username |
+| postgresql.auth.password | string | `"root"` | PostgreSQL database password |
+| postgresql.auth.database | string | `"infisicalDB"` | PostgreSQL database name |
+| postgresql.persistence.enabled | bool | `true` | Enable PostgreSQL Primary data persistence using PVC |
+| postgresql.persistence.existingClaim | string | `""` | Name of an existing PVC to use |
+| postgresql.persistence.mountPath | string | `"/bitnami/postgresql"` | The path the volume will be mounted at. Useful when using custom PostgreSQL images |
+| postgresql.persistence.storageClass | string | `""` | PVC Storage Class for PostgreSQL Primary data volume. If defined, `storageClassName: <storageClass>` If set to `"-"`, `storageClassName: ""`, which disables dynamic provisioning Default is undefined/null, no `storageClassName` spec is set. Using default provisioner |
+| postgresql.persistence.accessModes | list | `["ReadWriteOnce"]` | PVC Access Mode for PostgreSQL volume |
+| postgresql.persistence.size | string | `"8Gi"` | PVC Storage Request for PostgreSQL volume |
+| postgresql.persistence.annotations | object | `{}` | Annotations for the PVC |
+| postgresql.persistence.labels | object | `{}` | Labels for the PVC |
+| postgresql.persistence.selector | object | `{}` | Selector to match an existing Persistent Volume (this value is evaluated as a template) |
+| postgresql.persistence.dataSource | object | `{}` | Custom PVC data source |
+| redis.enabled | bool | `true` | Enable Redis |
+| redis.name | string | `"redis"` | Redis deployment name |
+| redis.fullnameOverride | string | `"redis"` | Redis deployment fullname override |
+| redis.usePassword | bool | `true` | Use password authentication |
+| redis.auth.password | string | `"mysecretpassword"` | Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set). Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true |
+| redis.architecture | string | `"standalone"` | Redis architecture. Allowed values: `standalone` or `replication` |
 
 ## Validation
 

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -1,0 +1,227 @@
+
+
+# Infisical Helm Chart
+
+| Name | Chart | Application |
+| - | - | - |
+| [infisical-standalone]() | [![Latest version of 'infisical-standalone' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/infisical-standalone/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/infisical-standalone/latest/) | `1.0.0` |
+
+A helm chart for a full Infisical application
+
+## Services
+
+| Service      | Description      |
+| ------------ | ---------------- |
+| `infisical`  | Infisical's API  |
+| `ingress`    | Ingress service  |
+| `postgresql` | Database service |
+| `redis`      | Cache service    |
+
+## Installation & upgrade
+
+To install or upgrade the `infisical-standalone` chart, run the following:
+
+```sh
+# add the Infisical Helm repository
+helm repo add infisical 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/' && helm repo update
+```
+
+```sh
+# create the required configuration secret (auto-generated secrets)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: infisical-dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: infisical-dev
+  name: infisical-secrets
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: "$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+  AUTH_SECRET: "$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]' | base64)"
+EOF
+```
+
+```sh
+# with default values
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  infisical-standalone infisical/infisical-standalone
+
+# with custom inline values (replace with your own values)
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  --set ingress.hostName=custom.example.org \
+  infisical-standalone infisical/infisical-standalone
+
+# with custom values file (replace with your own values file)
+helm upgrade --install --atomic \
+  -n infisical-dev --create-namespace \
+  -f custom-values.yaml \
+  infisical-standalone infisical/infisical-standalone
+```
+
+Documentation is also available here : https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
+
+> [!IMPORTANT]
+> If you change the configuration variables in the `infisical-secrets` resource, you might have to restart the infisical deployment to take effect
+
+### Encryption keys
+
+If you did not explicitly set required environment variables, the local setup ([./examples](./examples)) auto-generated them by default. It's recommended to save these credentials somewhere safe. Run the following command in your cluster where Infisical chart is installed.
+ 
+> [!NOTE]
+> Requires [`jq`](https://stedolan.github.io/jq/download/)
+
+```sh
+# export secrets to a given file
+kubectl get secrets -n infisical-dev infisical-secrets \
+  -o json | jq '.data | map_values(@base64d)' > \
+  infisical-secrets.$(date +%s).bak
+```
+
+### Upgrading
+
+Find the chart upgrade instructions below. When upgrading from your version to one of the listed below, please follow every instructions in between to correctly migrate all your data and avoid loss and unexpected issues.
+
+#### Instructions
+
+1. Make sure **you have all the required environment variables** defined in the value file (`values.yaml` or inline `--set`) you'll provide to `helm`
+   1. e.g. All the above mentioned variables
+1. **Backup your existing secrets** (before the upgrade, for safety precaution)
+   1. e.g. `kubectl get secret infisical-secrets --namespace infisical-dev -o json | jq '{name: .metadata.name,data: .data|map_values(@base64d)}'`
+2. **Upgrade the chart**, with the [instructions](#upgrading)
+3. You're all set!
+
+---
+
+<details open>
+<summary>
+
+### **`0.0.1`** (`v0.44.0`)
+MongoDB to PostgreSQL migration
+</summary>
+
+Since the new `infisical-standalone-postgres` chart, Infisical moved away from MongoDB to PostgreSQL.
+
+Here's the migration instructions : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
+
+</details>
+
+## Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| infisical.enabled | bool | `true` |  |
+| infisical.name | string | `"infisical"` |  |
+| infisical.autoDatabaseSchemaMigration | bool | `true` |  |
+| infisical.fullnameOverride | string | `""` |  |
+| infisical.podAnnotations | object | `{}` |  |
+| infisical.deploymentAnnotations | object | `{}` |  |
+| infisical.replicaCount | int | `2` |  |
+| infisical.image.repository | string | `"infisical/infisical"` |  |
+| infisical.image.tag | string | `"v0.46.3-postgres"` |  |
+| infisical.image.pullPolicy | string | `"IfNotPresent"` |  |
+| infisical.affinity | object | `{}` |  |
+| infisical.kubeSecretRef | string | `"infisical-secrets"` |  |
+| infisical.service.annotations | object | `{}` |  |
+| infisical.service.type | string | `"ClusterIP"` |  |
+| infisical.service.nodePort | string | `""` |  |
+| infisical.resources.limits.memory | string | `"350Mi"` |  |
+| infisical.resources.requests.cpu | string | `"350m"` |  |
+| ingress.enabled | bool | `true` |  |
+| ingress.hostName | string | `""` |  |
+| ingress.ingressClassName | string | `"nginx"` |  |
+| ingress.nginx.enabled | bool | `true` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.tls | list | `[]` |  |
+| postgresql.enabled | bool | `true` |  |
+| postgresql.name | string | `"postgresql"` |  |
+| postgresql.fullnameOverride | string | `"postgresql"` |  |
+| postgresql.auth.username | string | `"infisical"` |  |
+| postgresql.auth.password | string | `"root"` |  |
+| postgresql.auth.database | string | `"infisicalDB"` |  |
+| redis.enabled | bool | `true` |  |
+| redis.name | string | `"redis"` |  |
+| redis.fullnameOverride | string | `"redis"` |  |
+| redis.cluster.enabled | bool | `false` |  |
+| redis.usePassword | bool | `true` |  |
+| redis.auth.password | string | `"mysecretpassword"` |  |
+| redis.architecture | string | `"standalone"` |  |
+
+## Validation
+
+You can automatically validate your custom `values.yaml` schema and get YAML auto-completion in your IDE, refer to this [section](../README.md#validation)
+
+## Persistence
+
+The database persistence is enabled by default, your volumes will remain on your cluster even after uninstalling the chart. To disable persistence, set this value `postgres.persistence.enabled: false`
+
+## Local development
+
+Find the resources and configuration about how to setup your local development environment on a k8s cluster (locally or remotely).
+
+### Requirements
+
+To create a local k8s environment, you'll need at least :
+
+- [`helm`](https://helm.sh/docs/intro/install/) <kbd>required</kbd>
+  - to generate the manifests and deploy the chart
+- local/remote k8s cluster <kbd>required</kbd>
+  - e.g. [`kind`](https://kubernetes.io/docs/tasks/tools/), [`minikube`](https://kubernetes.io/docs/tasks/tools/) or an online provider
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) <kbd>required</kbd>
+  - to interact with the cluster
+
+### Setup
+
+Run one of the below scripts for easy setup :
+
+> [!WARNING]
+> The environment might take some minutes to setup the first time as it need to pull all required images and dependencies
+
+```sh
+cd infisical/helm-charts/infisical-standalone-postgres/examples
+
+# With 'kind' + 'helm', to create a local cluster and deploy the chart using 'ingress-nginx'
+./infisical-kind.sh
+
+# With 'helm' only, if you already have a cluster (local/remote) to deploy the chart
+./infisical-helm.sh
+```
+
+> [!NOTE]
+> Find complete setup scripts in [**./examples**](./examples). Comments make it easy to understand how to setup your local development environment step-by-step
+
+Above examples will deploy the following :
+
+- [**infisical.local**](https://infisical.local)
+  - Your local Infisical instance
+  - You may have to add `infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+  - Or access it directly on your [localhost](http://localhost:8080) with
+    - `kubectl port-forward -n infisical-dev $(kubectl get pods -n infisical-dev -l "app=infisical-standalone" -o jsonpath="{.items[0].metadata.name}") 8080 &`
+    - and stop the port-forward with `%` + <kbd>CTRL+C</kbd>
+
+- [**mailhog.infisical.local**](https://mailhog.infisical.local)
+  - Local SMTP server used to receive the emails (e.g. signup verification code)
+  - You may have to add `mailhog.infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+  - Or access it directly on your [localhost](http://localhost:8025) with:
+      - `kubectl port-forward -n infisical-dev $(kubectl get pods -n infisical-dev -l "app.kubernetes.io/name=mailhog,app.kubernetes.io/instance=infisical-mailhog-dev" -o jsonpath="{.items[0].metadata.name}") 8025 &`
+      - and stop the port-forward with `%` + <kbd>CTRL+C</kbd>
+
+Default credentials will be used (local use only, since unsecure):
+- **infisical**
+  - admin user is created at first login (if database is empty)
+- **database** (postgres)
+  - username: `infisical`
+  - password: `root`
+  - database: `infisicalDB`
+- **cache** (redis)
+  - password: `mysecretpassword`

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -99,9 +99,6 @@ Find the chart upgrade instructions below. When upgrading from your version to o
 
 ---
 
-<details open>
-<summary>
-
 ### **`0.0.1`** (`v0.44.0`)
 <details open>
 <summary><strong>Click for details</strong> (MongoDB to PostgreSQL migration)</summary>
@@ -109,7 +106,6 @@ Find the chart upgrade instructions below. When upgrading from your version to o
 Since the new `infisical-standalone-postgres` chart, Infisical moved away from MongoDB to PostgreSQL.
 
 Here's the migration instructions : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
-
 </details>
 
 ## Parameters
@@ -161,7 +157,7 @@ Here's the migration instructions : https://infisical.com/docs/self-hosting/guid
 | redis.enabled | bool | `true` | Enable Redis |
 | redis.name | string | `"redis"` | Redis deployment name |
 | redis.fullnameOverride | string | `"redis"` | Redis deployment fullname override |
-| redis.usePassword | bool | `true` | Use password authentication |
+| redis.auth.enabled | bool | `true` | Enable Redis password authentication |
 | redis.auth.password | string | `"mysecretpassword"` | Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set). Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true |
 | redis.architecture | string | `"standalone"` | Redis architecture. Allowed values: `standalone` or `replication` |
 

--- a/helm-charts/infisical-standalone-postgres/README.md.gotmpl
+++ b/helm-charts/infisical-standalone-postgres/README.md.gotmpl
@@ -23,17 +23,13 @@
 
 ---
 
-<details open>
-<summary>
-
 ### **`0.0.1`** (`v0.44.0`)
-MongoDB to PostgreSQL migration
-</summary>
+<details open>
+<summary><strong>Click for details</strong> (MongoDB to PostgreSQL migration)</summary>
 
 Since the new `infisical-standalone-postgres` chart, Infisical moved away from MongoDB to PostgreSQL.
 
 Here's the migration instructions : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
-
 </details>
 
 ## Parameters

--- a/helm-charts/infisical-standalone-postgres/README.md.gotmpl
+++ b/helm-charts/infisical-standalone-postgres/README.md.gotmpl
@@ -1,0 +1,110 @@
+# Infisical Helm Chart
+
+{{ template "infisical.description" . }}
+
+## Services
+
+| Service      | Description      |
+| ------------ | ---------------- |
+| `infisical`  | Infisical's API  |
+| `ingress`    | Ingress service  |
+| `postgresql` | Database service |
+| `redis`      | Cache service    |
+
+{{ template "infisical.installation.repo" . }}
+
+{{ template "infisical.installation.secrets" . }}
+
+{{ template "infisical.installation.chart" . }}
+
+{{ template "infisical.encryptionKeys" . }}
+
+{{ template "infisical.upgrading" . }}
+
+---
+
+<details open>
+<summary>
+
+### **`0.0.1`** (`v0.44.0`)
+MongoDB to PostgreSQL migration
+</summary>
+
+Since the new `infisical-standalone-postgres` chart, Infisical moved away from MongoDB to PostgreSQL.
+
+Here's the migration instructions : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
+
+</details>
+
+## Parameters
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "infisical.yamlValidation" . }}
+
+## Persistence
+
+The database persistence is enabled by default, your volumes will remain on your cluster even after uninstalling the chart. To disable persistence, set this value `postgres.persistence.enabled: false`
+
+## Local development
+
+Find the resources and configuration about how to setup your local development environment on a k8s cluster (locally or remotely).
+
+### Requirements
+
+To create a local k8s environment, you'll need at least :
+
+- [`helm`](https://helm.sh/docs/intro/install/) <kbd>required</kbd>
+  - to generate the manifests and deploy the chart 
+- local/remote k8s cluster <kbd>required</kbd>
+  - e.g. [`kind`](https://kubernetes.io/docs/tasks/tools/), [`minikube`](https://kubernetes.io/docs/tasks/tools/) or an online provider
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) <kbd>required</kbd>
+  - to interact with the cluster
+
+### Setup
+
+Run one of the below scripts for easy setup :
+
+> [!WARNING]
+> The environment might take some minutes to setup the first time as it need to pull all required images and dependencies
+
+```sh
+cd infisical/helm-charts/infisical-standalone-postgres/examples
+
+# With 'kind' + 'helm', to create a local cluster and deploy the chart using 'ingress-nginx'
+./infisical-kind.sh
+
+# With 'helm' only, if you already have a cluster (local/remote) to deploy the chart
+./infisical-helm.sh
+```
+
+> [!NOTE]
+> Find complete setup scripts in [**./examples**](./examples). Comments make it easy to understand how to setup your local development environment step-by-step
+
+Above examples will deploy the following :
+
+- [**infisical.local**](https://infisical.local)
+  - Your local Infisical instance
+  - You may have to add `infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+  - Or access it directly on your [localhost](http://localhost:8080) with
+    - `kubectl port-forward -n infisical-dev $(kubectl get pods -n infisical-dev -l "app=infisical-standalone" -o jsonpath="{.items[0].metadata.name}") 8080 &`
+    - and stop the port-forward with `%` + <kbd>CTRL+C</kbd>
+
+- [**mailhog.infisical.local**](https://mailhog.infisical.local)
+  - Local SMTP server used to receive the emails (e.g. signup verification code)
+  - You may have to add `mailhog.infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+  - Or access it directly on your [localhost](http://localhost:8025) with:
+      - `kubectl port-forward -n infisical-dev $(kubectl get pods -n infisical-dev -l "app.kubernetes.io/name=mailhog,app.kubernetes.io/instance=infisical-mailhog-dev" -o jsonpath="{.items[0].metadata.name}") 8025 &`
+      - and stop the port-forward with `%` + <kbd>CTRL+C</kbd>
+
+Default credentials will be used (local use only, since unsecure):
+- **infisical**
+  - admin user is created at first login (if database is empty)
+- **database** (postgres)
+  - username: `infisical`
+  - password: `root`
+  - database: `infisicalDB`
+- **cache** (redis)
+  - password: `mysecretpassword`

--- a/helm-charts/infisical-standalone-postgres/examples/infisical-helm.sh
+++ b/helm-charts/infisical-standalone-postgres/examples/infisical-helm.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+##
+## Infisical local k8s development environment setup script
+## using 'helm' and assume you already have a cluster and an ingress controller (nginx)
+##
+## DEVELOPMENT USE ONLY
+## DO NOT USE IN PRODUCTION
+##
+
+## Set the color code to pimp your outputs
+## echo "${bwhite}${fblack}My Text Here${reset}The rest here${fcyan}And some here${reset}"
+##
+function setcolors() {
+  # tput background color codes
+  declare -g bblack=$(tput setab 0)
+  declare -g bred=$(tput setab 1)
+  declare -g bgreen=$(tput setab 2)
+  declare -g byellow=$(tput setab 3)
+  declare -g bblue=$(tput setab 4)
+  declare -g bmagenta=$(tput setab 5)
+  declare -g bcyan=$(tput setab 6)
+  declare -g bwhite=$(tput setab 7)
+  declare -g bdefault=$(tput setab 9)
+
+  # tput foreground color codes
+  declare -g fblack=$(tput setaf 0)
+  declare -g fred=$(tput setaf 1)
+  declare -g fgreen=$(tput setaf 2)
+  declare -g fyellow=$(tput setaf 3)
+  declare -g fblue=$(tput setaf 4)
+  declare -g fmagenta=$(tput setaf 5)
+  declare -g fcyan=$(tput setaf 6)
+  declare -g fwhite=$(tput setaf 7)
+  declare -g fdefault=$(tput setaf 9)
+
+  declare -g reset=$(tput sgr0)
+}
+setcolors
+
+## Checking if the given command exist
+## requires "python" "https://example.com/installation-link"
+##
+function requires {
+  if ! [ "$(which "$1")" ]; then
+    info "requirements" "$fred" && echo -e "'$1' not found, please install it to run this script ($2)"
+    exit 1
+  fi
+}
+
+## Automatically return 'true' or wait for user's choice depending on two switches (--fix, --prompt)
+## user_prompt "Do you wish to proceed"
+##
+function user_prompt() {
+  choice=""
+  msg=${1:-"Yes or no"}
+  fix=${2:-"$fix"}
+  # Automatically approve
+  if [[ $fix -eq 1 ]]; then
+    return 0
+  # Wait for approval
+  elif [[ $prompt -eq 1 ]]; then
+    while true; do
+      choice=""
+      argreader "choice" "$msg? (y/n)"
+      case $choice in
+      [Yy]*) return 0 ;;
+      [Nn]*) return 1 ;;
+      *) echo "Please answer (y)es or (n)o!" ;;
+      esac
+    done
+  # Disapprove
+  else
+    return 1
+  fi
+}
+
+## Read argument from user prompt and store it in a variable
+## argreader "varname" "Please prompt your value" "foo"
+## argreader "password" "Please prompt your password" -s
+##
+function argreader() {
+  # Checking variable content (variable var name)
+  if [ -z "${!1}" ]; then
+    key=""
+    # Read until value is given
+    while [ -z "$key" ]; do
+      if [ "$3" == '-s' ]; then
+        read -s -p ">> $2 : " key && echo
+      else
+        read -p ">> $2 : " key && echo
+      fi
+      # Apply default value if given + blank
+      if [ -z "$key" ] && [ ! -z "$3" ]; then key=$3; fi
+    done
+    # Assigning inputed value
+    export ${1}="$key"
+  fi
+}
+
+## Prefix the output with a given text/category/name with color (to group outputs)
+##
+function info() {
+  echo -n "> ${2}[$1]${reset} "
+}
+
+## Terminate and cleanup the script on CTRL+C (SIGINT) signal
+##
+function cleanup() {
+  info "script" "$fred" && echo "${bred}${fwhite} Script aborted! ${reset}"
+  # Add your cleanup tasks below
+  exit 0
+}
+trap cleanup INT
+
+## Clear the terminal screen and output a custom ascii banner
+## Generate yours here : https://ascii.co.uk/text
+##
+showbanner() {
+  clear -x
+  cat <<'EOF'
+-- ∞ Infisical k8s local setup --
+
+██╗███╗   ██╗███████╗██╗███████╗██╗ ██████╗ █████╗ ██╗     
+██║████╗  ██║██╔════╝██║██╔════╝██║██╔════╝██╔══██╗██║     
+██║██╔██╗ ██║█████╗  ██║███████╗██║██║     ███████║██║     
+██║██║╚██╗██║██╔══╝  ██║╚════██║██║██║     ██╔══██║██║     
+██║██║ ╚████║██║     ██║███████║██║╚██████╗██║  ██║███████╗
+╚═╝╚═╝  ╚═══╝╚═╝     ╚═╝╚══════╝╚═╝ ╚═════╝╚═╝  ╚═╝╚══════╝
+EOF
+  echo "${reset}"
+}
+
+showbanner
+
+# defines requirements
+requires "helm" "https://helm.sh/docs/intro/install/"
+requires "kubectl" "https://kubernetes.io/docs/tasks/tools/"
+requires "cat"
+
+showbanner
+
+# define variables
+namespace="infisical-dev"
+cluster_name="infisical"
+host="infisical.local"
+fix=0
+prompt=1
+
+# switch to the local infisical k8s context
+kubectl config use-context "kind-$cluster_name" >/dev/null
+
+if user_prompt "Do you want to install Infisical on the current k8s cluster (${fcyan}$(kubectl config current-context)${reset})"; then
+
+  # configure the required variables
+  # further configuration variables can be found here : https://infisical.com/docs/self-hosting/configuration/envars
+  cat <<EOF >.env.local
+# auto-generated values
+ENCRYPTION_KEY=$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]')
+AUTH_SECRET=$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]' | base64)
+EOF
+
+  # create the Infisical namespace
+  if ! kubectl get ns $namespace >/dev/null 2>&1; then
+    kubectl create ns $namespace >/dev/null
+  fi
+
+  # create the required Infisical configuration secret
+  if ! kubectl get secrets -n $namespace "infisical-secrets" >/dev/null 2>&1; then
+    read -p ">> Please check the values generated in '${fcyan}.env.local${reset}', and press ${fcyan}[ENTER]${reset}" && echo
+    kubectl create secret generic infisical-secrets --from-env-file=.env.local -n $namespace >/dev/null
+  else
+    info "config" "${fred}" && echo -e "The secret '${fcyan}infisical-secrets${reset}' already exists in the '${fcyan}$namespace${reset}' namespace!"
+    if user_prompt "Do you want to overwrite current config"; then
+      read -p ">> Please check the values generated in '${fcyan}.env.local${reset}', and press ${fcyan}[ENTER]${reset}" && echo
+      kubectl delete secret infisical-secrets -n $namespace >/dev/null
+      kubectl create secret generic infisical-secrets --from-env-file=.env.local -n $namespace >/dev/null
+    else
+      info "config" "$fcyan" && echo "Current config kept!"
+    fi
+  fi
+
+  info "helm" "$fcyan" && echo "Installing..."
+
+  # fetch the required charts
+  cd ../ && helm dep update >/dev/null
+
+  # install infisical
+  helm upgrade --install --atomic \
+    -n $namespace --create-namespace \
+    --set SITE_URL=http://infisical.local \
+    --set infisical.config.SMTP_HOST="infisical-dev-mailhog" \
+    --set infisical.config.SMTP_USERNAME="dev@infisical.local" \
+    --set infisical.config.SMTP_PASSWORD="" \
+    --set infisical.config.SMTP_PORT="1025" \
+    --set infisical.config.SMTP_SECURE="false" \
+    --set infisical.config.SMTP_FROM_ADDRESS="dev@infisical.local" \
+    --set infisical.config.SMTP_FROM_NAME="Local Infisical" \
+    --set ingress.hostname="infisical.local" \
+    --set ingress.nginx.enabled="false" \
+    infisical-dev .
+
+  # install mailhog (local mail server/client)
+  helm upgrade --install --atomic \
+    -n $namespace --create-namespace \
+    --set ingress.enabled="true" \
+    --set ingress.ingressClassName="nginx" \
+    --set ingress.hosts[0].host="mailhog.infisical.local" \
+    --set ingress.hosts[0].paths[0].path="/" \
+    --set ingress.hosts[0].paths[0].pathType="Prefix" \
+    --repo https://codecentric.github.io/helm-charts \
+    --version "5.2.3" \
+    infisical-dev-mailhog mailhog
+else
+  cleanup
+fi

--- a/helm-charts/infisical-standalone-postgres/examples/infisical-kind.sh
+++ b/helm-charts/infisical-standalone-postgres/examples/infisical-kind.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+##
+## Infisical local k8s development environment setup script
+## using 'kind' and 'ingress-nginx'
+## https://kind.sigs.k8s.io/docs/user/ingress/
+##
+## DEVELOPMENT USE ONLY
+## DO NOT USE IN PRODUCTION
+##
+
+## Set the color code to pimp your outputs
+## echo "${bwhite}${fblack}My Text Here${reset}The rest here${fcyan}And some here${reset}"
+##
+function setcolors() {
+  # tput background color codes
+  declare -g bblack=$(tput setab 0)
+  declare -g bred=$(tput setab 1)
+  declare -g bgreen=$(tput setab 2)
+  declare -g byellow=$(tput setab 3)
+  declare -g bblue=$(tput setab 4)
+  declare -g bmagenta=$(tput setab 5)
+  declare -g bcyan=$(tput setab 6)
+  declare -g bwhite=$(tput setab 7)
+  declare -g bdefault=$(tput setab 9)
+
+  # tput foreground color codes
+  declare -g fblack=$(tput setaf 0)
+  declare -g fred=$(tput setaf 1)
+  declare -g fgreen=$(tput setaf 2)
+  declare -g fyellow=$(tput setaf 3)
+  declare -g fblue=$(tput setaf 4)
+  declare -g fmagenta=$(tput setaf 5)
+  declare -g fcyan=$(tput setaf 6)
+  declare -g fwhite=$(tput setaf 7)
+  declare -g fdefault=$(tput setaf 9)
+
+  declare -g reset=$(tput sgr0)
+}
+setcolors
+
+## Checking if the given command exist
+## requires "python" "https://example.com/installation-link"
+##
+function requires {
+  if ! [ "$(which "$1")" ]; then
+    info "requirements" "$fred" && echo -e "'$1' not found, please install it to run this script ($2)"
+    exit 1
+  fi
+}
+
+## Automatically return 'true' or wait for user's choice depending on two switches (--fix, --prompt)
+## user_prompt "Do you wish to proceed"
+##
+function user_prompt() {
+  choice=""
+  msg=${1:-"Yes or no"}
+  fix=${2:-"$fix"}
+  # Automatically approve
+  if [[ $fix -eq 1 ]]; then
+    return 0
+  # Wait for approval
+  elif [[ $prompt -eq 1 ]]; then
+    while true; do
+      choice=""
+      argreader "choice" "$msg? (y/n)"
+      case $choice in
+      [Yy]*) return 0 ;;
+      [Nn]*) return 1 ;;
+      *) echo "Please answer (y)es or (n)o!" ;;
+      esac
+    done
+  # Disapprove
+  else
+    return 1
+  fi
+}
+
+## Read argument from user prompt and store it in a variable
+## argreader "varname" "Please prompt your value" "foo"
+## argreader "password" "Please prompt your password" -s
+##
+function argreader() {
+  # Checking variable content (variable var name)
+  if [ -z "${!1}" ]; then
+    key=""
+    # Read until value is given
+    while [ -z "$key" ]; do
+      if [ "$3" == '-s' ]; then
+        read -s -p ">> $2 : " key && echo
+      else
+        read -p ">> $2 : " key && echo
+      fi
+      # Apply default value if given + blank
+      if [ -z "$key" ] && [ ! -z "$3" ]; then key=$3; fi
+    done
+    # Assigning inputed value
+    export ${1}="$key"
+  fi
+}
+
+## Prefix the output with a given text/category/name with color (to group outputs)
+##
+function info() {
+  echo -n "> ${2}[$1]${reset} "
+}
+
+## Terminate and cleanup the script on CTRL+C (SIGINT) signal
+##
+function cleanup() {
+  info "script" "$fred" && echo "${bred}${fwhite} Script aborted! ${reset}"
+  # Add your cleanup tasks below
+  exit 0
+}
+trap cleanup INT
+
+## Clear the terminal screen and output a custom ascii banner
+## Generate yours here : https://ascii.co.uk/text
+##
+showbanner() {
+  clear -x
+  cat <<'EOF'
+-- ∞ Infisical k8s local setup --
+
+██╗███╗   ██╗███████╗██╗███████╗██╗ ██████╗ █████╗ ██╗       
+██║████╗  ██║██╔════╝██║██╔════╝██║██╔════╝██╔══██╗██║       
+██║██╔██╗ ██║█████╗  ██║███████╗██║██║     ███████║██║       
+██║██║╚██╗██║██╔══╝  ██║╚════██║██║██║     ██╔══██║██║       
+██║██║ ╚████║██║     ██║███████║██║╚██████╗██║  ██║███████╗  
+╚═╝╚═╝  ╚═══╝╚═╝     ╚═╝╚══════╝╚═╝ ╚═════╝╚═╝  ╚═╝╚══════╝  
+EOF
+  echo "${reset}"
+}
+
+showbanner
+
+# defines requirements
+requires "helm" "https://helm.sh/docs/intro/install/"
+requires "kubectl" "https://kubernetes.io/docs/tasks/tools/"
+requires "kind" "https://kubernetes.io/docs/tasks/tools/"
+requires "cat"
+
+showbanner
+
+# define variables
+namespace="infisical-dev"
+cluster_name="infisical"
+host="infisical.local"
+fix=0
+prompt=1
+
+# create the local cluster (expose 80/443 on localhost)
+cat <<EOF | kind create cluster -n $cluster_name --wait 1m -q --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+EOF
+
+# switch to the local infisical k8s context
+kubectl config use-context "kind-$cluster_name" >/dev/null
+
+# install ingress-nginx
+# kind version : https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+if ! kubectl get pods -n ingress-nginx | grep "ingress-nginx-controller" >/dev/null; then
+  helm upgrade -i --atomic \
+    --repo https://kubernetes.github.io/ingress-nginx \
+    ingress-nginx ingress-nginx \
+    -n ingress-nginx --create-namespace \
+    --set controller.service.type="NodePort" \
+    --set controller.hostPort.enabled=true \
+    --set controller.service.externalTrafficPolicy=Local
+
+  # wait for the ingress controller to be ready
+  kubectl wait -n ingress-nginx \
+    --for=condition=ready pod \
+    --selector=app.kubernetes.io/component=controller \
+    --timeout=120s
+fi
+
+if user_prompt "Do you want to install/update Infisical on the current k8s cluster (${fcyan}$(kubectl config current-context)${reset})"; then
+
+  # configure the required variables
+  # further configuration variables can be found here : https://infisical.com/docs/self-hosting/configuration/envars
+  cat <<EOF >.env.local
+  # auto-generated values
+  ENCRYPTION_KEY=$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]')
+  AUTH_SECRET=$(tr -dc '[:alnum:]' </dev/urandom | dd bs=4 count=8 2>/dev/null | tr '[:upper:]' '[:lower:]' | base64)
+EOF
+
+  # create the Infisical namespace
+  if ! kubectl get ns $namespace >/dev/null 2>&1; then
+    kubectl create ns $namespace >/dev/null
+  fi
+
+  # create the required Infisical configuration secret
+  if ! kubectl get secrets -n $namespace "infisical-secrets" >/dev/null 2>&1; then
+    read -p ">> Please check the values generated in '${fcyan}.env.local${reset}', and press ${fcyan}[ENTER]${reset}" && echo
+    kubectl create secret generic infisical-secrets --from-env-file=.env.local -n $namespace >/dev/null
+  else
+    info "config" "${fred}" && echo -e "The secret '${fcyan}infisical-secrets${reset}' already exists in the '${fcyan}$namespace${reset}' namespace!"
+    if user_prompt "Do you want to overwrite current config"; then
+      read -p ">> Please check the values generated in '${fcyan}.env.local${reset}', and press ${fcyan}[ENTER]${reset}" && echo
+      kubectl delete secret infisical-secrets -n $namespace >/dev/null
+      kubectl create secret generic infisical-secrets --from-env-file=.env.local -n $namespace >/dev/null
+    else
+      info "config" "$fcyan" && echo "Current config kept!"
+    fi
+  fi
+
+  info "helm" "$fcyan" && echo "Installing..."
+
+  # fetch the required charts
+  cd ../ && helm dep update >/dev/null
+
+  # install infisical
+  helm upgrade --install --atomic \
+    -n $namespace --create-namespace \
+    --set SITE_URL=http://infisical.local \
+    --set infisical.config.SMTP_HOST="infisical-dev-mailhog" \
+    --set infisical.config.SMTP_USERNAME="dev@infisical.local" \
+    --set infisical.config.SMTP_PASSWORD="" \
+    --set infisical.config.SMTP_PORT="1025" \
+    --set infisical.config.SMTP_SECURE="false" \
+    --set infisical.config.SMTP_FROM_ADDRESS="dev@infisical.local" \
+    --set infisical.config.SMTP_FROM_NAME="Local Infisical" \
+    --set ingress.hostname="infisical.local" \
+    --set ingress.nginx.enabled="false" \
+    infisical-dev .
+
+  # install mailhog (local mail server/client)
+  helm upgrade --install --atomic \
+    -n $namespace --create-namespace \
+    --set ingress.enabled="true" \
+    --set ingress.ingressClassName="nginx" \
+    --set ingress.hosts[0].host="mailhog.infisical.local" \
+    --set ingress.hosts[0].paths[0].path="/" \
+    --set ingress.hosts[0].paths[0].pathType="Prefix" \
+    --repo https://codecentric.github.io/helm-charts \
+    --version "5.2.3" \
+    infisical-dev-mailhog mailhog
+else
+  cleanup
+fi

--- a/helm-charts/infisical-standalone-postgres/templates/NOTES.txt
+++ b/helm-charts/infisical-standalone-postgres/templates/NOTES.txt
@@ -1,6 +1,6 @@
 ##
 
--- Infisical Helm Chart --
+-- ∞ Infisical Helm Chart --
 
 ██╗███╗   ██╗███████╗██╗███████╗██╗ ██████╗ █████╗ ██╗     
 ██║████╗  ██║██╔════╝██║██╔════╝██║██╔════╝██╔══██╗██║     
@@ -19,25 +19,28 @@
 │
 │   Current installation (infisical) :
 │   • infisical          : {{ .Values.infisical.enabled }}
-|   • nginx              : {{ .Values.ingress.nginx.enabled }}
-|   • Postgres DB        : {{ .Values.postgresql.enabled }}
-|   • Redis              : {{ .Values.redis.enabled }}
+|   • ingress-nginx      : {{ .Values.ingress.nginx.enabled }}
+|   • postgresql         : {{ .Values.postgresql.enabled }}
+|   • redis              : {{ .Values.redis.enabled }}
 │
 ╰―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
 
 ――― Here's a list of helpful commands to get you started 📝  ―――――――――――――――――――――――――――――――――――――――――┤
 
 → Get all the Infisical resources (excluding secrets/pvcs)
-$ kubectl get all -n {{ .Release.Namespace }}
+kubectl get all -n {{ .Release.Namespace }}
  
 → Get your release status
-$ helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
+helm status -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Get your release resources
-$ helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}
+helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Uninstall your release
-$ helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}
+helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}
+
+→ Access the Infisical dashboard
+kubectl port-forward -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l "app=infisical-standalone" -o jsonpath="{.items[0].metadata.name}") 8080 &
  
 ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
 

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -89,7 +89,7 @@ spec:
     {{- include "infisical.matchLabels" . | nindent 8 }}
   ports:
     - protocol: TCP
-      port: 8080
+      port: 80
       targetPort: 8080
       {{- if eq $infisicalValues.service.type "NodePort" }}
       nodePort: {{ $infisicalValues.service.nodePort }}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -59,9 +59,15 @@ spec:
         - name: REDIS_URL
           value: {{ include "infisical.redisConnectionString" . }}
         {{- end }}
+        {{- range $key, $value := $infisicalValues.config }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if $infisicalValues.kubeSecretRef }}
         envFrom:
         - secretRef:
             name: {{ $infisicalValues.kubeSecretRef }}
+        {{- end }}
         {{- if  $infisicalValues.resources }}
         resources: {{- toYaml $infisicalValues.resources | nindent 12 }}
         {{- end }}

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -22,11 +22,18 @@ spec:
           image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
           command: ["npm", "run", "migration:latest"]
           env:
-          {{- if .Values.postgresql.enabled }}
+          {{/* requires only DB_CONNECTION_URI, given > built-in > secret */}}
+          {{- if hasKey $infisicalValues.config "DB_CONNECTION_URI" -}}
+          - name: DB_CONNECTION_URI
+            value: {{ $infisicalValues.config.DB_CONNECTION_URI }}
+          {{- else if .Values.postgresql.enabled -}}
           - name: DB_CONNECTION_URI
             value: {{ include "infisical.postgresDBConnectionString" . }}
+          {{- else -}}
+          - name: DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ $infisicalValues.kubeSecretRef }}
+                key: DB_CONNECTION_URI
           {{- end }}
-          envFrom:
-          - secretRef:
-              name: {{ $infisicalValues.kubeSecretRef }}
 {{- end }}

--- a/helm-charts/infisical-standalone-postgres/values.schema.json
+++ b/helm-charts/infisical-standalone-postgres/values.schema.json
@@ -1,8 +1,8 @@
 {
   "properties": {
     "fullnameOverride": {
-      "title": "fullnameOverride",
-      "type": "string"
+      "description": "Override release fullname",
+      "title": "fullnameOverride"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
@@ -10,231 +10,497 @@
       "type": "object"
     },
     "infisical": {
+      "additionalProperties": true,
       "properties": {
         "affinity": {
-          "title": "affinity",
-          "type": "object"
+          "additionalProperties": true,
+          "description": "Backend pod affinity",
+          "title": "affinity"
         },
         "autoDatabaseSchemaMigration": {
+          "description": "Automatically migrate database",
           "title": "autoDatabaseSchemaMigration",
           "type": "boolean"
         },
+        "config": {
+          "properties": {
+            "AUTH_SECRET": {
+              "description": "Must be a random 32 byte base64 string. Can be generated with `openssl rand -base64 32`.",
+              "type": "string"
+            },
+            "CLIENT_ID_AZURE": {
+              "description": "OAuth2 client id for Azure integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_BITBUCKET": {
+              "description": "OAuth2 client ID for BitBucket integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_GCP_SECRET_MANAGER": {
+              "description": "OAuth2 client id for GCP secrets manager integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_GITHUB": {
+              "description": "OAuth2 client ID for GitHub integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_GITHUB_LOGIN": {
+              "description": "OAuth2 client ID for GitHub login.",
+              "type": "string"
+            },
+            "CLIENT_ID_GITLAB": {
+              "description": "OAuth2 client id for Gitlab integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_GITLAB_LOGIN": {
+              "description": "OAuth2 client ID for GitLab login.",
+              "type": "string"
+            },
+            "CLIENT_ID_GOOGLE_LOGIN": {
+              "description": "OAuth2 client ID for Google login.",
+              "type": "string"
+            },
+            "CLIENT_ID_HEROKU": {
+              "description": "OAuth2 client ID for Heroku integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_NETLIFY": {
+              "description": "OAuth2 client ID for Netlify integration.",
+              "type": "string"
+            },
+            "CLIENT_ID_VERCEL": {
+              "description": "OAuth2 client ID for Vercel integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_AZURE": {
+              "description": "OAuth2 client secret for Azure integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_BITBUCKET": {
+              "description": "OAuth2 client secret for BitBucket integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GCP_SECRET_MANAGER": {
+              "description": "OAuth2 client secret for GCP secrets manager integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GITHUB": {
+              "description": "OAuth2 client secret for GitHub integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GITHUB_LOGIN": {
+              "description": "OAuth2 client secret for GitHub login.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GITLAB": {
+              "description": "OAuth2 client secret for Gitlab integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GITLAB_LOGIN": {
+              "description": "OAuth2 client secret for GitLab login.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_GOOGLE_LOGIN": {
+              "description": "OAuth2 client secret for Google login.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_HEROKU": {
+              "description": "OAuth2 client secret for Heroku integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_NETLIFY": {
+              "description": "OAuth2 client secret for Netlify integration.",
+              "type": "string"
+            },
+            "CLIENT_SECRET_VERCEL": {
+              "description": "OAuth2 client secret for Vercel integration.",
+              "type": "string"
+            },
+            "CLIENT_SLUG_VERCEL": {
+              "description": "OAuth2 slug for Vercel integration.",
+              "type": "string"
+            },
+            "DB_CONNECTION_URI": {
+              "description": "Database connection string (postgres, e.g. 'postgresql://user:pass@host:5432/my_db').",
+              "type": "string"
+            },
+            "DB_ROOT_CERT": {
+              "description": "Configure the SSL certificate for securing a Postgres connection by first encoding it in base64. To encode your certificate `echo \"\u003ccertificate\u003e\" | base64`",
+              "type": "string"
+            },
+            "ENCRYPTION_KEY": {
+              "description": "Must be a random 16 byte hex string. Can be generated with `openssl rand -hex 16`.",
+              "type": "string"
+            },
+            "POSTHOG_HOST": {
+              "type": "string"
+            },
+            "POSTHOG_PROJECT_API_KEY": {
+              "type": "string"
+            },
+            "REDIS_URL": {
+              "description": "Redis connection string (e.g. 'redis://user:pass@host:6379').",
+              "type": "string"
+            },
+            "SITE_URL": {
+              "description": "Must be an absolute URL including the protocol (e.g. https://app.infisical.com).",
+              "type": "string"
+            },
+            "SMTP_FROM_ADDRESS": {
+              "description": "Email address to be used for sending emails.",
+              "type": "string"
+            },
+            "SMTP_FROM_NAME": {
+              "description": "Name label to be used in From field (e.g. Team)",
+              "type": "string"
+            },
+            "SMTP_HOST": {
+              "description": "Hostname to connect to for establishing SMTP connections (e.g. smtp.sendgrid.net).",
+              "type": "string"
+            },
+            "SMTP_PASSWORD": {
+              "description": "Credential to connect to host.",
+              "type": "string"
+            },
+            "SMTP_PORT": {
+              "description": "Port to connect to for establishing SMTP connections.",
+              "type": "integer"
+            },
+            "SMTP_SECURE": {
+              "description": "If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported.",
+              "type": "boolean"
+            },
+            "SMTP_USERNAME": {
+              "description": "Credential to connect to host (e.g. team@infisical.com).",
+              "type": "string"
+            },
+            "URL_GITLAB_LOGIN": {
+              "description": "URL of your self-hosted instance of GitLab where the OAuth application is registered (default 'https://gitlab.com').",
+              "type": "string"
+            }
+          },
+          "description": "Backend [configuration variables](https://infisical.com/docs/self-hosting/configuration/envars) (inline, e.g. for gitops mechanism).\nThose variables take precedence over `infisical.kubeSecretRef`",
+          "title": "config"
+        },
         "deploymentAnnotations": {
-          "title": "deploymentAnnotations",
-          "type": "object"
+          "additionalProperties": true,
+          "description": "Backend deployment annotations",
+          "title": "deploymentAnnotations"
         },
         "enabled": {
+          "description": "Enable backend",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "description": "Backend deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "image": {
           "properties": {
             "pullPolicy": {
+              "description": "Backend image pullPolicy",
               "title": "pullPolicy",
-              "type": "string"
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ]
             },
             "repository": {
+              "description": "Backend image repository",
               "title": "repository",
               "type": "string"
             },
             "tag": {
+              "description": "Backend image [tag](https://hub.docker.com/r/infisical/infisical/tags)",
               "title": "tag",
               "type": "string"
             }
           },
+          "description": "Backend image parameters",
           "title": "image",
           "type": "object"
         },
         "kubeSecretRef": {
+          "description": "Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))",
           "title": "kubeSecretRef",
           "type": "string"
         },
         "name": {
+          "description": "Backend deployment name",
           "title": "name",
           "type": "string"
         },
         "podAnnotations": {
-          "title": "podAnnotations",
-          "type": "object"
+          "additionalProperties": true,
+          "description": "Backend pod annotations",
+          "title": "podAnnotations"
         },
         "replicaCount": {
-          "title": "replicaCount",
-          "type": "integer"
+          "minimum": 1,
+          "description": "Backend replicas count",
+          "title": "replicaCount"
         },
         "resources": {
           "properties": {
             "limits": {
               "properties": {
                 "memory": {
+                  "description": "Memory resource limit",
                   "title": "memory",
                   "type": "string"
                 }
               },
+              "description": "Above which Infisical's pods will not be able to use\nWarning: too low resources may alter the application's stability",
               "title": "limits",
               "type": "object"
             },
             "requests": {
               "properties": {
                 "cpu": {
+                  "description": "CPU resource request",
                   "title": "cpu",
                   "type": "string"
                 }
               },
+              "description": "Infisical's pods will at least use the below resources\nWarning: too low resources may alter the application's stability\nWarning: make sure your cluster have enough resources, taking into consideration the replicas amount",
               "title": "requests",
               "type": "object"
             }
           },
+          "description": "Infisical instance resources and limits",
           "title": "resources",
           "type": "object"
         },
         "service": {
           "properties": {
             "annotations": {
-              "title": "annotations",
-              "type": "object"
+              "additionalProperties": true,
+              "description": "Backend service annotations",
+              "title": "annotations"
             },
             "nodePort": {
+              "description": "Backend service nodePort (used if above type is `NodePort`)",
               "title": "nodePort",
-              "type": "string"
+              "type": "integer"
             },
             "type": {
+              "description": "Backend service type",
               "title": "type",
-              "type": "string"
+              "enum": [
+                "ClusterIP",
+                "NodePort"
+              ]
             }
           },
+          "description": "Backend service",
           "title": "service",
           "type": "object"
         }
       },
-      "title": "infisical",
-      "type": "object"
+      "description": "Infisical parameters\nhttps://infisical.com/docs/self-hosting/deployments/kubernetes",
+      "title": "infisical"
     },
     "ingress": {
+      "additionalProperties": true,
       "properties": {
         "annotations": {
-          "title": "annotations",
-          "type": "object"
+          "additionalProperties": true,
+          "description": "Ingress annotations",
+          "title": "annotations"
         },
         "enabled": {
+          "description": "Enable ingress",
           "title": "enabled",
           "type": "boolean"
         },
         "hostName": {
+          "description": "Your instance's hostname (e.g. `infisical.example.org`).\nReplace with your own domain",
           "title": "hostName",
           "type": "string"
         },
         "ingressClassName": {
+          "description": "Ingress class name",
           "title": "ingressClassName",
           "type": "string"
         },
         "nginx": {
           "properties": {
             "enabled": {
+              "description": "Enable and install NginX ingress controller",
               "title": "enabled",
               "type": "boolean"
             }
           },
-          "title": "nginx",
-          "type": "object"
+          "title": "nginx"
         },
         "tls": {
           "items": {},
-          "title": "tls",
-          "type": "array"
+          "description": "kubernetes.io/ingress.class: \"nginx\"\ncert-manager.io/issuer: letsencrypt-nginx\nIngress TLS hosts (matching above `ingress.hostName`).\nReplace with your own domain",
+          "title": "tls"
         }
       },
-      "title": "ingress",
-      "type": "object"
+      "description": "Ingress parameters\nhttps://kubernetes.io/docs/concepts/services-networking/ingress-controllers/",
+      "title": "ingress"
     },
     "nameOverride": {
-      "title": "nameOverride",
-      "type": "string"
+      "description": "Override release name",
+      "title": "nameOverride"
     },
     "postgresql": {
+      "additionalProperties": true,
       "properties": {
         "auth": {
+          "additionalProperties": true,
           "properties": {
             "database": {
+              "description": "PostgreSQL database name",
               "title": "database",
               "type": "string"
             },
             "password": {
+              "description": "PostgreSQL database password",
               "title": "password",
               "type": "string"
             },
             "username": {
+              "description": "PostgreSQL database username",
               "title": "username",
               "type": "string"
             }
           },
-          "title": "auth",
-          "type": "object"
+          "title": "auth"
         },
         "enabled": {
+          "description": "Enable PostgreSQL",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "description": "PostgreSQL deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "name": {
+          "description": "PostgreSQL deployment name",
           "title": "name",
           "type": "string"
+        },
+        "persistence": {
+          "properties": {
+            "accessModes": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "PVC Access Mode for PostgreSQL volume",
+              "title": "accessModes",
+              "type": "array"
+            },
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Annotations for the PVC",
+              "title": "annotations"
+            },
+            "dataSource": {
+              "additionalProperties": true,
+              "description": "Custom PVC data source",
+              "title": "dataSource"
+            },
+            "enabled": {
+              "description": "Enable PostgreSQL Primary data persistence using PVC",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "description": "Name of an existing PVC to use",
+              "title": "existingClaim",
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Labels for the PVC",
+              "title": "labels"
+            },
+            "mountPath": {
+              "description": "The path the volume will be mounted at.\nUseful when using custom PostgreSQL images",
+              "title": "mountPath",
+              "type": "string"
+            },
+            "selector": {
+              "additionalProperties": true,
+              "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+              "title": "selector"
+            },
+            "size": {
+              "description": "PVC Storage Request for PostgreSQL volume",
+              "title": "size",
+              "type": "string"
+            },
+            "storageClass": {
+              "description": "PVC Storage Class for PostgreSQL Primary data volume.\nIf defined, `storageClassName: \u003cstorageClass\u003e`\nIf set to `\"-\"`, `storageClassName: \"\"`, which disables dynamic provisioning\nDefault is undefined/null, no `storageClassName` spec is set. Using default provisioner",
+              "title": "storageClass",
+              "type": "string"
+            }
+          },
+          "description": "PostgreSQL Primary persistence configuration",
+          "title": "persistence",
+          "type": "object"
         }
       },
-      "title": "postgresql",
-      "type": "object"
+      "description": "PostgreSQL parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/postgresql",
+      "title": "postgresql"
     },
     "redis": {
+      "additionalProperties": true,
       "properties": {
         "architecture": {
+          "description": "Redis architecture. Allowed values: `standalone` or `replication`",
           "title": "architecture",
-          "type": "string"
+          "enum": [
+            "standalone",
+            "replication"
+          ]
         },
         "auth": {
+          "additionalProperties": true,
           "properties": {
             "password": {
+              "description": "Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).\nDefaults to a random 10-character alphanumeric string if not set and `usePassword` is true",
               "title": "password",
               "type": "string"
             }
           },
-          "title": "auth",
-          "type": "object"
-        },
-        "cluster": {
-          "properties": {
-            "enabled": {
-              "title": "enabled",
-              "type": "boolean"
-            }
-          },
-          "title": "cluster",
-          "type": "object"
+          "title": "auth"
         },
         "enabled": {
+          "description": "Enable Redis",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "description": "Redis deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "name": {
+          "description": "Redis deployment name",
           "title": "name",
           "type": "string"
         },
         "usePassword": {
+          "description": "Use password authentication",
           "title": "usePassword",
           "type": "boolean"
         }
       },
-      "title": "redis",
-      "type": "object"
+      "description": "Redis parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/redis",
+      "title": "redis"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/helm-charts/infisical-standalone-postgres/values.schema.json
+++ b/helm-charts/infisical-standalone-postgres/values.schema.json
@@ -1,0 +1,242 @@
+{
+  "properties": {
+    "fullnameOverride": {
+      "title": "fullnameOverride",
+      "type": "string"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "title": "global",
+      "type": "object"
+    },
+    "infisical": {
+      "properties": {
+        "affinity": {
+          "title": "affinity",
+          "type": "object"
+        },
+        "autoDatabaseSchemaMigration": {
+          "title": "autoDatabaseSchemaMigration",
+          "type": "boolean"
+        },
+        "deploymentAnnotations": {
+          "title": "deploymentAnnotations",
+          "type": "object"
+        },
+        "enabled": {
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "title": "image",
+          "type": "object"
+        },
+        "kubeSecretRef": {
+          "title": "kubeSecretRef",
+          "type": "string"
+        },
+        "name": {
+          "title": "name",
+          "type": "string"
+        },
+        "podAnnotations": {
+          "title": "podAnnotations",
+          "type": "object"
+        },
+        "replicaCount": {
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "resources": {
+          "properties": {
+            "limits": {
+              "properties": {
+                "memory": {
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "properties": {
+                "cpu": {
+                  "title": "cpu",
+                  "type": "string"
+                }
+              },
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "title": "resources",
+          "type": "object"
+        },
+        "service": {
+          "properties": {
+            "annotations": {
+              "title": "annotations",
+              "type": "object"
+            },
+            "nodePort": {
+              "title": "nodePort",
+              "type": "string"
+            },
+            "type": {
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "title": "service",
+          "type": "object"
+        }
+      },
+      "title": "infisical",
+      "type": "object"
+    },
+    "ingress": {
+      "properties": {
+        "annotations": {
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "hostName": {
+          "title": "hostName",
+          "type": "string"
+        },
+        "ingressClassName": {
+          "title": "ingressClassName",
+          "type": "string"
+        },
+        "nginx": {
+          "properties": {
+            "enabled": {
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "title": "nginx",
+          "type": "object"
+        },
+        "tls": {
+          "items": {},
+          "title": "tls",
+          "type": "array"
+        }
+      },
+      "title": "ingress",
+      "type": "object"
+    },
+    "nameOverride": {
+      "title": "nameOverride",
+      "type": "string"
+    },
+    "postgresql": {
+      "properties": {
+        "auth": {
+          "properties": {
+            "database": {
+              "title": "database",
+              "type": "string"
+            },
+            "password": {
+              "title": "password",
+              "type": "string"
+            },
+            "username": {
+              "title": "username",
+              "type": "string"
+            }
+          },
+          "title": "auth",
+          "type": "object"
+        },
+        "enabled": {
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "name": {
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "title": "postgresql",
+      "type": "object"
+    },
+    "redis": {
+      "properties": {
+        "architecture": {
+          "title": "architecture",
+          "type": "string"
+        },
+        "auth": {
+          "properties": {
+            "password": {
+              "title": "password",
+              "type": "string"
+            }
+          },
+          "title": "auth",
+          "type": "object"
+        },
+        "cluster": {
+          "properties": {
+            "enabled": {
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "title": "cluster",
+          "type": "object"
+        },
+        "enabled": {
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "name": {
+          "title": "name",
+          "type": "string"
+        },
+        "usePassword": {
+          "title": "usePassword",
+          "type": "boolean"
+        }
+      },
+      "title": "redis",
+      "type": "object"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/helm-charts/infisical-standalone-postgres/values.schema.json
+++ b/helm-charts/infisical-standalone-postgres/values.schema.json
@@ -470,6 +470,11 @@
         "auth": {
           "additionalProperties": true,
           "properties": {
+            "enabled": {
+              "description": "Enable Redis password authentication",
+              "title": "enabled",
+              "type": "boolean"
+            },
             "password": {
               "description": "Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).\nDefaults to a random 10-character alphanumeric string if not set and `usePassword` is true",
               "title": "password",
@@ -492,11 +497,6 @@
           "description": "Redis deployment name",
           "title": "name",
           "type": "string"
-        },
-        "usePassword": {
-          "description": "Use password authentication",
-          "title": "usePassword",
-          "type": "boolean"
         }
       },
       "description": "Redis parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/redis",

--- a/helm-charts/infisical-standalone-postgres/values.schema.json
+++ b/helm-charts/infisical-standalone-postgres/values.schema.json
@@ -1,8 +1,10 @@
 {
   "properties": {
     "fullnameOverride": {
+      "default": "",
       "description": "Override release fullname",
-      "title": "fullnameOverride"
+      "title": "fullnameOverride",
+      "type": "string"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
@@ -10,189 +12,240 @@
       "type": "object"
     },
     "infisical": {
-      "additionalProperties": true,
       "properties": {
         "affinity": {
-          "additionalProperties": true,
           "description": "Backend pod affinity",
-          "title": "affinity"
+          "title": "affinity",
+          "type": "object"
         },
         "autoDatabaseSchemaMigration": {
-          "description": "Automatically migrate database",
+          "default": "true",
+          "description": "Automatically apply database schema migration",
           "title": "autoDatabaseSchemaMigration",
           "type": "boolean"
         },
         "config": {
+          "patternProperties": {
+            "^CLIENT_.*": {
+              "type": "string"
+            }
+          },
           "properties": {
             "AUTH_SECRET": {
+              "pattern": "^[-A-Za-z0-9+\\/]{43}={0,3}$",
               "description": "Must be a random 32 byte base64 string. Can be generated with `openssl rand -base64 32`.",
-              "type": "string"
+              "title": "AUTH_SECRET",
+              "type": "string",
+              "examples": [
+                "kR4i4vGsaS1Cz2kCDLRO5LpKmtRuk09ThARraYOn5sQ="
+              ]
             },
             "CLIENT_ID_AZURE": {
               "description": "OAuth2 client id for Azure integration.",
-              "type": "string"
+              "title": "CLIENT_ID_AZURE"
             },
             "CLIENT_ID_BITBUCKET": {
               "description": "OAuth2 client ID for BitBucket integration.",
-              "type": "string"
+              "title": "CLIENT_ID_BITBUCKET"
             },
             "CLIENT_ID_GCP_SECRET_MANAGER": {
               "description": "OAuth2 client id for GCP secrets manager integration.",
-              "type": "string"
+              "title": "CLIENT_ID_GCP_SECRET_MANAGER"
             },
             "CLIENT_ID_GITHUB": {
               "description": "OAuth2 client ID for GitHub integration.",
-              "type": "string"
+              "title": "CLIENT_ID_GITHUB"
             },
             "CLIENT_ID_GITHUB_LOGIN": {
               "description": "OAuth2 client ID for GitHub login.",
-              "type": "string"
+              "title": "CLIENT_ID_GITHUB_LOGIN"
             },
             "CLIENT_ID_GITLAB": {
               "description": "OAuth2 client id for Gitlab integration.",
-              "type": "string"
+              "title": "CLIENT_ID_GITLAB"
             },
             "CLIENT_ID_GITLAB_LOGIN": {
               "description": "OAuth2 client ID for GitLab login.",
-              "type": "string"
+              "title": "CLIENT_ID_GITLAB_LOGIN"
             },
             "CLIENT_ID_GOOGLE_LOGIN": {
               "description": "OAuth2 client ID for Google login.",
-              "type": "string"
+              "title": "CLIENT_ID_GOOGLE_LOGIN"
             },
             "CLIENT_ID_HEROKU": {
               "description": "OAuth2 client ID for Heroku integration.",
-              "type": "string"
+              "title": "CLIENT_ID_HEROKU"
             },
             "CLIENT_ID_NETLIFY": {
               "description": "OAuth2 client ID for Netlify integration.",
-              "type": "string"
+              "title": "CLIENT_ID_NETLIFY"
             },
             "CLIENT_ID_VERCEL": {
               "description": "OAuth2 client ID for Vercel integration.",
-              "type": "string"
+              "title": "CLIENT_ID_VERCEL"
             },
             "CLIENT_SECRET_AZURE": {
               "description": "OAuth2 client secret for Azure integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_AZURE"
             },
             "CLIENT_SECRET_BITBUCKET": {
               "description": "OAuth2 client secret for BitBucket integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_BITBUCKET"
             },
             "CLIENT_SECRET_GCP_SECRET_MANAGER": {
               "description": "OAuth2 client secret for GCP secrets manager integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GCP_SECRET_MANAGER"
             },
             "CLIENT_SECRET_GITHUB": {
               "description": "OAuth2 client secret for GitHub integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GITHUB"
             },
             "CLIENT_SECRET_GITHUB_LOGIN": {
               "description": "OAuth2 client secret for GitHub login.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GITHUB_LOGIN"
             },
             "CLIENT_SECRET_GITLAB": {
               "description": "OAuth2 client secret for Gitlab integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GITLAB"
             },
             "CLIENT_SECRET_GITLAB_LOGIN": {
               "description": "OAuth2 client secret for GitLab login.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GITLAB_LOGIN"
             },
             "CLIENT_SECRET_GOOGLE_LOGIN": {
               "description": "OAuth2 client secret for Google login.",
-              "type": "string"
+              "title": "CLIENT_SECRET_GOOGLE_LOGIN"
             },
             "CLIENT_SECRET_HEROKU": {
               "description": "OAuth2 client secret for Heroku integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_HEROKU"
             },
             "CLIENT_SECRET_NETLIFY": {
               "description": "OAuth2 client secret for Netlify integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_NETLIFY"
             },
             "CLIENT_SECRET_VERCEL": {
               "description": "OAuth2 client secret for Vercel integration.",
-              "type": "string"
+              "title": "CLIENT_SECRET_VERCEL"
             },
             "CLIENT_SLUG_VERCEL": {
               "description": "OAuth2 slug for Vercel integration.",
-              "type": "string"
+              "title": "CLIENT_SLUG_VERCEL"
             },
             "DB_CONNECTION_URI": {
+              "pattern": "^postgresql:(?://[^/]+/)?(\\w+)",
               "description": "Database connection string (postgres, e.g. 'postgresql://user:pass@host:5432/my_db').",
-              "type": "string"
+              "title": "DB_CONNECTION_URI",
+              "type": "string",
+              "examples": [
+                "postgresql://user:pass@host:5432/my_db"
+              ]
             },
             "DB_ROOT_CERT": {
               "description": "Configure the SSL certificate for securing a Postgres connection by first encoding it in base64. To encode your certificate `echo \"\u003ccertificate\u003e\" | base64`",
+              "title": "DB_ROOT_CERT",
               "type": "string"
             },
             "ENCRYPTION_KEY": {
+              "pattern": "^[a-zA-Z0-9]{32}$",
               "description": "Must be a random 16 byte hex string. Can be generated with `openssl rand -hex 16`.",
-              "type": "string"
-            },
-            "POSTHOG_HOST": {
-              "type": "string"
-            },
-            "POSTHOG_PROJECT_API_KEY": {
-              "type": "string"
+              "title": "ENCRYPTION_KEY",
+              "type": "string",
+              "examples": [
+                "f47dc9501a44c19efe46ca982eb96c9f"
+              ]
             },
             "REDIS_URL": {
               "description": "Redis connection string (e.g. 'redis://user:pass@host:6379').",
+              "title": "REDIS_URL",
+              "type": "string",
+              "examples": [
+                "redis://user:pass@host:6379"
+              ]
+            },
+            "SENTRY_DSN": {
+              "description": "Sentry (optional) for monitoring errors",
               "type": "string"
             },
             "SITE_URL": {
               "description": "Must be an absolute URL including the protocol (e.g. https://app.infisical.com).",
-              "type": "string"
+              "title": "SITE_URL",
+              "type": "string",
+              "examples": [
+                "https://app.infisical.com"
+              ]
             },
             "SMTP_FROM_ADDRESS": {
+              "format": "idn-email",
               "description": "Email address to be used for sending emails.",
-              "type": "string"
+              "title": "SMTP_FROM_ADDRESS",
+              "type": "string",
+              "examples": [
+                "team@example.org"
+              ]
             },
             "SMTP_FROM_NAME": {
               "description": "Name label to be used in From field (e.g. Team)",
+              "title": "SMTP_FROM_NAME",
               "type": "string"
             },
             "SMTP_HOST": {
-              "description": "Hostname to connect to for establishing SMTP connections (e.g. smtp.sendgrid.net).",
-              "type": "string"
+              "description": "Hostname to connect to for establishing SMTP connections (e.g. smtp.example.org).",
+              "title": "SMTP_HOST",
+              "type": "string",
+              "examples": [
+                "smtp.example.org"
+              ]
             },
             "SMTP_PASSWORD": {
               "description": "Credential to connect to host.",
+              "title": "SMTP_PASSWORD",
               "type": "string"
             },
             "SMTP_PORT": {
               "description": "Port to connect to for establishing SMTP connections.",
+              "title": "SMTP_PORT",
               "type": "integer"
             },
             "SMTP_SECURE": {
               "description": "If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported.",
+              "title": "SMTP_SECURE",
               "type": "boolean"
             },
             "SMTP_USERNAME": {
-              "description": "Credential to connect to host (e.g. team@infisical.com).",
-              "type": "string"
+              "format": "idn-email",
+              "description": "Credential to connect to host (e.g. team@example.org).",
+              "title": "SMTP_USERNAME",
+              "type": "string",
+              "examples": [
+                "team@example.org"
+              ]
             },
             "URL_GITLAB_LOGIN": {
               "description": "URL of your self-hosted instance of GitLab where the OAuth application is registered (default 'https://gitlab.com').",
-              "type": "string"
+              "title": "URL_GITLAB_LOGIN",
+              "type": "string",
+              "examples": [
+                "https://gitlab.com"
+              ]
             }
           },
           "description": "Backend [configuration variables](https://infisical.com/docs/self-hosting/configuration/envars) (inline, e.g. for gitops mechanism).\nThose variables take precedence over `infisical.kubeSecretRef`",
           "title": "config"
         },
         "deploymentAnnotations": {
-          "additionalProperties": true,
           "description": "Backend deployment annotations",
-          "title": "deploymentAnnotations"
+          "title": "deploymentAnnotations",
+          "type": "object"
         },
         "enabled": {
-          "description": "Enable backend",
+          "default": "true",
+          "description": "Enable Infisical",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "",
           "description": "Backend deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
@@ -200,6 +253,7 @@
         "image": {
           "properties": {
             "pullPolicy": {
+              "default": "IfNotPresent",
               "description": "Backend image pullPolicy",
               "title": "pullPolicy",
               "enum": [
@@ -209,11 +263,13 @@
               ]
             },
             "repository": {
+              "default": "infisical/infisical",
               "description": "Backend image repository",
               "title": "repository",
               "type": "string"
             },
             "tag": {
+              "default": "v0.46.3-postgres",
               "description": "Backend image [tag](https://hub.docker.com/r/infisical/infisical/tags)",
               "title": "tag",
               "type": "string"
@@ -224,21 +280,26 @@
           "type": "object"
         },
         "kubeSecretRef": {
+          "default": "infisical-secrets",
           "description": "Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))",
           "title": "kubeSecretRef",
-          "type": "string"
+          "examples": [
+            "infisical-secrets"
+          ]
         },
         "name": {
+          "default": "infisical",
           "description": "Backend deployment name",
           "title": "name",
           "type": "string"
         },
         "podAnnotations": {
-          "additionalProperties": true,
           "description": "Backend pod annotations",
-          "title": "podAnnotations"
+          "title": "podAnnotations",
+          "type": "object"
         },
         "replicaCount": {
+          "default": "2",
           "minimum": 1,
           "description": "Backend replicas count",
           "title": "replicaCount"
@@ -248,6 +309,7 @@
             "limits": {
               "properties": {
                 "memory": {
+                  "default": "350Mi",
                   "description": "Memory resource limit",
                   "title": "memory",
                   "type": "string"
@@ -260,6 +322,7 @@
             "requests": {
               "properties": {
                 "cpu": {
+                  "default": "350m",
                   "description": "CPU resource request",
                   "title": "cpu",
                   "type": "string"
@@ -277,16 +340,18 @@
         "service": {
           "properties": {
             "annotations": {
-              "additionalProperties": true,
               "description": "Backend service annotations",
-              "title": "annotations"
+              "title": "annotations",
+              "type": "object"
             },
             "nodePort": {
+              "default": "0000",
               "description": "Backend service nodePort (used if above type is `NodePort`)",
               "title": "nodePort",
               "type": "integer"
             },
             "type": {
+              "default": "ClusterIP",
               "description": "Backend service type",
               "title": "type",
               "enum": [
@@ -301,27 +366,30 @@
         }
       },
       "description": "Infisical parameters\nhttps://infisical.com/docs/self-hosting/deployments/kubernetes",
-      "title": "infisical"
+      "title": "infisical",
+      "type": "object"
     },
     "ingress": {
-      "additionalProperties": true,
       "properties": {
         "annotations": {
-          "additionalProperties": true,
           "description": "Ingress annotations",
-          "title": "annotations"
+          "title": "annotations",
+          "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable ingress",
           "title": "enabled",
           "type": "boolean"
         },
         "hostName": {
+          "default": "",
+          "format": "idn-hostname",
           "description": "Your instance's hostname (e.g. `infisical.example.org`).\nReplace with your own domain",
-          "title": "hostName",
-          "type": "string"
+          "title": "hostName"
         },
         "ingressClassName": {
+          "default": "nginx",
           "description": "Ingress class name",
           "title": "ingressClassName",
           "type": "string"
@@ -329,61 +397,72 @@
         "nginx": {
           "properties": {
             "enabled": {
+              "default": "true",
               "description": "Enable and install NginX ingress controller",
               "title": "enabled",
               "type": "boolean"
             }
           },
-          "title": "nginx"
+          "title": "nginx",
+          "type": "object"
         },
         "tls": {
           "items": {},
           "description": "kubernetes.io/ingress.class: \"nginx\"\ncert-manager.io/issuer: letsencrypt-nginx\nIngress TLS hosts (matching above `ingress.hostName`).\nReplace with your own domain",
-          "title": "tls"
+          "title": "tls",
+          "type": "array"
         }
       },
       "description": "Ingress parameters\nhttps://kubernetes.io/docs/concepts/services-networking/ingress-controllers/",
-      "title": "ingress"
+      "title": "ingress",
+      "type": "object"
     },
     "nameOverride": {
+      "default": "",
       "description": "Override release name",
-      "title": "nameOverride"
+      "title": "nameOverride",
+      "type": "string"
     },
     "postgresql": {
-      "additionalProperties": true,
       "properties": {
         "auth": {
-          "additionalProperties": true,
           "properties": {
             "database": {
+              "default": "infisicalDB",
               "description": "PostgreSQL database name",
               "title": "database",
               "type": "string"
             },
             "password": {
+              "default": "root",
               "description": "PostgreSQL database password",
               "title": "password",
               "type": "string"
             },
             "username": {
+              "default": "infisical",
               "description": "PostgreSQL database username",
               "title": "username",
               "type": "string"
             }
           },
-          "title": "auth"
+          "title": "auth",
+          "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable PostgreSQL",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "postgresql",
           "description": "PostgreSQL deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "name": {
+          "default": "postgresql",
           "description": "PostgreSQL deployment name",
           "title": "name",
           "type": "string"
@@ -392,57 +471,63 @@
           "properties": {
             "accessModes": {
               "items": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  }
+                "enum": [
+                  "ReadWriteOnce",
+                  "ReadOnlyMany",
+                  "ReadWriteMany",
+                  "ReadWriteOncePod"
                 ]
               },
-              "description": "PVC Access Mode for PostgreSQL volume",
+              "description": "PVC [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for PostgreSQL volume",
               "title": "accessModes",
               "type": "array"
             },
             "annotations": {
-              "additionalProperties": true,
               "description": "Annotations for the PVC",
-              "title": "annotations"
+              "title": "annotations",
+              "type": "object"
             },
             "dataSource": {
-              "additionalProperties": true,
               "description": "Custom PVC data source",
-              "title": "dataSource"
+              "title": "dataSource",
+              "type": "object"
             },
             "enabled": {
+              "default": "true",
               "description": "Enable PostgreSQL Primary data persistence using PVC",
               "title": "enabled",
               "type": "boolean"
             },
             "existingClaim": {
+              "default": "",
               "description": "Name of an existing PVC to use",
               "title": "existingClaim",
               "type": "string"
             },
             "labels": {
-              "additionalProperties": true,
               "description": "Labels for the PVC",
-              "title": "labels"
+              "title": "labels",
+              "type": "object"
             },
             "mountPath": {
+              "default": "/bitnami/postgresql",
               "description": "The path the volume will be mounted at.\nUseful when using custom PostgreSQL images",
               "title": "mountPath",
               "type": "string"
             },
             "selector": {
-              "additionalProperties": true,
               "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
-              "title": "selector"
+              "title": "selector",
+              "type": "object"
             },
             "size": {
+              "default": "8Gi",
               "description": "PVC Storage Request for PostgreSQL volume",
               "title": "size",
               "type": "string"
             },
             "storageClass": {
+              "default": "",
               "description": "PVC Storage Class for PostgreSQL Primary data volume.\nIf defined, `storageClassName: \u003cstorageClass\u003e`\nIf set to `\"-\"`, `storageClassName: \"\"`, which disables dynamic provisioning\nDefault is undefined/null, no `storageClassName` spec is set. Using default provisioner",
               "title": "storageClass",
               "type": "string"
@@ -454,12 +539,13 @@
         }
       },
       "description": "PostgreSQL parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/postgresql",
-      "title": "postgresql"
+      "title": "postgresql",
+      "type": "object"
     },
     "redis": {
-      "additionalProperties": true,
       "properties": {
         "architecture": {
+          "default": "standalone",
           "description": "Redis architecture. Allowed values: `standalone` or `replication`",
           "title": "architecture",
           "enum": [
@@ -468,39 +554,57 @@
           ]
         },
         "auth": {
-          "additionalProperties": true,
           "properties": {
             "enabled": {
+              "default": "true",
               "description": "Enable Redis password authentication",
               "title": "enabled",
               "type": "boolean"
             },
+            "existingSecret": {
+              "default": "",
+              "description": "The name of an existing secret with Redis\u0026reg; credentials.",
+              "title": "existingSecret",
+              "type": "string"
+            },
+            "existingSecretPasswordKey": {
+              "default": "",
+              "description": "Password key to be retrieved from existing secret (ignored unless `existingSecret` parameter is set).",
+              "title": "existingSecretPasswordKey",
+              "type": "string"
+            },
             "password": {
+              "default": "mysecretpassword",
               "description": "Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).\nDefaults to a random 10-character alphanumeric string if not set and `usePassword` is true",
               "title": "password",
               "type": "string"
             }
           },
-          "title": "auth"
+          "title": "auth",
+          "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable Redis",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "redis",
           "description": "Redis deployment fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "name": {
+          "default": "redis",
           "description": "Redis deployment name",
           "title": "name",
           "type": "string"
         }
       },
       "description": "Redis parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/redis",
-      "title": "redis"
+      "title": "redis",
+      "type": "object"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -347,14 +347,14 @@ redis:
   # -- Redis deployment fullname override
   fullnameOverride: "redis"
   # @schema
-  # type: boolean
-  # @schema
-  # -- Use password authentication
-  usePassword: true
-  # @schema
   # additionalProperties: true
   # @schema
   auth:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Enable Redis password authentication
+    enabled: true
     # -- Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).
     # Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true
     password: "mysecretpassword"

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -1,42 +1,23 @@
 # yaml-language-server: $schema=values.schema.json
 
-# @schema
-# required: false
-# @schema
 # -- Override release name
 nameOverride: ""
-# @schema
-# required: false
-# @schema
 # -- Override release fullname
 fullnameOverride: ""
 
-# @schema
-# required: false
-# additionalProperties: true
-# @schema
 # Infisical parameters
 # https://infisical.com/docs/self-hosting/deployments/kubernetes
 infisical:
-  # @schema
-  # type: boolean
-  # @schema
-  # -- Enable backend
+  # -- Enable Infisical
   enabled: true
   # -- Backend deployment name
   name: infisical
-  # -- Automatically migrate database
+  # -- Automatically apply database schema migration
   autoDatabaseSchemaMigration: true
   # -- Backend deployment fullname override
   fullnameOverride: ""
-  # @schema
-  # additionalProperties: true
-  # @schema
   # -- Backend pod annotations
   podAnnotations: {}
-  # @schema
-  # additionalProperties: true
-  # @schema
   # -- Backend deployment annotations
   deploymentAnnotations: {}
   # @schema
@@ -51,154 +32,174 @@ infisical:
     # -- Backend image [tag](https://hub.docker.com/r/infisical/infisical/tags)
     tag: "v0.46.3-postgres"
     # @schema
-    # enum:
-    # - IfNotPresent
-    # - Always
-    # - Never
+    # enum: [IfNotPresent,Always,Never]
     # @schema
     # -- Backend image pullPolicy
     pullPolicy: IfNotPresent
-  # @schema
-  # additionalProperties: true
-  # @schema
   # -- Backend pod affinity
   affinity: {}
+  # @schema
+  # examples: [infisical-secrets]
+  # @schema
   # -- Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   kubeSecretRef: "infisical-secrets"
   # @schema
+  # patternProperties:
+  #   "^CLIENT_.*":
+  #     type: string
   # properties:
   #   ENCRYPTION_KEY:
+  #     title: ENCRYPTION_KEY
   #     description: Must be a random 16 byte hex string. Can be generated with `openssl rand -hex 16`.
   #     type: string
+  #     examples: [f47dc9501a44c19efe46ca982eb96c9f]
+  #     pattern: ^[a-zA-Z0-9]{32}$
   #   AUTH_SECRET:
+  #     title: AUTH_SECRET
   #     description: Must be a random 32 byte base64 string. Can be generated with `openssl rand -base64 32`.
   #     type: string
+  #     examples: [kR4i4vGsaS1Cz2kCDLRO5LpKmtRuk09ThARraYOn5sQ=]
+  #     pattern: ^[-A-Za-z0-9+\/]{43}={0,3}$
   #   SITE_URL:
+  #     title: SITE_URL
   #     description: Must be an absolute URL including the protocol (e.g. https://app.infisical.com).
   #     type: string
+  #     examples: [https://app.infisical.com]
   #   DB_CONNECTION_URI:
+  #     title: DB_CONNECTION_URI
   #     description: Database connection string (postgres, e.g. 'postgresql://user:pass@host:5432/my_db').
   #     type: string
+  #     examples: [postgresql://user:pass@host:5432/my_db]
+  #     pattern: ^postgresql:(?://[^/]+/)?(\w+)
   #   DB_ROOT_CERT:
+  #     title: DB_ROOT_CERT
   #     description: Configure the SSL certificate for securing a Postgres connection by first encoding it in base64. To encode your certificate `echo "<certificate>" | base64`
   #     type: string
   #   REDIS_URL:
+  #     title: REDIS_URL
   #     description: Redis connection string (e.g. 'redis://user:pass@host:6379').
   #     type: string
+  #     examples: [redis://user:pass@host:6379]
   #   SMTP_HOST:
-  #     description: Hostname to connect to for establishing SMTP connections (e.g. smtp.sendgrid.net).
+  #     title: SMTP_HOST
+  #     description: Hostname to connect to for establishing SMTP connections (e.g. smtp.example.org).
   #     type: string
+  #     examples: [smtp.example.org] 
   #   SMTP_PORT:
+  #     title: SMTP_PORT
   #     description: Port to connect to for establishing SMTP connections.
   #     type: integer
   #   SMTP_USERNAME:
-  #     description: Credential to connect to host (e.g. team@infisical.com).
+  #     title: SMTP_USERNAME
+  #     description: Credential to connect to host (e.g. team@example.org).
   #     type: string
+  #     examples: [team@example.org]
+  #     format: idn-email
   #   SMTP_PASSWORD:
+  #     title: SMTP_PASSWORD
   #     description: Credential to connect to host.
   #     type: string
   #   SMTP_SECURE:
+  #     title: SMTP_SECURE
   #     description: If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported.
   #     type: boolean
   #   SMTP_FROM_ADDRESS:
+  #     title: SMTP_FROM_ADDRESS
   #     description: Email address to be used for sending emails.
   #     type: string
+  #     examples: [team@example.org]
+  #     format: idn-email
   #   SMTP_FROM_NAME:
+  #     title: SMTP_FROM_NAME
   #     description: Name label to be used in From field (e.g. Team)
   #     type: string
   #   CLIENT_ID_HEROKU:
+  #     title: CLIENT_ID_HEROKU
   #     description: OAuth2 client ID for Heroku integration.
-  #     type: string
   #   CLIENT_ID_VERCEL:
+  #     title: CLIENT_ID_VERCEL
   #     description: OAuth2 client ID for Vercel integration.
-  #     type: string
   #   CLIENT_ID_NETLIFY:
+  #     title: CLIENT_ID_NETLIFY
   #     description: OAuth2 client ID for Netlify integration.
-  #     type: string
   #   CLIENT_ID_GITHUB:
+  #     title: CLIENT_ID_GITHUB
   #     description: OAuth2 client ID for GitHub integration.
-  #     type: string
   #   CLIENT_ID_GITLAB:
+  #     title: CLIENT_ID_GITLAB
   #     description: OAuth2 client id for Gitlab integration.
-  #     type: string
   #   CLIENT_ID_BITBUCKET:
+  #     title: CLIENT_ID_BITBUCKET
   #     description: OAuth2 client ID for BitBucket integration.
-  #     type: string
   #   CLIENT_SECRET_HEROKU:
+  #     title: CLIENT_SECRET_HEROKU
   #     description: OAuth2 client secret for Heroku integration.
-  #     type: string
   #   CLIENT_SECRET_VERCEL:
+  #     title: CLIENT_SECRET_VERCEL
   #     description: OAuth2 client secret for Vercel integration.
-  #     type: string
   #   CLIENT_SECRET_NETLIFY:
+  #     title: CLIENT_SECRET_NETLIFY
   #     description: OAuth2 client secret for Netlify integration.
-  #     type: string
   #   CLIENT_SECRET_GITHUB:
+  #     title: CLIENT_SECRET_GITHUB
   #     description: OAuth2 client secret for GitHub integration.
-  #     type: string
   #   CLIENT_SECRET_GITLAB:
+  #     title: CLIENT_SECRET_GITLAB
   #     description: OAuth2 client secret for Gitlab integration.
-  #     type: string
   #   CLIENT_SECRET_BITBUCKET:
+  #     title: CLIENT_SECRET_BITBUCKET
   #     description: OAuth2 client secret for BitBucket integration.
-  #     type: string
   #   CLIENT_SLUG_VERCEL:
+  #     title: CLIENT_SLUG_VERCEL
   #     description: OAuth2 slug for Vercel integration.
-  #     type: string
-  #   POSTHOG_HOST:
-  #     description: 
-  #     type: string
-  #   POSTHOG_PROJECT_API_KEY:
-  #     description: 
-  #     type: string
   #   CLIENT_ID_GOOGLE_LOGIN:
+  #     title: CLIENT_ID_GOOGLE_LOGIN
   #     description: OAuth2 client ID for Google login.
-  #     type: string
   #   CLIENT_SECRET_GOOGLE_LOGIN:
+  #     title: CLIENT_SECRET_GOOGLE_LOGIN
   #     description: OAuth2 client secret for Google login.
-  #     type: string
   #   CLIENT_ID_GITHUB_LOGIN:
+  #     title: CLIENT_ID_GITHUB_LOGIN
   #     description: OAuth2 client ID for GitHub login.
-  #     type: string
   #   CLIENT_SECRET_GITHUB_LOGIN:
+  #     title: CLIENT_SECRET_GITHUB_LOGIN
   #     description: OAuth2 client secret for GitHub login.
-  #     type: string
   #   CLIENT_ID_GITLAB_LOGIN:
+  #     title: CLIENT_ID_GITLAB_LOGIN
   #     description: OAuth2 client ID for GitLab login.
-  #     type: string
   #   CLIENT_SECRET_GITLAB_LOGIN:
+  #     title: CLIENT_SECRET_GITLAB_LOGIN
   #     description: OAuth2 client secret for GitLab login.
-  #     type: string
-  #   URL_GITLAB_LOGIN: 
+  #   URL_GITLAB_LOGIN:
+  #     title: URL_GITLAB_LOGIN 
   #     description: URL of your self-hosted instance of GitLab where the OAuth application is registered (default 'https://gitlab.com').
   #     type: string
+  #     examples: [https://gitlab.com] 
   #   CLIENT_ID_GCP_SECRET_MANAGER:
+  #     title: CLIENT_ID_GCP_SECRET_MANAGER
   #     description: OAuth2 client id for GCP secrets manager integration.
-  #     type: string
   #   CLIENT_SECRET_GCP_SECRET_MANAGER:
+  #     title: CLIENT_SECRET_GCP_SECRET_MANAGER
   #     description: OAuth2 client secret for GCP secrets manager integration.
-  #     type: string
   #   CLIENT_ID_AZURE:
+  #     title: CLIENT_ID_AZURE
   #     description: OAuth2 client id for Azure integration.
-  #     type: string
   #   CLIENT_SECRET_AZURE:
+  #     title: CLIENT_SECRET_AZURE
   #     description: OAuth2 client secret for Azure integration.
+  #   SENTRY_DSN:
+  #     description: Sentry (optional) for monitoring errors
   #     type: string
   # @schema
   # -- Backend [configuration variables](https://infisical.com/docs/self-hosting/configuration/envars) (inline, e.g. for gitops mechanism).
   # Those variables take precedence over `infisical.kubeSecretRef`
-  config: {}
+  config: {}    
   # Backend service
   service:
-    # @schema
-    # additionalProperties: true
-    # @schema
     # -- Backend service annotations
     annotations: {}
     # @schema
-    # enum:
-    # - ClusterIP
-    # - NodePort
+    # enum: [ClusterIP,NodePort]
     # @schema
     # -- Backend service type
     type: ClusterIP
@@ -218,42 +219,26 @@ infisical:
       # -- CPU resource request
       cpu: "350m"
 
-# @schema
-# additionalProperties: true
-# @schema
 # Ingress parameters
 # https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
 ingress:
-  # @schema
-  # type: boolean
-  # @schema
   # -- Enable ingress
   enabled: true
+  # @schema
+  # format: idn-hostname
+  # @schema
   # -- Your instance's hostname (e.g. `infisical.example.org`).
   # Replace with your own domain
   hostName: ""
   # -- Ingress class name
   ingressClassName: nginx
-  # @schema
-  # required: false
-  # @schema
   nginx:
-    # @schema
-    # type: boolean
-    # @schema
     # -- Enable and install NginX ingress controller
     enabled: true
-  # @schema
-  # additionalProperties: true
-  # required: false
-  # @schema
   # -- Ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # cert-manager.io/issuer: letsencrypt-nginx
-  # @schema
-  # required: false
-  # @schema
   # -- Ingress TLS hosts (matching above `ingress.hostName`).
   # Replace with your own domain
   tls: []
@@ -261,25 +246,15 @@ ingress:
     #   hosts:
     #     - infisical.example.org
 
-# @schema
-# required: false
-# additionalProperties: true
-# @schema
 # PostgreSQL parameters
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 postgresql:
-  # @schema
-  # type: boolean
-  # @schema
   # -- Enable PostgreSQL
   enabled: true
   # -- PostgreSQL deployment name
   name: "postgresql"
   # -- PostgreSQL deployment fullname override
   fullnameOverride: "postgresql"
-  # @schema
-  # additionalProperties: true
-  # @schema
   auth:
     # -- PostgreSQL database username
     username: infisical
@@ -289,9 +264,6 @@ postgresql:
     database: infisicalDB
   # PostgreSQL Primary persistence configuration
   persistence:
-    # @schema
-    # type: boolean
-    # @schema
     # -- Enable PostgreSQL Primary data persistence using PVC
     enabled: true
     # -- Name of an existing PVC to use
@@ -304,64 +276,46 @@ postgresql:
     # If set to `"-"`, `storageClassName: ""`, which disables dynamic provisioning
     # Default is undefined/null, no `storageClassName` spec is set. Using default provisioner
     storageClass: ""
-    # -- PVC Access Mode for PostgreSQL volume
+    # @schema
+    # type: array
+    # items:
+    #   enum: [ReadWriteOnce,ReadOnlyMany,ReadWriteMany,ReadWriteOncePod]
+    # @schema
+    # -- PVC [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for PostgreSQL volume
     accessModes:
       - ReadWriteOnce
     # -- PVC Storage Request for PostgreSQL volume
     size: 8Gi
-    # @schema
-    # additionalProperties: true
-    # @schema
     # -- Annotations for the PVC
     annotations: {}
-    # @schema
-    # additionalProperties: true
-    # @schema
     # -- Labels for the PVC
     labels: {}
-    # @schema
-    # additionalProperties: true
-    # @schema
     # -- Selector to match an existing Persistent Volume (this value is evaluated as a template)
     selector: {}
-    # @schema
-    # additionalProperties: true
-    # @schema
     # -- Custom PVC data source
     dataSource: {}
 
-# @schema
-# required: false
-# additionalProperties: true
-# @schema
 # Redis parameters
 # https://github.com/bitnami/charts/tree/main/bitnami/redis
 redis:
-  # @schema
-  # type: boolean
-  # @schema
   # -- Enable Redis
   enabled: true
   # -- Redis deployment name
   name: "redis"
   # -- Redis deployment fullname override
   fullnameOverride: "redis"
-  # @schema
-  # additionalProperties: true
-  # @schema
   auth:
-    # @schema
-    # type: boolean
-    # @schema
     # -- Enable Redis password authentication
     enabled: true
+    # -- The name of an existing secret with Redis&reg; credentials.
+    existingSecret: ""
+    # -- Password key to be retrieved from existing secret (ignored unless `existingSecret` parameter is set).
+    existingSecretPasswordKey: ""
     # -- Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).
     # Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true
     password: "mysecretpassword"
   # @schema
-  # enum:
-  # - standalone
-  # - replication
+  # enum: [standalone,replication]
   # @schema
   # -- Redis architecture. Allowed values: `standalone` or `replication`
   architecture: standalone

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -1,62 +1,367 @@
+# yaml-language-server: $schema=values.schema.json
+
+# @schema
+# required: false
+# @schema
+# -- Override release name
 nameOverride: ""
+# @schema
+# required: false
+# @schema
+# -- Override release fullname
 fullnameOverride: ""
 
+# @schema
+# required: false
+# additionalProperties: true
+# @schema
+# Infisical parameters
+# https://infisical.com/docs/self-hosting/deployments/kubernetes
 infisical:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Enable backend
   enabled: true
+  # -- Backend deployment name
   name: infisical
+  # -- Automatically migrate database
   autoDatabaseSchemaMigration: true
+  # -- Backend deployment fullname override
   fullnameOverride: ""
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Backend pod annotations
   podAnnotations: {}
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Backend deployment annotations
   deploymentAnnotations: {}
+  # @schema
+  # minimum: 1
+  # @schema
+  # -- Backend replicas count
   replicaCount: 2
-
+  # Backend image parameters
   image:
+    # -- Backend image repository
     repository: infisical/infisical
+    # -- Backend image [tag](https://hub.docker.com/r/infisical/infisical/tags)
     tag: "v0.46.3-postgres"
+    # @schema
+    # enum:
+    # - IfNotPresent
+    # - Always
+    # - Never
+    # @schema
+    # -- Backend image pullPolicy
     pullPolicy: IfNotPresent
-
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Backend pod affinity
   affinity: {}
+  # -- Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   kubeSecretRef: "infisical-secrets"
+  # @schema
+  # properties:
+  #   ENCRYPTION_KEY:
+  #     description: Must be a random 16 byte hex string. Can be generated with `openssl rand -hex 16`.
+  #     type: string
+  #   AUTH_SECRET:
+  #     description: Must be a random 32 byte base64 string. Can be generated with `openssl rand -base64 32`.
+  #     type: string
+  #   SITE_URL:
+  #     description: Must be an absolute URL including the protocol (e.g. https://app.infisical.com).
+  #     type: string
+  #   DB_CONNECTION_URI:
+  #     description: Database connection string (postgres, e.g. 'postgresql://user:pass@host:5432/my_db').
+  #     type: string
+  #   DB_ROOT_CERT:
+  #     description: Configure the SSL certificate for securing a Postgres connection by first encoding it in base64. To encode your certificate `echo "<certificate>" | base64`
+  #     type: string
+  #   REDIS_URL:
+  #     description: Redis connection string (e.g. 'redis://user:pass@host:6379').
+  #     type: string
+  #   SMTP_HOST:
+  #     description: Hostname to connect to for establishing SMTP connections (e.g. smtp.sendgrid.net).
+  #     type: string
+  #   SMTP_PORT:
+  #     description: Port to connect to for establishing SMTP connections.
+  #     type: integer
+  #   SMTP_USERNAME:
+  #     description: Credential to connect to host (e.g. team@infisical.com).
+  #     type: string
+  #   SMTP_PASSWORD:
+  #     description: Credential to connect to host.
+  #     type: string
+  #   SMTP_SECURE:
+  #     description: If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported.
+  #     type: boolean
+  #   SMTP_FROM_ADDRESS:
+  #     description: Email address to be used for sending emails.
+  #     type: string
+  #   SMTP_FROM_NAME:
+  #     description: Name label to be used in From field (e.g. Team)
+  #     type: string
+  #   CLIENT_ID_HEROKU:
+  #     description: OAuth2 client ID for Heroku integration.
+  #     type: string
+  #   CLIENT_ID_VERCEL:
+  #     description: OAuth2 client ID for Vercel integration.
+  #     type: string
+  #   CLIENT_ID_NETLIFY:
+  #     description: OAuth2 client ID for Netlify integration.
+  #     type: string
+  #   CLIENT_ID_GITHUB:
+  #     description: OAuth2 client ID for GitHub integration.
+  #     type: string
+  #   CLIENT_ID_GITLAB:
+  #     description: OAuth2 client id for Gitlab integration.
+  #     type: string
+  #   CLIENT_ID_BITBUCKET:
+  #     description: OAuth2 client ID for BitBucket integration.
+  #     type: string
+  #   CLIENT_SECRET_HEROKU:
+  #     description: OAuth2 client secret for Heroku integration.
+  #     type: string
+  #   CLIENT_SECRET_VERCEL:
+  #     description: OAuth2 client secret for Vercel integration.
+  #     type: string
+  #   CLIENT_SECRET_NETLIFY:
+  #     description: OAuth2 client secret for Netlify integration.
+  #     type: string
+  #   CLIENT_SECRET_GITHUB:
+  #     description: OAuth2 client secret for GitHub integration.
+  #     type: string
+  #   CLIENT_SECRET_GITLAB:
+  #     description: OAuth2 client secret for Gitlab integration.
+  #     type: string
+  #   CLIENT_SECRET_BITBUCKET:
+  #     description: OAuth2 client secret for BitBucket integration.
+  #     type: string
+  #   CLIENT_SLUG_VERCEL:
+  #     description: OAuth2 slug for Vercel integration.
+  #     type: string
+  #   POSTHOG_HOST:
+  #     description: 
+  #     type: string
+  #   POSTHOG_PROJECT_API_KEY:
+  #     description: 
+  #     type: string
+  #   CLIENT_ID_GOOGLE_LOGIN:
+  #     description: OAuth2 client ID for Google login.
+  #     type: string
+  #   CLIENT_SECRET_GOOGLE_LOGIN:
+  #     description: OAuth2 client secret for Google login.
+  #     type: string
+  #   CLIENT_ID_GITHUB_LOGIN:
+  #     description: OAuth2 client ID for GitHub login.
+  #     type: string
+  #   CLIENT_SECRET_GITHUB_LOGIN:
+  #     description: OAuth2 client secret for GitHub login.
+  #     type: string
+  #   CLIENT_ID_GITLAB_LOGIN:
+  #     description: OAuth2 client ID for GitLab login.
+  #     type: string
+  #   CLIENT_SECRET_GITLAB_LOGIN:
+  #     description: OAuth2 client secret for GitLab login.
+  #     type: string
+  #   URL_GITLAB_LOGIN: 
+  #     description: URL of your self-hosted instance of GitLab where the OAuth application is registered (default 'https://gitlab.com').
+  #     type: string
+  #   CLIENT_ID_GCP_SECRET_MANAGER:
+  #     description: OAuth2 client id for GCP secrets manager integration.
+  #     type: string
+  #   CLIENT_SECRET_GCP_SECRET_MANAGER:
+  #     description: OAuth2 client secret for GCP secrets manager integration.
+  #     type: string
+  #   CLIENT_ID_AZURE:
+  #     description: OAuth2 client id for Azure integration.
+  #     type: string
+  #   CLIENT_SECRET_AZURE:
+  #     description: OAuth2 client secret for Azure integration.
+  #     type: string
+  # @schema
+  # -- Backend [configuration variables](https://infisical.com/docs/self-hosting/configuration/envars) (inline, e.g. for gitops mechanism).
+  # Those variables take precedence over `infisical.kubeSecretRef`
+  config: {}
+  # Backend service
   service:
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Backend service annotations
     annotations: {}
+    # @schema
+    # enum:
+    # - ClusterIP
+    # - NodePort
+    # @schema
+    # -- Backend service type
     type: ClusterIP
-    nodePort: ""
-
+    # -- Backend service nodePort (used if above type is `NodePort`)
+    nodePort: 0000
+  # Infisical instance resources and limits
   resources:
+    # Above which Infisical's pods will not be able to use
+    # Warning: too low resources may alter the application's stability
     limits:
-      memory: 350Mi
+      # -- Memory resource limit
+      memory: "350Mi"
+    # Infisical's pods will at least use the below resources
+    # Warning: too low resources may alter the application's stability
+    # Warning: make sure your cluster have enough resources, taking into consideration the replicas amount
     requests:
-      cpu: 350m
+      # -- CPU resource request
+      cpu: "350m"
 
+# @schema
+# additionalProperties: true
+# @schema
+# Ingress parameters
+# https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
 ingress:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Enable ingress
   enabled: true
+  # -- Your instance's hostname (e.g. `infisical.example.org`).
+  # Replace with your own domain
   hostName: ""
+  # -- Ingress class name
   ingressClassName: nginx
+  # @schema
+  # required: false
+  # @schema
   nginx:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Enable and install NginX ingress controller
     enabled: true
+  # @schema
+  # additionalProperties: true
+  # required: false
+  # @schema
+  # -- Ingress annotations
   annotations: {}
-  tls:
-    []
+    # kubernetes.io/ingress.class: "nginx"
+    # cert-manager.io/issuer: letsencrypt-nginx
+  # @schema
+  # required: false
+  # @schema
+  # -- Ingress TLS hosts (matching above `ingress.hostName`).
+  # Replace with your own domain
+  tls: []
     # - secretName: letsencrypt-prod
     #   hosts:
-    #     - some.domain.com
+    #     - infisical.example.org
 
+# @schema
+# required: false
+# additionalProperties: true
+# @schema
+# PostgreSQL parameters
+# https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 postgresql:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Enable PostgreSQL
   enabled: true
+  # -- PostgreSQL deployment name
   name: "postgresql"
+  # -- PostgreSQL deployment fullname override
   fullnameOverride: "postgresql"
+  # @schema
+  # additionalProperties: true
+  # @schema
   auth:
+    # -- PostgreSQL database username
     username: infisical
+    # -- PostgreSQL database password
     password: root
+    # -- PostgreSQL database name
     database: infisicalDB
+  # PostgreSQL Primary persistence configuration
+  persistence:
+    # @schema
+    # type: boolean
+    # @schema
+    # -- Enable PostgreSQL Primary data persistence using PVC
+    enabled: true
+    # -- Name of an existing PVC to use
+    existingClaim: ""
+    # -- The path the volume will be mounted at.
+    # Useful when using custom PostgreSQL images
+    mountPath: /bitnami/postgresql
+    # -- PVC Storage Class for PostgreSQL Primary data volume.
+    # If defined, `storageClassName: <storageClass>`
+    # If set to `"-"`, `storageClassName: ""`, which disables dynamic provisioning
+    # Default is undefined/null, no `storageClassName` spec is set. Using default provisioner
+    storageClass: ""
+    # -- PVC Access Mode for PostgreSQL volume
+    accessModes:
+      - ReadWriteOnce
+    # -- PVC Storage Request for PostgreSQL volume
+    size: 8Gi
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Annotations for the PVC
+    annotations: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Labels for the PVC
+    labels: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Selector to match an existing Persistent Volume (this value is evaluated as a template)
+    selector: {}
+    # @schema
+    # additionalProperties: true
+    # @schema
+    # -- Custom PVC data source
+    dataSource: {}
 
+# @schema
+# required: false
+# additionalProperties: true
+# @schema
+# Redis parameters
+# https://github.com/bitnami/charts/tree/main/bitnami/redis
 redis:
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Enable Redis
   enabled: true
+  # -- Redis deployment name
   name: "redis"
+  # -- Redis deployment fullname override
   fullnameOverride: "redis"
-  cluster:
-    enabled: false
+  # @schema
+  # type: boolean
+  # @schema
+  # -- Use password authentication
   usePassword: true
+  # @schema
+  # additionalProperties: true
+  # @schema
   auth:
+    # -- Redis [password](https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run) (ignored if `existingSecret` set).
+    # Defaults to a random 10-character alphanumeric string if not set and `usePassword` is true
     password: "mysecretpassword"
+  # @schema
+  # enum:
+  # - standalone
+  # - replication
+  # @schema
+  # -- Redis architecture. Allowed values: `standalone` or `replication`
   architecture: standalone

--- a/helm-charts/infisical/.gitignore
+++ b/helm-charts/infisical/.gitignore
@@ -1,4 +1,0 @@
-charts/
-node_modules/
-package*.json
-*.bak

--- a/helm-charts/infisical/Chart.yaml
+++ b/helm-charts/infisical/Chart.yaml
@@ -1,19 +1,43 @@
 apiVersion: v2
 name: infisical
-description: A helm chart for a full Infisical application
+description: Standalone Infisical instance (mongo, deprecated). An open-source secret management platform.
+home: https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
 
+# A chart can be either an 'application' or a 'library' chart.
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.17.0"
+# https://hub.docker.com/r/infisical/infisical/tags
+appVersion: "v0.43.19"
+
+# A URL to an SVG or PNG image to be used as an icon (optional).
+icon: https://raw.githubusercontent.com/Infisical/infisical/main/img/logotransparent.png
+
+# A list of keywords about this project (optional)
+keywords:
+- secretops
+- keyvalue
+- security
+- inject
+
+# Maintainers list (name required, optional email/url)
+maintainers:
+- name: Infisical
+  url: https://infisical.com/
+  email: team@infisical.com
 
 dependencies:
   - name: mongodb
@@ -32,3 +56,6 @@ dependencies:
     version: 4.0.13
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress.nginx.enabled
+
+# Deprecation notice (https://helm.sh/docs/topics/charts/#deprecating-charts)
+deprecated: true

--- a/helm-charts/infisical/LICENSE
+++ b/helm-charts/infisical/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2022 Infisical Inc.
+
+Portions of this software are licensed as follows:
+
+- All content that resides under any "ee/" directory of this repository, if such directories exists, are licensed under the license defined in "ee/LICENSE".
+- All third party components incorporated into the Infisical Software are licensed under the original license provided by the owner of the applicable component.
+- Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/helm-charts/infisical/README.md
+++ b/helm-charts/infisical/README.md
@@ -83,11 +83,9 @@ Find the chart upgrade instructions below. When upgrading from your version to o
 
 ---
 
-<details>
-<summary>
-
 ### **`0.1.16`**
-</summary>
+<details open>
+<summary><strong>Click for details</strong></summary>
 
 - Auto-generation for the following variables, to ease your future upgrades or setups :
   - `ENCRYPTION_KEY`
@@ -103,7 +101,6 @@ The preference order is :
 - **user-defined** (values file or inline)
   - **existing-secret** (for existing installations, you don't have to specify the secrets when upgrading if they already exist)
     - **auto-generated** (if none of the values above have been found, we'll auto-generate a value for the user, only for the above mentioned variables)
-
 </details>
 
 ## Parameters

--- a/helm-charts/infisical/README.md
+++ b/helm-charts/infisical/README.md
@@ -1,284 +1,93 @@
+
+
 # Infisical Helm Chart
 
-This is the Infisical application Helm chart. This chart includes the following :
+> [!WARNING] 
+> This chart is deprecated and discontinued in favor of the new one using PostgreSQL available **[here](../infisical-standalone-postgres/README.md)**.
+> Some information here might be outdated! Please migrate to the new version : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
 
-| Service    | Description                         |
-| ---------- | ----------------------------------- |
-| `backend`  | Infisical's API                     |
-| `mongodb`  | Infisical's database                |
-| `redis`    | Infisical's cache service           |
-| `mailhog`  | Infisical's development SMTP server |
+| Name | Chart | Application |
+| - | - | - |
+| [infisical](https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm) | [![Latest version of 'infisical' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/infisical/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/infisical/latest/) | `v0.43.19` |
 
-## Installation
+Standalone Infisical instance (mongo, deprecated). An open-source secret management platform.
 
-To install the chart, run the following :
+## Services
+
+| Service   | Description      |
+| --------- | ---------------- |
+| `backend` | Infisical's API  |
+| `mongodb` | Database service |
+| `redis`   | Cache service    |
+| `mailhog` | SMTP server      |
+
+## Installation & upgrade
+
+To install or upgrade the `infisical` chart, run the following:
 
 ```sh
-# Add the Infisical repository
+# add the Infisical Helm repository
 helm repo add infisical 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/' && helm repo update
+```
 
-# Install Infisical (with default values)
+```sh
+# with default values
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
   infisical infisical/infisical
 
-# Install Infisical (with custom inline values, replace with your own values)
+# with custom inline values (replace with your own values)
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
-  --set mongodb.enabled=false \
-  --set mongodbConnection.externalMongoDBConnectionString="mongodb://<user>:<pass>@<host>:<port>/<database-name>" \
+  --set ingress.hostName=custom.example.org \
   infisical infisical/infisical
 
-# Install Infisical (with custom values file, replace with your own values file)
+# with custom values file (replace with your own values file)
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
   -f custom-values.yaml \
   infisical infisical/infisical
 ```
 
-### Backup up encryption keys
+Documentation is also available here : https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
 
-If you did not explicitly set required environment variables, this helm chart will auto-generated them by default. It's recommended to save these credentials somewhere safe. Run the following command in your cluster where Infisical chart is installed. 
-  
-This command requires [`jq`](https://stedolan.github.io/jq/download/)
+> [!IMPORTANT]
+> If you change the configuration variables in the `infisical-secrets` resource, you might have to restart the infisical deployment to take effect
+
+### Encryption keys
+
+If you did not explicitly set required environment variables, the local setup ([./examples](./examples)) auto-generated them by default. It's recommended to save these credentials somewhere safe. Run the following command in your cluster where Infisical chart is installed.
+ 
+> [!NOTE]
+> Requires [`jq`](https://stedolan.github.io/jq/download/)
 
 ```sh
-# export secrets to a given file (requires jq)
-kubectl get secrets -n <namespace> <secret-name> \
+# export secrets to a given file
+kubectl get secrets -n infisical-dev infisical-secrets \
   -o json | jq '.data | map_values(@base64d)' > \
-  <dest-filename>.bak
+  infisical-secrets.$(date +%s).bak
 ```
 
-## Parameters
+### Upgrading
 
-### Common parameters
-
-| Name               | Description               | Value |
-| ------------------ | ------------------------- | ----- |
-| `nameOverride`     | Override release name     | `""`  |
-| `fullnameOverride` | Override release fullname | `""`  |
-
-### Infisical backend parameters
-
-| Name                                                   | Description                                                                                                                                                                                                                         | Value                       |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `backend.enabled`                                      | Enable backend                                                                                                                                                                                                                      | `true`                      |
-| `backend.name`                                         | Backend name                                                                                                                                                                                                                        | `backend`                   |
-| `backend.fullnameOverride`                             | Backend fullnameOverride                                                                                                                                                                                                            | `""`                        |
-| `backend.podAnnotations`                               | Backend pod annotations                                                                                                                                                                                                             | `{}`                        |
-| `backend.deploymentAnnotations`                        | Backend deployment annotations                                                                                                                                                                                                      | `{}`                        |
-| `backend.replicaCount`                                 | Backend replica count                                                                                                                                                                                                               | `2`                         |
-| `backend.image.repository`                             | Backend image repository                                                                                                                                                                                                            | `infisical/infisical`       |
-| `backend.image.tag`                                    | Backend image tag                                                                                                                                                                                                                   | `latest`                    |
-| `backend.image.pullPolicy`                             | Backend image pullPolicy                                                                                                                                                                                                            | `IfNotPresent`              |
-| `backend.affinity`                                     | Backend pod affinity                                                                                                                                                                                                                | `{}`                        |
-| `backend.kubeSecretRef`                                | Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))                                                                        | `""`                        |
-| `backend.service.annotations`                          | Backend service annotations                                                                                                                                                                                                         | `{}`                        |
-| `backend.service.type`                                 | Backend service type                                                                                                                                                                                                                | `ClusterIP`                 |
-| `backend.service.nodePort`                             | Backend service nodePort (used if above type is `NodePort`)                                                                                                                                                                         | `""`                        |
-| `backendEnvironmentVariables.ENCRYPTION_KEY`           | **Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)           | `""`                        |
-| `backendEnvironmentVariables.JWT_SIGNUP_SECRET`        | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)       | `""`                        |
-| `backendEnvironmentVariables.JWT_REFRESH_SECRET`       | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)       | `""`                        |
-| `backendEnvironmentVariables.JWT_AUTH_SECRET`          | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)       | `""`                        |
-| `backendEnvironmentVariables.JWT_SERVICE_SECRET`       | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)       | `""`                        |
-| `backendEnvironmentVariables.JWT_MFA_SECRET`           | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)       | `""`                        |
-| `backendEnvironmentVariables.JWT_PROVIDER_AUTH_SECRET` | **Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) | `""`                        |
-| `backendEnvironmentVariables.SMTP_HOST`                | **Required** Hostname to connect to for establishing SMTP connections                                                                                                                                                               | `""`                        |
-| `backendEnvironmentVariables.SMTP_PORT`                | Port to connect to for establishing SMTP connections                                                                                                                                                                                | `587`                       |
-| `backendEnvironmentVariables.SMTP_SECURE`              | If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported                                                                                                                                       | `false`                     |
-| `backendEnvironmentVariables.SMTP_FROM_NAME`           | Name label to be used in From field (e.g. Infisical)                                                                                                                                                                                | `Infisical`                 |
-| `backendEnvironmentVariables.SMTP_FROM_ADDRESS`        | **Required** Email address to be used for sending emails (e.g. dev@infisical.com)                                                                                                                                                   | `""`                        |
-| `backendEnvironmentVariables.SMTP_USERNAME`            | **Required** Credential to connect to host (e.g. team@infisical.com)                                                                                                                                                                | `""`                        |
-| `backendEnvironmentVariables.SMTP_PASSWORD`            | **Required** Credential to connect to host                                                                                                                                                                                          | `""`                        |
-| `backendEnvironmentVariables.SITE_URL`                 | Absolute URL including the protocol (e.g. https://app.infisical.com)                                                                                                                                                                | `infisical.local`           |
-| `backendEnvironmentVariables.INVITE_ONLY_SIGNUP`       | To disable account creation from the login page (invites only)                                                                                                                                                                      | `false`                     |
-| `backendEnvironmentVariables.MONGO_URL`                | MongoDB connection string (external or internal)</br>Leave it empty for auto-generated connection string                                                                                                                            | `""`                        |
-| `backendEnvironmentVariables.REDIS_URL`                |                                                                                                                                                                                                                                     | `redis://redis-master:6379` |
-
-### MongoDB(&reg;) parameters
-
-| Name                                                | Description                                                                                                                                                                               | Value                |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `mongodb.enabled`                                   | Enable MongoDB(&reg;)                                                                                                                                                                     | `true`               |
-| `mongodb.name`                                      | Name used to build variables (deprecated)                                                                                                                                                 | `mongodb`            |
-| `mongodb.fullnameOverride`                          | Fullname override                                                                                                                                                                         | `mongodb`            |
-| `mongodb.nameOverride`                              | Name override                                                                                                                                                                             | `mongodb`            |
-| `mongodb.podAnnotations`                            | Pod annotations                                                                                                                                                                           | `{}`                 |
-| `mongodb.useStatefulSet`                            | Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`)                                                                                           | `true`               |
-| `mongodb.architecture`                              | MongoDB(&reg;) architecture (`standalone` or `replicaset`)                                                                                                                                | `standalone`         |
-| `mongodb.image.repository`                          | MongoDB(&reg;) image registry                                                                                                                                                             | `bitnami/mongodb`    |
-| `mongodb.image.tag`                                 | MongoDB(&reg;) image tag (immutable tags are recommended)                                                                                                                                 | `6.0.4-debian-11-r0` |
-| `mongodb.image.pullPolicy`                          | MongoDB(&reg;) image pull policy                                                                                                                                                          | `IfNotPresent`       |
-| `mongodb.livenessProbe.enabled`                     | Enable livenessProbe                                                                                                                                                                      | `true`               |
-| `mongodb.livenessProbe.initialDelaySeconds`         | Initial delay seconds for livenessProbe                                                                                                                                                   | `30`                 |
-| `mongodb.livenessProbe.periodSeconds`               | Period seconds for livenessProbe                                                                                                                                                          | `20`                 |
-| `mongodb.livenessProbe.timeoutSeconds`              | Timeout seconds for livenessProbe                                                                                                                                                         | `10`                 |
-| `mongodb.livenessProbe.failureThreshold`            | Failure threshold for livenessProbe                                                                                                                                                       | `6`                  |
-| `mongodb.livenessProbe.successThreshold`            | Success threshold for livenessProbe                                                                                                                                                       | `1`                  |
-| `mongodb.readinessProbe.enabled`                    | Enable readinessProbe                                                                                                                                                                     | `true`               |
-| `mongodb.readinessProbe.initialDelaySeconds`        | Initial delay seconds for readinessProbe                                                                                                                                                  | `5`                  |
-| `mongodb.readinessProbe.periodSeconds`              | Period seconds for readinessProbe                                                                                                                                                         | `10`                 |
-| `mongodb.readinessProbe.timeoutSeconds`             | Timeout seconds for readinessProbe                                                                                                                                                        | `10`                 |
-| `mongodb.readinessProbe.failureThreshold`           | Failure threshold for readinessProbe                                                                                                                                                      | `6`                  |
-| `mongodb.readinessProbe.successThreshold`           | Success threshold for readinessProbe                                                                                                                                                      | `1`                  |
-| `mongodb.service.annotations`                       | Service annotations                                                                                                                                                                       | `{}`                 |
-| `mongodb.auth.enabled`                              | Enable custom authentication                                                                                                                                                              | `true`               |
-| `mongodb.auth.usernames`                            | Custom usernames list ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format))                                  | `["infisical"]`      |
-| `mongodb.auth.passwords`                            | Custom passwords list, match the above usernames order ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format)) | `["infisical"]`      |
-| `mongodb.auth.databases`                            | Custom databases list ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format))                                  | `["infisical"]`      |
-| `mongodb.auth.rootUser`                             | Database root user name                                                                                                                                                                   | `root`               |
-| `mongodb.auth.rootPassword`                         | Database root user password                                                                                                                                                               | `root`               |
-| `mongodb.auth.existingSecret`                       | Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)                               | `""`                 |
-| `mongodb.persistence.enabled`                       | Enable database persistence                                                                                                                                                               | `true`               |
-| `mongodb.persistence.existingClaim`                 | Existing persistent volume claim name                                                                                                                                                     | `""`                 |
-| `mongodb.persistence.resourcePolicy`                | Keep the persistent volume even on deletion (`keep` or `""`)                                                                                                                              | `keep`               |
-| `mongodb.persistence.accessModes`                   | Persistent volume access modes                                                                                                                                                            | `["ReadWriteOnce"]`  |
-| `mongodb.persistence.size`                          | Persistent storage request size                                                                                                                                                           | `8Gi`                |
-| `mongodbConnection.externalMongoDBConnectionString` | Deprecated :warning: External MongoDB connection string</br>Use backendEnvironmentVariables.MONGO_URL instead                                                                             | `""`                 |
-
-### Ingress parameters
-
-| Name                       | Description                                                              | Value   |
-| -------------------------- | ------------------------------------------------------------------------ | ------- |
-| `ingress.enabled`          | Enable ingress                                                           | `true`  |
-| `ingress.ingressClassName` | Ingress class name                                                       | `nginx` |
-| `ingress.nginx.enabled`    | Ingress controller                                                       | `false` |
-| `ingress.annotations`      | Ingress annotations                                                      | `{}`    |
-| `ingress.hostName`         | Ingress hostname (your custom domain name, e.g. `infisical.example.org`) | `""`    |
-| `ingress.tls`              | Ingress TLS hosts (matching above hostName)                              | `[]`    |
-
-### Mailhog parameters
-
-| Name                               | Description                | Value                     |
-| ---------------------------------- | -------------------------- | ------------------------- |
-| `mailhog.enabled`                  | Enable Mailhog             | `false`                   |
-| `mailhog.fullnameOverride`         | Fullname override          | `mailhog`                 |
-| `mailhog.nameOverride`             | Name override              | `""`                      |
-| `mailhog.image.repository`         | Image repository           | `lytrax/mailhog`          |
-| `mailhog.image.tag`                | Image tag                  | `latest`                  |
-| `mailhog.image.pullPolicy`         | Image pull policy          | `IfNotPresent`            |
-| `mailhog.containerPort.http.port`  | Mailhog HTTP port (Web UI) | `8025`                    |
-| `mailhog.containerPort.smtp.port`  | Mailhog SMTP port (Mail)   | `1025`                    |
-| `mailhog.ingress.enabled`          | Enable ingress             | `true`                    |
-| `mailhog.ingress.ingressClassName` | Ingress class name         | `nginx`                   |
-| `mailhog.ingress.annotations`      | Ingress annotations        | `{}`                      |
-| `mailhog.ingress.labels`           | Ingress labels             | `{}`                      |
-| `mailhog.ingress.hosts[0].host`    | Mailhog host               | `mailhog.infisical.local` |
-
-### Redis parameters
-
-
-
-
-
-
-
-## Persistence
-
-The database persistence is enabled by default, your volumes will remain on your cluster even after uninstalling the chart. To disable persistence, set this value `mongodb.persistence.enabled: false`
-
-## Local development
-
-Find the resources and configuration about how to setup your local develoment environment on a k8s environment.
-
-### Requirements
-
-To create a local k8s environment, you'll need :
-
-- [`helm`](https://helm.sh/docs/intro/install/) <kbd>required</kbd>
-  - to generate the manifests and deploy the chart 
-- local/remote k8s cluster <kbd>required</kbd>
-  - e.g. [`kind`](https://kubernetes.io/docs/tasks/tools/), [`minikube`](https://kubernetes.io/docs/tasks/tools/) or an online provider
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) <kbd>optional</kbd>
-  - to interact with the cluster
-
-### Examples
-
-ℹ️ Find complete setup scripts in [**./examples**](./examples)
-
-Below example will deploy the following :
-
-- [**infisical.local**](https://infisical.local)
-  - Your local Infisical instance
-  - You may have to add `infisical.local` to your `/etc/hosts` or similar depending your OS
-    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
-
-- [**mailhog.infisical.local**](https://mailhog.infisical.local)
-  - Local SMTP server used to receive the emails (e.g. signup verification code)
-  - You may have to add `mailhog.infisical.local` to your `/etc/hosts` or similar depending your OS
-    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
-
-Use below values to setup a local development environment, adapt those variables as you need
-
-#### TL;DR
-
-If you're running a k8s cluster with `ingress-nginx`, you can run one of the below scripts :
-
-```sh
-# With 'kind' + 'helm', to create a local cluster and deploy the chart
-./examples.local-kind.sh
-
-# With 'helm' only, if you already have a cluster to deploy the chart
-./examples.local-helm.sh
-```
+Find the chart upgrade instructions below. When upgrading from your version to one of the listed below, please follow every instructions in between to correctly migrate all your data and avoid loss and unexpected issues.
 
 #### Instructions
 
-Here's the step-by-step instructions to setup your local development environment. First create the below file :
+1. Make sure **you have all the required environment variables** defined in the value file (`values.yaml` or inline `--set`) you'll provide to `helm`
+   1. e.g. All the above mentioned variables
+1. **Backup your existing secrets** (before the upgrade, for safety precaution)
+   1. e.g. `kubectl get secret infisical-secrets --namespace infisical-dev -o json | jq '{name: .metadata.name,data: .data|map_values(@base64d)}'`
+2. **Upgrade the chart**, with the [instructions](#upgrading)
+3. You're all set!
 
-```yaml
-# values.dev.yaml
+---
 
-# Enable mailhog for local development
-mailhog:
-    enabled: true
+<details>
+<summary>
 
-# Configure backend development variables (required)
-backendEnvironmentVariables:
-  SITE_URL: https://infisical.local
-  SMTP_FROM_ADDRESS: dev@infisical.local
-  SMTP_FROM_NAME: Local Infisical
-  SMTP_HOST: mailhog
-  SMTP_PASSWORD: ""
-  SMTP_PORT: 1025
-  SMTP_SECURE: false
-  SMTP_USERNAME: dev@infisical.local
-
-# Configure frontend development variables (required)
-frontendEnvironmentVariables:
-  SITE_URL: https://infisical.local
-```
-
-After creating the above file, run :
-
-```sh
-# Fetch the required charts
-helm dep update
-
-# Install/upgrade Infisical
-helm upgrade --install --atomic \
-  -n infisical-dev --create-namespace \
-  -f ./values.dev.yaml \
-  infisical-dev .
-```
-
-## Upgrading
-
-Find the chart upgrade instructions below. When upgrading from your version to one of the listed below, please follow every instructions in between.
-
-Here's a snippet to upgrade your installation manually :
-
-```sh
-# replace below '<placeholders>' with your own values
-helm upgrade --install --atomic \
-  -n "<your-namesapce>" --create-namespace \
-  -f "<your-values.yaml>" \
-  <your-release-name> .
-```
-
-ℹ️ Since we provide references to the k8s secret resources within the pods, their manifest file doesnt change and though doesnt reload (no changes detected). When upgrading your secrets, you'll have to do it through Helm (a timestamp field will be updated and your pods restarted)
-
-### 0.1.16
+### **`0.1.16`**
+</summary>
 
 - Auto-generation for the following variables, to ease your future upgrades or setups :
   - `ENCRYPTION_KEY`
@@ -295,34 +104,171 @@ The preference order is :
   - **existing-secret** (for existing installations, you don't have to specify the secrets when upgrading if they already exist)
     - **auto-generated** (if none of the values above have been found, we'll auto-generate a value for the user, only for the above mentioned variables)
 
-#### Instructions
+</details>
 
-1. Make sure **you have all the required environment variables** defined in the value file (or inline `--set`) you'll provide to `helm`
-   1. e.g. All the above mentioned variables
-1. **Backup your existing secrets** (safety precaution)
-   1. with below [snippets](#snippets)
-1. **Upgrade the chart**, with the [instructions](#upgrading)
-   1. It'll create a secret per service, and store the secrets/conf within (auto-generate if you don't provide the required ones)
-   1. It'll link the secret to the deployment through `envFrom`
-   1. It'll automatically remove the hard-coded `env.*` variables from your infisical deployments
-1. Make sure that the **created secrets match the ones in your backups**
-   1. e.g. `kubectl get secret -n <namespace> <release-name>-backend --template={{.data.ENCRYPTION_KEY}} | base64 -d`
-1. You're all set!
+## Parameters
 
-#### Snippets
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nameOverride | string | `""` | Override release name |
+| fullnameOverride | string | `""` | Override release fullname |
+| backend.enabled | bool | `true` | Enable backend |
+| backend.name | string | `"backend"` | Backend name |
+| backend.fullnameOverride | string | `""` | Backend fullnameOverride |
+| backend.podAnnotations | object | `{}` | Backend pod annotations |
+| backend.deploymentAnnotations | object | `{}` | Backend deployment annotations |
+| backend.replicaCount | int | `2` | Backend replica count |
+| backend.image.repository | string | `"infisical/infisical"` | Backend image repository |
+| backend.image.tag | string | `"latest"` | Backend image tag |
+| backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pullPolicy |
+| backend.affinity | object | `{}` | Backend pod affinity |
+| backend.kubeSecretRef | string | `""` | Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars)) |
+| backend.service.annotations | object | `{}` | Backend service annotations |
+| backend.service.type | string | `"ClusterIP"` | Backend service type |
+| backend.service.nodePort | string | `""` | Backend service nodePort (used if above type is `NodePort`) |
+| backendEnvironmentVariables.ENCRYPTION_KEY | string | `""` | **Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_SIGNUP_SECRET | string | `""` | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_REFRESH_SECRET | string | `""` | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_AUTH_SECRET | string | `""` | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_SERVICE_SECRET | string | `""` | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_MFA_SECRET | string | `""` | **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.JWT_PROVIDER_AUTH_SECRET | string | `""` | **Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret) |
+| backendEnvironmentVariables.SMTP_HOST | string | `""` | **Required** Hostname to connect to for establishing SMTP connections |
+| backendEnvironmentVariables.SMTP_PORT | int | `587` | Port to connect to for establishing SMTP connections |
+| backendEnvironmentVariables.SMTP_SECURE | bool | `false` | If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported |
+| backendEnvironmentVariables.SMTP_FROM_NAME | string | `"Infisical"` | Name label to be used in From field (e.g. Infisical) |
+| backendEnvironmentVariables.SMTP_FROM_ADDRESS | string | `""` | **Required** Email address to be used for sending emails (e.g. dev@infisical.com) |
+| backendEnvironmentVariables.SMTP_USERNAME | string | `""` | **Required** Credential to connect to host (e.g. team@infisical.com) |
+| backendEnvironmentVariables.SMTP_PASSWORD | string | `""` | **Required** Credential to connect to host |
+| backendEnvironmentVariables.SITE_URL | string | `"infisical.local"` | Absolute URL including the protocol (e.g. https://app.infisical.com) |
+| backendEnvironmentVariables.INVITE_ONLY_SIGNUP | bool | `false` | To disable account creation from the login page (invites only) |
+| backendEnvironmentVariables.MONGO_URL | string | `""` | MongoDB connection string (external or internal)</br>Leave it empty for auto-generated connection string |
+| backendEnvironmentVariables.REDIS_URL | string | `"redis://redis-master:6379"` | Redis URL (cache service) |
+| mongodb.enabled | bool | `true` | Enable MongoDB(&reg;) |
+| mongodb.name | string | `"mongodb"` | Name used to build variables (deprecated) |
+| mongodb.fullnameOverride | string | `"mongodb"` | Fullname override |
+| mongodb.nameOverride | string | `"mongodb"` | Name override |
+| mongodb.podAnnotations | object | `{}` | Pod annotations |
+| mongodb.useStatefulSet | bool | `true` | Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`) |
+| mongodb.architecture | string | `"standalone"` | MongoDB(&reg;) architecture (`standalone` or `replicaset`) |
+| mongodb.image.repository | string | `"bitnami/mongodb"` | MongoDB(&reg;) image registry |
+| mongodb.image.pullPolicy | string | `"IfNotPresent"` | MongoDB(&reg;) image pull policy |
+| mongodb.image.tag | string | `"6.0.4-debian-11-r0"` | MongoDB(&reg;) image tag (immutable tags are recommended) |
+| mongodb.livenessProbe.enabled | bool | `true` | Enable livenessProbe |
+| mongodb.livenessProbe.initialDelaySeconds | int | `30` | Initial delay seconds for livenessProbe |
+| mongodb.livenessProbe.periodSeconds | int | `20` | Period seconds for livenessProbe |
+| mongodb.livenessProbe.timeoutSeconds | int | `10` | Timeout seconds for livenessProbe |
+| mongodb.livenessProbe.failureThreshold | int | `6` | Failure threshold for livenessProbe |
+| mongodb.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe |
+| mongodb.readinessProbe.enabled | bool | `true` | Enable readinessProbe |
+| mongodb.readinessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for readinessProbe |
+| mongodb.readinessProbe.periodSeconds | int | `10` | Period seconds for readinessProbe |
+| mongodb.readinessProbe.timeoutSeconds | int | `10` | Timeout seconds for readinessProbe |
+| mongodb.readinessProbe.failureThreshold | int | `6` | Failure threshold for readinessProbe |
+| mongodb.readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
+| mongodb.service.annotations | object | `{}` | Service annotations |
+| mongodb.auth.enabled | bool | `true` | Enable custom authentication |
+| mongodb.auth.usernames | list | `["infisical"]` | Custom usernames list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format)) |
+| mongodb.auth.passwords | list | `["infisical"]` | Custom passwords list, match the above usernames order ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format)) |
+| mongodb.auth.databases | list | `["infisical"]` | Custom databases list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format)) |
+| mongodb.auth.rootUser | string | `"root"` | Database root user name |
+| mongodb.auth.rootPassword | string | `"root"` | Database root user password |
+| mongodb.auth.existingSecret | string | `""` | Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`) |
+| mongodb.persistence.enabled | bool | `true` | Enable database persistence |
+| mongodb.persistence.existingClaim | string | `""` | Existing persistent volume claim name |
+| mongodb.persistence.resourcePolicy | string | `"keep"` | Keep the persistent volume even on deletion (`keep` or `""`) |
+| mongodb.persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent volume access modes |
+| mongodb.persistence.size | string | `"8Gi"` | Persistent storage request size |
+| mongodbConnection.externalMongoDBConnectionString | string | `""` | Deprecated :warning: External MongoDB connection string</br>Use `backendEnvironmentVariables.MONGO_URL` instead |
+| ingress.enabled | bool | `true` | Enable ingress |
+| ingress.ingressClassName | string | `"nginx"` | Ingress class name |
+| ingress.nginx.enabled | bool | `false` | Enable and install `ingress-nginx` controller |
+| ingress.annotations | object | `{}` | Ingress annotations |
+| ingress.hostName | string | `""` | Ingress hostname (your custom domain name, e.g. `infisical.example.org`). Replace with your own domain |
+| ingress.tls | list | `[]` | Ingress TLS hosts (matching above hostName). Replace with your own domain |
+| mailhog.enabled | bool | `false` | Enable Mailhog |
+| mailhog.fullnameOverride | string | `"mailhog"` | Fullname override |
+| mailhog.nameOverride | string | `""` | Name override |
+| mailhog.image.repository | string | `"lytrax/mailhog"` | Image repository |
+| mailhog.image.tag | string | `"latest"` | Image tag |
+| mailhog.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mailhog.containerPort.http | object | `{"name":"http","port":8025}` | Mailhog HTTP port (Web UI) |
+| mailhog.containerPort.smtp | object | `{"name":"tcp-smtp","port":1025}` | Mailhog SMTP port (Mail) |
+| mailhog.service.annotations | object | `{}` |  |
+| mailhog.service.extraPorts | list | `[]` |  |
+| mailhog.service.clusterIP | string | `""` |  |
+| mailhog.service.externalIPs | list | `[]` |  |
+| mailhog.service.loadBalancerIP | string | `""` |  |
+| mailhog.service.loadBalancerSourceRanges | list | `[]` |  |
+| mailhog.service.type | string | `"ClusterIP"` |  |
+| mailhog.service.namedTargetPort | bool | `true` |  |
+| mailhog.service.port.http | int | `8025` |  |
+| mailhog.service.port.smtp | int | `1025` |  |
+| mailhog.service.nodePort.http | string | `""` |  |
+| mailhog.service.nodePort.smtp | string | `""` |  |
+| mailhog.ingress.enabled | bool | `true` | Enable ingress |
+| mailhog.ingress.ingressClassName | string | `"nginx"` | Ingress class name |
+| mailhog.ingress.annotations | object | `{}` | Ingress annotations |
+| mailhog.ingress.labels | object | `{}` | Ingress labels |
+| mailhog.ingress.hosts[0] | object | `{"host":"mailhog.infisical.local","paths":[{"path":"/","pathType":"Prefix"}]}` | Mailhog host |
+| mailhog.ingress.hosts[0].paths | list | `[{"path":"/","pathType":"Prefix"}]` | Mailhog paths |
+| redis.enabled | bool | `true` | Enable Redis |
+| redis.name | string | `"redis"` | Redis deployment name |
+| redis.fullnameOverride | string | `"redis"` | Redis fullname override |
+| redis.architecture | string | `"standalone"` | Redis architecture |
+| redis.auth.enabled | bool | `false` | Redis authentication |
 
-Here's some snippets to backup your current secrets **before the upgrade** (:warning: it requires [`jq`](https://stedolan.github.io/jq/download/)) :
+## Validation
+
+You can automatically validate your custom `values.yaml` schema and get YAML auto-completion in your IDE, refer to this [section](../README.md#validation)
+
+## Persistence
+
+The database persistence is enabled by default, your volumes will remain on your cluster even after uninstalling the chart. To disable persistence, set this value `mongodb.persistence.enabled: false`
+
+## Local development
+
+Find the resources and configuration about how to setup your local development environment on a k8s cluster (locally or remotely).
+
+### Requirements
+
+To create a local k8s environment, you'll need at least :
+
+- [`helm`](https://helm.sh/docs/intro/install/) <kbd>required</kbd>
+  - to generate the manifests and deploy the chart
+- local/remote k8s cluster <kbd>required</kbd>
+  - e.g. [`kind`](https://kubernetes.io/docs/tasks/tools/), [`minikube`](https://kubernetes.io/docs/tasks/tools/) or an online provider
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) <kbd>required</kbd>
+  - to interact with the cluster
+
+### Setup
+
+Run one of the below scripts for easy setup :
+
+> [!WARNING]
+> The environment might take some minutes to setup the first time as it need to pull all required images and dependencies
 
 ```sh
-# replace the below variables with yours (namespace + app)
-namespace=infisical; app=infisical; components="frontend backend"
+cd infisical/helm-charts/infisical/examples
 
-for component in $components; do
-  dpl=$(kubectl get deployment -n $namespace -l app=$app -l component=$component \
-    -o jsonpath="{.items[0].metadata.name}")
+# With 'kind' + 'helm', to create a local cluster and deploy the chart using 'ingress-nginx'
+./infisical-kind.sh
 
-  kubectl get deployments -n $namespace $dpl \
-    -o jsonpath='{.spec.template.spec.containers[0].env[*]}' | \
-    jq -r '.name + ":" + .value' > infisical-$component-conf.bak
-done
+# With 'helm' only, if you already have a cluster (local/remote) to deploy the chart
+./infisical-helm.sh
 ```
+
+> [!NOTE]
+> Find complete setup scripts in [**./examples**](./examples). Comments make it easy to understand how to setup your local development environment step-by-step
+
+Above examples will deploy the following :
+
+- [**infisical.local**](https://infisical.local)
+  - Your local Infisical instance
+  - You may have to add `infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+
+- [**mailhog.infisical.local**](https://mailhog.infisical.local)
+  - Local SMTP server used to receive the emails (e.g. signup verification code)
+  - You may have to add `mailhog.infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))

--- a/helm-charts/infisical/README.md.gotmpl
+++ b/helm-charts/infisical/README.md.gotmpl
@@ -1,0 +1,106 @@
+# Infisical Helm Chart
+
+> [!WARNING]  
+> This chart is deprecated and discontinued in favor of the new one using PostgreSQL available **[here](../infisical-standalone-postgres/README.md)**. 
+> Some information here might be outdated! Please migrate to the new version : https://infisical.com/docs/self-hosting/guides/mongo-to-postgres
+
+{{ template "infisical.description" . }}
+
+## Services
+
+| Service   | Description      |
+| --------- | ---------------- |
+| `backend` | Infisical's API  |
+| `mongodb` | Database service |
+| `redis`   | Cache service    |
+| `mailhog` | SMTP server      |
+
+{{ template "infisical.installation.repo" . }}
+
+{{ template "infisical.installation.chart" . }}
+
+{{ template "infisical.encryptionKeys" . }}
+
+{{ template "infisical.upgrading" . }}
+
+---
+
+<details>
+<summary>
+
+### **`0.1.16`**
+</summary>
+
+- Auto-generation for the following variables, to ease your future upgrades or setups :
+  - `ENCRYPTION_KEY`
+  - `JWT_SIGNUP_SECRET`
+  - `JWT_REFRESH_SECRET`
+  - `JWT_AUTH_SECRET`
+  - `JWT_SERVICE_SECRET`
+  - `JWT_MFA_SECRET`
+
+We've migrated the applications' environment variables into `secrets` resources, shared within the deployments through `envFrom`. If you upgrade your installation make sure to backup your deployments' environment variables (e.g. encryption key and jwt secrets).
+
+The preference order is :
+- **user-defined** (values file or inline)
+  - **existing-secret** (for existing installations, you don't have to specify the secrets when upgrading if they already exist)
+    - **auto-generated** (if none of the values above have been found, we'll auto-generate a value for the user, only for the above mentioned variables)
+
+</details>
+
+## Parameters
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "infisical.yamlValidation" . }}
+
+## Persistence
+
+The database persistence is enabled by default, your volumes will remain on your cluster even after uninstalling the chart. To disable persistence, set this value `mongodb.persistence.enabled: false`
+
+## Local development
+
+Find the resources and configuration about how to setup your local development environment on a k8s cluster (locally or remotely).
+
+### Requirements
+
+To create a local k8s environment, you'll need at least :
+
+- [`helm`](https://helm.sh/docs/intro/install/) <kbd>required</kbd>
+  - to generate the manifests and deploy the chart 
+- local/remote k8s cluster <kbd>required</kbd>
+  - e.g. [`kind`](https://kubernetes.io/docs/tasks/tools/), [`minikube`](https://kubernetes.io/docs/tasks/tools/) or an online provider
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) <kbd>required</kbd>
+  - to interact with the cluster
+
+### Setup
+
+Run one of the below scripts for easy setup :
+
+> [!WARNING]
+> The environment might take some minutes to setup the first time as it need to pull all required images and dependencies
+
+```sh
+cd infisical/helm-charts/infisical/examples
+
+# With 'kind' + 'helm', to create a local cluster and deploy the chart using 'ingress-nginx'
+./infisical-kind.sh
+
+# With 'helm' only, if you already have a cluster (local/remote) to deploy the chart
+./infisical-helm.sh
+```
+
+> [!NOTE]
+> Find complete setup scripts in [**./examples**](./examples). Comments make it easy to understand how to setup your local development environment step-by-step
+
+Above examples will deploy the following :
+
+- [**infisical.local**](https://infisical.local)
+  - Your local Infisical instance
+  - You may have to add `infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))
+
+- [**mailhog.infisical.local**](https://mailhog.infisical.local)
+  - Local SMTP server used to receive the emails (e.g. signup verification code)
+  - You may have to add `mailhog.infisical.local` to your `/etc/hosts` or similar depending your OS
+    - The corresponding IP will depend on the tool or the way you're exposing the services ([learn more](https://minikube.sigs.k8s.io/docs/handbook/host-access/))

--- a/helm-charts/infisical/README.md.gotmpl
+++ b/helm-charts/infisical/README.md.gotmpl
@@ -25,11 +25,9 @@
 
 ---
 
-<details>
-<summary>
-
 ### **`0.1.16`**
-</summary>
+<details open>
+<summary><strong>Click for details</strong></summary>
 
 - Auto-generation for the following variables, to ease your future upgrades or setups :
   - `ENCRYPTION_KEY`
@@ -45,7 +43,6 @@ The preference order is :
 - **user-defined** (values file or inline)
   - **existing-secret** (for existing installations, you don't have to specify the secrets when upgrading if they already exist)
     - **auto-generated** (if none of the values above have been found, we'll auto-generate a value for the user, only for the above mentioned variables)
-
 </details>
 
 ## Parameters

--- a/helm-charts/infisical/examples/infisical-helm.sh
+++ b/helm-charts/infisical/examples/infisical-helm.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-
+##
 ## Infisical local k8s development environment setup script
 ## using 'helm' and assume you already have a cluster and an ingress (nginx)
-##
-
 ##
 ## DEVELOPMENT USE ONLY
 ## DO NOT USE IN PRODUCTION

--- a/helm-charts/infisical/examples/infisical-kind.sh
+++ b/helm-charts/infisical/examples/infisical-kind.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-
+##
 ## Infisical local k8s development environment setup script
 ## using 'kind' and 'ingress-nginx'
 ## https://kind.sigs.k8s.io/docs/user/ingress/
-##
-
 ##
 ## DEVELOPMENT USE ONLY
 ## DO NOT USE IN PRODUCTION

--- a/helm-charts/infisical/values.schema.json
+++ b/helm-charts/infisical/values.schema.json
@@ -13,11 +13,13 @@
           "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable backend",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "",
           "description": "Backend fullnameOverride",
           "title": "fullnameOverride",
           "type": "string"
@@ -25,16 +27,19 @@
         "image": {
           "properties": {
             "pullPolicy": {
+              "default": "IfNotPresent",
               "description": "Backend image pullPolicy",
               "title": "pullPolicy",
               "type": "string"
             },
             "repository": {
+              "default": "infisical/infisical",
               "description": "Backend image repository",
               "title": "repository",
               "type": "string"
             },
             "tag": {
+              "default": "latest",
               "description": "Backend image tag",
               "title": "tag",
               "type": "string"
@@ -45,11 +50,13 @@
           "type": "object"
         },
         "kubeSecretRef": {
+          "default": "",
           "description": "Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))",
           "title": "kubeSecretRef",
           "type": "string"
         },
         "name": {
+          "default": "backend",
           "description": "Backend name",
           "title": "name",
           "type": "string"
@@ -60,6 +67,7 @@
           "type": "object"
         },
         "replicaCount": {
+          "default": "2",
           "description": "Backend replica count",
           "title": "replicaCount",
           "type": "integer"
@@ -72,11 +80,13 @@
               "type": "object"
             },
             "nodePort": {
+              "default": "",
               "description": "Backend service nodePort (used if above type is `NodePort`)",
               "title": "nodePort",
               "type": "string"
             },
             "type": {
+              "default": "ClusterIP",
               "description": "Backend service type",
               "title": "type",
               "type": "string"
@@ -94,91 +104,109 @@
     "backendEnvironmentVariables": {
       "properties": {
         "ENCRYPTION_KEY": {
+          "default": "",
           "description": "Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 \"%08X\" 1 \"\\n\"' /dev/urandom', 'openssl rand -hex 16'\n**Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "ENCRYPTION_KEY",
           "type": "string"
         },
         "INVITE_ONLY_SIGNUP": {
+          "default": "false",
           "description": "To disable account creation from the login page (invites only)",
           "title": "INVITE_ONLY_SIGNUP",
           "type": "boolean"
         },
         "JWT_AUTH_SECRET": {
+          "default": "",
           "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_AUTH_SECRET",
           "type": "string"
         },
         "JWT_MFA_SECRET": {
+          "default": "",
           "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_MFA_SECRET",
           "type": "string"
         },
         "JWT_PROVIDER_AUTH_SECRET": {
+          "default": "",
           "description": "**Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_PROVIDER_AUTH_SECRET",
           "type": "string"
         },
         "JWT_REFRESH_SECRET": {
+          "default": "",
           "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_REFRESH_SECRET",
           "type": "string"
         },
         "JWT_SERVICE_SECRET": {
+          "default": "",
           "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_SERVICE_SECRET",
           "type": "string"
         },
         "JWT_SIGNUP_SECRET": {
+          "default": "",
           "description": "Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 \"%08X\" 1 \"\\n\"' /dev/urandom', 'openssl rand -hex 16'\n**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
           "title": "JWT_SIGNUP_SECRET",
           "type": "string"
         },
         "MONGO_URL": {
+          "default": "",
           "description": "## By default the backend will automatically be connected to a Mongo instance within the cluster\n## However, it is recommended to add a managed document DB connection string for production-use (DBaaS)\n## Learn about connection string type here https://www.mongodb.com/docs/manual/reference/connection-string/\n## e.g. \"mongodb://\u003cuser\u003e:\u003cpass\u003e@\u003chost\u003e:\u003cport\u003e/\u003cdatabase-name\u003e\"\nMongoDB connection string (external or internal)\u003c/br\u003eLeave it empty for auto-generated connection string",
           "title": "MONGO_URL",
           "type": "string"
         },
         "REDIS_URL": {
+          "default": "redis://redis-master:6379",
           "description": "By default, the backend will use the Redis that is auto deployed along with Infisical\nRedis URL (cache service)",
           "title": "REDIS_URL",
           "type": "string"
         },
         "SITE_URL": {
+          "default": "infisical.local",
           "description": "Absolute URL including the protocol (e.g. https://app.infisical.com)",
           "title": "SITE_URL",
           "type": "string"
         },
         "SMTP_FROM_ADDRESS": {
+          "default": "",
           "description": "**Required** Email address to be used for sending emails (e.g. dev@infisical.com)",
           "title": "SMTP_FROM_ADDRESS",
           "type": "string"
         },
         "SMTP_FROM_NAME": {
+          "default": "Infisical",
           "description": "Name label to be used in From field (e.g. Infisical)",
           "title": "SMTP_FROM_NAME",
           "type": "string"
         },
         "SMTP_HOST": {
+          "default": "",
           "description": "**Required** Hostname to connect to for establishing SMTP connections",
           "title": "SMTP_HOST",
           "type": "string"
         },
         "SMTP_PASSWORD": {
+          "default": "",
           "description": "**Required** Credential to connect to host",
           "title": "SMTP_PASSWORD",
           "type": "string"
         },
         "SMTP_PORT": {
+          "default": "587",
           "description": "Port to connect to for establishing SMTP connections",
           "title": "SMTP_PORT",
           "type": "integer"
         },
         "SMTP_SECURE": {
+          "default": "false",
           "description": "If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported",
           "title": "SMTP_SECURE",
           "type": "boolean"
         },
         "SMTP_USERNAME": {
+          "default": "",
           "description": "**Required** Credential to connect to host (e.g. team@infisical.com)",
           "title": "SMTP_USERNAME",
           "type": "string"
@@ -189,6 +217,7 @@
       "type": "object"
     },
     "fullnameOverride": {
+      "default": "",
       "description": "Override release fullname",
       "title": "fullnameOverride",
       "type": "string"
@@ -206,16 +235,19 @@
           "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable ingress",
           "title": "enabled",
           "type": "boolean"
         },
         "hostName": {
+          "default": "",
           "description": "kubernetes.io/ingress.class: \"nginx\"\ncert-manager.io/issuer: letsencrypt-nginx\nIngress hostname (your custom domain name, e.g. `infisical.example.org`).\nReplace with your own domain",
           "title": "hostName",
           "type": "string"
         },
         "ingressClassName": {
+          "default": "nginx",
           "description": "Ingress class name",
           "title": "ingressClassName",
           "type": "string"
@@ -223,6 +255,7 @@
         "nginx": {
           "properties": {
             "enabled": {
+              "default": "false",
               "description": "Enable and install `ingress-nginx` controller",
               "title": "enabled",
               "type": "boolean"
@@ -249,10 +282,12 @@
             "http": {
               "properties": {
                 "name": {
+                  "default": "http",
                   "title": "name",
                   "type": "string"
                 },
                 "port": {
+                  "default": "8025",
                   "title": "port",
                   "type": "integer"
                 }
@@ -264,10 +299,12 @@
             "smtp": {
               "properties": {
                 "name": {
+                  "default": "tcp-smtp",
                   "title": "name",
                   "type": "string"
                 },
                 "port": {
+                  "default": "1025",
                   "title": "port",
                   "type": "integer"
                 }
@@ -281,11 +318,13 @@
           "type": "object"
         },
         "enabled": {
+          "default": "false",
           "description": "Enable Mailhog",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "mailhog",
           "description": "Fullname override",
           "title": "fullnameOverride",
           "type": "string"
@@ -293,16 +332,19 @@
         "image": {
           "properties": {
             "pullPolicy": {
+              "default": "IfNotPresent",
               "description": "Image pull policy",
               "title": "pullPolicy",
               "type": "string"
             },
             "repository": {
+              "default": "lytrax/mailhog",
               "description": "Why we use this version : https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362\nImage repository",
               "title": "repository",
               "type": "string"
             },
             "tag": {
+              "default": "latest",
               "description": "Image tag",
               "title": "tag",
               "type": "string"
@@ -319,6 +361,7 @@
               "type": "object"
             },
             "enabled": {
+              "default": "true",
               "description": "Enable ingress",
               "title": "enabled",
               "type": "boolean"
@@ -329,6 +372,7 @@
                   {
                     "properties": {
                       "host": {
+                        "default": "mailhog.infisical.local",
                         "title": "host",
                         "type": "string"
                       },
@@ -338,10 +382,12 @@
                             {
                               "properties": {
                                 "path": {
+                                  "default": "/",
                                   "title": "path",
                                   "type": "string"
                                 },
                                 "pathType": {
+                                  "default": "Prefix",
                                   "title": "pathType",
                                   "type": "string"
                                 }
@@ -361,6 +407,7 @@
               "type": "array"
             },
             "ingressClassName": {
+              "default": "nginx",
               "description": "Ingress class name",
               "title": "ingressClassName",
               "type": "string"
@@ -376,6 +423,7 @@
           "type": "object"
         },
         "nameOverride": {
+          "default": "",
           "description": "Name override",
           "title": "nameOverride",
           "type": "string"
@@ -387,6 +435,7 @@
               "type": "object"
             },
             "clusterIP": {
+              "default": "",
               "title": "clusterIP",
               "type": "string"
             },
@@ -401,6 +450,7 @@
               "type": "array"
             },
             "loadBalancerIP": {
+              "default": "",
               "title": "loadBalancerIP",
               "type": "string"
             },
@@ -410,6 +460,7 @@
               "type": "array"
             },
             "namedTargetPort": {
+              "default": "true",
               "description": "Named target ports are not supported by GCE health checks, so when deploying on GKE\nand exposing it via GCE ingress, the health checks fail and the load balancer returns a 502.",
               "title": "namedTargetPort",
               "type": "boolean"
@@ -417,10 +468,12 @@
             "nodePort": {
               "properties": {
                 "http": {
+                  "default": "",
                   "title": "http",
                   "type": "string"
                 },
                 "smtp": {
+                  "default": "",
                   "title": "smtp",
                   "type": "string"
                 }
@@ -431,10 +484,12 @@
             "port": {
               "properties": {
                 "http": {
+                  "default": "8025",
                   "title": "http",
                   "type": "integer"
                 },
                 "smtp": {
+                  "default": "1025",
                   "title": "smtp",
                   "type": "integer"
                 }
@@ -443,6 +498,7 @@
               "type": "object"
             },
             "type": {
+              "default": "ClusterIP",
               "title": "type",
               "type": "string"
             }
@@ -458,6 +514,7 @@
     "mongodb": {
       "properties": {
         "architecture": {
+          "default": "standalone",
           "description": "MongoDB(\u0026reg;) architecture (`standalone` or `replicaset`)",
           "title": "architecture",
           "type": "string"
@@ -477,11 +534,13 @@
               "type": "array"
             },
             "enabled": {
+              "default": "true",
               "description": "Enable custom authentication",
               "title": "enabled",
               "type": "boolean"
             },
             "existingSecret": {
+              "default": "",
               "description": "NOTE: When it's set the previous parameters are ignored.\nExisting secret with MongoDB(\u0026reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)",
               "title": "existingSecret",
               "type": "string"
@@ -499,11 +558,13 @@
               "type": "array"
             },
             "rootPassword": {
+              "default": "root",
               "description": "Database root user password",
               "title": "rootPassword",
               "type": "string"
             },
             "rootUser": {
+              "default": "root",
               "description": "Database root user name",
               "title": "rootUser",
               "type": "string"
@@ -526,11 +587,13 @@
           "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable MongoDB(\u0026reg;)",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "mongodb",
           "description": "Fullname override",
           "title": "fullnameOverride",
           "type": "string"
@@ -538,16 +601,19 @@
         "image": {
           "properties": {
             "pullPolicy": {
+              "default": "IfNotPresent",
               "description": "MongoDB(\u0026reg;) image pull policy",
               "title": "pullPolicy",
               "type": "string"
             },
             "repository": {
+              "default": "bitnami/mongodb",
               "description": "MongoDB(\u0026reg;) image registry",
               "title": "repository",
               "type": "string"
             },
             "tag": {
+              "default": "6.0.4-debian-11-r0",
               "description": "MongoDB(\u0026reg;) image tag (immutable tags are recommended)",
               "title": "tag",
               "type": "string"
@@ -560,31 +626,37 @@
         "livenessProbe": {
           "properties": {
             "enabled": {
+              "default": "true",
               "description": "Enable livenessProbe",
               "title": "enabled",
               "type": "boolean"
             },
             "failureThreshold": {
+              "default": "6",
               "description": "Failure threshold for livenessProbe",
               "title": "failureThreshold",
               "type": "integer"
             },
             "initialDelaySeconds": {
+              "default": "30",
               "description": "Initial delay seconds for livenessProbe",
               "title": "initialDelaySeconds",
               "type": "integer"
             },
             "periodSeconds": {
+              "default": "20",
               "description": "Period seconds for livenessProbe",
               "title": "periodSeconds",
               "type": "integer"
             },
             "successThreshold": {
+              "default": "1",
               "description": "Success threshold for livenessProbe",
               "title": "successThreshold",
               "type": "integer"
             },
             "timeoutSeconds": {
+              "default": "10",
               "description": "Timeout seconds for livenessProbe",
               "title": "timeoutSeconds",
               "type": "integer"
@@ -595,11 +667,13 @@
           "type": "object"
         },
         "name": {
+          "default": "mongodb",
           "description": "Name used to build variables (deprecated)",
           "title": "name",
           "type": "string"
         },
         "nameOverride": {
+          "default": "mongodb",
           "description": "Name override",
           "title": "nameOverride",
           "type": "string"
@@ -619,21 +693,25 @@
               "type": "array"
             },
             "enabled": {
+              "default": "true",
               "description": "Enable database persistence",
               "title": "enabled",
               "type": "boolean"
             },
             "existingClaim": {
+              "default": "",
               "description": "Existing persistent volume claim name",
               "title": "existingClaim",
               "type": "string"
             },
             "resourcePolicy": {
+              "default": "keep",
               "description": "Keep the persistent volume even on deletion (`keep` or `\"\"`)",
               "title": "resourcePolicy",
               "type": "string"
             },
             "size": {
+              "default": "8Gi",
               "description": "Persistent storage request size",
               "title": "size",
               "type": "string"
@@ -651,31 +729,37 @@
         "readinessProbe": {
           "properties": {
             "enabled": {
+              "default": "true",
               "description": "Enable readinessProbe",
               "title": "enabled",
               "type": "boolean"
             },
             "failureThreshold": {
+              "default": "6",
               "description": "Failure threshold for readinessProbe",
               "title": "failureThreshold",
               "type": "integer"
             },
             "initialDelaySeconds": {
+              "default": "5",
               "description": "Initial delay seconds for readinessProbe",
               "title": "initialDelaySeconds",
               "type": "integer"
             },
             "periodSeconds": {
+              "default": "10",
               "description": "Period seconds for readinessProbe",
               "title": "periodSeconds",
               "type": "integer"
             },
             "successThreshold": {
+              "default": "1",
               "description": "Success threshold for readinessProbe",
               "title": "successThreshold",
               "type": "integer"
             },
             "timeoutSeconds": {
+              "default": "10",
               "description": "Timeout seconds for readinessProbe",
               "title": "timeoutSeconds",
               "type": "integer"
@@ -697,6 +781,7 @@
           "type": "object"
         },
         "useStatefulSet": {
+          "default": "true",
           "description": "Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`)",
           "title": "useStatefulSet",
           "type": "boolean"
@@ -709,6 +794,7 @@
     "mongodbConnection": {
       "properties": {
         "externalMongoDBConnectionString": {
+          "default": "",
           "description": "By default the backend will be connected to a Mongo instance within the cluster\nHowever, it is recommended to add a managed document DB connection string for production-use (DBaaS)\nLearn about connection string type here https://www/docs/manual/reference/connection-string/\ne.g. \"mongodb://\u003cuser\u003e:\u003cpass\u003e@\u003chost\u003e:\u003cport\u003e/\u003cdatabase-name\u003e\"\nDeprecated :warning: External MongoDB connection string\u003c/br\u003eUse `backendEnvironmentVariables.MONGO_URL` instead",
           "title": "externalMongoDBConnectionString",
           "type": "string"
@@ -718,6 +804,7 @@
       "type": "object"
     },
     "nameOverride": {
+      "default": "",
       "description": "Override release name",
       "title": "nameOverride",
       "type": "string"
@@ -725,6 +812,7 @@
     "redis": {
       "properties": {
         "architecture": {
+          "default": "standalone",
           "description": "Redis architecture",
           "title": "architecture",
           "type": "string"
@@ -732,6 +820,7 @@
         "auth": {
           "properties": {
             "enabled": {
+              "default": "false",
               "description": "Redis authentication",
               "title": "enabled",
               "type": "boolean"
@@ -741,16 +830,19 @@
           "type": "object"
         },
         "enabled": {
+          "default": "true",
           "description": "Enable Redis",
           "title": "enabled",
           "type": "boolean"
         },
         "fullnameOverride": {
+          "default": "redis",
           "description": "Redis fullname override",
           "title": "fullnameOverride",
           "type": "string"
         },
         "name": {
+          "default": "redis",
           "description": "Redis deployment name",
           "title": "name",
           "type": "string"

--- a/helm-charts/infisical/values.schema.json
+++ b/helm-charts/infisical/values.schema.json
@@ -1,0 +1,766 @@
+{
+  "properties": {
+    "backend": {
+      "properties": {
+        "affinity": {
+          "description": "Backend pod affinity",
+          "title": "affinity",
+          "type": "object"
+        },
+        "deploymentAnnotations": {
+          "description": "Backend deployment annotations",
+          "title": "deploymentAnnotations",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Enable backend",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "description": "Backend fullnameOverride",
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "description": "Backend image pullPolicy",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "description": "Backend image repository",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Backend image tag",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "description": "Backend image parameters",
+          "title": "image",
+          "type": "object"
+        },
+        "kubeSecretRef": {
+          "description": "Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))",
+          "title": "kubeSecretRef",
+          "type": "string"
+        },
+        "name": {
+          "description": "Backend name",
+          "title": "name",
+          "type": "string"
+        },
+        "podAnnotations": {
+          "description": "Backend pod annotations",
+          "title": "podAnnotations",
+          "type": "object"
+        },
+        "replicaCount": {
+          "description": "Backend replica count",
+          "title": "replicaCount",
+          "type": "integer"
+        },
+        "service": {
+          "properties": {
+            "annotations": {
+              "description": "Backend service annotations",
+              "title": "annotations",
+              "type": "object"
+            },
+            "nodePort": {
+              "description": "Backend service nodePort (used if above type is `NodePort`)",
+              "title": "nodePort",
+              "type": "string"
+            },
+            "type": {
+              "description": "Backend service type",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "description": "Backend service",
+          "title": "service",
+          "type": "object"
+        }
+      },
+      "description": "Infisical backend parameters\nhttps://infisical.com/docs/self-hosting/deployments/kubernetes",
+      "title": "backend",
+      "type": "object"
+    },
+    "backendEnvironmentVariables": {
+      "properties": {
+        "ENCRYPTION_KEY": {
+          "description": "Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 \"%08X\" 1 \"\\n\"' /dev/urandom', 'openssl rand -hex 16'\n**Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "ENCRYPTION_KEY",
+          "type": "string"
+        },
+        "INVITE_ONLY_SIGNUP": {
+          "description": "To disable account creation from the login page (invites only)",
+          "title": "INVITE_ONLY_SIGNUP",
+          "type": "boolean"
+        },
+        "JWT_AUTH_SECRET": {
+          "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_AUTH_SECRET",
+          "type": "string"
+        },
+        "JWT_MFA_SECRET": {
+          "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_MFA_SECRET",
+          "type": "string"
+        },
+        "JWT_PROVIDER_AUTH_SECRET": {
+          "description": "**Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_PROVIDER_AUTH_SECRET",
+          "type": "string"
+        },
+        "JWT_REFRESH_SECRET": {
+          "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_REFRESH_SECRET",
+          "type": "string"
+        },
+        "JWT_SERVICE_SECRET": {
+          "description": "**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_SERVICE_SECRET",
+          "type": "string"
+        },
+        "JWT_SIGNUP_SECRET": {
+          "description": "Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 \"%08X\" 1 \"\\n\"' /dev/urandom', 'openssl rand -hex 16'\n**Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))\u003c/br\u003e\u003ckbd\u003eauto-generated\u003c/kbd\u003e variable (if not provided, and not found in an existing secret)",
+          "title": "JWT_SIGNUP_SECRET",
+          "type": "string"
+        },
+        "MONGO_URL": {
+          "description": "## By default the backend will automatically be connected to a Mongo instance within the cluster\n## However, it is recommended to add a managed document DB connection string for production-use (DBaaS)\n## Learn about connection string type here https://www.mongodb.com/docs/manual/reference/connection-string/\n## e.g. \"mongodb://\u003cuser\u003e:\u003cpass\u003e@\u003chost\u003e:\u003cport\u003e/\u003cdatabase-name\u003e\"\nMongoDB connection string (external or internal)\u003c/br\u003eLeave it empty for auto-generated connection string",
+          "title": "MONGO_URL",
+          "type": "string"
+        },
+        "REDIS_URL": {
+          "description": "By default, the backend will use the Redis that is auto deployed along with Infisical\nRedis URL (cache service)",
+          "title": "REDIS_URL",
+          "type": "string"
+        },
+        "SITE_URL": {
+          "description": "Absolute URL including the protocol (e.g. https://app.infisical.com)",
+          "title": "SITE_URL",
+          "type": "string"
+        },
+        "SMTP_FROM_ADDRESS": {
+          "description": "**Required** Email address to be used for sending emails (e.g. dev@infisical.com)",
+          "title": "SMTP_FROM_ADDRESS",
+          "type": "string"
+        },
+        "SMTP_FROM_NAME": {
+          "description": "Name label to be used in From field (e.g. Infisical)",
+          "title": "SMTP_FROM_NAME",
+          "type": "string"
+        },
+        "SMTP_HOST": {
+          "description": "**Required** Hostname to connect to for establishing SMTP connections",
+          "title": "SMTP_HOST",
+          "type": "string"
+        },
+        "SMTP_PASSWORD": {
+          "description": "**Required** Credential to connect to host",
+          "title": "SMTP_PASSWORD",
+          "type": "string"
+        },
+        "SMTP_PORT": {
+          "description": "Port to connect to for establishing SMTP connections",
+          "title": "SMTP_PORT",
+          "type": "integer"
+        },
+        "SMTP_SECURE": {
+          "description": "If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported",
+          "title": "SMTP_SECURE",
+          "type": "boolean"
+        },
+        "SMTP_USERNAME": {
+          "description": "**Required** Credential to connect to host (e.g. team@infisical.com)",
+          "title": "SMTP_USERNAME",
+          "type": "string"
+        }
+      },
+      "description": "Backend variables configuration\nhttps://infisical.com/docs/self-hosting/configuration/envars",
+      "title": "backendEnvironmentVariables",
+      "type": "object"
+    },
+    "fullnameOverride": {
+      "description": "Override release fullname",
+      "title": "fullnameOverride",
+      "type": "string"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "title": "global",
+      "type": "object"
+    },
+    "ingress": {
+      "properties": {
+        "annotations": {
+          "description": "Ingress annotations",
+          "title": "annotations",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Enable ingress",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "hostName": {
+          "description": "kubernetes.io/ingress.class: \"nginx\"\ncert-manager.io/issuer: letsencrypt-nginx\nIngress hostname (your custom domain name, e.g. `infisical.example.org`).\nReplace with your own domain",
+          "title": "hostName",
+          "type": "string"
+        },
+        "ingressClassName": {
+          "description": "Ingress class name",
+          "title": "ingressClassName",
+          "type": "string"
+        },
+        "nginx": {
+          "properties": {
+            "enabled": {
+              "description": "Enable and install `ingress-nginx` controller",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "title": "nginx",
+          "type": "object"
+        },
+        "tls": {
+          "items": {},
+          "description": "Ingress TLS hosts (matching above hostName).\nReplace with your own domain",
+          "title": "tls",
+          "type": "array"
+        }
+      },
+      "description": "Ingress parameters",
+      "title": "ingress",
+      "type": "object"
+    },
+    "mailhog": {
+      "properties": {
+        "containerPort": {
+          "properties": {
+            "http": {
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "type": "string"
+                },
+                "port": {
+                  "title": "port",
+                  "type": "integer"
+                }
+              },
+              "description": "Mailhog HTTP port (Web UI)",
+              "title": "http",
+              "type": "object"
+            },
+            "smtp": {
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "type": "string"
+                },
+                "port": {
+                  "title": "port",
+                  "type": "integer"
+                }
+              },
+              "description": "Mailhog SMTP port (Mail)",
+              "title": "smtp",
+              "type": "object"
+            }
+          },
+          "title": "containerPort",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Enable Mailhog",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "description": "Fullname override",
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "description": "Image pull policy",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "description": "Why we use this version : https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362\nImage repository",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "description": "Image tag",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "title": "image",
+          "type": "object"
+        },
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "description": "Ingress annotations",
+              "title": "annotations",
+              "type": "object"
+            },
+            "enabled": {
+              "description": "Enable ingress",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "hosts": {
+              "items": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "host": {
+                        "title": "host",
+                        "type": "string"
+                      },
+                      "paths": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "properties": {
+                                "path": {
+                                  "title": "path",
+                                  "type": "string"
+                                },
+                                "pathType": {
+                                  "title": "pathType",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "description": "Mailhog paths",
+                        "title": "paths",
+                        "type": "array"
+                      }
+                    }
+                  }
+                ]
+              },
+              "title": "hosts",
+              "type": "array"
+            },
+            "ingressClassName": {
+              "description": "Ingress class name",
+              "title": "ingressClassName",
+              "type": "string"
+            },
+            "labels": {
+              "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"\nIngress labels",
+              "title": "labels",
+              "type": "object"
+            }
+          },
+          "description": "Mailhog ingress",
+          "title": "ingress",
+          "type": "object"
+        },
+        "nameOverride": {
+          "description": "Name override",
+          "title": "nameOverride",
+          "type": "string"
+        },
+        "service": {
+          "properties": {
+            "annotations": {
+              "title": "annotations",
+              "type": "object"
+            },
+            "clusterIP": {
+              "title": "clusterIP",
+              "type": "string"
+            },
+            "externalIPs": {
+              "items": {},
+              "title": "externalIPs",
+              "type": "array"
+            },
+            "extraPorts": {
+              "items": {},
+              "title": "extraPorts",
+              "type": "array"
+            },
+            "loadBalancerIP": {
+              "title": "loadBalancerIP",
+              "type": "string"
+            },
+            "loadBalancerSourceRanges": {
+              "items": {},
+              "title": "loadBalancerSourceRanges",
+              "type": "array"
+            },
+            "namedTargetPort": {
+              "description": "Named target ports are not supported by GCE health checks, so when deploying on GKE\nand exposing it via GCE ingress, the health checks fail and the load balancer returns a 502.",
+              "title": "namedTargetPort",
+              "type": "boolean"
+            },
+            "nodePort": {
+              "properties": {
+                "http": {
+                  "title": "http",
+                  "type": "string"
+                },
+                "smtp": {
+                  "title": "smtp",
+                  "type": "string"
+                }
+              },
+              "title": "nodePort",
+              "type": "object"
+            },
+            "port": {
+              "properties": {
+                "http": {
+                  "title": "http",
+                  "type": "integer"
+                },
+                "smtp": {
+                  "title": "smtp",
+                  "type": "integer"
+                }
+              },
+              "title": "port",
+              "type": "object"
+            },
+            "type": {
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "title": "service",
+          "type": "object"
+        }
+      },
+      "description": "Mailhog parameters\nhttps://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml",
+      "title": "mailhog",
+      "type": "object"
+    },
+    "mongodb": {
+      "properties": {
+        "architecture": {
+          "description": "MongoDB(\u0026reg;) architecture (`standalone` or `replicaset`)",
+          "title": "architecture",
+          "type": "string"
+        },
+        "auth": {
+          "properties": {
+            "databases": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "Custom databases list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))",
+              "title": "databases",
+              "type": "array"
+            },
+            "enabled": {
+              "description": "Enable custom authentication",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "description": "NOTE: When it's set the previous parameters are ignored.\nExisting secret with MongoDB(\u0026reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)",
+              "title": "existingSecret",
+              "type": "string"
+            },
+            "passwords": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "Custom passwords list, match the above usernames order ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))",
+              "title": "passwords",
+              "type": "array"
+            },
+            "rootPassword": {
+              "description": "Database root user password",
+              "title": "rootPassword",
+              "type": "string"
+            },
+            "rootUser": {
+              "description": "Database root user name",
+              "title": "rootUser",
+              "type": "string"
+            },
+            "usernames": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "Custom usernames list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))",
+              "title": "usernames",
+              "type": "array"
+            }
+          },
+          "description": "Infisical MongoDB custom authentication",
+          "title": "auth",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Enable MongoDB(\u0026reg;)",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "description": "Fullname override",
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "image": {
+          "properties": {
+            "pullPolicy": {
+              "description": "MongoDB(\u0026reg;) image pull policy",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "description": "MongoDB(\u0026reg;) image registry",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "description": "MongoDB(\u0026reg;) image tag (immutable tags are recommended)",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "description": "Bitnami MongoDB(\u0026reg;) image\nhttps://hub.docker.com/r/bitnami/mongodb/tags/",
+          "title": "image",
+          "type": "object"
+        },
+        "livenessProbe": {
+          "properties": {
+            "enabled": {
+              "description": "Enable livenessProbe",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "failureThreshold": {
+              "description": "Failure threshold for livenessProbe",
+              "title": "failureThreshold",
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "description": "Initial delay seconds for livenessProbe",
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "Period seconds for livenessProbe",
+              "title": "periodSeconds",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Success threshold for livenessProbe",
+              "title": "successThreshold",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Timeout seconds for livenessProbe",
+              "title": "timeoutSeconds",
+              "type": "integer"
+            }
+          },
+          "description": "Bitnami MongoDB(\u0026reg;) pods' liveness probe\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes",
+          "title": "livenessProbe",
+          "type": "object"
+        },
+        "name": {
+          "description": "Name used to build variables (deprecated)",
+          "title": "name",
+          "type": "string"
+        },
+        "nameOverride": {
+          "description": "Name override",
+          "title": "nameOverride",
+          "type": "string"
+        },
+        "persistence": {
+          "properties": {
+            "accessModes": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "Persistent volume access modes",
+              "title": "accessModes",
+              "type": "array"
+            },
+            "enabled": {
+              "description": "Enable database persistence",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "description": "Existing persistent volume claim name",
+              "title": "existingClaim",
+              "type": "string"
+            },
+            "resourcePolicy": {
+              "description": "Keep the persistent volume even on deletion (`keep` or `\"\"`)",
+              "title": "resourcePolicy",
+              "type": "string"
+            },
+            "size": {
+              "description": "Persistent storage request size",
+              "title": "size",
+              "type": "string"
+            }
+          },
+          "description": "MongoDB persistence configuration",
+          "title": "persistence",
+          "type": "object"
+        },
+        "podAnnotations": {
+          "description": "Pod annotations",
+          "title": "podAnnotations",
+          "type": "object"
+        },
+        "readinessProbe": {
+          "properties": {
+            "enabled": {
+              "description": "Enable readinessProbe",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "failureThreshold": {
+              "description": "Failure threshold for readinessProbe",
+              "title": "failureThreshold",
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "description": "Initial delay seconds for readinessProbe",
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "description": "Period seconds for readinessProbe",
+              "title": "periodSeconds",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "description": "Success threshold for readinessProbe",
+              "title": "successThreshold",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "description": "Timeout seconds for readinessProbe",
+              "title": "timeoutSeconds",
+              "type": "integer"
+            }
+          },
+          "description": "Bitnami MongoDB(\u0026reg;) pods' readiness probe. Evaluated as a template.\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes",
+          "title": "readinessProbe",
+          "type": "object"
+        },
+        "service": {
+          "properties": {
+            "annotations": {
+              "description": "Service annotations",
+              "title": "annotations",
+              "type": "object"
+            }
+          },
+          "title": "service",
+          "type": "object"
+        },
+        "useStatefulSet": {
+          "description": "Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`)",
+          "title": "useStatefulSet",
+          "type": "boolean"
+        }
+      },
+      "description": "MongoDB parameters\nhttps://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml",
+      "title": "mongodb",
+      "type": "object"
+    },
+    "mongodbConnection": {
+      "properties": {
+        "externalMongoDBConnectionString": {
+          "description": "By default the backend will be connected to a Mongo instance within the cluster\nHowever, it is recommended to add a managed document DB connection string for production-use (DBaaS)\nLearn about connection string type here https://www/docs/manual/reference/connection-string/\ne.g. \"mongodb://\u003cuser\u003e:\u003cpass\u003e@\u003chost\u003e:\u003cport\u003e/\u003cdatabase-name\u003e\"\nDeprecated :warning: External MongoDB connection string\u003c/br\u003eUse `backendEnvironmentVariables.MONGO_URL` instead",
+          "title": "externalMongoDBConnectionString",
+          "type": "string"
+        }
+      },
+      "title": "mongodbConnection",
+      "type": "object"
+    },
+    "nameOverride": {
+      "description": "Override release name",
+      "title": "nameOverride",
+      "type": "string"
+    },
+    "redis": {
+      "properties": {
+        "architecture": {
+          "description": "Redis architecture",
+          "title": "architecture",
+          "type": "string"
+        },
+        "auth": {
+          "properties": {
+            "enabled": {
+              "description": "Redis authentication",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "title": "auth",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Enable Redis",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "fullnameOverride": {
+          "description": "Redis fullname override",
+          "title": "fullnameOverride",
+          "type": "string"
+        },
+        "name": {
+          "description": "Redis deployment name",
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "description": "Redis parameters\nhttps://github.com/bitnami/charts/tree/main/bitnami/redis#parameters",
+      "title": "redis",
+      "type": "object"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/helm-charts/infisical/values.yaml
+++ b/helm-charts/infisical/values.yaml
@@ -1,324 +1,246 @@
-## @section Common parameters
-##
+# yaml-language-server: $schema=values.schema.json
 
-## @param nameOverride Override release name
-##
+# -- Override release name
 nameOverride: ""
-## @param fullnameOverride Override release fullname
-##
+# -- Override release fullname
 fullnameOverride: ""
 
-## @section Infisical backend parameters
-## Documentation : https://infisical.com/docs/self-hosting/deployments/kubernetes
-##
-
+# Infisical backend parameters
+# https://infisical.com/docs/self-hosting/deployments/kubernetes
 backend:
-  ## @param backend.enabled Enable backend
-  ##
+  # -- Enable backend
   enabled: true
-  ## @param backend.name Backend name
-  ##
+  # -- Backend name
   name: backend
-  ## @param backend.fullnameOverride Backend fullnameOverride
-  ##
+  # -- Backend fullnameOverride
   fullnameOverride: ""
-  ## @param backend.podAnnotations Backend pod annotations
-  ##
+  # -- Backend pod annotations
   podAnnotations: {}
-  ## @param backend.deploymentAnnotations Backend deployment annotations
-  ##
+  # -- Backend deployment annotations
   deploymentAnnotations: {}
-  ## @param backend.replicaCount Backend replica count
-  ##
+  # -- Backend replica count
   replicaCount: 2
-  ## Backend image parameters
-  ##
+  # Backend image parameters
   image:
-    ## @param backend.image.repository Backend image repository
-    ##
+    # -- Backend image repository
     repository: infisical/infisical
-    ## @param backend.image.tag Backend image tag
-    ##
+    # -- Backend image tag
     tag: "latest"
-    ## @param backend.image.pullPolicy Backend image pullPolicy
-    ##
+    # -- Backend image pullPolicy
     pullPolicy: IfNotPresent
-  ## @param backend.affinity Backend pod affinity
-  ##
+  # -- Backend pod affinity
   affinity: {}
-  ## @param backend.kubeSecretRef Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
-  ##
+  # -- Backend secret resource reference name (containing required [backend configuration variables](https://infisical.com/docs/self-hosting/configuration/envars))
   kubeSecretRef: ""
-  ## Backend service
-  ##
+  # Backend service
   service:
-    ## @param backend.service.annotations Backend service annotations
-    ##
+    # -- Backend service annotations
     annotations: {}
-    ## @param backend.service.type Backend service type
-    ##
+    # -- Backend service type
     type: ClusterIP
-    ## @param backend.service.nodePort Backend service nodePort (used if above type is `NodePort`)
-    ##
+    # -- Backend service nodePort (used if above type is `NodePort`)
     nodePort: ""
 
-## Backend variables configuration
-## Documentation : https://infisical.com/docs/self-hosting/configuration/envars
-##
+# Backend variables configuration
+# https://infisical.com/docs/self-hosting/configuration/envars
 backendEnvironmentVariables:
-  ## @param backendEnvironmentVariables.ENCRYPTION_KEY **Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom', 'openssl rand -hex 16'
-  ##
+  # Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom', 'openssl rand -hex 16'
+  # -- **Required** Backend encryption key (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   ENCRYPTION_KEY: ""
-  ## @param backendEnvironmentVariables.JWT_SIGNUP_SECRET **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## @param backendEnvironmentVariables.JWT_REFRESH_SECRET **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## @param backendEnvironmentVariables.JWT_AUTH_SECRET **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## @param backendEnvironmentVariables.JWT_SERVICE_SECRET **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## @param backendEnvironmentVariables.JWT_MFA_SECRET **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## @param backendEnvironmentVariables.JWT_PROVIDER_AUTH_SECRET **Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
-  ## Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom', 'openssl rand -hex 16'
-  ##
+  # Command to generate the required value (linux) : 'hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom', 'openssl rand -hex 16'
+  # -- **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_SIGNUP_SECRET: ""
+  # -- **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_REFRESH_SECRET: ""
+  # -- **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_AUTH_SECRET: ""
+  # -- **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_SERVICE_SECRET: ""
+  # -- **Required** Secrets to sign JWT tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_MFA_SECRET: ""
+  # -- **Required** Secrets to sign JWT OAuth tokens (128-bit hex value, 32-characters hex, [example](https://stackoverflow.com/a/34329057))</br><kbd>auto-generated</kbd> variable (if not provided, and not found in an existing secret)
   JWT_PROVIDER_AUTH_SECRET: ""
-  ## @param backendEnvironmentVariables.SMTP_HOST **Required** Hostname to connect to for establishing SMTP connections
-  ## @param backendEnvironmentVariables.SMTP_PORT Port to connect to for establishing SMTP connections
-  ## @param backendEnvironmentVariables.SMTP_SECURE If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported
-  ## @param backendEnvironmentVariables.SMTP_FROM_NAME Name label to be used in From field (e.g. Infisical)
-  ## @param backendEnvironmentVariables.SMTP_FROM_ADDRESS **Required** Email address to be used for sending emails (e.g. dev@infisical.com)
-  ## @param backendEnvironmentVariables.SMTP_USERNAME **Required** Credential to connect to host (e.g. team@infisical.com)
-  ## @param backendEnvironmentVariables.SMTP_PASSWORD **Required** Credential to connect to host
-  ##
+  # -- **Required** Hostname to connect to for establishing SMTP connections
   SMTP_HOST: ""
+  # -- Port to connect to for establishing SMTP connections
   SMTP_PORT: 587
+  # -- If true, use TLS when connecting to host. If false, TLS will be used if STARTTLS is supported
   SMTP_SECURE: false
+  # -- Name label to be used in From field (e.g. Infisical)
   SMTP_FROM_NAME: Infisical
+  # -- **Required** Email address to be used for sending emails (e.g. dev@infisical.com)
   SMTP_FROM_ADDRESS: ""
+  # -- **Required** Credential to connect to host (e.g. team@infisical.com)
   SMTP_USERNAME: ""
+  # -- **Required** Credential to connect to host
   SMTP_PASSWORD: ""
-  ## @param backendEnvironmentVariables.SITE_URL Absolute URL including the protocol (e.g. https://app.infisical.com)
-  ##
+  # -- Absolute URL including the protocol (e.g. https://app.infisical.com)
   SITE_URL: infisical.local
-  ## @param backendEnvironmentVariables.INVITE_ONLY_SIGNUP To disable account creation from the login page (invites only)
-  ##
+  # -- To disable account creation from the login page (invites only)
   INVITE_ONLY_SIGNUP: false
-  ## @param backendEnvironmentVariables.MONGO_URL MongoDB connection string (external or internal)</br>Leave it empty for auto-generated connection string
   ## By default the backend will automatically be connected to a Mongo instance within the cluster
   ## However, it is recommended to add a managed document DB connection string for production-use (DBaaS)
   ## Learn about connection string type here https://www.mongodb.com/docs/manual/reference/connection-string/
   ## e.g. "mongodb://<user>:<pass>@<host>:<port>/<database-name>"
-  ##
+  # -- MongoDB connection string (external or internal)</br>Leave it empty for auto-generated connection string
   MONGO_URL: ""
 
-  ## @param backendEnvironmentVariables.REDIS_URL
-  ## By default, the backend will use the Redis that is auto deployed along with Infisical
+  # By default, the backend will use the Redis that is auto deployed along with Infisical
+  # -- Redis URL (cache service)
   REDIS_URL: "redis://redis-master:6379"
 
-## @section MongoDB(&reg;) parameters
-## Documentation : https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml
-##
-
+# MongoDB parameters
+# https://github.com/bitnami/charts/blob/main/bitnami/mongodb/values.yaml
 mongodb:
-  ## @param mongodb.enabled Enable MongoDB(&reg;)
-  ##
+  # -- Enable MongoDB(&reg;)
   enabled: true
-  ## @param mongodb.name Name used to build variables (deprecated)
-  ##
+  # -- Name used to build variables (deprecated)
   name: "mongodb"
-  ## @param mongodb.fullnameOverride Fullname override
-  ##
+  # -- Fullname override
   fullnameOverride: "mongodb"
-  ## @param mongodb.nameOverride Name override
-  ##
+  # -- Name override
   nameOverride: "mongodb"
-  ## @param mongodb.podAnnotations Pod annotations
-  ##
+  # -- Pod annotations
   podAnnotations: {}
-  ## @param mongodb.useStatefulSet Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`)
-  ##
+  # -- Set to true to use a StatefulSet instead of a Deployment (only when `architecture: standalone`)
   useStatefulSet: true
-  ## @param mongodb.architecture MongoDB(&reg;) architecture (`standalone` or `replicaset`)
-  ##
+  # -- MongoDB(&reg;) architecture (`standalone` or `replicaset`)
   architecture: "standalone"
-  ## Bitnami MongoDB(&reg;) image
-  ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
-  ## @param mongodb.image.repository MongoDB(&reg;) image registry
-  ## @param mongodb.image.tag MongoDB(&reg;) image tag (immutable tags are recommended)
-  ## @param mongodb.image.pullPolicy MongoDB(&reg;) image pull policy
-  ##
+  # Bitnami MongoDB(&reg;) image
+  # https://hub.docker.com/r/bitnami/mongodb/tags/
   image:
+    # -- MongoDB(&reg;) image registry
     repository: bitnami/mongodb
+    # -- MongoDB(&reg;) image pull policy
     pullPolicy: IfNotPresent
+    # -- MongoDB(&reg;) image tag (immutable tags are recommended)
     tag: "6.0.4-debian-11-r0"
-  ## Bitnami MongoDB(&reg;) pods' liveness probe
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param mongodb.livenessProbe.enabled Enable livenessProbe
-  ## @param mongodb.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
-  ## @param mongodb.livenessProbe.periodSeconds Period seconds for livenessProbe
-  ## @param mongodb.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
-  ## @param mongodb.livenessProbe.failureThreshold Failure threshold for livenessProbe
-  ## @param mongodb.livenessProbe.successThreshold Success threshold for livenessProbe
-  ##
+  # Bitnami MongoDB(&reg;) pods' liveness probe
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   livenessProbe:
+    # -- Enable livenessProbe
     enabled: true
+    # -- Initial delay seconds for livenessProbe
     initialDelaySeconds: 30
+    # -- Period seconds for livenessProbe
     periodSeconds: 20
+    # -- Timeout seconds for livenessProbe
     timeoutSeconds: 10
+    # -- Failure threshold for livenessProbe
     failureThreshold: 6
+    # -- Success threshold for livenessProbe
     successThreshold: 1
-  ## Bitnami MongoDB(&reg;) pods' readiness probe. Evaluated as a template.
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param mongodb.readinessProbe.enabled Enable readinessProbe
-  ## @param mongodb.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
-  ## @param mongodb.readinessProbe.periodSeconds Period seconds for readinessProbe
-  ## @param mongodb.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
-  ## @param mongodb.readinessProbe.failureThreshold Failure threshold for readinessProbe
-  ## @param mongodb.readinessProbe.successThreshold Success threshold for readinessProbe
-  ##
+  # Bitnami MongoDB(&reg;) pods' readiness probe. Evaluated as a template.
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   readinessProbe:
+    # -- Enable readinessProbe
     enabled: true
+    # -- Initial delay seconds for readinessProbe
     initialDelaySeconds: 5
+    # -- Period seconds for readinessProbe
     periodSeconds: 10
+    # -- Timeout seconds for readinessProbe
     timeoutSeconds: 10
+    # -- Failure threshold for readinessProbe
     failureThreshold: 6
+    # -- Success threshold for readinessProbe
     successThreshold: 1
-  ## @param mongodb.service.annotations Service annotations
-  ##
   service:
+    # -- Service annotations
     annotations: {}
-  ## Infisical MongoDB custom authentication
-  ##
+  # Infisical MongoDB custom authentication
   auth:
-    ## @param mongodb.auth.enabled Enable custom authentication
-    ##
+    # -- Enable custom authentication
     enabled: true
-    ## @param mongodb.auth.usernames Custom usernames list ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format))
-    ##
+    # -- Custom usernames list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))
     usernames:
       - "infisical"
-    ## @param mongodb.auth.passwords Custom passwords list, match the above usernames order ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format))
-    ##
+    # -- Custom passwords list, match the above usernames order ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))
     passwords:
       - "infisical"
-    ## @param mongodb.auth.databases Custom databases list ([special characters warning](https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format))
-    ##
+    # -- Custom databases list ([special characters warning](https://www/docs/manual/reference/connection-string/#standard-connection-string-format))
     databases:
       - "infisical"
-    ## @param mongodb.auth.rootUser Database root user name
-    ##
+    # -- Database root user name
     rootUser: root
-    ## @param mongodb.auth.rootPassword Database root user password
-    ##
+    # -- Database root user password
     rootPassword: root
 
-    ## @param mongodb.auth.existingSecret Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)
-    ## NOTE: When it's set the previous parameters are ignored.
-    ##
+    # NOTE: When it's set the previous parameters are ignored.
+    # -- Existing secret with MongoDB(&reg;) credentials (keys: `mongodb-passwords`, `mongodb-root-password`, `mongodb-metrics-password`, `mongodb-replica-set-key`)
     existingSecret: ""
 
-  ## MongoDB persistence configuration
-  ##
+  # MongoDB persistence configuration
   persistence:
-    ## @param mongodb.persistence.enabled Enable database persistence
-    ##
+    # -- Enable database persistence
     enabled: true
-    ## @param mongodb.persistence.existingClaim Existing persistent volume claim name
-    ##
+    # -- Existing persistent volume claim name
     existingClaim: ""
-    ## @param mongodb.persistence.resourcePolicy Keep the persistent volume even on deletion (`keep` or `""`)
-    ##
+    # -- Keep the persistent volume even on deletion (`keep` or `""`)
     resourcePolicy: "keep"
-    ## @param mongodb.persistence.accessModes Persistent volume access modes
-    ##
+    # -- Persistent volume access modes
     accessModes: ["ReadWriteOnce"]
-    ## @param mongodb.persistence.size Persistent storage request size
-    ##
+    # -- Persistent storage request size
     size: 8Gi
 
-## @param mongodbConnection.externalMongoDBConnectionString Deprecated :warning: External MongoDB connection string</br>Use backendEnvironmentVariables.MONGO_URL instead
-## By default the backend will be connected to a Mongo instance within the cluster
-## However, it is recommended to add a managed document DB connection string for production-use (DBaaS)
-## Learn about connection string type here https://www.mongodb.com/docs/manual/reference/connection-string/
-## e.g. "mongodb://<user>:<pass>@<host>:<port>/<database-name>"
-##
 mongodbConnection:
+  # By default the backend will be connected to a Mongo instance within the cluster
+  # However, it is recommended to add a managed document DB connection string for production-use (DBaaS)
+  # Learn about connection string type here https://www/docs/manual/reference/connection-string/
+  # e.g. "mongodb://<user>:<pass>@<host>:<port>/<database-name>"
+  # -- Deprecated :warning: External MongoDB connection string</br>Use `backendEnvironmentVariables.MONGO_URL` instead
   externalMongoDBConnectionString: ""
 
-## @section Ingress parameters
-##
-
+# Ingress parameters
 ingress:
-  ## @param ingress.enabled Enable ingress
-  ##
+  # -- Enable ingress
   enabled: true
-  ## @param ingress.ingressClassName Ingress class name
-  ##
+  # -- Ingress class name
   ingressClassName: nginx
-  ## @param ingress.nginx.enabled Ingress controller
-  ##
   nginx:
+    # -- Enable and install `ingress-nginx` controller
     enabled: false
-  ## @param ingress.annotations Ingress annotations
-  ##
-  annotations:
-    {}
+  # -- Ingress annotations
+  annotations: {}
     # kubernetes.io/ingress.class: "nginx"
     # cert-manager.io/issuer: letsencrypt-nginx
-  ## @param ingress.hostName Ingress hostname (your custom domain name, e.g. `infisical.example.org`)
-  ## Replace with your own domain
-  ##
+  # -- Ingress hostname (your custom domain name, e.g. `infisical.example.org`).
+  # Replace with your own domain
   hostName: ""
-  ## @param ingress.tls Ingress TLS hosts (matching above hostName)
-  ## Replace with your own domain
-  ##
-  tls:
-    []
+  # -- Ingress TLS hosts (matching above hostName).
+  # Replace with your own domain
+  tls: []
     # - secretName: letsencrypt-nginx
     #   hosts:
     #     - infisical.local
 
-## @section Mailhog parameters
-## Documentation : https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
-##
-
+# Mailhog parameters
+# https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:
-  ## @param mailhog.enabled Enable Mailhog
-  ##
+  # -- Enable Mailhog
   enabled: false
-  ## @param mailhog.fullnameOverride Fullname override
-  ##
+  # -- Fullname override
   fullnameOverride: "mailhog"
-  ## @param mailhog.nameOverride Name override
-  ##
+  # -- Name override
   nameOverride: ""
-  ## @param mailhog.image.repository Image repository
-  ## Why we use this version : https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362
-  ## @param mailhog.image.tag Image tag
-  ## @param mailhog.image.pullPolicy Image pull policy
-  ##
   image:
+    # Why we use this version : https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362
+    # -- Image repository
     repository: lytrax/mailhog
+    # -- Image tag
     tag: "latest"
+    # -- Image pull policy
     pullPolicy: IfNotPresent
 
   containerPort:
-    ## @param mailhog.containerPort.http.port Mailhog HTTP port (Web UI)
-    ## @skip mailhog.containerPort.http.name
-    ##
+    # -- Mailhog HTTP port (Web UI)
     http:
       name: http
       port: 8025
-    ## @param mailhog.containerPort.smtp.port Mailhog SMTP port (Mail)
-    ## @skip mailhog.containerPort.smtp.name
-    ##
+    # -- Mailhog SMTP port (Mail)
     smtp:
       name: tcp-smtp
       port: 1025
-  ## @skip mailhog.service
-  ##
   service:
     annotations: {}
     extraPorts: []
@@ -336,43 +258,37 @@ mailhog:
     nodePort:
       http: ""
       smtp: ""
-  ## Mailhog ingress
-  ##
+  # Mailhog ingress
   ingress:
-    ## @param mailhog.ingress.enabled Enable ingress
-    ##
+    # -- Enable ingress
     enabled: true
-    ## @param mailhog.ingress.ingressClassName Ingress class name
-    ##
+    # -- Ingress class name
     ingressClassName: nginx
-    ## @param mailhog.ingress.annotations Ingress annotations
-    ##
-    annotations:
-      {}
+    # -- Ingress annotations
+    annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    ## @param mailhog.ingress.labels Ingress labels
-    ##
+    # -- Ingress labels
     labels: {}
     hosts:
-      ## @param mailhog.ingress.hosts[0].host Mailhog host
-      ##
+      # -- Mailhog host
       - host: mailhog.infisical.local
-        ## @skip mailhog.ingress.hosts[0].paths
-        ##
+        # -- Mailhog paths
         paths:
           - path: "/"
             pathType: Prefix
 
-## @section Redis parameters
-## Documentation : https://github.com/bitnami/charts/tree/main/bitnami/redis#parameters
-##
-## @skip redis
-##
+# Redis parameters
+# https://github.com/bitnami/charts/tree/main/bitnami/redis#parameters
 redis:
-  name: "redis"
-  fullnameOverride: "redis"
+  # -- Enable Redis
   enabled: true
+  # -- Redis deployment name
+  name: "redis"
+  # -- Redis fullname override
+  fullnameOverride: "redis"
+  # -- Redis architecture
   architecture: standalone
   auth:
+    # -- Redis authentication
     enabled: false

--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -1,21 +1,44 @@
 apiVersion: v2
 name: secrets-operator
-description: A Helm chart for Infisical secrets
+description: Infisical secrets k8s operator. Sync your secrets from Infisical to your clusters
+home: https://infisical.com/docs/integrations/platforms/kubernetes#install-operator
+
 # A chart can be either an 'application' or a 'library' chart.
-#
 # Application charts are a collection of templates that can be packaged into versioned archives
 # to be deployed.
-#
 # Library charts provide useful utilities or functions for the chart developer. They're included as
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
+
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+# https://hub.docker.com/r/infisical/kubernetes-operator/tags
+appVersion: "v0.3.3"
+
+# A URL to an SVG or PNG image to be used as an icon (optional).
+icon: https://raw.githubusercontent.com/Infisical/infisical/main/img/logotransparent.png
+
+# A list of keywords about this project (optional)
+keywords:
+- secretops
+- operator
+- security
+- inject
+- kubernetes
+
+# Maintainers list (name required, optional email/url)
+maintainers:
+- name: Infisical
+  url: https://infisical.com/
+  email: team@infisical.com
+
+# Deprecation notice (https://helm.sh/docs/topics/charts/#deprecating-charts)
+deprecated: false

--- a/helm-charts/secrets-operator/LICENSE
+++ b/helm-charts/secrets-operator/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2022 Infisical Inc.
+
+Portions of this software are licensed as follows:
+
+- All content that resides under any "ee/" directory of this repository, if such directories exists, are licensed under the license defined in "ee/LICENSE".
+- All third party components incorporated into the Infisical Software are licensed under the original license provided by the owner of the applicable component.
+- Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/helm-charts/secrets-operator/README.md
+++ b/helm-charts/secrets-operator/README.md
@@ -1,32 +1,112 @@
-# Infisical Helm Chart
 
-This is the Infisical Secrets Operator Helm chart. Find the integration documentation [here](https://infisical.com/docs/integrations/platforms/kubernetes)
 
-## Installation
+# Infisical Operator Helm Chart
 
-To install the chart, run the following :
+| Name | Chart | Application |
+| - | - | - |
+| [secrets-operator](https://infisical.com/docs/integrations/platforms/kubernetes#install-operator) | [![Latest version of 'secrets-operator' @ Cloudsmith](https://api-prd.cloudsmith.io/v1/badges/version/infisical/helm-charts/helm/secrets-operator/latest/x/?render=true&show_latest=true)](https://cloudsmith.io/~infisical/repos/helm-charts/packages/detail/helm/secrets-operator/latest/) | `v0.3.3` |
+
+Infisical secrets k8s operator. Sync your secrets from Infisical to your clusters
+
+## Installation & upgrade
+
+To install or upgrade the `secrets-operator` chart, run the following:
 
 ```sh
-# Add the Infisical repository
+# add the Infisical Helm repository
 helm repo add infisical 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/' && helm repo update
+```
 
-# Install Infisical Secrets Operator (with default values)
+```sh
+# with default values
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
-  infisical-secrets-operator infisical/secrets-operator
+  secrets-operator infisical/secrets-operator
 
-# Install Infisical Secrets Operator (with custom inline values, replace with your own values)
+# with custom inline values (replace with your own values)
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
-  --set controllerManager.replicas=3 \
-  infisical-secrets-operator infisical/secrets-operator
+  --set ingress.hostName=custom.example.org \
+  secrets-operator infisical/secrets-operator
 
-# Install Infisical Secrets Operator (with custom values file, replace with your own values file)
+# with custom values file (replace with your own values file)
 helm upgrade --install --atomic \
   -n infisical-dev --create-namespace \
   -f custom-values.yaml \
-  infisical-secrets-operator infisical/secrets-operator
+  secrets-operator infisical/secrets-operator
 ```
+
+Documentation is also available here : https://infisical.com/docs/self-hosting/deployment-options/kubernetes-helm
+
+> [!IMPORTANT]
+> If you change the configuration variables in the `infisical-secrets` resource, you might have to restart the infisical deployment to take effect
+
+### Encryption keys
+
+If you did not explicitly set required environment variables, the local setup ([./examples](./examples)) auto-generated them by default. It's recommended to save these credentials somewhere safe. Run the following command in your cluster where Infisical chart is installed.
+ 
+> [!NOTE]
+> Requires [`jq`](https://stedolan.github.io/jq/download/)
+
+```sh
+# export secrets to a given file
+kubectl get secrets -n infisical-dev infisical-secrets \
+  -o json | jq '.data | map_values(@base64d)' > \
+  infisical-secrets.$(date +%s).bak
+```
+
+### Upgrading
+
+Find the chart upgrade instructions below. When upgrading from your version to one of the listed below, please follow every instructions in between to correctly migrate all your data and avoid loss and unexpected issues.
+
+#### Instructions
+
+1. Make sure **you have all the required environment variables** defined in the value file (`values.yaml` or inline `--set`) you'll provide to `helm`
+   1. e.g. All the above mentioned variables
+1. **Backup your existing secrets** (before the upgrade, for safety precaution)
+   1. e.g. `kubectl get secret infisical-secrets --namespace infisical-dev -o json | jq '{name: .metadata.name,data: .data|map_values(@base64d)}'`
+2. **Upgrade the chart**, with the [instructions](#upgrading)
+3. You're all set!
+
+---
+
+<details open>
+<summary>
+
+### **`0.3.4`** (`v0.3.3`)
+</summary>
+
+Latest stable version, no breaking changes
+
+</details>
+
+## Parameters
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| controllerManager.kubeRbacProxy.image.repository | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
+| controllerManager.kubeRbacProxy.image.tag | string | `"v0.15.0"` |  |
+| controllerManager.kubeRbacProxy.resources.limits.cpu | string | `"500m"` |  |
+| controllerManager.kubeRbacProxy.resources.limits.memory | string | `"128Mi"` |  |
+| controllerManager.kubeRbacProxy.resources.requests.cpu | string | `"5m"` |  |
+| controllerManager.kubeRbacProxy.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.manager.image.repository | string | `"infisical/kubernetes-operator"` |  |
+| controllerManager.manager.image.tag | string | `"latest"` |  |
+| controllerManager.manager.resources.limits.cpu | string | `"500m"` |  |
+| controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
+| controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |
+| controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.replicas | int | `1` |  |
+| kubernetesClusterDomain | string | `"cluster.local"` |  |
+| metricsService.ports[0].name | string | `"https"` |  |
+| metricsService.ports[0].port | int | `8443` |  |
+| metricsService.ports[0].protocol | string | `"TCP"` |  |
+| metricsService.ports[0].targetPort | string | `"https"` |  |
+| metricsService.type | string | `"ClusterIP"` |  |
+
+## Validation
+
+You can automatically validate your custom `values.yaml` schema and get YAML auto-completion in your IDE, refer to this [section](../README.md#validation)
 
 ## Synchronization
 
@@ -47,53 +127,66 @@ metadata:
 spec:
   # The host that should be used to pull secrets from. The default value is https://app.infisical.com/api.
   hostAPI: https://app.infisical.com/api
-
-  # The Kubernetes secret the stores the Infisical token
-  tokenSecretReference:
-    # Kubernetes secret name
-    secretName: infisical-example-service-token
-    # The secret namespace
-    secretNamespace: default
-
-  # The Kubernetes secret that Infisical Operator will create and populate with secrets from the above project
+  # time in seconds between each secret re-sync from Infisical (default 60s)
+  resyncInterval: 60
+  authentication:
+    serviceToken:
+      # k8s secret which stores then corresponding Infisical token
+      serviceTokenSecretReference:
+        secretName: service-token
+        secretNamespace: default
+      # scope of what secrets should be fetched from infisical
+      secretsScope:
+        envSlug: dev
+        secretsPath: "/"
+  # secret that's going to be created by the operator and populated with secrets from the above configuration
   managedSecretReference:
-    # The name of managed Kubernetes secret that should be created
-    secretName: infisical-managed-secret
-    # The namespace the managed secret should be installed in
+    # name of managed secret
+    secretName: managed-secret
+    # namespace of the managed secret
     secretNamespace: default
 EOF
 ```
 
-### Managed secrets
+Documentation is also available here : https://infisical.com/docs/integrations/platforms/kubernetes#sync-infisical-secrets-to-your-cluster
 
-#### Methods
+## Managed secrets
 
-To use the above created manage secrets, you can use the below methods :
+### Methods
+
+To use the above created manage secrets, you can use the below methods:
+
 - `env`
 - `envFrom`
 - `volumes`
 
 Check the [docs](https://infisical.com/docs/integrations/platforms/kubernetes#using-managed-secret-in-your-deployment) to learn more about their implementation within your k8s resources
 
-#### Auto-reload
+### Auto-reload
 
-And if you want to [auto-reload](https://infisical.com/docs/integrations/platforms/kubernetes#auto-redeployment) your deployments, add this annotation where the managed secret is consumed :
+To [auto-reload](https://infisical.com/docs/integrations/platforms/kubernetes#auto-redeployment) your deployments, add this annotation where the managed secret is consumed:
 
 ```yaml
 annotations:
   secrets.infisical.com/auto-reload: "true"
 ```
 
-## Parameters
+```yml
+# example
 
-*Coming soon*
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+  annotations:
+    # re-deployment annotation
+    secrets.infisical.com/auto-reload: "true"
+spec:
+  ...
+```
 
 ## Local development
 
 *Coming soon*
-
-## Upgrading
-
-### 0.1.2
-
-Latest stable version, no breaking changes

--- a/helm-charts/secrets-operator/README.md.gotmpl
+++ b/helm-charts/secrets-operator/README.md.gotmpl
@@ -1,0 +1,112 @@
+# Infisical Operator Helm Chart
+
+{{ template "infisical.description" . }}
+
+{{ template "infisical.installation.repo" . }}
+
+{{ template "infisical.installation.chart" . }}
+
+{{ template "infisical.encryptionKeys" . }}
+
+{{ template "infisical.upgrading" . }}
+
+---
+
+<details open>
+<summary>
+
+### **`0.3.4`** (`v0.3.3`)
+</summary>
+
+Latest stable version, no breaking changes
+
+</details>
+
+## Parameters
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "infisical.yamlValidation" . }}
+
+## Synchronization
+
+To sync your secrets from Infisical (or from your own instance), create the below resources :
+
+```sh
+# Create the tokenSecretReference (replace with your own token)
+kubectl create secret generic infisical-example-service-token \
+  --from-literal=infisicalToken="<infisical-token-here>"
+
+# Create the InfisicalSecret
+cat <<EOF | kubectl apply -f -
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  # Name of of this InfisicalSecret resource
+  name: infisicalsecret-example
+spec:
+  # The host that should be used to pull secrets from. The default value is https://app.infisical.com/api.
+  hostAPI: https://app.infisical.com/api
+  # time in seconds between each secret re-sync from Infisical (default 60s)
+  resyncInterval: 60
+  authentication:
+    serviceToken:
+      # k8s secret which stores then corresponding Infisical token
+      serviceTokenSecretReference:
+        secretName: service-token
+        secretNamespace: default
+      # scope of what secrets should be fetched from infisical
+      secretsScope:
+        envSlug: dev
+        secretsPath: "/"
+  # secret that's going to be created by the operator and populated with secrets from the above configuration
+  managedSecretReference:
+    # name of managed secret
+    secretName: managed-secret
+    # namespace of the managed secret
+    secretNamespace: default
+EOF
+```
+
+Documentation is also available here : https://infisical.com/docs/integrations/platforms/kubernetes#sync-infisical-secrets-to-your-cluster
+
+## Managed secrets
+
+### Methods
+
+To use the above created manage secrets, you can use the below methods:
+
+- `env`
+- `envFrom`
+- `volumes`
+
+Check the [docs](https://infisical.com/docs/integrations/platforms/kubernetes#using-managed-secret-in-your-deployment) to learn more about their implementation within your k8s resources
+
+### Auto-reload
+
+To [auto-reload](https://infisical.com/docs/integrations/platforms/kubernetes#auto-redeployment) your deployments, add this annotation where the managed secret is consumed:
+
+```yaml
+annotations:
+  secrets.infisical.com/auto-reload: "true"
+```
+
+```yml
+# example
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+  annotations: 
+    # re-deployment annotation
+    secrets.infisical.com/auto-reload: "true"
+spec:
+  ...
+```
+
+## Local development
+
+*Coming soon*

--- a/helm-charts/secrets-operator/templates/NOTES.txt
+++ b/helm-charts/secrets-operator/templates/NOTES.txt
@@ -1,6 +1,6 @@
 ##
 
--- ∞ Infisical Helm Chart --
+-- ∞ Infisical Secret Operator Helm Chart --
 
 ██╗███╗   ██╗███████╗██╗███████╗██╗ ██████╗ █████╗ ██╗     
 ██║████╗  ██║██╔════╝██║██╔════╝██║██╔════╝██╔══██╗██║     
@@ -11,19 +11,13 @@
 {{ .Chart.Name }} ({{ .Chart.Version }})
 
 
-╭―― Thank you for installing Infisical! 👋  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
+╭―― Thank you for installing Infisical Secret Operator! 👋  ――――――――――――――――――――――――――――――――――――――――――┤
 │
 │   Infisical / All-in-one open-source SecretOps solution to manage your secrets across your infra! 🔒🔑
 │
-│   Visit < https://infisical.com/docs/self-hosting/overview > for further documentation about self-hosting!
+│   Visit < https://infisical.com/docs/integrations/platforms/kubernetes > for further documentation about secret sync!
 │
-│   Current installation (infisical) :
-│   • infisical-backend  : {{ .Values.backend.enabled }}
-│   • mongodb            : {{ .Values.mongodb.enabled }}
-│   • mailhog            : {{ .Values.mailhog.enabled }}
-|   • nginx              : {{ .Values.ingress.nginx.enabled }}
-│
-╰―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
+╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
 
 ――― Here's a list of helpful commands to get you started 📝  ―――――――――――――――――――――――――――――――――――――――――┤
 
@@ -38,18 +32,6 @@ $ helm get all -n {{ .Release.Namespace }} {{ .Release.Name }}
 
 → Uninstall your release
 $ helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}
-
-→ Get MongoDB root password
-$ kubectl get secret -n {{ .Release.Namespace }} mongodb
-   -o jsonpath="{.data['mongodb-root-password']}" | base64 -d
-
-→ Get MongoDB users passwords
-$ kubectl get secret -n {{ .Release.Namespace }} mongodb
-   -o jsonpath="{.data['mongodb-passwords']}" | base64 -d 
-
-→ Export your backend secrets (requires jq)
-$ kubectl get secrets/<your-secret-name> -n {{ .Release.Namespace }} \
-   -o json | jq '.data | map_values(@base64d)' > <dest-filename>.bak
  
 ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――┤
 

--- a/helm-charts/secrets-operator/values.schema.json
+++ b/helm-charts/secrets-operator/values.schema.json
@@ -1,0 +1,172 @@
+{
+  "properties": {
+    "controllerManager": {
+      "properties": {
+        "kubeRbacProxy": {
+          "properties": {
+            "image": {
+              "properties": {
+                "repository": {
+                  "title": "repository",
+                  "type": "string"
+                },
+                "tag": {
+                  "title": "tag",
+                  "type": "string"
+                }
+              },
+              "title": "image",
+              "type": "object"
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "properties": {
+                    "cpu": {
+                      "title": "cpu",
+                      "type": "string"
+                    },
+                    "memory": {
+                      "title": "memory",
+                      "type": "string"
+                    }
+                  },
+                  "title": "limits",
+                  "type": "object"
+                },
+                "requests": {
+                  "properties": {
+                    "cpu": {
+                      "title": "cpu",
+                      "type": "string"
+                    },
+                    "memory": {
+                      "title": "memory",
+                      "type": "string"
+                    }
+                  },
+                  "title": "requests",
+                  "type": "object"
+                }
+              },
+              "title": "resources",
+              "type": "object"
+            }
+          },
+          "title": "kubeRbacProxy",
+          "type": "object"
+        },
+        "manager": {
+          "properties": {
+            "image": {
+              "properties": {
+                "repository": {
+                  "title": "repository",
+                  "type": "string"
+                },
+                "tag": {
+                  "title": "tag",
+                  "type": "string"
+                }
+              },
+              "title": "image",
+              "type": "object"
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "properties": {
+                    "cpu": {
+                      "title": "cpu",
+                      "type": "string"
+                    },
+                    "memory": {
+                      "title": "memory",
+                      "type": "string"
+                    }
+                  },
+                  "title": "limits",
+                  "type": "object"
+                },
+                "requests": {
+                  "properties": {
+                    "cpu": {
+                      "title": "cpu",
+                      "type": "string"
+                    },
+                    "memory": {
+                      "title": "memory",
+                      "type": "string"
+                    }
+                  },
+                  "title": "requests",
+                  "type": "object"
+                }
+              },
+              "title": "resources",
+              "type": "object"
+            }
+          },
+          "title": "manager",
+          "type": "object"
+        },
+        "replicas": {
+          "title": "replicas",
+          "type": "integer"
+        }
+      },
+      "description": "test",
+      "title": "controllerManager",
+      "type": "object"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "title": "global",
+      "type": "object"
+    },
+    "kubernetesClusterDomain": {
+      "title": "kubernetesClusterDomain",
+      "type": "string"
+    },
+    "metricsService": {
+      "properties": {
+        "ports": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "name": {
+                    "title": "name",
+                    "type": "string"
+                  },
+                  "port": {
+                    "title": "port",
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "title": "protocol",
+                    "type": "string"
+                  },
+                  "targetPort": {
+                    "title": "targetPort",
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
+          "title": "ports",
+          "type": "array"
+        },
+        "type": {
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "title": "metricsService",
+      "type": "object"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object"
+}

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=values.schema.json
+
 controllerManager:
   kubeRbacProxy:
     image:


### PR DESCRIPTION
# Description 📣

> [!NOTE]
> I know there's a lot of addition, but it's mostly auto-generated. Schemas and documentation ✌🏽 

Documentation was missing for the new `infisical-standalone` chart, and previous helm charts documentations were a bit outdated. This PR aims to resolve this.

What have been done:

- ✅ implement `helm-docs` instead of the previous automated documentation generator
  - used gotemplates for DRY and automation purposes
  - generated the charts' documentation

- ✅ implement [`helm-schema`](https://github.com/dadav/helm-schema) to automatically generate YAML validation schema for Helm
  - as for today the schema is pretty permissive, to avoid any issues with the current developers
  - not yet implemented in `helm-docs`: https://github.com/norwoodj/helm-docs/issues/90

- ✅ set the infisical service port to `80` instead of `8080` (standard port for `http`)
  - to avoid thinking about the port when trying to use the service's URL in-cluster (e.g. self-hosted + operator)

- ✅ add license to each of the charts, aiming to be used one day by either cloudsmith/artifact.io... (common in other helm charts)

- ✅ add alternative for the developers to define their infisical configuration directly through helm with `infisical.config.<CONFIG_KEY>`
  - it allows developers using gitops mechanism to easily provide every variables in a normalized way through the same tool
  - but of course we're keeping the other alternatives like `infisical-secrets` to provide the same variables
  - order of precedence is now: `infisical.config` > `infisical.secrets` > `default` (e.g. for postgres and redis)
    - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#container-v1-core
  - post discussing about benefits between `env:` and `envFrom:`: https://flagzeta.org/articles/difference-between-env-and-envfrom-kubernetes-deployments/

- ✅ deprecate the `infisical` (mongodb) chart

- ✅ update all the `Chart.yaml` to be a bit more complete
  - those additional keys help the registries to scan your chart correctly and provide accurate information to the developers

- ✅ remove and rename some redis keys not found in the remote chart
  - https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
  - `usePassword` doesnt seems to be available and have been replaced by `auth.enabled`
  - `cluster.enabled` doesnt exist and have been removed (as its a complete different chart in Bitnami's repo)

- ✅ merge postgres persistence common settings to current `values.yaml`
  - if the developer wants to increase the PVC size for example

---

BTW we might need to update the old deprecated images on https://hub.docker.com?
- [ ] add deprecation warning on front/backend images
  - https://hub.docker.com/r/infisical/backend
  - https://hub.docker.com/r/infisical/frontend

---

Some resources about schema validation:
- https://objectpartners.com/2021/01/21/why-we-started-using-json-schema-in-our-internal-helm-charts/
- https://austindewey.com/2020/06/13/helm-tricks-input-validation-with-values-schema-json/

## Type ✨

- [x] New feature
- [x] Documentation

# Tests 🛠️

You can follow the doc provided in this PR, everything is explained. Let me know if you need further explanations

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝