### PR TITLE
Fix: CLI user authentication

### DIFF
--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -97,6 +97,11 @@ func RequireLogin() {
 	}
 }
 
+func IsLoggedIn() bool {
+	configFile, _ := GetConfigFile()
+	return configFile.LoggedInUserEmail != ""
+}
+
 func RequireServiceToken() {
 	serviceToken := os.Getenv(INFISICAL_TOKEN_NAME)
 	if serviceToken == "" {

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -427,6 +427,8 @@ func ExpandSecrets(secrets []models.SingleEnvironmentVariable, auth models.Expan
 					refSecs, err = GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: env, InfisicalToken: auth.InfisicalToken, SecretsPath: secPath}, projectConfigPathDir)
 				} else if auth.UniversalAuthAccessToken != "" {
 					refSecs, err = GetAllEnvironmentVariables((models.GetAllSecretsParameters{Environment: env, UniversalAuthAccessToken: auth.UniversalAuthAccessToken, SecretsPath: secPath, WorkspaceId: sec.WorkspaceId}), projectConfigPathDir)
+				} else if IsLoggedIn() {
+					refSecs, err = GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: env, SecretsPath: secPath}, projectConfigPathDir)
 				} else {
 					HandleError(errors.New("no authentication provided"), "Please provide authentication to fetch secrets")
 				}


### PR DESCRIPTION
# Description 📣

Fix for version 0.18.2, where it will fail to expand secrets and throw an "invalid auth" error if you aren't using service tokens. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->