### PR TITLE
Fix typo on Copy button tooltip

### DIFF
--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
@@ -188,7 +188,7 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: 10, opacity: 0 }}
               >
-                <Tooltip content="Copy secret">
+                <Tooltip content="Copy secret name">
                   <IconButton
                     ariaLabel="copy-value"
                     variant="plain"


### PR DESCRIPTION
# Description 📣

Change tooltip text from `Copy secret` to `Copy secret name` on Key copy button 
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->