### PR TITLE
Remove recursive behavior in AWS PS integration

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -459,7 +459,7 @@ const syncSecretsAWSParameterStore = async ({
 
   const params = {
     Path: integration.path as string,
-    Recursive: true,
+    Recursive: false,
     WithDecryption: true
   };
 


### PR DESCRIPTION
# Description 📣

This PR sets the recursive behavior flag to `false` for the AWS Parameter Store integration.

Previously, configuring the integration sync to AWS PS would override all nested parameter values in sub-routes; setting the flag to `false` avoids such unintended recursive deletion.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝