### PR TITLE
Fix: Mintlify interactive API docs defaulting to localhost server

### DIFF
--- a/backend/src/server/plugins/swagger.ts
+++ b/backend/src/server/plugins/swagger.ts
@@ -15,12 +15,12 @@ export const fastifySwagger = fp(async (fastify) => {
       },
       servers: [
         {
-          url: "http://localhost:8080",
-          description: "Local server"
-        },
-        {
           url: "https://app.infisical.com",
           description: "Production server"
+        },
+        {
+          url: "http://localhost:8080",
+          description: "Local server"
         }
       ],
       components: {


### PR DESCRIPTION
# Description 📣

We are having an issue with Mintlify defaulting to the dev server. Changing the order in our swagger config resolves this issue. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->