### PR TITLE
Fix: Remove required org slug from create project route

### DIFF
--- a/backend/src/server/routes/v2/project-router.ts
+++ b/backend/src/server/routes/v2/project-router.ts
@@ -150,8 +150,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
             message: "Slug must be a valid slug"
           })
           .optional()
-          .describe(PROJECTS.CREATE.slug),
-        organizationSlug: z.string().trim().describe(PROJECTS.CREATE.organizationSlug)
+          .describe(PROJECTS.CREATE.slug)
       }),
       response: {
         200: z.object({
@@ -166,7 +165,6 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         actor: req.permission.type,
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod,
-        orgSlug: req.body.organizationSlug,
         workspaceName: req.body.projectName,
         slug: req.body.slug
       });

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -92,7 +92,6 @@ export const projectServiceFactory = ({
    * Create workspace. Make user the admin
    * */
   const createProject = async ({
-    orgSlug,
     actor,
     actorId,
     actorOrgId,
@@ -100,13 +99,7 @@ export const projectServiceFactory = ({
     workspaceName,
     slug: projectSlug
   }: TCreateProjectDTO) => {
-    if (!orgSlug) {
-      throw new BadRequestError({
-        message: "Must provide organization slug to create project"
-      });
-    }
-
-    const organization = await orgDAL.findOne({ slug: orgSlug });
+    const organization = await orgDAL.findOne({ id: actorOrgId });
 
     const { permission, membership: orgMembership } = await permissionService.getOrgPermission(
       actor,

--- a/backend/src/services/project/project-types.ts
+++ b/backend/src/services/project/project-types.ts
@@ -24,7 +24,6 @@ export type TCreateProjectDTO = {
   actorAuthMethod: ActorAuthMethod;
   actorId: string;
   actorOrgId?: string;
-  orgSlug: string;
   workspaceName: string;
   slug?: string;
 };

--- a/frontend/src/components/signup/UserInfoStep.tsx
+++ b/frontend/src/components/signup/UserInfoStep.tsx
@@ -196,10 +196,8 @@ export default function UserInfoStep({
 
               const userOrgs = await fetchOrganizations();
 
-              const orgSlug = userOrgs[0]?.slug;
               const orgId = userOrgs[0]?.id;
               const project = await ProjectService.initProject({
-                organizationSlug: orgSlug,
                 projectName: "Example Project"
               });
 

--- a/frontend/src/helpers/project.ts
+++ b/frontend/src/helpers/project.ts
@@ -77,18 +77,11 @@ const secretsToBeAdded = [
  * @param {String} obj.projectName - name of new project
  * @returns {Project} project - new project
  */
-const initProjectHelper = async ({
-  organizationSlug,
-  projectName
-}: {
-  organizationSlug: string;
-  projectName: string;
-}) => {
+const initProjectHelper = async ({ projectName }: { projectName: string }) => {
   // create new project
   const {
     data: { project }
   } = await createWorkspace({
-    organizationSlug,
     projectName
   });
 

--- a/frontend/src/hooks/api/workspace/queries.tsx
+++ b/frontend/src/hooks/api/workspace/queries.tsx
@@ -199,19 +199,17 @@ export const useGetWorkspaceIntegrations = (workspaceId: string) =>
   });
 
 export const createWorkspace = ({
-  organizationSlug,
   projectName
 }: CreateWorkspaceDTO): Promise<{ data: { project: Workspace } }> => {
-  return apiRequest.post("/api/v2/workspace", { projectName, organizationSlug });
+  return apiRequest.post("/api/v2/workspace", { projectName });
 };
 
 export const useCreateWorkspace = () => {
   const queryClient = useQueryClient();
 
   return useMutation<{ data: { project: Workspace } }, {}, CreateWorkspaceDTO>({
-    mutationFn: async ({ organizationSlug, projectName }) =>
+    mutationFn: async ({ projectName }) =>
       createWorkspace({
-        organizationSlug,
         projectName
       }),
     onSuccess: () => {
@@ -325,7 +323,13 @@ export const useDeleteUserFromWorkspace = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ usernames, workspaceId }: { workspaceId: string; usernames: string[] }) => {
+    mutationFn: async ({
+      usernames,
+      workspaceId
+    }: {
+      workspaceId: string;
+      usernames: string[];
+    }) => {
       const {
         data: { deletedMembership }
       } = await apiRequest.delete(`/api/v2/workspace/${workspaceId}/memberships`, {
@@ -391,11 +395,7 @@ export const useAddIdentityToWorkspace = () => {
 export const useUpdateIdentityWorkspaceRole = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      identityId,
-      workspaceId,
-      roles
-    }:TUpdateWorkspaceIdentityRoleDTO)=> {
+    mutationFn: async ({ identityId, workspaceId, roles }: TUpdateWorkspaceIdentityRoleDTO) => {
       const {
         data: { identityMembership }
       } = await apiRequest.patch(

--- a/frontend/src/hooks/api/workspace/types.ts
+++ b/frontend/src/hooks/api/workspace/types.ts
@@ -45,7 +45,6 @@ export type TGetUpgradeProjectStatusDTO = {
 // mutation dto
 export type CreateWorkspaceDTO = {
   projectName: string;
-  organizationSlug: string;
 };
 
 export type RenameWorkspaceDTO = { workspaceID: string; newWorkspaceName: string };
@@ -82,16 +81,16 @@ export type TUpdateWorkspaceUserRoleDTO = {
   workspaceId: string;
   roles: (
     | {
-      role: string;
-      isTemporary?: false;
-    }
+        role: string;
+        isTemporary?: false;
+      }
     | {
-      role: string;
-      isTemporary: true;
-      temporaryMode: ProjectUserMembershipTemporaryMode;
-      temporaryRange: string;
-      temporaryAccessStartTime: string;
-    }
+        role: string;
+        isTemporary: true;
+        temporaryMode: ProjectUserMembershipTemporaryMode;
+        temporaryRange: string;
+        temporaryAccessStartTime: string;
+      }
   )[];
 };
 
@@ -100,15 +99,15 @@ export type TUpdateWorkspaceIdentityRoleDTO = {
   workspaceId: string;
   roles: (
     | {
-      role: string;
-      isTemporary?: false;
-    }
+        role: string;
+        isTemporary?: false;
+      }
     | {
-      role: string;
-      isTemporary: true;
-      temporaryMode: ProjectUserMembershipTemporaryMode;
-      temporaryRange: string;
-      temporaryAccessStartTime: string;
-    }
+        role: string;
+        isTemporary: true;
+        temporaryMode: ProjectUserMembershipTemporaryMode;
+        temporaryRange: string;
+        temporaryAccessStartTime: string;
+      }
   )[];
 };

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -236,7 +236,6 @@ export const AppLayout = ({ children }: LayoutProps) => {
           project: { id: newProjectId }
         }
       } = await createWs.mutateAsync({
-        organizationSlug: currentOrg.slug,
         projectName: name
       });
 

--- a/frontend/src/pages/org/[id]/overview/index.tsx
+++ b/frontend/src/pages/org/[id]/overview/index.tsx
@@ -512,7 +512,6 @@ const OrganizationPage = withPermission(
             project: { id: newProjectId }
           }
         } = await createWs.mutateAsync({
-          organizationSlug: currentOrg.slug,
           projectName: name
         });
 

--- a/frontend/src/services/ProjectService.ts
+++ b/frontend/src/services/ProjectService.ts
@@ -9,15 +9,8 @@ class ProjectService {
    * @param {String} obj.projectName - name of new project
    * @returns {Project} project - new project
    */
-  static async initProject({
-    organizationSlug,
-    projectName
-  }: {
-    organizationSlug: string;
-    projectName: string;
-  }) {
+  static async initProject({ projectName }: { projectName: string }) {
     return initProjectHelper({
-      organizationSlug,
       projectName
     });
   }

--- a/frontend/src/views/Signup/components/UserInfoSSOStep/UserInfoSSOStep.tsx
+++ b/frontend/src/views/Signup/components/UserInfoSSOStep/UserInfoSSOStep.tsx
@@ -189,14 +189,12 @@ export const UserInfoSSOStep = ({
 
               const userOrgs = await fetchOrganizations();
               const orgId = userOrgs[0]?.id;
-              const orgSlug = userOrgs[0]?.slug;
 
               await selectOrganization({
                 organizationId: orgId
               });
 
               const project = await ProjectService.initProject({
-                organizationSlug: orgSlug,
                 projectName: "Example Project"
               });
 


### PR DESCRIPTION
# Description 📣

We actually don't need to take an org slug as a parameter anymore, since we can be sure the `actorOrgId` is always defined now!

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->