### PR TITLE
Feat: Recursively get all secrets from all folders in specified path

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -215,6 +215,7 @@ export const SECRETS = {
 
 export const RAW_SECRETS = {
   LIST: {
+    recursive: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
     workspaceId: "The ID of the project to list secrets from.",
     workspaceSlug: "The slug of the project to list secrets from. This parameter is only usable by machine identities.",
     environment: "The slug of the environment to list secrets from.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -215,7 +215,7 @@ export const SECRETS = {
 
 export const RAW_SECRETS = {
   LIST: {
-    recursive: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
+    deep: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
     workspaceId: "The ID of the project to list secrets from.",
     workspaceSlug: "The slug of the project to list secrets from. This parameter is only usable by machine identities.",
     environment: "The slug of the environment to list secrets from.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -215,7 +215,7 @@ export const SECRETS = {
 
 export const RAW_SECRETS = {
   LIST: {
-    deep: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
+    recursive: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
     workspaceId: "The ID of the project to list secrets from.",
     workspaceSlug: "The slug of the project to list secrets from. This parameter is only usable by machine identities.",
     environment: "The slug of the environment to list secrets from.",

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -479,6 +479,7 @@ export const registerRoutes = async (
     snapshotService,
     secretQueueService,
     secretImportDAL,
+    projectEnvDAL,
     projectBotService
   });
   const sarService = secretApprovalRequestServiceFactory({

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -171,11 +171,9 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
       response: {
         200: z.object({
           secrets: secretRawSchema
-            .merge(
-              z.object({
-                secretPath: z.string().optional()
-              })
-            )
+            .extend({
+              secretPath: z.string().optional()
+            })
             .array(),
           imports: z
             .object({
@@ -620,20 +618,18 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
       response: {
         200: z.object({
           secrets: SecretsSchema.omit({ secretBlindIndex: true })
-            .merge(
-              z.object({
-                _id: z.string(),
-                workspace: z.string(),
-                environment: z.string(),
-                secretPath: z.string().optional(),
-                tags: SecretTagsSchema.pick({
-                  id: true,
-                  slug: true,
-                  name: true,
-                  color: true
-                }).array()
-              })
-            )
+            .extend({
+              _id: z.string(),
+              workspace: z.string(),
+              environment: z.string(),
+              secretPath: z.string().optional(),
+              tags: SecretTagsSchema.pick({
+                id: true,
+                slug: true,
+                name: true,
+                color: true
+              }).array()
+            })
             .array(),
           imports: z
             .object({

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -157,11 +157,11 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         workspaceSlug: z.string().trim().optional().describe(RAW_SECRETS.LIST.workspaceSlug),
         environment: z.string().trim().optional().describe(RAW_SECRETS.LIST.environment),
         secretPath: z.string().trim().default("/").transform(removeTrailingSlash).describe(RAW_SECRETS.LIST.secretPath),
-        deep: z
+        recursive: z
           .enum(["true", "false"])
           .default("false")
           .transform((value) => value === "true")
-          .describe(RAW_SECRETS.LIST.deep),
+          .describe(RAW_SECRETS.LIST.recursive),
         include_imports: z
           .enum(["true", "false"])
           .default("false")
@@ -228,7 +228,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         projectId: workspaceId,
         path: secretPath,
         includeImports: req.query.include_imports,
-        deep: req.query.deep
+        recursive: req.query.recursive
       });
 
       await server.services.auditLog.createAuditLog({
@@ -606,7 +606,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         workspaceId: z.string().trim(),
         environment: z.string().trim(),
         secretPath: z.string().trim().default("/").transform(removeTrailingSlash),
-        deep: z
+        recursive: z
           .enum(["true", "false"])
           .default("false")
           .transform((value) => value === "true"),
@@ -662,7 +662,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         projectId: req.query.workspaceId,
         path: req.query.secretPath,
         includeImports: req.query.include_imports,
-        deep: req.query.deep
+        recursive: req.query.recursive
       });
 
       await server.services.auditLog.createAuditLog({

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -157,11 +157,11 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         workspaceSlug: z.string().trim().optional().describe(RAW_SECRETS.LIST.workspaceSlug),
         environment: z.string().trim().optional().describe(RAW_SECRETS.LIST.environment),
         secretPath: z.string().trim().default("/").transform(removeTrailingSlash).describe(RAW_SECRETS.LIST.secretPath),
-        recursive: z
+        deep: z
           .enum(["true", "false"])
           .default("false")
           .transform((value) => value === "true")
-          .describe(RAW_SECRETS.LIST.recursive),
+          .describe(RAW_SECRETS.LIST.deep),
         include_imports: z
           .enum(["true", "false"])
           .default("false")
@@ -230,7 +230,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         projectId: workspaceId,
         path: secretPath,
         includeImports: req.query.include_imports,
-        recursive: req.query.recursive
+        deep: req.query.deep
       });
 
       await server.services.auditLog.createAuditLog({
@@ -608,6 +608,10 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         workspaceId: z.string().trim(),
         environment: z.string().trim(),
         secretPath: z.string().trim().default("/").transform(removeTrailingSlash),
+        deep: z
+          .enum(["true", "false"])
+          .default("false")
+          .transform((value) => value === "true"),
         include_imports: z
           .enum(["true", "false"])
           .default("false")
@@ -621,6 +625,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
                 _id: z.string(),
                 workspace: z.string(),
                 environment: z.string(),
+                secretPath: z.string().optional(),
                 tags: SecretTagsSchema.pick({
                   id: true,
                   slug: true,
@@ -660,7 +665,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         environment: req.query.environment,
         projectId: req.query.workspaceId,
         path: req.query.secretPath,
-        includeImports: req.query.include_imports
+        includeImports: req.query.include_imports,
+        deep: req.query.deep
       });
 
       await server.services.auditLog.createAuditLog({

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -473,14 +473,15 @@ export const secretServiceFactory = ({
 
       if (!deepPaths) return { secrets: [], imports: [] };
     } else {
-      const folder = await folderDAL.findBySecretPath(projectId, environment, path);
-      if (!folder) return { secrets: [], imports: [] };
-      paths = [{ folderId: folder.id, path }];
-
       ForbiddenError.from(permission).throwUnlessCan(
         ProjectPermissionActions.Read,
-        subject(ProjectPermissionSub.Secrets, { environment, secretPath: folder.path })
+        subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
       );
+
+      const folder = await folderDAL.findBySecretPath(projectId, environment, path);
+      if (!folder) return { secrets: [], imports: [] };
+
+      paths = [{ folderId: folder.id, path }];
     }
 
     const groupedPaths = groupBy(paths, (p) => p.folderId);

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -440,7 +440,7 @@ export const secretServiceFactory = ({
     actorOrgId,
     actorAuthMethod,
     includeImports,
-    deep
+    recursive
   }: TGetSecretsDTO) => {
     const { permission } = await permissionService.getProjectPermission(
       actor,
@@ -452,7 +452,7 @@ export const secretServiceFactory = ({
 
     let paths: { folderId: string; path: string }[] = [];
 
-    if (deep) {
+    if (recursive) {
       const getPaths = recursivelyGetSecretPaths({
         permissionService,
         folderDAL,
@@ -852,7 +852,7 @@ export const secretServiceFactory = ({
     actorAuthMethod,
     environment,
     includeImports,
-    deep
+    recursive
   }: TGetSecretsRawDTO) => {
     const botKey = await projectBotService.getBotKey(projectId);
     if (!botKey) throw new BadRequestError({ message: "Project bot not found", name: "bot_not_found_error" });
@@ -866,7 +866,7 @@ export const secretServiceFactory = ({
       actorAuthMethod,
       path,
       includeImports,
-      deep
+      recursive
     });
 
     return {

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -472,6 +472,8 @@ export const secretServiceFactory = ({
       });
 
       if (!deepPaths) return { secrets: [], imports: [] };
+
+      paths = deepPaths.map(({ folderId, path: p }) => ({ folderId, path: p }));
     } else {
       ForbiddenError.from(permission).throwUnlessCan(
         ProjectPermissionActions.Read,

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -471,7 +471,7 @@ export const secretServiceFactory = ({
         }
       });
 
-      paths = deepPaths.length === 0 ? paths : deepPaths;
+      if (!deepPaths) return { secrets: [], imports: [] };
     } else {
       const folder = await folderDAL.findBySecretPath(projectId, environment, path);
       if (!folder) return { secrets: [], imports: [] };

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -140,6 +140,7 @@ export type TGetSecretsRawDTO = {
   path: string;
   environment: string;
   includeImports?: boolean;
+  recursive?: boolean;
 } & TProjectPermission;
 
 export type TGetASecretRawDTO = {

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -74,6 +74,7 @@ export type TGetSecretsDTO = {
   path: string;
   environment: string;
   includeImports?: boolean;
+  deep?: boolean;
 } & TProjectPermission;
 
 export type TGetASecretDTO = {
@@ -140,7 +141,7 @@ export type TGetSecretsRawDTO = {
   path: string;
   environment: string;
   includeImports?: boolean;
-  recursive?: boolean;
+  deep?: boolean;
 } & TProjectPermission;
 
 export type TGetASecretRawDTO = {

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -74,7 +74,7 @@ export type TGetSecretsDTO = {
   path: string;
   environment: string;
   includeImports?: boolean;
-  deep?: boolean;
+  recursive?: boolean;
 } & TProjectPermission;
 
 export type TGetASecretDTO = {
@@ -141,7 +141,7 @@ export type TGetSecretsRawDTO = {
   path: string;
   environment: string;
   includeImports?: boolean;
-  deep?: boolean;
+  recursive?: boolean;
 } & TProjectPermission;
 
 export type TGetASecretRawDTO = {

--- a/cli/packages/api/api.go
+++ b/cli/packages/api/api.go
@@ -277,8 +277,8 @@ func CallGetSecretsV3(httpClient *resty.Client, request GetEncryptedSecretsV3Req
 		SetQueryParam("environment", request.Environment).
 		SetQueryParam("workspaceId", request.WorkspaceId)
 
-	if request.DeepSearch {
-		httpRequest.SetQueryParam("deep", "true")
+	if request.Recursive {
+		httpRequest.SetQueryParam("recursive", "true")
 	}
 
 	if request.IncludeImport {

--- a/cli/packages/api/api.go
+++ b/cli/packages/api/api.go
@@ -277,6 +277,10 @@ func CallGetSecretsV3(httpClient *resty.Client, request GetEncryptedSecretsV3Req
 		SetQueryParam("environment", request.Environment).
 		SetQueryParam("workspaceId", request.WorkspaceId)
 
+	if request.DeepSearch {
+		httpRequest.SetQueryParam("deep", "true")
+	}
+
 	if request.IncludeImport {
 		httpRequest.SetQueryParam("include_imports", "true")
 	}

--- a/cli/packages/api/model.go
+++ b/cli/packages/api/model.go
@@ -291,6 +291,7 @@ type GetEncryptedSecretsV3Request struct {
 	WorkspaceId   string `json:"workspaceId"`
 	SecretPath    string `json:"secretPath"`
 	IncludeImport bool   `json:"include_imports"`
+	DeepSearch    bool   `json:"deep"`
 }
 
 type GetFoldersV1Request struct {

--- a/cli/packages/api/model.go
+++ b/cli/packages/api/model.go
@@ -291,7 +291,7 @@ type GetEncryptedSecretsV3Request struct {
 	WorkspaceId   string `json:"workspaceId"`
 	SecretPath    string `json:"secretPath"`
 	IncludeImport bool   `json:"include_imports"`
-	DeepSearch    bool   `json:"deep"`
+	Recursive     bool   `json:"recursive"`
 }
 
 type GetFoldersV1Request struct {
@@ -511,7 +511,7 @@ type CreateDynamicSecretLeaseV1Request struct {
 
 type CreateDynamicSecretLeaseV1Response struct {
 	Lease struct {
-		Id       string `json:"id"`
+		Id       string    `json:"id"`
 		ExpireAt time.Time `json:"expireAt"`
 	} `json:"lease"`
 	DynamicSecret struct {

--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -332,7 +332,7 @@ func ParseAgentConfig(configFile []byte) (*Config, error) {
 
 func secretTemplateFunction(accessToken string, existingEtag string, currentEtag *string) func(string, string, string) ([]models.SingleEnvironmentVariable, error) {
 	return func(projectID, envSlug, secretPath string) ([]models.SingleEnvironmentVariable, error) {
-		res, err := util.GetPlainTextSecretsViaMachineIdentity(accessToken, projectID, envSlug, secretPath, false)
+		res, err := util.GetPlainTextSecretsViaMachineIdentity(accessToken, projectID, envSlug, secretPath, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -98,7 +98,12 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports}, projectConfigDir)
+		deepSearch, err := cmd.Flags().GetBool("deep")
+		if err != nil {
+			util.HandleError(err, "Unable to parse flag")
+		}
+
+		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, DeepSearch: deepSearch}, projectConfigDir)
 
 		if err != nil {
 			util.HandleError(err, "Could not fetch secrets", "If you are using a service token to fetch secrets, please ensure it is valid")
@@ -202,6 +207,7 @@ func init() {
 	runCmd.Flags().StringP("env", "e", "dev", "Set the environment (dev, prod, etc.) from which your secrets should be pulled from")
 	runCmd.Flags().Bool("expand", true, "Parse shell parameter expansions in your secrets")
 	runCmd.Flags().Bool("include-imports", true, "Import linked secrets ")
+	runCmd.Flags().Bool("deep", false, "Fetch secrets from all sub-folders")
 	runCmd.Flags().Bool("secret-overriding", true, "Prioritizes personal secrets, if any, with the same name over shared secrets")
 	runCmd.Flags().StringP("command", "c", "", "chained commands to execute (e.g. \"npm install && npm run dev; echo ...\")")
 	runCmd.Flags().StringP("tags", "t", "", "filter secrets by tag slugs ")

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -98,12 +98,12 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		deepSearch, err := cmd.Flags().GetBool("deep")
+		recursive, err := cmd.Flags().GetBool("recursive")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, DeepSearch: deepSearch}, projectConfigDir)
+		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, Recursive: recursive}, projectConfigDir)
 
 		if err != nil {
 			util.HandleError(err, "Could not fetch secrets", "If you are using a service token to fetch secrets, please ensure it is valid")
@@ -207,7 +207,7 @@ func init() {
 	runCmd.Flags().StringP("env", "e", "dev", "Set the environment (dev, prod, etc.) from which your secrets should be pulled from")
 	runCmd.Flags().Bool("expand", true, "Parse shell parameter expansions in your secrets")
 	runCmd.Flags().Bool("include-imports", true, "Import linked secrets ")
-	runCmd.Flags().Bool("deep", false, "Fetch secrets from all sub-folders")
+	runCmd.Flags().Bool("recursive", false, "Fetch secrets from all sub-folders")
 	runCmd.Flags().Bool("secret-overriding", true, "Prioritizes personal secrets, if any, with the same name over shared secrets")
 	runCmd.Flags().StringP("command", "c", "", "chained commands to execute (e.g. \"npm install && npm run dev; echo ...\")")
 	runCmd.Flags().StringP("tags", "t", "", "filter secrets by tag slugs ")

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -63,6 +63,13 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
+		deepSearch, err := cmd.Flags().GetBool("deep")
+		if err != nil {
+			util.HandleError(err)
+		}
+
+		fmt.Printf("Is deep search: %v\n", deepSearch)
+
 		tagSlugs, err := cmd.Flags().GetString("tags")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
@@ -73,7 +80,7 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports}, "")
+		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, DeepSearch: deepSearch}, "")
 		if err != nil {
 			util.HandleError(err)
 		}
@@ -413,12 +420,17 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse path flag")
 	}
 
+	deepSearch, err := cmd.Flags().GetBool("deep")
+	if err != nil {
+		util.HandleError(err, "Unable to parse deep flag")
+	}
+
 	showOnlyValue, err := cmd.Flags().GetBool("raw-value")
 	if err != nil {
 		util.HandleError(err, "Unable to parse path flag")
 	}
 
-	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: true}, "")
+	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: true, DeepSearch: deepSearch}, "")
 	if err != nil {
 		util.HandleError(err, "To fetch all secrets")
 	}
@@ -727,6 +739,7 @@ func init() {
 	secretsCmd.PersistentFlags().String("env", "dev", "Used to select the environment name on which actions should be taken on")
 	secretsCmd.Flags().Bool("expand", true, "Parse shell parameter expansions in your secrets")
 	secretsCmd.Flags().Bool("include-imports", true, "Imported linked secrets ")
+	secretsCmd.Flags().Bool("deep", false, "Fetch secrets from all sub-folders")
 	secretsCmd.PersistentFlags().StringP("tags", "t", "", "filter secrets by tag slugs")
 	secretsCmd.Flags().String("path", "/", "get secrets within a folder path")
 	rootCmd.AddCommand(secretsCmd)

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -63,12 +63,10 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
-		deepSearch, err := cmd.Flags().GetBool("deep")
+		recursive, err := cmd.Flags().GetBool("recursive")
 		if err != nil {
 			util.HandleError(err)
 		}
-
-		fmt.Printf("Is deep search: %v\n", deepSearch)
 
 		tagSlugs, err := cmd.Flags().GetString("tags")
 		if err != nil {
@@ -80,7 +78,7 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, DeepSearch: deepSearch}, "")
+		secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: includeImports, Recursive: recursive}, "")
 		if err != nil {
 			util.HandleError(err)
 		}
@@ -420,9 +418,9 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse path flag")
 	}
 
-	deepSearch, err := cmd.Flags().GetBool("deep")
+	recursive, err := cmd.Flags().GetBool("recursive")
 	if err != nil {
-		util.HandleError(err, "Unable to parse deep flag")
+		util.HandleError(err, "Unable to parse recursive flag")
 	}
 
 	showOnlyValue, err := cmd.Flags().GetBool("raw-value")
@@ -430,7 +428,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse path flag")
 	}
 
-	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: true, DeepSearch: deepSearch}, "")
+	secrets, err := util.GetAllEnvironmentVariables(models.GetAllSecretsParameters{Environment: environmentName, InfisicalToken: infisicalToken, TagSlugs: tagSlugs, SecretsPath: secretsPath, IncludeImport: true, Recursive: recursive}, "")
 	if err != nil {
 		util.HandleError(err, "To fetch all secrets")
 	}
@@ -739,7 +737,7 @@ func init() {
 	secretsCmd.PersistentFlags().String("env", "dev", "Used to select the environment name on which actions should be taken on")
 	secretsCmd.Flags().Bool("expand", true, "Parse shell parameter expansions in your secrets")
 	secretsCmd.Flags().Bool("include-imports", true, "Imported linked secrets ")
-	secretsCmd.Flags().Bool("deep", false, "Fetch secrets from all sub-folders")
+	secretsCmd.Flags().Bool("recursive", false, "Fetch secrets from all sub-folders")
 	secretsCmd.PersistentFlags().StringP("tags", "t", "", "filter secrets by tag slugs")
 	secretsCmd.Flags().String("path", "/", "get secrets within a folder path")
 	rootCmd.AddCommand(secretsCmd)

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -93,6 +93,7 @@ type GetAllSecretsParameters struct {
 	WorkspaceId              string
 	SecretsPath              string
 	IncludeImport            bool
+	DeepSearch               bool
 }
 
 type GetAllFoldersParameters struct {

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -93,7 +93,7 @@ type GetAllSecretsParameters struct {
 	WorkspaceId              string
 	SecretsPath              string
 	IncludeImport            bool
-	DeepSearch               bool
+	Recursive                bool
 }
 
 type GetAllFoldersParameters struct {

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func GetPlainTextSecretsViaServiceToken(fullServiceToken string, environment string, secretPath string, includeImports bool, deepSearch bool) ([]models.SingleEnvironmentVariable, api.GetServiceTokenDetailsResponse, error) {
+func GetPlainTextSecretsViaServiceToken(fullServiceToken string, environment string, secretPath string, includeImports bool, recursive bool) ([]models.SingleEnvironmentVariable, api.GetServiceTokenDetailsResponse, error) {
 	serviceTokenParts := strings.SplitN(fullServiceToken, ".", 4)
 	if len(serviceTokenParts) < 4 {
 		return nil, api.GetServiceTokenDetailsResponse{}, fmt.Errorf("invalid service token entered. Please double check your service token and try again")
@@ -49,7 +49,7 @@ func GetPlainTextSecretsViaServiceToken(fullServiceToken string, environment str
 		Environment:   environment,
 		SecretPath:    secretPath,
 		IncludeImport: includeImports,
-		DeepSearch:    deepSearch,
+		Recursive:     recursive,
 	})
 
 	if err != nil {
@@ -81,7 +81,7 @@ func GetPlainTextSecretsViaServiceToken(fullServiceToken string, environment str
 	return plainTextSecrets, serviceTokenDetails, nil
 }
 
-func GetPlainTextSecretsViaJTW(JTWToken string, receiversPrivateKey string, workspaceId string, environmentName string, tagSlugs string, secretsPath string, includeImports bool, deepSearch bool) ([]models.SingleEnvironmentVariable, error) {
+func GetPlainTextSecretsViaJTW(JTWToken string, receiversPrivateKey string, workspaceId string, environmentName string, tagSlugs string, secretsPath string, includeImports bool, recursive bool) ([]models.SingleEnvironmentVariable, error) {
 	httpClient := resty.New()
 	httpClient.SetAuthToken(JTWToken).
 		SetHeader("Accept", "application/json")
@@ -126,7 +126,7 @@ func GetPlainTextSecretsViaJTW(JTWToken string, receiversPrivateKey string, work
 		WorkspaceId:   workspaceId,
 		Environment:   environmentName,
 		IncludeImport: includeImports,
-		DeepSearch:    deepSearch,
+		Recursive:     recursive,
 		// TagSlugs:    tagSlugs,
 	}
 
@@ -154,7 +154,7 @@ func GetPlainTextSecretsViaJTW(JTWToken string, receiversPrivateKey string, work
 	return plainTextSecrets, nil
 }
 
-func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId string, environmentName string, secretsPath string, includeImports bool, deepSearch bool) (models.PlaintextSecretResult, error) {
+func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId string, environmentName string, secretsPath string, includeImports bool, recursive bool) (models.PlaintextSecretResult, error) {
 	httpClient := resty.New()
 	httpClient.SetAuthToken(accessToken).
 		SetHeader("Accept", "application/json")
@@ -163,7 +163,7 @@ func GetPlainTextSecretsViaMachineIdentity(accessToken string, workspaceId strin
 		WorkspaceId:   workspaceId,
 		Environment:   environmentName,
 		IncludeImport: includeImports,
-		DeepSearch:    deepSearch,
+		Recursive:     recursive,
 		// TagSlugs:    tagSlugs,
 	}
 
@@ -332,7 +332,7 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 		}
 
 		secretsToReturn, errorToReturn = GetPlainTextSecretsViaJTW(loggedInUserDetails.UserCredentials.JTWToken, loggedInUserDetails.UserCredentials.PrivateKey, infisicalDotJson.WorkspaceId,
-			params.Environment, params.TagSlugs, params.SecretsPath, params.IncludeImport, params.DeepSearch)
+			params.Environment, params.TagSlugs, params.SecretsPath, params.IncludeImport, params.Recursive)
 		log.Debug().Msgf("GetAllEnvironmentVariables: Trying to fetch secrets JTW token [err=%s]", errorToReturn)
 
 		backupSecretsEncryptionKey := []byte(loggedInUserDetails.UserCredentials.PrivateKey)[0:32]
@@ -353,10 +353,10 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 	} else {
 		if params.InfisicalToken != "" {
 			log.Debug().Msg("Trying to fetch secrets using service token")
-			secretsToReturn, _, errorToReturn = GetPlainTextSecretsViaServiceToken(params.InfisicalToken, params.Environment, params.SecretsPath, params.IncludeImport, params.DeepSearch)
+			secretsToReturn, _, errorToReturn = GetPlainTextSecretsViaServiceToken(params.InfisicalToken, params.Environment, params.SecretsPath, params.IncludeImport, params.Recursive)
 		} else if params.UniversalAuthAccessToken != "" {
 			log.Debug().Msg("Trying to fetch secrets using universal auth")
-			res, err := GetPlainTextSecretsViaMachineIdentity(params.UniversalAuthAccessToken, params.WorkspaceId, params.Environment, params.SecretsPath, params.IncludeImport, params.DeepSearch)
+			res, err := GetPlainTextSecretsViaMachineIdentity(params.UniversalAuthAccessToken, params.WorkspaceId, params.Environment, params.SecretsPath, params.IncludeImport, params.Recursive)
 
 			errorToReturn = err
 			secretsToReturn = res.Secrets


### PR DESCRIPTION
# Description 📣

We have been getting a lot of requests for fetching secrets recursively, which we didn't have support for.

When the user specifies a path when making API calls, we will recursively get all folders that lives inside that path. We then get all the secrets from those paths and return them just like we used to. The only big change is that the `getSecrets` service now functions as a loop instead of just running a single time. Additionally the response now includes a `secretPath` field on each secret. 

This works on both the list secrets and list raw secrets endpoint. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->