### PR TITLE
Feat: Standalone tag attaching & detaching

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -241,7 +241,6 @@ export const RAW_SECRETS = {
     includeImports: "Weather to include imported secrets or not."
   },
   UPDATE: {
-    tags: "An array of tag IDs to attach to the secret.",
     secretName: "The name of the secret to update.",
     environment: "The slug of the environment where the secret is located.",
     secretPath: "The path of the secret to update",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -194,6 +194,25 @@ export const FOLDERS = {
   }
 } as const;
 
+export const SECRETS = {
+  ATTACH_TAGS: {
+    secretName: "The name of the secret to attach tags to.",
+    secretPath: "The path of the secret to attach tags to.",
+    type: "The type of the secret to attach tags to. (shared/personal)",
+    environment: "The slug of the environment where the secret is located",
+    projectSlug: "The slug of the project where the secret is located",
+    tagSlugs: "An array of tag slugs to attach to the secret."
+  },
+  DETACH_TAGS: {
+    secretName: "The name of the secret to detach tags from.",
+    secretPath: "The path of the secret to detach tags from.",
+    type: "The type of the secret to attach tags to. (shared/personal)",
+    environment: "The slug of the environment where the secret is located",
+    projectSlug: "The slug of the project where the secret is located",
+    tagSlugs: "An array of tag slugs to detach from the secret."
+  }
+} as const;
+
 export const RAW_SECRETS = {
   LIST: {
     workspaceId: "The ID of the project to list secrets from.",
@@ -222,6 +241,7 @@ export const RAW_SECRETS = {
     includeImports: "Weather to include imported secrets or not."
   },
   UPDATE: {
+    tags: "An array of tag IDs to attach to the secret.",
     secretName: "The name of the secret to update.",
     environment: "The slug of the environment where the secret is located.",
     secretPath: "The path of the secret to update",
@@ -283,5 +303,21 @@ export const AUDIT_LOGS = {
     offset: "The offset to start from. If you enter 10, it will start from the 10th audit log.",
     limit: "The number of audit logs to return.",
     actor: "The actor to filter the audit logs by."
+  }
+} as const;
+
+export const SECRET_TAGS = {
+  LIST: {
+    projectId: "The ID of the project to list tags from."
+  },
+  CREATE: {
+    projectId: "The ID of the project to create the tag in.",
+    name: "The name of the tag to create.",
+    slug: "The slug of the tag to create.",
+    color: "The color of the tag to create."
+  },
+  DELETE: {
+    tagId: "The ID of the tag to delete.",
+    projectId: "The ID of the project to delete the tag from."
   }
 } as const;

--- a/backend/src/server/routes/v1/secret-tag-router.ts
+++ b/backend/src/server/routes/v1/secret-tag-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SecretTagsSchema } from "@app/db/schemas";
+import { SECRET_TAGS } from "@app/lib/api-docs";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
@@ -10,7 +11,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
     method: "GET",
     schema: {
       params: z.object({
-        projectId: z.string().trim()
+        projectId: z.string().trim().describe(SECRET_TAGS.LIST.projectId)
       }),
       response: {
         200: z.object({
@@ -36,12 +37,12 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     schema: {
       params: z.object({
-        projectId: z.string().trim()
+        projectId: z.string().trim().describe(SECRET_TAGS.CREATE.projectId)
       }),
       body: z.object({
-        name: z.string().trim(),
-        slug: z.string().trim(),
-        color: z.string()
+        name: z.string().trim().describe(SECRET_TAGS.CREATE.name),
+        slug: z.string().trim().describe(SECRET_TAGS.CREATE.slug),
+        color: z.string().trim().describe(SECRET_TAGS.CREATE.color)
       }),
       response: {
         200: z.object({
@@ -68,8 +69,8 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
     method: "DELETE",
     schema: {
       params: z.object({
-        projectId: z.string().trim(),
-        tagId: z.string().trim()
+        projectId: z.string().trim().describe(SECRET_TAGS.DELETE.projectId),
+        tagId: z.string().trim().describe(SECRET_TAGS.DELETE.tagId)
       }),
       response: {
         200: z.object({

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -168,8 +168,12 @@ export const projectDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findProjectBySlug = async (slug: string, orgId: string) => {
+  const findProjectBySlug = async (slug: string, orgId: string | undefined) => {
     try {
+      if (!orgId) {
+        throw new BadRequestError({ message: "Organization ID is required when querying with slugs" });
+      }
+
       const projects = await db(TableName.ProjectMembership)
         .where(`${TableName.Project}.slug`, slug)
         .where(`${TableName.Project}.orgId`, orgId)

--- a/backend/src/services/secret/secret-dal.ts
+++ b/backend/src/services/secret/secret-dal.ts
@@ -150,6 +150,27 @@ export const secretDALFactory = (db: TDbClient) => {
     }
   };
 
+  const getSecretTags = async (secretId: string, tx?: Knex) => {
+    try {
+      const tags = await (tx || db)(TableName.JnSecretTag)
+        .join(TableName.SecretTag, `${TableName.JnSecretTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
+        .where({ [`${TableName.Secret}Id` as const]: secretId })
+        .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
+        .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
+        .select(db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"))
+        .select(db.ref("name").withSchema(TableName.SecretTag).as("tagName"));
+
+      return tags.map((el) => ({
+        id: el.tagId,
+        color: el.tagColor,
+        slug: el.tagSlug,
+        name: el.tagName
+      }));
+    } catch (error) {
+      throw new DatabaseError({ error, name: "get secret tags" });
+    }
+  };
+
   const findByBlindIndexes = async (
     folderId: string,
     blindIndexes: Array<{ blindIndex: string; type: SecretType }>,
@@ -184,6 +205,7 @@ export const secretDALFactory = (db: TDbClient) => {
     bulkUpdate,
     deleteMany,
     bulkUpdateNoVersionIncrement,
+    getSecretTags,
     findByFolderId,
     findByBlindIndexes
   };

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -22,6 +22,7 @@ import { TSecretDALFactory } from "./secret-dal";
 import { decryptSecretRaw, fnSecretBlindIndexCheck, fnSecretBulkInsert, fnSecretBulkUpdate } from "./secret-fns";
 import { TSecretQueueFactory } from "./secret-queue";
 import {
+  TAttachSecretTagsDTO,
   TCreateBulkSecretDTO,
   TCreateSecretDTO,
   TCreateSecretRawDTO,
@@ -47,7 +48,7 @@ type TSecretServiceFactoryDep = {
   secretTagDAL: TSecretTagDALFactory;
   secretVersionDAL: TSecretVersionDALFactory;
   folderDAL: Pick<TSecretFolderDALFactory, "findBySecretPath" | "updateById" | "findById" | "findByManySecretPath">;
-  projectDAL: Pick<TProjectDALFactory, "checkProjectUpgradeStatus">;
+  projectDAL: Pick<TProjectDALFactory, "checkProjectUpgradeStatus" | "findProjectBySlug">;
   secretBlindIndexDAL: TSecretBlindIndexDALFactory;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   snapshotService: Pick<TSecretSnapshotServiceFactory, "performSnapshot">;
@@ -307,6 +308,7 @@ export const secretServiceFactory = ({
     if ((inputSecret.tags || []).length !== tags.length) throw new BadRequestError({ message: "Tag not found" });
 
     const { secretName, ...el } = inputSecret;
+
     const updatedSecret = await secretDAL.transaction(async (tx) =>
       fnSecretBulkUpdate({
         folderId,
@@ -442,6 +444,7 @@ export const secretServiceFactory = ({
     const folderId = folder.id;
 
     const secrets = await secretDAL.findByFolderId(folderId, actorId);
+
     if (includeImports) {
       const secretImports = await secretImportDAL.find({ folderId });
       const allowedImports = secretImports.filter(({ importEnv, importPath }) =>
@@ -994,7 +997,209 @@ export const secretServiceFactory = ({
     return secretVersions;
   };
 
+  const attachTags = async ({
+    secretName,
+    tagSlugs,
+    path: secretPath,
+    environment,
+    type,
+    projectSlug,
+    actor,
+    actorAuthMethod,
+    actorOrgId,
+    actorId
+  }: TAttachSecretTagsDTO) => {
+    const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
+
+    const { permission } = await permissionService.getProjectPermission(
+      actor,
+      actorId,
+      project.id,
+      actorAuthMethod,
+      actorOrgId
+    );
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionActions.Edit,
+      subject(ProjectPermissionSub.Secrets, { environment, secretPath })
+    );
+
+    await projectDAL.checkProjectUpgradeStatus(project.id);
+
+    const secret = await getSecretByName({
+      actorId,
+      actor,
+      actorOrgId,
+      actorAuthMethod,
+      projectId: project.id,
+      environment,
+      path: secretPath,
+      secretName,
+      type
+    });
+
+    if (!secret) {
+      throw new BadRequestError({ message: "Secret not found" });
+    }
+    const folder = await folderDAL.findBySecretPath(project.id, environment, secretPath);
+
+    if (!folder) {
+      throw new BadRequestError({ message: "Folder not found" });
+    }
+
+    const tags = await secretTagDAL.find({
+      projectId: project.id,
+      $in: {
+        slug: tagSlugs
+      }
+    });
+
+    if (tags.length !== tagSlugs.length) {
+      throw new BadRequestError({ message: "One or more tags not found." });
+    }
+
+    const secretTags = await secretDAL.getSecretTags(secret.id);
+
+    if (secretTags.some((tag) => tagSlugs.includes(tag.slug))) {
+      throw new BadRequestError({ message: "One or more tags already exist on the secret" });
+    }
+
+    const combinedTags = new Set([...secretTags.map((tag) => tag.id), ...tags.map((el) => el.id)]);
+
+    const updatedSecret = await secretDAL.transaction(async (tx) =>
+      fnSecretBulkUpdate({
+        folderId: folder.id,
+        projectId: project.id,
+        inputSecrets: [
+          {
+            filter: { id: secret.id },
+            data: {
+              tags: Array.from(combinedTags)
+            }
+          }
+        ],
+        secretDAL,
+        secretVersionDAL,
+        secretTagDAL,
+        secretVersionTagDAL,
+        tx
+      })
+    );
+
+    await snapshotService.performSnapshot(folder.id);
+    await secretQueueService.syncSecrets({ secretPath, projectId: project.id, environment });
+
+    return {
+      ...updatedSecret[0],
+      tags: [...secretTags, ...tags].map((t) => ({ id: t.id, slug: t.slug, name: t.name, color: t.color }))
+    };
+  };
+
+  const detachTags = async ({
+    secretName,
+    tagSlugs,
+    path: secretPath,
+    environment,
+    type,
+    projectSlug,
+    actor,
+    actorAuthMethod,
+    actorOrgId,
+    actorId
+  }: TAttachSecretTagsDTO) => {
+    const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
+
+    const { permission } = await permissionService.getProjectPermission(
+      actor,
+      actorId,
+      project.id,
+      actorAuthMethod,
+      actorOrgId
+    );
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionActions.Edit,
+      subject(ProjectPermissionSub.Secrets, { environment, secretPath })
+    );
+
+    await projectDAL.checkProjectUpgradeStatus(project.id);
+
+    const secret = await getSecretByName({
+      actorId,
+      actor,
+      actorOrgId,
+      actorAuthMethod,
+      projectId: project.id,
+      environment,
+      path: secretPath,
+      secretName,
+      type
+    });
+
+    if (!secret) {
+      throw new BadRequestError({ message: "Secret not found" });
+    }
+    const folder = await folderDAL.findBySecretPath(project.id, environment, secretPath);
+
+    if (!folder) {
+      throw new BadRequestError({ message: "Folder not found" });
+    }
+
+    const tags = await secretTagDAL.find({
+      projectId: project.id,
+      $in: {
+        slug: tagSlugs
+      }
+    });
+
+    if (tags.length !== tagSlugs.length) {
+      throw new BadRequestError({ message: "One or more tags not found." });
+    }
+
+    const secretTags = await secretDAL.getSecretTags(secret.id);
+
+    // Make sure all the tags exist on the secret
+    const tagIdsToRemove = tags.map((tag) => tag.id);
+    const secretTagIds = secretTags.map((tag) => tag.id);
+
+    if (!tagIdsToRemove.every((el) => secretTagIds.includes(el))) {
+      throw new BadRequestError({ message: "One or more tags not found on the secret" });
+    }
+
+    const newTags = secretTags.filter((tag) => !tagIdsToRemove.includes(tag.id));
+
+    const updatedSecret = await secretDAL.transaction(async (tx) =>
+      fnSecretBulkUpdate({
+        folderId: folder.id,
+        projectId: project.id,
+        inputSecrets: [
+          {
+            filter: { id: secret.id },
+            data: {
+              tags: newTags.map((tag) => tag.id)
+            }
+          }
+        ],
+        secretDAL,
+        secretVersionDAL,
+        secretTagDAL,
+        secretVersionTagDAL,
+        tx
+      })
+    );
+
+    await snapshotService.performSnapshot(folder.id);
+    await secretQueueService.syncSecrets({ secretPath, projectId: project.id, environment });
+
+    return {
+      ...updatedSecret[0],
+      tags: newTags
+    };
+  };
+
   return {
+    attachTags,
+    detachTags,
     createSecret,
     deleteSecret,
     updateSecret,

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -206,6 +206,15 @@ export type TFnSecretBulkUpdate = {
   tx?: Knex;
 };
 
+export type TAttachSecretTagsDTO = {
+  projectSlug: string;
+  secretName: string;
+  tagSlugs: string[];
+  environment: string;
+  path: string;
+  type: SecretType;
+} & Omit<TProjectPermission, "projectId">;
+
 export type TFnSecretBulkDelete = {
   folderId: string;
   projectId: string;

--- a/docs/api-reference/endpoints/secret-tags/create.mdx
+++ b/docs/api-reference/endpoints/secret-tags/create.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create"
+openapi: "POST /api/v1/workspace/{projectId}/tags"
+---

--- a/docs/api-reference/endpoints/secret-tags/delete.mdx
+++ b/docs/api-reference/endpoints/secret-tags/delete.mdx
@@ -1,0 +1,4 @@
+---
+title: "Delete"
+openapi: "DELETE /api/v1/workspace/{projectId}/tags/{tagId}"
+---

--- a/docs/api-reference/endpoints/secret-tags/list.mdx
+++ b/docs/api-reference/endpoints/secret-tags/list.mdx
@@ -1,0 +1,4 @@
+---
+title: "List"
+openapi: "GET /api/v1/workspace/{projectId}/tags"
+---

--- a/docs/api-reference/endpoints/secrets/attach-tags.mdx
+++ b/docs/api-reference/endpoints/secrets/attach-tags.mdx
@@ -1,0 +1,4 @@
+---
+title: "Attach tags"
+openapi: "POST /api/v3/secrets/tags/{secretName}"
+---

--- a/docs/api-reference/endpoints/secrets/detach-tags.mdx
+++ b/docs/api-reference/endpoints/secrets/detach-tags.mdx
@@ -1,0 +1,4 @@
+---
+title: "Detach tags"
+openapi: "DELETE /api/v3/secrets/tags/{secretName}"
+---

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -468,13 +468,23 @@
           ]
         },
         {
+          "group": "Secret tags",
+          "pages": [
+            "api-reference/endpoints/secret-tags/list",
+            "api-reference/endpoints/secret-tags/create",
+            "api-reference/endpoints/secret-tags/delete"
+          ]
+        },
+        {
           "group": "Secrets",
           "pages": [
             "api-reference/endpoints/secrets/list",
             "api-reference/endpoints/secrets/create",
             "api-reference/endpoints/secrets/read",
             "api-reference/endpoints/secrets/update",
-            "api-reference/endpoints/secrets/delete"
+            "api-reference/endpoints/secrets/delete",
+            "api-reference/endpoints/secrets/attach-tags",
+            "api-reference/endpoints/secrets/detach-tags"
           ]
         },
         {


### PR DESCRIPTION
# Description 📣

- The current way to add/remove tags from secrets isn't exactly built to be used by the public. To make the process of removing / adding tags programmatically more appealing to our API users, I have decided to create two new endpoints that make the process of adding/removing tags a whole lot easier.
- Exposed the existing tag router endpoints in docs
- Added docs for the new endpoints


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->