### PR TITLE
chore(ci): optimize Depot build workflows

### DIFF
--- a/.github/workflows/build-docker-image-to-prod.yml
+++ b/.github/workflows/build-docker-image-to-prod.yml
@@ -41,6 +41,7 @@ jobs:
           load: true
           context: backend
           tags: infisical/infisical:test
+          platforms: linux/amd64,linux/arm64
       - name: ⏻ Spawn backend container and dependencies
         run: |
           docker compose -f .github/resources/docker-compose.be-test.yml up --wait --quiet-pull
@@ -92,6 +93,7 @@ jobs:
           project: 64mmf0n610
           context: frontend
           tags: infisical/frontend:test
+          platforms: linux/amd64,linux/arm64
           build-args: |
             POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}
             NEXT_INFISICAL_PLATFORM_VERSION=${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/build-staging-and-deploy-aws.yml
+++ b/.github/workflows/build-staging-and-deploy-aws.yml
@@ -27,15 +27,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
-      - name: 📦 Build backend and export to Docker
-        uses: depot/build-push-action@v1
-        with:
-          project: 64mmf0n610
-          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
-          load: true
-          context: .
-          file: Dockerfile.standalone-infisical
-          tags: infisical/infisical:test
       - name: 🏗️ Build backend and push to docker hub
         uses: depot/build-push-action@v1
         with:


### PR DESCRIPTION
# Description 📣

This PR optimizes the Depot build workflows to reduce their overall runtime, with two primary changes:

1. When building the release production images, the workflows now build for both `amd64` and `arm64` first, in the `load: true` step. While the arm64 image is not actually necessary for the integration tests to run, this allows the arm64 image to be built at the same time as the amd64 one, so after the tests pass and the `push: true` step executes, both platforms will be pre-cached and can immediately push.

2. The deployment pipeline workflow built the standalone Docker image twice unnecessarily, likely a copy-paste from another CI workflow. I've removed the unnecessary `load: true` step, since nothing actually happens to the loaded image.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Optimization

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->