### PR TITLE
add maintenance mode

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -114,7 +114,8 @@ const envSchema = z
       .enum(["true", "false"])
       .transform((val) => val === "true")
       .optional(),
-    INFISICAL_CLOUD: zodStrBool.default("false")
+    INFISICAL_CLOUD: zodStrBool.default("false"),
+    MAINTENANCE_MODE: zodStrBool.default("false")
   })
   .transform((data) => ({
     ...data,

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -24,6 +24,7 @@ import { fastifyErrHandler } from "./plugins/error-handler";
 import { registerExternalNextjs } from "./plugins/external-nextjs";
 import { serializerCompiler, validatorCompiler, ZodTypeProvider } from "./plugins/fastify-zod";
 import { fastifyIp } from "./plugins/ip";
+import { maintenanceMode } from "./plugins/maintenanceMode";
 import { fastifySwagger } from "./plugins/swagger";
 import { registerRoutes } from "./routes";
 
@@ -71,6 +72,8 @@ export const main = async ({ db, smtp, logger, queue, keyStore }: TMain) => {
       await server.register<FastifyRateLimitOptions>(ratelimiter, globalRateLimiterCfg());
     }
     await server.register(helmet, { contentSecurityPolicy: false });
+
+    await server.register(maintenanceMode);
 
     await server.register(registerRoutes, { smtp, queue, db, keyStore });
 

--- a/backend/src/server/plugins/maintenanceMode.ts
+++ b/backend/src/server/plugins/maintenanceMode.ts
@@ -1,0 +1,12 @@
+import fp from "fastify-plugin";
+
+import { getConfig } from "@app/lib/config/env";
+
+export const maintenanceMode = fp(async (fastify) => {
+  fastify.addHook("onRequest", async (req) => {
+    const serverEnvs = getConfig();
+    if (req.url !== "/api/v1/auth/checkAuth" && req.method !== "GET" && serverEnvs.MAINTENANCE_MODE) {
+      throw new Error("Infisical is in maintenance mode. Please try again later.");
+    }
+  });
+});

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -16,13 +16,16 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
     schema: {
       response: {
         200: z.object({
-          config: SuperAdminSchema.omit({ createdAt: true, updatedAt: true })
+          config: SuperAdminSchema.omit({ createdAt: true, updatedAt: true }).merge(
+            z.object({ isMigrationModeOn: z.boolean() })
+          )
         })
       }
     },
     handler: async () => {
       const config = await getServerCfg();
-      return { config };
+      const serverEnvs = getConfig();
+      return { config: { ...config, isMigrationModeOn: serverEnvs.MAINTENANCE_MODE } };
     }
   });
 


### PR DESCRIPTION
Adds maintenance mode which can be toggled via `MAINTENANCE_MODE`. This will show maintenance mode on the frontend and block all get requests expect the post route needed to check auth for the cli.

Checked secret fetch via CLI and it works when maintenance mode is on.