### PR TITLE
Move default slug init for users/identities out of fastify schema

### DIFF
--- a/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
@@ -31,11 +31,11 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
           .min(1)
           .max(60)
           .trim()
-          .default(slugify(alphaNumericNanoId(12)))
           .refine((val) => val.toLowerCase() === val, "Must be lowercase")
           .refine((v) => slugify(v) === v, {
             message: "Slug must be a valid slug"
           })
+          .optional()
           .describe(IDENTITY_ADDITIONAL_PRIVILEGE.CREATE.slug),
         permissions: z.any().array().describe(IDENTITY_ADDITIONAL_PRIVILEGE.CREATE.permissions)
       }),
@@ -53,6 +53,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod,
         ...req.body,
+        slug: req.body.slug ? slugify(req.body.slug) : slugify(alphaNumericNanoId(12)),
         isTemporary: false,
         permissions: JSON.stringify(packRules(req.body.permissions))
       });
@@ -78,11 +79,11 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
           .min(1)
           .max(60)
           .trim()
-          .default(slugify(alphaNumericNanoId(12)))
           .refine((val) => val.toLowerCase() === val, "Must be lowercase")
           .refine((v) => slugify(v) === v, {
             message: "Slug must be a valid slug"
           })
+          .optional()
           .describe(IDENTITY_ADDITIONAL_PRIVILEGE.CREATE.slug),
         permissions: z.any().array().describe(IDENTITY_ADDITIONAL_PRIVILEGE.CREATE.permissions),
         temporaryMode: z
@@ -111,6 +112,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod,
         ...req.body,
+        slug: req.body.slug ? slugify(req.body.slug) : slugify(alphaNumericNanoId(12)),
         isTemporary: true,
         permissions: JSON.stringify(packRules(req.body.permissions))
       });

--- a/backend/src/ee/routes/v1/user-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v1/user-additional-privilege-router.ts
@@ -21,11 +21,11 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
           .min(1)
           .max(60)
           .trim()
-          .default(slugify(alphaNumericNanoId(12)))
           .refine((v) => v.toLowerCase() === v, "Slug must be lowercase")
           .refine((v) => slugify(v) === v, {
             message: "Slug must be a valid slug"
           })
+          .optional()
           .describe(PROJECT_USER_ADDITIONAL_PRIVILEGE.CREATE.slug),
         permissions: z.any().array().describe(PROJECT_USER_ADDITIONAL_PRIVILEGE.CREATE.permissions)
       }),
@@ -43,6 +43,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod,
         ...req.body,
+        slug: req.body.slug ? slugify(req.body.slug) : slugify(alphaNumericNanoId(12)),
         isTemporary: false,
         permissions: JSON.stringify(req.body.permissions)
       });
@@ -61,11 +62,11 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
           .min(1)
           .max(60)
           .trim()
-          .default(`privilege-${slugify(alphaNumericNanoId(12))}`)
           .refine((v) => v.toLowerCase() === v, "Slug must be lowercase")
           .refine((v) => slugify(v) === v, {
             message: "Slug must be a valid slug"
           })
+          .optional()
           .describe(PROJECT_USER_ADDITIONAL_PRIVILEGE.CREATE.slug),
         permissions: z.any().array().describe(PROJECT_USER_ADDITIONAL_PRIVILEGE.CREATE.permissions),
         temporaryMode: z
@@ -94,6 +95,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod,
         ...req.body,
+        slug: req.body.slug ? slugify(req.body.slug) : `privilege-${slugify(alphaNumericNanoId(12))}`,
         isTemporary: true,
         permissions: JSON.stringify(req.body.permissions)
       });


### PR DESCRIPTION
# Description 📣

This PR moves the default slug initialization for additional privileges out of the Fastify schema; it was otherwise defaulting to the same slug per instance of Infisical on each call to the API.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝