### PR TITLE
Fix: Duplicate organization memberships

### DIFF
--- a/backend/scripts/create-migration.ts
+++ b/backend/scripts/create-migration.ts
@@ -7,10 +7,10 @@ const prompt = promptSync({ sigint: true });
 
 const migrationName = prompt("Enter name for migration: ");
 
+// Remove spaces from migration name and replace with hyphens
+const formattedMigrationName = migrationName.replace(/\s+/g, "-");
+
 execSync(
-  `npx knex migrate:make --knexfile ${path.join(
-    __dirname,
-    "../src/db/knexfile.ts"
-  )} -x ts ${migrationName}`,
+  `npx knex migrate:make --knexfile ${path.join(__dirname, "../src/db/knexfile.ts")} -x ts ${formattedMigrationName}`,
   { stdio: "inherit" }
 );

--- a/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
+++ b/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.OrgMembership, (table) => {
+    table.unique(["userId", "orgId"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.OrgMembership, (table) => {
+    table.dropUnique(["userId", "orgId"]);
+  });
+}


### PR DESCRIPTION
# Description 📣

We currently have no unique constraint on the `userId` and `orgId` field, which has led to duplicate organization memberships. We have as a part of this PR removed all duplicate (and broken) organization memberships from the production database. 

After this has been deployed, we should be getting error logs when it tries to create a duplicate membership, which will help us narrow down the exact cause of this. 

A small note: If self-hosted customers have duplicate memberships, they will have trouble upgrading to the latest version as the migration will fail to apply if there are duplicate memberships. To fix this they would simply have to remove the duplicate memberships from their database. This is an unlikely case but worth mentioning. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->