### PR TITLE
fix: Run make kubectl-install

### DIFF
--- a/k8-operator/README.md
+++ b/k8-operator/README.md
@@ -72,6 +72,12 @@ If you are editing the API definitions, generate the manifests such as CRs or CR
 make manifests
 ```
 
+Also, after editing the API definitions, update the kubectl-install folder:
+
+```sh
+make kubectl-install
+```
+
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)

--- a/k8-operator/kubectl-install/install-secrets-operator.yaml
+++ b/k8-operator/kubectl-install/install-secrets-operator.yaml
@@ -96,12 +96,47 @@ spec:
                     - secretsScope
                     - serviceTokenSecretReference
                     type: object
+                  universalAuth:
+                    properties:
+                      credentialsRef:
+                        properties:
+                          secretName:
+                            description: The name of the Kubernetes Secret
+                            type: string
+                          secretNamespace:
+                            description: The name space where the Kubernetes Secret is located
+                            type: string
+                        required:
+                        - secretName
+                        - secretNamespace
+                        type: object
+                      secretsScope:
+                        properties:
+                          envSlug:
+                            type: string
+                          projectSlug:
+                            type: string
+                          secretsPath:
+                            type: string
+                        required:
+                        - envSlug
+                        - projectSlug
+                        - secretsPath
+                        type: object
+                    required:
+                    - credentialsRef
+                    - secretsScope
+                    type: object
                 type: object
               hostAPI:
                 description: Infisical host to pull secrets from
                 type: string
               managedSecretReference:
                 properties:
+                  creationPolicy:
+                    default: Orphan
+                    description: 'The Kubernetes Secret creation policy. Enum with values: ''Owner'', ''Orphan''. Owner creates the secret and sets .metadata.ownerReferences of the InfisicalSecret CRD that created it. Orphan will not set the secret owner. This will result in the secret being orphaned and not deleted when the resource is deleted.'
+                    type: string
                   secretName:
                     description: The name of the Kubernetes Secret
                     type: string


### PR DESCRIPTION
# Description 📣

About two weeks ago, [support for `universalAuth`](https://github.com/Infisical/infisical/blame/3f6999b2e32429134c34c9ad5d857a954a2850ec/k8-operator/api/v1alpha1/infisicalsecret_types.go#L13)  was added to the k8s-operator types.  After this change, `install-secrets-operator.yaml` was not updated.

This PR is simple, and checks in the file generated by `make kubectl-install`
I have also updated k8s-operator/README to include this as a step in the future, although there may be a better way to update Makefile targets to do this automatically. 

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

1. Verified manually that the `install-secrets-operator.yaml` file is updated with universalAuth after running make command.
2. Installed the operator using `kubectl apply -f install-secrets-operator.yaml` and verified presence of updated schema using `kubectl explain InfisicalSecret --recursive`


---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->