### PR TITLE
Environment variables with a false value should be properly set

### DIFF
--- a/helm-charts/infisical/templates/backend-deployment.yaml
+++ b/helm-charts/infisical/templates/backend-deployment.yaml
@@ -95,7 +95,11 @@ stringData:
   {{ range $key, $value := .Values.backendEnvironmentVariables }}
     {{- $default := get $requiredVars $key -}}
     {{- $current := get $secretData $key | b64dec -}}
-    {{- $v := $value | default ($current | default $default) -}}
-    {{ $key }}: {{ $v | quote }}
+    {{- if eq $value false }}
+      {{ $key }}: "false"
+    {{- else }}
+      {{- $v := $value | default ($current | default $default) -}}
+      {{ $key }}: {{ $v | quote }}
+    {{- end }} 
   {{ end -}}
 {{- end }}


### PR DESCRIPTION
# Description 📣

By default, this template was eating the environment variables with a false value (and trying to quote them resulted in an undesirable double quote due to the ` | quote` that appears there).

Explicitly managing the falsy value should solve this issue.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->