### PR TITLE
Fix: Hard limit on recursive secret fetching

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -221,7 +221,8 @@ export const SECRETS = {
 
 export const RAW_SECRETS = {
   LIST: {
-    recursive: "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories.",
+    recursive:
+      "Whether or not to fetch all secrets from the specified base path, and all of its subdirectories. Note, the max depth is 20 deep.",
     workspaceId: "The ID of the project to list secrets from.",
     workspaceSlug: "The slug of the project to list secrets from. This parameter is only usable by machine identities.",
     environment: "The slug of the environment to list secrets from.",

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -112,8 +112,8 @@ const generatePaths = (
       folderId: child.id
     });
 
-    // We make sure that the max depth doesn't exceed 20.
-    // We do this to make as a "circuit break", basically to ensure that we can't encounter any potential memory leaks.
+    // We make sure that the recursion depth doesn't exceed 20.
+    // We do this to create "circuit break", basically to ensure that we can't encounter any potential memory leaks.
     if (currentDepth >= 20) {
       return;
     }

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/lib/crypto";
 import { BadRequestError } from "@app/lib/errors";
 import { groupBy, unique } from "@app/lib/fn";
+import { logger } from "@app/lib/logger";
 
 import { ActorAuthMethod, ActorType } from "../auth/auth-type";
 import { getBotKeyFnFactory } from "../project-bot/project-bot-fns";
@@ -115,6 +116,7 @@ const generatePaths = (
     // We make sure that the recursion depth doesn't exceed 20.
     // We do this to create "circuit break", basically to ensure that we can't encounter any potential memory leaks.
     if (currentDepth >= 20) {
+      logger.info(`generatePaths: Recursion depth exceeded 20, breaking out of recursion [map=${JSON.stringify(map)}]`);
       return;
     }
     // Recursively generate paths for children, passing down the formatted path


### PR DESCRIPTION
# Description 📣

We are experiencing a surge in resource consumption sometimes, and the recursive fetch may be a cause of this after investigating logs.

This PR introduces a "hard limit" on how deep the recursive search can go. I've set it to 20 depth, which should be more than enough for the vast majority of use-cases.

## Type ✨
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝