### PR TITLE
Hotfix: CLI run command null pointer reference crash

### DIFF
--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -179,8 +179,8 @@ var runCmd = &cobra.Command{
 			posthog.NewProperties().
 				Set("secretsCount", len(secrets)).
 				Set("environment", environmentName).
-				Set("isUsingServiceToken", token.Type == util.SERVICE_TOKEN_IDENTIFIER).
-				Set("isUsingUniversalAuthToken", token.Type == util.UNIVERSAL_AUTH_TOKEN_IDENTIFIER).
+				Set("isUsingServiceToken", token != nil && token.Type == util.SERVICE_TOKEN_IDENTIFIER).
+				Set("isUsingUniversalAuthToken", token != nil && token.Type == util.UNIVERSAL_AUTH_TOKEN_IDENTIFIER).
 				Set("single-command", strings.Join(args, " ")).
 				Set("multi-command", cmd.Flag("command").Value.String()).
 				Set("version", util.CLI_VERSION))


### PR DESCRIPTION
# Description 📣

CLI fix pointer reference crash on `run` command.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->