### PR TITLE
fix(cli): add project and environment as built-in env to secrets

### DIFF
--- a/cli/packages/cmd/init.go
+++ b/cli/packages/cmd/init.go
@@ -123,7 +123,8 @@ func init() {
 
 func writeWorkspaceFile(selectedWorkspace models.Workspace) error {
 	workspaceFileToSave := models.WorkspaceConfigFile{
-		WorkspaceId: selectedWorkspace.ID,
+		WorkspaceId:   selectedWorkspace.ID,
+		WorkspaceName: selectedWorkspace.Name,
 	}
 
 	marshalledWorkspaceFile, err := json.MarshalIndent(workspaceFileToSave, "", "    ")

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -78,6 +78,7 @@ type Workspace struct {
 }
 
 type WorkspaceConfigFile struct {
+	WorkspaceName                 string            `json:"workspaceName"`
 	WorkspaceId                   string            `json:"workspaceId"`
 	DefaultEnvironment            string            `json:"defaultEnvironment"`
 	GitBranchToEnvironmentMapping map[string]string `json:"gitBranchToEnvironmentMapping"`

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -15,6 +15,8 @@ const (
 	KEYRING_SERVICE_NAME                        = "infisical"
 	PERSONAL_SECRET_TYPE_NAME                   = "personal"
 	SHARED_SECRET_TYPE_NAME                     = "shared"
+	PROJECT_NAME                                = "INFISICAL_PROJECT"
+	ENVIRONMENT_NAME                            = "INFISICAL_ENVIRONMENT"
 
 	SERVICE_TOKEN_IDENTIFIER        = "service-token"
 	UNIVERSAL_AUTH_TOKEN_IDENTIFIER = "universal-auth-token"

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -17,7 +17,7 @@ func (e *TimeoutError) Error() string {
 func SetValueInKeyring(key, value string) error {
 	currentVaultBackend, err := GetCurrentVaultBackend()
 	if err != nil {
-		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical rest] then try again")
+		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical reset] then try again")
 	}
 
 	return keyring.Set(currentVaultBackend, MAIN_KEYRING_SERVICE, key, value)
@@ -26,7 +26,7 @@ func SetValueInKeyring(key, value string) error {
 func GetValueInKeyring(key string) (string, error) {
 	currentVaultBackend, err := GetCurrentVaultBackend()
 	if err != nil {
-		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical rest] then try again")
+		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical reset] then try again")
 	}
 
 	return keyring.Get(currentVaultBackend, MAIN_KEYRING_SERVICE, key)

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -286,6 +286,8 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 	// var serviceTokenDetails api.GetServiceTokenDetailsResponse
 	var errorToReturn error
 
+	var infisicalDotJson models.WorkspaceConfigFile
+
 	if params.InfisicalToken == "" && params.UniversalAuthAccessToken == "" {
 		if isConnected {
 			log.Debug().Msg("GetAllEnvironmentVariables: Connected to internet, checking logged in creds")
@@ -309,8 +311,6 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 		if loggedInUserDetails.LoginExpired {
 			PrintErrorMessageAndExit("Your login session has expired, please run [infisical login] and try again")
 		}
-
-		var infisicalDotJson models.WorkspaceConfigFile
 
 		if projectConfigFilePath == "" {
 			projectConfig, err := GetWorkSpaceFromFile()
@@ -368,6 +368,19 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 			secretsToReturn = res.Secrets
 		}
 	}
+
+	project := models.SingleEnvironmentVariable{
+		Key:   string(PROJECT_NAME),
+		Value: string(infisicalDotJson.WorkspaceName),
+	}
+
+	environment := models.SingleEnvironmentVariable{
+		Key:   string(ENVIRONMENT_NAME),
+		Value: string(params.Environment),
+	}
+
+	// add some built-in env to the secrets
+	secretsToReturn = append(secretsToReturn, project, environment)
 
 	return secretsToReturn, errorToReturn
 }


### PR DESCRIPTION
- fix(cli): add project and environment as built-in env to secrets
- correct typo in 'infisical rest' to 'infisical reset'

# Description 📣
This PR addresses the 3rd point raised in issue [#1598](https://github.com/Infisical/infisical/issues/1598). 

It entails adding the project name and environment name to the secrets. 

## Type ✨
- [x] New feature

# Tests 🛠️

The effect of this PR can be verified by running `infisical secrets` on the terminal. The response should include 2 new envs namely;


```
INFISICAL_PROJECT
INFISICAL_ENVIRONMENT
```

for the project/workspace name and environment name.

Here is a screencast showcasing the PR

[Screencast from 18-04-2024 13:28:09.webm](https://github.com/Infisical/infisical/assets/40923477/43e42da7-ef00-4fea-845e-f03cbef4d04a)
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->