### PR TITLE
Fix: Invite project member

### DIFF
--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -134,8 +134,7 @@ export const projectMembershipServiceFactory = ({
       const projectMemberships = await projectMembershipDAL.insertMany(
         orgMembers.map(({ userId }) => ({
           projectId,
-          userId: userId as string,
-          role: ProjectMembershipRole.Member
+          userId: userId as string
         })),
         tx
       );
@@ -267,8 +266,7 @@ export const projectMembershipServiceFactory = ({
       const projectMemberships = await projectMembershipDAL.insertMany(
         orgMembers.map(({ user }) => ({
           projectId,
-          userId: user.id,
-          role: ProjectMembershipRole.Member
+          userId: user.id
         })),
         tx
       );


### PR DESCRIPTION
Fixed inviting project members. The invite logic broke after we removed the `role` field from the project membership table. 