### PR TITLE
Fix: Duplicate org membership migration

### DIFF
--- a/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
+++ b/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
@@ -42,6 +42,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.transaction(async (tx) => {
     const duplicateRows = await tx(TableName.OrgMembership)
       .select("userId", "orgId") // Select the userId and orgId so we can group by them
+      .whereNotNull("userId") // Ensure that the userId is not null
       .count("* as cnt") // Count the number of rows for each userId and orgId, so we can make sure there are more than 1 row (a duplicate)
       .groupBy("userId", "orgId")
       .havingRaw("count(*) > ?", [1]); // Using havingRaw for direct SQL expressions
@@ -97,6 +98,8 @@ export async function up(knex: Knex): Promise<void> {
         `Deleted ${numberOfRowsDeleted} duplicate organization memberships for ${row.userId} and ${row.orgId}`
       );
     }
+
+    throw new Error("This is a test error");
   });
 
   await knex.schema.alterTable(TableName.OrgMembership, (table) => {

--- a/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
+++ b/backend/src/db/migrations/20240405000045_org-memberships-unique-constraint.ts
@@ -98,8 +98,6 @@ export async function up(knex: Knex): Promise<void> {
         `Deleted ${numberOfRowsDeleted} duplicate organization memberships for ${row.userId} and ${row.orgId}`
       );
     }
-
-    throw new Error("This is a test error");
   });
 
   await knex.schema.alterTable(TableName.OrgMembership, (table) => {


### PR DESCRIPTION
Fixed edge case for org membership migration where org membership user ID's could be null, causing a zod validation error, which results in the migration not being completed. 