### PR TITLE
Feat: Allow "secrets folders get" command to be used with service token & universal auth

### DIFF
--- a/cli/packages/cmd/folder.go
+++ b/cli/packages/cmd/folder.go
@@ -22,10 +22,6 @@ var folderCmd = &cobra.Command{
 var getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get folders in a directory",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		util.RequireLocalWorkspaceFile()
-		util.RequireLogin()
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		environmentName, _ := cmd.Flags().GetString("env")

--- a/cli/packages/util/folders.go
+++ b/cli/packages/util/folders.go
@@ -15,6 +15,8 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 	var foldersToReturn []models.SingleFolder
 	var folderErr error
 	if params.InfisicalToken == "" && params.UniversalAuthAccessToken == "" {
+		RequireLogin()
+		RequireLocalWorkspaceFile()
 
 		log.Debug().Msg("GetAllFolders: Trying to fetch folders using logged in details")
 

--- a/cli/packages/util/folders.go
+++ b/cli/packages/util/folders.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/api"
@@ -12,10 +11,6 @@ import (
 )
 
 func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder, error) {
-
-	if params.InfisicalToken == "" {
-		params.InfisicalToken = os.Getenv(INFISICAL_TOKEN_NAME)
-	}
 
 	var foldersToReturn []models.SingleFolder
 	var folderErr error


### PR DESCRIPTION
# Description 📣

Previously it wasn't possible to list folders with service tokens or universal auth, even though the functionality is there for it. I did some very minor tweaks to allow for service tokens and universal auth to be used. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->