### PR TITLE
Fix: SAML organization invite bug

### DIFF
--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -340,11 +340,12 @@ export const samlConfigServiceFactory = ({
               orgId,
               inviteEmail: email,
               role: OrgMembershipRole.Member,
-              status: OrgMembershipStatus.Accepted
+              status: user.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
             },
             tx
           );
-        } else if (orgMembership.status === OrgMembershipStatus.Invited) {
+          // Only update the membership to Accepted if the user account is already completed.
+        } else if (orgMembership.status === OrgMembershipStatus.Invited && user.isAccepted) {
           await orgDAL.updateMembershipById(
             orgMembership.id,
             {


### PR DESCRIPTION
# Description 📣


This PR addresses a bug with SAML which causes an organization membership to be set as "accepted" before the user has fully setup their account. This results in errors when trying to invite the organization member to projects, because there are no encryption keys associated to the user before the account has been fully set up.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->