### PR TITLE
Add ability to use existing postgres server with infisical-standalone helm chart. Fixes #1765

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -55,12 +55,12 @@ spec:
         ports: 
         - containerPort: 8080
         env:
-        {{- if .Values.postgresql.preexistingPostgres.enabled }}
+        {{- if .Values.postgresql.useExistingPostgres.enabled }}
         - name: DB_CONNECTION_URI
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.postgresql.preexistingPostgres.uriSecret.name }}
-              key: {{ .Values.postgresql.preexistingPostgres.uriSecret.key }}
+              name: {{ .Values.postgresql.useExistingPostgres.existingUriSecret.name }}
+              key: {{ .Values.postgresql.useExistingPostgres.existingUriSecret.key }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: DB_CONNECTION_URI

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -55,6 +55,13 @@ spec:
         ports: 
         - containerPort: 8080
         env:
+        {{- if .Values.postgresql.preexistingPostgres.enabled }}
+        - name: DB_CONNECTION_URI
+          valueFrom:
+            secretKeyRef:
+              name: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.name }}
+              key: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.uri }}
+        {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -59,8 +59,8 @@ spec:
         - name: DB_CONNECTION_URI
           valueFrom:
             secretKeyRef:
-              name: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.name }}
-              key: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.uri }}
+              name: {{ .Values.postgresql.preexistingPostgres.uriSecret.name }}
+              key: {{ .Values.postgresql.preexistingPostgres.uriSecret.key }}
         {{- end }}
         {{- if .Values.postgresql.enabled }}
         - name: DB_CONNECTION_URI

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -26,12 +26,12 @@ spec:
           image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
           command: ["npm", "run", "migration:latest"]
           env:
-          {{- if .Values.postgresql.preexistingPostgres.enabled }}
+          {{- if .Values.postgresql.useExistingPostgres.enabled }}
           - name: DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgresql.preexistingPostgres.uriSecret.name }}
-                key: {{ .Values.postgresql.preexistingPostgres.uriSecret.key }}
+                name: {{ .Values.postgresql.useExistingPostgres.existingUriSecret.name }}
+                key: {{ .Values.postgresql.useExistingPostgres.existingUriSecret.key }}
           {{- end }}
           {{- if .Values.postgresql.enabled }}
           - name: DB_CONNECTION_URI

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -26,6 +26,13 @@ spec:
           image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
           command: ["npm", "run", "migration:latest"]
           env:
+          {{- if .Values.postgresql.preexistingPostgres.enabled }}
+          - name: DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.name }}
+                key: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.uri }}
+          {{- end }}
           {{- if .Values.postgresql.enabled }}
           - name: DB_CONNECTION_URI
             value: {{ include "infisical.postgresDBConnectionString" . }}

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -30,8 +30,8 @@ spec:
           - name: DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:
-                name: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.name }}
-                key: {{ $infisicalValues.postgresql.preexistingPostgres.uriSecret.uri }}
+                name: {{ .Values.postgresql.preexistingPostgres.uriSecret.name }}
+                key: {{ .Values.postgresql.preexistingPostgres.uriSecret.key }}
           {{- end }}
           {{- if .Values.postgresql.enabled }}
           - name: DB_CONNECTION_URI

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -50,11 +50,11 @@ postgresql:
     username: infisical
     password: root
     database: infisicalDB
-  preexistingPostgres:
+  useExistingPostgres:
     # -- When this is enabled, postgresql.enabled needs to be false
     enabled: false
     # -- The name from where to get the existing postgresql connection URI
-    uriSecret:
+    existingUriSecret:
       # -- The name of the secret that contains the uri
       name: ""
       # -- Secret key name that contains the uri

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -50,6 +50,15 @@ postgresql:
     username: infisical
     password: root
     database: infisicalDB
+  preexistingPostgres:
+    # -- When this is enabled, postgresql.enabled needs to be false
+    enabled: false
+    # -- The name from where to get the existing postgresql connection URI
+    uriSecret:
+      # -- The name of the secret that contains the uri
+      name: ""
+      # -- Secret key name that contains the uri
+      key: ""
 
 redis:
   enabled: true


### PR DESCRIPTION
# Description 📣

This adds the option to use a existing Postgres instance with the infisical-standalone helm chart. It uses an existing secret to get the database connection URI.

Fixes: https://github.com/Infisical/infisical/issues/1765

## Type ✨

- [ ] Bug fix
- [x]  New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I set the values and run helm template .


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

