### PR TITLE
Add deprecation notice banner to service token section

### DIFF
--- a/frontend/src/views/Project/MembersPage/components/ServiceTokenTab/ServiceTokenTab.tsx
+++ b/frontend/src/views/Project/MembersPage/components/ServiceTokenTab/ServiceTokenTab.tsx
@@ -1,3 +1,5 @@
+import { faWarning } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { motion } from "framer-motion";
 
 import { ServiceTokenSection } from "./components";
@@ -11,7 +13,37 @@ export const ServiceTokenTab = () => {
       animate={{ opacity: 1, translateX: 0 }}
       exit={{ opacity: 0, translateX: 30 }}
     >
-      <ServiceTokenSection />
+      <div className="space-y-3">
+        <div className="flex w-full flex-row items-center rounded-md border border-primary-600/70 bg-primary/[.07] p-4 text-base text-white">
+          <FontAwesomeIcon icon={faWarning} className="pr-6 text-4xl text-white/80" />
+          <div className="flex w-full flex-col text-sm">
+            <span className="mb-4 text-lg font-semibold">Deprecation Notice</span>
+            <p>
+              Service Tokens are being deprecated in favor of Machine Identities.
+              <br />
+              They will be removed in the future in accordance with the deprecation notice and
+              timeline stated{" "}
+              <a
+                href="https://infisical.com/blog/deprecating-api-keys"
+                target="_blank"
+                className="font-semibold text-primary-400" rel="noreferrer"
+              >
+                here
+              </a>
+              .
+              <br />
+              <a
+                href="https://infisical.com/docs/documentation/platform/identities/overview"
+                target="_blank"
+                className="font-semibold text-primary-400" rel="noreferrer"
+              >
+                Learn more about Machine Identities
+              </a>
+            </p>
+          </div>
+        </div>
+        <ServiceTokenSection />
+      </div>
     </motion.div>
   );
 };

--- a/frontend/src/views/Settings/PersonalSettingsPage/PersonalTabGroup/PersonalTabGroup.tsx
+++ b/frontend/src/views/Settings/PersonalSettingsPage/PersonalTabGroup/PersonalTabGroup.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from "react";
-import Link from "next/link";
 import { faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tab } from "@headlessui/react";
@@ -47,18 +46,29 @@ export const PersonalTabGroup = () => {
               <div className="flex w-full flex-col text-sm">
                 <span className="mb-4 text-lg font-semibold">Deprecation Notice</span>
                 <p>
-                  API Keys are deprecated and will be removed in the future.
-                  <br /> Please use Machine Identity authentication for your applications and
-                  services.
-                </p>
-                <Link href="https://infisical.com/docs/documentation/platform/identities/overview">
-                  <a target="_blank" className="font-semibold text-primary-400">
+                  API Keys are being deprecated in favor of Machine Identities.
+                  <br />
+                  They will be removed in the future in accordance with the deprecation notice and
+                  timeline stated{" "}
+                  <a
+                    href="https://infisical.com/blog/deprecating-api-keys"
+                    target="_blank"
+                    className="font-semibold text-primary-400" rel="noreferrer"
+                  >
+                    here
+                  </a>
+                  .
+                  <br />
+                  <a
+                    href="https://infisical.com/docs/documentation/platform/identities/overview"
+                    target="_blank"
+                    className="font-semibold text-primary-400" rel="noreferrer"
+                  >
                     Learn more about Machine Identities
                   </a>
-                </Link>
+                </p>
               </div>
             </div>
-
             <PersonalAPIKeyTab />
           </div>
         </Tab.Panel>


### PR DESCRIPTION
# Description 📣

This PR adds a deprecation notice banner to the Service Token section; it also updates the deprecation notice banner in the API Key section.

Details of the Service Token + API Key deprecation can be found [here](https://infisical.com/blog/deprecating-api-keys).

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->