### PR TITLE
Add option to not delete secrets in parameter store

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -625,7 +625,8 @@ export const INTEGRATION = {
       shouldAutoRedeploy: "Used by Render to trigger auto deploy.",
       secretGCPLabel: "The label for GCP secrets.",
       secretAWSTag: "The tags for AWS secrets.",
-      kmsKeyId: "The ID of the encryption key from AWS KMS."
+      kmsKeyId: "The ID of the encryption key from AWS KMS.",
+      shouldDisableDelete: "The flag to disable deletion of secrets in AWS Parameter Store."
     }
   },
   UPDATE: {

--- a/backend/src/server/routes/v1/integration-router.ts
+++ b/backend/src/server/routes/v1/integration-router.ts
@@ -66,7 +66,8 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
               )
               .optional()
               .describe(INTEGRATION.CREATE.metadata.secretAWSTag),
-            kmsKeyId: z.string().optional().describe(INTEGRATION.CREATE.metadata.kmsKeyId)
+            kmsKeyId: z.string().optional().describe(INTEGRATION.CREATE.metadata.kmsKeyId),
+            shouldDisableDelete: z.boolean().optional().describe(INTEGRATION.CREATE.metadata.shouldDisableDelete)
           })
           .default({})
       }),

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -517,20 +517,22 @@ const syncSecretsAWSParameterStore = async ({
     })
   );
 
-  // Identify secrets to delete
-  await Promise.all(
-    Object.keys(awsParameterStoreSecretsObj).map(async (key) => {
-      if (!(key in secrets)) {
-        // case:
-        // -> delete secret
-        await ssm
-          .deleteParameter({
-            Name: awsParameterStoreSecretsObj[key].Name as string
-          })
-          .promise();
-      }
-    })
-  );
+  if (!metadata.shouldDisableDelete) {
+    // Identify secrets to delete
+    await Promise.all(
+      Object.keys(awsParameterStoreSecretsObj).map(async (key) => {
+        if (!(key in secrets)) {
+          // case:
+          // -> delete secret
+          await ssm
+            .deleteParameter({
+              Name: awsParameterStoreSecretsObj[key].Name as string
+            })
+            .promise();
+        }
+      })
+    );
+  }
 };
 
 /**

--- a/backend/src/services/integration/integration-types.ts
+++ b/backend/src/services/integration/integration-types.ts
@@ -27,6 +27,7 @@ export type TCreateIntegrationDTO = {
       value: string;
     }[];
     kmsKeyId?: string;
+    shouldDisableDelete?: boolean;
   };
 } & Omit<TProjectPermission, "projectId">;
 

--- a/frontend/src/hooks/api/integrations/queries.tsx
+++ b/frontend/src/hooks/api/integrations/queries.tsx
@@ -68,6 +68,7 @@ export const useCreateIntegration = () => {
           value: string;
         }[];
         kmsKeyId?: string;
+        shouldDisableDelete?: boolean;
       };
     }) => {
       const {

--- a/frontend/src/pages/integrations/aws-parameter-store/create.tsx
+++ b/frontend/src/pages/integrations/aws-parameter-store/create.tsx
@@ -89,6 +89,7 @@ export default function AWSParameterStoreCreateIntegrationPage() {
 
   const [isLoading, setIsLoading] = useState(false);
   const [shouldTag, setShouldTag] = useState(false);
+  const [shouldDisableDelete, setShouldDisableDelete] = useState(false);
   const [tagKey, setTagKey] = useState("");
   const [tagValue, setTagValue] = useState("");
   const [kmsKeyId, setKmsKeyId] = useState("");
@@ -144,7 +145,8 @@ export default function AWSParameterStoreCreateIntegrationPage() {
                 ]
               }
             : {}),
-          ...(kmsKeyId && { kmsKeyId })
+          ...(kmsKeyId && { kmsKeyId }),
+          ...(shouldDisableDelete && { shouldDisableDelete })
         }
       });
 
@@ -273,6 +275,15 @@ export default function AWSParameterStoreCreateIntegrationPage() {
               exit={{ opacity: 0, translateX: 30 }}
             >
               <div className="mt-2 ml-1">
+                <Switch
+                  id="delete-aws"
+                  onCheckedChange={() => setShouldDisableDelete(!shouldDisableDelete)}
+                  isChecked={shouldDisableDelete}
+                >
+                  Disable deleting secrets in AWS Parameter Store
+                </Switch>
+              </div>
+              <div className="mt-4 ml-1">
                 <Switch
                   id="tag-aws"
                   onCheckedChange={() => setShouldTag(!shouldTag)}

--- a/pg-migrator/src/models/integration/types.ts
+++ b/pg-migrator/src/models/integration/types.ts
@@ -10,4 +10,5 @@ export type Metadata = {
         value: string;
     }[]
     kmsKeyId?: string;
+    shouldDisableDelete?: boolean;
 }


### PR DESCRIPTION
# Description 📣

This feature creates a boolean flag that allows users not to delete secrets in aws parameter store (only edit and create operations will be propagated from Infisical to AWS PS). 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->