### PR TITLE
feat: cli env upload

### DIFF
--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -310,16 +310,16 @@ export const secretServiceFactory = ({
     }
 
     let newSecretNameBlindIndex: string | undefined;
-    if (inputSecret?.newSecretName) {
-      const { keyName2BlindIndex: kN2NewBlindIndex } = await fnSecretBlindIndexCheck({
-        inputSecrets: [{ secretName: inputSecret.newSecretName }],
-        folderId,
-        isNew: true,
-        blindIndexCfg,
-        secretDAL
-      });
-      newSecretNameBlindIndex = kN2NewBlindIndex[inputSecret.newSecretName];
-    }
+    // if (inputSecret?.newSecretName) {
+    //   const { keyName2BlindIndex: kN2NewBlindIndex } = await fnSecretBlindIndexCheck({
+    //     inputSecrets: [{ secretName: inputSecret.newSecretName }],
+    //     folderId,
+    //     isNew: true,
+    //     blindIndexCfg,
+    //     secretDAL
+    //   });
+    //   newSecretNameBlindIndex = kN2NewBlindIndex[inputSecret.newSecretName];
+    // }
 
     await secretQueueService.handleSecretReminder({
       newSecret: {

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bufio"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -802,4 +803,25 @@ func GetPlainTextWorkspaceKey(authenticationToken string, receiverPrivateKey str
 	}
 
 	return crypto.DecryptAsymmetric(encryptedWorkspaceKey, encryptedWorkspaceKeyNonce, encryptedWorkspaceKeySenderPublicKey, currentUsersPrivateKey), nil
+}
+
+func ParseSecretsFromDotEnvFile(filePath string) ([]string, error) {
+	cwd,err:=os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	filePath = path.Join(cwd, filePath)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	
+	defer file.Close()
+	env:=make([]string,0)
+	
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		env = append(env, scanner.Text())
+	}
+	return env, nil
 }


### PR DESCRIPTION

Closes #1612 
@maidul98 

@akhilmhdh wrt the commented out block in `secret-service.ts`, using the cli secrets set command where in this case the secret key already exists, instead of updating the existing secret with the new value it always gave this response
```
error: CallUpdateSecretsV3: Unsuccessful response. Please make sure your secret path, workspace and environment name are all correct [response={"statusCode":400,"message":"Secret already exist","error":"BadRequest"}]
Unable to process secret update request
```
Commenting out that block resolves it. Is it by design or its a bug?