### PR TITLE
feat: delimiter flag for export command

### DIFF
--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -351,7 +351,7 @@ func dynamicSecretTemplateFunction(accessToken string, dynamicSecretManager *Dyn
 	return func(args ...string) (map[string]interface{}, error) {
 		argLength := len(args)
 		if argLength != 4 && argLength != 5 {
-			return nil, fmt.Errorf("Invalid arguments found for dynamic-secret function. Check template %i", templateId)
+			return nil, fmt.Errorf("Invalid arguments found for dynamic-secret function. Check template %d", templateId)
 		}
 
 		projectSlug, envSlug, secretPath, slug, ttl := args[0], args[1], args[2], args[3], ""

--- a/cli/packages/cmd/cmd_test.go
+++ b/cli/packages/cmd/cmd_test.go
@@ -47,3 +47,81 @@ func TestFilterReservedEnvVars(t *testing.T) {
 	}
 
 }
+
+func TestExportAsDotEnv(t *testing.T) {
+	envs := []models.SingleEnvironmentVariable{
+		{Key: "key1", Value: "val1"},
+		{Key: "key2", Value: "val2"},
+		{Key: "key3", Value: "val3"},
+	}
+
+	res := "key1='val1'\nkey2='val2'\nkey3='val3'\n"
+	out, err := formatEnvs(envs, FormatDotenv, "", "")
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to export to .env")
+	}
+
+	res = "key1=\"val1\"\nkey2=\"val2\"\nkey3=\"val3\"\n"
+	out, err = formatEnvs(envs, FormatDotenv, "", `"`)
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to replace quota")
+	}
+}
+
+func TestExportAsDotEnvExport(t *testing.T) {
+	envs := []models.SingleEnvironmentVariable{
+		{Key: "key1", Value: "val1"},
+		{Key: "key2", Value: "val2"},
+		{Key: "key3", Value: "val3"},
+	}
+
+	res := "export key1='val1'\nexport key2='val2'\nexport key3='val3'\n"
+	out, err := formatEnvs(envs, FormatDotEnvExport, "", "")
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to export to .env")
+	}
+
+	res = "export key1=\"val1\"\nexport key2=\"val2\"\nexport key3=\"val3\"\n"
+	out, err = formatEnvs(envs, FormatDotEnvExport, "", `"`)
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to replace quota")
+	}
+}
+
+func TestExportAsCSV(t *testing.T) {
+	envs := []models.SingleEnvironmentVariable{
+		{Key: "key1", Value: "val1"},
+		{Key: "key2", Value: "val2"},
+		{Key: "key3", Value: "val3"},
+	}
+
+	res := "Key,Value\nkey1,val1\nkey2,val2\nkey3,val3\n"
+	out, err := formatEnvs(envs, FormatCSV, "", "")
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to export to .env")
+	}
+
+	res = "Key/Value\nkey1/val1\nkey2/val2\nkey3/val3\n"
+	out, err = formatEnvs(envs, FormatCSV, "/", "")
+	if err != nil {
+		t.Errorf("formatEnvs failed")
+	}
+	if res != out {
+		t.Errorf("failed to replace delimiter")
+	}
+}

--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -133,7 +133,7 @@ var loginCmd = &cobra.Command{
 
 			err = util.StoreUserCredsInKeyRing(&userCredentialsToBeStored)
 			if err != nil {
-				log.Error().Msgf("Unable to store your credentials in system vault [%s]")
+				log.Error().Msgf("Unable to store your credentials in system vault")
 				log.Error().Msgf("\nTo trouble shoot further, read https://infisical.com/docs/cli/faq")
 				log.Debug().Err(err)
 				//return here


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Creates new flags `delimit` and `quota` for the `export` command. `delimit` is currently only for CSV format. `quota` is only for .env formats. There are 2 flags rather than 1 because default handling is clearer and it allows for the possibility to extend delimit flag to .env for changing `=` in the future. Flags are permissive -- if format is not CSV or .env and a flag is provided, the flag is ignored and the command doesn't fail
 
Resolves: https://github.com/Infisical/infisical/issues/1103

## Type ✨

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

See unit tests in `cli/cmd_test.go`

Manually:

<img width="619" alt="Screenshot 2024-05-13 at 3 14 21 PM" src="https://github.com/Infisical/infisical/assets/19435271/5ff9516a-79ac-4e75-92fb-2641a0459467">


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->