### PR TITLE
Fix: Secret expansion with recursive mode enabled

### DIFF
--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -353,7 +353,7 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
 };
 
 export const decryptSecretRaw = (
-  secret: TSecrets & { workspace: string; environment: string; secretPath?: string },
+  secret: TSecrets & { workspace: string; environment: string; secretPath: string },
   key: string
 ) => {
   const secretKey = decryptSymmetric128BitHexKeyUTF8({


### PR DESCRIPTION
# Description 📣

There is currently a bug that occurs when calling the V3 list secrets endpoint with`recursive` and `expandSecretReferences` set to true. 

If there are two or more secrets with the same key is found, the value will be identical for all the secrets found. This was due to a "unique" mapping issue. Before recursive mode was a thing, this would've worked just fine the way it is. But after adding recursive mode, we need to factor in the possibility of duplicate secret keys for the secrets we are iterating through. 

Smaller: I also decided to make the secretPath consistent, so we don't need to check for undefined anymore.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->