### PR TITLE
fix: get all secrets from aws ssm

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -479,10 +479,10 @@ const syncSecretsAWSParameterStore = async ({
       .promise();
 
     if (parameters.Parameters) {
-      parameters.Parameters.forEach((sec) => {
-        if (sec.Name) {
-          const secKey = sec.Name.substring((integration.path as string).length);
-          awsParameterStoreSecretsObj[secKey] = sec;
+      parameters.Parameters.forEach((parameter) => {
+        if (parameter.Name) {
+          const secKey = parameter.Name.substring((integration.path as string).length);
+          awsParameterStoreSecretsObj[secKey] = parameter;
         }
       });
     }


### PR DESCRIPTION
# Description 📣

1. By default ssm get secrets paginate by 10
2. Now it fetches everything from it

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->