### PR TITLE
fix: run command universal auth by env

### DIFF
--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -85,10 +85,29 @@ func GetInfisicalToken(cmd *cobra.Command) (token *models.TokenDetails, err erro
 
 	if infisicalToken == "" { // If no flag is passed, we first check for the universal auth access token env variable.
 		infisicalToken = os.Getenv(INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN_NAME)
+	}
 
-		if infisicalToken == "" { // If it's still empty after the first env check, we check for the service token env variable.
-			infisicalToken = os.Getenv(INFISICAL_TOKEN_NAME)
+	if infisicalToken == "" { // If it's still empty after the first env check, we check for the service token env variable.
+		infisicalToken = os.Getenv(INFISICAL_TOKEN_NAME)
+	}
+
+	if infisicalToken == "" { // If it's still empty after the second env check, we try to login with universal auth.
+		clientId := os.Getenv(INFISICAL_UNIVERSAL_AUTH_CLIENT_ID_NAME)
+		if clientId == "" {
+			PrintErrorMessageAndExit("Please provide client-id")
 		}
+		clientSecret := os.Getenv(INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET_NAME)
+		if clientSecret == "" {
+			PrintErrorMessageAndExit("Please provide client-secret")
+		}
+
+		res, err := UniversalAuthLogin(clientId, clientSecret)
+
+		if err != nil {
+			HandleError(err)
+		}
+
+		infisicalToken = res.AccessToken
 	}
 
 	if infisicalToken == "" { // If it's empty, we return nothing at all.


### PR DESCRIPTION
# Description 📣

fixes #1831

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
INFISICAL_API_URL=xxx INFISICAL_UNIVERSAL_AUTH_CLIENT_ID=xxx INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET=xxx ./infisical run --projectId xxx -- printenv
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->