### PR TITLE
Patch Identity Access Token Trusted IPs validation for AWS/GCP Auth

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-dal.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
-import { TableName, TIdentityAccessTokens } from "@app/db/schemas";
+import { IdentityAuthMethod, TableName, TIdentityAccessTokens } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
 
@@ -15,23 +15,46 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
       const doc = await (tx || db)(TableName.IdentityAccessToken)
         .where(filter)
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.IdentityAccessToken}.identityId`)
-        .leftJoin(
-          TableName.IdentityUaClientSecret,
-          `${TableName.IdentityAccessToken}.identityUAClientSecretId`,
-          `${TableName.IdentityUaClientSecret}.id`
-        )
-        .leftJoin(
-          TableName.IdentityUniversalAuth,
-          `${TableName.IdentityUaClientSecret}.identityUAId`,
-          `${TableName.IdentityUniversalAuth}.id`
-        )
+        .leftJoin(TableName.IdentityUaClientSecret, (qb) => {
+          qb.on(`${TableName.Identity}.authMethod`, db.raw("?", [IdentityAuthMethod.Univeral])).andOn(
+            `${TableName.IdentityAccessToken}.identityUAClientSecretId`,
+            `${TableName.IdentityUaClientSecret}.id`
+          );
+        })
+        .leftJoin(TableName.IdentityUniversalAuth, (qb) => {
+          qb.on(`${TableName.Identity}.authMethod`, db.raw("?", [IdentityAuthMethod.Univeral])).andOn(
+            `${TableName.IdentityUaClientSecret}.identityUAId`,
+            `${TableName.IdentityUniversalAuth}.id`
+          );
+        })
+        .leftJoin(TableName.IdentityGcpAuth, (qb) => {
+          qb.on(`${TableName.Identity}.authMethod`, db.raw("?", [IdentityAuthMethod.GCP_AUTH])).andOn(
+            `${TableName.Identity}.id`,
+            `${TableName.IdentityGcpAuth}.identityId`
+          );
+        })
+        .leftJoin(TableName.IdentityAwsAuth, (qb) => {
+          qb.on(`${TableName.Identity}.authMethod`, db.raw("?", [IdentityAuthMethod.AWS_AUTH])).andOn(
+            `${TableName.Identity}.id`,
+            `${TableName.IdentityAwsAuth}.identityId`
+          );
+        })
         .select(selectAllTableCols(TableName.IdentityAccessToken))
         .select(
-          db.ref("accessTokenTrustedIps").withSchema(TableName.IdentityUniversalAuth),
+          db.ref("accessTokenTrustedIps").withSchema(TableName.IdentityUniversalAuth).as("accessTokenTrustedIpsUa"),
+          db.ref("accessTokenTrustedIps").withSchema(TableName.IdentityGcpAuth).as("accessTokenTrustedIpsGcp"),
+          db.ref("accessTokenTrustedIps").withSchema(TableName.IdentityAwsAuth).as("accessTokenTrustedIpsAws"),
           db.ref("name").withSchema(TableName.Identity)
         )
         .first();
-      return doc;
+
+      if (!doc) return;
+
+      return {
+        ...doc,
+        accessTokenTrustedIps:
+          doc.accessTokenTrustedIpsUa || doc.accessTokenTrustedIpsGcp || doc.accessTokenTrustedIpsAws
+      };
     } catch (error) {
       throw new DatabaseError({ error, name: "IdAccessTokenFindOne" });
     }

--- a/docs/documentation/platform/identities/gcp-auth.mdx
+++ b/docs/documentation/platform/identities/gcp-auth.mdx
@@ -123,7 +123,7 @@ access the Infisical API using the GCP ID Token authentication method.
                 <CodeGroup>
                 ```bash curl
                 curl -H "Metadata-Flavor: Google" \
-                'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=<identityId>'
+                'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=<identityId>&format=full'
                 ```
                 </CodeGroup>
 


### PR DESCRIPTION
# Description 📣

This PR adds the necessary joins to validate access token IP addresses for AWS/GCP auth.

Previously, the missing joins resulted in the IP address validation always failing when trying to use an access token issued under one of these newer authentication methods.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->