### PR TITLE
feat(cli): enable include-imports in infisical agent

### DIFF
--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -332,7 +332,7 @@ func ParseAgentConfig(configFile []byte) (*Config, error) {
 
 func secretTemplateFunction(accessToken string, existingEtag string, currentEtag *string) func(string, string, string) ([]models.SingleEnvironmentVariable, error) {
 	return func(projectID, envSlug, secretPath string) ([]models.SingleEnvironmentVariable, error) {
-		res, err := util.GetPlainTextSecretsViaMachineIdentity(accessToken, projectID, envSlug, secretPath, false, false)
+		res, err := util.GetPlainTextSecretsViaMachineIdentity(accessToken, projectID, envSlug, secretPath, true, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description 📣

Same logic as `infisical run` and `infisical export` for imported secrets

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️


1. Create two folders `folder-a` and `folder-b` in `dev` environment
2. Create new secrets in `folder-a`
3. Create import in `folder-b` with `folder-a` as target, and create some secrets
4. This command should ouput `folder-a` and `folder-b` secrets
5. Prepare source template for `infisical agent` with filename `source-template`: 
```
{{- with secret "<project id>" "dev" "/folder-b" }}
{{- range . }}
{{ .Key }}={{ .Value }}
{{- end }}
{{- end }}
```
6. Prepare config file `infisical-agent.yaml`:
```
infisical:
  address: "<url>"
auth:
  type: "universal-auth"
  config:
    client-id: "./client-id"
    client-secret: "./client-secret"
    remove_client_secret_on_read: false
sinks:
  - type: "file"
    config:
      path: "./access-token"
templates:
  - source-path: "./source-template"
    destination-path: "/target-env"
    config:
      polling-interval: 60s
      execute:
        timeout: 30
        command: ./reload.sh
```
7. Run and check that `folder-b` and `folder-a` secrets are present in `target-env` file

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝