### PR TITLE
Fix: No orgs selectable if a user has been removed from an organization

### DIFF
--- a/frontend/src/pages/login/select-organization.tsx
+++ b/frontend/src/pages/login/select-organization.tsx
@@ -121,6 +121,14 @@ export default function LoginPage() {
     }
   }, [router]);
 
+  // Case: User has no organizations.
+  // This can happen if the user was previously a member, but the organization was deleted or the user was removed.
+  useEffect(() => {
+    if (!organizations.isLoading && organizations.data?.length === 0) {
+      router.push("/org/none");
+    }
+  }, [organizations.isLoading, organizations.data]);
+
   if (userLoading || !user) {
     return <LoadingScreen />;
   }


### PR DESCRIPTION
# Description 📣

This PR covers an edge case where the user wouldn't be able to select an organization if the user had previously been removed from the only org they were a member of. 

We now redirect to `/org/none` where the user will be prompted to create a new organization. 

![CleanShot 2024-05-23 at 15 12 07](https://github.com/Infisical/infisical/assets/62331820/c14ef3c6-e8fd-4855-9630-31a93c1dd14f)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->