### PR TITLE
doc: added reminder for GCP oauth user permissions

### DIFF
--- a/docs/integrations/cloud/gcp-secret-manager.mdx
+++ b/docs/integrations/cloud/gcp-secret-manager.mdx
@@ -52,7 +52,7 @@ description: "How to sync secrets from Infisical to GCP Secret Manager"
                 Using Infisical to sync secrets to GCP Secret Manager requires that you enable
                 the Service Usage API and Cloud Resource Manager API in the Google Cloud project you want to sync secrets to. More on that [here](https://cloud.google.com/service-usage/docs/set-up-development-environment).
 
-                Additionally, ensure that your GCP account has sufficient permission to manage secret and service resources (you can assign Secret Manager Admin and Service Usage Admin roles)
+                Additionally, ensure that your GCP account has sufficient permission to manage secret and service resources (you can assign Secret Manager Admin and Service Usage Admin roles for testing purposes)
             </Warning>
           </Step>
         </Steps>

--- a/docs/integrations/cloud/gcp-secret-manager.mdx
+++ b/docs/integrations/cloud/gcp-secret-manager.mdx
@@ -51,6 +51,8 @@ description: "How to sync secrets from Infisical to GCP Secret Manager"
             <Warning>
                 Using Infisical to sync secrets to GCP Secret Manager requires that you enable
                 the Service Usage API and Cloud Resource Manager API in the Google Cloud project you want to sync secrets to. More on that [here](https://cloud.google.com/service-usage/docs/set-up-development-environment).
+
+                Additionally, ensure that your GCP account has the right roles for the selected project (Secrets Manager Admin and Service Usage Admin)
             </Warning>
           </Step>
         </Steps>
@@ -115,6 +117,7 @@ description: "How to sync secrets from Infisical to GCP Secret Manager"
         </Steps>
       </Accordion>
     </AccordionGroup>
+
   </Tab>
   <Tab title="Self-Hosted Setup">
     Using the GCP Secret Manager integration (via the OAuth2 method) on a self-hosted instance of Infisical requires configuring an OAuth2 application in GCP
@@ -123,27 +126,27 @@ description: "How to sync secrets from Infisical to GCP Secret Manager"
     <Steps>
       <Step title="Create an OAuth2 application in GCP">
         Navigate to your project API & Services > Credentials to create a new OAuth2 application.
-        
-        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-api-services.png) 
-        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app.png) 
-          
+
+        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-api-services.png)
+        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app.png)
+
           Create the application. As part of the form, add to **Authorized redirect URIs**: `https://your-domain.com/integrations/gcp-secret-manager/oauth2/callback`.
-        
-        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app-form.png) 
+
+        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-new-app-form.png)
       </Step>
       <Step title="Add your OAuth2 application credentials to Infisical">
         Obtain the **Client ID** and **Client Secret** for your GCP OAuth2 application.
-        
-        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-credentials.png) 
-        
+
+        ![integrations GCP secret manager config](../../images/integrations/gcp-secret-manager/integrations-gcp-secret-manager-config-credentials.png)
+
         Back in your Infisical instance, add two new environment variables for the credentials of your GCP OAuth2 application:
 
         - `CLIENT_ID_GCP_SECRET_MANAGER`: The **Client ID** of your GCP OAuth2 application.
         - `CLIENT_SECRET_GCP_SECRET_MANAGER`: The **Client Secret** of your GCP OAuth2 application.
-        
+
         Once added, restart your Infisical instance and use the GCP Secret Manager integration.
       </Step>
     </Steps>
+
   </Tab>
 </Tabs>
-

--- a/docs/integrations/cloud/gcp-secret-manager.mdx
+++ b/docs/integrations/cloud/gcp-secret-manager.mdx
@@ -52,7 +52,7 @@ description: "How to sync secrets from Infisical to GCP Secret Manager"
                 Using Infisical to sync secrets to GCP Secret Manager requires that you enable
                 the Service Usage API and Cloud Resource Manager API in the Google Cloud project you want to sync secrets to. More on that [here](https://cloud.google.com/service-usage/docs/set-up-development-environment).
 
-                Additionally, ensure that your GCP account has the right roles for the selected project (Secrets Manager Admin and Service Usage Admin)
+                Additionally, ensure that your GCP account has sufficient permission to manage secret and service resources (you can assign Secret Manager Admin and Service Usage Admin roles)
             </Warning>
           </Step>
         </Steps>


### PR DESCRIPTION
# Description 📣
- added permission reminder for oauth usage. this is so that users who want to integrate with GCP secrets manager are made aware that their account will need to have sufficient IAM permissions 
<img width="944" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/2fdc8f9a-ff2c-4196-a243-2b4d9d40dd05">


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->