### PR TITLE
fix: resolved trailing slash issue with additional privileges

### DIFF
--- a/frontend/src/helpers/string.ts
+++ b/frontend/src/helpers/string.ts
@@ -1,0 +1,5 @@
+export const removeTrailingSlash = (str: string) => {
+  if (str === "/") return str;
+
+  return str.endsWith("/") ? str.slice(0, -1) : str;
+};

--- a/frontend/src/views/Project/MembersPage/components/MemberListTab/MemberRoleForm/SpecificPrivilegeSection.tsx
+++ b/frontend/src/views/Project/MembersPage/components/MemberListTab/MemberRoleForm/SpecificPrivilegeSection.tsx
@@ -43,6 +43,7 @@ import {
   useProjectPermission,
   useWorkspace
 } from "@app/context";
+import { removeTrailingSlash } from "@app/helpers/string";
 import { usePopUp } from "@app/hooks";
 import {
   TProjectUserPrivilege,
@@ -104,7 +105,9 @@ export const SpecificPrivilegeSecretForm = ({
         ? {
             environmentSlug: privilege.permissions?.[0]?.conditions?.environment,
             // secret path will be inside $glob operator
-            secretPath: privilege.permissions?.[0]?.conditions?.secretPath?.$glob || "",
+            secretPath: privilege.permissions?.[0]?.conditions?.secretPath?.$glob
+              ? removeTrailingSlash(privilege.permissions?.[0]?.conditions?.secretPath?.$glob)
+              : "",
             read: privilege.permissions?.some(({ action }) =>
               action.includes(ProjectPermissionActions.Read)
             ),
@@ -183,7 +186,7 @@ export const SpecificPrivilegeSecretForm = ({
       ];
       const conditions: Record<string, any> = { environment: data.environmentSlug };
       if (data.secretPath) {
-        conditions.secretPath = { $glob: data.secretPath };
+        conditions.secretPath = { $glob: removeTrailingSlash(data.secretPath) };
       }
       await updateUserPrivilege.mutateAsync({
         privilegeId: privilege.id,


### PR DESCRIPTION
# Description 📣
Previously, fetching secrets for users with additional privilege does not work. Upon investigation, this is because we're saving the path condition with no sanitation or pre-processing (in this case, removal of trailing slash)

Admin view of level1 path:
<img width="1510" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/47ecd217-23e3-45ec-b3c0-5ab8576bf502">

Permission of user1:
<img width="1507" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/8161af27-e078-42dc-8897-bd1650476cb9">

View of user1 in level1 path
<img width="1508" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/c21a7984-d506-4b97-92cf-d5fd3a024bfe">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->