### PR TITLE
Fix: Select organization query invalidation

### DIFF
--- a/frontend/src/hooks/api/auth/queries.tsx
+++ b/frontend/src/hooks/api/auth/queries.tsx
@@ -79,8 +79,10 @@ export const useSelectOrganization = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(organizationKeys.getUserOrganizations);
-      queryClient.invalidateQueries(workspaceKeys.getAllUserWorkspace);
+      queryClient.invalidateQueries([
+        organizationKeys.getUserOrganizations,
+        workspaceKeys.getAllUserWorkspace
+      ]);
     }
   });
 };

--- a/frontend/src/hooks/api/auth/queries.tsx
+++ b/frontend/src/hooks/api/auth/queries.tsx
@@ -5,6 +5,7 @@ import { apiRequest } from "@app/config/request";
 import { setAuthToken } from "@app/reactQuery";
 
 import { organizationKeys } from "../organization/queries";
+import { workspaceKeys } from "../workspace/queries";
 import {
   ChangePasswordDTO,
   CompleteAccountDTO,
@@ -79,6 +80,7 @@ export const useSelectOrganization = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries(organizationKeys.getUserOrganizations);
+      queryClient.invalidateQueries(workspaceKeys.getAllUserWorkspace);
     }
   });
 };


### PR DESCRIPTION
# Description 📣

Currently there's a rare bug that causes the "Failed to get permissions" page to show when switching between organizations. This would sometimes happen because the projects wouldn't be invalidated properly, and then when the user clicked the project, their newly acquired access token wouldn't have access to the project because the token is scoped on an organization-level.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->