### PR TITLE
add index to secret version secrets table 

### DIFF
--- a/backend/src/db/migrations/20240529043051_snap-shot-secret-index-secretversionid.ts
+++ b/backend/src/db/migrations/20240529043051_snap-shot-secret-index-secretversionid.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const doesSecretVersionIdExist = await knex.schema.hasColumn(TableName.SnapshotSecret, "secretVersionId");
+  if (await knex.schema.hasTable(TableName.SnapshotSecret)) {
+    await knex.schema.alterTable(TableName.SnapshotSecret, (t) => {
+      if (doesSecretVersionIdExist) t.index("secretVersionId");
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const doesSecretVersionIdExist = await knex.schema.hasColumn(TableName.SnapshotSecret, "secretVersionId");
+  if (await knex.schema.hasTable(TableName.SnapshotSecret)) {
+    await knex.schema.alterTable(TableName.SnapshotSecret, (t) => {
+      if (doesSecretVersionIdExist) t.dropIndex("secretVersionId");
+    });
+  }
+}

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -8,7 +8,6 @@ import {
   UsersSchema
 } from "@app/db/schemas";
 import { PROJECTS } from "@app/lib/api-docs";
-import { BadRequestError } from "@app/lib/errors";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -193,19 +192,18 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       }
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
-    handler: async () => {
-      // const workspace = await server.services.project.deleteProject({
-      //   filter: {
-      //     type: ProjectFilterType.ID,
-      //     projectId: req.params.workspaceId
-      //   },
-      //   actorId: req.permission.id,
-      //   actorAuthMethod: req.permission.authMethod,
-      //   actor: req.permission.type,
-      //   actorOrgId: req.permission.orgId
-      // });
-      // return { workspace };
-      throw new BadRequestError({ message: "Project delete has been paused temporarily, please try again later" });
+    handler: async (req) => {
+      const workspace = await server.services.project.deleteProject({
+        filter: {
+          type: ProjectFilterType.ID,
+          projectId: req.params.workspaceId
+        },
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actor: req.permission.type,
+        actorOrgId: req.permission.orgId
+      });
+      return { workspace };
     }
   });
 


### PR DESCRIPTION
Before this index, deleting a project would take up to 4 hours. With this index, the same query now takes 6 seconds. Brining back project delete because now the delete should run smoothly