### PR TITLE
feat: removed the need to pass /api for cli domain

### DIFF
--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -15,7 +15,6 @@ import (
 	"path"
 	"runtime"
 	"slices"
-	"strings"
 	"sync"
 	"syscall"
 	"text/template"
@@ -257,19 +256,6 @@ func WriteBytesToFile(data *bytes.Buffer, outputPath string) error {
 	return err
 }
 
-func appendAPIEndpoint(address string) string {
-	// Ensure the address does not already end with "/api"
-	if strings.HasSuffix(address, "/api") {
-		return address
-	}
-
-	// Check if the address ends with a slash and append accordingly
-	if address[len(address)-1] == '/' {
-		return address + "api"
-	}
-	return address + "/api"
-}
-
 func ParseAgentConfig(configFile []byte) (*Config, error) {
 	var rawConfig struct {
 		Infisical InfisicalConfig `yaml:"infisical"`
@@ -290,7 +276,7 @@ func ParseAgentConfig(configFile []byte) (*Config, error) {
 		rawConfig.Infisical.Address = DEFAULT_INFISICAL_CLOUD_URL
 	}
 
-	config.INFISICAL_URL = appendAPIEndpoint(rawConfig.Infisical.Address)
+	config.INFISICAL_URL = util.AppendAPIEndpoint(rawConfig.Infisical.Address)
 
 	log.Info().Msgf("Infisical instance address set to %s", rawConfig.Infisical.Address)
 

--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -101,7 +101,7 @@ var loginCmd = &cobra.Command{
 				//set domainQuery to false
 				if !overrideDomain {
 					domainQuery = false
-					config.INFISICAL_URL = config.INFISICAL_URL_MANUAL_OVERRIDE
+					config.INFISICAL_URL = util.AppendAPIEndpoint(config.INFISICAL_URL_MANUAL_OVERRIDE)
 				}
 
 			}

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -43,6 +43,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("silent", false, "Disable output of tip/info messages. Useful when running in scripts or CI/CD pipelines.")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		silent, err := cmd.Flags().GetBool("silent")
+		config.INFISICAL_URL = util.AppendAPIEndpoint(config.INFISICAL_URL)
 		if err != nil {
 			util.HandleError(err)
 		}

--- a/cli/packages/cmd/user.go
+++ b/cli/packages/cmd/user.go
@@ -237,7 +237,7 @@ func NewDomainPrompt() (string, error) {
 		return "", err
 	}
 
-	return domain, nil
+	return util.AppendAPIEndpoint(domain), nil
 }
 
 func LoggedInUsersPrompt(profiles []string) (string, error) {

--- a/cli/packages/util/credentials.go
+++ b/cli/packages/util/credentials.go
@@ -88,7 +88,7 @@ func GetCurrentLoggedInUserDetails() (LoggedInUserDetails, error) {
 		//configFile.LoggedInUserDomain
 		//if not empty set as infisical url
 		if configFile.LoggedInUserDomain != "" {
-			config.INFISICAL_URL = configFile.LoggedInUserDomain
+			config.INFISICAL_URL = AppendAPIEndpoint(configFile.LoggedInUserDomain)
 		}
 
 		isAuthenticated := api.CallIsAuthenticated(httpClient)

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -233,3 +233,16 @@ func getCurrentBranch() (string, error) {
 	}
 	return path.Base(strings.TrimSpace(out.String())), nil
 }
+
+func AppendAPIEndpoint(address string) string {
+	// Ensure the address does not already end with "/api"
+	if strings.HasSuffix(address, "/api") {
+		return address
+	}
+
+	// Check if the address ends with a slash and append accordingly
+	if address[len(address)-1] == '/' {
+		return address + "api"
+	}
+	return address + "/api"
+}


### PR DESCRIPTION
# Description 📣
With this update, users will no longer have to add the `/api` suffix when setting up the domain for the CLI

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->