### PR TITLE
fix: remove ghost users being added as seats in stripe

### DIFF
--- a/backend/src/ee/services/license/license-dal.ts
+++ b/backend/src/ee/services/license/license-dal.ts
@@ -16,6 +16,8 @@ export const licenseDALFactory = (db: TDbClient) => {
             void bd.where({ orgId });
           }
         })
+        .join(TableName.Users, `${TableName.OrgMembership}.userId`, `${TableName.Users}.id`)
+        .where(`${TableName.Users}.isGhost`, false)
         .count();
       return doc?.[0].count;
     } catch (error) {


### PR DESCRIPTION
# Description 📣
Currently on Stripe we add all users (including Ghost users) which makes the pricing inconsistent with the actual seats. This PR adds a filter to ignore the ghost users in this counting.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
- Create a project
- invite a couple of teammates to the org
- Now see the `users` table and see 3 of your non-ghost users & each project's 1 ghost user
- Now call the `licenseDALFactory.countOfOrgMembers()` method which is used in billing as well and you'll see now only non-ghost user count is reported

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->