### PR TITLE
feat: added support for configuring trust of custom SSL certs

### DIFF
--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -55,6 +55,7 @@ VOLUME /app/.next/cache/images
 COPY --chown=non-root-user:nodejs --chmod=555 frontend/scripts ./scripts
 COPY --from=frontend-builder /app/public ./public
 RUN chown non-root-user:nodejs ./public/data
+
 COPY --from=frontend-builder --chown=non-root-user:nodejs /app/.next/standalone ./
 COPY --from=frontend-builder --chown=non-root-user:nodejs /app/.next/static ./.next/static
 
@@ -93,8 +94,17 @@ RUN mkdir frontend-build
 
 # Production stage
 FROM base AS production
+RUN apk add --upgrade --no-cache ca-certificates
 RUN addgroup --system --gid 1001 nodejs \
   && adduser --system --uid 1001 non-root-user
+
+# Give non-root-user permission to update SSL certs
+RUN chown -R non-root-user /etc/ssl/certs
+RUN chown non-root-user /etc/ssl/certs/ca-certificates.crt
+RUN chmod -R u+rwx /etc/ssl/certs
+RUN chmod u+rw /etc/ssl/certs/ca-certificates.crt
+RUN chown non-root-user /usr/sbin/update-ca-certificates
+RUN chmod u+rx /usr/sbin/update-ca-certificates
 
 ## set pre baked keys
 ARG POSTHOG_API_KEY

--- a/standalone-entrypoint.sh
+++ b/standalone-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+update-ca-certificates
+
 cd frontend-build
 scripts/initialize-standalone-build.sh
 


### PR DESCRIPTION
# Description 📣
- This PR will enable self-hosted users to configure trust of custom SSL certs. This will be useful for configuring SSL between a self-hosted infisical instance and a self-hosted integration/SSO provider like Gitlab

**How to use**
mount the directory containing the `.pem` files to the `/usr/local/share/ca-certificates/` directory like the following:
<img width="642" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/6d35a50c-fc18-47f1-ab1e-3cf61da6bcc3">


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->