### PR TITLE
Add optional parameter to generate kubeSecretRef Template when using Helm chart.

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/secrets.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.infisical.kubeSecretGenerate.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.infisical.kubeSecretRef }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    {{- include "infisical.labels" . | nindent 4 }}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+type: Opaque
+stringData:
+  {{ toYaml .Values.infisical.kubeSecretGenerate.env | nindent 2 }}
+{{- end }}

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -18,6 +18,14 @@ infisical:
 
   affinity: {}
   kubeSecretRef: "infisical-secrets"
+  kubeSecretGenerate:
+    enabled: false
+    env:
+      AUTH_SECRET: "Requred" #genarate: `openssl rand -base64 32`
+      ENCRYPTION_KEY: "Requerd" #generate: `openssl rand -hex 16`
+      REDIS_URL: "Requerd" #redis://$user:$password@$service_domain:$service_port
+      DB_CONNECTION_URI: "Requerd" #postgresql://$user:$password@$service_domain:$service_port/$database
+
   service:
     annotations: {}
     type: ClusterIP


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

### env
```sh
namespace=infisical
AUTH_SECRET=$(openssl rand -base64 32)
ENCRYPTION_KEY=$(openssl rand -hex 16)
REDIS_URL=redis://default:redis@redis-infisical-master.datastore.svc:6379
DB_CONNECTION_URI=postgresql://infisical:infisical@postgresql.datastore.svc:5432/infisical
```

### AS-IS (When using external Redis and Postgresql)
```sh
kubectl apply -n $namespace -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: infisical-secrets
type: Opaque
stringData:
  AUTH_SECRET: $AUTH_SECRET
  ENCRYPTION_KEY: $ENCRYPTION_KEY
  REDIS_URL: $REDIS_URL
  DB_CONNECTION_URI: $DB_CONNECTION_URI
EOF

helm install -n $namespace infisical infisical/infisical-standalone \
--set postgresql.enabled=false \
--set redis.enabled=false
```

### TO-BE (When using external Redis and Postgresql)
```
helm install -n $namespace infisical infisical/infisical-standalone \
--set postgresql.enabled=false \
--set redis.enabled=false \
--set infisical.kubeSecretGenerate.enabled=true \
--set infisical.kubeSecretGenerate.env.AUTH_SECRET=$AUTH_SECRET \
--set infisical.kubeSecretGenerate.env.ENCRYPTION_KEY=$ENCRYPTION_KEY \
--set infisical.kubeSecretGenerate.env.REDIS_URL=$REDIS_URL \
--set infisical.kubeSecretGenerate.env.DB_CONNECTION_URI=$DB_CONNECTION_URI
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->