### PR TITLE
feat: added support for tagging existing aws params

### DIFF
--- a/docs/integrations/cloud/aws-parameter-store.mdx
+++ b/docs/integrations/cloud/aws-parameter-store.mdx
@@ -28,6 +28,7 @@ Prerequisites:
           "Action": [
             "ssm:PutParameter",
             "ssm:DeleteParameter",
+            "ssm:GetParameters",
             "ssm:GetParametersByPath",
             "ssm:DeleteParameters",
             "ssm:AddTagsToResource", // if you need to add tags to secrets


### PR DESCRIPTION
# Description 📣
- Previously, tags configured in a newly created AWS parameter store integration won't get attached to already existing parameters. This PR fixes addresses that. It also makes sure that changes made to the tags of an integration will apply to the parameters in AWS

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->