### PR TITLE
Feat: Expand secret references with Machine Identity

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.5.1
+version: v0.5.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.0"
+appVersion: "v0.5.2"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.5.1 # fixed to prevent accidental upgrade
+      tag: v0.5.2 # fixed to prevent accidental upgrade
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/packages/api/api.go
+++ b/k8-operator/packages/api/api.go
@@ -163,6 +163,9 @@ func CallGetDecryptedSecretsV3(httpClient *resty.Client, request GetDecryptedSec
 	if request.Recursive {
 		req.SetQueryParam("recursive", "true")
 	}
+	if request.ExpandSecretReferences {
+		req.SetQueryParam("expandSecretReferences", "true")
+	}
 
 	response, err := req.Get(fmt.Sprintf("%v/v3/secrets/raw", API_HOST_URL))
 

--- a/k8-operator/packages/api/api.go
+++ b/k8-operator/packages/api/api.go
@@ -156,6 +156,7 @@ func CallGetDecryptedSecretsV3(httpClient *resty.Client, request GetDecryptedSec
 		R().
 		SetResult(&decryptedSecretsResponse).
 		SetHeader("User-Agent", USER_AGENT_NAME).
+		SetQueryParam("include_imports", "true").
 		SetQueryParam("secretPath", request.SecretPath).
 		SetQueryParam("workspaceSlug", request.ProjectSlug).
 		SetQueryParam("environment", request.Environment)

--- a/k8-operator/packages/api/models.go
+++ b/k8-operator/packages/api/models.go
@@ -98,11 +98,12 @@ type GetDecryptedSecretsV3Response struct {
 }
 
 type GetDecryptedSecretsV3Request struct {
-	ProjectSlug string `json:"workspaceSlug"`
-	Environment string `json:"environment"`
-	SecretPath  string `json:"secretPath"`
-	Recursive   bool   `json:"recursive"`
-	ETag        string `json:"etag,omitempty"`
+	ProjectSlug            string `json:"workspaceSlug"`
+	Environment            string `json:"environment"`
+	SecretPath             string `json:"secretPath"`
+	Recursive              bool   `json:"recursive"`
+	ExpandSecretReferences bool   `json:"expandSecretReferences"`
+	ETag                   string `json:"etag,omitempty"`
 }
 
 type GetServiceTokenDetailsResponse struct {

--- a/k8-operator/packages/api/models.go
+++ b/k8-operator/packages/api/models.go
@@ -84,6 +84,13 @@ type ImportedSecretV3 struct {
 	Secrets     []EncryptedSecretV3 `json:"secrets"`
 }
 
+type ImportedRawSecretV3 struct {
+	Environment string              `json:"environment"`
+	FolderId    string              `json:"folderId"`
+	SecretPath  string              `json:"secretPath"`
+	Secrets     []DecryptedSecretV3 `json:"secrets"`
+}
+
 type GetEncryptedSecretsV3Response struct {
 	Secrets         []EncryptedSecretV3 `json:"secrets"`
 	ImportedSecrets []ImportedSecretV3  `json:"imports,omitempty"`
@@ -92,9 +99,10 @@ type GetEncryptedSecretsV3Response struct {
 }
 
 type GetDecryptedSecretsV3Response struct {
-	Secrets  []DecryptedSecretV3 `json:"secrets"`
-	ETag     string              `json:"ETag,omitempty"`
-	Modified bool                `json:"modified,omitempty"`
+	Secrets  []DecryptedSecretV3   `json:"secrets"`
+	ETag     string                `json:"ETag,omitempty"`
+	Modified bool                  `json:"modified,omitempty"`
+	Imports  []ImportedRawSecretV3 `json:"imports,omitempty"`
 }
 
 type GetDecryptedSecretsV3Request struct {

--- a/k8-operator/packages/util/secrets.go
+++ b/k8-operator/packages/util/secrets.go
@@ -58,11 +58,12 @@ func GetPlainTextSecretsViaUniversalAuth(accessToken string, etag string, secret
 	httpClient.SetAuthToken(accessToken)
 
 	secretsResponse, err := api.CallGetDecryptedSecretsV3(httpClient, api.GetDecryptedSecretsV3Request{
-		ProjectSlug: secretScope.ProjectSlug,
-		Environment: secretScope.EnvSlug,
-		Recursive:   secretScope.Recursive,
-		SecretPath:  secretScope.SecretsPath,
-		ETag:        etag,
+		ProjectSlug:            secretScope.ProjectSlug,
+		Environment:            secretScope.EnvSlug,
+		Recursive:              secretScope.Recursive,
+		SecretPath:             secretScope.SecretsPath,
+		ExpandSecretReferences: true,
+		ETag:                   etag,
 	})
 
 	if err != nil {


### PR DESCRIPTION
# Description 📣

Currently only service token's support secret referencing. This PR adds secret referencing support by default to Machine Identity auth.

For service tokens we are using client-side secret referencing, but for Machine Identities we are using the new server-side functionality. We need to keep using the clientside secret referencing for service tokens, as they aren't running on the new `raw` endpoints. We need to keep it this way for now for backwards compatibility. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->