### PR TITLE
fix: share secret input now masks value onBlur

### DIFF
--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -96,12 +96,8 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
             }}
             disabled={isDisabled}
             spellCheck={false}
-            onKeyDown={(evt) => {
-              if (evt.key === "Tab") {
-                setIsSecretFocused.off();
-              }
-            }}
-            onBlur={() => {
+            onBlur={(evt) => {
+              onBlur?.(evt);
               setIsSecretFocused.off();
             }}
             value={value || ""}

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -96,8 +96,12 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
             }}
             disabled={isDisabled}
             spellCheck={false}
-            onBlur={(evt) => {
-              onBlur?.(evt);
+            onKeyDown={(evt) => {
+              if (evt.key === "Tab") {
+                setIsSecretFocused.off();
+              }
+            }}
+            onBlur={() => {
               setIsSecretFocused.off();
             }}
             value={value || ""}

--- a/frontend/src/views/ShareSecretPage/components/AddShareSecretModal.tsx
+++ b/frontend/src/views/ShareSecretPage/components/AddShareSecretModal.tsx
@@ -178,7 +178,7 @@ export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
                   errorText={error?.message}
                 >
                   <SecretInput
-                    isVisible
+                    isVisible={false}
                     {...field}
                     containerClassName="py-1.5 rounded-md transition-all group-hover:mr-2 text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 min-h-[100px]"
                   />


### PR DESCRIPTION
# Description 📣
`SecretInput` component in Share Secret Modal now masks when not in focus

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->