### PR TITLE
fix: preserve existing annotations when updating managed secret

### DIFF
--- a/k8-operator/controllers/infisicalsecret_helper.go
+++ b/k8-operator/controllers/infisicalsecret_helper.go
@@ -232,7 +232,6 @@ func (r *InfisicalSecretReconciler) UpdateInfisicalManagedKubeSecret(ctx context
 	}
 
 	managedKubeSecret.Data = plainProcessedSecrets
-	managedKubeSecret.ObjectMeta.Annotations = map[string]string{}
 	managedKubeSecret.ObjectMeta.Annotations[SECRET_VERSION_ANNOTATION] = ETag
 
 	err := r.Client.Update(ctx, &managedKubeSecret)


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This pull request fixes https://github.com/Infisical/infisical/issues/1930 where the annotations on a managed Kubernetes secret were being reset during the update process. With this change, we ensure that existing annotations are preserved and only the `ETag` annotation is updated.

- Fixed the bug where updating the managed secret would reset all annotations. Now, only the `ETag` annotation is updated, preserving existing annotations.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

1. Deploy the Kubernetes operator.
2. Check the annotations on the managed secret before updating.
3. Trigger an update.
4. Verify the annotations on the managed secret after the update.

### Before the fix:
- Before update (annotations present)
  <img width="1179" alt="before-the-fix-1" src="https://github.com/Infisical/infisical/assets/112928337/9b5d1f70-fceb-4327-a3bd-401eb050ca5f">
- After update before the fix (annotations reset)
  <img width="806" alt="before-the-fix-2" src="https://github.com/Infisical/infisical/assets/112928337/dd4733ad-6104-4596-b9a8-e6d0e27cb840">


### After the fix:
- After update with the fix (annotations preserved)
  <img width="1183" alt="after-the-fix-1" src="https://github.com/Infisical/infisical/assets/112928337/af984eb9-f7f9-4511-a5d0-94a708c55ca5">


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->