### PR TITLE
fix: remove extraneous 'r' causing script error in github actions

### DIFF
--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Wait for container to be stable and check logs
         run: |
           SECONDS=0
- r        HEALTHY=0
+          HEALTHY=0
           while [ $SECONDS -lt 60 ]; do
             if docker ps | grep infisical-api | grep -q healthy; then
               echo "Container is healthy."


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

<img width="644" alt="image" src="https://github.com/Infisical/infisical/assets/112928337/0ce847c7-26e7-4cb5-832d-20726ca77808">  

This fixes a typo in the GitHub Actions workflow file `.github/workflows/check-api-for-breaking-changes.yml`.

https://github.com/Infisical/infisical/blob/faa1572faf567d185b28dfab183e64192320d67c/.github/workflows/check-api-for-breaking-changes.yml#L50

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->