### PR TITLE
fix: update org seats whenever membership status is accepted

### DIFF
--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -77,7 +77,7 @@ type TLdapConfigServiceFactoryDep = {
   >;
   userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
-  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan" | "updateSubscriptionOrgMemberCount">;
 };
 
 export type TLdapConfigServiceFactory = ReturnType<typeof ldapConfigServiceFactory>;
@@ -510,6 +510,7 @@ export const ldapConfigServiceFactory = ({
         return newUserAlias;
       });
     }
+    await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
     const user = await userDAL.transaction(async (tx) => {
       const newUser = await userDAL.findOne({ id: userAlias.userId }, tx);

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -50,7 +50,7 @@ type TSamlConfigServiceFactoryDep = {
   orgMembershipDAL: Pick<TOrgMembershipDALFactory, "create">;
   orgBotDAL: Pick<TOrgBotDALFactory, "findOne" | "create" | "transaction">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
-  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan" | "updateSubscriptionOrgMemberCount">;
   tokenService: Pick<TAuthTokenServiceFactory, "createTokenForUser">;
   smtpService: Pick<TSmtpService, "sendMail">;
 };
@@ -449,6 +449,7 @@ export const samlConfigServiceFactory = ({
         return newUser;
       });
     }
+    await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
     const isUserCompleted = Boolean(user.isAccepted);
     const providerAuthToken = jwt.sign(

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -391,7 +391,7 @@ export const scimServiceFactory = ({
           );
         }
       }
-      await licenseService.updateSubscriptionOrgMemberCount(orgMembership.id);
+      await licenseService.updateSubscriptionOrgMemberCount(org.id);
       return { user, orgMembership };
     });
 

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -391,7 +391,7 @@ export const scimServiceFactory = ({
           );
         }
       }
-
+      await licenseService.updateSubscriptionOrgMemberCount(orgMembership.id);
       return { user, orgMembership };
     });
 

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -315,6 +315,7 @@ export const orgServiceFactory = ({
         },
         tx
       );
+      await licenseService.updateSubscriptionOrgMemberCount(org.id);
       await orgBotDAL.create(
         {
           name: org.name,


### PR DESCRIPTION
# Description 📣
Currently the pricing is updated only when a user does signup via email. This PR adds it to other auth service methods as well.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Add a user via any non-email auth method and see the org seats being updated.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->