### PR TITLE
Fix: Updated docker compose command (from compose V1 to compose v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ To set up and run Infisical locally, make sure you have Git and Docker installed
 Linux/macOS:
 
 ```console
-git clone https://github.com/Infisical/infisical && cd "$(basename $_ .git)" && cp .env.example .env && docker-compose -f docker-compose.prod.yml up
+git clone https://github.com/Infisical/infisical && cd "$(basename $_ .git)" && cp .env.example .env && docker compose -f docker-compose.prod.yml up
 ```
 
 Windows Command Prompt:
 
 ```console
-git clone https://github.com/Infisical/infisical && cd infisical && copy .env.example .env && docker-compose -f docker-compose.prod.yml up
+git clone https://github.com/Infisical/infisical && cd infisical && copy .env.example .env && docker compose -f docker-compose.prod.yml up
 ```
 
 Create an account at `http://localhost:80`


### PR DESCRIPTION
# Description 📣

Updated docker compose command (from compose V1 to compose v2). From July 2023 Compose V1 stopped receiving updates. Compose V2 comes automatically with latest docker

[https://docs.docker.com/compose/migrate/](https://docs.docker.com/compose/migrate/
)
## Type ✨

- [x] Bug fix
