### PR TITLE
Fix: Email confirmation during SAML login failing (edge-case)

### DIFF
--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -231,7 +231,7 @@ export const authSignupServiceFactory = ({
 
     const accessToken = jwt.sign(
       {
-        authMethod: AuthMethod.EMAIL,
+        authMethod: authMethod || AuthMethod.EMAIL,
         authTokenType: AuthTokenType.ACCESS_TOKEN,
         userId: updateduser.info.id,
         tokenVersionId: tokenSession.id,
@@ -244,7 +244,7 @@ export const authSignupServiceFactory = ({
 
     const refreshToken = jwt.sign(
       {
-        authMethod: AuthMethod.EMAIL,
+        authMethod: authMethod || AuthMethod.EMAIL,
         authTokenType: AuthTokenType.REFRESH_TOKEN,
         userId: updateduser.info.id,
         tokenVersionId: tokenSession.id,

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -94,14 +94,6 @@ export const userDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findMergeableUsers = async (email: string, tx?: Knex) => {
-    const users = await (tx || db)(TableName.Users).where((builder) => {
-      void builder.where({ email, isEmailVerified: true }).orWhere({ email, isAccepted: false });
-    });
-
-    return users;
-  };
-
   const updateUserEncryptionByUserId = async (userId: string, data: TUserEncryptionKeysUpdate, tx?: Knex) => {
     try {
       const [userEnc] = await (tx || db)(TableName.UserEncryptionKey)
@@ -162,7 +154,6 @@ export const userDALFactory = (db: TDbClient) => {
     findUsersByProjectMembershipIds,
     upsertUserEncryptionKey,
     createUserEncryption,
-    findMergeableUsers,
     findOneUserAction,
     createUserAction
   };

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -94,6 +94,14 @@ export const userDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findMergeableUsers = async (email: string, tx?: Knex) => {
+    const users = await (tx || db)(TableName.Users).where((builder) => {
+      void builder.where({ email, isEmailVerified: true }).orWhere({ email, isAccepted: false });
+    });
+
+    return users;
+  };
+
   const updateUserEncryptionByUserId = async (userId: string, data: TUserEncryptionKeysUpdate, tx?: Knex) => {
     try {
       const [userEnc] = await (tx || db)(TableName.UserEncryptionKey)
@@ -154,6 +162,7 @@ export const userDALFactory = (db: TDbClient) => {
     findUsersByProjectMembershipIds,
     upsertUserEncryptionKey,
     createUserEncryption,
+    findMergeableUsers,
     findOneUserAction,
     createUserAction
   };

--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -12,6 +12,7 @@ type TUserServiceFactoryDep = {
   userDAL: Pick<
     TUserDALFactory,
     | "find"
+    | "findMergeableUsers"
     | "findOne"
     | "findById"
     | "transaction"
@@ -86,13 +87,7 @@ export const userServiceFactory = ({
       );
 
       // check if there are users with the same email.
-      const users = await userDAL.find(
-        {
-          email,
-          isEmailVerified: true
-        },
-        { tx }
-      );
+      const users = await userDAL.findMergeableUsers(email, tx);
 
       if (users.length > 1) {
         // merge users
@@ -134,59 +129,14 @@ export const userServiceFactory = ({
           );
         }
       } else {
-        const existingUserWithUsername = await userDAL.findOne({
-          username: email
-        });
-
-        if (existingUserWithUsername && existingUserWithUsername.id !== user.id) {
-          // merge users
-          const mergeUserOrgMembershipSet = new Set(
-            (await orgMembershipDAL.find({ userId: existingUserWithUsername.id }, { tx })).map((m) => m.orgId)
-          );
-
-          const myOrgMemberships = (await orgMembershipDAL.find({ userId: user.id }, { tx })).filter(
-            (m) => !mergeUserOrgMembershipSet.has(m.orgId)
-          );
-
-          const userAliases = await userAliasDAL.find(
-            {
-              userId: user.id
-            },
-            { tx }
-          );
-
-          // delete current user
-          await userDAL.deleteById(user.id, tx);
-
-          if (myOrgMemberships.length) {
-            await orgMembershipDAL.insertMany(
-              myOrgMemberships.map((orgMembership) => ({
-                ...orgMembership,
-                userId: existingUserWithUsername.id
-              })),
-              tx
-            );
-          }
-
-          if (userAliases.length) {
-            await userAliasDAL.insertMany(
-              userAliases.map((userAlias) => ({
-                ...userAlias,
-                userId: existingUserWithUsername.id
-              })),
-              tx
-            );
-          }
-        } else {
-          // update current user's username to [email]
-          await userDAL.updateById(
-            user.id,
-            {
-              username: email
-            },
-            tx
-          );
-        }
+        // update current user's username to [email]
+        await userDAL.updateById(
+          user.id,
+          {
+            username: email
+          },
+          tx
+        );
       }
     });
   };


### PR DESCRIPTION
# Description 📣

Currently there's an issue related to email confirmation after logging in with SAML. The request will fail because a unique constraint is violated. Specifically, this happens when there are no verified users to merge, but a user with the same username already exists.

This is resolved by adding merge logic to cover the edge-case where the username is already reserved by another user.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->