### PR TITLE
Patch multi line encoding when expandSecretRef is enabled

### DIFF
--- a/backend/src/db/schemas/secrets.ts
+++ b/backend/src/db/schemas/secrets.ts
@@ -23,7 +23,7 @@ export const SecretsSchema = z.object({
   secretCommentTag: z.string().nullable().optional(),
   secretReminderNote: z.string().nullable().optional(),
   secretReminderRepeatDays: z.number().nullable().optional(),
-  skipMultilineEncoding: z.boolean().default(false).optional(),
+  skipMultilineEncoding: z.boolean().default(false).nullable().optional(),
   algorithm: z.string().default("aes-256-gcm"),
   keyEncoding: z.string().default("utf8"),
   metadata: z.unknown().nullable().optional(),

--- a/backend/src/db/schemas/secrets.ts
+++ b/backend/src/db/schemas/secrets.ts
@@ -23,7 +23,7 @@ export const SecretsSchema = z.object({
   secretCommentTag: z.string().nullable().optional(),
   secretReminderNote: z.string().nullable().optional(),
   secretReminderRepeatDays: z.number().nullable().optional(),
-  skipMultilineEncoding: z.boolean().default(false).nullable().optional(),
+  skipMultilineEncoding: z.boolean().default(false).optional(),
   algorithm: z.string().default("aes-256-gcm"),
   keyEncoding: z.string().default("utf8"),
   metadata: z.unknown().nullable().optional(),

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -329,8 +329,8 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
         // should not do multi line encoding if user has set it to skip
         // eslint-disable-next-line
         secrets[key].value = secrets[key].skipMultilineEncoding
-          ? expandedSec[key]
-          : formatMultiValueEnv(expandedSec[key]);
+          ? formatMultiValueEnv(expandedSec[key])
+          : expandedSec[key];
         // eslint-disable-next-line
         continue;
       }
@@ -347,7 +347,7 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
       );
 
       // eslint-disable-next-line
-      secrets[key].value = secrets[key].skipMultilineEncoding ? expandedVal : formatMultiValueEnv(expandedVal);
+      secrets[key].value = secrets[key].skipMultilineEncoding ? formatMultiValueEnv(expandedVal) : expandedVal;
     }
 
     return secrets;
@@ -395,7 +395,8 @@ export const decryptSecretRaw = (
     type: secret.type,
     _id: secret.id,
     id: secret.id,
-    user: secret.userId
+    user: secret.userId,
+    skipMultilineEncoding: secret.skipMultilineEncoding
   };
 };
 

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -309,7 +309,7 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
   };
 
   const expandSecrets = async (
-    secrets: Record<string, { value: string; comment?: string; skipMultilineEncoding: boolean | null | undefined }>
+    secrets: Record<string, { value: string; comment?: string; skipMultilineEncoding?: boolean | null }>
   ) => {
     const expandedSec: Record<string, string> = {};
     const interpolatedSec: Record<string, string> = {};

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -309,7 +309,7 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
   };
 
   const expandSecrets = async (
-    secrets: Record<string, { value: string; comment?: string; skipMultilineEncoding?: boolean }>
+    secrets: Record<string, { value: string; comment?: string; skipMultilineEncoding: boolean | null | undefined }>
   ) => {
     const expandedSec: Record<string, string> = {};
     const interpolatedSec: Record<string, string> = {};

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -67,7 +67,10 @@ const MAX_SYNC_SECRET_DEPTH = 5;
 export const uniqueSecretQueueKey = (environment: string, secretPath: string) =>
   `secret-queue-dedupe-${environment}-${secretPath}`;
 
-type TIntegrationSecret = Record<string, { value: string; comment?: string; skipMultilineEncoding?: boolean }>;
+type TIntegrationSecret = Record<
+  string,
+  { value: string; comment?: string; skipMultilineEncoding?: boolean | null | undefined }
+>;
 export const secretQueueFactory = ({
   queueService,
   integrationDAL,

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -976,13 +976,18 @@ export const secretServiceFactory = ({
           secretValue: string;
           secretComment?: string;
           secretPath: string;
-          skipMultilineEncoding?: boolean;
+          skipMultilineEncoding: boolean | null | undefined;
         }[]
       ) => {
         // Group secrets by secretPath
         const secretsByPath: Record<
           string,
-          { secretKey: string; secretValue: string; secretComment?: string; skipMultilineEncoding?: boolean }[]
+          {
+            secretKey: string;
+            secretValue: string;
+            secretComment?: string;
+            skipMultilineEncoding: boolean | null | undefined;
+          }[]
         > = {};
 
         secretBatch.forEach((secret) => {
@@ -999,7 +1004,10 @@ export const secretServiceFactory = ({
             continue;
           }
 
-          const secretRecord: Record<string, { value: string; comment?: string; skipMultilineEncoding?: boolean }> = {};
+          const secretRecord: Record<
+            string,
+            { value: string; comment?: string; skipMultilineEncoding: boolean | null | undefined }
+          > = {};
           secretsByPath[secPath].forEach((decryptedSecret) => {
             secretRecord[decryptedSecret.secretKey] = {
               value: decryptedSecret.secretValue,

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -971,10 +971,19 @@ export const secretServiceFactory = ({
       });
 
       const batchSecretsExpand = async (
-        secretBatch: { secretKey: string; secretValue: string; secretComment?: string; secretPath: string }[]
+        secretBatch: {
+          secretKey: string;
+          secretValue: string;
+          secretComment?: string;
+          secretPath: string;
+          skipMultilineEncoding?: boolean;
+        }[]
       ) => {
         // Group secrets by secretPath
-        const secretsByPath: Record<string, { secretKey: string; secretValue: string; secretComment?: string }[]> = {};
+        const secretsByPath: Record<
+          string,
+          { secretKey: string; secretValue: string; secretComment?: string; skipMultilineEncoding?: boolean }[]
+        > = {};
 
         secretBatch.forEach((secret) => {
           if (!secretsByPath[secret.secretPath]) {
@@ -994,7 +1003,8 @@ export const secretServiceFactory = ({
           secretsByPath[secPath].forEach((decryptedSecret) => {
             secretRecord[decryptedSecret.secretKey] = {
               value: decryptedSecret.secretValue,
-              comment: decryptedSecret.secretComment
+              comment: decryptedSecret.secretComment,
+              skipMultilineEncoding: decryptedSecret.skipMultilineEncoding
             };
           });
 

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -393,15 +393,15 @@ export const SecretDetailSidebar = ({
                       {(isAllowed) => (
                         <Switch
                           id="skipmultiencoding-option"
-                          onCheckedChange={(isChecked) => onChange(!isChecked)}
-                          isChecked={!value}
+                          onCheckedChange={(isChecked) => onChange(isChecked)}
+                          isChecked={value}
                           onBlur={onBlur}
                           isDisabled={!isAllowed}
                           className="items-center"
                         >
-                          Enable multi line encoding
+                          Multi line encoding
                           <Tooltip
-                            content="Infisical encodes multiline secrets by escaping newlines and wrapping in quotes. To disable, enable this option"
+                            content="When enabled, multiline secrets will be handled by escaping newlines and enclosing the entire value in double quotes."
                             className="z-[100]"
                           >
                             <FontAwesomeIcon icon={faCircleQuestion} className="ml-1" size="sm" />


### PR DESCRIPTION
By default when you create a secret, it will have multi line encoding off but we actually treat this as true in the backend and UI. User’s aren’t expecting their multi line secrets to be double quoted by and made into a single line with/n, however we are doing it by default at the moment. This PR makes multi line encoding opt in and not opt out