### PR TITLE
Update SMTP configuration

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -39,7 +39,9 @@ const envSchema = z
     HTTPS_ENABLED: zodStrBool,
     // smtp options
     SMTP_HOST: zpStr(z.string().optional()),
-    SMTP_SECURE: zodStrBool,
+    SMTP_IGNORE_TLS: zodStrBool.default("false"),
+    SMTP_REQUIRE_TLS: zodStrBool.default("true"),
+    SMTP_TLS_REJECT_UNAUTHORIZED: zodStrBool.default("true"),
     SMTP_PORT: z.coerce.number().default(587),
     SMTP_USERNAME: zpStr(z.string().optional()),
     SMTP_PASSWORD: zpStr(z.string().optional()),
@@ -152,13 +154,20 @@ export const initEnvConfig = (logger: Logger) => {
   return envCfg;
 };
 
-export const formatSmtpConfig = () => ({
-  host: envCfg.SMTP_HOST,
-  port: envCfg.SMTP_PORT,
-  auth:
-    envCfg.SMTP_USERNAME && envCfg.SMTP_PASSWORD
-      ? { user: envCfg.SMTP_USERNAME, pass: envCfg.SMTP_PASSWORD }
-      : undefined,
-  secure: envCfg.SMTP_SECURE,
-  from: `"${envCfg.SMTP_FROM_NAME}" <${envCfg.SMTP_FROM_ADDRESS}>`
-});
+export const formatSmtpConfig = () => {
+  return {
+    host: envCfg.SMTP_HOST,
+    port: envCfg.SMTP_PORT,
+    auth:
+      envCfg.SMTP_USERNAME && envCfg.SMTP_PASSWORD
+        ? { user: envCfg.SMTP_USERNAME, pass: envCfg.SMTP_PASSWORD }
+        : undefined,
+    secure: envCfg.SMTP_PORT === 465,
+    from: `"${envCfg.SMTP_FROM_NAME}" <${envCfg.SMTP_FROM_ADDRESS}>`,
+    ignoreTLS: envCfg.SMTP_IGNORE_TLS,
+    requireTLS: envCfg.SMTP_REQUIRE_TLS,
+    tls: {
+      rejectUnauthorized: envCfg.SMTP_TLS_REJECT_UNAUTHORIZED
+    }
+  };
+};

--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -5,7 +5,6 @@ import { createTransport } from "nodemailer";
 
 import { formatSmtpConfig, getConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
-import { getTlsOption } from "@app/services/smtp/smtp-service";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 
 type BootstrapOpt = {
@@ -44,7 +43,7 @@ export const bootstrapCheck = async ({ db }: BootstrapOpt) => {
   console.info("Testing smtp connection");
 
   const smtpCfg = formatSmtpConfig();
-  await createTransport({ ...smtpCfg, ...getTlsOption(smtpCfg.host, smtpCfg.secure) })
+  await createTransport(smtpCfg)
     .verify()
     .then(async () => {
       console.info("SMTP successfully connected");

--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -41,21 +41,8 @@ export enum SmtpHost {
   Office365 = "smtp.office365.com"
 }
 
-export const getTlsOption = (host?: SmtpHost | string, secure?: boolean) => {
-  if (!secure) return { secure: false };
-  if (!host) return { secure: true };
-
-  if ((host as SmtpHost) === SmtpHost.Sendgrid) {
-    return { secure: true, port: 465 }; // more details here https://nodemailer.com/smtp/
-  }
-  if (host.includes("amazonaws.com")) {
-    return { tls: { ciphers: "TLSv1.2" } };
-  }
-  return { requireTLS: true, tls: { ciphers: "TLSv1.2" } };
-};
-
 export const smtpServiceFactory = (cfg: TSmtpConfig) => {
-  const smtp = createTransport({ ...cfg, ...getTlsOption(cfg.host, cfg.secure) });
+  const smtp = createTransport(cfg);
   const isSmtpOn = Boolean(cfg.host);
 
   const sendMail = async ({ substitutions, recipients, template, subjectLine }: TSmtpSendMail) => {

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -48,44 +48,44 @@ The platform utilizes Postgres to persist all of its data and Redis for caching 
 Without email configuration, Infisical's core functions like sign-up/login and secret operations work, but this disables multi-factor authentication, email invites for projects, alerts for suspicious logins, and all other email-dependent features.
 
 <Accordion title="Generic Configuration">
-  <ParamField query="SMTP_HOST" type="string" default="none" optional>
-    Hostname to connect to for establishing SMTP connections
-  </ParamField>
-
-{" "}
-
-<ParamField query="SMTP_USERNAME" type="string" default="none" optional>
-  Credential to connect to host (e.g. team@infisical.com)
+<ParamField query="SMTP_HOST" type="string" default="none" optional>
+  Hostname to connect to for establishing SMTP connections
 </ParamField>
-
-{" "}
-
-<ParamField query="SMTP_PASSWORD" type="string" default="none" optional>
-  Credential to connect to host
-</ParamField>
-
-{" "}
 
 <ParamField query="SMTP_PORT" type="string" default="587" optional>
   Port to connect to for establishing SMTP connections
 </ParamField>
 
-{" "}
-
-<ParamField query="SMTP_SECURE" type="string" default="none" optional>
-  If true, use TLS when connecting to host. If false, TLS will be used if
-  STARTTLS is supported
+<ParamField query="SMTP_USERNAME" type="string" default="none" optional>
+  Credential to connect to host (e.g. team@infisical.com)
 </ParamField>
 
-{" "}
+<ParamField query="SMTP_PASSWORD" type="string" default="none" optional>
+  Credential to connect to host
+</ParamField>
 
 <ParamField query="SMTP_FROM_ADDRESS" type="string" default="none" optional>
   Email address to be used for sending emails
 </ParamField>
 
-  <ParamField query="SMTP_FROM_NAME" type="string" default="none" optional>
-    Name label to be used in From field (e.g. Team)
-  </ParamField>
+<ParamField query="SMTP_FROM_NAME" type="string" default="none" optional>
+  Name label to be used in From field (e.g. Team)
+</ParamField>
+
+<ParamField query="SMTP_IGNORE_TLS" type="bool" default="false" optional>
+  If this is `true` and `SMTP_PORT` is not 465 then TLS is not used even if the
+  server supports STARTTLS extension.
+</ParamField>
+
+<ParamField query="SMTP_REQUIRE_TLS" type="bool" default="true" optional>
+  If this is `true` and `SMTP_PORT` is not 465 then Infisical tries to use
+  STARTTLS even if the server does not advertise support for it. If the
+  connection can not be encrypted then message is not sent.
+</ParamField>
+
+<ParamField query="SMTP_TLS_REJECT_UNAUTHORIZED" type="bool" default="true" optional>
+  If this is `true`, Infisical will validate the server's SSL/TLS certificate and reject the connection if the certificate is invalid or not trusted. If set to `false`, the client will accept the server's certificate regardless of its validity, which can be useful in development or testing environments but is not recommended for production use.
+</ParamField>
 </Accordion>
 
 <Accordion title="Twilio SendGrid">
@@ -105,7 +105,6 @@ SMTP_HOST=smtp.sendgrid.net
 SMTP_USERNAME=apikey
 SMTP_PASSWORD=SG.rqFsfjxYPiqE1lqZTgD_lz7x8IVLx # your SendGrid API Key from step above
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@example.com # your email address being used to send out emails
 SMTP_FROM_NAME=Infisical
 ```
@@ -128,7 +127,6 @@ SMTP_HOST=smtp.mailgun.org # obtained from credentials page
 SMTP_USERNAME=postmaster@example.mailgun.org # obtained from credentials page
 SMTP_PASSWORD=password # obtained from credentials page
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@example.com # your email address being used to send out emails
 SMTP_FROM_NAME=Infisical
 ```
@@ -159,7 +157,6 @@ SMTP_FROM_NAME=Infisical
       SMTP_USERNAME=xxx # your SMTP username
       SMTP_PASSWORD=xxx # your SMTP password
       SMTP_PORT=465
-      SMTP_SECURE=true
       SMTP_FROM_ADDRESS=hey@example.com # your email address being used to send out emails
       SMTP_FROM_NAME=Infisical
       ```
@@ -187,7 +184,6 @@ SMTP_HOST=smtp.socketlabs.com
 SMTP_USERNAME=username # obtained from your credentials
 SMTP_PASSWORD=password # obtained from your credentials
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@example.com # your email address being used to send out emails
 SMTP_FROM_NAME=Infisical
 ```
@@ -229,7 +225,6 @@ SMTP_HOST=smtp.resend.com
 SMTP_USERNAME=resend
 SMTP_PASSWORD=YOUR_API_KEY
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@example.com # your email address being used to send out emails
 SMTP_FROM_NAME=Infisical
 ```
@@ -253,7 +248,6 @@ SMTP_HOST=smtp.gmail.com
 SMTP_USERNAME=hey@gmail.com # your email
 SMTP_PASSWORD=password # your password
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@gmail.com
 SMTP_FROM_NAME=Infisical
 ```
@@ -277,7 +271,6 @@ SMTP_HOST=smtp.office365.com
 SMTP_USERNAME=username@yourdomain.com # your username
 SMTP_PASSWORD=password # your password
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=username@yourdomain.com
 SMTP_FROM_NAME=Infisical
 ```
@@ -294,7 +287,6 @@ SMTP_HOST=smtp.zoho.com
 SMTP_USERNAME=username # your email
 SMTP_PASSWORD=password # your password
 SMTP_PORT=587
-SMTP_SECURE=true
 SMTP_FROM_ADDRESS=hey@example.com # your personal Zoho email or domain-based email linked to Zoho Mail
 SMTP_FROM_NAME=Infisical
 ```
@@ -320,7 +312,8 @@ To login into Infisical with OAuth providers such as Google, configure the assoc
 
 <ParamField query="DEFAULT_SAML_ORG_SLUG" type="string">
 
-  When set, all visits to the Infisical login page will automatically redirect users of your Infisical instance to the SAML identity provider associated with the specified organization slug.
+When set, all visits to the Infisical login page will automatically redirect users of your Infisical instance to the SAML identity provider associated with the specified organization slug.
+
 </ParamField>
 
 <Accordion title="Google">


### PR DESCRIPTION
# Description 📣

This PR streamlines the SMTP configuration for Infisical to be inline with the parameters given by Nodemailer [here](https://nodemailer.com/smtp/); it should now be much more reliable various SMTP providers — that said self-signed certificates are currently not supported.

Specific adjustments:
- Removed `SMTP_SECURE` environment variable; the `secure` parameter as part of Nodemailer will be set to `true` henceforth when the `SMTP_PORT` is `465`.
- Added `SMTP_IGNORE_TLS`.
- Added `SMTP_REQUIRE_TLS`.
- Added `SMTP_TLS_REJECT_UNAUTHORIZED`.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->