### PR TITLE
Allow secret tag api for machine identity and raw secret endpoint tag support

### DIFF
--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -35,7 +35,7 @@ jobs:
             echo "SECRET_SCANNING_GIT_APP_ID=793712" >> .env
             echo "SECRET_SCANNING_PRIVATE_KEY=some-random" >> .env
             echo "SECRET_SCANNING_WEBHOOK_SECRET=some-random" >> .env
-            docker run --name infisical-api -d -p 4000:4000 -e DB_CONNECTION_URI=$DB_CONNECTION_URI -e REDIS_URL=$REDIS_URL -e JWT_AUTH_SECRET=$JWT_AUTH_SECRET --env-file .env --entrypoint '/bin/sh' infisical-api -c "npm run migration:latest && ls && node dist/main.mjs"
+            docker run --name infisical-api -d -p 4000:4000 -e DB_CONNECTION_URI=$DB_CONNECTION_URI -e REDIS_URL=$REDIS_URL -e JWT_AUTH_SECRET=$JWT_AUTH_SECRET -e ENCRYPTION_KEY=$ENCRYPTION_KEY --env-file .env --entrypoint '/bin/sh' infisical-api -c "npm run migration:latest && ls && node dist/main.mjs"
         env:
           REDIS_URL: redis://172.17.0.1:6379
           DB_CONNECTION_URI: postgres://infisical:infisical@172.17.0.1:5432/infisical?sslmode=disable

--- a/backend/src/db/migrations/20240614115952_tag-machine-identity.ts
+++ b/backend/src/db/migrations/20240614115952_tag-machine-identity.ts
@@ -1,0 +1,25 @@
+import { Knex } from "knex";
+
+import { ActorType } from "@app/services/auth/auth-type";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasCreatedByActorType = await knex.schema.hasColumn(TableName.SecretTag, "createdByActorType");
+  await knex.schema.alterTable(TableName.SecretTag, (tb) => {
+    if (!hasCreatedByActorType) {
+      tb.string("createdByActorType").notNullable().defaultTo(ActorType.USER);
+      tb.dropForeign("createdBy");
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasCreatedByActorType = await knex.schema.hasColumn(TableName.SecretTag, "createdByActorType");
+  await knex.schema.alterTable(TableName.SecretTag, (tb) => {
+    if (hasCreatedByActorType) {
+      tb.dropColumn("createdByActorType");
+      tb.foreign("createdBy").references("id").inTable(TableName.Users).onDelete("SET NULL");
+    }
+  });
+}

--- a/backend/src/db/schemas/secret-tags.ts
+++ b/backend/src/db/schemas/secret-tags.ts
@@ -15,7 +15,8 @@ export const SecretTagsSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   createdBy: z.string().uuid().nullable().optional(),
-  projectId: z.string()
+  projectId: z.string(),
+  createdByActorType: z.string().default("user")
 });
 
 export type TSecretTags = z.infer<typeof SecretTagsSchema>;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -343,7 +343,8 @@ export const RAW_SECRETS = {
     secretValue: "The value of the secret to create.",
     skipMultilineEncoding: "Skip multiline encoding for the secret value.",
     type: "The type of the secret to create.",
-    workspaceId: "The ID of the project to create the secret in."
+    workspaceId: "The ID of the project to create the secret in.",
+    tagIds: "The ID of the tags to be attached to the created secret."
   },
   GET: {
     secretName: "The name of the secret to get.",
@@ -364,7 +365,8 @@ export const RAW_SECRETS = {
     skipMultilineEncoding: "Skip multiline encoding for the secret value.",
     type: "The type of the secret to update.",
     projectSlug: "The slug of the project to update the secret in.",
-    workspaceId: "The ID of the project to update the secret in."
+    workspaceId: "The ID of the project to update the secret in.",
+    tagIds: "The ID of the tags to be attached to the updated secret."
   },
   DELETE: {
     secretName: "The name of the secret to delete.",

--- a/backend/src/server/routes/v1/secret-tag-router.ts
+++ b/backend/src/server/routes/v1/secret-tag-router.ts
@@ -23,7 +23,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const workspaceTags = await server.services.secretTag.getProjectTags({
         actor: req.permission.type,
@@ -57,7 +57,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.createTag({
         actor: req.permission.type,
@@ -88,7 +88,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.deleteTag({
         actor: req.permission.type,

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -306,7 +306,16 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
       }),
       response: {
         200: z.object({
-          secret: secretRawSchema
+          secret: secretRawSchema.extend({
+            tags: SecretTagsSchema.pick({
+              id: true,
+              slug: true,
+              name: true,
+              color: true
+            })
+              .array()
+              .optional()
+          })
         })
       }
     },
@@ -404,6 +413,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
           .transform((val) => (val.at(-1) === "\n" ? `${val.trim()}\n` : val.trim()))
           .describe(RAW_SECRETS.CREATE.secretValue),
         secretComment: z.string().trim().optional().default("").describe(RAW_SECRETS.CREATE.secretComment),
+        tagIds: z.string().array().optional().describe(RAW_SECRETS.CREATE.tagIds),
         skipMultilineEncoding: z.boolean().optional().describe(RAW_SECRETS.CREATE.skipMultilineEncoding),
         type: z.nativeEnum(SecretType).default(SecretType.Shared).describe(RAW_SECRETS.CREATE.type)
       }),
@@ -427,7 +437,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         type: req.body.type,
         secretValue: req.body.secretValue,
         skipMultilineEncoding: req.body.skipMultilineEncoding,
-        secretComment: req.body.secretComment
+        secretComment: req.body.secretComment,
+        tagIds: req.body.tagIds
       });
 
       await server.services.auditLog.createAuditLog({
@@ -492,7 +503,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
           .transform(removeTrailingSlash)
           .describe(RAW_SECRETS.UPDATE.secretPath),
         skipMultilineEncoding: z.boolean().optional().describe(RAW_SECRETS.UPDATE.skipMultilineEncoding),
-        type: z.nativeEnum(SecretType).default(SecretType.Shared).describe(RAW_SECRETS.UPDATE.type)
+        type: z.nativeEnum(SecretType).default(SecretType.Shared).describe(RAW_SECRETS.UPDATE.type),
+        tagIds: z.string().array().optional().describe(RAW_SECRETS.UPDATE.tagIds)
       }),
       response: {
         200: z.object({
@@ -513,7 +525,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         secretName: req.params.secretName,
         type: req.body.type,
         secretValue: req.body.secretValue,
-        skipMultilineEncoding: req.body.skipMultilineEncoding
+        skipMultilineEncoding: req.body.skipMultilineEncoding,
+        tagIds: req.body.tagIds
       });
 
       await server.services.auditLog.createAuditLog({

--- a/backend/src/services/secret-tag/secret-tag-service.ts
+++ b/backend/src/services/secret-tag/secret-tag-service.ts
@@ -42,7 +42,8 @@ export const secretTagServiceFactory = ({ secretTagDAL, permissionService }: TSe
       name,
       slug,
       color,
-      createdBy: actorId
+      createdBy: actorId,
+      createdByActorType: actor
     });
     return newTag;
   };

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -356,7 +356,17 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
 };
 
 export const decryptSecretRaw = (
-  secret: TSecrets & { workspace: string; environment: string; secretPath: string },
+  secret: TSecrets & {
+    workspace: string;
+    environment: string;
+    secretPath: string;
+    tags?: {
+      id: string;
+      slug: string;
+      color?: string | null;
+      name: string;
+    }[];
+  },
   key: string
 ) => {
   const secretKey = decryptSymmetric128BitHexKeyUTF8({
@@ -396,6 +406,7 @@ export const decryptSecretRaw = (
     _id: secret.id,
     id: secret.id,
     user: secret.userId,
+    tags: secret.tags,
     skipMultilineEncoding: secret.skipMultilineEncoding
   };
 };

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -608,7 +608,7 @@ export const secretServiceFactory = ({
     }
 
     const secret = await (version === undefined
-      ? secretDAL.findOne({
+      ? secretDAL.findOneWithTags({
           folderId,
           type: secretType,
           userId: secretType === SecretType.Personal ? actorId : null,
@@ -1120,7 +1120,8 @@ export const secretServiceFactory = ({
     secretPath,
     secretValue,
     secretComment,
-    skipMultilineEncoding
+    skipMultilineEncoding,
+    tagIds
   }: TCreateSecretRawDTO) => {
     const botKey = await projectBotService.getBotKey(projectId);
     if (!botKey) throw new BadRequestError({ message: "Project bot not found", name: "bot_not_found_error" });
@@ -1148,7 +1149,8 @@ export const secretServiceFactory = ({
       secretCommentCiphertext: secretCommentEncrypted.ciphertext,
       secretCommentIV: secretCommentEncrypted.iv,
       secretCommentTag: secretCommentEncrypted.tag,
-      skipMultilineEncoding
+      skipMultilineEncoding,
+      tags: tagIds
     });
 
     return decryptSecretRaw(secret, botKey);
@@ -1165,7 +1167,8 @@ export const secretServiceFactory = ({
     type,
     secretPath,
     secretValue,
-    skipMultilineEncoding
+    skipMultilineEncoding,
+    tagIds
   }: TUpdateSecretRawDTO) => {
     const botKey = await projectBotService.getBotKey(projectId);
     if (!botKey) throw new BadRequestError({ message: "Project bot not found", name: "bot_not_found_error" });
@@ -1185,7 +1188,8 @@ export const secretServiceFactory = ({
       secretValueCiphertext: secretValueEncrypted.ciphertext,
       secretValueIV: secretValueEncrypted.iv,
       secretValueTag: secretValueEncrypted.tag,
-      skipMultilineEncoding
+      skipMultilineEncoding,
+      tags: tagIds
     });
 
     await snapshotService.performSnapshot(secret.folderId);

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -164,6 +164,7 @@ export type TCreateSecretRawDTO = TProjectPermission & {
   secretName: string;
   secretValue: string;
   type: SecretType;
+  tagIds?: string[];
   secretComment?: string;
   skipMultilineEncoding?: boolean;
 };
@@ -174,6 +175,7 @@ export type TUpdateSecretRawDTO = TProjectPermission & {
   secretName: string;
   secretValue?: string;
   type: SecretType;
+  tagIds?: string[];
   skipMultilineEncoding?: boolean;
   secretReminderRepeatDays?: number | null;
   secretReminderNote?: string | null;


### PR DESCRIPTION
# Description 📣

This PR addresses the adds machine identity support to secret tag endpoints. The raw secret endpoints now accepts tag ids to attach tags to both created and updated secret. This PR is for tag support in terraform

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->