### PR TITLE
Improve k8s docs

### DIFF
--- a/docs/integrations/platforms/kubernetes.mdx
+++ b/docs/integrations/platforms/kubernetes.mdx
@@ -253,16 +253,122 @@ spec:
   The Kubernetes machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalSecret resource. This authentication method can only be used within a Kubernetes environment.
 
   <Steps>
-    <Step title="Create a machine identity">
-      You need to create a machine identity, and give it access to the project(s) you want to interact with. You can [read more about Kubernetes machine identities here](/documentation/platform/identities/kubernetes-auth).
+    <Step title="Obtaining the token reviewer JWT for Infisical">
+        1.1. Start by creating a service account in your Kubernetes cluster that will be used by Infisical to authenticate with the Kubernetes API Server.
+
+        ```yaml infisical-service-account.yaml
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: infisical-auth
+          namespace: default
+
+        ```
+
+        ```
+        kubectl apply -f infisical-service-account.yaml
+        ```
+
+        1.2. Bind the service account to the `system:auth-delegator` cluster role. As described [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#other-component-roles), this role allows delegated authentication and authorization checks, specifically for Infisical to access the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/). You can apply the following configuration file:
+
+        ```yaml cluster-role-binding.yaml
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: role-tokenreview-binding
+          namespace: default
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:auth-delegator
+        subjects:
+          - kind: ServiceAccount
+            name: infisical-auth
+            namespace: default
+        ```
+
+        ```
+        kubectl apply -f cluster-role-binding.yaml
+        ```
+
+        1.3. Next, create a long-lived service account JWT token (i.e. the token reviewer JWT token) for the service account using this configuration file for a new `Secret` resource:
+
+        ```yaml service-account-token.yaml
+        apiVersion: v1
+        kind: Secret
+        type: kubernetes.io/service-account-token
+        metadata:
+          name: infisical-auth-token
+          annotations:
+            kubernetes.io/service-account.name: "infisical-auth"
+        ```
+
+
+        ```
+        kubectl apply -f service-account-token.yaml
+        ```
+
+        1.4. Link the secret in step 1.3 to the service account in step 1.1:
+
+        ```bash
+        kubectl patch serviceaccount infisical-auth -p '{"secrets": [{"name": "infisical-auth-token"}]}' -n default
+        ```
+
+        1.5. Finally, retrieve the token reviewer JWT token from the secret.
+
+        ```bash
+        kubectl get secret infisical-auth-token -n default -o=jsonpath='{.data.token}' | base64 --decode
+        ```
+
+        Keep this JWT token handy as you will need it for the **Token Reviewer JWT** field when configuring the Kubernetes Auth authentication method for the identity in step 2.
+
     </Step>
-    <Step title="Add your identity ID to your InfisicalSecret resource">
-      Once you have created your machine identity and added it to your project(s), you will need to add the identity ID to your InfisicalSecret resource. In the `authentication.kubernetesAuth.identityId` field, add the identity ID of the machine identity you created. See the example below for more details.
+
+    <Step title="Creating an identity">
+      To create an identity, head to your Organization Settings > Access Control > Machine Identities and press **Create identity**.
+
+      ![identities organization](/images/platform/identities/identities-org.png)
+
+      When creating an identity, you specify an organization level [role](/documentation/platform/role-based-access-controls) for it to assume; you can configure roles in Organization Settings > Access Control > Organization Roles.
+
+      ![identities organization create](/images/platform/identities/identities-org-create.png)
+
+      Now input a few details for your new identity. Here's some guidance for each field:
+
+      - Name (required): A friendly name for the identity.
+      - Role (required): A role from the **Organization Roles** tab for the identity to assume. The organization role assigned will determine what organization level resources this identity can have access to.
+
+      Once you've created an identity, you'll be prompted to configure the authentication method for it. Here, select **Kubernetes Auth**.
+
+      <Info>
+        To learn more about each field of the Kubernetes native authentication method, see step 2 of [guide](/documentation/platform/identities/kubernetes-auth#guide).
+      </Info>
+
+      ![identities organization create auth method](/images/platform/identities/identities-org-create-kubernetes-auth-method.png)
+
+
+    </Step>
+    <Step title="Adding an identity to a project">
+      To allow the operator to use the given identity to access secrets, you will need to add the identity to project(s) that you would like  to grant it access to.
+
+      To do this, head over to the project you want to add the identity to and go to Project Settings > Access Control > Machine Identities and press **Add identity**.
+
+      Next, select the identity you want to add to the project and the project level role you want to allow it to assume. The project role assigned will determine what project level resources this identity can have access to.
+
+      ![identities project](/images/platform/identities/identities-project.png)
+
+      ![identities project create](/images/platform/identities/identities-project-create.png)
+
+    </Step>
+    <Step title="Add your identity ID & service account to your InfisicalSecret resource">
+      Once you have created your machine identity and added it to your project(s), you will need to add the identity ID to your InfisicalSecret resource. 
+      In the `authentication.kubernetesAuth.identityId` field, add the identity ID of the machine identity you created. 
+      See the example below for more details.
     </Step>
     <Step title="Add your Kubernetes service account token to the InfisicalSecret resource">
-    When you configured your Kubernetes machine identity, you would have created a service account token if you followed the [Kubernetes machine identity guide](/documentation/platform/identities/kubernetes-auth). If you did not create a service account token, please follow the guide to do so.
-
-    You will need to enter the name of the service account and the namespace where the service account lives. The example below shows how to add the service account token to the InfisicalSecret resource.
+      Add the service account details from the previous steps under `authentication.kubernetesAuth.serviceAccountRef`. 
+      Here you will need to enter the name and namespace of the service account. 
+      The example below shows a complete InfisicalSecret resource with all required fields defined.
     </Step> 
 
   </Steps>


### PR DESCRIPTION
I think it would be clearer if the Kubernetes documentation included all the steps. The existing link to the guide is mostly applicable if using REST endpoints, not the operator.

I have copied the documentation from the Kubernetes authentication docs page and made some modifications.