### PR TITLE
feat(k8-operator): reconcile on managed secret deletion

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -18,4 +18,4 @@ version: v0.6.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.0"
+appVersion: "v0.6.1"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.6.0
+      tag: v0.6.1
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/controllers/infisicalsecret_controller.go
+++ b/k8-operator/controllers/infisicalsecret_controller.go
@@ -75,7 +75,7 @@ func (r *InfisicalSecretReconciler) handleFinalizer(ctx context.Context, infisic
 	return nil
 }
 
-func (r *InfisicalSecretReconciler) handleManagedSecretDeletion(a client.Object) []ctrl.Request {
+func (r *InfisicalSecretReconciler) handleManagedSecretDeletion(secret client.Object) []ctrl.Request {
 	var requests []ctrl.Request
 	infisicalSecrets := &secretsv1alpha1.InfisicalSecretList{}
 	err := r.List(context.Background(), infisicalSecrets)
@@ -85,15 +85,15 @@ func (r *InfisicalSecretReconciler) handleManagedSecretDeletion(a client.Object)
 	}
 
 	for _, infisicalSecret := range infisicalSecrets.Items {
-		if a.GetName() == infisicalSecret.Spec.ManagedSecretReference.SecretName &&
-			a.GetNamespace() == infisicalSecret.Spec.ManagedSecretReference.SecretNamespace {
+		if secret.GetName() == infisicalSecret.Spec.ManagedSecretReference.SecretName &&
+			secret.GetNamespace() == infisicalSecret.Spec.ManagedSecretReference.SecretNamespace {
 			requests = append(requests, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Namespace: infisicalSecret.Namespace,
 					Name:      infisicalSecret.Name,
 				},
 			})
-			fmt.Printf("\nManaged secret deleted in resource %s: [name=%v] [namespace=%v]\n", infisicalSecret.Name, a.GetName(), a.GetNamespace())
+			fmt.Printf("\nManaged secret deleted in resource %s: [name=%v] [namespace=%v]\n", infisicalSecret.Name, secret.GetName(), secret.GetNamespace())
 		}
 	}
 

--- a/k8-operator/controllers/infisicalsecret_controller.go
+++ b/k8-operator/controllers/infisicalsecret_controller.go
@@ -200,28 +200,3 @@ func (r *InfisicalSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Complete(r)
 }
-
-func (r *InfisicalSecretReconciler) HandleManagedSecretDeletion(a client.Object) []ctrl.Request {
-	var requests []ctrl.Request
-	infisicalSecrets := &secretsv1alpha1.InfisicalSecretList{}
-	err := r.List(context.Background(), infisicalSecrets)
-	if err != nil {
-		fmt.Printf("unable to list Infisical Secrets from cluster because [err=%v]", err)
-		return requests
-	}
-
-	for _, infisicalSecret := range infisicalSecrets.Items {
-		if a.GetName() == infisicalSecret.Spec.ManagedSecretReference.SecretName &&
-			a.GetNamespace() == infisicalSecret.Spec.ManagedSecretReference.SecretNamespace {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Namespace: infisicalSecret.Namespace,
-					Name:      infisicalSecret.Name,
-				},
-			})
-			fmt.Printf("\nManaged secret deleted in resource %s: [name=%v] [namespace=%v]\n", infisicalSecret.Name, a.GetName(), a.GetNamespace())
-		}
-	}
-
-	return requests
-}


### PR DESCRIPTION
# Description 📣

Currently when the managed secret is deleted it'll be populated again on the next reconcile. This can be problematic especially if your resync interval is high. By adding reconcile on deletion, the user has a way to instantly refresh their secrets if needed.

The implementation takes place directly in the Manager, with minimal structural changes.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->