### PR TITLE
feat(api): Expand single secret references

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -347,6 +347,7 @@ export const RAW_SECRETS = {
     tagIds: "The ID of the tags to be attached to the created secret."
   },
   GET: {
+    expand: "Whether or not to expand secret references",
     secretName: "The name of the secret to get.",
     workspaceId: "The ID of the project to get the secret from.",
     workspaceSlug: "The slug of the project to get the secret from.",

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -300,6 +300,11 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         secretPath: z.string().trim().default("/").transform(removeTrailingSlash).describe(RAW_SECRETS.GET.secretPath),
         version: z.coerce.number().optional().describe(RAW_SECRETS.GET.version),
         type: z.nativeEnum(SecretType).default(SecretType.Shared).describe(RAW_SECRETS.GET.type),
+        expandSecretReferences: z
+          .enum(["true", "false"])
+          .default("false")
+          .transform((value) => value === "true")
+          .describe(RAW_SECRETS.GET.expand),
         include_imports: z
           .enum(["true", "false"])
           .default("false")
@@ -344,6 +349,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         actor: req.permission.type,
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId,
+        expandSecretReferences: req.query.expandSecretReferences,
         environment,
         projectId: workspaceId,
         projectSlug: workspaceSlug,

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -151,6 +151,7 @@ export type TGetASecretRawDTO = {
   secretName: string;
   path: string;
   environment: string;
+  expandSecretReferences?: boolean;
   type: "shared" | "personal";
   includeImports?: boolean;
   version?: number;


### PR DESCRIPTION
# Description 📣

Currently we only support expansion when listing all secrets, but not when getting a singular secret. This PR adds support for secret expansion on a single secret. 

The implementation is borrowed from the existing secret expansion logic from the `getSecretsRaw` method. It has been tweaked to accept a single secret instead of an array.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->