### PR TITLE
feat: enabled customization of project audit logs retention period

### DIFF
--- a/backend/src/db/migrations/20240625115447_configurable-audit-log-retention.ts
+++ b/backend/src/db/migrations/20240625115447_configurable-audit-log-retention.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.Project, "auditLogsRetentionDays"))) {
+    await knex.schema.alterTable(TableName.Project, (tb) => {
+      tb.integer("auditLogsRetentionDays").nullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.Project, "auditLogsRetentionDays")) {
+    await knex.schema.alterTable(TableName.Project, (t) => {
+      t.dropColumn("auditLogsRetentionDays");
+    });
+  }
+}

--- a/backend/src/db/schemas/projects.ts
+++ b/backend/src/db/schemas/projects.ts
@@ -18,7 +18,8 @@ export const ProjectsSchema = z.object({
   version: z.number().default(1),
   upgradeStatus: z.string().nullable().optional(),
   pitVersionLimit: z.number().default(10),
-  kmsCertificateKeyId: z.string().uuid().nullable().optional()
+  kmsCertificateKeyId: z.string().uuid().nullable().optional(),
+  auditLogsRetentionDays: z.number().nullable().optional()
 });
 
 export type TProjects = z.infer<typeof ProjectsSchema>;

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -383,7 +383,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         workspaceSlug: z.string().trim()
       }),
       body: z.object({
-        auditLogsRetentionDays: z.number().min(1).max(100)
+        auditLogsRetentionDays: z.number().min(0)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -404,7 +404,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       });
 
       return {
-        message: "Successfull changed project audit log retention",
+        message: "Successfully updated project's audit logs retention period",
         workspace
       };
     }

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -373,6 +373,44 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
   });
 
   server.route({
+    method: "PUT",
+    url: "/:workspaceSlug/audit-logs-retention",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      params: z.object({
+        workspaceSlug: z.string().trim()
+      }),
+      body: z.object({
+        auditLogsRetentionDays: z.number().min(1).max(100)
+      }),
+      response: {
+        200: z.object({
+          message: z.string(),
+          workspace: ProjectsSchema
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const workspace = await server.services.project.updateAuditLogsRetention({
+        actorId: req.permission.id,
+        actor: req.permission.type,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        workspaceSlug: req.params.workspaceSlug,
+        auditLogsRetentionDays: req.body.auditLogsRetentionDays
+      });
+
+      return {
+        message: "Successfull changed project audit log retention",
+        workspace
+      };
+    }
+  });
+
+  server.route({
     method: "GET",
     url: "/:workspaceId/integrations",
     config: {

--- a/backend/src/services/project/project-types.ts
+++ b/backend/src/services/project/project-types.ts
@@ -49,6 +49,11 @@ export type TUpdateProjectVersionLimitDTO = {
   workspaceSlug: string;
 } & Omit<TProjectPermission, "projectId">;
 
+export type TUpdateAuditLogsRetentionDTO = {
+  auditLogsRetentionDays: number;
+  workspaceSlug: string;
+} & Omit<TProjectPermission, "projectId">;
+
 export type TUpdateProjectNameDTO = {
   name: string;
 } & TProjectPermission;

--- a/frontend/src/hooks/api/workspace/queries.tsx
+++ b/frontend/src/hooks/api/workspace/queries.tsx
@@ -22,6 +22,7 @@ import {
   ToggleAutoCapitalizationDTO,
   TUpdateWorkspaceIdentityRoleDTO,
   TUpdateWorkspaceUserRoleDTO,
+  UpdateAuditLogsRetentionDTO,
   UpdateEnvironmentDTO,
   UpdatePitVersionLimitDTO,
   Workspace
@@ -276,6 +277,21 @@ export const useUpdateWorkspaceVersionLimit = () => {
     mutationFn: ({ projectSlug, pitVersionLimit }) => {
       return apiRequest.put(`/api/v1/workspace/${projectSlug}/version-limit`, {
         pitVersionLimit
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(workspaceKeys.getAllUserWorkspace);
+    }
+  });
+};
+
+export const useUpdateWorkspaceAuditLogsRetention = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<{}, {}, UpdateAuditLogsRetentionDTO>({
+    mutationFn: ({ projectSlug, auditLogsRetentionDays }) => {
+      return apiRequest.put(`/api/v1/workspace/${projectSlug}/audit-logs-retention`, {
+        auditLogsRetentionDays
       });
     },
     onSuccess: () => {

--- a/frontend/src/hooks/api/workspace/types.ts
+++ b/frontend/src/hooks/api/workspace/types.ts
@@ -18,6 +18,7 @@ export type Workspace = {
   autoCapitalization: boolean;
   environments: WorkspaceEnv[];
   pitVersionLimit: number;
+  auditLogsRetentionDays: number;
   slug: string;
 };
 
@@ -51,6 +52,7 @@ export type CreateWorkspaceDTO = {
 
 export type RenameWorkspaceDTO = { workspaceID: string; newWorkspaceName: string };
 export type UpdatePitVersionLimitDTO = { projectSlug: string; pitVersionLimit: number };
+export type UpdateAuditLogsRetentionDTO = { projectSlug: string; auditLogsRetentionDays: number };
 export type ToggleAutoCapitalizationDTO = { workspaceID: string; state: boolean };
 
 export type DeleteWorkspaceDTO = { workspaceID: string };

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
@@ -73,6 +73,14 @@ export const AuditLogsRetentionSection = () => {
     }
   };
 
+  // render only for dedicated/self-hosted instances of Infisical
+  if (
+    window.location.origin.includes("https://app.infisical.com") ||
+    window.location.origin.includes("https://gamma.infisical.com")
+  ) {
+    return null;
+  }
+
   const isAdmin = membership.roles.includes(ProjectMembershipRole.Admin);
   return (
     <>

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
@@ -1,0 +1,120 @@
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import { Button, FormControl, Input, UpgradePlanModal } from "@app/components/v2";
+import { useProjectPermission, useSubscription, useWorkspace } from "@app/context";
+import { usePopUp } from "@app/hooks";
+import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
+import { useUpdateWorkspaceAuditLogsRetention } from "@app/hooks/api/workspace/queries";
+
+const formSchema = z.object({
+  auditLogsRetentionDays: z.coerce.number().min(0)
+});
+
+type TForm = z.infer<typeof formSchema>;
+
+export const AuditLogsRetentionSection = () => {
+  const { mutateAsync: updateAuditLogsRetention } = useUpdateWorkspaceAuditLogsRetention();
+
+  const { currentWorkspace } = useWorkspace();
+  const { membership } = useProjectPermission();
+  const { subscription } = useSubscription();
+  const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
+
+  const {
+    control,
+    formState: { isSubmitting, isDirty },
+    handleSubmit
+  } = useForm<TForm>({
+    resolver: zodResolver(formSchema),
+    values: {
+      auditLogsRetentionDays:
+        currentWorkspace?.auditLogsRetentionDays ?? subscription?.auditLogsRetentionDays ?? 0
+    }
+  });
+
+  if (!currentWorkspace) return null;
+
+  const handleAuditLogsRetentionSubmit = async ({ auditLogsRetentionDays }: TForm) => {
+    try {
+      if (!subscription?.auditLogs) {
+        handlePopUpOpen("upgradePlan", {
+          description: "You can only configure audit logs retention if you upgrade your plan."
+        });
+
+        return;
+      }
+
+      if (subscription && auditLogsRetentionDays > subscription?.auditLogsRetentionDays) {
+        handlePopUpOpen("upgradePlan", {
+          description:
+            "To update your audit logs retention period to a higher value, upgrade your plan."
+        });
+
+        return;
+      }
+
+      await updateAuditLogsRetention({
+        auditLogsRetentionDays,
+        projectSlug: currentWorkspace.slug
+      });
+
+      createNotification({
+        text: "Successfully updated audit logs retention period",
+        type: "success"
+      });
+    } catch (err) {
+      createNotification({
+        text: "Failed updating audit logs retention period",
+        type: "error"
+      });
+    }
+  };
+
+  const isAdmin = membership.roles.includes(ProjectMembershipRole.Admin);
+  return (
+    <>
+      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+        <div className="flex w-full items-center justify-between">
+          <p className="text-xl font-semibold">Audit Logs Retention</p>
+        </div>
+        <p className="mb-4 mt-2 max-w-2xl text-sm text-gray-400">
+          Set the number of days to keep your project audit logs.
+        </p>
+        <form onSubmit={handleSubmit(handleAuditLogsRetentionSubmit)} autoComplete="off">
+          <div className="max-w-xs">
+            <Controller
+              control={control}
+              defaultValue={0}
+              name="auditLogsRetentionDays"
+              render={({ field, fieldState: { error } }) => (
+                <FormControl
+                  isError={Boolean(error)}
+                  errorText={error?.message}
+                  label="Number of days"
+                >
+                  <Input {...field} type="number" min={1} step={1} isDisabled={!isAdmin} />
+                </FormControl>
+              )}
+            />
+          </div>
+          <Button
+            colorSchema="secondary"
+            type="submit"
+            isLoading={isSubmitting}
+            disabled={!isAdmin || !isDirty}
+          >
+            Save
+          </Button>
+        </form>
+      </div>
+      <UpgradePlanModal
+        isOpen={popUp.upgradePlan.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+        text={(popUp.upgradePlan?.data as { description: string })?.description}
+      />
+    </>
+  );
+};

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/index.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/AuditLogsRetentionSection/index.tsx
@@ -1,0 +1,1 @@
+export { AuditLogsRetentionSection } from "./AuditLogsRetentionSection";

--- a/frontend/src/views/Settings/ProjectSettingsPage/components/ProjectGeneralTab/ProjectGeneralTab.tsx
+++ b/frontend/src/views/Settings/ProjectSettingsPage/components/ProjectGeneralTab/ProjectGeneralTab.tsx
@@ -1,3 +1,4 @@
+import { AuditLogsRetentionSection } from "../AuditLogsRetentionSection";
 import { AutoCapitalizationSection } from "../AutoCapitalizationSection";
 import { BackfillSecretReferenceSecretion } from "../BackfillSecretReferenceSection";
 import { DeleteProjectSection } from "../DeleteProjectSection";
@@ -17,6 +18,7 @@ export const ProjectGeneralTab = () => {
       <AutoCapitalizationSection />
       <E2EESection />
       <PointInTimeVersionLimitSection />
+      <AuditLogsRetentionSection />
       <BackfillSecretReferenceSecretion />
       <RebuildSecretIndicesSection />
       <DeleteProjectSection />


### PR DESCRIPTION
# Description 📣
- This PR will enable users to configure audit logs retention period per project. For org-level logs, retention is set to their plan's value

<img width="1496" alt="image" src="https://github.com/Infisical/infisical/assets/65645666/ccdb7483-3e4f-475f-a51f-a09d942e95e0">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->