### PR TITLE
Resolved identity roleId not setting null for predefined role selection

### DIFF
--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -115,7 +115,7 @@ export const identityServiceFactory = ({
           { identityId: id },
           {
             role: customRole ? OrgMembershipRole.Custom : role,
-            roleId: customRole?.id
+            roleId: customRole?.id || null
           },
           tx
         );


### PR DESCRIPTION
# Description 📣

This PR resolves a present bug in which when switching a role of an identity from a custom role to a predefined role like `developer`, `admin` the role id not setting it to null. This causes the role deletion failing due to tangling reference

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->