### PR TITLE
fix(k8-operator): crash on predefined managed secret

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.6.1
+version: v0.6.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.1"
+appVersion: "v0.6.2"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.6.1
+      tag: v0.6.2
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/controllers/infisicalsecret_helper.go
+++ b/k8-operator/controllers/infisicalsecret_helper.go
@@ -267,6 +267,11 @@ func (r *InfisicalSecretReconciler) UpdateInfisicalManagedKubeSecret(ctx context
 		plainProcessedSecrets[secret.Key] = []byte(secret.Value)
 	}
 
+	// Initialize the Annotations map if it's nil
+	if managedKubeSecret.ObjectMeta.Annotations == nil {
+		managedKubeSecret.ObjectMeta.Annotations = make(map[string]string)
+	}
+
 	managedKubeSecret.Data = plainProcessedSecrets
 	managedKubeSecret.ObjectMeta.Annotations[SECRET_VERSION_ANNOTATION] = ETag
 


### PR DESCRIPTION
# Description 📣

Fixes crash caused by users pre-creating secrets. It would fail to update the managed secret because the anotations map was `nil`.



```
2024-06-28T21:23:23+02:00       INFO    Observed a panic in reconciler: assignment to entry in nil map  {"controller": "infisicalsecret", "controllerGroup": "secrets.infisical.com", "controllerKind": "InfisicalSecret", "InfisicalSecret": {"name":"infisicalsecret-sample","namespace":"default"}, "namespace": "default", "name": "infisicalsecret-sample", "reconcileID": "1ccbe9a0-3d51-473f-853d-83c092cc7c81"}
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 150 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:119 +0x1e5
panic({0x24ebb80?, 0x2a10800?})
        /usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/Infisical/infisical/k8-operator/controllers.(*InfisicalSecretReconciler).UpdateInfisicalManagedKubeSecret(_, {_, _}, {{{0x234da00, 0x6}, {0x275da7e, 0x2}}, {{0xc000a6efb0, 0xf}, {0x0, ...}, ...}, ...}, ...)
        REDACTED/infisical/k8-operator/controllers/infisicalsecret_helper.go:271 +0x207
github.com/Infisical/infisical/k8-operator/controllers.(*InfisicalSecretReconciler).ReconcileInfisicalSecret(_, {_, _}, {{{0x2387d60, 0xf}, {0xc0009b60e0, 0x1e}}, {{0xc00012fc98, 0x16}, {0x0, ...}, ...}, ...})
        REDACTED/infisical/k8-operator/controllers/infisicalsecret_helper.go:405 +0xbdf
github.com/Infisical/infisical/k8-operator/controllers.(*InfisicalSecretReconciler).Reconcile(0xc00037f188, {0x2a31a78, 0xc00061de60}, {{{0xc00035b420?, 0x0?}, {0xc00012fc98?, 0x1011025?}}})
        REDACTED/infisical/k8-operator/controllers/infisicalsecret_controller.go:162 +0x44c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2a31a78?, {0x2a31a78?, 0xc00061de60?}, {{{0xc00035b420?, 0x2421e20?}, {0xc00012fc98?, 0x10129b5?}}})
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:122 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000498640, {0x2a31ab0, 0xc0002d0a00}, {0x256b200?, 0xc000139660?})
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:323 +0x365
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000498640, {0x2a31ab0, 0xc0002d0a00})
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:274 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:235 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 73
        /REDACTED/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.4/pkg/internal/controller/controller.go:231 +0x565
exit status 2
make: *** [run] Error 1
```

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->