### PR TITLE
Fix provider not found error for secret rotation

### DIFF
--- a/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
@@ -331,7 +331,7 @@ export const secretRotationQueueFactory = ({
 
       logger.info("Finished rotating: rotation id: ", rotationId);
     } catch (error) {
-      logger.error(error);
+      logger.error(error, "Failed to execute secret rotation");
       if (error instanceof DisableRotationErrors) {
         if (job.id) {
           await queue.stopRepeatableJobByJobId(QueueName.SecretRotation, job.id);


### PR DESCRIPTION
# Description 📣

PR to fix "provider not found" error thrown for some users on secret rotation. Transaction not finishing before queue starting causing document not found. 

Added a message for secret rotation failure logging too for debugging

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->