### PR TITLE
Changed audit log deletion to batched process

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -75,6 +75,10 @@ export const auditLogDALFactory = (db: TDbClient) => {
           .del()
           .returning("id");
         numberOfRetryOnFailure = 0; // reset
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100); // time to breathe for db
+        });
       } catch (error) {
         numberOfRetryOnFailure += 1;
         logger.error(error, "Failed to delete audit log on pruning");


### PR DESCRIPTION
# Description 📣

This PR relieves write lock load caused by bulk audit log deletion that happens every day midnight UTC. Instead of a full delete the query is converted to a batched one that deletes one batch at a time. This reduces the write ahead lock time for a full scan.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->