### PR TITLE
Fix posthog events on app.infisical frontend

### DIFF
--- a/frontend/src/components/analytics/posthog.ts
+++ b/frontend/src/components/analytics/posthog.ts
@@ -10,7 +10,7 @@ export const initPostHog = () => {
   try {
     if (typeof window !== "undefined") {
       // @ts-ignore
-      if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === "true") {
+      if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === true) {
         posthog.init(POSTHOG_API_KEY, {
           api_host: POSTHOG_HOST
         });

--- a/frontend/src/components/utilities/telemetry/Telemetry.ts
+++ b/frontend/src/components/utilities/telemetry/Telemetry.ts
@@ -13,7 +13,7 @@ class Capturer {
   }
 
   capture(item: string) {
-    if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === "true") {
+    if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === true) {
       try {
         this.api.capture(item);
       } catch (error) {
@@ -23,7 +23,7 @@ class Capturer {
   }
 
   identify(id: string, email?: string) {
-    if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === "true") {
+    if (ENV === "production" && TELEMETRY_CAPTURING_ENABLED === true) {
       try {
         this.api.identify(id, {
           email: email


### PR DESCRIPTION
Before this fix it used to be `ENV === "production" && TELEMETRY_CAPTURING_ENABLED === "true"` but this always set to false because TELEMETRY_CAPTURING_ENABLED is not a string, it is a bool