### PR TITLE
feat: banner on warning secret deletion in fly.io integration

### DIFF
--- a/frontend/src/components/v2/Alert/Alert.tsx
+++ b/frontend/src/components/v2/Alert/Alert.tsx
@@ -81,7 +81,7 @@ const AlertDescription = forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={twMerge("text-sm [&_p]:leading-relaxed", className)} {...props} />
+  <div ref={ref} className={twMerge("text-sm", className)} {...props} />
 ));
 AlertDescription.displayName = "AlertDescription";
 

--- a/frontend/src/pages/integrations/flyio/create.tsx
+++ b/frontend/src/pages/integrations/flyio/create.tsx
@@ -15,6 +15,8 @@ import queryString from "query-string";
 import { useCreateIntegration } from "@app/hooks/api";
 
 import {
+  Alert,
+  AlertDescription,
   Button,
   Card,
   CardTitle,
@@ -40,7 +42,7 @@ export default function FlyioCreateIntegrationPage() {
   const { data: integrationAuth, isLoading: isIntegrationAuthLoading } = useGetIntegrationAuthById(
     (integrationAuthId as string) ?? ""
   );
-  const { data: integrationAuthApps, isLoading: isIntegrationAuthAppsLoading } =
+  const { data: integrationAuthApps = [], isLoading: isIntegrationAuthAppsLoading } =
     useGetIntegrationAuthApps({
       integrationAuthId: (integrationAuthId as string) ?? ""
     });
@@ -130,6 +132,14 @@ export default function FlyioCreateIntegrationPage() {
             </Link>
           </div>
         </CardTitle>
+        <div className="px-6 pb-4">
+          <Alert hideTitle variant="warning">
+            <AlertDescription>
+              All existing secrets of your connected flyio project will be permanently removed upon
+              integration.
+            </AlertDescription>
+          </Alert>
+        </div>
         <FormControl label="Project Environment" className="px-6">
           <Select
             value={selectedSourceEnvironment}

--- a/frontend/src/pages/integrations/flyio/create.tsx
+++ b/frontend/src/pages/integrations/flyio/create.tsx
@@ -135,8 +135,7 @@ export default function FlyioCreateIntegrationPage() {
         <div className="px-6 pb-4">
           <Alert hideTitle variant="warning">
             <AlertDescription>
-              All existing secrets of your connected flyio project will be permanently removed upon
-              integration.
+              All current secrets linked to the related Fly.io project will be deleted before Infisical secrets are pushed to your Fly.io project.
             </AlertDescription>
           </Alert>
         </div>


### PR DESCRIPTION
# Description 📣

This PR adds a banner to fly io integration as warning message to note users that there existing secrets will get removed upon integration.

This is because infisical has no way to compare the value from fly io secrets api as due to fly io security measure never returns the value of the secret. Thus cannot understand whether its a modified secret or not. 

![Screenshot 2024-07-08 at 12 53 03 PM](https://github.com/Infisical/infisical/assets/31166322/af200969-0a57-4873-bede-569de612b5b6)

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->