### PR TITLE
Update dynamic seat count on prem

### DIFF
--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -218,6 +218,8 @@ export const licenseServiceFactory = ({
     } else if (instanceType === InstanceType.EnterpriseOnPrem) {
       const usedSeats = await licenseDAL.countOfOrgMembers(null, tx);
       const usedIdentitySeats = await licenseDAL.countOrgUsersAndIdentities(null, tx);
+      onPremFeatures.membersUsed = usedSeats;
+      onPremFeatures.identitiesUsed = usedIdentitySeats;
       await licenseServerOnPremApi.request.patch(`/api/license/v1/license`, {
         usedSeats,
         usedIdentitySeats

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -30,9 +30,9 @@ export type TFeatureSet = {
   workspacesUsed: 0;
   dynamicSecret: false;
   memberLimit: null;
-  membersUsed: 0;
+  membersUsed: number;
   identityLimit: null;
-  identitiesUsed: 0;
+  identitiesUsed: number;
   environmentLimit: null;
   environmentsUsed: 0;
   secretVersioning: true;


### PR DESCRIPTION
# Description 📣

This PR updates the `membersUsed` and `identitiesUsed` fields in the instance feature set on each call to `updateSubscriptionOrgMemberCount` for on-prem.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->