### PR TITLE
feat: bulk save secrets

### DIFF
--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -54,6 +54,7 @@ type Props = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange" | "val
   secretPath?: string;
   environment?: string;
   containerClassName?: string;
+  handleSecretInputChange?: (val: string) => void;
 };
 
 type ReferenceItem = {
@@ -70,6 +71,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
       containerClassName,
       secretPath: propSecretPath,
       environment: propEnvironment,
+      handleSecretInputChange,
       ...props
     },
     ref
@@ -282,7 +284,10 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
               if (!(evt.relatedTarget?.getAttribute("aria-label") === "suggestion-item"))
                 setIsFocused.off();
             }}
-            onChange={(e) => onChange?.(e.target.value)}
+            onChange={(e) => {
+              handleSecretInputChange?.(e.target.value);
+              onChange?.(e.target.value)
+            }}
             containerClassName={containerClassName}
           />
         </Popover.Trigger>

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -196,3 +196,12 @@ export type CreateSecretDTO = {
     source?: string;
   };
 };
+
+export type SecretBulkUpdate = {
+  env: string,
+  key: string,
+  value: string,
+  type: SecretType,
+  secretId?: string,
+  isCreatable?: boolean
+}

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -394,7 +394,6 @@ export const SecretOverviewPage = () => {
             secretId
           );
         }
-        
       })
       createNotification({
         type: "success",
@@ -631,21 +630,23 @@ export const SecretOverviewPage = () => {
                 />
               </div>
               {userAvailableEnvs.length > 0 && (
-                <div>
+                <div className="flex justify-between">
                   <ProjectPermissionCan
                     I={ProjectPermissionActions.Create}
                     a={subject(ProjectPermissionSub.Secrets, { secretPath })}
                   >
                     {(isAllowed) => (
-                      <div className="flex space-x-2">
-                        <Button
-                          variant="outline_bg"
-                          onClick={() => handleBulkSecretUpdate()}
-                          className="h-10 rounded-r-none"
-                          isDisabled={!isAllowed}
-                        >
-                          Save
-                        </Button>
+                      <div className="flex justify-between space-x-1">
+                        {bulkSecretUpdateContent.length > 0 && (
+                          <Button
+                            variant="outline_bg"
+                            onClick={() => handleBulkSecretUpdate()}
+                            className="h-10"
+                            isDisabled={!isAllowed}
+                          >
+                            Save
+                          </Button>
+                        )}
                         <Button
                           variant="outline_bg"
                           leftIcon={<FontAwesomeIcon icon={faPlus} />}

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -378,34 +378,23 @@ export const SecretOverviewPage = () => {
   };
 
   const handleBulkSecretUpdate = async() => {
-    try{
-      bulkSecretUpdateContent.map(async(secretContent: SecretBulkUpdate)=>{
-        if(secretContent?.isCreatable){
-          await handleSecretCreate(secretContent.env,secretContent.key,secretContent.value)
-        }
-        else{
-          let secretId =  secretContent.secretId;
-          let type = secretContent.type
-          await handleSecretUpdate(
-            secretContent.env,
-            secretContent.key,
-            secretContent?.value,
-            type,
-            secretId
-          );
-        }
-      })
-      createNotification({
-        type: "success",
-        text: "Successfully updated secrets"
-      });
-    }catch(error){
-      console.log(error)
-      createNotification({
-        type: "error",
-        text: "Failed to update secrets"
-      });
-    }
+    bulkSecretUpdateContent.map(async(secretContent: SecretBulkUpdate)=>{
+      if(secretContent?.isCreatable){
+        await handleSecretCreate(secretContent.env,secretContent.key,secretContent.value)
+      }
+      else{
+        let secretId =  secretContent.secretId;
+        let type = secretContent.type
+        await handleSecretUpdate(
+          secretContent.env,
+          secretContent.key,
+          secretContent?.value,
+          type,
+          secretId
+        );
+      }
+    })
+    setBulkSecretUpdateContent([]);
   }
 
   const handleSecretDelete = async (env: string, key: string, secretId?: string) => {

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -81,6 +81,16 @@ export enum EntryType {
   SECRET = "secret"
 }
 
+export type SecretBulkUpdate = {
+  env: string,
+  key: string,
+  value: string,
+  type: SecretType.Shared,
+  secretId?: string
+}
+
+
+
 export const SecretOverviewPage = () => {
   const { t } = useTranslation();
 
@@ -106,6 +116,7 @@ export const SecretOverviewPage = () => {
   const { data: latestFileKey } = useGetUserWsKey(workspaceId);
   const [searchFilter, setSearchFilter] = useState("");
   const secretPath = (router.query?.secretPath as string) || "/";
+  const [bulkSecretUpdateContent,setBulkSecretUpdateContent] = useState<SecretBulkUpdate[]>([])
 
   const [selectedEntries, setSelectedEntries] = useState<{
     [EntryType.FOLDER]: Record<string, boolean>;
@@ -375,6 +386,22 @@ export const SecretOverviewPage = () => {
     }
   };
 
+  const handleBulkSecretUpdate = async() => {
+    try{
+      console.log(bulkSecretUpdateContent)
+      createNotification({
+        type: "success",
+        text: "Successfully updated secrets"
+      });
+    }catch(error){
+      console.log(error)
+      createNotification({
+        type: "error",
+        text: "Failed to update secrets"
+      });
+    }
+  }
+
   const handleSecretDelete = async (env: string, key: string, secretId?: string) => {
     try {
       await deleteSecretV3({
@@ -603,15 +630,25 @@ export const SecretOverviewPage = () => {
                     a={subject(ProjectPermissionSub.Secrets, { secretPath })}
                   >
                     {(isAllowed) => (
-                      <Button
-                        variant="outline_bg"
-                        leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                        onClick={() => handlePopUpOpen("addSecretsInAllEnvs")}
-                        className="h-10 rounded-r-none"
-                        isDisabled={!isAllowed}
-                      >
-                        Add Secret
-                      </Button>
+                      <div className="flex space-x-2">
+                        <Button
+                          variant="outline_bg"
+                          onClick={() => handleBulkSecretUpdate()}
+                          className="h-10 rounded-r-none"
+                          isDisabled={!isAllowed}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          variant="outline_bg"
+                          leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                          onClick={() => handlePopUpOpen("addSecretsInAllEnvs")}
+                          className="h-10 rounded-r-none"
+                          isDisabled={!isAllowed}
+                        >
+                          Add Secret
+                        </Button>
+                      </div>
                     )}
                   </ProjectPermissionCan>
                   <DropdownMenu
@@ -823,6 +860,7 @@ export const SecretOverviewPage = () => {
                       secretKey={key}
                       getSecretByKey={getSecretByKey}
                       expandableColWidth={expandableTableWidth}
+                      setBulkSecretUpdateContent={setBulkSecretUpdateContent}
                     />
                   ))}
               </TBody>

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -64,7 +64,7 @@ import {
 } from "@app/hooks/api";
 import { useUpdateFolderBatch } from "@app/hooks/api/secretFolders/queries";
 import { TUpdateFolderBatchDTO } from "@app/hooks/api/secretFolders/types";
-import { SecretType, TSecretFolder } from "@app/hooks/api/types";
+import { SecretType, TSecretFolder, SecretBulkUpdate } from "@app/hooks/api/types";
 import { ProjectVersion } from "@app/hooks/api/workspace/types";
 
 import { FolderForm } from "../SecretMainPage/components/ActionBar/FolderForm";
@@ -80,15 +80,6 @@ export enum EntryType {
   FOLDER = "folder",
   SECRET = "secret"
 }
-
-export type SecretBulkUpdate = {
-  env: string,
-  key: string,
-  value: string,
-  type: SecretType.Shared,
-  secretId?: string
-}
-
 
 
 export const SecretOverviewPage = () => {
@@ -388,7 +379,23 @@ export const SecretOverviewPage = () => {
 
   const handleBulkSecretUpdate = async() => {
     try{
-      console.log(bulkSecretUpdateContent)
+      bulkSecretUpdateContent.map(async(secretContent: SecretBulkUpdate)=>{
+        if(secretContent?.isCreatable){
+          await handleSecretCreate(secretContent.env,secretContent.key,secretContent.value)
+        }
+        else{
+          let secretId =  secretContent.secretId;
+          let type = secretContent.type
+          await handleSecretUpdate(
+            secretContent.env,
+            secretContent.key,
+            secretContent?.value,
+            type,
+            secretId
+          );
+        }
+        
+      })
       createNotification({
         type: "success",
         text: "Successfully updated secrets"

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -129,6 +129,20 @@ export const SecretEditRow = ({
     setIsDeleting.on();
     try {
       await onSecretDelete(environment, secretName, secretId);
+      
+      // updating bulksecretupdatecontent array to prevent it from being updated when secret that was changed is deleted
+      setBulkSecretUpdateContent((prevContent) => {
+        let data = [...prevContent];
+
+        const secretObjectIndex = data.findIndex(secretObject => 
+          (secretId && secretObject.secretId === secretId && secretObject.env === environment)
+        );
+
+        if (secretObjectIndex !== -1) {
+          data.splice(secretObjectIndex, 1);
+        }
+        return data
+      })
       reset({ value: null });
     } finally {
       setIsDeleting.off();

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -29,7 +29,8 @@ type Props = {
     value: string,
     type?: SecretType,
     secretId?: string
-  ) => Promise<void>;
+  ) => Promise<void>;,
+  setBulkSecretUpdateContent: 
   onSecretDelete: (env: string, key: string, secretId?: string) => Promise<void>;
 };
 
@@ -45,7 +46,8 @@ export const SecretEditRow = ({
   environment,
   secretPath,
   isVisible,
-  secretId
+  secretId,
+  setBulkSecretUpdateContent
 }: Props) => {
   const {
     handleSubmit,

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -13,7 +13,7 @@ import { twMerge } from "tailwind-merge";
 
 import { Button, Checkbox, TableContainer, Td, Tooltip, Tr } from "@app/components/v2";
 import { useToggle } from "@app/hooks";
-import { DecryptedSecret, SecretType } from "@app/hooks/api/secrets/types";
+import { DecryptedSecret, SecretType, SecretBulkUpdate } from "@app/hooks/api/secrets/types";
 import { WorkspaceEnv } from "@app/hooks/api/types";
 
 import { SecretEditRow } from "./SecretEditRow";
@@ -41,6 +41,7 @@ type Props = {
     env: string,
     secretName: string
   ) => { secret?: DecryptedSecret; environmentInfo?: WorkspaceEnv } | undefined;
+  setBulkSecretUpdateContent: (content: SecretBulkUpdate) => void;
 };
 
 export const SecretOverviewTableRow = ({

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -55,7 +55,8 @@ export const SecretOverviewTableRow = ({
   getImportedSecretByKey,
   expandableColWidth,
   onToggleSecretSelect,
-  isSelected
+  isSelected,
+  setBulkSecretUpdateContent
 }: Props) => {
   const [isFormExpanded, setIsFormExpanded] = useToggle();
   const totalCols = environments.length + 1; // secret key row
@@ -233,6 +234,7 @@ export const SecretOverviewTableRow = ({
                               onSecretCreate={onSecretCreate}
                               onSecretUpdate={onSecretUpdate}
                               environment={slug}
+                              setBulkSecretUpdateContent={setBulkSecretUpdateContent}
                             />
                           </td>
                         </tr>


### PR DESCRIPTION
# Description 📣

Solves #2031

This PR adds the feature to bulk update secrets. To solve the issue I have used the `prop drilling` method and have sent `setBulkSecretUpdateContent` array state and updating it when a secret is updated or added.

## Type ✨

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Edge cases Tested:

1. Updating secrets under a single secretname
2. Updating and saving secrets under multiple secretnames
3. Updating a secret and then deleting the secret using already existing delete functionality (in this case the secret should also be removed from the array that contains the updated secrets)
4. Create a folder and then update the secrets

https://github.com/user-attachments/assets/e51dcddd-c631-401b-8c1e-987e628470b3

https://github.com/user-attachments/assets/62ec35de-3862-498e-b3fa-c28f8807817b






---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->