### PR TITLE
Remove org read check on project fetch 

### DIFF
--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -144,10 +144,7 @@ export const orgServiceFactory = ({
     return members;
   };
 
-  const findAllWorkspaces = async ({ actor, actorId, actorOrgId, actorAuthMethod, orgId }: TFindAllWorkspacesDTO) => {
-    const { permission } = await permissionService.getOrgPermission(actor, actorId, orgId, actorAuthMethod, actorOrgId);
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Workspace);
-
+  const findAllWorkspaces = async ({ actor, actorId, orgId }: TFindAllWorkspacesDTO) => {
     const organizationWorkspaceIds = new Set((await projectDAL.find({ orgId })).map((workspace) => workspace.id));
 
     let workspaces: (TProjects & { organization: string } & {


### PR DESCRIPTION
In the past, a machine identity could be a part of a project but it could have no access role at the organization level, and this would prevent the actor from fetching the list of projects they have access to. If the user is a part of a project already, they should be able to fetch its details. Organization permission shouldn't get in the way.