### PR TITLE
Fix Identity-Project Provisioning Modal — Filter Current Org Projects

### DIFF
--- a/frontend/src/views/Org/IdentityPage/components/IdentityProjectsSection/IdentityAddToProjectModal.tsx
+++ b/frontend/src/views/Org/IdentityPage/components/IdentityProjectsSection/IdentityAddToProjectModal.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { Button, FormControl, Modal, ModalContent, Select, SelectItem } from "@app/components/v2";
-import { useWorkspace } from "@app/context";
+import { useOrganization,useWorkspace } from "@app/context";
 import {
   useAddIdentityToWorkspace,
   useGetIdentityProjectMemberships,
@@ -33,6 +33,7 @@ type Props = {
 };
 
 export const IdentityAddToProjectModal = ({ identityId, popUp, handlePopUpToggle }: Props) => {
+  const { currentOrg } = useOrganization();
   const { workspaces } = useWorkspace();
   const { mutateAsync: addIdentityToWorkspace } = useAddIdentityToWorkspace();
 
@@ -58,7 +59,9 @@ export const IdentityAddToProjectModal = ({ identityId, popUp, handlePopUpToggle
       wsWorkspaceIds.set(projectMembership.project.id, true);
     });
 
-    return (workspaces || []).filter(({ id }) => !wsWorkspaceIds.has(id));
+    return (workspaces || []).filter(
+      ({ id, orgId }) => !wsWorkspaceIds.has(id) && orgId === currentOrg?.id
+    );
   }, [workspaces, projectMemberships]);
 
   const onFormSubmit = async ({ projectId: workspaceId, role }: FormData) => {


### PR DESCRIPTION
# Description 📣

This PR filters out the projects listed in the identity-project provisioning modal to be only those in the current organization scope.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->