### PR TITLE
Add SCIM user activation/deactivation

### DIFF
--- a/backend/src/db/migrations/20240715113110_org-membership-active-status.ts
+++ b/backend/src/db/migrations/20240715113110_org-membership-active-status.ts
@@ -1,0 +1,25 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.OrgMembership)) {
+    await knex.schema.alterTable(TableName.OrgMembership, (t) => {
+      t.boolean("isActive").nullable();
+    });
+
+    await knex(TableName.OrgMembership).update("isActive", true);
+
+    await knex.schema.alterTable(TableName.OrgMembership, (t) => {
+      t.boolean("isActive").notNullable().alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.OrgMembership)) {
+    await knex.schema.alterTable(TableName.OrgMembership, (t) => {
+      t.dropColumn("isActive");
+    });
+  }
+}

--- a/backend/src/db/migrations/20240715113110_org-membership-active-status.ts
+++ b/backend/src/db/migrations/20240715113110_org-membership-active-status.ts
@@ -4,22 +4,22 @@ import { TableName } from "../schemas";
 
 export async function up(knex: Knex): Promise<void> {
   if (await knex.schema.hasTable(TableName.OrgMembership)) {
+    const doesUserIdExist = await knex.schema.hasColumn(TableName.OrgMembership, "userId");
+    const doesOrgIdExist = await knex.schema.hasColumn(TableName.OrgMembership, "orgId");
     await knex.schema.alterTable(TableName.OrgMembership, (t) => {
-      t.boolean("isActive").nullable();
-    });
-
-    await knex(TableName.OrgMembership).update("isActive", true);
-
-    await knex.schema.alterTable(TableName.OrgMembership, (t) => {
-      t.boolean("isActive").notNullable().alter();
+      t.boolean("isActive").notNullable().defaultTo(true);
+      if (doesUserIdExist && doesOrgIdExist) t.index(["userId", "orgId"]);
     });
   }
 }
 
 export async function down(knex: Knex): Promise<void> {
   if (await knex.schema.hasTable(TableName.OrgMembership)) {
+    const doesUserIdExist = await knex.schema.hasColumn(TableName.OrgMembership, "userId");
+    const doesOrgIdExist = await knex.schema.hasColumn(TableName.OrgMembership, "orgId");
     await knex.schema.alterTable(TableName.OrgMembership, (t) => {
       t.dropColumn("isActive");
+      if (doesUserIdExist && doesOrgIdExist) t.dropIndex(["userId", "orgId"]);
     });
   }
 }

--- a/backend/src/db/schemas/org-memberships.ts
+++ b/backend/src/db/schemas/org-memberships.ts
@@ -17,7 +17,8 @@ export const OrgMembershipsSchema = z.object({
   userId: z.string().uuid().nullable().optional(),
   orgId: z.string().uuid(),
   roleId: z.string().uuid().nullable().optional(),
-  projectFavorites: z.string().array().nullable().optional()
+  projectFavorites: z.string().array().nullable().optional(),
+  isActive: z.boolean()
 });
 
 export type TOrgMemberships = z.infer<typeof OrgMembershipsSchema>;

--- a/backend/src/db/seeds/2-org.ts
+++ b/backend/src/db/seeds/2-org.ts
@@ -29,7 +29,8 @@ export async function seed(knex: Knex): Promise<void> {
       role: OrgMembershipRole.Admin,
       orgId: org.id,
       status: OrgMembershipStatus.Accepted,
-      userId: user.id
+      userId: user.id,
+      isActive: true
     }
   ]);
 }

--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -186,7 +186,13 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
             })
           ),
           displayName: z.string().trim(),
-          active: z.boolean()
+          active: z.boolean(),
+          groups: z.array(
+            z.object({
+              value: z.string().trim(),
+              display: z.string().trim()
+            })
+          )
         })
       }
     },
@@ -572,7 +578,13 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
             })
           ),
           displayName: z.string().trim(),
-          active: z.boolean()
+          active: z.boolean(),
+          groups: z.array(
+            z.object({
+              value: z.string().trim(),
+              display: z.string().trim()
+            })
+          )
         })
       }
     },

--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -162,11 +162,26 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findUserGroupMembershipsInOrg = async (userId: string, orgId: string) => {
+    try {
+      const docs = await db
+        .replicaNode()(TableName.UserGroupMembership)
+        .join(TableName.Groups, `${TableName.UserGroupMembership}.groupId`, `${TableName.Groups}.id`)
+        .where(`${TableName.UserGroupMembership}.userId`, userId)
+        .where(`${TableName.Groups}.orgId`, orgId);
+
+      return docs;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "findTest" });
+    }
+  };
+
   return {
     ...userGroupMembershipOrm,
     filterProjectsByUserMembership,
     findUserGroupMembershipsInProject,
     findGroupMembersNotInProject,
-    deletePendingUserGroupMembershipsByUserIds
+    deletePendingUserGroupMembershipsByUserIds,
+    findUserGroupMembershipsInOrg
   };
 };

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -449,7 +449,8 @@ export const ldapConfigServiceFactory = ({
               userId: userAlias.userId,
               orgId,
               role: OrgMembershipRole.Member,
-              status: OrgMembershipStatus.Accepted
+              status: OrgMembershipStatus.Accepted,
+              isActive: true
             },
             tx
           );
@@ -534,7 +535,8 @@ export const ldapConfigServiceFactory = ({
               inviteEmail: email,
               orgId,
               role: OrgMembershipRole.Member,
-              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited, // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              isActive: true
             },
             tx
           );

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -193,7 +193,8 @@ export const oidcConfigServiceFactory = ({
               inviteEmail: email,
               orgId,
               role: OrgMembershipRole.Member,
-              status: foundUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              status: foundUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited, // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              isActive: true
             },
             tx
           );
@@ -266,7 +267,8 @@ export const oidcConfigServiceFactory = ({
               inviteEmail: email,
               orgId,
               role: OrgMembershipRole.Member,
-              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited, // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              isActive: true
             },
             tx
           );

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -370,7 +370,8 @@ export const samlConfigServiceFactory = ({
               inviteEmail: email,
               orgId,
               role: OrgMembershipRole.Member,
-              status: foundUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              status: foundUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited, // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              isActive: true
             },
             tx
           );
@@ -457,7 +458,8 @@ export const samlConfigServiceFactory = ({
               inviteEmail: email,
               orgId,
               role: OrgMembershipRole.Member,
-              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              status: newUser.isAccepted ? OrgMembershipStatus.Accepted : OrgMembershipStatus.Invited, // if user is fully completed, then set status to accepted, otherwise set it to invited so we can update it later
+              isActive: true
             },
             tx
           );

--- a/backend/src/ee/services/scim/scim-fns.ts
+++ b/backend/src/ee/services/scim/scim-fns.ts
@@ -32,12 +32,19 @@ export const parseScimFilter = (filterToParse: string | undefined) => {
   return { [attributeName]: parsedValue.replace(/"/g, "") };
 };
 
+export function extractScimValueFromPath(path: string): string | null {
+  const regex = /members\[value eq "([^"]+)"\]/;
+  const match = path.match(regex);
+  return match ? match[1] : null;
+}
+
 export const buildScimUser = ({
   orgMembershipId,
   username,
   email,
   firstName,
   lastName,
+  groups = [],
   active
 }: {
   orgMembershipId: string;
@@ -45,6 +52,10 @@ export const buildScimUser = ({
   email?: string | null;
   firstName: string;
   lastName: string;
+  groups?: {
+    value: string;
+    display: string;
+  }[];
   active: boolean;
 }): TScimUser => {
   const scimUser = {
@@ -67,7 +78,7 @@ export const buildScimUser = ({
         ]
       : [],
     active,
-    groups: [],
+    groups,
     meta: {
       resourceType: "User",
       location: null

--- a/backend/src/ee/services/scim/scim-types.ts
+++ b/backend/src/ee/services/scim/scim-types.ts
@@ -158,7 +158,10 @@ export type TScimUser = {
     type: string;
   }[];
   active: boolean;
-  groups: string[];
+  groups: {
+    value: string;
+    display: string;
+  }[];
   meta: {
     resourceType: string;
     location: null;

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -331,7 +331,7 @@ export const registerRoutes = async (
     permissionService,
     secretApprovalPolicyDAL
   });
-  const tokenService = tokenServiceFactory({ tokenDAL: authTokenDAL, userDAL });
+  const tokenService = tokenServiceFactory({ tokenDAL: authTokenDAL, userDAL, orgMembershipDAL });
 
   const samlService = samlConfigServiceFactory({
     permissionService,

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -74,6 +74,7 @@ export const orgDALFactory = (db: TDbClient) => {
           db.ref("role").withSchema(TableName.OrgMembership),
           db.ref("roleId").withSchema(TableName.OrgMembership),
           db.ref("status").withSchema(TableName.OrgMembership),
+          db.ref("isActive").withSchema(TableName.OrgMembership),
           db.ref("email").withSchema(TableName.Users),
           db.ref("username").withSchema(TableName.Users),
           db.ref("firstName").withSchema(TableName.Users),

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -207,7 +207,8 @@ export const orgServiceFactory = ({
       orgId,
       userId: user.id,
       role: OrgMembershipRole.Admin,
-      status: OrgMembershipStatus.Accepted
+      status: OrgMembershipStatus.Accepted,
+      isActive: true
     };
 
     await orgDAL.createMembership(createMembershipData, tx);
@@ -311,7 +312,8 @@ export const orgServiceFactory = ({
           userId,
           orgId: org.id,
           role: OrgMembershipRole.Admin,
-          status: OrgMembershipStatus.Accepted
+          status: OrgMembershipStatus.Accepted,
+          isActive: true
         },
         tx
       );
@@ -460,7 +462,8 @@ export const orgServiceFactory = ({
               inviteEmail: inviteeEmail,
               orgId,
               role: OrgMembershipRole.Member,
-              status: OrgMembershipStatus.Invited
+              status: OrgMembershipStatus.Invited,
+              isActive: true
             },
             tx
           );
@@ -491,7 +494,8 @@ export const orgServiceFactory = ({
           orgId,
           userId: user.id,
           role: OrgMembershipRole.Member,
-          status: OrgMembershipStatus.Invited
+          status: OrgMembershipStatus.Invited,
+          isActive: true
         },
         tx
       );

--- a/frontend/src/hooks/api/users/types.ts
+++ b/frontend/src/hooks/api/users/types.ts
@@ -60,6 +60,7 @@ export type OrgUser = {
   status: "invited" | "accepted" | "verified" | "completed";
   deniedPermissions: any[];
   roleId: string;
+  isActive: boolean;
 };
 
 export type TProjectMembership = {

--- a/frontend/src/views/Org/MembersPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersTable.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersTable.tsx
@@ -171,14 +171,14 @@ export const OrgMembersTable = ({ handlePopUpOpen, setCompleteInviteLink }: Prop
             {isLoading && <TableSkeleton columns={5} innerKey="org-members" />}
             {!isLoading &&
               filterdUser?.map(
-                ({ user: u, inviteEmail, role, roleId, id: orgMembershipId, status }) => {
+                ({ user: u, inviteEmail, role, roleId, id: orgMembershipId, status, isActive }) => {
                   const name = u && u.firstName ? `${u.firstName} ${u.lastName}` : "-";
                   const email = u?.email || inviteEmail;
                   const username = u?.username ?? inviteEmail ?? "-";
                   return (
                     <Tr key={`org-membership-${orgMembershipId}`} className="w-full">
-                      <Td>{name}</Td>
-                      <Td>{username}</Td>
+                      <Td className={isActive ? "" : "text-mineshaft-400"}>{name}</Td>
+                      <Td className={isActive ? "" : "text-mineshaft-400"}>{username}</Td>
                       <Td>
                         <OrgPermissionCan
                           I={OrgPermissionActions.Edit}
@@ -186,7 +186,18 @@ export const OrgMembersTable = ({ handlePopUpOpen, setCompleteInviteLink }: Prop
                         >
                           {(isAllowed) => (
                             <>
-                              {status === "accepted" && (
+                              {!isActive && (
+                                <Button
+                                  isDisabled
+                                  className="w-40"
+                                  colorSchema="primary"
+                                  variant="outline_bg"
+                                  onClick={() => {}}
+                                >
+                                  Suspended
+                                </Button>
+                              )}
+                              {isActive && status === "accepted" && (
                                 <Select
                                   value={role === "custom" ? findRoleFromId(roleId)?.slug : role}
                                   isDisabled={userId === u?.id || !isAllowed}
@@ -207,7 +218,8 @@ export const OrgMembersTable = ({ handlePopUpOpen, setCompleteInviteLink }: Prop
                                     ))}
                                 </Select>
                               )}
-                              {(status === "invited" || status === "verified") &&
+                              {isActive &&
+                                (status === "invited" || status === "verified") &&
                                 email &&
                                 serverDetails?.emailConfigured && (
                                   <Button


### PR DESCRIPTION
# Description 📣

This PR polishes the SCIM server implementation specifically to now account for user activation/deactivation.

The advantage of user activation/deactivation over deleting users is that users can be deactivated and reactivated, retaining all roles and permissions from pre-deactivation. This also more closely aligns with the model in SCIM.

More specifically:
- Adds an `isActive` field to the `OrgMembership` table.
- Adds logic into auth middleware to reject requests made by deactivated users. Note: This does mean making an extra call to fetch organization membership for user on each request.
- Adds logic into SCIM endpoints to deactivate users where necessary instead of deleting them.

This PR does not include internal user activation/deactivation that is outside the SCIM identity provider; this will be included in a separate PR.

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->