### PR TITLE
Further SCIM Smoothening

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -350,7 +350,12 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
               schemas: z.array(z.string()),
               id: z.string().trim(),
               displayName: z.string().trim(),
-              members: z.array(z.any()).length(0),
+              members: z.array(
+                z.object({
+                  value: z.string(),
+                  display: z.string()
+                })
+              ),
               meta: z.object({
                 resourceType: z.string().trim()
               })
@@ -423,7 +428,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
         displayName: z.string().trim(),
         members: z.array(
           z.object({
-            value: z.string(), // infisical orgMembershipId
+            value: z.string(),
             display: z.string()
           })
         )

--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -205,7 +205,7 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
         );
       return docs;
     } catch (error) {
-      throw new DatabaseError({ error, name: "Find group memberships by user id in org" });
+      throw new DatabaseError({ error, name: "Find group memberships by group id in org" });
     }
   };
 

--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -162,17 +162,50 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findUserGroupMembershipsInOrg = async (userId: string, orgId: string) => {
+  const findGroupMembershipsByUserIdInOrg = async (userId: string, orgId: string) => {
     try {
       const docs = await db
         .replicaNode()(TableName.UserGroupMembership)
         .join(TableName.Groups, `${TableName.UserGroupMembership}.groupId`, `${TableName.Groups}.id`)
+        .join(TableName.OrgMembership, `${TableName.UserGroupMembership}.userId`, `${TableName.OrgMembership}.userId`)
+        .join(TableName.Users, `${TableName.UserGroupMembership}.userId`, `${TableName.Users}.id`)
         .where(`${TableName.UserGroupMembership}.userId`, userId)
-        .where(`${TableName.Groups}.orgId`, orgId);
+        .where(`${TableName.Groups}.orgId`, orgId)
+        .select(
+          db.ref("id").withSchema(TableName.UserGroupMembership),
+          db.ref("groupId").withSchema(TableName.UserGroupMembership),
+          db.ref("name").withSchema(TableName.Groups).as("groupName"),
+          db.ref("id").withSchema(TableName.OrgMembership).as("orgMembershipId"),
+          db.ref("firstName").withSchema(TableName.Users).as("firstName"),
+          db.ref("lastName").withSchema(TableName.Users).as("lastName")
+        );
 
       return docs;
     } catch (error) {
-      throw new DatabaseError({ error, name: "findTest" });
+      throw new DatabaseError({ error, name: "Find group memberships by user id in org" });
+    }
+  };
+
+  const findGroupMembershipsByGroupIdInOrg = async (groupId: string, orgId: string) => {
+    try {
+      const docs = await db
+        .replicaNode()(TableName.UserGroupMembership)
+        .join(TableName.Groups, `${TableName.UserGroupMembership}.groupId`, `${TableName.Groups}.id`)
+        .join(TableName.OrgMembership, `${TableName.UserGroupMembership}.userId`, `${TableName.OrgMembership}.userId`)
+        .join(TableName.Users, `${TableName.UserGroupMembership}.userId`, `${TableName.Users}.id`)
+        .where(`${TableName.Groups}.id`, groupId)
+        .where(`${TableName.Groups}.orgId`, orgId)
+        .select(
+          db.ref("id").withSchema(TableName.UserGroupMembership),
+          db.ref("groupId").withSchema(TableName.UserGroupMembership),
+          db.ref("name").withSchema(TableName.Groups).as("groupName"),
+          db.ref("id").withSchema(TableName.OrgMembership).as("orgMembershipId"),
+          db.ref("firstName").withSchema(TableName.Users).as("firstName"),
+          db.ref("lastName").withSchema(TableName.Users).as("lastName")
+        );
+      return docs;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find group memberships by user id in org" });
     }
   };
 
@@ -182,6 +215,7 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     findUserGroupMembershipsInProject,
     findGroupMembersNotInProject,
     deletePendingUserGroupMembershipsByUserIds,
-    findUserGroupMembershipsInOrg
+    findGroupMembershipsByUserIdInOrg,
+    findGroupMembershipsByGroupIdInOrg
   };
 };


### PR DESCRIPTION
# Description 📣

This PR further smoothens the SCIM implementation primarily by returning group memberships where needed; previously returned empty in various places which was not reflective of the actual group memberships in each group.

It also makes the add user to group operation idempotent to avoid throwing errors as JumpCloud tends to make such repeat operations.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->