### PR TITLE
Add SMTP2GO credentials for email configuration

### DIFF
--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -328,6 +328,25 @@ SMTP_FROM_NAME=Infisical
   </Info>
 </Accordion>
 
+<Accordion title="SMTP2Go"> 
+1. Create an account and configure [SMTP2Go](https://www.smtp2go.com/) to send emails.
+2. Turn on SMTP authentication  
+```
+SMTP server: mail.smtp2go.com
+SMTP port: You can use one of the following ports: 2525, 80, 25, 8025, or 587
+Username: Your SMTP2GO account's SMTP username
+Password: Your SMTP2GO account's SMTP password
+```
+{" "}
+
+<Note> 
+Optional (for TLS/SSL):
+
+TLS: Available on the same ports (2525, 80, 25, 8025, or 587)
+SSL: Available on ports 465, 8465, and 443
+</Note>
+</Accordion> 
+
 ## Authentication
 
 By default, users can only login via email/password based login method.


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️
Followed the documentation on SMTP2GO , Here's a screenshot showing the exact credentials : 

![Screenshot ](https://github.com/user-attachments/assets/ffed928e-5dab-444b-8b35-87a807b4868b)

```sh

```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
