### PR TITLE
feat: add Ctrl+Enter submit action on secret-box input 

### DIFF
--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -248,6 +248,13 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
           e.preventDefault();
         }
       }
+
+      if (e.key === 'Enter' && e.ctrlKey) {
+        e.preventDefault();
+        if (props.submitForm) {
+          props.submitForm();
+        }
+      }
     };
 
     const handlePopUpOpen = () => {

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -164,6 +164,7 @@ export const CreateSecretForm = ({
                 <InfisicalSecretInput
                   {...field}
                   containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
+                  submitForm={handleSubmit(handleFormSubmit)}
                 />
               </FormControl>
             )}


### PR DESCRIPTION
# Description
- This pull request introduces a new feature that allows users to submit the form by pressing `Ctrl+Enter` while focused on the secret input box. This enhancement improves the user experience by providing a convenient keyboard shortcut for form submission.

# Changes Made
- InfisicalSecretInput Component: Added a keydown event handler to detect `Ctrl+Enter` and trigger the form submission.
- Form Integration: Ensured the secret input box can submit the form when `Ctrl+Enter` is pressed.

Fixes: #2071