### PR TITLE
misc: added checks for formatting email templates for self-hosted or cloud

### DIFF
--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -5,6 +5,7 @@ import handlebars from "handlebars";
 import { createTransport } from "nodemailer";
 import SMTPTransport from "nodemailer/lib/smtp-transport";
 
+import { getConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 
 export type TSmtpConfig = SMTPTransport.Options;
@@ -12,7 +13,7 @@ export type TSmtpSendMail = {
   template: SmtpTemplates;
   subjectLine: string;
   recipients: string[];
-  substitutions: unknown;
+  substitutions: object;
 };
 export type TSmtpService = ReturnType<typeof smtpServiceFactory>;
 
@@ -47,9 +48,11 @@ export const smtpServiceFactory = (cfg: TSmtpConfig) => {
   const isSmtpOn = Boolean(cfg.host);
 
   const sendMail = async ({ substitutions, recipients, template, subjectLine }: TSmtpSendMail) => {
+    const appCfg = getConfig();
     const html = await fs.readFile(path.resolve(__dirname, "./templates/", template), "utf8");
     const temp = handlebars.compile(html);
-    const htmlToSend = temp(substitutions);
+    const htmlToSend = temp({ ...substitutions, isCloud: appCfg.isCloud });
+
     if (isSmtpOn) {
       await smtp.sendMail({
         from: cfg.from,

--- a/backend/src/services/smtp/templates/emailMfa.handlebars
+++ b/backend/src/services/smtp/templates/emailMfa.handlebars
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>MFA Code</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <h2>Infisical</h2>
     <h2>Sign in attempt requires further verification</h2>
     <p>Your MFA code is below — enter it where you started signing in to Infisical.</p>
     <h2>{{code}}</h2>
     <p>The MFA code will be valid for 2 minutes.</p>
-    <p>Not you? Contact Infisical or your administrator immediately.</p>
-</body>
+    <p>Not you? Contact {{#if isCloud}}Infisical{{else}}your administrator{{/if}} immediately.</p>
+  </body>
 
 </html>

--- a/backend/src/services/smtp/templates/newDevice.handlebars
+++ b/backend/src/services/smtp/templates/newDevice.handlebars
@@ -1,19 +1,19 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>Successful login for {{email}} from new device</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <h2>Infisical</h2>
     <p>We're verifying a recent login for {{email}}:</p>
     <p><strong>Timestamp</strong>: {{timestamp}}</p>
     <p><strong>IP address</strong>: {{ip}}</p>
     <p><strong>User agent</strong>: {{userAgent}}</p>
-    <p>If you believe that this login is suspicious, please contact Infisical or reset your password immediately.</p>
-</body>
+    <p>If you believe that this login is suspicious, please contact {{#if isCloud}}Infisical{{else}}your administrator{{/if}} or reset your password immediately.</p>
+  </body>
 
 </html>

--- a/backend/src/services/smtp/templates/passwordReset.handlebars
+++ b/backend/src/services/smtp/templates/passwordReset.handlebars
@@ -9,6 +9,6 @@
     <h2>Reset your password</h2>
     <p>Someone requested a password reset.</p>
     <a href="{{callback_url}}?token={{token}}&to={{email}}">Reset password</a>
-    <p>If you didn't initiate this request, please contact us immediately at team@infisical.com</p>
+    <p>If you didn't initiate this request, please contact {{#if isCloud}}us immediately at team@infisical.com.{{else}}your administrator immediately.{{/if}}</p>
 </body>
 </html>


### PR DESCRIPTION
# Description 📣
- This PR ensures that emails being sent are formatted differently when instance is self-hosted or on the cloud

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->