### PR TITLE
fix(binary): aarch64 binary native bindings fix

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,7 +14,6 @@ defaults:
 
 jobs:
     build-and-deploy:
-        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 arch: [x64, arm64]
@@ -24,6 +23,7 @@ jobs:
                       target: node20-linux
                     - os: win
                       target: node20-win
+        runs-on: ${{ (matrix.arch == 'arm64' && matrix.os == 'linux') && 'ubuntu24-arm64' || 'ubuntu-20.04' }}
 
         steps:
             - name: Checkout code

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -49,9 +49,9 @@ jobs:
             - name: Package into node binary
               run: |
                   if [ "${{ matrix.os }}" != "linux" ]; then
-                    pkg --no-bytecode --public-packages "*" --public --compress Brotli --target ${{ matrix.target }}-${{ matrix.arch }} --output ./binary/infisical-core-${{ matrix.os }}-${{ matrix.arch }} .
+                    pkg --no-bytecode --public-packages "*" --public --target ${{ matrix.target }}-${{ matrix.arch }} --output ./binary/infisical-core-${{ matrix.os }}-${{ matrix.arch }} .
                   else
-                    pkg --no-bytecode --public-packages "*" --public --compress Brotli --target ${{ matrix.target }}-${{ matrix.arch }} --output ./binary/infisical-core .
+                    pkg --no-bytecode --public-packages "*" --public --target ${{ matrix.target }}-${{ matrix.arch }} --output ./binary/infisical-core .
                   fi
 
             # Set up .deb package structure (Debian/Ubuntu only)

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -84,7 +84,12 @@ jobs:
                   mv infisical-core.deb ./binary/infisical-core-${{matrix.arch}}.deb
 
             - uses: actions/setup-python@v4
-            - run: pip install --upgrade cloudsmith-cli
+              with:
+                  python-version: "3.x" # Specify the Python version you need
+            - name: Install Python dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install --upgrade cloudsmith-cli
 
             # Publish .deb file to Cloudsmith (Debian/Ubuntu only)
             - name: Publish to Cloudsmith (Debian/Ubuntu)

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -23,7 +23,7 @@ jobs:
                       target: node20-linux
                     - os: win
                       target: node20-win
-        runs-on: ${{ (matrix.arch == 'arm64' && matrix.os == 'linux') && 'ubuntu24-arm64' || 'ubuntu-20.04' }}
+        runs-on: ${{ (matrix.arch == 'arm64' && matrix.os == 'linux') && 'ubuntu24-arm64' || 'ubuntu-latest' }}
 
         steps:
             - name: Checkout code


### PR DESCRIPTION
# Description 📣

We were building the Binary on an amd64 architecture, which resulted in issues when dealing with libraries that use node native bindings (like our own SDK does, and like argon2 does). When using a package that uses native bindings, it uses "optional dependencies", and those will be installed when the package itself is installed via `npm install`.

The way it works is that it checks your OS/arch to figure out which native binding to download, and we were always building on am amd64 architecture. This means that PKG would always bundle the amd64 native bindings, instead of the arch-specific bindings.

The solution for this was creating a self-hosted runner, which will always run on `ubuntu 24.04, arm64`. I've updated the Github workflow to use the self-hosted runner when building for Linux arm64.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->