### PR TITLE
Update envars.mdx - Added PORT

### DIFF
--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -25,6 +25,10 @@ Used to configure platform-specific security and operational settings
   https://app.infisical.com).
 </ParamField>
 
+<ParamField query="PORT" type="int" default="8080" optional>
+  Specifies the internal port on which the application listens.
+</ParamField>
+
 <ParamField query="TELEMETRY_ENABLED" type="string" default="true" optional>
   Telemetry helps us improve Infisical but if you want to dsiable it you may set this to `false`.
 </ParamField>


### PR DESCRIPTION
Added the PORT configuration option to the documentation which controls the port the application listens on.

# Description 📣

Added a missing `PORT` environment variable that changes which port the application listens in on.

I chose to add this because in my Docker deployments I like to specify the external IP with the `PORT` variable in the .env file.

However, when deploying this I was unable to connect to Infisical and after troubleshooting I noticed that the application was also listening on the port configured in the variable rather than the `8080` default. When I checked this documentation I found it was lacking this option.

Please feel free to edit the description text as you see fit.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->