### PR TITLE
Fix updating org role details should not send empty array of permissions

### DIFF
--- a/backend/src/ee/routes/v1/org-role-router.ts
+++ b/backend/src/ee/routes/v1/org-role-router.ts
@@ -107,7 +107,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
           }),
         name: z.string().trim().optional(),
         description: z.string().trim().optional(),
-        permissions: z.any().array()
+        permissions: z.any().array().optional()
       }),
       response: {
         200: z.object({

--- a/frontend/src/hooks/api/roles/mutation.tsx
+++ b/frontend/src/hooks/api/roles/mutation.tsx
@@ -79,7 +79,7 @@ export const useUpdateOrgRole = () => {
         data: { role }
       } = await apiRequest.patch(`/api/v1/organization/${orgId}/roles/${id}`, {
         ...dto,
-        permissions: permissions?.length ? packRules(permissions) : []
+        permissions: permissions?.length ? packRules(permissions) : undefined
       });
 
       return role;


### PR DESCRIPTION
# Description 📣

Previously, when updating Organization Role Details (e.g. name, description, slug), the frontend would send an empty array of permissions for the role to the server — this would in effect clear/reset the permissions on that role.

This PR prevents empty arrays from being sent on the update call and allows the `permissions` field on the PATCH endpoint to be `optional` as it should be for `PATCH`.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->