### PR TITLE
feat(cli): persistant `file` vault passphrase

### DIFF
--- a/cli/packages/cmd/vault.go
+++ b/cli/packages/cmd/vault.go
@@ -9,95 +9,86 @@ import (
 	"strings"
 
 	"github.com/Infisical/infisical-merge/packages/util"
+	"github.com/manifoldco/promptui"
 	"github.com/posthog/posthog-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
-var AvailableVaultsAndDescriptions = []string{"auto (automatically select native vault on system)", "file (encrypted file vault)"}
-var AvailableVaults = []string{"auto", "file"}
+type VaultBackendType struct {
+	Name        string
+	Description string
+}
 
-var vaultSetPassphraseCmd = &cobra.Command{
-	Example:               `infisical vault set-passphrase [your-passphrase]`,
-	Use:                   "set-passphrase [your-passphrase]",
-	Short:                 "Used to set the passphrase for the file vault",
-	DisableFlagsInUseLine: true,
-	Args:                  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			log.Error().Msgf("Please provide a passphrase to set for the file vault")
-			return
-		}
-
-		passphrase := args[0]
-
-		configFile, err := util.GetConfigFile()
-		if err != nil {
-			log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
-			return
-		}
-
-		if configFile.VaultBackendType != "file" {
-			log.Error().Msgf("You are not using file vault to store your login details. You can only set passphrase for file vault")
-			return
-		}
-
-		// encode with base64
-		encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
-		configFile.VaultBackendPassphrase = encodedPassphrase
-
-		err = util.WriteConfigFile(&configFile)
-		if err != nil {
-			log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
-			return
-		}
-
-		fmt.Printf("\nSuccessfully, set passphrase for file vault. You can now store your login details securely at rest\n")
+var AvailableVaults = []VaultBackendType{
+	{
+		Name:        "auto",
+		Description: "automatically select native vault on system",
+	},
+	{
+		Name:        "file",
+		Description: "encrypted file vault",
 	},
 }
 
 var vaultSetCmd = &cobra.Command{
-	Example:               `infisical vault set [file|auto]`,
-	Use:                   "set [file|auto]",
+	Example:               `infisical vault set [file|auto] [option]`,
+	Use:                   "set [file|auto] [option]",
 	Short:                 "Used to set the type of vault backend to store your login details securely at rest",
+	Long:                  "Used to set the type of vault backend to store your login details securely at rest",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		wantedVaultTypeName := args[0]
-		currentVaultBackend, err := util.GetCurrentVaultBackend()
-		if err != nil {
-			log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
-			return
-		}
 
-		if wantedVaultTypeName == string(currentVaultBackend) {
-			log.Error().Msgf("You are already on vault backend [%s]", currentVaultBackend)
-			return
-		}
+		if len(args) >= 2 {
+			vaultType := args[0]
+			option := args[1]
 
-		if wantedVaultTypeName == "auto" || wantedVaultTypeName == "file" {
-			configFile, err := util.GetConfigFile()
-			if err != nil {
-				log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
+			// Todo, add more vault types / configurations
+			if vaultType != util.VAULT_BACKEND_FILE_MODE {
+				log.Error().Msgf("No configuration options are available for vault type [%s]\n", vaultType)
 				return
 			}
 
-			configFile.VaultBackendType = wantedVaultTypeName // save selected vault
-			configFile.LoggedInUserEmail = ""                 // reset the logged in user to prompt them to re login
+			switch option {
+			case "passphrase":
+				{
 
-			err = util.WriteConfigFile(&configFile)
-			if err != nil {
-				log.Error().Msgf("Unable to set vault to [%s] because an error occurred when saving the config file [err=%s]", wantedVaultTypeName, err)
-				return
+					passphrasePrompt := promptui.Prompt{
+						Label: "File vault passphrase",
+					}
+
+					passphrase, err := passphrasePrompt.Run()
+					if err != nil {
+						log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
+						return
+					}
+
+					if passphrase == "" || len(passphrase) < 8 {
+						log.Error().Msgf("Passphrase must be at least 8 characters long")
+						return
+					}
+					setFileVaultPassphrase(passphrase)
+				}
+			default:
+				log.Error().Msgf("Unknown option [%s] for vault set command", option)
 			}
 
-			fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]\n", currentVaultBackend, wantedVaultTypeName)
-
-			Telemetry.CaptureEvent("cli-command:vault set", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("wantedVault", wantedVaultTypeName).Set("version", util.CLI_VERSION))
-		} else {
-			log.Error().Msgf("The requested vault type [%s] is not available on this system. Only the following vault backends are available for you system: %s", wantedVaultTypeName, strings.Join(AvailableVaults, ", "))
+			return
 		}
+
+		fmt.Printf("Warning: This command has been deprecated. Please use 'infisical vault use [file|auto]' to select which vault to use.\n")
+		selectVaultTypeCmd(cmd, args)
 	},
+}
+
+var vaultUseCmd = &cobra.Command{
+	Example:               `infisical vault use [file|auto]`,
+	Use:                   "use [file|auto]",
+	Short:                 "Used to set the type of vault backend to store your login details securely at rest",
+	DisableFlagsInUseLine: true,
+	Args:                  cobra.MinimumNArgs(1),
+	Run:                   selectVaultTypeCmd,
 }
 
 // runCmd represents the run command
@@ -111,10 +102,35 @@ var vaultCmd = &cobra.Command{
 	},
 }
 
+func setFileVaultPassphrase(passphrase string) {
+	configFile, err := util.GetConfigFile()
+	if err != nil {
+		log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
+		return
+	}
+
+	if configFile.VaultBackendType != "file" {
+		log.Error().Msgf("You are not using file vault to store your login details. You can only set passphrase for file vault")
+		return
+	}
+
+	// encode with base64
+	encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
+	configFile.VaultBackendPassphrase = encodedPassphrase
+
+	err = util.WriteConfigFile(&configFile)
+	if err != nil {
+		log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
+		return
+	}
+
+	fmt.Printf("\nSuccessfully, set passphrase for file vault. You can now store your login details securely at rest\n")
+}
+
 func printAvailableVaultBackends() {
 	fmt.Printf("Vaults are used to securely store your login details locally. Available vaults:")
-	for _, backend := range AvailableVaultsAndDescriptions {
-		fmt.Printf("\n- %s", backend)
+	for _, vaultType := range AvailableVaults {
+		fmt.Printf("\n- %s (%s)", vaultType.Name, vaultType.Description)
 	}
 
 	currentVaultBackend, err := util.GetCurrentVaultBackend()
@@ -127,8 +143,50 @@ func printAvailableVaultBackends() {
 	fmt.Printf("\n\nYou are currently using [%s] vault to store your login credentials\n", string(currentVaultBackend))
 }
 
+func selectVaultTypeCmd(cmd *cobra.Command, args []string) {
+	wantedVaultTypeName := args[0]
+	currentVaultBackend, err := util.GetCurrentVaultBackend()
+	if err != nil {
+		log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
+		return
+	}
+
+	if wantedVaultTypeName == string(currentVaultBackend) {
+		log.Error().Msgf("You are already on vault backend [%s]", currentVaultBackend)
+		return
+	}
+
+	if wantedVaultTypeName == util.VAULT_BACKEND_AUTO_MODE || wantedVaultTypeName == util.VAULT_BACKEND_FILE_MODE {
+		configFile, err := util.GetConfigFile()
+		if err != nil {
+			log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
+			return
+		}
+
+		configFile.VaultBackendType = wantedVaultTypeName // save selected vault
+		configFile.LoggedInUserEmail = ""                 // reset the logged in user to prompt them to re login
+
+		err = util.WriteConfigFile(&configFile)
+		if err != nil {
+			log.Error().Msgf("Unable to set vault to [%s] because an error occurred when saving the config file [err=%s]", wantedVaultTypeName, err)
+			return
+		}
+
+		fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]\n", currentVaultBackend, wantedVaultTypeName)
+
+		Telemetry.CaptureEvent("cli-command:vault set", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("wantedVault", wantedVaultTypeName).Set("version", util.CLI_VERSION))
+	} else {
+		var availableVaultsNames []string
+		for _, vault := range AvailableVaults {
+			availableVaultsNames = append(availableVaultsNames, vault.Name)
+		}
+		log.Error().Msgf("The requested vault type [%s] is not available on this system. Only the following vault backends are available for you system: %s", wantedVaultTypeName, strings.Join(availableVaultsNames, ", "))
+	}
+}
+
 func init() {
 	vaultCmd.AddCommand(vaultSetCmd)
-	vaultCmd.AddCommand(vaultSetPassphraseCmd)
+	vaultCmd.AddCommand(vaultUseCmd)
+
 	rootCmd.AddCommand(vaultCmd)
 }

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -11,10 +11,11 @@ type UserCredentials struct {
 
 // The file struct for Infisical config file
 type ConfigFile struct {
-	LoggedInUserEmail  string         `json:"loggedInUserEmail"`
-	LoggedInUserDomain string         `json:"LoggedInUserDomain,omitempty"`
-	LoggedInUsers      []LoggedInUser `json:"loggedInUsers,omitempty"`
-	VaultBackendType   string         `json:"vaultBackendType,omitempty"`
+	LoggedInUserEmail      string         `json:"loggedInUserEmail"`
+	LoggedInUserDomain     string         `json:"LoggedInUserDomain,omitempty"`
+	LoggedInUsers          []LoggedInUser `json:"loggedInUsers,omitempty"`
+	VaultBackendType       string         `json:"vaultBackendType,omitempty"`
+	VaultBackendPassphrase string         `json:"vaultBackendPassphrase,omitempty"`
 }
 
 type LoggedInUser struct {

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -8,6 +8,10 @@ const (
 	INFISICAL_WORKSPACE_CONFIG_FILE_NAME       = ".infisical.json"
 	INFISICAL_TOKEN_NAME                       = "INFISICAL_TOKEN"
 	INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN_NAME = "INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN"
+	INFISICAL_VAULT_FILE_PASSPHRASE_ENV_NAME   = "INFISICAL_VAULT_FILE_PASSPHRASE" // This works because we've forked the keyring package and added support for this env variable. This explains why you won't find any occurrences of it in the CLI codebase.
+
+	VAULT_BACKEND_AUTO_MODE = "auto"
+	VAULT_BACKEND_FILE_MODE = "file"
 
 	// Universal Auth
 	INFISICAL_UNIVERSAL_AUTH_CLIENT_ID_NAME     = "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID"

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -30,8 +30,10 @@ func SetValueInKeyring(key, value string) error {
 	err = keyring.Set(currentVaultBackend, MAIN_KEYRING_SERVICE, key, value)
 
 	if err == keyring.ErrUnsupportedPlatform || keyringNotConfigured(err) {
-		boldGreen := color.New(color.FgGreen).Add(color.Bold)
-		boldGreen.Printf("Warning: Fallback file keyring is being used")
+		boldYellow := color.New(color.FgYellow).Add(color.Bold)
+		boldYellow.Printf("Warning: Fallback file keyring is being used\n\n")
+		boldYellow.Printf("You can persist your file passphrase by running the following command:\n")
+		boldYellow.Printf("infisical vault set file passphrase <your-passphrase>\n\n")
 		err = keyring.Set(VAULT_BACKEND_FILE_MODE, MAIN_KEYRING_SERVICE, key, value)
 	}
 

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -1,10 +1,17 @@
 package util
 
 import (
+	"strings"
+
+	"github.com/fatih/color"
 	"github.com/zalando/go-keyring"
 )
 
 const MAIN_KEYRING_SERVICE = "infisical-cli"
+
+func keyringNotConfigured(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "was not provided by any .service files")
+}
 
 type TimeoutError struct {
 	message string
@@ -20,16 +27,30 @@ func SetValueInKeyring(key, value string) error {
 		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical rest] then try again")
 	}
 
-	return keyring.Set(currentVaultBackend, MAIN_KEYRING_SERVICE, key, value)
+	err = keyring.Set(currentVaultBackend, MAIN_KEYRING_SERVICE, key, value)
+
+	if err == keyring.ErrUnsupportedPlatform || keyringNotConfigured(err) {
+		boldGreen := color.New(color.FgGreen).Add(color.Bold)
+		boldGreen.Printf("Warning: Fallback file keyring is being used")
+		err = keyring.Set(VAULT_BACKEND_FILE_MODE, MAIN_KEYRING_SERVICE, key, value)
+	}
+
+	return err
 }
 
 func GetValueInKeyring(key string) (string, error) {
 	currentVaultBackend, err := GetCurrentVaultBackend()
 	if err != nil {
-		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical rest] then try again")
+		PrintErrorAndExit(1, err, "Unable to get current vault. Tip: run [infisical reset] then try again")
 	}
 
-	return keyring.Get(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+	value, err := keyring.Get(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+
+	if err == keyring.ErrUnsupportedPlatform || keyringNotConfigured(err) {
+		value, err = keyring.Get(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+	}
+	return value, err
+
 }
 
 func DeleteValueInKeyring(key string) error {
@@ -38,5 +59,11 @@ func DeleteValueInKeyring(key string) error {
 		return err
 	}
 
-	return keyring.Delete(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+	err = keyring.Delete(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+
+	if err == keyring.ErrUnsupportedPlatform || keyringNotConfigured(err) {
+		err = keyring.Delete(currentVaultBackend, MAIN_KEYRING_SERVICE, key)
+	}
+
+	return err
 }

--- a/cli/packages/util/vault.go
+++ b/cli/packages/util/vault.go
@@ -11,11 +11,11 @@ func GetCurrentVaultBackend() (string, error) {
 	}
 
 	if configFile.VaultBackendType == "" {
-		return "auto", nil
+		return VAULT_BACKEND_AUTO_MODE, nil
 	}
 
-	if configFile.VaultBackendType != "auto" && configFile.VaultBackendType != "file" {
-		return "auto", nil
+	if configFile.VaultBackendType != VAULT_BACKEND_AUTO_MODE && configFile.VaultBackendType != VAULT_BACKEND_FILE_MODE {
+		return VAULT_BACKEND_AUTO_MODE, nil
 	}
 
 	return configFile.VaultBackendType, nil

--- a/docs/cli/commands/vault.mdx
+++ b/docs/cli/commands/vault.mdx
@@ -32,6 +32,6 @@ description: "Change the vault type in Infisical"
 
 To safeguard your login details when using the CLI, Infisical places them in a system vault or an encrypted text file, protected by a passphrase that only the user knows.
 
-<Tip>To avoid constantly entering your passphrase when using the `file` vault type, set the `INFISICAL_VAULT_FILE_PASSPHRASE` environment variable with your password in your shell</Tip>
+<Tip>To avoid constantly entering your passphrase when using the `file` vault type, use the `infisical vault set file passphrase` CLI command to specify your password once.</Tip>
 
 


### PR DESCRIPTION
# Description 📣

We've been seeing issues with using the CLI keyring vault on certain linux systems, due to a default keyring not being present. Our solution to this has been to point people towards our file-based keyring, which works great except for this:
1. If the keyring fails, and the user hasn't explicitly set the keyring to `file` type, the CLI will throw an error and exit.
2. The user will need to re-enter their passphrase often, unless an environment variable is set to specify it. 

This PR addresses both of these issues.

We've introduced a new command called `vault set [auto|file] passphrase` _(only works with `file` currently)_, which will persist the password entered indefinitely. 

When the keyring get's used, we now have an error check in place that will fallback to the `file` keyring. This means that if something is wrong while using the normal keyring, we'll use the file-based keyring instead. 

## Type ✨

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->