### PR TITLE
misc: added error prompt for fetch secrets issue with kms

### DIFF
--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -108,6 +108,16 @@ export const useGetProjectSecrets = ({
     enabled: Boolean(workspaceId && environment) && (options?.enabled ?? true),
     queryKey: secretKeys.getProjectSecret({ workspaceId, environment, secretPath }),
     queryFn: async () => fetchProjectSecrets({ workspaceId, environment, secretPath }),
+    onError: (error) => {
+      if (axios.isAxiosError(error)) {
+        const serverResponse = error.response?.data as { message: string };
+        createNotification({
+          title: "Error fetching secrets",
+          type: "error",
+          text: serverResponse.message
+        });
+      }
+    },
     select: ({ secrets }) => mergePersonalSecrets(secrets)
   });
 

--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { subject } from "@casl/ability";
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import axios from "axios";
 
 import NavHeader from "@app/components/navigation/NavHeader";
 import { createNotification } from "@app/components/notifications";
@@ -93,7 +94,12 @@ export const SecretMainPage = () => {
   }, [isWorkspaceLoading, currentWorkspace, environment, router.isReady]);
 
   // fetch secrets
-  const { data: secrets, isLoading: isSecretsLoading } = useGetProjectSecrets({
+  const {
+    data: secrets,
+    isLoading: isSecretsLoading,
+    isError: isErrorFetchingSecrets,
+    error: fetchSecretsError
+  } = useGetProjectSecrets({
     environment,
     workspaceId,
     secretPath,
@@ -101,6 +107,17 @@ export const SecretMainPage = () => {
       enabled: canReadSecret
     }
   });
+
+  if (isErrorFetchingSecrets) {
+    if (axios.isAxiosError(fetchSecretsError)) {
+      const serverResponse = fetchSecretsError.response?.data as { message: string };
+      createNotification({
+        title: "Error fetching secrets",
+        type: "error",
+        text: serverResponse.message
+      });
+    }
+  }
 
   // fetch folders
   const { data: folders, isLoading: isFoldersLoading } = useGetProjectFolders({

--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router";
 import { subject } from "@casl/ability";
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import axios from "axios";
 
 import NavHeader from "@app/components/navigation/NavHeader";
 import { createNotification } from "@app/components/notifications";
@@ -94,12 +93,7 @@ export const SecretMainPage = () => {
   }, [isWorkspaceLoading, currentWorkspace, environment, router.isReady]);
 
   // fetch secrets
-  const {
-    data: secrets,
-    isLoading: isSecretsLoading,
-    isError: isErrorFetchingSecrets,
-    error: fetchSecretsError
-  } = useGetProjectSecrets({
+  const { data: secrets, isLoading: isSecretsLoading } = useGetProjectSecrets({
     environment,
     workspaceId,
     secretPath,
@@ -107,17 +101,6 @@ export const SecretMainPage = () => {
       enabled: canReadSecret
     }
   });
-
-  if (isErrorFetchingSecrets) {
-    if (axios.isAxiosError(fetchSecretsError)) {
-      const serverResponse = fetchSecretsError.response?.data as { message: string };
-      createNotification({
-        title: "Error fetching secrets",
-        type: "error",
-        text: serverResponse.message
-      });
-    }
-  }
 
   // fetch folders
   const { data: folders, isLoading: isFoldersLoading } = useGetProjectFolders({

--- a/frontend/src/views/SecretOverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
@@ -33,7 +33,7 @@ export const SecretV2MigrationSection = () => {
     currentWorkspace?.version === ProjectVersion.V3 ? "" : currentWorkspace?.id || "",
     {
       refetchInterval:
-        currentWorkspace?.upgradeStatus === ProjectUpgradeStatus.InProgress ? 3000 : false
+        currentWorkspace?.upgradeStatus === ProjectUpgradeStatus.InProgress ? 2000 : false
     }
   );
   const { membership } = useProjectPermission();


### PR DESCRIPTION
# Description 📣
- in this PR, error notification prompts will show up in secrets overview and secrets main page when secrets cannot be fetched 
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/213c760b-bfc4-445a-917f-53491bda8cfc">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->