### PR TITLE
refactor(secret-key-input): pass `isRequired` prop to secret key input

### DIFF
--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -82,8 +82,8 @@ export const CreateSecretForm = ({
         title="Create secret"
         subTitle="Add a secret to the particular environment and folder"
       >
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <FormControl label="Key" isError={Boolean(errors?.key)} errorText={errors?.key?.message}>
+        <form onSubmit={handleSubmit(handleFormSubmit)} noValidate>
+          <FormControl label="Key" isRequired isError={Boolean(errors?.key)} errorText={errors?.key?.message}>
             <Input
               {...register("key")}
               placeholder="Type your secret name"

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -140,8 +140,8 @@ export const CreateSecretForm = ({
         title="Bulk Create & Update"
         subTitle="Create & update a secret across many environments"
       >
-        <form onSubmit={handleSubmit(handleFormSubmit)}>
-          <FormControl label="Key" isError={Boolean(errors?.key)} errorText={errors?.key?.message}>
+        <form onSubmit={handleSubmit(handleFormSubmit)} noValidate>
+          <FormControl label="Key" isRequired isError={Boolean(errors?.key)} errorText={errors?.key?.message}>
             <Input
               {...register("key")}
               placeholder="Type your secret name"


### PR DESCRIPTION
# Description 📣

This PR enhances the user experience and accessibility of our secret creation forms by passing `isRequired` prop to `FormControl`. The `noValidate` attribute disables the browser's built-in form validation. This allows custom error messages from `react-hook-form` to be displayed instead of the default browser messages with keeping accessibility benefits(screen readers will announce that fields with `required` attribute set are required). In this implementation, form validation is handled independently using the Zod library, without relying on the browser's validation mechanisms.



### Before:
![CleanShot 2024-08-01 at 06 16 38@2x](https://github.com/user-attachments/assets/992fd9f0-2640-41f1-b173-46b004252baf)

### After:
![CleanShot 2024-08-01 at 06 17 37@2x](https://github.com/user-attachments/assets/734d00b7-387b-47d1-a448-cc8de70769bb)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->