### PR TITLE
feat: parse secrets (key,value) on paste

### DIFF
--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -1,26 +1,14 @@
 /** Extracts the key and value from a passed in env string based on the provided delimiters. */
 export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
-  let splitIndex = -1
-  let key = ""
-  let value = ""
+  const foundDelimiter = delimiters.find((delimiter) => pastedContent.includes(delimiter));
 
-  for (const delimiter of delimiters) {
-    const idx = pastedContent.indexOf(delimiter)
-
-    if (idx !== -1) {
-      splitIndex = idx
-      break;
-    }
+  if (!foundDelimiter) {
+    return { key: pastedContent.trim(), value: "" };
   }
 
-  // if only key is pasted
-  if (splitIndex === -1) {
-    key = pastedContent.trim()
-    return { key, value: "" }
-  }
-
-  key = pastedContent.slice(0, splitIndex).trim()
-  value = pastedContent.slice(splitIndex + 1).trim()
-
-  return { key, value }
+  const [key, value] = pastedContent.split(foundDelimiter);
+  return {
+    key: key.trim(),
+    value: (value ?? "").trim()
+  };
 };

--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -1,0 +1,26 @@
+/** Extracts the key and value from a passed in env string based on the provided delimiters. */
+export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
+  let splitIndex = -1
+  let key = ""
+  let value = ""
+
+  for (const delimiter of delimiters) {
+    const idx = pastedContent.indexOf(delimiter)
+
+    if (idx !== -1) {
+      splitIndex = idx
+      break;
+    }
+  }
+
+  // if only key is pasted
+  if (splitIndex === -1) {
+    key = pastedContent.trim()
+    return { key, value: "" }
+  }
+
+  key = pastedContent.slice(0, splitIndex).trim()
+  value = pastedContent.slice(splitIndex + 1).trim()
+
+  return { key, value }
+};

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -80,7 +80,7 @@ export const CreateSecretForm = ({
     const pastedContent = e.clipboardData.getData('text');
     const splitIndex = pastedContent.indexOf("=");
 
-    if (splitIndex == -1) return
+    if (splitIndex === -1) return
 
     const key = pastedContent.slice(0, splitIndex)
     const value = pastedContent.slice(splitIndex + 1);

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -1,3 +1,4 @@
+import { ClipboardEvent } from 'react';
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -38,6 +39,7 @@ export const CreateSecretForm = ({
     handleSubmit,
     control,
     reset,
+    setValue,
     formState: { errors, isSubmitting }
   } = useForm<TFormSchema>({ resolver: zodResolver(typeSchema) });
   const { isOpen } = usePopUpState(PopUpNames.CreateSecretForm);
@@ -73,6 +75,20 @@ export const CreateSecretForm = ({
     }
   };
 
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pastedContent = e.clipboardData.getData('text');
+    const splitIndex = pastedContent.indexOf("=");
+
+    if (splitIndex == -1) return
+
+    const key = pastedContent.slice(0, splitIndex)
+    const value = pastedContent.slice(splitIndex + 1);
+
+    setValue('key', key);
+    setValue('value', value);
+  }
+
   return (
     <Modal
       isOpen={isOpen}
@@ -87,6 +103,7 @@ export const CreateSecretForm = ({
             <Input
               {...register("key")}
               placeholder="Type your secret name"
+              onPaste={handlePaste}
               autoCapitalization={autoCapitalize}
             />
           </FormControl>

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -8,6 +8,7 @@ import { Button, FormControl, Input, Modal, ModalContent } from "@app/components
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import { useCreateSecretV3 } from "@app/hooks/api";
 import { SecretType } from "@app/hooks/api/types";
+import { getKeyValue } from '@app/helpers/parseEnvVar';
 
 import { PopUpNames, usePopUpAction, usePopUpState } from "../../SecretMainPage.store";
 
@@ -77,16 +78,12 @@ export const CreateSecretForm = ({
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
-    const pastedContent = e.clipboardData.getData('text');
-    const splitIndex = pastedContent.indexOf("=");
+    const delimitters = [":", "="];
+    const pastedContent = e.clipboardData.getData("text");
+    const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    if (splitIndex === -1) return
-
-    const key = pastedContent.slice(0, splitIndex)
-    const value = pastedContent.slice(splitIndex + 1);
-
-    setValue('key', key);
-    setValue('value', value);
+    setValue("key", key);
+    setValue("value", value);
   }
 
   return (

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -141,7 +141,7 @@ export const CreateSecretForm = ({
     const pastedContent = e.clipboardData.getData('text');
     const splitIndex = pastedContent.indexOf("=");
 
-    if (splitIndex == -1) return
+    if (splitIndex === -1) return
 
     const key = pastedContent.slice(0, splitIndex)
     const value = pastedContent.slice(splitIndex + 1);

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -20,6 +20,7 @@ import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import { useWorkspace } from "@app/context";
 import { useCreateFolder, useCreateSecretV3, useUpdateSecretV3 } from "@app/hooks/api";
 import { SecretType,SecretV3RawSanitized } from "@app/hooks/api/types";
+import { getKeyValue } from '@app/helpers/parseEnvVar';
 
 const typeSchema = z
   .object({
@@ -138,16 +139,12 @@ export const CreateSecretForm = ({
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
-    const pastedContent = e.clipboardData.getData('text');
-    const splitIndex = pastedContent.indexOf("=");
+    const delimitters = [":", "="];
+    const pastedContent = e.clipboardData.getData("text");
+    const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    if (splitIndex === -1) return
-
-    const key = pastedContent.slice(0, splitIndex)
-    const value = pastedContent.slice(splitIndex + 1);
-
-    setValue('key', key);
-    setValue('value', value);
+    setValue("key", key);
+    setValue("value", value);
   }
 
   return (

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -1,3 +1,4 @@
+import { ClipboardEvent } from 'react';
 import { Controller, useForm } from "react-hook-form";
 import { faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -54,6 +55,7 @@ export const CreateSecretForm = ({
     control,
     reset,
     watch,
+    setValue,
     formState: { isSubmitting, errors }
   } = useForm<TFormSchema>({ resolver: zodResolver(typeSchema) });
   const newSecretKey = watch("key");
@@ -133,6 +135,21 @@ export const CreateSecretForm = ({
       });
     }
   };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pastedContent = e.clipboardData.getData('text');
+    const splitIndex = pastedContent.indexOf("=");
+
+    if (splitIndex == -1) return
+
+    const key = pastedContent.slice(0, splitIndex)
+    const value = pastedContent.slice(splitIndex + 1);
+
+    setValue('key', key);
+    setValue('value', value);
+  }
+
   return (
     <Modal isOpen={isOpen} onOpenChange={onTogglePopUp}>
       <ModalContent
@@ -145,6 +162,7 @@ export const CreateSecretForm = ({
             <Input
               {...register("key")}
               placeholder="Type your secret name"
+              onPaste={handlePaste}
               autoCapitalization={currentWorkspace?.autoCapitalization}
             />
           </FormControl>


### PR DESCRIPTION
# Description 📣

Parse Env Secret when Pasting from the clipboard. Splits the secret from the first "=" sign.

As Vercel does it.

# Video

https://github.com/user-attachments/assets/0c7aed76-ac7f-4547-9258-4695937ed3ac


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->