### PR TITLE
misc: addressed reported flaws with CLI usage

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -155,22 +155,24 @@ var secretsSetCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		util.RequireLocalWorkspaceFile()
-
-		environmentName, _ := cmd.Flags().GetString("env")
-		if !cmd.Flags().Changed("env") {
-			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
-			if environmentFromWorkspace != "" {
-				environmentName = environmentFromWorkspace
-			}
-		}
-
 		token, err := util.GetInfisicalToken(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		if (token == nil) {
+			util.RequireLocalWorkspaceFile()
+		}
+
+		environmentName, _ := cmd.Flags().GetString("env")
+		if !cmd.Flags().Changed("env") {
+			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()	
+			if environmentFromWorkspace != "" {
+				environmentName = environmentFromWorkspace
+			}
+		}
+
+				projectId, err := cmd.Flags().GetString("projectId")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -415,11 +415,13 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		if value, ok := secretsMap[secretKeyFromArg]; ok {
 			requestedSecrets = append(requestedSecrets, value)
 		} else {
-			requestedSecrets = append(requestedSecrets, models.SingleEnvironmentVariable{
-				Key:   secretKeyFromArg,
-				Type:  "*not found*",
-				Value: "*not found*",
-			})
+			if !(plainOutput || showOnlyValue) {
+				requestedSecrets = append(requestedSecrets, models.SingleEnvironmentVariable{
+					Key:   secretKeyFromArg,
+					Type:  "*not found*",
+					Value: "*not found*",
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description 📣

This PR addresses two issues in the CLI:
1. `secrets set` command requiring local workspace config file even when using auth tokens
2. "not-found" texts are being displayed during `secrets get` even with the `--plain` flag

The PR also adds an API for fetching project ID by slug or name which will make CLI usage easier to automate


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->