### PR TITLE
patch findProjectUserWorkspaceKey

### DIFF
--- a/backend/src/services/project-bot/project-bot-dal.ts
+++ b/backend/src/services/project-bot/project-bot-dal.ts
@@ -46,6 +46,7 @@ export const projectBotDALFactory = (db: TDbClient) => {
       const doc = await db
         .replicaNode()(TableName.ProjectMembership)
         .where(`${TableName.ProjectMembership}.projectId` as "projectId", projectId)
+        .where(`${TableName.ProjectKeys}.projectId` as "projectId", projectId)
         .where(`${TableName.Users}.isGhost` as "isGhost", false)
         .join(TableName.Users, `${TableName.ProjectMembership}.userId`, `${TableName.Users}.id`)
         .join(TableName.ProjectKeys, `${TableName.ProjectMembership}.userId`, `${TableName.ProjectKeys}.receiverId`)


### PR DESCRIPTION
Before we used to select any one of the project keys the user is apart of but this is incorrect because we need to only choose the project key for the project we are querying for. This pr adds another query to further scope the request.

Credits to: AKHI!