### PR TITLE
Patch CLI auto select file vault 

### DIFF
--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -39,13 +39,15 @@ func SetValueInKeyring(key, value string) error {
 			if err != nil {
 				return err
 			}
+			encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
+			configFile.VaultBackendPassphrase = encodedPassphrase
 			configFile.VaultBackendType = VAULT_BACKEND_FILE_MODE
-			err = WriteConfigFile(&configFile)
 			if err != nil {
 				return err
 			}
 
-			os.Setenv("INFISICAL_VAULT_FILE_PASSPHRASE", passphrase)
+			// We call this function at last to trigger the environment variable to be set
+			GetConfigFile()
 		}
 
 		err = keyring.Set(VAULT_BACKEND_FILE_MODE, MAIN_KEYRING_SERVICE, key, value)

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -33,7 +33,7 @@ func SetValueInKeyring(key, value string) error {
 
 		if configFile.VaultBackendPassphrase == "" {
 			passphrasePrompt := promptui.Prompt{
-				Label: "Enter a passphrase to protect your local backup secrets & login access token",
+				Label: "Enter a passphrase to protect your local secret backups & login access token",
 			}
 			passphrase, err := passphrasePrompt.Run()
 			if err != nil {

--- a/cli/packages/util/keyringwrapper.go
+++ b/cli/packages/util/keyringwrapper.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"encoding/base64"
 	"fmt"
+	"os"
 
 	"github.com/manifoldco/promptui"
 	"github.com/rs/zerolog/log"
@@ -33,23 +33,19 @@ func SetValueInKeyring(key, value string) error {
 
 		if configFile.VaultBackendPassphrase == "" {
 			passphrasePrompt := promptui.Prompt{
-				Label: "Enter a passphrase to protect your local secret backups & login access token",
+				Label: "Enter a passphrase to encrypt sensitive CLI data at rest",
 			}
 			passphrase, err := passphrasePrompt.Run()
 			if err != nil {
 				return err
 			}
-
-			encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
-			configFile.VaultBackendPassphrase = encodedPassphrase
 			configFile.VaultBackendType = VAULT_BACKEND_FILE_MODE
 			err = WriteConfigFile(&configFile)
 			if err != nil {
 				return err
 			}
 
-			// We call this function at last to trigger the environment variable to be set
-			GetConfigFile()
+			os.Setenv("INFISICAL_VAULT_FILE_PASSPHRASE", passphrase)
 		}
 
 		err = keyring.Set(VAULT_BACKEND_FILE_MODE, MAIN_KEYRING_SERVICE, key, value)


### PR DESCRIPTION
# Description 📣

When we auto select file vault, we also need to set it's type. When we set the type, we don't need to fall back to file vault in the `GetValueInKeyring` and `DeleteValueInKeyring` because `currentVaultBackend` will be `file`. 

Also rephrased the text asking the user to eneter a passphrase.