### PR TITLE
Resolved keyring dataset too big by keeping only the encryption key

### DIFF
--- a/cli/packages/cmd/vault.go
+++ b/cli/packages/cmd/vault.go
@@ -31,37 +31,52 @@ var AvailableVaults = []VaultBackendType{
 }
 
 var vaultSetCmd = &cobra.Command{
-	Example:               `infisical vault set file --passphrase <your-passphrase>`,
-	Use:                   "set [file|auto] [flags]",
+	Example:               `infisical vault set file`,
+	Use:                   "set [file|auto]",
 	Short:                 "Used to configure the vault backends",
 	DisableFlagsInUseLine: true,
 	Args:                  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-
-		vaultType := args[0]
-
-		passphrase, err := cmd.Flags().GetString("passphrase")
+		wantedVaultTypeName := args[0]
+		currentVaultBackend, err := util.GetCurrentVaultBackend()
 		if err != nil {
-			util.HandleError(err, "Unable to get passphrase flag")
-		}
-
-		if vaultType == util.VAULT_BACKEND_FILE_MODE && passphrase != "" {
-			setFileVaultPassphrase(passphrase)
+			log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
 			return
 		}
 
-		util.PrintWarning("This command has been deprecated. Please use 'infisical vault use [file|auto]' to select which vault to use.\n")
-		selectVaultTypeCmd(cmd, args)
-	},
-}
+		if wantedVaultTypeName == string(currentVaultBackend) {
+			log.Error().Msgf("You are already on vault backend [%s]", currentVaultBackend)
+			return
+		}
 
-var vaultUseCmd = &cobra.Command{
-	Example:               `infisical vault use [file|auto]`,
-	Use:                   "use [file|auto]",
-	Short:                 "Used to select the the type of vault backend to store sensitive data securely at rest",
-	DisableFlagsInUseLine: true,
-	Args:                  cobra.MinimumNArgs(1),
-	Run:                   selectVaultTypeCmd,
+		if wantedVaultTypeName == util.VAULT_BACKEND_AUTO_MODE || wantedVaultTypeName == util.VAULT_BACKEND_FILE_MODE {
+			configFile, err := util.GetConfigFile()
+			if err != nil {
+				log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
+				return
+			}
+
+			configFile.VaultBackendType = wantedVaultTypeName
+			configFile.LoggedInUserEmail = ""
+			configFile.VaultBackendPassphrase = base64.StdEncoding.EncodeToString([]byte(util.GenerateRandomString(10)))
+
+			err = util.WriteConfigFile(&configFile)
+			if err != nil {
+				log.Error().Msgf("Unable to set vault to [%s] because an error occurred when saving the config file [err=%s]", wantedVaultTypeName, err)
+				return
+			}
+
+			fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]\n", currentVaultBackend, wantedVaultTypeName)
+
+			Telemetry.CaptureEvent("cli-command:vault set", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("wantedVault", wantedVaultTypeName).Set("version", util.CLI_VERSION))
+		} else {
+			var availableVaultsNames []string
+			for _, vault := range AvailableVaults {
+				availableVaultsNames = append(availableVaultsNames, vault.Name)
+			}
+			log.Error().Msgf("The requested vault type [%s] is not available on this system. Only the following vault backends are available for you system: %s", wantedVaultTypeName, strings.Join(availableVaultsNames, ", "))
+		}
+	},
 }
 
 // runCmd represents the run command
@@ -73,26 +88,6 @@ var vaultCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		printAvailableVaultBackends()
 	},
-}
-
-func setFileVaultPassphrase(passphrase string) {
-	configFile, err := util.GetConfigFile()
-	if err != nil {
-		log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
-		return
-	}
-
-	// encode with base64
-	encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
-	configFile.VaultBackendPassphrase = encodedPassphrase
-
-	err = util.WriteConfigFile(&configFile)
-	if err != nil {
-		log.Error().Msgf("Unable to set passphrase for file vault because of [err=%s]", err)
-		return
-	}
-
-	util.PrintSuccessMessage("\nSuccessfully, set passphrase for file vault.\n")
 }
 
 func printAvailableVaultBackends() {
@@ -111,53 +106,8 @@ func printAvailableVaultBackends() {
 	fmt.Printf("\n\nYou are currently using [%s] vault to store your login credentials\n", string(currentVaultBackend))
 }
 
-func selectVaultTypeCmd(cmd *cobra.Command, args []string) {
-	wantedVaultTypeName := args[0]
-	currentVaultBackend, err := util.GetCurrentVaultBackend()
-	if err != nil {
-		log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
-		return
-	}
-
-	if wantedVaultTypeName == string(currentVaultBackend) {
-		log.Error().Msgf("You are already on vault backend [%s]", currentVaultBackend)
-		return
-	}
-
-	if wantedVaultTypeName == util.VAULT_BACKEND_AUTO_MODE || wantedVaultTypeName == util.VAULT_BACKEND_FILE_MODE {
-		configFile, err := util.GetConfigFile()
-		if err != nil {
-			log.Error().Msgf("Unable to set vault to [%s] because of [err=%s]", wantedVaultTypeName, err)
-			return
-		}
-
-		configFile.VaultBackendType = wantedVaultTypeName // save selected vault
-		configFile.LoggedInUserEmail = ""                 // reset the logged in user to prompt them to re login
-
-		err = util.WriteConfigFile(&configFile)
-		if err != nil {
-			log.Error().Msgf("Unable to set vault to [%s] because an error occurred when saving the config file [err=%s]", wantedVaultTypeName, err)
-			return
-		}
-
-		fmt.Printf("\nSuccessfully, switched vault backend from [%s] to [%s]. Please login in again to store your login details in the new vault with [infisical login]\n", currentVaultBackend, wantedVaultTypeName)
-
-		Telemetry.CaptureEvent("cli-command:vault set", posthog.NewProperties().Set("currentVault", currentVaultBackend).Set("wantedVault", wantedVaultTypeName).Set("version", util.CLI_VERSION))
-	} else {
-		var availableVaultsNames []string
-		for _, vault := range AvailableVaults {
-			availableVaultsNames = append(availableVaultsNames, vault.Name)
-		}
-		log.Error().Msgf("The requested vault type [%s] is not available on this system. Only the following vault backends are available for you system: %s", wantedVaultTypeName, strings.Join(availableVaultsNames, ", "))
-	}
-}
-
 func init() {
-
-	vaultSetCmd.Flags().StringP("passphrase", "p", "", "Set the passphrase for the file vault")
-
 	vaultCmd.AddCommand(vaultSetCmd)
-	vaultCmd.AddCommand(vaultUseCmd)
 
 	rootCmd.AddCommand(vaultCmd)
 }

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -38,7 +38,9 @@ const (
 	SERVICE_TOKEN_IDENTIFIER        = "service-token"
 	UNIVERSAL_AUTH_TOKEN_IDENTIFIER = "universal-auth-token"
 
-	INFISICAL_BACKUP_SECRET = "infisical-backup-secrets"
+	// akhilmhdh: @depreciated remove in version v0.30
+	INFISICAL_BACKUP_SECRET                = "infisical-backup-secrets"
+	INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY = "infisical-backup-secret-encryption-key"
 )
 
 var (

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -38,8 +38,7 @@ const (
 	SERVICE_TOKEN_IDENTIFIER        = "service-token"
 	UNIVERSAL_AUTH_TOKEN_IDENTIFIER = "universal-auth-token"
 
-	// akhilmhdh: @depreciated remove in version v0.30
-	INFISICAL_BACKUP_SECRET                = "infisical-backup-secrets"
+	INFISICAL_BACKUP_SECRET                = "infisical-backup-secrets" // akhilmhdh: @depreciated remove in version v0.30
 	INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY = "infisical-backup-secret-encryption-key"
 )
 

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -24,6 +25,8 @@ type DecodedSymmetricEncryptionDetails = struct {
 	Tag    []byte
 	Key    []byte
 }
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func GetBase64DecodedSymmetricEncryptionDetails(key string, cipher string, IV string, tag string) (DecodedSymmetricEncryptionDetails, error) {
 	cipherx, err := base64.StdEncoding.DecodeString(cipher)
@@ -286,4 +289,12 @@ func GetCmdFlagOrEnv(cmd *cobra.Command, flag, envName string) (string, error) {
 		return "", fmt.Errorf("please provide %s flag", flag)
 	}
 	return value, nil
+}
+
+func GenerateRandomString(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
 }

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -1,14 +1,15 @@
 package util
 
 import (
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"regexp"
-	"slices"
 	"strings"
 	"unicode"
 
@@ -285,18 +286,25 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 		log.Debug().Msgf("GetAllEnvironmentVariables: Trying to fetch secrets JTW token [err=%s]", err)
 
 		if err == nil {
-			WriteBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath, res.Secrets)
+			backupEncryptionKey, err := GetBackupEncryptionKey()
+			if err != nil {
+				return nil, err
+			}
+			WriteBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey, res.Secrets)
 		}
 
 		secretsToReturn = res.Secrets
 		errorToReturn = err
 		// only attempt to serve cached secrets if no internet connection and if at least one secret cached
 		if !isConnected {
-			backedSecrets, err := ReadBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath)
-			if len(backedSecrets) > 0 {
-				PrintWarning("Unable to fetch latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug")
-				secretsToReturn = backedSecrets
-				errorToReturn = err
+			backupEncryptionKey, _ := GetBackupEncryptionKey()
+			if backupEncryptionKey != nil {
+				backedSecrets, err := ReadBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey)
+				if len(backedSecrets) > 0 {
+					PrintWarning("Unable to fetch latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug")
+					secretsToReturn = backedSecrets
+					errorToReturn = err
+				}
 			}
 		}
 
@@ -476,71 +484,90 @@ func OverrideSecrets(secrets []models.SingleEnvironmentVariable, secretType stri
 	return secretsToReturn
 }
 
-func WriteBackupSecrets(workspace string, environment string, secretsPath string, secrets []models.SingleEnvironmentVariable) error {
-	var backedUpSecrets []models.BackupSecretKeyRing
-	secretValueInKeyRing, err := GetValueInKeyring(INFISICAL_BACKUP_SECRET)
+func GetBackupEncryptionKey() ([]byte, error) {
+	encryptionKey, err := GetValueInKeyring(INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY)
 	if err != nil {
 		if err == keyring.ErrUnsupportedPlatform {
-			return errors.New("your OS does not support keyring. Consider using a service token https://infisical.com/docs/documentation/platform/token")
-		} else if err != keyring.ErrNotFound {
-			return fmt.Errorf("something went wrong, failed to retrieve value from system keyring [error=%v]", err)
+			return nil, errors.New("your OS does not support keyring. Consider using a service token https://infisical.com/docs/documentation/platform/token")
+		} else if err == keyring.ErrNotFound {
+			// generate a new key
+			randomizedKey := make([]byte, 16)
+			rand.Read(randomizedKey)
+			encryptionKey = hex.EncodeToString(randomizedKey)
+			if err := SetValueInKeyring(INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY, encryptionKey); err != nil {
+				return nil, err
+			}
+			return []byte(encryptionKey), nil
+		} else {
+			return nil, fmt.Errorf("something went wrong, failed to retrieve value from system keyring [error=%v]", err)
 		}
 	}
-	_ = json.Unmarshal([]byte(secretValueInKeyRing), &backedUpSecrets)
+	return []byte(encryptionKey), nil
+}
 
-	backedUpSecrets = slices.DeleteFunc(backedUpSecrets, func(e models.BackupSecretKeyRing) bool {
-		return e.SecretPath == secretsPath && e.ProjectID == workspace && e.Environment == environment
-	})
-	newBackupSecret := models.BackupSecretKeyRing{
-		ProjectID:   workspace,
-		Environment: environment,
-		SecretPath:  secretsPath,
-		Secrets:     secrets,
-	}
-	backedUpSecrets = append(backedUpSecrets, newBackupSecret)
+func WriteBackupSecrets(workspace string, environment string, secretsPath string, encryptionKey []byte, secrets []models.SingleEnvironmentVariable) error {
+	formattedPath := strings.ReplaceAll(secretsPath, "/", "-")
+	fileName := fmt.Sprintf("project_secrets_%s_%s_%s.json", workspace, environment, formattedPath)
+	secrets_backup_folder_name := "secrets-backup"
 
-	listOfSecretsMarshalled, err := json.Marshal(backedUpSecrets)
+	_, fullConfigFileDirPath, err := GetFullConfigFilePath()
 	if err != nil {
-		return err
+		return fmt.Errorf("WriteBackupSecrets: unable to get full config folder path [err=%s]", err)
 	}
 
-	err = SetValueInKeyring(INFISICAL_BACKUP_SECRET, string(listOfSecretsMarshalled))
+	// create secrets backup directory
+	fullPathToSecretsBackupFolder := fmt.Sprintf("%s/%s", fullConfigFileDirPath, secrets_backup_folder_name)
+	if _, err := os.Stat(fullPathToSecretsBackupFolder); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(fullPathToSecretsBackupFolder, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	marshaledSecrets, _ := json.Marshal(secrets)
+	result, err := crypto.EncryptSymmetric(marshaledSecrets, encryptionKey)
+	listOfSecretsMarshalled, _ := json.Marshal(result)
+	err = os.WriteFile(fmt.Sprintf("%s/%s", fullPathToSecretsBackupFolder, fileName), listOfSecretsMarshalled, 0600)
 	if err != nil {
-		return fmt.Errorf("StoreUserCredsInKeyRing: unable to store user credentials because [err=%s]", err)
+		return fmt.Errorf("WriteBackupSecrets: Unable to write backup secrets to file [err=%s]", err)
 	}
 
 	return nil
 }
 
-func ReadBackupSecrets(workspace string, environment string, secretsPath string) ([]models.SingleEnvironmentVariable, error) {
-	secretValueInKeyRing, err := GetValueInKeyring(INFISICAL_BACKUP_SECRET)
+func ReadBackupSecrets(workspace string, environment string, secretsPath string, encryptionKey []byte) ([]models.SingleEnvironmentVariable, error) {
+	formattedPath := strings.ReplaceAll(secretsPath, "/", "-")
+	fileName := fmt.Sprintf("project_secrets_%s_%s_%s.json", workspace, environment, formattedPath)
+	secrets_backup_folder_name := "secrets-backup"
+
+	_, fullConfigFileDirPath, err := GetFullConfigFilePath()
 	if err != nil {
-		if err == keyring.ErrUnsupportedPlatform {
-			return nil, errors.New("your OS does not support keyring. Consider using a service token https://infisical.com/docs/documentation/platform/token")
-		} else if err == keyring.ErrNotFound {
-			return nil, errors.New("credentials not found in system keyring")
-		} else {
-			return nil, fmt.Errorf("something went wrong, failed to retrieve value from system keyring [error=%v]", err)
-		}
+		return nil, fmt.Errorf("ReadBackupSecrets: unable to write config file because an error occurred when getting config file path [err=%s]", err)
 	}
 
-	var backedUpSecrets []models.BackupSecretKeyRing
-	err = json.Unmarshal([]byte(secretValueInKeyRing), &backedUpSecrets)
+	fullPathToSecretsBackupFolder := fmt.Sprintf("%s/%s", fullConfigFileDirPath, secrets_backup_folder_name)
+	if _, err := os.Stat(fullPathToSecretsBackupFolder); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	encryptedBackupSecretsFilePath := fmt.Sprintf("%s/%s", fullPathToSecretsBackupFolder, fileName)
+
+	encryptedBackupSecretsAsBytes, err := os.ReadFile(encryptedBackupSecretsFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("getUserCredsFromKeyRing: Something went wrong when unmarshalling user creds [err=%s]", err)
+		return nil, err
 	}
 
-	for _, backupSecret := range backedUpSecrets {
-		if backupSecret.Environment == environment && backupSecret.ProjectID == workspace && backupSecret.SecretPath == secretsPath {
-			return backupSecret.Secrets, nil
-		}
-	}
+	var encryptedBackUpSecrets models.SymmetricEncryptionResult
+	_ = json.Unmarshal(encryptedBackupSecretsAsBytes, &encryptedBackUpSecrets)
+	result, err := crypto.DecryptSymmetric(encryptionKey, encryptedBackUpSecrets.CipherText, encryptedBackUpSecrets.AuthTag, encryptedBackUpSecrets.Nonce)
 
-	return nil, nil
+	var plainTextSecrets []models.SingleEnvironmentVariable
+	_ = json.Unmarshal(result, &plainTextSecrets)
+
+	return plainTextSecrets, nil
+
 }
 
 func DeleteBackupSecrets() error {
-	// keeping this logic for now. Need to remove it later as more users migrate keyring would be used and this folder will be removed completely by then
 	secrets_backup_folder_name := "secrets-backup"
 
 	_, fullConfigFileDirPath, err := GetFullConfigFilePath()
@@ -549,8 +576,8 @@ func DeleteBackupSecrets() error {
 	}
 
 	fullPathToSecretsBackupFolder := fmt.Sprintf("%s/%s", fullConfigFileDirPath, secrets_backup_folder_name)
-
 	DeleteValueInKeyring(INFISICAL_BACKUP_SECRET)
+	DeleteValueInKeyring(INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY)
 
 	return os.RemoveAll(fullPathToSecretsBackupFolder)
 }

--- a/docs/cli/commands/vault.mdx
+++ b/docs/cli/commands/vault.mdx
@@ -30,8 +30,5 @@ description: "Change the vault type in Infisical"
 
 ## Description
 
-To safeguard your login details when using the CLI, Infisical places them in a system vault or an encrypted text file, protected by a passphrase that only the user knows.
-
-<Tip>To avoid constantly entering your passphrase when using the `file` vault type, use the `infisical vault set file --passphrase <your-passphrase>` CLI command to specify your password once.</Tip>
-
+To safeguard your login details when using the CLI, Infisical attempts to store them in a system keyring. If a system keyring cannot be found on your machine, the data is stored in a config file.
 


### PR DESCRIPTION
# Description 📣

This PR fixes a major issue in CLI that got popped up due to recent release. Some of the users who started using  it suddenly ended up having the new fallback vault when doing normal commands like `run` etc. This caused a big hit on user experience. The fallback should not have triggered because else login would not have happened. 

The root issue was the switch from backup secret for offline access towards the keyring. According to docs keyring cannot sustain more than 3kb in mac. Thus total payload going more than that would fail. This is why we couldn't reproduce this on our end initially. To resolve this we moved back to old way but the encryption key is saved in keyring now.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->