### PR TITLE
feat(identities/machine): add ability to disable a machine identity

### DIFF
--- a/backend/src/db/migrations/20240808151815_identity-add-is-disabled-field.ts
+++ b/backend/src/db/migrations/20240808151815_identity-add-is-disabled-field.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.Identity, "isDisabled"))) {
+    await knex.schema.alterTable(TableName.Identity, (tb) => {
+      tb.boolean("isDisabled").notNullable().defaultTo(false);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.Identity, "isDisabled")) {
+    await knex.schema.alterTable(TableName.Identity, (t) => {
+      t.dropColumn("isDisabled");
+    });
+  }
+}

--- a/backend/src/db/schemas/identities.ts
+++ b/backend/src/db/schemas/identities.ts
@@ -12,7 +12,8 @@ export const IdentitiesSchema = z.object({
   name: z.string(),
   authMethod: z.string().nullable().optional(),
   createdAt: z.date(),
-  updatedAt: z.date()
+  updatedAt: z.date(),
+  isDisabled: z.boolean().default(false)
 });
 
 export type TIdentities = z.infer<typeof IdentitiesSchema>;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -38,7 +38,8 @@ export const IDENTITIES = {
   UPDATE: {
     identityId: "The ID of the identity to update.",
     name: "The new name of the identity.",
-    role: "The new role of the identity."
+    role: "The new role of the identity.",
+    isDisabled: "Indicates whether this identity is going to be disabled."
   },
   DELETE: {
     identityId: "The ID of the identity to delete."

--- a/backend/src/lib/fn/object.ts
+++ b/backend/src/lib/fn/object.ts
@@ -20,7 +20,7 @@ export const pick = <T extends object, TKeys extends keyof T>(obj: T, keys: TKey
  */
 export const shake = <RemovedKeys extends string, T = object>(
   obj: T,
-  filter: (value: unknown) => boolean = (x) => x === undefined || x === null
+  filter: (value: T[keyof T]) => boolean = (x) => x === undefined || x === null
 ): Omit<T, RemovedKeys> => {
   if (!obj) return {} as T;
   const keys = Object.keys(obj) as (keyof T)[];

--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -93,7 +93,8 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
       }),
       body: z.object({
         name: z.string().trim().optional().describe(IDENTITIES.UPDATE.name),
-        role: z.string().trim().min(1).optional().describe(IDENTITIES.UPDATE.role)
+        role: z.string().trim().min(1).optional().describe(IDENTITIES.UPDATE.role),
+        isDisabled: z.boolean().optional().describe(IDENTITIES.UPDATE.isDisabled)
       }),
       response: {
         200: z.object({
@@ -200,7 +201,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
               permissions: true,
               description: true
             }).optional(),
-            identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true })
+            identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true, isDisabled: true })
           })
         })
       }

--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -246,7 +246,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
               permissions: true,
               description: true
             }).optional(),
-            identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true })
+            identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true, isDisabled: true })
           }).array()
         })
       }

--- a/backend/src/server/routes/v2/identity-org-router.ts
+++ b/backend/src/server/routes/v2/identity-org-router.ts
@@ -35,7 +35,7 @@ export const registerIdentityOrgRouter = async (server: FastifyZodProvider) => {
                 permissions: true,
                 description: true
               }).optional(),
-              identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true })
+              identity: IdentitiesSchema.pick({ name: true, id: true, authMethod: true, isDisabled: true })
             })
           ).array()
         })

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -57,6 +57,7 @@ export const identityUaServiceFactory = ({
     if (!identityUa) throw new UnauthorizedError({ message: "Invalid credentials" });
 
     const identityMembershipOrg = await identityOrgMembershipDAL.findOne({ identityId: identityUa.identityId });
+    if (identityMembershipOrg.identity.isDisabled) throw new UnauthorizedError({ message: "Identity is disabled" });
 
     checkIPAgainstBlocklist({
       ipAddress: ip,

--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -17,10 +17,11 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         .join(TableName.Identity, `${TableName.IdentityOrgMembership}.identityId`, `${TableName.Identity}.id`)
         .select(selectAllTableCols(TableName.IdentityOrgMembership))
         .select(db.ref("name").withSchema(TableName.Identity))
-        .select(db.ref("authMethod").withSchema(TableName.Identity));
+        .select(db.ref("authMethod").withSchema(TableName.Identity))
+        .select(db.ref("isDisabled").withSchema(TableName.Identity));
       if (data) {
-        const { name, authMethod } = data;
-        return { ...data, identity: { id: data.identityId, name, authMethod } };
+        const { name, authMethod, isDisabled } = data;
+        return { ...data, identity: { id: data.identityId, name, authMethod, isDisabled } };
       }
     } catch (error) {
       throw new DatabaseError({ error, name: "FindOne" });
@@ -43,6 +44,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         .select(db.ref("permissions").as("crPermission").withSchema(TableName.OrgRoles))
         .select(db.ref("id").as("identityId").withSchema(TableName.Identity))
         .select(db.ref("name").as("identityName").withSchema(TableName.Identity))
+        .select(db.ref("isDisabled").as("identityIsDisabled").withSchema(TableName.Identity))
         .select(db.ref("authMethod").as("identityAuthMethod").withSchema(TableName.Identity));
       return docs.map(
         ({
@@ -54,6 +56,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           identityId,
           identityName,
           identityAuthMethod,
+          identityIsDisabled,
           ...el
         }) => ({
           ...el,
@@ -61,7 +64,8 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           identity: {
             id: identityId,
             name: identityName,
-            authMethod: identityAuthMethod
+            authMethod: identityAuthMethod,
+            isDisabled: identityIsDisabled
           },
           customRole: el.roleId
             ? {

--- a/backend/src/services/identity/identity-types.ts
+++ b/backend/src/services/identity/identity-types.ts
@@ -10,6 +10,7 @@ export type TUpdateIdentityDTO = {
   id: string;
   role?: string;
   name?: string;
+  isDisabled?: boolean;
 } & Omit<TOrgPermission, "orgId">;
 
 export type TDeleteIdentityDTO = {

--- a/frontend/src/components/basic/Toggle.tsx
+++ b/frontend/src/components/basic/Toggle.tsx
@@ -1,42 +1,39 @@
 import { Switch } from "@headlessui/react";
+import { twMerge } from "tailwind-merge";
 
 interface ToggleProps {
+  className?: string;
+  label?: string;
   enabled: boolean;
   setEnabled: (value: boolean) => void;
-  addOverride: (value: string | undefined, id: string) => void;
-  id: string;
 }
 
 /**
  * This is a typical 'iPhone' toggle (e.g., user for overriding secrets with personal values)
  * @param obj
  * @param {boolean} obj.enabled - whether the toggle is turned on or off
- * @param {function} obj.setEnabled - change the state of the toggle
- * @param {function} obj.addOverride - a function that adds an override to a certain secret
  * @param {number} obj.id - id of a certain secret
  * @returns
  */
-const Toggle = ({ enabled, setEnabled, addOverride, id }: ToggleProps): JSX.Element => {
+const Toggle = ({ className, label, enabled, setEnabled }: ToggleProps): JSX.Element => {
   return (
     <Switch
       checked={enabled}
       onChange={() => {
-        if (enabled === false) {
-          addOverride("", id);
-        } else {
-          addOverride(undefined, id);
-        }
         setEnabled(!enabled);
       }}
-      className={`${
-        enabled ? "bg-primary" : "bg-bunker-400"
-      } relative inline-flex h-5 w-9 items-center rounded-full`}
+      className={twMerge(
+        `${
+          enabled ? "bg-primary" : "bg-bunker-400"
+        } relative inline-flex h-5 w-9 items-center rounded-full`,
+        className
+      )}
     >
-      <span className="sr-only">Enable notifications</span>
+      {label ? <span className="sr-only">{label}</span> : null}
       <span
         className={`${
           enabled ? "translate-x-[1.26rem]" : "translate-x-0.5"
-        } inline-block h-3.5 w-3.5 transform rounded-full bg-bunker-800 transition`}
+        } inline-block h-3.5 w-3.5 translate-x-0.5 transform rounded-full bg-bunker-800 transition`}
       />
     </Switch>
   );

--- a/frontend/src/hooks/api/identities/mutations.tsx
+++ b/frontend/src/hooks/api/identities/mutations.tsx
@@ -67,12 +67,13 @@ export const useCreateIdentity = () => {
 export const useUpdateIdentity = () => {
   const queryClient = useQueryClient();
   return useMutation<Identity, {}, UpdateIdentityDTO>({
-    mutationFn: async ({ identityId, name, role }) => {
+    mutationFn: async ({ identityId, name, role, isDisabled }) => {
       const {
         data: { identity }
       } = await apiRequest.patch(`/api/v1/identities/${identityId}`, {
         name,
-        role
+        role,
+        isDisabled
       });
 
       return identity;

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -13,6 +13,7 @@ export type Identity = {
   id: string;
   name: string;
   authMethod?: IdentityAuthMethod;
+  isDisabled: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -86,6 +87,7 @@ export type UpdateIdentityDTO = {
   name?: string;
   role?: string;
   organizationId: string;
+  isDisabled: boolean;
 };
 
 export type DeleteIdentityDTO = {

--- a/frontend/src/views/Org/IdentityPage/components/IdentityDetailsSection.tsx
+++ b/frontend/src/views/Org/IdentityPage/components/IdentityDetailsSection.tsx
@@ -39,6 +39,7 @@ export const IdentityDetailsSection = ({ identityId, handlePopUpOpen }: Props) =
                     handlePopUpOpen("identity", {
                       identityId,
                       name: data.identity.name,
+                      isDisabled: data.identity.isDisabled,
                       role: data.role,
                       customRole: data.customRole
                     });
@@ -76,6 +77,10 @@ export const IdentityDetailsSection = ({ identityId, handlePopUpOpen }: Props) =
         <div className="mb-4">
           <p className="text-sm font-semibold text-mineshaft-300">Name</p>
           <p className="text-sm text-mineshaft-300">{data.identity.name}</p>
+        </div>
+        <div className="mb-4">
+          <p className="text-sm font-semibold text-mineshaft-300">Disabled</p>
+          <p className="text-sm text-mineshaft-300">{data.identity.isDisabled ? "yes" : "no"}</p>
         </div>
         <div>
           <p className="text-sm font-semibold text-mineshaft-300">Organization Role</p>

--- a/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityModal.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityModal.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
+import Toggle from "@app/components/basic/Toggle";
 import { createNotification } from "@app/components/notifications";
 import {
   Button,
@@ -16,16 +17,14 @@ import {
 } from "@app/components/v2";
 import { useOrganization } from "@app/context";
 import { useCreateIdentity, useGetOrgRoles, useUpdateIdentity } from "@app/hooks/api";
-import {
-  // IdentityAuthMethod,
-  useAddIdentityUniversalAuth
-} from "@app/hooks/api/identities";
+import { useAddIdentityUniversalAuth } from "@app/hooks/api/identities";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 const schema = yup
   .object({
     name: yup.string().required("MI name is required"),
-    role: yup.string()
+    role: yup.string(),
+    isDisabled: yup.boolean().default(false)
   })
   .required();
 
@@ -63,7 +62,8 @@ export const IdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
   } = useForm<FormData>({
     resolver: yupResolver(schema),
     defaultValues: {
-      name: ""
+      name: "",
+      isDisabled: false
     }
   });
 
@@ -71,6 +71,7 @@ export const IdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
     const identity = popUp?.identity?.data as {
       identityId: string;
       name: string;
+      isDisabled: boolean;
       role: string;
       customRole: {
         name: string;
@@ -83,22 +84,25 @@ export const IdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
     if (identity) {
       reset({
         name: identity.name,
-        role: identity?.customRole?.slug ?? identity.role
+        role: identity?.customRole?.slug ?? identity.role,
+        isDisabled: identity.isDisabled
       });
     } else {
       reset({
         name: "",
-        role: roles[0].slug
+        role: roles[0].slug,
+        isDisabled: false
       });
     }
   }, [popUp?.identity?.data, roles]);
 
-  const onFormSubmit = async ({ name, role }: FormData) => {
+  const onFormSubmit = async ({ name, role, isDisabled }: FormData) => {
     try {
       const identity = popUp?.identity?.data as {
         identityId: string;
         name: string;
         role: string;
+        isDisabled: boolean;
       };
 
       if (identity) {
@@ -108,7 +112,8 @@ export const IdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
           identityId: identity.identityId,
           name,
           role: role || undefined,
-          organizationId: orgId
+          organizationId: orgId,
+          isDisabled
         });
 
         handlePopUpToggle("identity", false);
@@ -204,6 +209,16 @@ export const IdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
                     </SelectItem>
                   ))}
                 </Select>
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            defaultValue={false}
+            name="isDisabled"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl label="Disabled" isError={Boolean(error)} errorText={error?.message}>
+                <Toggle className="ml-1" enabled={field.value} setEnabled={field.onChange} />
               </FormControl>
             )}
           />

--- a/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityTable.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityTable.tsx
@@ -77,13 +77,14 @@ export const IdentityTable = ({ handlePopUpOpen }: Props) => {
           <Tr>
             <Th>Name</Th>
             <Th>Role</Th>
+            <Th>Disabled</Th>
             <Th className="w-5" />
           </Tr>
         </THead>
         <TBody>
           {isLoading && <TableSkeleton columns={4} innerKey="org-identities" />}
           {!isLoading &&
-            data?.map(({ identity: { id, name }, role, customRole }) => {
+            data?.map(({ identity: { id, name, isDisabled }, role, customRole }) => {
               return (
                 <Tr
                   className="h-10 cursor-pointer transition-colors duration-100 hover:bg-mineshaft-700"
@@ -120,6 +121,7 @@ export const IdentityTable = ({ handlePopUpOpen }: Props) => {
                       }}
                     </OrgPermissionCan>
                   </Td>
+                  <Td>{isDisabled ? "true" : "false"}</Td>
                   <Td>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild className="rounded-lg">


### PR DESCRIPTION
# Description 📣

This pull request introduces a new feature that allows the enabling or disabling of machine identities without the need to delete them or their related client secrets. This is particularly useful in scenarios where temporarily pausing the usage of an identity is necessary. The addition of this feature enhances the flexibility and control over machine identities within the system.

### Changes
* Database Update: Added a new `isDisabled` boolean column to the identities table to track the enabled/disabled state of each identity.
* Added the ability to toggle the `isDisabled` state on the identity detail page, allowing users to enable or disable an identity as needed.
* Added `Disabled` column to the identity data table.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

https://github.com/user-attachments/assets/40aa45b5-b06c-407b-89ed-dfb95cac7261



```sh
# Here's some code block to paste some code snippets
```

---

Resolves #2240

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->