### PR TITLE
Secret migration switched to chunking based batch insert

### DIFF
--- a/backend/src/lib/knex/index.ts
+++ b/backend/src/lib/knex/index.ts
@@ -128,6 +128,16 @@ export const ormify = <DbOps extends object, Tname extends keyof Tables>(db: Kne
       throw new DatabaseError({ error, name: "Create" });
     }
   },
+  // This spilit the insert into multiple chunk
+  batchInsert: async (data: readonly Tables[Tname]["insert"][], tx?: Knex) => {
+    try {
+      if (!data.length) return [];
+      const res = await (tx || db).batchInsert(tableName, data as never).returning("*");
+      return res as Tables[Tname]["base"][];
+    } catch (error) {
+      throw new DatabaseError({ error, name: "batchInsert" });
+    }
+  },
   upsert: async (data: readonly Tables[Tname]["insert"][], onConflictField: keyof Tables[Tname]["base"], tx?: Knex) => {
     try {
       if (!data.length) return [];

--- a/backend/src/services/secret-tag/secret-tag-dal.ts
+++ b/backend/src/services/secret-tag/secret-tag-dal.ts
@@ -51,7 +51,7 @@ export const secretTagDALFactory = (db: TDbClient) => {
     ...secretTagOrm,
     saveTagsToSecret: secretJnTagOrm.insertMany,
     deleteTagsToSecret: secretJnTagOrm.delete,
-    saveTagsToSecretV2: secretV2JnTagOrm.insertMany,
+    saveTagsToSecretV2: secretV2JnTagOrm.batchInsert,
     deleteTagsToSecretV2: secretV2JnTagOrm.delete,
     findSecretTagsByProjectId,
     deleteTagsManySecret,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -287,7 +287,7 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           }))
         );
       if (!newSecretReferences.length) return;
-      const secretReferences = await (tx || db)(TableName.SecretReferenceV2).insert(newSecretReferences);
+      const secretReferences = await (tx || db).batchInsert(TableName.SecretReferenceV2, newSecretReferences);
       return secretReferences;
     } catch (error) {
       throw new DatabaseError({ error, name: "UpsertSecretReference" });


### PR DESCRIPTION
# Description 📣

This PR adds the knex batchInsert to our ormify function. BatchInsert allows chunking a lot of records into multiple chunks and insert each chunk thus overcoming max parameter issue with postgres

This is added to secret migration to support bigger folders

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->