### PR TITLE
replaced "creditnals" to "credentials"

### DIFF
--- a/cli/packages/util/credentials.go
+++ b/cli/packages/util/credentials.go
@@ -71,7 +71,7 @@ func GetCurrentLoggedInUserDetails() (LoggedInUserDetails, error) {
 			if strings.Contains(err.Error(), "credentials not found in system keyring") {
 				return LoggedInUserDetails{}, errors.New("we couldn't find your logged in details, try running [infisical login] then try again")
 			} else {
-				return LoggedInUserDetails{}, fmt.Errorf("failed to fetch creditnals from keyring because [err=%s]", err)
+				return LoggedInUserDetails{}, fmt.Errorf("failed to fetch credentials from keyring because [err=%s]", err)
 			}
 		}
 


### PR DESCRIPTION
# Description 📣
Fixed Issue "creditnals misspeled in error #2269"

In file credentials.go at line 74 "credentials" was spelled wrong.

## Type ✨

- [ ✅] Bug fix

---

- [ ✅] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
