### PR TITLE
Fixed Pagination Disappearing on Secret Sharing Page

### DIFF
--- a/frontend/src/views/ShareSecretPage/components/ShareSecretsTable.tsx
+++ b/frontend/src/views/ShareSecretPage/components/ShareSecretsTable.tsx
@@ -61,7 +61,7 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
       </Table>
       {!isLoading &&
         data?.secrets &&
-        data.secrets.length >= perPage &&
+        data?.totalCount >= perPage &&
         data?.totalCount !== undefined && (
           <Pagination
             count={data.totalCount}


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
The table on secret's sharing page has incorrect pagination. After going to next page, if it had less items then the per page limit, the pagination used to disapper.

Before:

https://github.com/user-attachments/assets/a42dab7b-d7b9-4380-9c2a-739dffd2a555


After fix:

https://github.com/user-attachments/assets/ac421656-99ef-49b5-a333-27621426e98c



## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->