### PR TITLE
Add DISABLE_AUDIT_LOG_GENERATION

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 
+import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 
 import { TPermissionServiceFactory } from "../permission/permission-service";
@@ -61,6 +62,10 @@ export const auditLogServiceFactory = ({
   };
 
   const createAuditLog = async (data: TCreateAuditLogDTO) => {
+    const appCfg = getConfig();
+    if (appCfg.DISABLE_AUDIT_LOG_GENERATION) {
+      return;
+    }
     // add all cases in which project id or org id cannot be added
     if (data.event.type !== EventType.LOGIN_IDENTITY_UNIVERSAL_AUTH) {
       if (!data.projectId && !data.orgId) throw new BadRequestError({ message: "Must either project id or org id" });

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -140,7 +140,8 @@ const envSchema = z
     MAINTENANCE_MODE: zodStrBool.default("false"),
     CAPTCHA_SECRET: zpStr(z.string().optional()),
     PLAIN_API_KEY: zpStr(z.string().optional()),
-    PLAIN_WISH_LABEL_IDS: zpStr(z.string().optional())
+    PLAIN_WISH_LABEL_IDS: zpStr(z.string().optional()),
+    DISABLE_AUDIT_LOG_GENERATION: zodStrBool.default("false")
   })
   .transform((data) => ({
     ...data,


### PR DESCRIPTION
Added `DISABLE_AUDIT_LOG_GENERATION` which when set to true will prevent the creation of audit logs in Infisical. 

This will be used for load testing purposes and help verify if audit logs are a bottle neck for performance  