### PR TITLE
Fix: Remove notification when unable to read secrets from environment

### DIFF
--- a/frontend/src/hooks/api/secrets/constants.ts
+++ b/frontend/src/hooks/api/secrets/constants.ts
@@ -1,0 +1,1 @@
+export const ERROR_NOT_ALLOWED_READ_SECRETS = "You are not allowed to read on secrets";

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -7,6 +7,7 @@ import { createNotification } from "@app/components/notifications";
 import { apiRequest } from "@app/config/request";
 import { useToggle } from "@app/hooks/useToggle";
 
+import { ERROR_NOT_ALLOWED_READ_SECRETS } from "./constants";
 import {
   GetSecretVersionsDTO,
   SecretType,
@@ -135,11 +136,13 @@ export const useGetProjectSecretsAllEnv = ({
       onError: (error: unknown) => {
         if (axios.isAxiosError(error) && !isErrorHandled) {
           const serverResponse = error.response?.data as { message: string };
-          createNotification({
-            title: "Error fetching secrets",
-            type: "error",
-            text: serverResponse.message
-          });
+          if (serverResponse.message !== ERROR_NOT_ALLOWED_READ_SECRETS) {
+            createNotification({
+              title: "Error fetching secrets",
+              type: "error",
+              text: serverResponse.message
+            });
+          }
 
           setIsErrorHandled.on();
         }


### PR DESCRIPTION
# Description 📣

Removed a notification alert that would appear if a user doesn't have access to a certain environment. Since we load all environments on the load page, this notification would always appear if the user has restricted access (as in, they can't read production but can read all other environments as an example).

The fix for this is very straightforward, as we just filter out the "You are not allowed to read on secrets" error.

I've added a new `constants.ts` file which contains the error message as a variable. This is done to follow @dangtony98's file structure that he used when implementing certificates. Example can be [found here](https://github.com/Infisical/infisical/blob/main/frontend/src/hooks/api/certificates/constants.tsx). 

![CleanShot 2024-08-20 at 21 49 37@2x](https://github.com/user-attachments/assets/17f98600-2d60-4473-96d4-2f6666586886)


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->