### PR TITLE
Automatically validate the email verification code

### DIFF
--- a/frontend/src/components/signup/CodeInputStep.tsx
+++ b/frontend/src/components/signup/CodeInputStep.tsx
@@ -74,7 +74,6 @@ export default function CodeInputStep({
 }: CodeInputStepProps): JSX.Element {
   const { mutateAsync } = useSendVerificationEmail();
   const [isLoading, setIsLoading] = useState(false);
-  const [runEffect, setRunEffect] = useState(false);
   const [isResendingVerificationEmail, setIsResendingVerificationEmail] = useState(false);
   const { t } = useTranslation();
 

--- a/frontend/src/components/signup/CodeInputStep.tsx
+++ b/frontend/src/components/signup/CodeInputStep.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ReactCodeInput from "react-code-input";
 import { useTranslation } from "react-i18next";
 
@@ -50,6 +50,7 @@ interface CodeInputStepProps {
   email: string;
   incrementStep: () => void;
   setCode: (value: string) => void;
+  code: string;
   codeError: boolean;
   isCodeInputCheckLoading: boolean;
 }
@@ -67,11 +68,13 @@ export default function CodeInputStep({
   email,
   incrementStep,
   setCode,
+  code,
   codeError,
   isCodeInputCheckLoading
 }: CodeInputStepProps): JSX.Element {
   const { mutateAsync } = useSendVerificationEmail();
   const [isLoading, setIsLoading] = useState(false);
+  const [runEffect, setRunEffect] = useState(false);
   const [isResendingVerificationEmail, setIsResendingVerificationEmail] = useState(false);
   const { t } = useTranslation();
 
@@ -84,6 +87,10 @@ export default function CodeInputStep({
       setIsResendingVerificationEmail(false);
     }, 2000);
   };
+
+  useEffect(() => {
+    if (code.length === 6 && code != "123456") incrementStep();
+  }, [code]);
 
   return (
     <div className="mx-auto h-full w-full pb-4 md:px-8">

--- a/frontend/src/pages/signup/index.tsx
+++ b/frontend/src/pages/signup/index.tsx
@@ -110,6 +110,7 @@ export default function SignUp() {
           email={email}
           incrementStep={incrementStep}
           setCode={setCode}
+          code={code}
           codeError={codeError}
           isCodeInputCheckLoading={isCodeInputCheckLoading}
         />


### PR DESCRIPTION
# Description 📣

Solves [#1582](https://github.com/Infisical/infisical/issues/1582)

Added another prop 'code' to the CodeInputStep component to keep track of the code entered so far. A useEffect is utilized to run whenever the code value changes. The incrementStep() function is only called when the length of the code is 6 and it is not equal to "123456".

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Used a local mailhog server to send dummy emails. Then generated the verification codes and tested it. An error message is displayed if the code isn't correct. If the code is correct, it re-directs to the next page, without having to press the enter key again.


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝