### PR TITLE
Set default to host sts endpoint for aws auth

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -65,7 +65,7 @@ export const identityAwsAuthServiceFactory = ({
       }
     }: { data: TGetCallerIdentityResponse } = await axios({
       method: iamHttpRequestMethod,
-      url: identityAwsAuth.stsEndpoint,
+      url: headers?.Host ? `https://${headers.Host}` : identityAwsAuth.stsEndpoint,
       headers,
       data: body
     });


### PR DESCRIPTION
When the signing header has host defined, it will use that endpoint over the one in the identity. This will allow for cross region use.