### PR TITLE
fix: this pr addresses null null name issue with invited users

### DIFF
--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -583,7 +583,13 @@ export const authLoginServiceFactory = ({
     } else {
       const isLinkingRequired = !user?.authMethods?.includes(authMethod);
       if (isLinkingRequired) {
-        user = await userDAL.updateById(user.id, { authMethods: [...(user.authMethods || []), authMethod] });
+        // we update the names here because upon org invitation, the names are set to be NULL
+        // if user is signing up with SSO after invitation, their names should be set based on their SSO profile
+        user = await userDAL.updateById(user.id, {
+          authMethods: [...(user.authMethods || []), authMethod],
+          firstName: !user.isAccepted ? firstName : undefined,
+          lastName: !user.isAccepted ? lastName : undefined
+        });
       }
     }
 


### PR DESCRIPTION
# Description 📣
- This PR resolves the issue regarding "null null" names during user signup after invitation to an organization
<img width="757" alt="d08b22ec-83de-46a0-a942-fa1b087e3618" src="https://github.com/user-attachments/assets/28801d3f-4ad5-4630-9920-9a0a8c46c0cd">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->