### PR TITLE
feat: auto set SITE_URL when Ingress defined for OAUTH2 integrations

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -63,6 +63,10 @@ spec:
         - name: REDIS_URL
           value: {{ include "infisical.redisConnectionString" . }}
         {{- end }}
+        {{- if .Values.ingress.enabled }}
+        - name: SITE_URL
+          value: {{ .Values.ingress.hostName }}
+        {{- end }}        
         envFrom:
         - secretRef:
             name: {{ $infisicalValues.kubeSecretRef }}


### PR DESCRIPTION
# Description 📣

When specifying OIDC authentication, it's necessary to set the `SITE_URL` environment variable to ensure the `redirect_uri` in the link is correct. I encountered this issue and resolved it by reading the [source code](https://github.com/Infisical/infisical/blob/main/backend/src/ee/routes/v1/oidc-router.ts#L117), as it's not mentioned in the [documentation](https://infisical.com/docs/documentation/platform/identities/oidc-auth/general). This behavior could be confusing for others:

[Issue #1880](https://github.com/Infisical/infisical/issues/1880)
[Issue #1875](https://github.com/Infisical/infisical/issues/1875)

Would it make sense to automatically set SITE_URL when Ingress is defined?


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->