### PR TITLE
Feat: Persistent self-hosting domains on `infisical login`

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -152,6 +152,28 @@ var loginCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		clearSelfHostedDomains, err := cmd.Flags().GetBool("clear-domains")
+		if err != nil {
+			util.HandleError(err)
+		}
+
+		if clearSelfHostedDomains {
+			infisicalConfig, err := util.GetConfigFile()
+			if err != nil {
+				util.HandleError(err)
+			}
+
+			infisicalConfig.Domains = []string{}
+			err = util.WriteConfigFile(&infisicalConfig)
+
+			if err != nil {
+				util.HandleError(err)
+			}
+
+			fmt.Println("Cleared all self-hosted domains from the config file")
+			return
+		}
+
 		infisicalClient := infisicalSdk.NewInfisicalClient(infisicalSdk.Config{
 			SiteUrl:   config.INFISICAL_URL,
 			UserAgent: api.USER_AGENT,
@@ -464,6 +486,7 @@ func cliDefaultLogin(userCredentialsToBeStored *models.UserCredentials) {
 
 func init() {
 	rootCmd.AddCommand(loginCmd)
+	loginCmd.Flags().Bool("clear-domains", false, "clear all self-hosting domains from the config file")
 	loginCmd.Flags().BoolP("interactive", "i", false, "login via the command line")
 	loginCmd.Flags().String("method", "user", "login method [user, universal-auth]")
 	loginCmd.Flags().Bool("plain", false, "only output the token without any formatting")
@@ -499,10 +522,12 @@ func DomainOverridePrompt() (bool, error) {
 }
 
 func askForDomain() error {
-	//query user to choose between Infisical cloud or self hosting
+
+	// query user to choose between Infisical cloud or self hosting
 	const (
 		INFISICAL_CLOUD = "Infisical Cloud"
 		SELF_HOSTING    = "Self Hosting"
+		ADD_NEW_DOMAIN  = "Add a new domain"
 	)
 
 	options := []string{INFISICAL_CLOUD, SELF_HOSTING}
@@ -524,6 +549,36 @@ func askForDomain() error {
 		return nil
 	}
 
+	infisicalConfig, err := util.GetConfigFile()
+	if err != nil {
+		return fmt.Errorf("askForDomain: unable to get config file because [err=%s]", err)
+	}
+
+	if infisicalConfig.Domains != nil && len(infisicalConfig.Domains) > 0 {
+		// If domains are present in the config, let the user select from the list or select to add a new domain
+
+		items := append(infisicalConfig.Domains, ADD_NEW_DOMAIN)
+
+		prompt := promptui.Select{
+			Label: "Which domain would you like to use?",
+			Items: items,
+			Size:  5,
+		}
+
+		_, selectedOption, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+
+		if selectedOption != ADD_NEW_DOMAIN {
+			config.INFISICAL_URL = fmt.Sprintf("%s/api", selectedOption)
+			config.INFISICAL_LOGIN_URL = fmt.Sprintf("%s/login", selectedOption)
+			return nil
+
+		}
+
+	}
+
 	urlValidation := func(input string) error {
 		_, err := url.ParseRequestURI(input)
 		if err != nil {
@@ -542,12 +597,20 @@ func askForDomain() error {
 	if err != nil {
 		return err
 	}
-	//trimmed the '/' from the end of the self hosting url
+
+	// Trimmed the '/' from the end of the self hosting url, and set the api & login url
 	domain = strings.TrimRight(domain, "/")
-	//set api and login url
 	config.INFISICAL_URL = fmt.Sprintf("%s/api", domain)
 	config.INFISICAL_LOGIN_URL = fmt.Sprintf("%s/login", domain)
-	//return nil
+
+	// Write the new domain to the config file, to allow the user to select it in the future if needed
+	infisicalConfig.Domains = append(infisicalConfig.Domains, domain)
+	err = util.WriteConfigFile(&infisicalConfig)
+
+	if err != nil {
+		return fmt.Errorf("askForDomain: unable to write domains to config file because [err=%s]", err)
+	}
+
 	return nil
 }
 

--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -604,11 +604,14 @@ func askForDomain() error {
 	config.INFISICAL_LOGIN_URL = fmt.Sprintf("%s/login", domain)
 
 	// Write the new domain to the config file, to allow the user to select it in the future if needed
-	infisicalConfig.Domains = append(infisicalConfig.Domains, domain)
-	err = util.WriteConfigFile(&infisicalConfig)
+	// First check if infiscialConfig.Domains already includes the domain, if it does, do not add it again
+	if !util.ArrayContains(infisicalConfig.Domains, domain) {
+		infisicalConfig.Domains = append(infisicalConfig.Domains, domain)
+		err = util.WriteConfigFile(&infisicalConfig)
 
-	if err != nil {
-		return fmt.Errorf("askForDomain: unable to write domains to config file because [err=%s]", err)
+		if err != nil {
+			return fmt.Errorf("askForDomain: unable to write domains to config file because [err=%s]", err)
+		}
 	}
 
 	return nil

--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -605,7 +606,7 @@ func askForDomain() error {
 
 	// Write the new domain to the config file, to allow the user to select it in the future if needed
 	// First check if infiscialConfig.Domains already includes the domain, if it does, do not add it again
-	if !util.ArrayContains(infisicalConfig.Domains, domain) {
+	if !slices.Contains(infisicalConfig.Domains, domain) {
 		infisicalConfig.Domains = append(infisicalConfig.Domains, domain)
 		err = util.WriteConfigFile(&infisicalConfig)
 

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -16,6 +16,7 @@ type ConfigFile struct {
 	LoggedInUsers          []LoggedInUser `json:"loggedInUsers,omitempty"`
 	VaultBackendType       string         `json:"vaultBackendType,omitempty"`
 	VaultBackendPassphrase string         `json:"vaultBackendPassphrase,omitempty"`
+	Domains                []string       `json:"domains,omitempty"`
 }
 
 type LoggedInUser struct {

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -298,12 +298,3 @@ func GenerateRandomString(length int) string {
 	}
 	return string(b)
 }
-
-func ArrayContains(arr []string, val string) bool {
-	for _, item := range arr {
-		if item == val {
-			return true
-		}
-	}
-	return false
-}

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -298,3 +298,12 @@ func GenerateRandomString(length int) string {
 	}
 	return string(b)
 }
+
+func ArrayContains(arr []string, val string) bool {
+	for _, item := range arr {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Description 📣

This PR implements persistent self-hosting domains for `infisical login`. Additionally, it also incldues a new flag on the login command, called `clear-domains`. In some cases users may want to wipe their saved domains, and this flag does exactly yhat.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->