### PR TITLE
feat(cli): `run` watch mode

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gitleaks/go-gitdiff v0.8.0
 	github.com/h2non/filetype v1.1.3
 	github.com/infisical/go-sdk v0.3.3
-	github.com/mattn/go-isatty v0.0.18
+	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/reflow v0.3.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -297,6 +297,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var INTERRUPT_ERR = fmt.Errorf("signal: interrupt")
+
 // runCmd represents the run command
 var runCmd = &cobra.Command{
 	Example: `
@@ -250,6 +252,10 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string,
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
+		if err.Error() == INTERRUPT_ERR.Error() {
+			log.Debug().Msg(color.HiMagentaString("Process was terminated manually by the user"))
+			os.Exit(1)
+		}
 		util.HandleError(err, "Failed to start command")
 	}
 
@@ -343,6 +349,10 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
+		if err.Error() == INTERRUPT_ERR.Error() {
+			log.Debug().Msg(color.HiMagentaString("Process was terminated manually by the user"))
+			os.Exit(1)
+		}
 		util.HandleError(err, "Failed to start command")
 	}
 

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var INTERRUPT_ERR = fmt.Errorf("signal: interrupt")
+var ManualInterruptErr = fmt.Errorf("signal: interrupt")
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
@@ -252,7 +252,7 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string,
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
-		if err.Error() == INTERRUPT_ERR.Error() {
+		if err.Error() == ManualInterruptErr.Error() {
 			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}
@@ -349,7 +349,7 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
-		if err.Error() == INTERRUPT_ERR.Error() {
+		if err.Error() == ManualInterruptErr.Error() {
 			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var ManualInterruptErr = fmt.Errorf("signal: interrupt")
+var ErrManualInterrupt = fmt.Errorf("signal: interrupt")
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
@@ -252,7 +252,7 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string,
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
-		if err.Error() == ManualInterruptErr.Error() {
+		if err.Error() == ErrManualInterrupt.Error() {
 			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}
@@ -349,7 +349,7 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
-		if err.Error() == ManualInterruptErr.Error() {
+		if err.Error() == ErrManualInterrupt.Error() {
 			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -350,7 +350,7 @@ func executeMultipleCommandWithEnvs(fullCommand string, secretsCount int, env []
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
 		if err.Error() == INTERRUPT_ERR.Error() {
-			log.Debug().Msg(color.HiMagentaString("Process was terminated manually by the user"))
+			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}
 		util.HandleError(err, "Failed to start command")

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -253,7 +253,7 @@ func executeSingleCommandWithEnvs(args []string, secretsCount int, env []string,
 	err := startCmd() // Initial command start, if no --watch flag is passed, it will work like in old versions of infisical CLI.
 	if err != nil {
 		if err.Error() == INTERRUPT_ERR.Error() {
-			log.Debug().Msg(color.HiMagentaString("Process was terminated manually by the user"))
+			log.Debug().Msg(("Process was terminated manually by the user"))
 			os.Exit(1)
 		}
 		util.HandleError(err, "Failed to start command")

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -59,7 +59,7 @@ var runCmd = &cobra.Command{
 
 		// If the --watch flag has been set, the --watch-interval flag should also be set
 		if watchFlagSet && watchIntervalFlagSet {
-			// Ensure that the --watch-interval flag is set to a positive integer, and is at least 10 seconds
+			// Ensure that the --watch-interval flag is set to a positive integer, and is at least 5 seconds
 
 			watchInterval, err := cmd.Flags().GetInt("watch-interval")
 			if err != nil {
@@ -273,7 +273,7 @@ func executeSpecifiedCommand(commandFlag string, args []string, watchMode bool, 
 
 	initialEnvironment, err := createInjectableEnvironment(request, projectConfigDir, secretOverriding, expandSecrets, token)
 	if err != nil {
-		util.HandleError(err, "[HOT RELOAD] Failed to fetch secrets")
+		util.HandleError(err, "Failed to fetch secrets")
 	}
 	startProcess(initialEnvironment)
 	recheckSecretsChannel := make(chan bool, 1)
@@ -282,7 +282,7 @@ func executeSpecifiedCommand(commandFlag string, args []string, watchMode bool, 
 	if watchMode {
 		log.Info().Msg(color.HiMagentaString("[HOT RELOAD] Watching for secret changes..."))
 
-		// a simple goroutine that triggers the recheckSecretsChan every 5 seconds
+		// a simple goroutine that triggers the recheckSecretsChan every watch interval (defaults to 10 seconds)
 		go func() {
 			for {
 				time.Sleep(time.Duration(watchModeInterval) * time.Second)
@@ -406,7 +406,6 @@ func createInjectableEnvironment(request models.GetAllSecretsParameters, project
 		environmentVariables[k] = v.Value
 	}
 
-	// Create and sort the env slice using slices.SortFunc
 	env := make([]string, 0, len(environmentVariables))
 	for key, value := range environmentVariables {
 		env = append(env, key+"="+value)

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -104,13 +104,19 @@ type GetAllSecretsParameters struct {
 	Recursive                bool
 }
 
+type InjectableEnvironmentResult struct {
+	Variables    []string
+	ETag         string
+	SecretsCount int
+}
+
 type ExecuteCommandHotReloadParameters struct {
 	Enabled           bool
 	GetSecretsDetails GetAllSecretsParameters
 	ProjectConfigDir  string
 	SecretOverriding  bool
 	ExpandSecrets     bool
-	InitialETag       string
+	CurrentETag       string
 }
 
 type GetAllFoldersParameters struct {

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -110,15 +110,6 @@ type InjectableEnvironmentResult struct {
 	SecretsCount int
 }
 
-type ExecuteCommandHotReloadParameters struct {
-	Enabled           bool
-	GetSecretsDetails GetAllSecretsParameters
-	ProjectConfigDir  string
-	SecretOverriding  bool
-	ExpandSecrets     bool
-	CurrentETag       string
-}
-
 type GetAllFoldersParameters struct {
 	WorkspaceId              string
 	Environment              string

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -104,6 +104,15 @@ type GetAllSecretsParameters struct {
 	Recursive                bool
 }
 
+type ExecuteCommandHotReloadParameters struct {
+	Enabled           bool
+	GetSecretsDetails GetAllSecretsParameters
+	ProjectConfigDir  string
+	SecretOverriding  bool
+	ExpandSecrets     bool
+	InitialETag       string
+}
+
 type GetAllFoldersParameters struct {
 	WorkspaceId              string
 	Environment              string

--- a/cli/packages/util/exec.go
+++ b/cli/packages/util/exec.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/mattn/go-isatty"
+)
+
+func RunCommand(singleCommand string, args []string, env []string) (*exec.Cmd, error) {
+	var c *exec.Cmd
+	var err error
+
+	if singleCommand != "" {
+		c, err = RunCommandFromString(singleCommand, env)
+	} else {
+		c, err = RunCommandFromArgs(args, env)
+	}
+
+	return c, err
+}
+
+func IsProcessRunning(p *os.Process) bool {
+	err := p.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// For "infisical run -- COMMAND"
+func RunCommandFromArgs(command []string, env []string) (*exec.Cmd, error) {
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := execCommand(cmd)
+
+	return cmd, err
+}
+
+func execCommand(cmd *exec.Cmd) error {
+
+	shouldForward := !isatty.IsTerminal(os.Stdout.Fd())
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// handle all signals
+	go func() {
+		for {
+			if shouldForward {
+				// forward to process
+				sig := <-sigChan
+				cmd.Process.Signal(sig)
+			} else {
+				<-sigChan
+			}
+		}
+	}()
+
+	return nil
+}
+
+// For "infisical run --command=COMMAND"
+func RunCommandFromString(command string, env []string) (*exec.Cmd, error) {
+	shell := [2]string{"sh", "-c"}
+	if runtime.GOOS == "windows" {
+		shell = [2]string{"cmd", "/C"}
+	} else {
+		// these shells all support the same options we use for sh
+		shells := []string{"/bash", "/dash", "/fish", "/zsh", "/ksh", "/csh", "/tcsh"}
+		envShell := os.Getenv("SHELL")
+		for _, s := range shells {
+			if strings.HasSuffix(envShell, s) {
+				shell[0] = envShell
+				break
+			}
+		}
+	}
+	cmd := exec.Command(shell[0], shell[1], command) // #nosec G204 nosemgrep: semgrep_configs.prohibit-exec-command
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := execCommand(cmd)
+	return cmd, err
+}

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"os"
@@ -297,4 +298,17 @@ func GenerateRandomString(length int) string {
 		b[i] = charset[rand.Intn(len(charset))]
 	}
 	return string(b)
+}
+
+func GenerateETagFromSecrets(secrets []models.SingleEnvironmentVariable) string {
+	sortedSecrets := SortSecretsByKeys(secrets)
+	content := []byte{}
+
+	for _, secret := range sortedSecrets {
+		content = append(content, []byte(secret.Key)...)
+		content = append(content, []byte(secret.Value)...)
+	}
+
+	hash := sha256.Sum256(content)
+	return fmt.Sprintf(`"%s"`, hex.EncodeToString(hash[:]))
 }

--- a/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
+++ b/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
@@ -1,4 +1,4 @@
-error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&include_imports=true&recursive=true&secretPath=%2F&workspaceId=***] [status-code=500] [response={"statusCode":500,"error":"Internal Server Error","message":"'invalid-env' environment not found in project with ID ***"}]
+error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&include_imports=true&recursive=true&secretPath=%2F&workspaceId=bef697d4-849b-4a75-b284-0922f87f8ba2] [status-code=500] [response={"statusCode":500,"error":"Internal Server Error","message":"'invalid-env' environment not found in project with ID bef697d4-849b-4a75-b284-0922f87f8ba2"}]
 
 
 If this issue continues, get support at https://infisical.com/slack

--- a/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
+++ b/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
@@ -1,4 +1,4 @@
-error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&include_imports=true&recursive=true&secretPath=%2F&workspaceId=bef697d4-849b-4a75-b284-0922f87f8ba2] [status-code=500] [response={"statusCode":500,"error":"Internal Server Error","message":"'invalid-env' environment not found in project with ID bef697d4-849b-4a75-b284-0922f87f8ba2"}]
+error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&include_imports=true&recursive=true&secretPath=%2F&workspaceId=***] [status-code=500] [response={"statusCode":500,"error":"Internal Server Error","message":"'invalid-env' environment not found in project with ID ***"}]
 
 
 If this issue continues, get support at https://infisical.com/slack

--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -47,20 +47,20 @@ $ infisical run -- npm run dev
     Used to fetch secrets via a [machine identity](/documentation/platform/identities/machine-identities) apposed to logged in credentials. Simply, export this variable in the terminal before running this command.
 
     ```bash
-    # Example
-    export INFISICAL_TOKEN=$(infisical login --method=universal-auth --client-id=<identity-client-id> --client-secret=<identity-client-secret> --silent --plain) # --plain flag will output only the token, so it can be fed to an environment variable. --silent will disable any update messages.
+      # Example
+      export INFISICAL_TOKEN=$(infisical login --method=universal-auth --client-id=<identity-client-id> --client-secret=<identity-client-secret> --silent --plain) # --plain flag will output only the token, so it can be fed to an environment variable. --silent will disable any update messages.
     ```
 
     <Info>
       Alternatively, you may use service tokens.
 
       Please note, however, that service tokens are being deprecated in favor of [machine identities](/documentation/platform/identities/machine-identities). They will be removed in the future in accordance with the deprecation notice and timeline stated [here](https://infisical.com/blog/deprecating-api-keys).
+      
       ```bash
-      # Example
-      export INFISICAL_TOKEN=<service-token>
+        # Example
+        export INFISICAL_TOKEN=<service-token>
       ```
-
-  </Info>
+    </Info>
   </Accordion>
 
   <Accordion title="INFISICAL_DISABLE_UPDATE_CHECK">
@@ -69,22 +69,30 @@ $ infisical run -- npm run dev
     To use, simply export this variable in the terminal before running this command.
 
     ```bash
-    # Example
-    export INFISICAL_DISABLE_UPDATE_CHECK=true
+      # Example
+      export INFISICAL_DISABLE_UPDATE_CHECK=true
     ```
-
   </Accordion>
 
 ### Flags
 
-   <Accordion title="--project-config-dir">
+  <Accordion title="--watch">
+    By passing the `watch` flag, you are telling the CLI to watch for changes that happen in your Infisical project.
+    If secret changes happen, the command you provided will automatically be restarted with the new environment variables attached.
+
+    ```bash
+      # Example
+      infisical run --watch -- printenv
+    ```
+  </Accordion>
+
+  <Accordion title="--project-config-dir">
     Explicitly set the directory where the .infisical.json resides. This is useful for some monorepo setups.
 
     ```bash
-    # Example
-    infisical run --project-config-dir=/some-dir -- printenv
+      # Example
+      infisical run --project-config-dir=/some-dir -- printenv
     ```
-
   </Accordion>
 
   <Accordion title="--command">
@@ -172,3 +180,19 @@ $ infisical run -- npm run dev
   </Accordion>
 
 </Accordion>
+
+
+## Automatically reload command when secrets change
+
+To automatically reload your command when secrets change, use the `--watch` flag.
+
+```bash
+infisical run --watch -- npm run dev
+```
+
+This will watch for changes in your secrets and automatically restart your command with the new secrets.
+When your command restarts, it will have the new environment variables injeceted into it.
+
+<Note>
+  Please note that this feature is intended for development purposes. It is not recommended to use this in production environments. Generally it's not recommended to automatically reload your application in production when remote changes are made.
+</Note>


### PR DESCRIPTION
# Description 📣

This PR aims to add support for secret watching. The user will now be able to pass a `--watch` flag to the `infisical run` command. When the `watch` flag is passed, Infisical will automatically reload the command passed to `infisical run`.

### New flow example

1. User runs `infisical run --watch --comand="while true; do printenv; sleep 500000; done"`. _(Both --command and -- supports the new `watch` flag)_
   * At first this acts exactly like it always has, and prints the environment to the console and hangs until interrupted.
2. The user now changes a secret in Infisical.
3. At some point within the next 10 seconds (due to polling), the application will detect a change in the Infisical secrets, and then trigger a reload of the application.
4. The application reloads and the new secrets are loaded into the application. 


This is especially useful in local development setups, where the user usually would have to manually restart the entire process for the new secrets to load in. This implementation streamlines everything and in a sense acts like [Nodemon](https://github.com/remy/nodemon) acts when detecting changes in a Node.js project.

This can also be used in production environments where you'd want to reload an application when secret changes happen in Infisical. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->