### PR TITLE
Fix: Removed protocol parsing on secret change emails

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-fns.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-fns.ts
@@ -36,9 +36,7 @@ export const sendApprovalEmailsFn = async ({
         firstName: reviewerUser.firstName,
         projectName: project.name,
         organizationName: project.organization.name,
-        approvalUrl: `${cfg.isDevelopmentMode ? "https" : "http"}://${cfg.SITE_URL}/project/${
-          project.id
-        }/approval?requestId=${secretApprovalRequest.id}`
+        approvalUrl: `${cfg.SITE_URL}/project/${project.id}/approval?requestId=${secretApprovalRequest.id}`
       },
       template: SmtpTemplates.SecretApprovalRequestNeedsReview
     });


### PR DESCRIPTION
# Description 📣

A bug recently introduced in the secret change emails PR resulted in the links being incorrectly formatted in the emails sent. The SITE_URL variable contains the protocol, and we were previously adding the protocol manually before the SITE_URL. This led to the URL being incorrectly formatted

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->