### PR TITLE
Fix: Always remove trailing slashes from SITE_URL

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -1,6 +1,7 @@
 import { Logger } from "pino";
 import { z } from "zod";
 
+import { removeTrailingSlash } from "../fn";
 import { zpStr } from "../zod";
 
 export const GITLAB_URL = "https://gitlab.com";
@@ -63,7 +64,9 @@ const envSchema = z
       .string()
       .min(32)
       .default("#5VihU%rbXHcHwWwCot5L3vyPsx$7dWYw^iGk!EJg2bC*f$PD$%KCqx^R@#^LSEf"),
-    SITE_URL: zpStr(z.string().optional()),
+
+    // Ensure that the SITE_URL never ends with a trailing slash
+    SITE_URL: zpStr(z.string().transform((val) => (val ? removeTrailingSlash(val) : val))).optional(),
     // Telemetry
     TELEMETRY_ENABLED: zodStrBool.default("true"),
     POSTHOG_HOST: zpStr(z.string().optional().default("https://app.posthog.com")),


### PR DESCRIPTION
# Description 📣

A basic fail-safe for trailing slashes in the SITE_URL. When we use the SITE_URL throughout the code, we assume that there is no trailing slash. This PR removes the need to assume. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->