### PR TITLE
Fix: Security attributes for dynamic secret endpoints

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
@@ -2,7 +2,7 @@ import ms from "ms";
 import { z } from "zod";
 
 import { DynamicSecretLeasesSchema } from "@app/db/schemas";
-import { DYNAMIC_SECRET_LEASES } from "@app/lib/api-docs";
+import { DEFAULT_REQUEST_SCHEMA, DYNAMIC_SECRET_LEASES } from "@app/lib/api-docs";
 import { daysToMillisecond } from "@app/lib/dates";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -18,6 +18,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       body: z.object({
         dynamicSecretName: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.CREATE.dynamicSecretName).toLowerCase(),
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.CREATE.projectSlug),
@@ -65,6 +66,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.DELETE.leaseId)
       }),
@@ -107,6 +109,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.RENEW.leaseId)
       }),
@@ -160,6 +163,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
       rateLimit: readLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.GET_BY_LEASEID.leaseId)
       }),

--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { DynamicSecretLeasesSchema } from "@app/db/schemas";
 import { DynamicSecretProviderSchema } from "@app/ee/services/dynamic-secret/providers/models";
-import { DYNAMIC_SECRETS } from "@app/lib/api-docs";
+import { DEFAULT_REQUEST_SCHEMA, DYNAMIC_SECRETS } from "@app/lib/api-docs";
 import { daysToMillisecond } from "@app/lib/dates";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -20,6 +20,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       body: z.object({
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRETS.CREATE.projectSlug),
         provider: DynamicSecretProviderSchema.describe(DYNAMIC_SECRETS.CREATE.provider),
@@ -84,6 +85,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         name: z.string().toLowerCase().describe(DYNAMIC_SECRETS.UPDATE.name)
       }),
@@ -151,6 +153,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: writeLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         name: z.string().toLowerCase().describe(DYNAMIC_SECRETS.DELETE.name)
       }),
@@ -187,6 +190,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: readLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         name: z.string().min(1).describe(DYNAMIC_SECRETS.GET_BY_NAME.name)
       }),
@@ -224,6 +228,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: readLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       querystring: z.object({
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRETS.LIST.projectSlug),
         path: z.string().trim().default("/").transform(removeTrailingSlash).describe(DYNAMIC_SECRETS.LIST.path),
@@ -255,6 +260,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
       rateLimit: readLimit
     },
     schema: {
+      ...DEFAULT_REQUEST_SCHEMA,
       params: z.object({
         name: z.string().min(1).describe(DYNAMIC_SECRETS.LIST_LEAES_BY_NAME.name)
       }),

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1,3 +1,12 @@
+export const DEFAULT_REQUEST_SCHEMA = {
+  // Add more default attributes here if needed
+  security: [
+    {
+      bearerAuth: []
+    }
+  ]
+};
+
 export const GROUPS = {
   CREATE: {
     name: "The name of the group to create.",


### PR DESCRIPTION
# Description 📣

Our new SDK requires the security attribute to be set on the API endpoints we want to be accessible. This issue wasn't spotted earlier because we never tested against endpoints that didn't have the `security` attribute set. This is happening because our new SDK's are based on our OpenAPI spec, and without the security / bearerAuth field set, it will fail to authenticate. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->