### PR TITLE
Added functionality to open login window using browser #2351

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -36,6 +36,9 @@ import (
 	"golang.org/x/term"
 
 	infisicalSdk "github.com/infisical/go-sdk"
+
+	"runtime"
+	"os/exec"
 )
 
 type params struct {
@@ -44,6 +47,20 @@ type params struct {
 	parallelism uint8
 	saltLength  uint32
 	keyLength   uint32
+}
+
+func openBrowser(url string) bool {
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		args = []string{"open"}
+	case "windows":
+		args = []string{"cmd", "/c", "start"}
+	default:
+		args = []string{"xdg-open"}
+	}
+	cmd := exec.Command(args[0], append(args[1:], url)...)
+	return cmd.Start() == nil
 }
 
 func handleUniversalAuthLogin(cmd *cobra.Command, infisicalClient infisicalSdk.InfisicalClientInterface) (credential infisicalSdk.MachineIdentityCredential, e error) {
@@ -847,7 +864,9 @@ func browserCliLogin() (models.UserCredentials, error) {
 	callbackPort := listener.Addr().(*net.TCPAddr).Port
 	url := fmt.Sprintf("%s?callback_port=%d", config.INFISICAL_LOGIN_URL, callbackPort)
 
-	fmt.Printf("\n\nTo complete your login, open this address in your browser: %v \n", url)
+	openBrowser(url);
+	fmt.Printf("Brower requested to open login")
+	fmt.Printf("\n\nTo complete your login, if browser does not open automatically, open this address in your browser: %v \n", url)
 
 	//flow channels
 	success := make(chan models.UserCredentials)


### PR DESCRIPTION
# Description 📣 #2351 

I have added the functionality for the `$ infisical login` command to open a browser tab with the url instead of regular copying and pasting. If the machine is running headless, then the function will return false resulting in a default to the previous method.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝