### PR TITLE
Audit log queue looping

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -62,6 +62,7 @@ export const auditLogDALFactory = (db: TDbClient) => {
     const today = new Date();
     let deletedAuditLogIds: { id: string }[] = [];
     let numberOfRetryOnFailure = 0;
+    let isRetrying = false;
 
     do {
       try {
@@ -84,7 +85,8 @@ export const auditLogDALFactory = (db: TDbClient) => {
           setTimeout(resolve, 10); // time to breathe for db
         });
       }
-    } while (deletedAuditLogIds.length > 0 || numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE);
+      isRetrying = numberOfRetryOnFailure > 0;
+    } while (deletedAuditLogIds.length > 0 || (isRetrying && numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE));
   };
 
   return { ...auditLogOrm, pruneAuditLog, find };

--- a/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
+++ b/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
@@ -16,6 +16,7 @@ import {
 import { DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TSnapshotDALFactory = ReturnType<typeof snapshotDALFactory>;
 
@@ -599,6 +600,7 @@ export const snapshotDALFactory = (db: TDbClient) => {
   const pruneExcessSnapshots = async () => {
     const PRUNE_FOLDER_BATCH_SIZE = 10000;
 
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret snapshots started`);
     try {
       let uuidOffset = "00000000-0000-0000-0000-000000000000";
       // cleanup snapshots from current folders
@@ -714,6 +716,7 @@ export const snapshotDALFactory = (db: TDbClient) => {
     } catch (error) {
       throw new DatabaseError({ error, name: "SnapshotPrune" });
     }
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret snapshots completed`);
   };
 
   // special query for migration for secret v2

--- a/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
+++ b/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
@@ -30,6 +30,7 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
 
     let deletedClientSecret: { id: string }[] = [];
     let numberOfRetryOnFailure = 0;
+    let isRetrying = false;
 
     do {
       try {
@@ -71,7 +72,8 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
           setTimeout(resolve, 10); // time to breathe for db
         });
       }
-    } while (deletedClientSecret.length > 0 || numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE);
+      isRetrying = numberOfRetryOnFailure > 0;
+    } while (deletedClientSecret.length > 0 || (isRetrying && numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE));
   };
 
   return { ...uaClientSecretOrm, incrementUsage, removeExpiredClientSecrets };

--- a/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
+++ b/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
@@ -5,6 +5,7 @@ import { TableName } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 import { ormify } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TIdentityUaClientSecretDALFactory = ReturnType<typeof identityUaClientSecretDALFactory>;
 
@@ -32,6 +33,7 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
     let numberOfRetryOnFailure = 0;
     let isRetrying = false;
 
+    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired univesal auth client secret started`);
     do {
       try {
         const findExpiredClientSecretQuery = (tx || db)(TableName.IdentityUaClientSecret)
@@ -74,6 +76,7 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
       }
       isRetrying = numberOfRetryOnFailure > 0;
     } while (deletedClientSecret.length > 0 || (isRetrying && numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE));
+    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired univesal auth client secret completed`);
   };
 
   return { ...uaClientSecretOrm, incrementUsage, removeExpiredClientSecrets };

--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -37,13 +37,21 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
 }: TDailyResourceCleanUpQueueServiceFactoryDep) => {
   queueService.start(QueueName.DailyResourceCleanUp, async () => {
     logger.info(`${QueueName.DailyResourceCleanUp}: queue task started`);
+    logger.info(`${QueueName.DailyResourceCleanUp}: audit log`);
     await auditLogDAL.pruneAuditLog();
+    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired access token`);
     await identityAccessTokenDAL.removeExpiredTokens();
+    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired univesal auth client secret`);
     await identityUniversalAuthClientSecretDAL.removeExpiredClientSecrets();
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret`);
     await secretSharingDAL.pruneExpiredSharedSecrets();
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret snapshots`);
     await snapshotDAL.pruneExcessSnapshots();
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v1`);
     await secretVersionDAL.pruneExcessVersions();
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v2`);
     await secretVersionV2DAL.pruneExcessVersions();
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret folder versions`);
     await secretFolderVersionDAL.pruneExcessVersions();
     logger.info(`${QueueName.DailyResourceCleanUp}: queue task completed`);
   });

--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -37,21 +37,13 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
 }: TDailyResourceCleanUpQueueServiceFactoryDep) => {
   queueService.start(QueueName.DailyResourceCleanUp, async () => {
     logger.info(`${QueueName.DailyResourceCleanUp}: queue task started`);
-    logger.info(`${QueueName.DailyResourceCleanUp}: audit log`);
     await auditLogDAL.pruneAuditLog();
-    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired access token`);
     await identityAccessTokenDAL.removeExpiredTokens();
-    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired univesal auth client secret`);
     await identityUniversalAuthClientSecretDAL.removeExpiredClientSecrets();
-    logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret`);
     await secretSharingDAL.pruneExpiredSharedSecrets();
-    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret snapshots`);
     await snapshotDAL.pruneExcessSnapshots();
-    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v1`);
     await secretVersionDAL.pruneExcessVersions();
-    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v2`);
     await secretVersionV2DAL.pruneExcessVersions();
-    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret folder versions`);
     await secretFolderVersionDAL.pruneExcessVersions();
     logger.info(`${QueueName.DailyResourceCleanUp}: queue task completed`);
   });

--- a/backend/src/services/secret-folder/secret-folder-version-dal.ts
+++ b/backend/src/services/secret-folder/secret-folder-version-dal.ts
@@ -4,6 +4,8 @@ import { TDbClient } from "@app/db";
 import { TableName, TSecretFolderVersions } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TSecretFolderVersionDALFactory = ReturnType<typeof secretFolderVersionDALFactory>;
 
@@ -65,6 +67,7 @@ export const secretFolderVersionDALFactory = (db: TDbClient) => {
   };
 
   const pruneExcessVersions = async () => {
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret folder versions started`);
     try {
       await db(TableName.SecretFolderVersion)
         .with("folder_cte", (qb) => {
@@ -89,6 +92,7 @@ export const secretFolderVersionDALFactory = (db: TDbClient) => {
         name: "Secret Folder Version Prune"
       });
     }
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret folder versions completed`);
   };
 
   return { ...secretFolderVerOrm, findLatestFolderVersions, findLatestVersionByFolderId, pruneExcessVersions };

--- a/backend/src/services/secret-sharing/secret-sharing-dal.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-dal.ts
@@ -4,6 +4,8 @@ import { TDbClient } from "@app/db";
 import { TableName, TSecretSharing } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TSecretSharingDALFactory = ReturnType<typeof secretSharingDALFactory>;
 
@@ -30,6 +32,7 @@ export const secretSharingDALFactory = (db: TDbClient) => {
   };
 
   const pruneExpiredSharedSecrets = async (tx?: Knex) => {
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret started`);
     try {
       const today = new Date();
       const docs = await (tx || db)(TableName.SecretSharing)
@@ -40,6 +43,7 @@ export const secretSharingDALFactory = (db: TDbClient) => {
           tag: "",
           iv: ""
         });
+      logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret completed`);
       return docs;
     } catch (error) {
       throw new DatabaseError({ error, name: "pruneExpiredSharedSecrets" });

--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -4,6 +4,8 @@ import { TDbClient } from "@app/db";
 import { TableName, TSecretVersionsV2, TSecretVersionsV2Update } from "@app/db/schemas";
 import { BadRequestError, DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TSecretVersionV2DALFactory = ReturnType<typeof secretVersionV2BridgeDALFactory>;
 
@@ -87,6 +89,7 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
   };
 
   const pruneExcessVersions = async () => {
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v2 started`);
     try {
       await db(TableName.SecretVersionV2)
         .with("version_cte", (qb) => {
@@ -112,6 +115,7 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
         name: "Secret Version Prune"
       });
     }
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v2 completed`);
   };
 
   return {

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -4,6 +4,8 @@ import { TDbClient } from "@app/db";
 import { TableName, TSecretVersions, TSecretVersionsUpdate } from "@app/db/schemas";
 import { BadRequestError, DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { logger } from "@app/lib/logger";
+import { QueueName } from "@app/queue";
 
 export type TSecretVersionDALFactory = ReturnType<typeof secretVersionDALFactory>;
 
@@ -112,6 +114,7 @@ export const secretVersionDALFactory = (db: TDbClient) => {
   };
 
   const pruneExcessVersions = async () => {
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v1 started`);
     try {
       await db(TableName.SecretVersion)
         .with("version_cte", (qb) => {
@@ -137,6 +140,7 @@ export const secretVersionDALFactory = (db: TDbClient) => {
         name: "Secret Version Prune"
       });
     }
+    logger.info(`${QueueName.DailyResourceCleanUp}: pruning secret version v1 completed`);
   };
 
   return {


### PR DESCRIPTION
# Description 📣

This PR fixes a bug in resource clean up that could cause a looping in audit log and token cleanup. Also adds log point to identity present status of pruning. 

Root cause of multiple clean up runs:
If there are no issues then `deletedClientSecret.length > 0`  is false but `numberOfRetryOnFailure < MAX_RETRY_ON_FAILURE` will always be true because numberOfRetryOnFailure will be zero which is always less than max. To fix this, we need to check for `isretrying`

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->