### PR TITLE
fix(ui): show info notification when secret change is pending review

### DIFF
--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -61,8 +61,9 @@ export const CreateSecretForm = ({
       });
       closePopUp(PopUpNames.CreateSecretForm);
       reset();
+
       createNotification({
-        type: "success",
+        type: isProtectedBranch ? "info" : "success",
         text: isProtectedBranch
           ? "Requested changes have been sent for review"
           : "Successfully created secret"

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
@@ -270,7 +270,7 @@ export const SecretListView = ({
         queryClient.invalidateQueries(secretApprovalRequestKeys.count({ workspaceId }));
         handlePopUpClose("secretDetail");
         createNotification({
-          type: "success",
+          type: isProtectedBranch ? "info" : "success",
           text: isProtectedBranch
             ? "Requested changes have been sent for review"
             : "Successfully saved secrets"
@@ -304,7 +304,7 @@ export const SecretListView = ({
       handlePopUpClose("deleteSecret");
       handlePopUpClose("secretDetail");
       createNotification({
-        type: "success",
+        type: isProtectedBranch ? "info" : "success",
         text: isProtectedBranch
           ? "Requested changes have been sent for review"
           : "Successfully deleted secret"


### PR DESCRIPTION
# Description 📣

Previously we were always showing a "success" notification when a secret change happened, regardless if it was pending review or not. Now we show an "info" / blue notification when the secret needs to be reviewed. This should help clear up confusion when making secret changes. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->