### PR TITLE
fix: resolve cert invalid issue due to invalid root EKU

### DIFF
--- a/backend/src/services/certificate-authority/certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-service.ts
@@ -213,7 +213,6 @@ export const certificateAuthorityServiceFactory = ({
           keys,
           extensions: [
             new x509.BasicConstraintsExtension(true, maxPathLength === -1 ? undefined : maxPathLength, true),
-            new x509.ExtendedKeyUsageExtension(["1.2.3.4.5.6.7", "2.3.4.5.6.7.8"], true),
             // eslint-disable-next-line no-bitwise
             new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
             await x509.SubjectKeyIdentifierExtension.create(keys.publicKey)
@@ -496,7 +495,6 @@ export const certificateAuthorityServiceFactory = ({
               ca.maxPathLength === -1 || !ca.maxPathLength ? undefined : ca.maxPathLength,
               true
             ),
-            new x509.ExtendedKeyUsageExtension(["1.2.3.4.5.6.7", "2.3.4.5.6.7.8"], true),
             // eslint-disable-next-line no-bitwise
             new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
             await x509.SubjectKeyIdentifierExtension.create(caPublicKey)


### PR DESCRIPTION
# Description 📣
- This PR addresses "cert invalid" issue thrown by Chrome, Firefox, and Brave browsers when using Infisical-generated certificates as server certificates
https://github.com/Infisical/infisical/issues/2346

Note: for this fix to work with existing setups, you will need to renew your Root CA using the same key pair and migrate your infra to use this newly generated certificate (i.e. in server certificate chains and trust stores)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->