### PR TITLE
misc: support glob patterns for OIDC

### DIFF
--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-fns.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-fns.ts
@@ -1,0 +1,4 @@
+import picomatch from "picomatch";
+
+export const doesFieldValueMatchOidcPolicy = (fieldValue: string, policyValue: string) =>
+  policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue);

--- a/docs/documentation/platform/identities/oidc-auth/general.mdx
+++ b/docs/documentation/platform/identities/oidc-auth/general.mdx
@@ -93,7 +93,12 @@ In the following steps, we explore how to create and use identities to access th
     - Access Token Max TTL (default is `2592000`  equivalent to 30 days): The maximum lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max Number of Uses (default is `0`): The maximum number of times that an access token can be used; a value of `0` implies infinite number of uses.
     - Access Token Trusted IPs: The IPs or CIDR ranges that access tokens can be used from. By default, each token is given the `0.0.0.0/0`, allowing usage from any network address.
+    <Info>
+        The `subject`, `audiences`, and `claims` fields support glob pattern matching; however, we highly recommend using hardcoded values whenever possible.
+    </Info>
+
     </Step>
+
     <Step title="Adding an identity to a project">
     To enable the identity to access project-level resources such as secrets within a specific project, you should add it to that project.
 

--- a/docs/documentation/platform/identities/oidc-auth/github.mdx
+++ b/docs/documentation/platform/identities/oidc-auth/github.mdx
@@ -92,8 +92,8 @@ In the following steps, we explore how to create and use identities to access th
     - Access Token Max TTL (default is `2592000`  equivalent to 30 days): The maximum lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max Number of Uses (default is `0`): The maximum number of times that an access token can be used; a value of `0` implies infinite number of uses.
     - Access Token Trusted IPs: The IPs or CIDR ranges that access tokens can be used from. By default, each token is given the `0.0.0.0/0`, allowing usage from any network address.
-
     <Tip>If you are unsure about what to configure for the subject, audience, and claims fields you can use [github/actions-oidc-debugger](https://github.com/github/actions-oidc-debugger) to get the appropriate values. Alternatively, you can fetch the JWT from the workflow and inspect the fields manually.</Tip>
+    <Info>The `subject`, `audiences`, and `claims` fields support glob pattern matching; however, we highly recommend using hardcoded values whenever possible.</Info>
     </Step>
     <Step title="Adding an identity to a project">
     To enable the identity to access project-level resources such as secrets within a specific project, you should add it to that project.

--- a/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityOidcAuthForm.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgIdentityTab/components/IdentitySection/IdentityOidcAuthForm.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
 import { faPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, IconButton, Input, TextArea } from "@app/components/v2";
+import { Button, FormControl, IconButton, Input, TextArea, Tooltip } from "@app/components/v2";
 import { useOrganization, useSubscription } from "@app/context";
 import { useAddIdentityOidcAuth, useUpdateIdentityOidcAuth } from "@app/hooks/api";
 import { IdentityAuthMethod } from "@app/hooks/api/identities";
@@ -258,7 +259,19 @@ export const IdentityOidcAuthForm = ({
         control={control}
         name="boundSubject"
         render={({ field, fieldState: { error } }) => (
-          <FormControl label="Subject" isError={Boolean(error)} errorText={error?.message}>
+          <FormControl
+            label="Subject"
+            isError={Boolean(error)}
+            errorText={error?.message}
+            icon={
+              <Tooltip
+                className="text-center"
+                content={<span>This field supports glob patterns</span>}
+              >
+                <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+              </Tooltip>
+            }
+          >
             <Input {...field} type="text" />
           </FormControl>
         )}
@@ -267,7 +280,19 @@ export const IdentityOidcAuthForm = ({
         control={control}
         name="boundAudiences"
         render={({ field, fieldState: { error } }) => (
-          <FormControl label="Audiences" isError={Boolean(error)} errorText={error?.message}>
+          <FormControl
+            label="Audiences"
+            isError={Boolean(error)}
+            errorText={error?.message}
+            icon={
+              <Tooltip
+                className="text-center"
+                content={<span>This field supports glob patterns</span>}
+              >
+                <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+              </Tooltip>
+            }
+          >
             <Input {...field} type="text" placeholder="service1, service2" />
           </FormControl>
         )}
@@ -282,6 +307,16 @@ export const IdentityOidcAuthForm = ({
                 <FormControl
                   className="mb-0 flex-grow"
                   label={index === 0 ? "Claims" : undefined}
+                  icon={
+                    index === 0 ? (
+                      <Tooltip
+                        className="text-center"
+                        content={<span>This field supports glob patterns</span>}
+                      >
+                        <FontAwesomeIcon icon={faQuestionCircle} size="sm" />
+                      </Tooltip>
+                    ) : undefined
+                  }
                   isError={Boolean(error)}
                   errorText={error?.message}
                 >


### PR DESCRIPTION
# Description 📣
- This PR will allow users to configure machine identity OIDC auth configurations using glob patterns like the following:
<img width="611" alt="image" src="https://github.com/user-attachments/assets/7264c134-8269-4aeb-a3eb-1c380ff96e61">

E.g.

To match something like repo:sheen-org/personal-assistant:ref:refs/heads/master
You can use:
repo:sheen-org/personal-assistant:ref:*/**
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->