### PR TITLE
misc: throw SAML or SSO errors properly

### DIFF
--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -118,7 +118,7 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
           cb(null, { isUserCompleted, providerAuthToken });
         } catch (error) {
           logger.error(error);
-          cb(null, {});
+          cb(error as Error);
         }
       },
       () => {}

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -57,7 +57,7 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
             cb(null, { isUserCompleted, providerAuthToken });
           } catch (error) {
             logger.error(error);
-            cb(null, false);
+            cb(error as Error, false);
           }
         }
       )
@@ -91,7 +91,7 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
             return cb(null, { isUserCompleted, providerAuthToken });
           } catch (error) {
             logger.error(error);
-            cb(null, false);
+            cb(error as Error, false);
           }
         }
       )
@@ -126,7 +126,7 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
             return cb(null, { isUserCompleted, providerAuthToken });
           } catch (error) {
             logger.error(error);
-            cb(null, false);
+            cb(error as Error, false);
           }
         }
       )


### PR DESCRIPTION
# Description 📣
This PR ensures that errors thrown during SAML/SSO logins are displayed to the user to allow them to debug the setup issues they encounter.

Before this PR, when errors are thrown during the SAML login process, it redirects the user to the signup page with an undefined token:
![image](https://github.com/user-attachments/assets/db64f9fb-786a-4f39-b884-3aeeda1f3519)

This PR updates the flow so that users actually see the error like the ff:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9237ce15-11b5-48d0-b4ef-2fb9b45084a9">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->