### PR TITLE
misc: ensure that selected kms key in aws param integration is followed

### DIFF
--- a/docs/integrations/cloud/aws-parameter-store.mdx
+++ b/docs/integrations/cloud/aws-parameter-store.mdx
@@ -30,6 +30,7 @@ Prerequisites:
             "ssm:DeleteParameter",
             "ssm:GetParameters",
             "ssm:GetParametersByPath",
+            "ssm:DescribeParameters",
             "ssm:DeleteParameters",
             "ssm:AddTagsToResource", // if you need to add tags to secrets
             "kms:ListKeys", // if you need to specify the KMS key


### PR DESCRIPTION
# Description 📣
This PR modifies AWS Parameter integration sync logic to ensure that selected KMS key of integration is applied for ALL matching parameters on AWS (even those that already existed before the integration was created). This PR also removes keys from the logs

For this update to work for existing integrations, add the "ssm:DescribeParameters" permission to the linked AWS account/role.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->