### PR TITLE
fix: stale session after logging into CLI

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -468,7 +468,7 @@ export const registerRoutes = async (
     projectMembershipDAL
   });
 
-  const loginService = authLoginServiceFactory({ userDAL, smtpService, tokenService, orgDAL, tokenDAL: authTokenDAL });
+  const loginService = authLoginServiceFactory({ userDAL, smtpService, tokenService, orgDAL });
   const passwordService = authPaswordServiceFactory({
     tokenService,
     smtpService,

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -42,7 +42,8 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       body: z.object({
-        organizationId: z.string().trim()
+        organizationId: z.string().trim(),
+        customUserAgent: z.enum(["cli"]).optional()
       }),
       response: {
         200: z.object({
@@ -53,7 +54,7 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
     handler: async (req, res) => {
       const cfg = getConfig();
       const tokens = await server.services.login.selectOrganization({
-        userAgent: req.headers["user-agent"],
+        userAgent: req.body.customUserAgent ?? req.headers["user-agent"],
         authJwtToken: req.headers.authorization,
         organizationId: req.body.organizationId,
         ipAddress: req.realIp

--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -12,7 +12,6 @@ import { BadRequestError, DatabaseError, UnauthorizedError } from "@app/lib/erro
 import { logger } from "@app/lib/logger";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 
-import { TTokenDALFactory } from "../auth-token/auth-token-dal";
 import { TAuthTokenServiceFactory } from "../auth-token/auth-token-service";
 import { TokenType } from "../auth-token/auth-token-types";
 import { TOrgDALFactory } from "../org/org-dal";
@@ -34,7 +33,6 @@ type TAuthLoginServiceFactoryDep = {
   orgDAL: TOrgDALFactory;
   tokenService: TAuthTokenServiceFactory;
   smtpService: TSmtpService;
-  tokenDAL: TTokenDALFactory;
 };
 
 export type TAuthLoginFactory = ReturnType<typeof authLoginServiceFactory>;
@@ -42,8 +40,7 @@ export const authLoginServiceFactory = ({
   userDAL,
   tokenService,
   smtpService,
-  orgDAL,
-  tokenDAL
+  orgDAL
 }: TAuthLoginServiceFactoryDep) => {
   /*
    * Private
@@ -375,8 +372,6 @@ export const authLoginServiceFactory = ({
         message: `User does not have access to the organization named ${selectedOrg?.name}`
       });
     }
-
-    await tokenDAL.incrementTokenSessionVersion(user.id, decodedToken.tokenVersionId);
 
     const tokens = await generateUserTokens({
       authMethod: decodedToken.authMethod,

--- a/frontend/src/hooks/api/auth/queries.tsx
+++ b/frontend/src/hooks/api/auth/queries.tsx
@@ -60,7 +60,10 @@ export const useLogin1 = () => {
   });
 };
 
-export const selectOrganization = async (data: { organizationId: string }) => {
+export const selectOrganization = async (data: {
+  organizationId: string;
+  customUserAgent?: string;
+}) => {
   const { data: res } = await apiRequest.post<{ token: string }>(
     "/api/v3/auth/select-organization",
     data
@@ -71,11 +74,14 @@ export const selectOrganization = async (data: { organizationId: string }) => {
 export const useSelectOrganization = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (details: { organizationId: string }) => {
+    mutationFn: async (details: { organizationId: string; customUserAgent?: string }) => {
       const data = await selectOrganization(details);
 
-      SecurityClient.setToken(data.token);
-      SecurityClient.setProviderAuthToken("");
+      // If a custom user agent is set, then this session is meant for another consuming application, not the web application.
+      if (!details.customUserAgent) {
+        SecurityClient.setToken(data.token);
+        SecurityClient.setProviderAuthToken("");
+      }
 
       return data;
     },

--- a/frontend/src/pages/login/select-organization.tsx
+++ b/frontend/src/pages/login/select-organization.tsx
@@ -68,7 +68,10 @@ export default function LoginPage() {
         return;
       }
 
-      const { token } = await selectOrg.mutateAsync({ organizationId: organization.id });
+      const { token } = await selectOrg.mutateAsync({
+        organizationId: organization.id,
+        customUserAgent: callbackPort ? "cli" : undefined
+      });
 
       if (callbackPort) {
         const privateKey = localStorage.getItem("PRIVATE_KEY");


### PR DESCRIPTION
# Description 📣

This PR fixes a rare bug with sessions going stale after logging into the CLI. The issue is multi-part, but what was happening was:

1. After logging into the CLI, a new session is created based on user ID, user agent, and IP address. When logging in with the CLI, the user agent should always be `cli`. However, the user agent is always set to the browser's user agent, because we can't set the user agent on requests sent with the browser (unsafe header limitation).
   * The fix for this was adding a new "customUserAgent" parameter to the `/select-organization` endpoint. This allows us to specify user agents for sessions that deviate from the browsers user agent.
2. We were incrementing the session version whenever a user selected an organization.
   *  We are only supposed to increment the version when we want tokens to become invalid (such as after changing passwords or logging out. Bumping the session version is not relevant for switching organization.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->