### PR TITLE
fix: redirect to selected org if already present

### DIFF
--- a/frontend/src/views/Login/Login.utils.tsx
+++ b/frontend/src/views/Login/Login.utils.tsx
@@ -43,6 +43,11 @@ export const useNavigateToSelectOrganization = () => {
       await navigateUserToOrg(router, config.defaultAuthOrgId);
     }
 
+    let localOrgId = localStorage.getItem("orgData.id")
+    if(!cliCallbackPort && localOrgId != null){
+      await navigateUserToOrg(router, localOrgId);
+    }
+
     queryClient.invalidateQueries(userKeys.getUser);
     let redirectTo = "/login/select-organization";
 


### PR DESCRIPTION
# Description 📣
Redirect users to already selected organization (if present) when they land at the base url. Fixes [ENG-1514](https://linear.app/infisical/issue/ENG-1514/refreshing-page-keeps-asking-you-to-choose-org).

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

- Log in to a user who is a part of two orgs and select one. 
- Navigate to the base url `localhost:8080`. 
- This should redirect to the selected organization now instead of the org selection page.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->