### PR TITLE
Fix: Apply Project Identity Pagination Prior to Left Join of Roles

### DIFF
--- a/backend/src/services/identity-project/identity-project-dal.ts
+++ b/backend/src/services/identity-project/identity-project-dal.ts
@@ -1,10 +1,11 @@
 import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
-import { TableName } from "@app/db/schemas";
+import { TableName, TIdentities } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
-import { ormify, sqlNestRelationships } from "@app/lib/knex";
-import { TListProjectIdentityDTO } from "@app/services/identity-project/identity-project-types";
+import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
+import { OrderByDirection } from "@app/lib/types";
+import { ProjectIdentityOrderBy, TListProjectIdentityDTO } from "@app/services/identity-project/identity-project-types";
 
 export type TIdentityProjectDALFactory = ReturnType<typeof identityProjectDALFactory>;
 
@@ -117,17 +118,37 @@ export const identityProjectDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
+      // TODO: scott - optimize, there's redundancy here with project membership and the below query
+      const fetchIdentitySubquery = (tx || db.replicaNode())(TableName.Identity)
+        .where((qb) => {
+          if (filter.search) {
+            void qb.whereILike(`${TableName.Identity}.name`, `%${filter.search}%`);
+          }
+        })
+        .join(
+          TableName.IdentityProjectMembership,
+          `${TableName.IdentityProjectMembership}.identityId`,
+          `${TableName.Identity}.id`
+        )
+        .where(`${TableName.IdentityProjectMembership}.projectId`, projectId)
+        .offset(filter.offset ?? 0)
+        .limit(filter.limit ?? 100)
+        .orderBy(
+          `${TableName.Identity}.${filter.orderBy ?? ProjectIdentityOrderBy.Name}`,
+          filter.orderDirection ?? OrderByDirection.ASC
+        )
+        .select(selectAllTableCols(TableName.Identity))
+        .as(TableName.Identity); // required for subqueries
+
       const query = (tx || db.replicaNode())(TableName.IdentityProjectMembership)
         .where(`${TableName.IdentityProjectMembership}.projectId`, projectId)
         .join(TableName.Project, `${TableName.IdentityProjectMembership}.projectId`, `${TableName.Project}.id`)
-        .join(TableName.Identity, `${TableName.IdentityProjectMembership}.identityId`, `${TableName.Identity}.id`)
+        .join<TIdentities, TIdentities>(fetchIdentitySubquery, (bd) => {
+          bd.on(`${TableName.IdentityProjectMembership}.identityId`, `${TableName.Identity}.id`);
+        })
         .where((qb) => {
           if (filter.identityId) {
             void qb.where("identityId", filter.identityId);
-          }
-
-          if (filter.search) {
-            void qb.whereILike(`${TableName.Identity}.name`, `%${filter.search}%`);
           }
         })
         .join(
@@ -166,10 +187,7 @@ export const identityProjectDALFactory = (db: TDbClient) => {
           db.ref("name").as("projectName").withSchema(TableName.Project)
         );
 
-      if (filter.limit) {
-        void query.offset(filter.offset ?? 0).limit(filter.limit);
-      }
-
+      // TODO: scott - joins seem to reorder identities so need to order again, for the sake of urgency will optimize at a later point
       if (filter.orderBy) {
         switch (filter.orderBy) {
           case "name":

--- a/backend/src/services/identity-project/identity-project-dal.ts
+++ b/backend/src/services/identity-project/identity-project-dal.ts
@@ -131,14 +131,16 @@ export const identityProjectDALFactory = (db: TDbClient) => {
           `${TableName.Identity}.id`
         )
         .where(`${TableName.IdentityProjectMembership}.projectId`, projectId)
-        .offset(filter.offset ?? 0)
-        .limit(filter.limit ?? 100)
         .orderBy(
           `${TableName.Identity}.${filter.orderBy ?? ProjectIdentityOrderBy.Name}`,
           filter.orderDirection ?? OrderByDirection.ASC
         )
         .select(selectAllTableCols(TableName.Identity))
         .as(TableName.Identity); // required for subqueries
+
+      if (filter.limit) {
+        void fetchIdentitySubquery.offset(filter.offset ?? 0).limit(filter.limit);
+      }
 
       const query = (tx || db.replicaNode())(TableName.IdentityProjectMembership)
         .where(`${TableName.IdentityProjectMembership}.projectId`, projectId)


### PR DESCRIPTION
# Description 📣

This PR rectifies a pagination bug with project identities. Previously pagination was being applied after left join of membership roles causing identities with multiple roles to skew pagination. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝