### PR TITLE
Fix: Account for secret import count in secrets offset

### DIFF
--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -280,7 +280,10 @@ export const SecretMainPage = () => {
         : [];
 
     remainingRows -= paginatedFolders.length;
-    const dynamicSecretStartIndex = Math.max(0, paginationOffset - filteredFolders.length);
+    const dynamicSecretStartIndex = Math.max(
+      0,
+      paginationOffset - filteredSecretImports.length - filteredFolders.length
+    );
     const paginatiedDynamicSecrets =
       remainingRows > 0
         ? filteredDynamicSecrets.slice(
@@ -292,7 +295,10 @@ export const SecretMainPage = () => {
     remainingRows -= paginatiedDynamicSecrets.length;
     const secretStartIndex = Math.max(
       0,
-      paginationOffset - filteredFolders.length - filteredDynamicSecrets.length
+      paginationOffset -
+        filteredSecretImports.length -
+        filteredFolders.length -
+        filteredDynamicSecrets.length
     );
 
     const paginatiedSecrets =


### PR DESCRIPTION
# Description 📣

This PR corrects the secret offset in the environment view pagination when imports are present.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝