### PR TITLE
feat(integrations): aws secrets manager secrets prefixing support

### DIFF
--- a/backend/src/services/integration-auth/integration-app-list.ts
+++ b/backend/src/services/integration-auth/integration-app-list.ts
@@ -242,37 +242,12 @@ const getAppsGithub = async ({ accessToken }: { accessToken: string }) => {
     };
   }
 
-  const octokit = new Octokit({
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const repos = (await new Octokit({
     auth: accessToken
-  });
-
-  const getAllRepos = async () => {
-    let repos: GitHubApp[] = [];
-    let page = 1;
-    const perPage = 100;
-    let hasMore = true;
-
-    while (hasMore) {
-      const response = await octokit.request(
-        "GET /user/repos{?visibility,affiliation,type,sort,direction,per_page,page,since,before}",
-        {
-          per_page: perPage,
-          page
-        }
-      );
-
-      if ((response.data as GitHubApp[]).length > 0) {
-        repos = repos.concat(response.data as GitHubApp[]);
-        page += 1;
-      } else {
-        hasMore = false;
-      }
-    }
-
-    return repos;
-  };
-
-  const repos = await getAllRepos();
+  }).paginate("GET /user/repos{?visibility,affiliation,type,sort,direction,per_page,page,since,before}", {
+    per_page: 100
+  })) as GitHubApp[];
 
   const apps = repos
     .filter((a: GitHubApp) => a.permissions.admin === true)

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -1006,28 +1006,12 @@ const syncSecretsAWSSecretManager = async ({
     }
   };
 
-  let secretsToProcess: Record<string, { value: string; comment?: string }> = {};
-  if (metadata && metadata.secretPrefix) {
-    const { secretPrefix } = metadata;
-
-    // Update each secret to have the secret prefix
-    Object.keys(secrets).forEach((key) => {
-      if (key.startsWith(secretPrefix)) {
-        secretsToProcess[key] = secrets[key];
-      } else {
-        secretsToProcess[`${secretPrefix}${key}`] = secrets[key];
-      }
-    });
-  } else {
-    secretsToProcess = secrets;
-  }
-
   if (metadata.mappingBehavior === IntegrationMappingBehavior.ONE_TO_ONE) {
-    for await (const [key, value] of Object.entries(secretsToProcess)) {
+    for await (const [key, value] of Object.entries(secrets)) {
       await processAwsSecret(key, value.value);
     }
   } else {
-    await processAwsSecret(integration.app as string, getSecretKeyValuePair(secretsToProcess));
+    await processAwsSecret(integration.app as string, getSecretKeyValuePair(secrets));
   }
 };
 

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -1006,12 +1006,28 @@ const syncSecretsAWSSecretManager = async ({
     }
   };
 
+  let secretsToProcess: Record<string, { value: string; comment?: string }> = {};
+  if (metadata && metadata.secretPrefix) {
+    const { secretPrefix } = metadata;
+
+    // Update each secret to have the secret prefix
+    Object.keys(secrets).forEach((key) => {
+      if (key.startsWith(secretPrefix)) {
+        secretsToProcess[key] = secrets[key];
+      } else {
+        secretsToProcess[`${secretPrefix}${key}`] = secrets[key];
+      }
+    });
+  } else {
+    secretsToProcess = secrets;
+  }
+
   if (metadata.mappingBehavior === IntegrationMappingBehavior.ONE_TO_ONE) {
-    for await (const [key, value] of Object.entries(secrets)) {
+    for await (const [key, value] of Object.entries(secretsToProcess)) {
       await processAwsSecret(key, value.value);
     }
   } else {
-    await processAwsSecret(integration.app as string, getSecretKeyValuePair(secrets));
+    await processAwsSecret(integration.app as string, getSecretKeyValuePair(secretsToProcess));
   }
 };
 

--- a/frontend/src/pages/integrations/aws-secret-manager/create.tsx
+++ b/frontend/src/pages/integrations/aws-secret-manager/create.tsx
@@ -104,6 +104,7 @@ export default function AWSSecretManagerCreateIntegrationPage() {
   const [tagKey, setTagKey] = useState("");
   const [tagValue, setTagValue] = useState("");
   const [kmsKeyId, setKmsKeyId] = useState("");
+  const [secretPrefix, setSecretPrefix] = useState("");
 
   // const [path, setPath] = useState('');
   // const [pathErrorText, setPathErrorText] = useState('');
@@ -165,6 +166,7 @@ export default function AWSSecretManagerCreateIntegrationPage() {
                 ]
               }
             : {}),
+          ...(secretPrefix && { secretPrefix }),
           ...(kmsKeyId && { kmsKeyId }),
           mappingBehavior: selectedMappingBehavior
         }
@@ -325,7 +327,7 @@ export default function AWSSecretManagerCreateIntegrationPage() {
                 </Switch>
               </div>
               {shouldTag && (
-                <div className="mt-4">
+                <div className="mt-4 flex justify-between">
                   <FormControl label="Tag Key">
                     <Input
                       placeholder="managed-by"
@@ -342,10 +344,20 @@ export default function AWSSecretManagerCreateIntegrationPage() {
                   </FormControl>
                 </div>
               )}
+
+              <FormControl label="Secret Prefix" className="mt-4">
+                <Input
+                  value={secretPrefix}
+                  onChange={(e) => setSecretPrefix(e.target.value)}
+                  placeholder="INFISICAL_"
+                />
+              </FormControl>
+
               <FormControl label="Encryption Key" className="mt-4">
                 <Select
                   value={kmsKeyId}
                   onValueChange={(e) => {
+                    if (e === "no-keys") return;
                     setKmsKeyId(e);
                   }}
                   className="w-full border border-mineshaft-500"
@@ -363,7 +375,9 @@ export default function AWSSecretManagerCreateIntegrationPage() {
                       );
                     })
                   ) : (
-                    <div />
+                    <SelectItem isDisabled value="no-keys" key="no-keys">
+                      No KMS keys available
+                    </SelectItem>
                   )}
                 </Select>
               </FormControl>


### PR DESCRIPTION
# Description 📣

This PR introduces support for secrets prefixing for the AWS Secrets Manager integration.

Additionally I've also taken the liberty to improve our GitHub repos fetching. Previously we were handling the pagination logic manually, but GitHub actually exposes a [`pagination` method](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28#example-using-the-octokitjs-pagination-method) which handles this for us. It's also the recommended method of handling pagination.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->