### PR TITLE
🩹 — Don’t try to mask unmaskable Gitlab variables

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -2354,13 +2354,14 @@ const syncSecretsGitLab = async ({
 
   // From https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/concerns/ci/maskable.rb#L14
   // \A and \z replaced with the solution on https://stackoverflow.com/a/73843315
+  // eslint-disable-next-line no-useless-escape
   const maskRegex = /(?<![\r\n])^[a-zA-Z0-9_+=\/@:.~-]{8,}$(?![\r\n])/;
 
   for await (const key of Object.keys(secrets)) {
     const existingSecret = getSecretsRes.find((s) => s.key === key);
     let shouldMaskSecret = Boolean(metadata.shouldMaskSecrets);
-    if (shouldMaskSecret && ! secrets[key].value.match(maskRegex)) {
-        shouldMaskSecret = false;
+    if (shouldMaskSecret && !secrets[key].value.match(maskRegex)) {
+      shouldMaskSecret = false;
     }
     if (!existingSecret) {
       await request.post(


### PR DESCRIPTION
# Description 📣

Fix issue #2035 

I choose to not mask unmaskable secrets.

If #2036 is implemented, the regex should be adapted (see [here](https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/concerns/ci/maskable.rb#L19)).

The frontend should have a warning saying that unmaskable secrets will not be masked, but I’m not a frontend guy, I can’t do that myself, sorry.

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Tested in production: maskable secrets are masked, the other are not.

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->