### PR TITLE
add trip on identityId for identity logins

### DIFF
--- a/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
@@ -22,7 +22,7 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
     schema: {
       description: "Login with AWS Auth",
       body: z.object({
-        identityId: z.string().describe(AWS_AUTH.LOGIN.identityId),
+        identityId: z.string().trim().describe(AWS_AUTH.LOGIN.identityId),
         iamHttpRequestMethod: z.string().default("POST").describe(AWS_AUTH.LOGIN.iamHttpRequestMethod),
         iamRequestBody: z.string().describe(AWS_AUTH.LOGIN.iamRequestBody),
         iamRequestHeaders: z.string().describe(AWS_AUTH.LOGIN.iamRequestHeaders)

--- a/backend/src/server/routes/v1/identity-azure-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-azure-auth-router.ts
@@ -19,7 +19,7 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
     schema: {
       description: "Login with Azure Auth",
       body: z.object({
-        identityId: z.string().describe(AZURE_AUTH.LOGIN.identityId),
+        identityId: z.string().trim().describe(AZURE_AUTH.LOGIN.identityId),
         jwt: z.string()
       }),
       response: {

--- a/backend/src/server/routes/v1/identity-gcp-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-gcp-auth-router.ts
@@ -19,7 +19,7 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
     schema: {
       description: "Login with GCP Auth",
       body: z.object({
-        identityId: z.string().describe(GCP_AUTH.LOGIN.identityId),
+        identityId: z.string().trim().describe(GCP_AUTH.LOGIN.identityId).trim(),
         jwt: z.string()
       }),
       response: {


### PR DESCRIPTION
When using the agent, the identity id is read from a file. The file i was using had a new line and this caused the login to fail. Adding in trim to resolve this.