### PR TITLE
fix: add loading screen for user context

### DIFF
--- a/frontend/src/context/UserContext/UserContext.tsx
+++ b/frontend/src/context/UserContext/UserContext.tsx
@@ -25,6 +25,21 @@ export const UserProvider = ({ children }: Props): JSX.Element => {
     };
   }, [data, isLoading]);
 
+  if (isLoading) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-bunker-800">
+        <img
+          src="/images/loading/loading.gif"
+          height={70}
+          width={120}
+          decoding="async"
+          loading="lazy"
+          alt="infisical loading indicator"
+        />
+      </div>
+    );
+  }
+
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 };
 


### PR DESCRIPTION
# Description 📣
- This solves the following error which occurs when page is loaded before the user data is available
![image](https://github.com/user-attachments/assets/d5b27f56-abf1-43b6-a203-b703532e7835)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->