### PR TITLE
feat(integrations): email when integration sync fails

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -22,15 +22,12 @@ export const KeyStorePrefixes = {
     `sync-integration-last-run-${projectId}-${environmentSlug}-${secretPath}` as const,
   IdentityAccessTokenStatusUpdate: (identityAccessTokenId: string) =>
     `identity-access-token-status:${identityAccessTokenId}`,
-  ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
-  SendFailedIntegrationSyncEmails: (projectId: string, secretPath: string, environmentSlug: string) =>
-    `send-failed-integration-sync-emails-${projectId}-${secretPath}-${environmentSlug}` as const
+  ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`
 };
 
 export const KeyStoreTtls = {
   SetSyncSecretIntegrationLastRunTimestampInSeconds: 10,
-  AccessTokenStatusUpdateInSeconds: 120,
-  SendFailedIntegrationSyncEmailsInSeconds: 60
+  AccessTokenStatusUpdateInSeconds: 120
 };
 
 type TWaitTillReady = {

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -22,12 +22,15 @@ export const KeyStorePrefixes = {
     `sync-integration-last-run-${projectId}-${environmentSlug}-${secretPath}` as const,
   IdentityAccessTokenStatusUpdate: (identityAccessTokenId: string) =>
     `identity-access-token-status:${identityAccessTokenId}`,
-  ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`
+  ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
+  SendFailedIntegrationSyncEmails: (projectId: string, secretPath: string, environmentSlug: string) =>
+    `send-failed-integration-sync-emails-${projectId}-${secretPath}-${environmentSlug}` as const
 };
 
 export const KeyStoreTtls = {
   SetSyncSecretIntegrationLastRunTimestampInSeconds: 10,
-  AccessTokenStatusUpdateInSeconds: 120
+  AccessTokenStatusUpdateInSeconds: 120,
+  SendFailedIntegrationSyncEmailsInSeconds: 60
 };
 
 type TWaitTillReady = {

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -7,7 +7,11 @@ import {
   TScanFullRepoEventPayload,
   TScanPushEventPayload
 } from "@app/ee/services/secret-scanning/secret-scanning-queue/secret-scanning-queue-types";
-import { TIntegrationSyncPayload, TSyncSecretsDTO } from "@app/services/secret/secret-types";
+import {
+  TFailedIntegrationSyncEmailsPayload,
+  TIntegrationSyncPayload,
+  TSyncSecretsDTO
+} from "@app/services/secret/secret-types";
 
 export enum QueueName {
   SecretRotation = "secret-rotation",
@@ -107,11 +111,7 @@ export type TQueueJobTypes = {
       }
     | {
         name: QueueJobs.SendFailedIntegrationSyncEmails;
-        payload: {
-          projectId: string;
-          environmentSlug: string;
-          secretPath: string;
-        };
+        payload: TFailedIntegrationSyncEmailsPayload;
       };
   [QueueName.SecretFullRepoScan]: {
     name: QueueJobs.SecretScan;

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -1,4 +1,5 @@
 import { Knex } from "knex";
+import { z } from "zod";
 
 import { SecretType, TSecretBlindIndexes, TSecrets, TSecretsInsert, TSecretsUpdate } from "@app/db/schemas";
 import { TProjectPermission } from "@app/lib/types";
@@ -20,6 +21,29 @@ import { TSecretVersionV2TagDALFactory } from "../secret-v2-bridge/secret-versio
 type TPartialSecret = Pick<TSecrets, "id" | "secretReminderRepeatDays" | "secretReminderNote">;
 
 type TPartialInputSecret = Pick<TSecrets, "type" | "secretReminderNote" | "secretReminderRepeatDays" | "id">;
+
+export const FailedIntegrationSyncEmailsPayloadSchema = z.object({
+  projectId: z.string(),
+  secretPath: z.string(),
+  environmentName: z.string(),
+  environmentSlug: z.string(),
+
+  count: z.number(),
+  syncMessage: z.string().optional(),
+  manuallyTriggeredByUserId: z.string().optional()
+});
+
+export type TFailedIntegrationSyncEmailsPayload = z.infer<typeof FailedIntegrationSyncEmailsPayloadSchema>;
+
+export type TIntegrationSyncPayload = {
+  isManual?: boolean;
+  actorId?: string;
+  projectId: string;
+  environment: string;
+  secretPath: string;
+  depth?: number;
+  deDupeQueue?: Record<string, boolean>;
+};
 
 export type TCreateSecretDTO = {
   secretName: string;

--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -33,7 +33,8 @@ export enum SmtpTemplates {
   SecretLeakIncident = "secretLeakIncident.handlebars",
   WorkspaceInvite = "workspaceInvitation.handlebars",
   ScimUserProvisioned = "scimUserProvisioned.handlebars",
-  PkiExpirationAlert = "pkiExpirationAlert.handlebars"
+  PkiExpirationAlert = "pkiExpirationAlert.handlebars",
+  IntegrationSyncFailed = "integrationSyncFailed.handlebars"
 }
 
 export enum SmtpHost {

--- a/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
+++ b/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
@@ -8,13 +8,20 @@
 
   <body>
     <h2>Infisical</h2>
-    <p>An integration in your project
-      <b>{{projectName}}</b>
-      failed to sync secrets.<br />
+
+    <div>
+      <p>{{count}} integration(s) failed to sync.</p>
       <a href="{{integrationUrl}}">
-        View integration details.
+        View your project integrations.
       </a>
-    </p>
+    </div>
+
+    <br />
+    <div>
+      <p><strong>Project</strong>: {{projectName}}</p>
+      <p><strong>Environment</strong>: {{environment}}</p>
+      <p><strong>Secret Path</strong>: {{secretPath}}</p>
+    </div>
 
     {{#if syncMessage}}
       <p><b>Reason: </b>{{syncMessage}}</p>

--- a/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
+++ b/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
@@ -1,0 +1,24 @@
+<html>
+
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Integration Sync Failed</title>
+  </head>
+
+  <body>
+    <h2>Infisical</h2>
+    <p>An integration in your project
+      <b>{{projectName}}</b>
+      failed to sync secrets.<br />
+      <a href="{{integrationUrl}}">
+        View integration details.
+      </a>
+    </p>
+
+    {{#if syncMessage}}
+      <p><b>Reason: </b>{{syncMessage}}</p>
+    {{/if}}
+  </body>
+
+</html>


### PR DESCRIPTION
# Description 📣

This PR aims to add support for email notifications, when an integration fails to sync for whatever reason. A key difference is that: If the integration is manually triggered, only the actor who triggered it will get the email. If it's an automated sync, all project members will receive the notification.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->