### PR TITLE
feat: next.js error boundary 

### DIFF
--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { ErrorInfo, ReactNode } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { faBugs } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -16,12 +17,16 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
   const router = useRouter();
   const currentUrl = router?.asPath?.split("?")?.[0];
 
+  error = new Error(
+    "e26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefined"
+  );
+
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-mineshaft-900">
       <div className="flex max-w-md flex-col rounded-md border border-mineshaft-600 bg-mineshaft-800 p-6 text-center text-mineshaft-200">
-        <FontAwesomeIcon icon={faBugs} className="inlineli my-2 text-6xl" />
+        <FontAwesomeIcon icon={faBugs} className="my-2 inline text-6xl" />
         <p>
-          Something unexpected went wrong. Please contact{" "}
+          Something went wrong. Please contact{" "}
           <a
             className="inline cursor-pointer text-mineshaft-100 underline decoration-primary-500 underline-offset-4 opacity-80 duration-200 hover:opacity-100"
             target="_blank"
@@ -29,22 +34,34 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
             href="mailto:support@infisical.com"
           >
             support@infisical.com
-          </a>{" "}
+          </a>
+          , or{" "}
+          <Link passHref href="https://infisical.com/slack">
+            <a
+              className="inline cursor-pointer text-mineshaft-100 underline decoration-primary-500 underline-offset-4 opacity-80 duration-200 hover:opacity-100"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              join our Slack community
+            </a>
+          </Link>{" "}
           if the issue persists.
         </p>
 
-        {error && (
-          <div className="space-y-4">
+        <div className="my-4 h-px w-full bg-mineshaft-600" />
+
+        {error?.message && (
+          <div className="space-y-2">
             <div>
-              <p className="mt-4">Error details:</p>
-              <p className="text-xs italic">
+              <p>Error details:</p>
+              <p className="text-xs italic opacity-70">
                 Please provide this error message when contacting support, as it will help us
                 diagnose the issue at hand.
               </p>
             </div>
             <p className="max-h-44 w-full overflow-auto text-ellipsis rounded-md bg-mineshaft-700">
               <code className="p-2 text-xs">
-                {currentUrl}, {error?.message}
+                {currentUrl}, {error.message}
               </code>
             </p>
           </div>
@@ -72,7 +89,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     const { hasError, error } = this.state;
     const { children } = this.props;
 
-    if (hasError) {
+    if (!hasError) {
       return <ErrorPage error={error} />;
     }
     return children;

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -17,10 +17,6 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
   const router = useRouter();
   const currentUrl = router?.asPath?.split("?")?.[0];
 
-  error = new Error(
-    "e26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefinede26eabc714f1/secrets/dev, error on line 45: Cannot read property 'split' of undefined"
-  );
-
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-mineshaft-900">
       <div className="flex max-w-md flex-col rounded-md border border-mineshaft-600 bg-mineshaft-800 p-6 text-center text-mineshaft-200">
@@ -89,7 +85,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     const { hasError, error } = this.state;
     const { children } = this.props;
 
-    if (!hasError) {
+    if (hasError) {
       return <ErrorPage error={error} />;
     }
     return children;

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -57,7 +57,7 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
         </p>
 
         {orgId && (
-          <Button className="mt-4" size="xs" onClick={() => router.push(`/org/${orgId}`)}>
+          <Button className="mt-4" size="xs" onClick={() => router.push(`/org/${orgId}/overview`)}>
             <FontAwesomeIcon icon={faHome} className="mr-2" />
             Back To Home
           </Button>

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -1,0 +1,86 @@
+import React, { ErrorInfo, ReactNode } from "react";
+import { useRouter } from "next/router";
+import { faBugs } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+const ErrorPage = ({ error }: { error: Error | null }) => {
+  const router = useRouter();
+  const currentUrl = router?.asPath?.split("?")?.[0];
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center bg-mineshaft-900">
+      <div className="flex max-w-md flex-col rounded-md border border-mineshaft-600 bg-mineshaft-800 p-6 text-center text-mineshaft-200">
+        <FontAwesomeIcon icon={faBugs} className="inlineli my-2 text-6xl" />
+        <p>
+          Something unexpected went wrong. Please contact{" "}
+          <a
+            className="inline cursor-pointer text-mineshaft-100 underline decoration-primary-500 underline-offset-4 opacity-80 duration-200 hover:opacity-100"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="mailto:support@infisical.com"
+          >
+            support@infisical.com
+          </a>{" "}
+          if the issue persists.
+        </p>
+
+        {error && (
+          <div className="space-y-4">
+            <div>
+              <p className="mt-4">Error details:</p>
+              <p className="text-xs italic">
+                Please provide this error message when contacting support, as it will help us
+                diagnose the issue at hand.
+              </p>
+            </div>
+            <p className="max-h-44 w-full overflow-auto text-ellipsis rounded-md bg-mineshaft-700">
+              <code className="p-2 text-xs">
+                {currentUrl}, {error?.message}
+              </code>
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("Error caught by ErrorBoundary:", error, errorInfo);
+  }
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return <ErrorPage error={error} />;
+    }
+    return children;
+  }
+}
+
+const ErrorBoundaryWrapper: React.FC<ErrorBoundaryProps> = ({ children }) => {
+  return <ErrorBoundary>{children}</ErrorBoundary>;
+};
+
+export default ErrorBoundaryWrapper;

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -1,8 +1,10 @@
-import React, { ErrorInfo, ReactNode } from "react";
+import React, { ErrorInfo, ReactNode, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { faBugs } from "@fortawesome/free-solid-svg-icons";
+import { faBugs, faHome } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { Button } from "@app/components/v2";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -14,12 +16,22 @@ interface ErrorBoundaryState {
 }
 
 const ErrorPage = ({ error }: { error: Error | null }) => {
+  const [orgId, setOrgId] = React.useState<string | null>(null);
   const router = useRouter();
   const currentUrl = router?.asPath?.split("?")?.[0];
 
+  // Workaround: Fixes localStorage not being available in the error boundary until the next render.
+  useEffect(() => {
+    const savedOrgId = localStorage.getItem("orgData.id");
+
+    if (savedOrgId) {
+      setOrgId(savedOrgId);
+    }
+  }, []);
+
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-mineshaft-900">
-      <div className="flex max-w-md flex-col rounded-md border border-mineshaft-600 bg-mineshaft-800 p-6 text-center text-mineshaft-200">
+      <div className="flex max-w-md flex-col rounded-md border border-mineshaft-600 bg-mineshaft-800 p-8 text-center text-mineshaft-200">
         <FontAwesomeIcon icon={faBugs} className="my-2 inline text-6xl" />
         <p>
           Something went wrong. Please contact{" "}
@@ -44,23 +56,22 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
           if the issue persists.
         </p>
 
-        <div className="my-4 h-px w-full bg-mineshaft-600" />
+        {orgId && (
+          <Button className="mt-4" size="xs" onClick={() => router.push(`/org/${orgId}`)}>
+            <FontAwesomeIcon icon={faHome} className="mr-2" />
+            Back To Home
+          </Button>
+        )}
 
         {error?.message && (
-          <div className="space-y-2">
-            <div>
-              <p>Error details:</p>
-              <p className="text-xs italic opacity-70">
-                Please provide this error message when contacting support, as it will help us
-                diagnose the issue at hand.
-              </p>
-            </div>
-            <p className="max-h-44 w-full overflow-auto text-ellipsis rounded-md bg-mineshaft-700">
-              <code className="p-2 text-xs">
+          <>
+            <div className="my-4 h-px w-full bg-mineshaft-600" />
+            <p className="thin-scrollbar max-h-44 w-full overflow-auto text-ellipsis rounded-md bg-mineshaft-700 p-2">
+              <code className="text-xs">
                 {currentUrl}, {error.message}
               </code>
             </p>
-          </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -79,7 +79,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   }
 }
 
-const ErrorBoundaryWrapper: React.FC<ErrorBoundaryProps> = ({ children }) => {
+const ErrorBoundaryWrapper = ({ children }: ErrorBoundaryProps) => {
   return <ErrorBoundary>{children}</ErrorBoundary>;
 };
 

--- a/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
+++ b/frontend/src/layouts/AppLayout/ErrorBoundary.tsx
@@ -57,7 +57,14 @@ const ErrorPage = ({ error }: { error: Error | null }) => {
         </p>
 
         {orgId && (
-          <Button className="mt-4" size="xs" onClick={() => router.push(`/org/${orgId}/overview`)}>
+          <Button
+            className="mt-4"
+            size="xs"
+            onClick={() =>
+              // we need to go to /org/${orgId}/overview, but we need to do a full page reload to ensure that the error the user is facing is properly reset.
+              window.location.assign(`/org/${orgId}/overview`)
+            }
+          >
             <FontAwesomeIcon icon={faHome} className="mr-2" />
             Back To Home
           </Button>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -27,6 +27,7 @@ import {
   WorkspaceProvider
 } from "@app/context";
 import { AppLayout } from "@app/layouts";
+import ErrorBoundaryWrapper from "@app/layouts/AppLayout/ErrorBoundary";
 import { queryClient } from "@app/reactQuery";
 
 import "nprogress/nprogress.css";
@@ -85,46 +86,50 @@ const App = ({ Component, pageProps, ...appProps }: NextAppProp): JSX.Element =>
     !Component.requireAuth
   ) {
     return (
-      <QueryClientProvider client={queryClient}>
-        <NotificationContainer />
-        <ServerConfigProvider>
-          <UserProvider>
-            <AuthProvider>
-              <Component {...pageProps} />
-            </AuthProvider>
-          </UserProvider>
-        </ServerConfigProvider>
-      </QueryClientProvider>
+      <ErrorBoundaryWrapper>
+        <QueryClientProvider client={queryClient}>
+          <NotificationContainer />
+          <ServerConfigProvider>
+            <UserProvider>
+              <AuthProvider>
+                <Component {...pageProps} />
+              </AuthProvider>
+            </UserProvider>
+          </ServerConfigProvider>
+        </QueryClientProvider>
+      </ErrorBoundaryWrapper>
     );
   }
 
   const Layout = Component?.layout || AppLayout;
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <NotificationContainer />
-        <ServerConfigProvider>
-          <AuthProvider>
-            <OrgProvider>
-              <OrgPermissionProvider>
-                <WorkspaceProvider>
-                  <ProjectPermissionProvider>
-                    <SubscriptionProvider>
-                      <UserProvider>
-                        <Layout>
-                          <Component {...pageProps} />
-                        </Layout>
-                      </UserProvider>
-                    </SubscriptionProvider>
-                  </ProjectPermissionProvider>
-                </WorkspaceProvider>
-              </OrgPermissionProvider>
-            </OrgProvider>
-          </AuthProvider>
-        </ServerConfigProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ErrorBoundaryWrapper>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <NotificationContainer />
+          <ServerConfigProvider>
+            <AuthProvider>
+              <OrgProvider>
+                <OrgPermissionProvider>
+                  <WorkspaceProvider>
+                    <ProjectPermissionProvider>
+                      <SubscriptionProvider>
+                        <UserProvider>
+                          <Layout>
+                            <Component {...pageProps} />
+                          </Layout>
+                        </UserProvider>
+                      </SubscriptionProvider>
+                    </ProjectPermissionProvider>
+                  </WorkspaceProvider>
+                </OrgPermissionProvider>
+              </OrgProvider>
+            </AuthProvider>
+          </ServerConfigProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ErrorBoundaryWrapper>
   );
 };
 


### PR DESCRIPTION
# Description 📣

This PR aims to add a better and more descriptive error page when we would usually show the default Next.js application error page. 

![CleanShot 2024-09-20 at 01 25 44@2x](https://github.com/user-attachments/assets/59e08c4d-d3c1-47ca-afee-4e33ff93240e)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->