### PR TITLE
misc: removed teams from cloud plans

### DIFF
--- a/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/ManagePlansTable.tsx
+++ b/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/ManagePlansTable.tsx
@@ -66,12 +66,11 @@ export const ManagePlansTable = ({ billingCycle }: Props) => {
           {subscription &&
             !isTableDataLoading &&
             tableData &&
-            tableData.rows.map(({ name, starter, team, pro, enterprise }) => {
+            tableData.rows.map(({ name, starter, pro, enterprise }) => {
               return (
                 <Tr className="h-12" key={`plans-feature-row-${billingCycle}-${name}`}>
                   <Td>{displayCell(name)}</Td>
                   <Td className="text-center">{displayCell(starter)}</Td>
-                  <Td className="text-center">{displayCell(team)}</Td>
                   <Td className="text-center">{displayCell(pro)}</Td>
                   <Td className="text-center">{displayCell(enterprise)}</Td>
                 </Tr>


### PR DESCRIPTION
# Description 📣
This PR removes the column for the team plan so that the cloud-plans modal now looks like the following:
![image](https://github.com/user-attachments/assets/48034eca-e7c4-43a8-8d9a-a8388d4e2cfb)


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->