### PR TITLE
docs: redirect node docs to new sdk

### DIFF
--- a/docs/sdks/languages/node.mdx
+++ b/docs/sdks/languages/node.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Infisical Node.js SDK"
 sidebarTitle: "Node.js"
+url: "https://github.com/Infisical/node-sdk-v2"
 icon: "node"
 ---
 
+{/*
 If you're working with Node.js, the official [Infisical Node SDK](https://github.com/Infisical/sdk/tree/main/languages/node) package is the easiest way to fetch and work with secrets for your application.
 
 - [NPM Package](https://www.npmjs.com/package/@infisical/sdk)
@@ -552,3 +554,5 @@ const decryptedString = await client.decryptSymmetric({
 
 #### Returns (string)
 `plaintext` (string): The decrypted plaintext.
+
+*/}

--- a/docs/sdks/overview.mdx
+++ b/docs/sdks/overview.mdx
@@ -10,7 +10,7 @@ From local development to production, Infisical SDKs provide the easiest way for
 -   Fetch secrets on demand
 
 <CardGroup cols={2}>
-    <Card title="Node" href="/sdks/languages/node" icon="node" color="#68a063">
+    <Card title="Node" href="https://github.com/Infisical/node-sdk-v2" icon="node" color="#68a063">
         Manage secrets for your Node application on demand
     </Card>
     <Card href="https://github.com/Infisical/python-sdk-official" title="Python" icon="python" color="#4c8abe">


### PR DESCRIPTION
# Description 📣

Redirects node documentation to new SDK docs, hosted on GitHub.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->