### PR TITLE
check user group membership correctly

### DIFF
--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -94,9 +94,12 @@ export const accessApprovalPolicyServiceFactory = ({
     >[] = [];
 
     for (const groupId of groupApprovers) {
-      usersPromises.push(groupDAL.findAllGroupMembers({ orgId: actorOrgId, groupId, offset: 0 }));
+      usersPromises.push(groupDAL.findAllGroupPossibleMembers({ orgId: actorOrgId, groupId, offset: 0 }));
     }
-    const verifyGroupApprovers = (await Promise.all(usersPromises)).flat().map((user) => user.id);
+    const verifyGroupApprovers = (await Promise.all(usersPromises))
+      .flat()
+      .filter((user) => user.isPartOfGroup)
+      .map((user) => user.id);
     verifyAllApprovers.push(...verifyGroupApprovers);
 
     await verifyApprovers({
@@ -251,7 +254,7 @@ export const accessApprovalPolicyServiceFactory = ({
         >[] = [];
 
         for (const groupId of groupApprovers) {
-          usersPromises.push(groupDAL.findAllGroupMembers({ orgId: actorOrgId, groupId, offset: 0 }));
+          usersPromises.push(groupDAL.findAllGroupPossibleMembers({ orgId: actorOrgId, groupId, offset: 0 }));
         }
         const verifyGroupApprovers = (await Promise.all(usersPromises)).flat().map((user) => user.id);
 

--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -58,7 +58,7 @@ type TSecretApprovalRequestServiceFactoryDep = {
     TAccessApprovalRequestReviewerDALFactory,
     "create" | "find" | "findOne" | "transaction"
   >;
-  groupDAL: Pick<TGroupDALFactory, "findAllGroupMembers">;
+  groupDAL: Pick<TGroupDALFactory, "findAllGroupPossibleMembers">;
   projectMembershipDAL: Pick<TProjectMembershipDALFactory, "findById">;
   smtpService: Pick<TSmtpService, "sendMail">;
   userDAL: Pick<
@@ -145,14 +145,14 @@ export const accessApprovalRequestServiceFactory = ({
     const groupUsers = (
       await Promise.all(
         approverGroupIds.map((groupApproverId) =>
-          groupDAL.findAllGroupMembers({
+          groupDAL.findAllGroupPossibleMembers({
             orgId: actorOrgId,
             groupId: groupApproverId
           })
         )
       )
     ).flat();
-    approverIds.push(...groupUsers.map((user) => user.id));
+    approverIds.push(...groupUsers.filter((user) => user.isPartOfGroup).map((user) => user.id));
 
     const approverUsers = await userDAL.find({
       $in: {

--- a/backend/src/ee/services/group/group-dal.ts
+++ b/backend/src/ee/services/group/group-dal.ts
@@ -60,7 +60,7 @@ export const groupDALFactory = (db: TDbClient) => {
   };
 
   // special query
-  const findAllGroupMembers = async ({
+  const findAllGroupPossibleMembers = async ({
     orgId,
     groupId,
     offset = 0,
@@ -125,7 +125,7 @@ export const groupDALFactory = (db: TDbClient) => {
   return {
     findGroups,
     findByOrgId,
-    findAllGroupMembers,
+    findAllGroupPossibleMembers,
     ...groupOrm
   };
 };

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -30,7 +30,10 @@ import { TUserGroupMembershipDALFactory } from "./user-group-membership-dal";
 
 type TGroupServiceFactoryDep = {
   userDAL: Pick<TUserDALFactory, "find" | "findUserEncKeyByUserIdsBatch" | "transaction" | "findOne">;
-  groupDAL: Pick<TGroupDALFactory, "create" | "findOne" | "update" | "delete" | "findAllGroupMembers" | "findById">;
+  groupDAL: Pick<
+    TGroupDALFactory,
+    "create" | "findOne" | "update" | "delete" | "findAllGroupPossibleMembers" | "findById"
+  >;
   groupProjectDAL: Pick<TGroupProjectDALFactory, "find">;
   orgDAL: Pick<TOrgDALFactory, "findMembership" | "countAllOrgMembers">;
   userGroupMembershipDAL: Pick<
@@ -242,7 +245,7 @@ export const groupServiceFactory = ({
         message: `Failed to find group with ID ${id}`
       });
 
-    const users = await groupDAL.findAllGroupMembers({
+    const users = await groupDAL.findAllGroupPossibleMembers({
       orgId: group.orgId,
       groupId: group.id,
       offset,

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -75,7 +75,14 @@ type TScimServiceFactoryDep = {
   projectMembershipDAL: Pick<TProjectMembershipDALFactory, "find" | "delete" | "findProjectMembershipsByUserId">;
   groupDAL: Pick<
     TGroupDALFactory,
-    "create" | "findOne" | "findAllGroupMembers" | "delete" | "findGroups" | "transaction" | "updateById" | "update"
+    | "create"
+    | "findOne"
+    | "findAllGroupPossibleMembers"
+    | "delete"
+    | "findGroups"
+    | "transaction"
+    | "updateById"
+    | "update"
   >;
   groupProjectDAL: Pick<TGroupProjectDALFactory, "find">;
   userGroupMembershipDAL: Pick<
@@ -775,7 +782,7 @@ export const scimServiceFactory = ({
       });
     }
 
-    const users = await groupDAL.findAllGroupMembers({
+    const users = await groupDAL.findAllGroupPossibleMembers({
       orgId: group.orgId,
       groupId: group.id
     });


### PR DESCRIPTION
# Description 📣
findAllGroupMembers in groupDAL fetches all users irrespective of whether they are present in the group or not and returns a flag to indicate if present or not. This renames it to findAllGroupPossibleMembers and adds a filter on this flag for approvals using groups.


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->