### PR TITLE
fix(k8-operator): updating CRD does not reflect in operator

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.7.1
+version: v0.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.1"
+appVersion: "v0.7.2"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
         - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.7.1
+      tag: v0.7.2
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/controllers/infisicalsecret_controller.go
+++ b/k8-operator/controllers/infisicalsecret_controller.go
@@ -5,17 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	controllerUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	secretsv1alpha1 "github.com/Infisical/infisical/k8-operator/api/v1alpha1"
 	"github.com/Infisical/infisical/k8-operator/packages/api"
@@ -46,59 +42,10 @@ type ResourceVariables struct {
 	authDetails     AuthenticationDetails
 }
 
-// Maps the infisicalSecretCR.UID to a infisicalSdk.InfisicalClientInterface and AuthenticationDetails.
-var resourceVariablesMap = make(map[string]ResourceVariables)
-
 const FINALIZER_NAME = "secrets.finalizers.infisical.com"
 
-func (r *InfisicalSecretReconciler) addFinalizer(ctx context.Context, infisicalSecret *secretsv1alpha1.InfisicalSecret) error {
-	if !controllerUtil.ContainsFinalizer(infisicalSecret, FINALIZER_NAME) {
-		controllerUtil.AddFinalizer(infisicalSecret, FINALIZER_NAME)
-		if err := r.Update(ctx, infisicalSecret); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *InfisicalSecretReconciler) handleFinalizer(ctx context.Context, infisicalSecret *secretsv1alpha1.InfisicalSecret) error {
-	if controllerUtil.ContainsFinalizer(infisicalSecret, FINALIZER_NAME) {
-		// Cleanup deployment variables
-		delete(resourceVariablesMap, string(infisicalSecret.UID))
-
-		// Remove the finalizer and update the resource
-		controllerUtil.RemoveFinalizer(infisicalSecret, FINALIZER_NAME)
-		if err := r.Update(ctx, infisicalSecret); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *InfisicalSecretReconciler) handleManagedSecretDeletion(secret client.Object) []ctrl.Request {
-	var requests []ctrl.Request
-	infisicalSecrets := &secretsv1alpha1.InfisicalSecretList{}
-	err := r.List(context.Background(), infisicalSecrets)
-	if err != nil {
-		fmt.Printf("unable to list Infisical Secrets from cluster because [err=%v]", err)
-		return requests
-	}
-
-	for _, infisicalSecret := range infisicalSecrets.Items {
-		if secret.GetName() == infisicalSecret.Spec.ManagedSecretReference.SecretName &&
-			secret.GetNamespace() == infisicalSecret.Spec.ManagedSecretReference.SecretNamespace {
-			requests = append(requests, ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Namespace: infisicalSecret.Namespace,
-					Name:      infisicalSecret.Name,
-				},
-			})
-			fmt.Printf("\nManaged secret deleted in resource %s: [name=%v] [namespace=%v]\n", infisicalSecret.Name, secret.GetName(), secret.GetNamespace())
-		}
-	}
-
-	return requests
-}
+// Maps the infisicalSecretCR.UID to a infisicalSdk.InfisicalClientInterface and AuthenticationDetails.
+var resourceVariablesMap = make(map[string]ResourceVariables)
 
 func (r *InfisicalSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var infisicalSecretCR secretsv1alpha1.InfisicalSecret
@@ -118,6 +65,20 @@ func (r *InfisicalSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// Remove finalizers if they exist. This is to support previous InfisicalSecret CRD's that have finalizers on them.
+	// In order to delete secrets with finalizers, we first remove the finalizers so we can use the simplified and improved deletion process
+	if !infisicalSecretCR.ObjectMeta.DeletionTimestamp.IsZero() && len(infisicalSecretCR.ObjectMeta.Finalizers) > 0 {
+		fmt.Printf("Infisical Secret %s is being deleted\n", infisicalSecretCR.Name)
+		fmt.Printf("Removing finalizers from Infisical Secret %s\n", infisicalSecretCR.Name)
+		infisicalSecretCR.ObjectMeta.Finalizers = []string{}
+		if err := r.Update(ctx, &infisicalSecretCR); err != nil {
+			fmt.Printf("Error removing finalizers from Infisical Secret %s: %v\n", infisicalSecretCR.Name, err)
+			return ctrl.Result{}, err
+		}
+		// Our finalizers have been removed, so the reconciler can do nothing.
+		return ctrl.Result{}, nil
+	}
+
 	if infisicalSecretCR.Spec.ResyncInterval != 0 {
 		requeueTime = time.Second * time.Duration(infisicalSecretCR.Spec.ResyncInterval)
 		fmt.Printf("\nManual re-sync interval set. Interval: %v\n", requeueTime)
@@ -125,20 +86,8 @@ func (r *InfisicalSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		fmt.Printf("\nRe-sync interval set. Interval: %v\n", requeueTime)
 	}
 
-	// Add the finalizer if it does not exist, and only add it if the resource is not marked for deletion
-	if infisicalSecretCR.GetDeletionTimestamp() == nil || infisicalSecretCR.GetDeletionTimestamp().IsZero() {
-		if err := r.addFinalizer(ctx, &infisicalSecretCR); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Check if the resource is already marked for deletion
 	if infisicalSecretCR.GetDeletionTimestamp() != nil {
-		// Handle the finalizer logic
-		if err := r.handleFinalizer(ctx, &infisicalSecretCR); err != nil {
-			return ctrl.Result{}, err
-		}
-
 		return ctrl.Result{
 			Requeue: false,
 		}, nil
@@ -187,28 +136,15 @@ func (r *InfisicalSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 func (r *InfisicalSecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		// For the Infisical Secret CRD we specifically watch for the update event, because we need to delete the entry in the resourceVariablesMap, so it will refresh the variables used to fetch secrets.
 		For(&secretsv1alpha1.InfisicalSecret{}, builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				delete(resourceVariablesMap, string(e.ObjectNew.GetUID()))
 				return true
 			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				delete(resourceVariablesMap, string(e.Object.GetUID()))
+				return true
+			},
 		})).
-		// We only monitor the delete events for the Secret resource, so we can handle them in a finalizer.
-		Watches(
-			&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(r.handleManagedSecretDeletion),
-			builder.WithPredicates(predicate.Funcs{
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					return true
-				},
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					return false
-				},
-				CreateFunc: func(e event.CreateEvent) bool {
-					return false
-				},
-			}),
-		).
 		Complete(r)
 }

--- a/k8-operator/controllers/infisicalsecret_controller.go
+++ b/k8-operator/controllers/infisicalsecret_controller.go
@@ -68,8 +68,6 @@ func (r *InfisicalSecretReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Remove finalizers if they exist. This is to support previous InfisicalSecret CRD's that have finalizers on them.
 	// In order to delete secrets with finalizers, we first remove the finalizers so we can use the simplified and improved deletion process
 	if !infisicalSecretCR.ObjectMeta.DeletionTimestamp.IsZero() && len(infisicalSecretCR.ObjectMeta.Finalizers) > 0 {
-		fmt.Printf("Infisical Secret %s is being deleted\n", infisicalSecretCR.Name)
-		fmt.Printf("Removing finalizers from Infisical Secret %s\n", infisicalSecretCR.Name)
 		infisicalSecretCR.ObjectMeta.Finalizers = []string{}
 		if err := r.Update(ctx, &infisicalSecretCR); err != nil {
 			fmt.Printf("Error removing finalizers from Infisical Secret %s: %v\n", infisicalSecretCR.Name, err)


### PR DESCRIPTION
# Description 📣

This PR resolves a bug in the operator which was causing the operator not to reflect changes to the Infisical CRD. This was due to a state issue which caused the old CRD details to remain, even after updating the CRD.

The full issue is mentioned in https://github.com/Infisical/infisical/issues/2400

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->