### PR TITLE
feat: added error feedback on secret items saving for debugging

### DIFF
--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretItem.tsx
@@ -549,7 +549,15 @@ export const SecretItem = memo(
                     animate={{ x: 0, opacity: 1 }}
                     exit={{ x: -10, opacity: 0 }}
                   >
-                    <Tooltip content={errors.key ? errors.key?.message : "Save"}>
+                    <Tooltip
+                      content={
+                        Object.keys(errors || {}).length
+                          ? Object.entries(errors)
+                              .map(([key, { message }]) => `Field ${key}: ${message}`)
+                              .join("\n")
+                          : "Save"
+                      }
+                    >
                       <IconButton
                         ariaLabel="more"
                         variant="plain"
@@ -568,7 +576,7 @@ export const SecretItem = memo(
                             symbolName={FontAwesomeSpriteName.Check}
                             className={twMerge(
                               "h-4 w-4 text-primary",
-                              errors.key && "text-mineshaft-300"
+                              Boolean(Object.keys(errors || {}).length) && "text-red"
                             )}
                           />
                         )}


### PR DESCRIPTION
# Description 📣

Added a error feedback ui to show error when saving secret item and fails in validation for client.
![Screenshot 2024-09-26 at 4 41 59 PM](https://github.com/user-attachments/assets/852b59f3-98a5-4816-90da-1923e76b4fa9)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->