### PR TITLE
fix: resolved permission not defined for custom org role

### DIFF
--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -50,6 +50,7 @@ export const permissionDALFactory = (db: TDbClient) => {
         .select(
           selectAllTableCols(TableName.OrgMembership),
           db.ref("slug").withSchema(TableName.OrgRoles).withSchema(TableName.OrgRoles).as("customRoleSlug"),
+          db.ref("permissions").withSchema(TableName.OrgRoles),
           db.ref("authEnforced").withSchema(TableName.Organization).as("orgAuthEnforced"),
           db.ref("groupId").withSchema("userGroups"),
           db.ref("groupOrgId").withSchema("userGroups"),

--- a/frontend/src/hooks/api/kms/queries.tsx
+++ b/frontend/src/hooks/api/kms/queries.tsx
@@ -10,9 +10,10 @@ export const kmsKeys = {
   getActiveProjectKms: (projectId: string) => ["get-active-project-kms", { projectId }]
 };
 
-export const useGetExternalKmsList = (orgId: string) => {
+export const useGetExternalKmsList = (orgId: string, { enabled }: { enabled?: boolean } = {}) => {
   return useQuery({
     queryKey: kmsKeys.getExternalKmsList(orgId),
+    enabled,
     queryFn: async () => {
       const {
         data: { externalKmsList }

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -155,7 +155,6 @@ export const AppLayout = ({ children }: LayoutProps) => {
   const { data: secretApprovalReqCount } = useGetSecretApprovalRequestCount({ workspaceId });
   const { data: accessApprovalRequestCount } = useGetAccessRequestsCount({ projectSlug });
   const { permission } = useOrgPermission();
-  console.log(permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms));
   const { data: externalKmsList } = useGetExternalKmsList(currentOrg?.id!, {
     enabled: permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms)
   });

--- a/frontend/src/layouts/AppLayout/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout/AppLayout.tsx
@@ -59,6 +59,7 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
+  useOrgPermission,
   useSubscription,
   useUser,
   useWorkspace
@@ -153,7 +154,11 @@ export const AppLayout = ({ children }: LayoutProps) => {
 
   const { data: secretApprovalReqCount } = useGetSecretApprovalRequestCount({ workspaceId });
   const { data: accessApprovalRequestCount } = useGetAccessRequestsCount({ projectSlug });
-  const { data: externalKmsList } = useGetExternalKmsList(currentOrg?.id!);
+  const { permission } = useOrgPermission();
+  console.log(permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms));
+  const { data: externalKmsList } = useGetExternalKmsList(currentOrg?.id!, {
+    enabled: permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms)
+  });
 
   const pendingRequestsCount = useMemo(() => {
     return (secretApprovalReqCount?.open || 0) + (accessApprovalRequestCount?.pendingCount || 0);

--- a/frontend/src/pages/org/[id]/overview/index.tsx
+++ b/frontend/src/pages/org/[id]/overview/index.tsx
@@ -56,6 +56,7 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
+  useOrgPermission,
   useSubscription,
   useUser,
   useWorkspace
@@ -494,6 +495,7 @@ const OrganizationPage = () => {
 
   const { workspaces, isLoading: isWorkspaceLoading } = useWorkspace();
   const { currentOrg } = useOrganization();
+  const { permission } = useOrgPermission();
   const routerOrgId = String(router.query.id);
   const orgWorkspaces = workspaces?.filter((workspace) => workspace.orgId === routerOrgId) || [];
   const { data: projectFavorites, isLoading: isProjectFavoritesLoading } =
@@ -531,7 +533,9 @@ const OrganizationPage = () => {
     (localStorage.getItem("projectsViewMode") as ProjectsViewMode) || ProjectsViewMode.GRID
   );
 
-  const { data: externalKmsList } = useGetExternalKmsList(currentOrg?.id!);
+  const { data: externalKmsList } = useGetExternalKmsList(currentOrg?.id!, {
+    enabled: permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms)
+  });
 
   const onCreateProject = async ({ name, addMembers, kmsKeyId }: TAddProjectFormData) => {
     // type check


### PR DESCRIPTION
# Description 📣

This PR fixes org permission not able to retrieve when its a custom role not in group level rather in direct org membership. Seems the zod validator didn't catch it as it was optional or unknown. 

This PR also fixes external kms throwing forbidden error for members in an org

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->