### PR TITLE
Fix: Secrets Overview Endpoint Filter Secrets for Read Permissive Environments

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -313,23 +313,26 @@ export const dynamicSecretServiceFactory = ({
     projectId,
     path,
     environmentSlugs,
-    search
+    search,
+    isInternal
   }: TListDynamicSecretsMultiEnvDTO) => {
-    const { permission } = await permissionService.getProjectPermission(
-      actor,
-      actorId,
-      projectId,
-      actorAuthMethod,
-      actorOrgId
-    );
+    if (!isInternal) {
+      const { permission } = await permissionService.getProjectPermission(
+        actor,
+        actorId,
+        projectId,
+        actorAuthMethod,
+        actorOrgId
+      );
 
-    // verify user has access to each env in request
-    environmentSlugs.forEach((environmentSlug) =>
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
-        subject(ProjectPermissionSub.Secrets, { environment: environmentSlug, secretPath: path })
-      )
-    );
+      // verify user has access to each env in request
+      environmentSlugs.forEach((environmentSlug) =>
+        ForbiddenError.from(permission).throwUnlessCan(
+          ProjectPermissionActions.Read,
+          subject(ProjectPermissionSub.Secrets, { environment: environmentSlug, secretPath: path })
+        )
+      );
+    }
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environmentSlugs, path);
     if (!folders.length) throw new BadRequestError({ message: "Folders not found" });
@@ -434,23 +437,26 @@ export const dynamicSecretServiceFactory = ({
     path,
     environmentSlugs,
     projectId,
+    isInternal,
     ...params
   }: TListDynamicSecretsMultiEnvDTO) => {
-    const { permission } = await permissionService.getProjectPermission(
-      actor,
-      actorId,
-      projectId,
-      actorAuthMethod,
-      actorOrgId
-    );
+    if (!isInternal) {
+      const { permission } = await permissionService.getProjectPermission(
+        actor,
+        actorId,
+        projectId,
+        actorAuthMethod,
+        actorOrgId
+      );
 
-    // verify user has access to each env in request
-    environmentSlugs.forEach((environmentSlug) =>
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
-        subject(ProjectPermissionSub.Secrets, { environment: environmentSlug, secretPath: path })
-      )
-    );
+      // verify user has access to each env in request
+      environmentSlugs.forEach((environmentSlug) =>
+        ForbiddenError.from(permission).throwUnlessCan(
+          ProjectPermissionActions.Read,
+          subject(ProjectPermissionSub.Secrets, { environment: environmentSlug, secretPath: path })
+        )
+      );
+    }
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environmentSlugs, path);
     if (!folders.length) throw new BadRequestError({ message: "Folders not found" });

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -63,7 +63,7 @@ export type TListDynamicSecretsDTO = {
 export type TListDynamicSecretsMultiEnvDTO = Omit<
   TListDynamicSecretsDTO,
   "projectId" | "environmentSlug" | "projectSlug"
-> & { projectId: string; environmentSlugs: string[] };
+> & { projectId: string; environmentSlugs: string[]; isInternal?: boolean };
 
 export type TGetDynamicSecretsCountDTO = Omit<TListDynamicSecretsDTO, "projectSlug" | "projectId"> & {
   projectId: string;

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -455,31 +455,34 @@ export const secretV2BridgeServiceFactory = ({
   const getSecretsCountMultiEnv = async ({
     actorId,
     path,
-
     projectId,
     actor,
     actorOrgId,
     actorAuthMethod,
     environments,
+    isInternal,
     ...params
   }: Pick<TGetSecretsDTO, "actorId" | "actor" | "path" | "projectId" | "actorOrgId" | "actorAuthMethod" | "search"> & {
     environments: string[];
+    isInternal?: boolean;
   }) => {
-    const { permission } = await permissionService.getProjectPermission(
-      actor,
-      actorId,
-      projectId,
-      actorAuthMethod,
-      actorOrgId
-    );
+    if (!isInternal) {
+      const { permission } = await permissionService.getProjectPermission(
+        actor,
+        actorId,
+        projectId,
+        actorAuthMethod,
+        actorOrgId
+      );
 
-    // verify user has access to all environments
-    environments.forEach((environment) =>
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
-        subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
-      )
-    );
+      // verify user has access to all environments
+      environments.forEach((environment) =>
+        ForbiddenError.from(permission).throwUnlessCan(
+          ProjectPermissionActions.Read,
+          subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
+        )
+      );
+    }
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environments, path);
     if (!folders.length) return 0;
@@ -546,27 +549,31 @@ export const secretV2BridgeServiceFactory = ({
     actor,
     actorOrgId,
     actorAuthMethod,
+    isInternal,
     ...params
   }: Pick<TGetSecretsDTO, "actorId" | "actor" | "path" | "projectId" | "actorOrgId" | "actorAuthMethod" | "search"> & {
     environments: string[];
+    isInternal?: boolean;
   }) => {
-    const { permission } = await permissionService.getProjectPermission(
-      actor,
-      actorId,
-      projectId,
-      actorAuthMethod,
-      actorOrgId
-    );
+    if (!isInternal) {
+      const { permission } = await permissionService.getProjectPermission(
+        actor,
+        actorId,
+        projectId,
+        actorAuthMethod,
+        actorOrgId
+      );
+
+      // verify user has access to all environments
+      environments.forEach((environment) =>
+        ForbiddenError.from(permission).throwUnlessCan(
+          ProjectPermissionActions.Read,
+          subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
+        )
+      );
+    }
 
     let paths: { folderId: string; path: string; environment: string }[] = [];
-
-    // verify user has access to all environments
-    environments.forEach((environment) =>
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
-        subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
-      )
-    );
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environments, path);
 

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -1011,7 +1011,7 @@ export const secretServiceFactory = ({
   }: Pick<
     TGetSecretsRawDTO,
     "projectId" | "path" | "actor" | "actorId" | "actorOrgId" | "actorAuthMethod" | "search"
-  > & { environments: string[] }) => {
+  > & { environments: string[]; isInternal?: boolean }) => {
     const { shouldUseSecretV2Bridge } = await projectBotService.getBotKey(projectId);
 
     if (!shouldUseSecretV2Bridge)
@@ -1045,6 +1045,7 @@ export const secretServiceFactory = ({
     ...params
   }: Omit<TGetSecretsRawDTO, "environment" | "includeImports" | "expandSecretReferences" | "recursive" | "tagSlugs"> & {
     environments: string[];
+    isInternal?: boolean;
   }) => {
     const { shouldUseSecretV2Bridge } = await projectBotService.getBotKey(projectId);
 

--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -91,6 +91,19 @@ export const SecretMainPage = () => {
   });
   const debouncedSearchFilter = useDebounce(filter.searchFilter);
 
+  // change filters if permissions change at different paths/env
+  useEffect(() => {
+    setFilter((prev) => ({
+      ...prev,
+      include: {
+        [RowType.Folder]: true,
+        [RowType.Import]: canReadSecret,
+        [RowType.DynamicSecret]: canReadSecret,
+        [RowType.Secret]: canReadSecret
+      }
+    }));
+  }, [canReadSecret]);
+
   useEffect(() => {
     if (
       !isWorkspaceLoading &&

--- a/frontend/src/views/SecretMainPage/SecretMainPage.tsx
+++ b/frontend/src/views/SecretMainPage/SecretMainPage.tsx
@@ -267,15 +267,7 @@ export const SecretMainPage = () => {
           <NavHeader
             pageName={t("dashboard.title")}
             currentEnv={environment}
-            userAvailableEnvs={currentWorkspace?.environments.filter(({ slug }) =>
-              permission.can(
-                ProjectPermissionActions.Read,
-                subject(ProjectPermissionSub.Secrets, {
-                  environment: slug,
-                  secretPath
-                })
-              )
-            )}
+            userAvailableEnvs={currentWorkspace?.environments}
             isFolderMode
             secretPath={secretPath}
             isProjectRelated


### PR DESCRIPTION
# Description 📣

This PR refactors the secrets overview endpoint to filter environments for secrets based off the users read access. This allows retrieval of folders for all environments but only permissive secrets.

https://github.com/user-attachments/assets/638cf8a2-b724-4ba7-8c47-f64aac3d78b5

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝