### PR TITLE
docs: added oidc method in login command method argument and changed order to make auth section first

### DIFF
--- a/docs/cli/commands/login.mdx
+++ b/docs/cli/commands/login.mdx
@@ -22,107 +22,6 @@ If you have added multiple users, you can switch between the users by using the 
 
     </Info>
 
-### Flags
-
-The login command supports a number of flags that you can use for different authentication methods. Below is a list of all the flags that can be used with the login command.
-
-<AccordionGroup>
-  <Accordion title="--method">
-    ```bash
-    infisical login --method=<auth-method> # Optional, will default to 'user'.
-    ```
-
-    #### Valid values for the `method` flag are:
-    - `user`: Login using email and password. (default)
-    - `universal-auth`: Login using a universal auth client ID and client secret.
-    - `kubernetes`: Login using a Kubernetes native auth.
-    - `azure`: Login using an Azure native auth.
-    - `gcp-id-token`: Login using a GCP ID token native auth.
-    - `gcp-iam`: Login using a GCP IAM.
-    - `aws-iam`: Login using an AWS IAM native auth.
-
-  </Accordion>
-  <Accordion title="--client-id">
-    ```bash
-    infisical login --client-id=<client-id> # Optional, required if --method=universal-auth.
-    ```
-
-    #### Description
-    The client ID of the universal auth machine identity. This is required if the `--method` flag is set to `universal-auth`.
-
-    <Tip>
-      The `client-id` flag can be substituted with the `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` environment variable.
-    </Tip>
-
-  </Accordion>
-  <Accordion title="--client-secret">
-    ```bash
-    infisical login --client-secret=<client-secret> # Optional, required if --method=universal-auth.
-    ```
-    #### Description
-    The client secret of the universal auth machine identity. This is required if the `--method` flag is set to `universal-auth`.
-
-    <Tip>
-      The `client-secret` flag can be substituted with the `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` environment variable.
-    </Tip>
-
-  </Accordion>
-  <Accordion title="--machine-identity-id">
-    ```bash
-    infisical login --machine-identity-id=<your-machine-identity-id> # Optional, required if --method=kubernetes, azure, gcp-id-token, gcp-iam, or aws-iam.
-    ```
-
-    #### Description
-    The ID of the machine identity. This is required if the `--method` flag is set to `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, or `aws-iam`.
-
-    <Tip>
-      The `machine-identity-id` flag can be substituted with the `INFISICAL_MACHINE_IDENTITY_ID` environment variable.
-    </Tip>
-
-  </Accordion>
-  <Accordion title="--service-account-token-path">
-    ```bash
-    infisical login --service-account-token-path=<service-account-token-path> # Optional Will default to '/var/run/secrets/kubernetes.io/serviceaccount/token'.
-    ```
-
-    #### Description
-    The path to the Kubernetes service account token to use for authentication.
-    This is optional and will default to `/var/run/secrets/kubernetes.io/serviceaccount/token`.
-
-    <Tip>
-    The `service-account-token-path` flag can be substituted with the `INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH` environment variable.
-    </Tip>
-
-  </Accordion>
-  <Accordion title="--service-account-key-file-path">
-    ```bash
-    infisical login --service-account-key-file-path=<gcp-service-account-key-file-path> # Optional, but required if --method=gcp-iam.
-    ```
-
-    #### Description
-    The path to your GCP service account key file. This is required if the `--method` flag is set to `gcp-iam`.
-
-    <Tip>
-      The `service-account-key-path` flag can be substituted with the `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH` environment variable.
-    </Tip>
-
-  </Accordion>
-</AccordionGroup>
-
-  <Accordion title="--oidc-jwt">
-    ```bash
-    infisical login --oidc-jwt=<oidc-jwt-token>
-    ```
-
-    #### Description
-    The JWT provided by an identity provider for OIDC authentication.
-
-    <Tip>
-    The `oidc-jwt` flag can be substituted with the `INFISICAL_OIDC_AUTH_JWT` environment variable.
-    </Tip>
-
-  </Accordion>
-
 ### Authentication Methods
 
 The Infisical CLI supports multiple authentication methods. Below are the available authentication methods, with their respective flags.
@@ -320,6 +219,109 @@ The Infisical CLI supports multiple authentication methods. Below are the availa
 
   </Accordion>
 </AccordionGroup>
+
+### Flags
+
+The login command supports a number of flags that you can use for different authentication methods. Below is a list of all the flags that can be used with the login command.
+
+<AccordionGroup>
+  <Accordion title="--method">
+    ```bash
+    infisical login --method=<auth-method> # Optional, will default to 'user'.
+    ```
+
+    #### Valid values for the `method` flag are:
+    - `user`: Login using email and password. (default)
+    - `universal-auth`: Login using a universal auth client ID and client secret.
+    - `kubernetes`: Login using a Kubernetes native auth.
+    - `azure`: Login using an Azure native auth.
+    - `gcp-id-token`: Login using a GCP ID token native auth.
+    - `gcp-iam`: Login using a GCP IAM.
+    - `aws-iam`: Login using an AWS IAM native auth.
+    - `oidc-auth`: Login using oidc auth.
+
+  </Accordion>
+  <Accordion title="--client-id">
+    ```bash
+    infisical login --client-id=<client-id> # Optional, required if --method=universal-auth.
+    ```
+
+    #### Description
+    The client ID of the universal auth machine identity. This is required if the `--method` flag is set to `universal-auth`.
+
+    <Tip>
+      The `client-id` flag can be substituted with the `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` environment variable.
+    </Tip>
+
+  </Accordion>
+  <Accordion title="--client-secret">
+    ```bash
+    infisical login --client-secret=<client-secret> # Optional, required if --method=universal-auth.
+    ```
+    #### Description
+    The client secret of the universal auth machine identity. This is required if the `--method` flag is set to `universal-auth`.
+
+    <Tip>
+      The `client-secret` flag can be substituted with the `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` environment variable.
+    </Tip>
+
+  </Accordion>
+  <Accordion title="--machine-identity-id">
+    ```bash
+    infisical login --machine-identity-id=<your-machine-identity-id> # Optional, required if --method=kubernetes, azure, gcp-id-token, gcp-iam, or aws-iam.
+    ```
+
+    #### Description
+    The ID of the machine identity. This is required if the `--method` flag is set to `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, or `aws-iam`.
+
+    <Tip>
+      The `machine-identity-id` flag can be substituted with the `INFISICAL_MACHINE_IDENTITY_ID` environment variable.
+    </Tip>
+
+  </Accordion>
+  <Accordion title="--service-account-token-path">
+    ```bash
+    infisical login --service-account-token-path=<service-account-token-path> # Optional Will default to '/var/run/secrets/kubernetes.io/serviceaccount/token'.
+    ```
+
+    #### Description
+    The path to the Kubernetes service account token to use for authentication.
+    This is optional and will default to `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+
+    <Tip>
+    The `service-account-token-path` flag can be substituted with the `INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH` environment variable.
+    </Tip>
+
+  </Accordion>
+  <Accordion title="--service-account-key-file-path">
+    ```bash
+    infisical login --service-account-key-file-path=<gcp-service-account-key-file-path> # Optional, but required if --method=gcp-iam.
+    ```
+
+    #### Description
+    The path to your GCP service account key file. This is required if the `--method` flag is set to `gcp-iam`.
+
+    <Tip>
+      The `service-account-key-path` flag can be substituted with the `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH` environment variable.
+    </Tip>
+
+  </Accordion>
+</AccordionGroup>
+
+  <Accordion title="--oidc-jwt">
+    ```bash
+    infisical login --oidc-jwt=<oidc-jwt-token>
+    ```
+
+    #### Description
+    The JWT provided by an identity provider for OIDC authentication.
+
+    <Tip>
+    The `oidc-jwt` flag can be substituted with the `INFISICAL_OIDC_AUTH_JWT` environment variable.
+    </Tip>
+
+  </Accordion>
+
 
 ### Machine Identity Authentication Quick Start
 


### PR DESCRIPTION
# Description 📣

1. Add `oidc-auth` in method options in documentation for cli login 
2. Changed order in login command documentation to make the auth section first and then flags section. The auth section makes sense to come first because most will refer that to do various authentication. The flag section is a bit confusing for many users as it doesn't tell the relation between various options together

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->