### PR TITLE
fix: address modal close unresponsive

### DIFF
--- a/frontend/src/views/Project/CertificatesPage/components/CertificatesTab/components/CertificateModal.tsx
+++ b/frontend/src/views/Project/CertificatesPage/components/CertificatesTab/components/CertificateModal.tsx
@@ -514,7 +514,11 @@ export const CertificateModal = ({ popUp, handlePopUpToggle }: Props) => {
                 >
                   Create
                 </Button>
-                <Button colorSchema="secondary" variant="plain">
+                <Button
+                  colorSchema="secondary"
+                  variant="plain"
+                  onClick={() => handlePopUpToggle("certificate", false)}
+                >
                   Cancel
                 </Button>
               </div>

--- a/frontend/src/views/Project/CertificatesPage/components/PkiAlertsTab/components/PkiAlertModal.tsx
+++ b/frontend/src/views/Project/CertificatesPage/components/PkiAlertsTab/components/PkiAlertModal.tsx
@@ -280,7 +280,11 @@ export const PkiAlertModal = ({ popUp, handlePopUpToggle }: Props) => {
             >
               {alert ? "Update" : "Create"}
             </Button>
-            <Button colorSchema="secondary" variant="plain">
+            <Button
+              colorSchema="secondary"
+              variant="plain"
+              onClick={() => handlePopUpToggle("pkiAlert", false)}
+            >
               Cancel
             </Button>
           </div>

--- a/frontend/src/views/Project/CertificatesPage/components/PkiAlertsTab/components/PkiCollectionModal.tsx
+++ b/frontend/src/views/Project/CertificatesPage/components/PkiAlertsTab/components/PkiCollectionModal.tsx
@@ -149,7 +149,11 @@ export const PkiCollectionModal = ({ popUp, handlePopUpToggle }: Props) => {
             >
               {pkiCollection ? "Update" : "Create"}
             </Button>
-            <Button colorSchema="secondary" variant="plain">
+            <Button
+              colorSchema="secondary"
+              variant="plain"
+              onClick={() => handlePopUpToggle("pkiCollection", false)}
+            >
               Cancel
             </Button>
           </div>


### PR DESCRIPTION
# Description 📣
This PR resolves modal close unresponsive issues in certificate-related modals

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->