### PR TITLE
misc: added proper notifs for paths with policies in overview

### DIFF
--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -351,7 +351,7 @@ export const SecretOverviewPage = () => {
           });
         }
       }
-      await createSecretV3({
+      const result = await createSecretV3({
         environment: env,
         workspaceId,
         secretPath,
@@ -360,10 +360,18 @@ export const SecretOverviewPage = () => {
         secretComment: "",
         type: SecretType.Shared
       });
-      createNotification({
-        type: "success",
-        text: "Successfully created secret"
-      });
+
+      if ("approval" in result) {
+        createNotification({
+          type: "info",
+          text: "Requested change has been sent for review"
+        });
+      } else {
+        createNotification({
+          type: "success",
+          text: "Successfully created secret"
+        });
+      }
     } catch (error) {
       console.log(error);
       createNotification({
@@ -388,7 +396,7 @@ export const SecretOverviewPage = () => {
     type = SecretType.Shared
   ) => {
     try {
-      await updateSecretV3({
+      const result = await updateSecretV3({
         environment: env,
         workspaceId,
         secretPath,
@@ -396,10 +404,18 @@ export const SecretOverviewPage = () => {
         secretValue: value,
         type
       });
-      createNotification({
-        type: "success",
-        text: "Successfully updated secret"
-      });
+
+      if ("approval" in result) {
+        createNotification({
+          type: "info",
+          text: "Requested change has been sent for review"
+        });
+      } else {
+        createNotification({
+          type: "success",
+          text: "Successfully updated secret"
+        });
+      }
     } catch (error) {
       console.log(error);
       createNotification({
@@ -411,7 +427,7 @@ export const SecretOverviewPage = () => {
 
   const handleSecretDelete = async (env: string, key: string, secretId?: string) => {
     try {
-      await deleteSecretV3({
+      const result = await deleteSecretV3({
         environment: env,
         workspaceId,
         secretPath,
@@ -419,10 +435,18 @@ export const SecretOverviewPage = () => {
         secretId,
         type: SecretType.Shared
       });
-      createNotification({
-        type: "success",
-        text: "Successfully deleted secret"
-      });
+
+      if ("approval" in result) {
+        createNotification({
+          type: "info",
+          text: "Requested change has been sent for review"
+        });
+      } else {
+        createNotification({
+          type: "success",
+          text: "Successfully deleted secret"
+        });
+      }
     } catch (error) {
       console.log(error);
       createNotification({


### PR DESCRIPTION
# Description 📣
- This PR ensures that the correct notification modal pops up after secret modification in overview page when path has an approval policy

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9bfeed01-693c-43fe-9d26-cef84a9c0dee">

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->