### PR TITLE
fix: made all update fields optional

### DIFF
--- a/backend/src/server/routes/v1/integration-router.ts
+++ b/backend/src/server/routes/v1/integration-router.ts
@@ -131,9 +131,9 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
           .default("/")
           .transform(removeTrailingSlash)
           .describe(INTEGRATION.UPDATE.secretPath),
-        targetEnvironment: z.string().trim().describe(INTEGRATION.UPDATE.targetEnvironment),
-        owner: z.string().trim().describe(INTEGRATION.UPDATE.owner),
-        environment: z.string().trim().describe(INTEGRATION.UPDATE.environment),
+        targetEnvironment: z.string().trim().optional().describe(INTEGRATION.UPDATE.targetEnvironment),
+        owner: z.string().trim().optional().describe(INTEGRATION.UPDATE.owner),
+        environment: z.string().trim().optional().describe(INTEGRATION.UPDATE.environment),
         metadata: IntegrationMetadataSchema.optional()
       }),
       response: {

--- a/backend/src/services/integration/integration-types.ts
+++ b/backend/src/services/integration/integration-types.ts
@@ -48,10 +48,10 @@ export type TUpdateIntegrationDTO = {
   app?: string;
   appId?: string;
   isActive?: boolean;
-  secretPath: string;
-  targetEnvironment: string;
-  owner: string;
-  environment: string;
+  secretPath?: string;
+  targetEnvironment?: string;
+  owner?: string;
+  environment?: string;
   metadata?: {
     secretPrefix?: string;
     secretSuffix?: string;


### PR DESCRIPTION
# Description 📣

This PR is a prerequisite for adding integrations support to Terraform. It sets all the update fields to optional, like it should be. Currently the update endpoint _requires_ you to make certain changes. 
## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation



---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->