### PR TITLE
fix(dev conatiner): healthcheck for db before migration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,11 @@ services:
       POSTGRES_PASSWORD: infisical
       POSTGRES_USER: infisical
       POSTGRES_DB: infisical
+    healthcheck:
+      test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
   redis:
     image: redis
@@ -59,7 +64,8 @@ services:
   db-migration:
     container_name: infisical-db-migration
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
@@ -120,7 +126,8 @@ services:
     ports:
       - 5050:80
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   smtp-server:
     container_name: infisical-dev-smtp-server


### PR DESCRIPTION
# Description 📣

This change affects development docker containers. Previously there used to be race condition between db-migration and db. Due to which sometimes migration used to fail. 
I have added Health check in db so migration doesn't get triggered if database is not ready. 

**Before:** 
![Screenshot_2024-10-03_20-38-23](https://github.com/user-attachments/assets/a2fab930-78fe-4869-a704-4126fca34921)

**After:**
![Screenshot_2024-10-03_20-40-15](https://github.com/user-attachments/assets/4646ec85-b420-4939-bc91-d5a8c9a3bfc6)


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
