### PR TITLE
Resolve identity count issue

### DIFF
--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -50,10 +50,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         void paginatedFetchIdentity.whereILike(`${TableName.Identity}.name`, `%${search}%`);
       }
 
-      if (limit) {
-        void paginatedFetchIdentity.offset(offset).limit(limit);
-      }
-
       const query = (tx || db.replicaNode())(TableName.IdentityOrgMembership)
         .where(filter)
         .join<Awaited<typeof paginatedFetchIdentity>>(paginatedFetchIdentity, (queryBuilder) => {
@@ -84,6 +80,10 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue")
         )
         .orderBy(`${TableName.Identity}.${orderBy}`, orderDirection);
+
+      if (limit) {
+        void query.offset(offset).limit(limit);
+      }
 
       const docs = await query;
       const formattedDocs = sqlNestRelationships({


### PR DESCRIPTION
The counts on the identity at the org level were incorrect. This fix applies the limit on the parent query instead of the subquery