### PR TITLE
Self signed certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ frontend-build
 cli/infisical-merge
 cli/test/infisical-merge
 /backend/binary
+nginx/certs/*

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     ports:
       - 8080:80
-      - 8443:443
+      - 443:443
     volumes:
       - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/certs:/etc/nginx/certs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
       - 8443:443
     volumes:
       - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/certs:/etc/nginx/certs
     depends_on:
       - backend
       - frontend

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -3,8 +3,10 @@ server {
     listen 443 ssl;
     server_name localhost;
 
-    ssl_certificate /etc/nginx/certs/fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_certificate /etc/nginx/certs/localhost+2.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost+2-key.pem
+;
+    
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers on;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -1,12 +1,22 @@
 server {
     listen 80;
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 
     large_client_header_buffers 8 128k;
     client_header_buffer_size 128k;
     
     location /api {
-        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
@@ -14,33 +24,30 @@ server {
         proxy_pass http://backend:4000;
         proxy_redirect off;
 
-        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict; Secure";
     }
-
     location /.well-known/est {
-
-        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
 
         proxy_set_header X-SSL-Client-Cert $ssl_client_escaped_cert;
-        # proxy_set_header X-SSL-Client-Cert $http_x_ssl_client_cert;
-        # proxy_pass_request_headers on;
 
         proxy_pass http://backend:4000;
         proxy_redirect off;
 
-        # proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
-        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict; Secure";
     }
 
     location / {
         include /etc/nginx/mime.types;
         
-        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
@@ -52,3 +59,4 @@ server {
         proxy_redirect off;
     }
 }
+


### PR DESCRIPTION
used mkcert to generate local SSL certificates inside the nginx/certs directory, and then path binded that directory to /etc/nginx/certs directory inside the container, which I added in the nginx's default.dev.conf

# Description 📣

This pull request adds support for local SSL certificates in the development environment. The changes include:

1. Updating the `nginx/default.dev.conf` file to use locally generated SSL certificates.
2. Adding new certificate files (`localhost+2.pem` and `localhost+2-key.pem`) to the `nginx/certs/` directory.

These changes will allow developers to run the application locally with HTTPS support, improving the local development experience and making it more closely match the production environment.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

To test these changes:

1. Install mkcert if you haven't already (installation instructions vary by OS).

2. Generate local certificates using mkcert:
   ```sh
   mkcert -install
   cd nginx/certs/
   mkcert localhost 127.0.0.1 ::1
   ```

3. Verify that the `nginx/default.dev.conf` file has been updated with the correct certificate paths:
   ```nginx
   ssl_certificate /etc/nginx/certs/localhost+2.pem;
   ssl_certificate_key /etc/nginx/certs/localhost+2-key.pem;
   ```

4. Run the application locally using Docker Compose with the development configuration:
   ```sh
   docker-compose -f docker-compose.dev.yml up
   ```

5. Access the application via HTTPS (https://localhost) and confirm that there are no certificate warnings in the browser.

6. Verify that the application functions correctly over HTTPS.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝