### PR TITLE
feat: add migration script to migrate org

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -52,6 +52,7 @@
     "migration:latest": "knex --knexfile ./src/db/knexfile.ts --client pg migrate:latest",
     "migration:status": "knex --knexfile ./src/db/knexfile.ts --client pg migrate:status",
     "migration:rollback": "knex --knexfile ./src/db/knexfile.ts migrate:rollback",
+    "migrate:org": "tsx ./scripts/migrate-organization.ts",
     "seed:new": "tsx ./scripts/create-seed-file.ts",
     "seed": "knex --knexfile ./src/db/knexfile.ts --client pg seed:run",
     "db:reset": "npm run migration:rollback -- --all && npm run migration:latest"

--- a/backend/scripts/migrate-organization.ts
+++ b/backend/scripts/migrate-organization.ts
@@ -1,0 +1,55 @@
+/* eslint-disable */
+import promptSync from "prompt-sync";
+import { execSync } from "child_process";
+import path from "path";
+import { existsSync } from "fs";
+
+const prompt = promptSync({
+    sigint: true
+});
+
+const exportDb = () => {
+    const exportHost = prompt("Enter your Postgres Host to migrate from: ");
+    const exportPort = prompt("Enter your Postgres Port to migrate from [Default = 5432]: ") ?? "5432";
+    const exportUser = prompt("Enter your Postgres User to migrate from: [Default = infisical]: ") ?? "infisical";
+    const exportPassword = prompt("Enter your Postgres Password to migrate from: ");
+    const exportDatabase = prompt("Enter your Postgres Database to migrate from [Default = infisical]: ") ?? "infisical";
+
+    execSync(
+        `PGDATABASE="${exportDatabase}" PGPASSWORD="${exportPassword}" PGHOST="${exportHost}" PGPORT=${exportPort} PGUSER=${exportUser} pg_dump infisical --exclude-table "audit_log*" > ${path.join(__dirname, "../src/db/dump.sql")}`,
+        { stdio: "inherit" }
+    );
+}
+
+const importDbForOrg = () => {
+    const importHost = prompt("Enter your Postgres Host to migrate to: ");
+    const importPort = prompt("Enter your Postgres Port to migrate to [Default = 5432]: ") ?? "5432";
+    const importUser = prompt("Enter your Postgres User to migrate to: [Default = infisical]: ") ?? "infisical";
+    const importPassword = prompt("Enter your Postgres Password to migrate to: ");
+    const importDatabase = prompt("Enter your Postgres Database to migrate to [Default = infisical]: ") ?? "infisical";
+    const orgId = prompt("Enter the organization ID to migrate: ");
+
+    if (!existsSync(path.join(__dirname, "../src/db/dump.sql"))) {
+        console.log("File not found, please export the database first.");
+        return;
+    }
+
+    execSync(`PGDATABASE="${importDatabase}" PGPASSWORD="${importPassword}" PGHOST="${importHost}" PGPORT=${importPort} PGUSER=${importUser} psql -f ${path.join(__dirname, "../src/db/dump.sql")}`);
+
+    execSync(`PGDATABASE="${importDatabase}" PGPASSWORD="${importPassword}" PGHOST="${importHost}" PGPORT=${importPort} PGUSER=${importUser} psql -c "DELETE FROM public.organizations WHERE id != '${orgId}'"`);
+
+    console.log("Organization migrated successfully.");
+}
+
+const main = () => {
+    const action = prompt("Enter the action to perform\n 1. Export from existing instance.\n 2. Import org to instance.\n \n Action: ");
+    if (action === "1") {
+        exportDb();
+    } else if (action === "2") {
+        importDbForOrg();
+    } else {
+        console.log("Invalid action");
+    }
+}
+
+main();


### PR DESCRIPTION
# Description 📣
Script to dump database apart from the audit logs table, import into another Postgres instance and delete all data for organizations except one given organization.

Use `npm run migrate:org` in backend to test.

Note: 
- Ensure you run the import scripts on an empty postgres instance. 
- This can be done by just using `docker-compose -f <>.yml up db --build` and then using `npm run migrate:org` to import first.
- You use same `ENCRYPTION_KEY` and `ROOT_ENCRYPTION_KEY`



## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->