### PR TITLE
Added option to include imports when running the agent

### DIFF
--- a/cli/agent-config.yaml
+++ b/cli/agent-config.yaml
@@ -1,5 +1,6 @@
 infisical:
   address: "https://app.infisical.com/"
+  include-imports: false
 auth:
   type: "universal-auth"
   config:

--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -117,7 +117,7 @@ var exportCmd = &cobra.Command{
 				accessToken = loggedInUserDetails.UserCredentials.JTWToken
 			}
 
-			processedTemplate, err := ProcessTemplate(1, templatePath, nil, accessToken, "", &newEtag, dynamicSecretLeases)
+			processedTemplate, err := ProcessTemplate(1, templatePath, nil, accessToken, "", &newEtag, dynamicSecretLeases, request.IncludeImport)
 			if err != nil {
 				util.HandleError(err)
 			}


### PR DESCRIPTION
# Description 📣

I've added an configuration option that adds the possibillity to include the imported secrets into the selected environment.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I ran the agent against Infisical, once with the option `infisical.include-imports` set to false. This will only write the secrets from the selected environment to the template. Setting this option to true, will add the imported secrets.



---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
