### PR TITLE
Fetch Project ID from environment var or command flag

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -51,7 +51,7 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetCmdFlagOrEnv(cmd, "projectId", util.INFISICAL_PROJECT_ID_NAME)
 		if err != nil {
 			util.HandleError(err)
 		}

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -9,6 +9,7 @@ const (
 	INFISICAL_TOKEN_NAME                       = "INFISICAL_TOKEN"
 	INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN_NAME = "INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN"
 	INFISICAL_VAULT_FILE_PASSPHRASE_ENV_NAME   = "INFISICAL_VAULT_FILE_PASSPHRASE" // This works because we've forked the keyring package and added support for this env variable. This explains why you won't find any occurrences of it in the CLI codebase.
+	INFISICAL_PROJECT_ID_NAME                  = "INFISICAL_PROJECT_ID"
 
 	VAULT_BACKEND_AUTO_MODE = "auto"
 	VAULT_BACKEND_FILE_MODE = "file"


### PR DESCRIPTION
# Description 📣

I made the export command fetch the Project ID from the environment variable INFISICAL_PROJECT_ID.
If that doesn't exist, it will fall back to `--projectId`, or it will error if neither exists.
This improves the uses of the export command in a CI / CD or development setting

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

These tests assume you are already logged into your Infisical instance
To use the environment variable, export it first:
```sh
export INFISICAL_PROJECT_ID=<your project ID>
```
And then run the export command:
```
infisical export 
```
This should return all the secrets from your selected project and environment

To test the export command as it behaved before, unset the env var and run the export command again. The output should be identical.

```sh
unset INFISICAL_PROJECT_ID
infisical export 
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
