### PR TITLE
fix: allow 25MB uploads for migrations

### DIFF
--- a/backend/src/server/routes/v3/external-migration-router.ts
+++ b/backend/src/server/routes/v3/external-migration-router.ts
@@ -4,9 +4,12 @@ import { readLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
+const MB25_IN_BYTES = 26214400;
+
 export const registerExternalMigrationRouter = async (server: FastifyZodProvider) => {
   server.route({
     method: "POST",
+    bodyLimit: MB25_IN_BYTES,
     url: "/env-key",
     config: {
       rateLimit: readLimit

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -15,6 +15,21 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+    location /api/v3/migrate {
+        client_max_body_size 25M;
+
+        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+    }
+
     location /.well-known/est {
         proxy_set_header X-Real-RIP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -17,6 +17,21 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+    location /api/v3/migrate {
+        client_max_body_size 25M;
+
+        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+    }
+
     location /.well-known/est {
 
         proxy_set_header X-Real-RIP $remote_addr;


### PR DESCRIPTION
# Description 📣

This PR allows larger file uploads specifically for the /api/v3/migrate route. It fixes both Nginx and Fastify restrictions. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->