### PR TITLE
Updated docs to use docker compose instead of docker-compose

### DIFF
--- a/docs/contributing/platform/developing.mdx
+++ b/docs/contributing/platform/developing.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Local development'
-description: 'This guide will help you set up and run the Infisical platform in local development.'
+title: "Local development"
+description: "This guide will help you set up and run the Infisical platform in local development."
 ---
 
 ## Fork and clone the repo
@@ -15,28 +15,28 @@ git checkout -b MY_BRANCH_NAME
 
 ## Set up environment variables
 
-
 Start by creating a .env file at the root of the Infisical directory then copy the contents of the file linked [here](https://github.com/Infisical/infisical/blob/main/.env.example). View all available [environment variables](https://infisical.com/docs/self-hosting/configuration/envars) and guidance for each.
 
 ## Starting Infisical for development
 
 We use Docker to spin up all required services for Infisical in local development. If you are unfamiliar with Docker, don’t worry, all you have to do is install Docker for your
-machine and run the command below to start up the development server. 
+machine and run the command below to start up the development server.
 
-#### Start local server 
+#### Start local server
 
 ```bash
-docker-compose -f docker-compose.dev.yml up --build --force-recreate
+docker compose -f docker-compose.dev.yml up --build --force-recreate
 ```
-#### Access local server 
+
+#### Access local server
 
 Once all the services have spun up, browse to http://localhost:8080.
 
-#### Shutdown local server 
+#### Shutdown local server
 
 ```bash
 # To stop environment use Control+C (on Mac) CTRL+C (on Win) or
-docker-compose -f docker-compose.dev.yml down
+docker compose -f docker-compose.dev.yml down
 ```
 
 ## Starting Infisical docs locally
@@ -56,6 +56,7 @@ yarn global add mintlify
 ```
 
 #### Running the docs
+
 Go to `docs` directory and run `mintlify dev`. This will start up the docs on `localhost:3000`
 
 ```bash


### PR DESCRIPTION
# Description 📣

This PR updates the documentation to replace the deprecated `docker-compose` command with `docker compose`. This change resolves the issue where developers may encounter errors if they use the outdated `docker-compose` command on newer Docker installations.

**Fixes Issue #2576 **

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

Testing involved following the setup instructions in the updated documentation and running `docker compose -f docker-compose.dev.yml up --build --force-recreate` to ensure compatibility.

```sh
adityagoyal@Adityas-MBP-3 infisical % docker compose -f docker-compose.dev.yml up --build --force-recreate
WARN[0000] /Users/adityagoyal/Projects/OpenSource/infisical/docker-compose.dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 57/43
 ✔ smtp-server Pulled                                                                              46.4s 
 ✔ redis Pulled                                                                                    38.3s 
 ✔ db Pulled                                                                                       41.7s 
 ✔ pgadmin Pulled                                                                                  64.4s 
 ✔ nginx Pulled                                                                                    42.5s 
 ✔ redis-commander Pulled                                                                          27.9s 
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
