### PR TITLE
fix: envkey project imports

### DIFF
--- a/backend/src/services/external-migration/external-migration-fns.ts
+++ b/backend/src/services/external-migration/external-migration-fns.ts
@@ -89,13 +89,6 @@ export const parseEnvKeyDataFn = async (decryptedJson: string): Promise<Infisica
     });
   }
 
-  // make sure that all the projectIds in the enviroments are present in the projects
-  for (const env of infisicalImportData.environments) {
-    if (!infisicalImportData.projects.find((project) => project.id === env.projectId)) {
-      infisicalImportData.projects.push({ name: "Unknown", id: env.projectId });
-    }
-  }
-
   // secrets
   for (const env of Object.keys(parsedJson.envs)) {
     if (!env.includes("|")) {

--- a/backend/src/services/external-migration/external-migration-queue.ts
+++ b/backend/src/services/external-migration/external-migration-queue.ts
@@ -97,7 +97,7 @@ export const externalMigrationQueueFactory = ({
 
       const decryptedJson = JSON.parse(decrypted) as TImportInfisicalDataCreate;
 
-      await importDataIntoInfisicalFn({
+      const { projectsNotImported } = await importDataIntoInfisicalFn({
         input: decryptedJson,
         projectDAL,
         projectEnvDAL,
@@ -111,6 +111,17 @@ export const externalMigrationQueueFactory = ({
         projectEnvService,
         secretV2BridgeService
       });
+
+      if (projectsNotImported.length) {
+        logger.info(
+          {
+            actorEmail,
+            actorOrgId: decryptedJson.actorOrgId,
+            projectsNotImported
+          },
+          "One or more projects were not imported during import from external source"
+        );
+      }
 
       await smtpService.sendMail({
         recipients: [actorEmail],


### PR DESCRIPTION
# Description 📣

There is an edge-case in EnvKey imports, resulting in imports failing due to a vague database error. The error is happening because we're trying to find a project env with an undefined projectId. This PR introduces an extra step that will "backfill" any missing / corrupt data.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->