### PR TITLE
prevent sync of empty secret in ssm

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -728,7 +728,7 @@ const syncSecretsAWSParameterStore = async ({
           awsParameterStoreSecretsObj[key].KeyId !== metadata.kmsKeyId;
 
         // we ensure that the KMS key configured in the integration is applied for ALL parameters on AWS
-        if (shouldUpdateKms || awsParameterStoreSecretsObj[key].Value !== secrets[key].value) {
+        if (secrets[key].value && (shouldUpdateKms || awsParameterStoreSecretsObj[key].Value !== secrets[key].value)) {
           await ssm
             .putParameter({
               Name: `${integration.path}${key}`,
@@ -789,7 +789,7 @@ const syncSecretsAWSParameterStore = async ({
         logger.info(
           `getIntegrationSecrets: inside of shouldDisableDelete AWS SSM [projectId=${projectId}] [environment=${integration.environment.slug}]  [secretPath=${integration.secretPath}] [step=2]`
         );
-        if (!(key in secrets)) {
+        if (!(key in secrets) || !secrets[key].value) {
           logger.info(
             `getIntegrationSecrets: inside of shouldDisableDelete AWS SSM [projectId=${projectId}] [environment=${integration.environment.slug}]  [secretPath=${integration.secretPath}] [step=3]`
           );


### PR DESCRIPTION
This PR covers the following case: When a secret exists in aws parameter store but has a empty value for the corresponding key in Infisical. When we try to sync the empty secret to aws, aws will throw a error because all values must have at least one value.

This PR fixes this by requiring that all syncs for aws parameter will require a value in Infisical. If `shouldDisableDelete` isn't enabled (meaning we can delete secrets in aws) and we remove the corresponding key from aws for which a value does not exist in Infisical.

