### PR TITLE
Address UI layout misalignments on the SecretsOverviewPage

### DIFF
--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -808,9 +808,9 @@ export const SecretOverviewPage = () => {
           <TableContainer className="rounded-b-none">
             <Table>
               <THead>
-                <Tr className="sticky top-0 z-20 border-0">
-                  <Th className="sticky left-0 z-20 min-w-[20rem] border-b-0 p-0">
-                    <div className="flex items-center border-b border-r border-mineshaft-600 px-5 pt-3.5 pb-3">
+                <Tr className="border-0">
+                  <Th className="  min-w-[20rem] border-b border-r p-0">
+                    <div className="flex items-center border-mineshaft-600 px-5 pt-3.5 pb-3">
                       Name
                       <IconButton
                         variant="plain"
@@ -837,10 +837,10 @@ export const SecretOverviewPage = () => {
 
                     return (
                       <Th
-                        className="min-table-row min-w-[11rem] border-b-0 p-0 text-center"
+                        className="min-table-row min-w-[11rem] border-b p-0 text-center"
                         key={`secret-overview-${name}-${index + 1}`}
                       >
-                        <div className="flex items-center justify-center border-b border-mineshaft-600 px-5 pt-3.5 pb-[0.83rem]">
+                        <div className="flex items-center justify-center  border-mineshaft-600 px-5 pt-3.5 pb-3">
                           <button
                             type="button"
                             className="text-sm font-medium duration-100 hover:text-mineshaft-100"
@@ -980,15 +980,15 @@ export const SecretOverviewPage = () => {
               </TBody>
               <TFoot>
                 <Tr className="sticky bottom-0 z-10 border-0 bg-mineshaft-800">
-                  <Td className="sticky left-0 z-10 border-0 bg-mineshaft-800 p-0">
+                  <Td className="sticky left-0 z-10 border-t border-r border-mineshaft-600 g-mineshaft-800 p-0">
                     <div
-                      className="w-full border-t border-r border-mineshaft-600"
+                      className="w-full border-mineshaft-600"
                       style={{ height: "45px" }}
                     />
                   </Td>
                   {visibleEnvs?.map(({ name, slug }) => (
-                    <Td key={`explore-${name}-btn`} className="border-0 border-mineshaft-600 p-0">
-                      <div className="flex w-full items-center justify-center border-r border-t border-mineshaft-600 px-5 py-2">
+                    <Td key={`explore-${name}-btn`} className="border-t  border-mineshaft-600 p-0">
+                      <div className="flex w-full items-center justify-center   border-mineshaft-600 px-5 py-2">
                         <Button
                           size="xs"
                           variant="outline_bg"

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -808,8 +808,8 @@ export const SecretOverviewPage = () => {
           <TableContainer className="rounded-b-none">
             <Table>
               <THead>
-                <Tr className="border-0">
-                  <Th className="  min-w-[20rem] border-b border-r p-0">
+                <Tr className="sticky top-0 z-20 border-0">
+                  <Th className="sticky left-0 z-20 min-w-[20rem] border-b border-r p-0">
                     <div className="flex items-center border-mineshaft-600 px-5 pt-3.5 pb-3">
                       Name
                       <IconButton
@@ -840,7 +840,7 @@ export const SecretOverviewPage = () => {
                         className="min-table-row min-w-[11rem] border-b p-0 text-center"
                         key={`secret-overview-${name}-${index + 1}`}
                       >
-                        <div className="flex items-center justify-center  border-mineshaft-600 px-5 pt-3.5 pb-3">
+                        <div className="flex items-center justify-center border-mineshaft-600 px-5 pt-3.5 pb-3">
                           <button
                             type="button"
                             className="text-sm font-medium duration-100 hover:text-mineshaft-100"
@@ -988,7 +988,7 @@ export const SecretOverviewPage = () => {
                   </Td>
                   {visibleEnvs?.map(({ name, slug }) => (
                     <Td key={`explore-${name}-btn`} className="border-t  border-mineshaft-600 p-0">
-                      <div className="flex w-full items-center justify-center   border-mineshaft-600 px-5 py-2">
+                      <div className="flex w-full items-center justify-center border-mineshaft-600 px-5 py-2">
                         <Button
                           size="xs"
                           variant="outline_bg"

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -67,11 +67,11 @@ export const SecretOverviewTableRow = ({
     <>
       <Tr isHoverable isSelectable onClick={() => setIsFormExpanded.toggle()} className="group">
         <Td
-          className={`sticky left-0 z-10 bg-mineshaft-800 bg-clip-padding py-0 px-0 group-hover:bg-mineshaft-700 ${
-            isFormExpanded && "border-t-2 border-mineshaft-500"
+          className={`sticky left-0 z-10 border-r bg-mineshaft-800 bg-clip-padding py-0 px-0 group-hover:bg-mineshaft-700 ${
+            isFormExpanded ? "border-t-2 border-mineshaft-500" : "border-mineshaft-600"
           }`}
         >
-          <div className="h-full w-full border-r border-mineshaft-600 py-2.5 px-5">
+          <div className="h-full w-full border-mineshaft-600 py-2.5 px-5">
             <div className="flex items-center space-x-5">
               <div className="text-bunker-300">
                 <Checkbox

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
@@ -146,7 +146,7 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
       className="secret-table relative mb-2 flex w-full flex-row items-center justify-between overflow-hidden rounded-lg border border-solid border-mineshaft-700 bg-mineshaft-800 font-inter"
     >
       <div className="flex h-11 flex-1 flex-shrink-0 items-center">
-        <span className="flex h-full min-w-[11rem] items-center justify-start border-r-2 border-mineshaft-600 px-4">
+        <span className="flex h-full min-w-[11rem] items-center justify-start border-r border-mineshaft-600 px-4">
           Key
         </span>
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

I started this pull request to resolve misalignments on the SecretsOverviewPage by adjusting the borders to their correct positions.

## Before

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/03dda7d4-011d-4a66-8a90-fa99d1aabcd9">

<img width="1197" alt="Untitled" src="https://github.com/user-attachments/assets/6709ef63-0a22-4fd1-adb9-e5c82883e544">

<img width="1027" alt="Untitled (1)" src="https://github.com/user-attachments/assets/a531a69b-bea7-4df5-9372-10a065eba6b1">

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/2cba87de-ac03-4ae2-bcef-812397e1d6cb">

## After

<img width="1728" alt="Screenshot 2024-10-16 at 00 58 31" src="https://github.com/user-attachments/assets/9c48e99f-9846-490b-96b3-b58d3de45564">

<img width="1728" alt="Screenshot 2024-10-16 at 00 58 38" src="https://github.com/user-attachments/assets/4cc6740e-b939-4ac5-851a-3d6fbf86e921">


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->