### PR TITLE
feat: field type is not even used in schema so removed as some providers don't provide it

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -20,7 +20,7 @@ const ScimUserSchema = z.object({
       z.object({
         primary: z.boolean(),
         value: z.string().email(),
-        type: z.string().trim()
+        type: z.string().trim().default("work")
       })
     )
     .optional(),
@@ -210,8 +210,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
           .array(
             z.object({
               primary: z.boolean(),
-              value: z.string().email(),
-              type: z.string().trim()
+              value: z.string().email()
             })
           )
           .optional(),
@@ -281,8 +280,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
           .array(
             z.object({
               primary: z.boolean(),
-              value: z.string().email(),
-              type: z.string().trim()
+              value: z.string().email()
             })
           )
           .optional(),
@@ -301,7 +299,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
             z.object({
               primary: z.boolean(),
               value: z.string().email(),
-              type: z.string().trim()
+              type: z.string().trim().default("work")
             })
           ),
           displayName: z.string().trim(),


### PR DESCRIPTION
# Description 📣

Some providers like okta don't provider type in emails section it seems. I just. removed it as we don't even use it also. So why make it required. We only care about primary flag in email.

On response we just make it fallback to work.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->