### PR TITLE
Fix(docker-compose): prevent container restart failures on system reboot

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,7 @@ services:
     image: redis
     container_name: infisical-dev-redis
     env_file: .env
+    restart: always
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:


### PR DESCRIPTION
# Description 📣

Added restart policies for Redis container to enhance stability and prevent failures during system restarts or crashes. These policies ensure the services restart automatically, making the setup more resilient in environments where reboots or failures may occur.

As discussed in this [thread on slack](https://infisical-users.slack.com/archives/C04BSBMQAQ7/p1729154447243339) - 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Tested by rebooting the system and ensuring that Redis and PostgreSQL containers restart automatically and remain stable without manual intervention.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
