### PR TITLE
Fix: Set Default Value for Color in Tags Modal

### DIFF
--- a/frontend/src/components/tags/CreateTagModal/CreateTagModal.tsx
+++ b/frontend/src/components/tags/CreateTagModal/CreateTagModal.tsx
@@ -115,7 +115,10 @@ export const CreateTagModal = ({ isOpen, onToggle }: Props): JSX.Element => {
     formState: { isSubmitting },
     handleSubmit
   } = useForm<FormData>({
-    resolver: zodResolver(createTagSchema)
+    resolver: zodResolver(createTagSchema),
+    defaultValues: {
+      color: secretTagsColors[0].hex
+    }
   });
 
   const { currentWorkspace } = useWorkspace();


### PR DESCRIPTION
# Description 📣

This PR fixes a default color not being set in the create tag modal for secrets.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝