### PR TITLE
Improvement: Cap Expanded Secret View Width when Overview Table Overflows

### DIFF
--- a/frontend/src/components/v2/Table/Table.tsx
+++ b/frontend/src/components/v2/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactNode, TdHTMLAttributes } from "react";
+import { DetailedHTMLProps, HTMLAttributes, ReactNode, TdHTMLAttributes } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { Skeleton } from "../Skeleton";
@@ -7,12 +7,13 @@ export type TableContainerProps = {
   children: ReactNode;
   isRounded?: boolean;
   className?: string;
-};
+} & DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
 export const TableContainer = ({
   children,
   className,
-  isRounded = true
+  isRounded = true,
+  ...props
 }: TableContainerProps): JSX.Element => (
   <div
     className={twMerge(
@@ -20,6 +21,7 @@ export const TableContainer = ({
       isRounded && "rounded-lg",
       className
     )}
+    {...props}
   >
     {children}
   </div>

--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -23,7 +23,6 @@ type Props = {
   secretKey: string;
   secretPath: string;
   environments: { name: string; slug: string }[];
-  expandableColWidth: number;
   isSelected: boolean;
   onToggleSecretSelect: (key: string) => void;
   getSecretByKey: (slug: string, key: string) => SecretV3RawSanitized | undefined;
@@ -41,6 +40,7 @@ type Props = {
     env: string,
     secretName: string
   ) => { secret?: SecretV3RawSanitized; environmentInfo?: WorkspaceEnv } | undefined;
+  scrollOffset: number;
 };
 
 export const SecretOverviewTableRow = ({
@@ -53,9 +53,7 @@ export const SecretOverviewTableRow = ({
   onSecretDelete,
   isImportedSecretPresentInEnv,
   getImportedSecretByKey,
-  // temporary until below todo is resolved
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  expandableColWidth,
+  scrollOffset,
   onToggleSecretSelect,
   isSelected
 }: Props) => {
@@ -152,11 +150,11 @@ export const SecretOverviewTableRow = ({
             }`}
           >
             <div
-              className="ml-2 w-[99%] p-2"
-              // TODO: scott expandableColWidth sometimes 0 due to parent ref not mounting, opting for relative width until resolved
-              // style={{
-              //   width: `calc(${expandableColWidth} - 1rem)`
-              // }}
+              className="ml-2 p-2"
+              style={{
+                marginLeft: scrollOffset,
+                width: "calc(100vw - 290px)" // 290px accounts for sidebar and margin
+              }}
             >
               <SecretRenameRow
                 secretKey={secretKey}


### PR DESCRIPTION
# Description 📣

This PR caps the width of expanded secrets on the overview table to prevent the need to scroll back and forth when editing secrets with table overflow.

![CleanShot 2024-10-18 at 16 09 22@2x](https://github.com/user-attachments/assets/7495bdb2-0790-48de-9165-470a5ce81a0e)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝