### PR TITLE
fix: better rate limit errors

### DIFF
--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -71,6 +71,13 @@ export class BadRequestError extends Error {
   }
 }
 
+export class RateLimitError extends Error {
+  constructor({ message }: { message?: string }) {
+    super(message || "Rate limit exceeded");
+    this.name = "RateLimitExceeded";
+  }
+}
+
 export class NotFoundError extends Error {
   name: string;
 

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -2,6 +2,7 @@ import type { RateLimitOptions, RateLimitPluginOptions } from "@fastify/rate-lim
 import { Redis } from "ioredis";
 
 import { getConfig } from "@app/lib/config/env";
+import { RateLimitError } from "@app/lib/errors";
 
 export const globalRateLimiterCfg = (): RateLimitPluginOptions => {
   const appCfg = getConfig();
@@ -10,6 +11,11 @@ export const globalRateLimiterCfg = (): RateLimitPluginOptions => {
     : null;
 
   return {
+    errorResponseBuilder: (_, context) => {
+      throw new RateLimitError({
+        message: `Rate limit exceeded. Please try again in ${context.after}`
+      });
+    },
     timeWindow: 60 * 1000,
     max: 600,
     redis,

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -29,7 +29,7 @@ enum HttpStatusCodes {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   InternalServerError = 500,
   GatewayTimeout = 504,
-  RateLimitExceeded = 429
+  TooManyRequests = 429
 }
 
 export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider) => {
@@ -72,8 +72,8 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         error: error.name
       });
     } else if (error instanceof RateLimitError) {
-      void res.status(HttpStatusCodes.RateLimitExceeded).send({
-        statusCode: HttpStatusCodes.RateLimitExceeded,
+      void res.status(HttpStatusCodes.TooManyRequests).send({
+        statusCode: HttpStatusCodes.TooManyRequests,
         message: error.message,
         error: error.name
       });

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -10,6 +10,7 @@ import {
   GatewayTimeoutError,
   InternalServerError,
   NotFoundError,
+  RateLimitError,
   ScimRequestError,
   UnauthorizedError
 } from "@app/lib/errors";
@@ -27,7 +28,8 @@ enum HttpStatusCodes {
   Forbidden = 403,
   // eslint-disable-next-line @typescript-eslint/no-shadow
   InternalServerError = 500,
-  GatewayTimeout = 504
+  GatewayTimeout = 504,
+  RateLimitExceeded = 429
 }
 
 export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider) => {
@@ -66,6 +68,12 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
     } else if (error instanceof ForbiddenRequestError) {
       void res.status(HttpStatusCodes.Forbidden).send({
         statusCode: HttpStatusCodes.Forbidden,
+        message: error.message,
+        error: error.name
+      });
+    } else if (error instanceof RateLimitError) {
+      void res.status(HttpStatusCodes.RateLimitExceeded).send({
+        statusCode: HttpStatusCodes.RateLimitExceeded,
         message: error.message,
         error: error.name
       });


### PR DESCRIPTION
# Description 📣

Previously rate limits were throwing 500 errors which is not descriptive at all. This PR adds a new error type specifically for rate limits, and modifies the rate limiter config to throw a custom error.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->