### PR TITLE
Fix: cap width for tw container size on uw monitors

### DIFF
--- a/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -153,7 +153,8 @@ export const SecretOverviewTableRow = ({
               className="ml-2 p-2"
               style={{
                 marginLeft: scrollOffset,
-                width: "calc(100vw - 290px)" // 290px accounts for sidebar and margin
+                width: "calc(100vw - 300px)", // 300px accounts for sidebar and margin
+                maxWidth: "calc(1536px - 50px)" // tw container max width minus padding for uw displays
               }}
             >
               <SecretRenameRow


### PR DESCRIPTION
# Description 📣

This PR caps secret overview expanded secret view width to tw container max to prevent overflow on uw monitors

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝