### PR TITLE
Fix: refine check of when to display region select

### DIFF
--- a/frontend/src/components/navigation/RegionSelect.tsx
+++ b/frontend/src/components/navigation/RegionSelect.tsx
@@ -78,10 +78,16 @@ export const RegionSelect = () => {
     router.push(`https://${value}.infisical.com/${router.pathname}`);
   };
 
-  const [subdomain, domain] = window.location.host.split(".");
+  const shouldDisplay =
+    window.location.origin.includes("https://app.infisical.com") ||
+    window.location.origin.includes("https://us.infisical.com") ||
+    window.location.origin.includes("https://eu.infisical.com") ||
+    window.location.origin.includes("http://localhost:8080");
 
   // only display region select for cloud
-  if (!domain?.match(/infisical/)) return null;
+  if (!shouldDisplay) return null;
+
+  const [subdomain] = window.location.host.split(".");
 
   // default to US if not eu
   const currentRegion = subdomain === Region.EU ? regions[1] : regions[0];


### PR DESCRIPTION
# Description 📣

This PR refines the region select display check to prevent dedicated cloud instances from seeing the select.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝