### PR TITLE
Improvement: Display Full Invite Link in Insecure Context and Increase Default Pagination Size to 100

### DIFF
--- a/frontend/src/hooks/usePagination.tsx
+++ b/frontend/src/hooks/usePagination.tsx
@@ -5,7 +5,7 @@ import { useDebounce } from "@app/hooks/useDebounce";
 
 export const usePagination = <T extends string>(initialOrderBy: T) => {
   const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(20);
+  const [perPage, setPerPage] = useState(100);
   const [orderDirection, setOrderDirection] = useState(OrderByDirection.ASC);
   const [orderBy, setOrderBy] = useState<T>(initialOrderBy);
   const [search, setSearch] = useState("");

--- a/frontend/src/views/Org/MembersPage/components/OrgMembersTab/components/OrgMembersSection/OrgInviteLink.tsx
+++ b/frontend/src/views/Org/MembersPage/components/OrgMembersTab/components/OrgMembersSection/OrgInviteLink.tsx
@@ -1,5 +1,6 @@
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
 import { IconButton, Tooltip } from "@app/components/v2";
@@ -30,7 +31,12 @@ export const OrgInviteLink = ({ invite }: Props) => {
         Invite for <span className="font-medium">{invite.email}</span>
       </p>
       <div className="flex flex-col gap-1 rounded-md bg-white/[0.04] p-2 text-base text-gray-400">
-        <p className="line-clamp-1 mr-4 overflow-hidden text-ellipsis whitespace-nowrap	">
+        <p
+          className={twMerge(
+            "line-clamp-1 mr-4",
+            window.isSecureContext ? "overflow-hidden text-ellipsis whitespace-nowrap" : "break-all"
+          )}
+        >
           {invite.link}
         </p>
         <Tooltip content={`Copy invitation link for ${invite.email}`}>


### PR DESCRIPTION
# Description 📣

This PR prevents truncation of invite links when in an insecure context to allow direct copy of link and also increases the default page size for pagination to 100.

![CleanShot 2024-10-29 at 11 09 36@2x](https://github.com/user-attachments/assets/da4b5192-c2c7-4159-b36e-e59fea80ac81)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝