### PR TITLE
Make synced Azure DevOps variables secret

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -2540,9 +2540,9 @@ const syncSecretsAzureDevops = async ({
 
   const { groupId, groupName } = await getEnvGroupId(integration.app, integration.appId, integration.environment.name);
 
-  const variables: Record<string, { value: string }> = {};
+  const variables: Record<string, { value: string, isSecret: boolean }> = {};
   for (const key of Object.keys(secrets)) {
-    variables[key] = { value: secrets[key].value };
+    variables[key] = { value: secrets[key].value, isSecret: true };
   }
 
   if (!groupId) {


### PR DESCRIPTION
# Description 📣

Tiny PR to make Azure DevOps (ADO) variables encrypted rather than plaintext when synced from Infisical. Previously, ADO variables were being synced from Infisical as plain variables, which would show up in ADO variable groups and build logs in plaintext. Since many values stored in Infisical are meant to be secret, these variables should be encrypted in ADO.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Relevant REST API documentation for ADO variable group updates: https://learn.microsoft.com/en-us/rest/api/azure/devops/distributedtask/variablegroups/update?view=azure-devops-rest-7.2. I've tested this API call and can confirm this correctly encrypts the values at rest in ADO. When these variables are referenced in ADO processes, they are appropriately masked in any output logs.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝