### PR TITLE
feat: added queue level debounce for secret sync and removed stale check

### DIFF
--- a/backend/e2e-test/routes/v1/secret-replication.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-replication.spec.ts
@@ -118,9 +118,9 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
         value: "stage-value"
       });
 
-      // wait for 5 second for  replication to finish
+      // wait for 10 second for  replication to finish
       await new Promise((resolve) => {
-        setTimeout(resolve, 5000); // time to breathe for db
+        setTimeout(resolve, 10000); // time to breathe for db
       });
 
       const secret = await getSecretByNameV2({
@@ -173,9 +173,9 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
         value: "prod-value"
       });
 
-      // wait for 5 second for  replication to finish
+      // wait for 10 second for  replication to finish
       await new Promise((resolve) => {
-        setTimeout(resolve, 5000); // time to breathe for db
+        setTimeout(resolve, 10000); // time to breathe for db
       });
 
       const secret = await getSecretByNameV2({
@@ -343,9 +343,9 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
         value: "prod-value"
       });
 
-      // wait for 5 second for  replication to finish
+      // wait for 10 second for  replication to finish
       await new Promise((resolve) => {
-        setTimeout(resolve, 5000); // time to breathe for db
+        setTimeout(resolve, 10000); // time to breathe for db
       });
 
       const secret = await getSecretByNameV2({

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -29,7 +29,7 @@ export const KeyStorePrefixes = {
 };
 
 export const KeyStoreTtls = {
-  SetSyncSecretIntegrationLastRunTimestampInSeconds: 10,
+  SetSyncSecretIntegrationLastRunTimestampInSeconds: 60,
   AccessTokenStatusUpdateInSeconds: 120
 };
 


### PR DESCRIPTION
# Description 📣

This PR resolves a race condition in stale check that was happening. We now have a debounce in queue level with 3second buffer to handle this corner case. I have also made get integration list after the lock acquire to work with consistent data.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->