### PR TITLE
Remove unused ip package from frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,7 +65,6 @@
         "i18next-browser-languagedetector": "^7.0.1",
         "i18next-http-backend": "^2.2.0",
         "infisical-node": "^1.0.37",
-        "ip": "^2.0.1",
         "jspdf": "^2.5.2",
         "jsrp": "^0.2.4",
         "jwt-decode": "^3.1.2",
@@ -15975,11 +15974,6 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,6 @@
     "i18next-browser-languagedetector": "^7.0.1",
     "i18next-http-backend": "^2.2.0",
     "infisical-node": "^1.0.37",
-    "ip": "^2.0.1",
     "jspdf": "^2.5.2",
     "jsrp": "^0.2.4",
     "jwt-decode": "^3.1.2",


### PR DESCRIPTION
# Description 📣

This PR removes the `ip` package from the frontend which is unused; in doing so, it removes the vulnerable dependency as stated [here](https://github.com/advisories/GHSA-2p57-rm9w-gvfp).

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->