### PR TITLE
misc: added OIDC error and edge-case handling

### DIFF
--- a/backend/e2e-test/mocks/smtp.ts
+++ b/backend/e2e-test/mocks/smtp.ts
@@ -5,6 +5,9 @@ export const mockSmtpServer = (): TSmtpService => {
   return {
     sendMail: async (data) => {
       storage.push(data);
+    },
+    verify: async () => {
+      return true;
     }
   };
 };

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -240,6 +240,13 @@ export const oidcConfigServiceFactory = ({
               },
               tx
             );
+
+            if (newUser && !newUser.isEmailVerified) {
+              // we automatically mark it as email-verified because we've configured trust for OIDC emails
+              newUser = await userDAL.updateById(newUser.id, {
+                isEmailVerified: true
+              });
+            }
           }
         }
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -425,7 +425,8 @@ export const oidcConfigServiceFactory = ({
       const isSmtpConnected = await smtpService.verify();
       if (!isSmtpConnected) {
         throw new BadRequestError({
-          message: "Cannot enable OIDC when there are issues with the instance's SMTP configuration"
+          message:
+            "Cannot enable OIDC when there are issues with the instance's SMTP configuration. Bypass this by turning on trust for OIDC emails in the server admin console."
         });
       }
     }

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -361,7 +361,7 @@ export const oidcConfigServiceFactory = ({
         })
         .catch((err: Error) => {
           throw new OidcAuthError({
-            message: `Error with SMTP configuration - contact the Infisical instance admin. ${err.message}`
+            message: `Error sending email confirmation code for user registration - contact the Infisical instance admin. ${err.message}`
           });
         });
     }

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -133,3 +133,15 @@ export class ScimRequestError extends Error {
     this.status = status;
   }
 }
+
+export class OidcAuthError extends Error {
+  name: string;
+
+  error: unknown;
+
+  constructor({ name, error, message }: { message?: string; name?: string; error?: unknown }) {
+    super(message || "Something went wrong");
+    this.name = name || "OidcAuthError";
+    this.error = error;
+  }
+}

--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -48,8 +48,8 @@ export const bootstrapCheck = async ({ db }: BootstrapOpt) => {
     .then(async () => {
       console.info("SMTP successfully connected");
     })
-    .catch((err) => {
-      console.error(`SMTP - Failed to connect to ${appCfg.SMTP_HOST}:${appCfg.SMTP_PORT}`);
+    .catch((err: Error) => {
+      console.error(`SMTP - Failed to connect to ${appCfg.SMTP_HOST}:${appCfg.SMTP_PORT} - ${err.message}`);
       logger.error(err);
     });
 

--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -46,7 +46,7 @@ export const bootstrapCheck = async ({ db }: BootstrapOpt) => {
   await createTransport(smtpCfg)
     .verify()
     .then(async () => {
-      console.info("SMTP successfully connected");
+      console.info(`SMTP - Verified connection to ${appCfg.SMTP_HOST}:${appCfg.SMTP_PORT}`);
     })
     .catch((err: Error) => {
       console.error(`SMTP - Failed to connect to ${appCfg.SMTP_HOST}:${appCfg.SMTP_PORT} - ${err.message}`);

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -10,6 +10,7 @@ import {
   GatewayTimeoutError,
   InternalServerError,
   NotFoundError,
+  OidcAuthError,
   RateLimitError,
   ScimRequestError,
   UnauthorizedError
@@ -83,7 +84,10 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         status: error.status,
         detail: error.detail
       });
-      // Handle JWT errors and make them more human-readable for the end-user.
+    } else if (error instanceof OidcAuthError) {
+      void res
+        .status(HttpStatusCodes.InternalServerError)
+        .send({ statusCode: HttpStatusCodes.InternalServerError, message: error.message, error: error.name });
     } else if (error instanceof jwt.JsonWebTokenError) {
       const message = (() => {
         if (error.message === JWTErrors.JwtExpired) {

--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -77,5 +77,21 @@ export const smtpServiceFactory = (cfg: TSmtpConfig) => {
     }
   };
 
-  return { sendMail };
+  const verify = async () => {
+    const isConnected = smtp
+      .verify()
+      .then(async () => {
+        logger.info("SMTP connected");
+        return true;
+      })
+      .catch((err: Error) => {
+        logger.error("SMTP error");
+        logger.error(err);
+        return false;
+      });
+
+    return isConnected;
+  };
+
+  return { sendMail, verify };
 };


### PR DESCRIPTION
# Description 📣
- shows SMTP errors to the OIDC error callback page for immediate feedback
- ensures that OIDC cannot be enabled when SMTP is not confirmed to be good
- updates bootstrap SMTP check to display the actual error
- ensures that user can login with OIDC if user account is previously created using org invite flow 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->