### PR TITLE
Feature: Add API endpoint to retrieve Project ID by Project Name

### DIFF
--- a/backend/src/server/routes/v2/project-router.ts
+++ b/backend/src/server/routes/v2/project-router.ts
@@ -489,4 +489,39 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       return { certificateTemplates };
     }
   });
+
+  /* Get a project ID by slug */
+  server.route({
+    method: "GET",
+    url: "/:slug/id",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      params: z.object({
+        slug: slugSchema.describe("The slug of the project to get the ID for.")
+      }),
+      response: {
+        200: z.object({
+          id: z.string().describe("The ID of the project.")
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const project = await server.services.project.getAProject({
+        filter: {
+          slug: req.params.slug,
+          orgId: req.permission.orgId,
+          type: ProjectFilterType.SLUG
+        },
+        actorId: req.permission.id,
+        actorOrgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod,
+        actor: req.permission.type
+      });
+
+      return { id: project.id };
+    }
+  });
 };


### PR DESCRIPTION
# Description 📣

This PR introduces a new API endpoint that allows users to retrieve the project ID by specifying the project slug. This enhancement is particularly useful for users interacting with the API, as it enables them to use memorable project names rather than having to look up and remember GUIDs.

The endpoint is accessible through /api/v2/workspace/[project_slug]/id

 #2594 

## Type ✨

- [ ] Bug fix
- [X] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->