### PR TITLE
Fix: Secret Reference Multiple References and Special Character Stripping

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -444,7 +444,6 @@ export const expandSecretReferencesFactory = ({
       // eslint-disable-next-line no-continue
       if (depth > MAX_SECRET_REFERENCE_DEPTH) continue;
       const refs = value?.match(INTERPOLATION_SYNTAX_REG);
-      console.log("refs", refs);
 
       if (refs) {
         for (const interpolationSyntax of refs) {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -444,6 +444,7 @@ export const expandSecretReferencesFactory = ({
       // eslint-disable-next-line no-continue
       if (depth > MAX_SECRET_REFERENCE_DEPTH) continue;
       const refs = value?.match(INTERPOLATION_SYNTAX_REG);
+      console.log("refs", refs);
 
       if (refs) {
         for (const interpolationSyntax of refs) {
@@ -518,7 +519,10 @@ export const expandSecretReferencesFactory = ({
           }
 
           if (referencedSecretValue) {
-            expandedValue = expandedValue.replaceAll(interpolationSyntax, referencedSecretValue);
+            expandedValue = expandedValue.replaceAll(
+              interpolationSyntax,
+              () => referencedSecretValue // prevents special characters from triggering replacement patterns
+            );
           }
         }
       }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -150,9 +150,9 @@ export const secretV2BridgeServiceFactory = ({
       }
     });
 
-    if (referredSecrets.length !== references.length)
+    if (new Set(referredSecrets.map((sec) => sec.key)).size !== new Set(references.map((sec) => sec.secretKey)).size)
       throw new BadRequestError({
-        message: `Referenced secret not found. Found only ${diff(
+        message: `Referenced secret(s) not found: ${diff(
           references.map((el) => el.secretKey),
           referredSecrets.map((el) => el.key)
         ).join(",")}`

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -150,7 +150,11 @@ export const secretV2BridgeServiceFactory = ({
       }
     });
 
-    if (new Set(referredSecrets.map((sec) => sec.key)).size !== new Set(references.map((sec) => sec.secretKey)).size)
+    if (
+      referredSecrets.length !==
+      new Set(references.map(({ secretKey, secretPath, environment }) => `${secretKey}.${secretPath}.${environment}`))
+        .size // only count unique references
+    )
       throw new BadRequestError({
         message: `Referenced secret(s) not found: ${diff(
           references.map((el) => el.secretKey),


### PR DESCRIPTION
# Description 📣

This PR includes the following fixes for secret references:
- Allow secrets to reference the same secret multiple times
- Prevent stripping of special characters when expanding secret references

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝