### PR TITLE
fix: cli npm release windows and symlink bugs

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -9,10 +9,20 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "tar": "^6.2.0"
+        "tar": "^6.2.0",
+        "yauzl": "^3.2.0"
       },
       "bin": {
         "infisical": "bin/infisical"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chownr": {
@@ -87,6 +97,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
@@ -107,6 +123,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     }
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,7 +8,7 @@
     "command-line"
   ],
   "bin": {
-    "infisical": "bin/infisical"
+    "infisical": "./bin/infisical"
   },
   "repository": {
     "type": "git",
@@ -16,9 +16,10 @@
   },
   "author": "Infisical Inc, <daniel@infisical.com>",
   "scripts": {
-    "postinstall": "node src/index.cjs"
+    "preinstall": "node src/index.cjs"
   },
   "dependencies": {
-    "tar": "^6.2.0"
+    "tar": "^6.2.0",
+    "yauzl": "^3.2.0"
   }
 }


### PR DESCRIPTION
# Description 📣

While going over the NPM CLI port I found an issue with the Windows download, causing it to fail during Windows downloads due to a wrong extension format. I've added zip support to resolve this.

Additionally I also found a discrepancy with the symlink creation on global installations. This PR also resolves that issue.

This can be tested locally by CD'ing into the /npm folder and running

```bash
cd /npm
npm install -g .

whereis infisical # Should print a path pointing to a correctly symlinked path
``` 

Make sure to change the `version` field in the `package.json` file when doing a local test, since 0.0.0 is not a valid CLI version.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->