### PR TITLE
Fix: Handle Missing User/Identity Metadata Keys in Permissions Check

### DIFF
--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -29,4 +29,18 @@ function validateOrgSSO(actorAuthMethod: ActorAuthMethod, isOrgSsoEnforced: TOrg
   }
 }
 
-export { isAuthMethodSaml, validateOrgSSO };
+const escapeHandlebarsMissingMetadata = (obj: Record<string, string>) => {
+  const handler = {
+    get(target: Record<string, string>, prop: string) {
+      if (!(prop in target)) {
+        // eslint-disable-next-line no-param-reassign
+        target[prop] = `{{identity.metadata.${prop}}}`; // Add missing key as an "own" property
+      }
+      return target[prop];
+    }
+  };
+
+  return new Proxy(obj, handler);
+};
+
+export { escapeHandlebarsMissingMetadata, isAuthMethodSaml, validateOrgSSO };

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -21,7 +21,7 @@ import { TServiceTokenDALFactory } from "@app/services/service-token/service-tok
 
 import { orgAdminPermissions, orgMemberPermissions, orgNoAccessPermissions, OrgPermissionSet } from "./org-permission";
 import { TPermissionDALFactory } from "./permission-dal";
-import { validateOrgSSO } from "./permission-fns";
+import { escapeHandlebarsMissingMetadata, validateOrgSSO } from "./permission-fns";
 import { TBuildOrgPermissionDTO, TBuildProjectPermissionDTO } from "./permission-service-types";
 import {
   buildServiceTokenProjectPermission,
@@ -227,11 +227,13 @@ export const permissionServiceFactory = ({
       })) || [];
 
     const rules = buildProjectPermissionRules(rolePermissions.concat(additionalPrivileges));
-    const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false, strict: true });
-    const metadataKeyValuePair = objectify(
-      userProjectPermission.metadata,
-      (i) => i.key,
-      (i) => i.value
+    const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false });
+    const metadataKeyValuePair = escapeHandlebarsMissingMetadata(
+      objectify(
+        userProjectPermission.metadata,
+        (i) => i.key,
+        (i) => i.value
+      )
     );
     const interpolateRules = templatedRules(
       {
@@ -292,12 +294,15 @@ export const permissionServiceFactory = ({
       })) || [];
 
     const rules = buildProjectPermissionRules(rolePermissions.concat(additionalPrivileges));
-    const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false, strict: true });
-    const metadataKeyValuePair = objectify(
-      identityProjectPermission.metadata,
-      (i) => i.key,
-      (i) => i.value
+    const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false });
+    const metadataKeyValuePair = escapeHandlebarsMissingMetadata(
+      objectify(
+        identityProjectPermission.metadata,
+        (i) => i.key,
+        (i) => i.value
+      )
     );
+
     const interpolateRules = templatedRules(
       {
         identity: {


### PR DESCRIPTION
# Description 📣

This PR addresses handling of missing keys in user/identity metadata during permissions checks by proxying the template value if not present.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝