### PR TITLE
Fix ca version migration 

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,70 +3,70 @@ version: "3"
 services:
   db-migration:
     container_name: infisical-db-migration
-    depends_on:
-      db:
-        condition: service_healthy
-    image: infisical/infisical:latest-postgres
+    # depends_on:
+    #   db:
+    #     condition: service_healthy
+    image: infisical/infisical:v0.94.0-postgres
     env_file: .env
     command: npm run migration:latest
     pull_policy: always
-    networks:
-      - infisical
+    # networks:
+    #   - infisical
 
-  backend:
-    container_name: infisical-backend
-    restart: unless-stopped
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_started
-      db-migration:
-        condition: service_completed_successfully
-    image: infisical/infisical:latest-postgres
-    pull_policy: always
-    env_file: .env
-    ports:
-      - 80:8080
-    environment:
-      - NODE_ENV=production
-    networks:
-      - infisical
+#   backend:
+#     container_name: infisical-backend
+#     restart: unless-stopped
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#       redis:
+#         condition: service_started
+#       db-migration:
+#         condition: service_completed_successfully
+#     image: infisical/infisical:latest-postgres
+#     pull_policy: always
+#     env_file: .env
+#     ports:
+#       - 80:8080
+#     environment:
+#       - NODE_ENV=production
+#     networks:
+#       - infisical
 
-  redis:
-    image: redis
-    container_name: infisical-dev-redis
-    env_file: .env
-    restart: always
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-    ports:
-      - 6379:6379
-    networks:
-      - infisical
-    volumes:
-      - redis_data:/data
+#   redis:
+#     image: redis
+#     container_name: infisical-dev-redis
+#     env_file: .env
+#     restart: always
+#     environment:
+#       - ALLOW_EMPTY_PASSWORD=yes
+#     ports:
+#       - 6379:6379
+#     networks:
+#       - infisical
+#     volumes:
+#       - redis_data:/data
 
-  db:
-    container_name: infisical-db
-    image: postgres:14-alpine
-    restart: always
-    env_file: .env
-    volumes:
-      - pg_data:/var/lib/postgresql/data
-    networks:
-      - infisical
-    healthcheck:
-      test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
-      interval: 5s
-      timeout: 10s
-      retries: 10
+#   db:
+#     container_name: infisical-db
+#     image: postgres:14-alpine
+#     restart: always
+#     env_file: .env
+#     volumes:
+#       - pg_data:/var/lib/postgresql/data
+#     networks:
+#       - infisical
+#     healthcheck:
+#       test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
+#       interval: 5s
+#       timeout: 10s
+#       retries: 10
 
-volumes:
-  pg_data:
-    driver: local
-  redis_data:
-    driver: local
+# volumes:
+#   pg_data:
+#     driver: local
+#   redis_data:
+#     driver: local
 
-networks:
-  infisical:
+# networks:
+#   infisical:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,70 +3,70 @@ version: "3"
 services:
   db-migration:
     container_name: infisical-db-migration
-    # depends_on:
-    #   db:
-    #     condition: service_healthy
-    image: infisical/infisical:v0.94.0-postgres
+    depends_on:
+      db:
+        condition: service_healthy
+    image: infisical/infisical:latest-postgres
     env_file: .env
     command: npm run migration:latest
     pull_policy: always
-    # networks:
-    #   - infisical
+    networks:
+      - infisical
 
-#   backend:
-#     container_name: infisical-backend
-#     restart: unless-stopped
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#       redis:
-#         condition: service_started
-#       db-migration:
-#         condition: service_completed_successfully
-#     image: infisical/infisical:latest-postgres
-#     pull_policy: always
-#     env_file: .env
-#     ports:
-#       - 80:8080
-#     environment:
-#       - NODE_ENV=production
-#     networks:
-#       - infisical
+  backend:
+    container_name: infisical-backend
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      db-migration:
+        condition: service_completed_successfully
+    image: infisical/infisical:latest-postgres
+    pull_policy: always
+    env_file: .env
+    ports:
+      - 80:8080
+    environment:
+      - NODE_ENV=production
+    networks:
+      - infisical
 
-#   redis:
-#     image: redis
-#     container_name: infisical-dev-redis
-#     env_file: .env
-#     restart: always
-#     environment:
-#       - ALLOW_EMPTY_PASSWORD=yes
-#     ports:
-#       - 6379:6379
-#     networks:
-#       - infisical
-#     volumes:
-#       - redis_data:/data
+  redis:
+    image: redis
+    container_name: infisical-dev-redis
+    env_file: .env
+    restart: always
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - 6379:6379
+    networks:
+      - infisical
+    volumes:
+      - redis_data:/data
 
-#   db:
-#     container_name: infisical-db
-#     image: postgres:14-alpine
-#     restart: always
-#     env_file: .env
-#     volumes:
-#       - pg_data:/var/lib/postgresql/data
-#     networks:
-#       - infisical
-#     healthcheck:
-#       test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
-#       interval: 5s
-#       timeout: 10s
-#       retries: 10
+  db:
+    container_name: infisical-db
+    image: postgres:14-alpine
+    restart: always
+    env_file: .env
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    networks:
+      - infisical
+    healthcheck:
+      test: "pg_isready --username=${POSTGRES_USER} && psql --username=${POSTGRES_USER} --list"
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
-# volumes:
-#   pg_data:
-#     driver: local
-#   redis_data:
-#     driver: local
+volumes:
+  pg_data:
+    driver: local
+  redis_data:
+    driver: local
 
-# networks:
-#   infisical:
+networks:
+  infisical:


### PR DESCRIPTION
We didn't do a check to see if the column already exists. Because of this, we get this error during migrations:

```
| migration file "20240802181855_ca-cert-version.ts" failed
infisical-db-migration  | migration failed with error: alter table "certificates" add column "caCertId" uuid null - column "caCertId" of relation "certificates" already exists
```