### PR TITLE
only create triggers when create new table

### DIFF
--- a/backend/src/db/migrations/20240818024923_cert-alerting.ts
+++ b/backend/src/db/migrations/20240818024923_cert-alerting.ts
@@ -13,9 +13,9 @@ export async function up(knex: Knex): Promise<void> {
       t.string("name").notNullable();
       t.string("description").notNullable();
     });
-  }
 
-  await createOnUpdateTrigger(knex, TableName.PkiCollection);
+    await createOnUpdateTrigger(knex, TableName.PkiCollection);
+  }
 
   if (!(await knex.schema.hasTable(TableName.PkiCollectionItem))) {
     await knex.schema.createTable(TableName.PkiCollectionItem, (t) => {
@@ -28,9 +28,9 @@ export async function up(knex: Knex): Promise<void> {
       t.uuid("certId").nullable();
       t.foreign("certId").references("id").inTable(TableName.Certificate).onDelete("CASCADE");
     });
-  }
 
-  await createOnUpdateTrigger(knex, TableName.PkiCollectionItem);
+    await createOnUpdateTrigger(knex, TableName.PkiCollectionItem);
+  }
 
   if (!(await knex.schema.hasTable(TableName.PkiAlert))) {
     await knex.schema.createTable(TableName.PkiAlert, (t) => {
@@ -45,9 +45,9 @@ export async function up(knex: Knex): Promise<void> {
       t.string("recipientEmails").notNullable();
       t.unique(["name", "projectId"]);
     });
-  }
 
-  await createOnUpdateTrigger(knex, TableName.PkiAlert);
+    await createOnUpdateTrigger(knex, TableName.PkiAlert);
+  }
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/backend/src/db/migrations/20240818024923_cert-alerting.ts
+++ b/backend/src/db/migrations/20240818024923_cert-alerting.ts
@@ -13,9 +13,9 @@ export async function up(knex: Knex): Promise<void> {
       t.string("name").notNullable();
       t.string("description").notNullable();
     });
-
-    await createOnUpdateTrigger(knex, TableName.PkiCollection);
   }
+
+  await createOnUpdateTrigger(knex, TableName.PkiCollection);
 
   if (!(await knex.schema.hasTable(TableName.PkiCollectionItem))) {
     await knex.schema.createTable(TableName.PkiCollectionItem, (t) => {
@@ -28,9 +28,9 @@ export async function up(knex: Knex): Promise<void> {
       t.uuid("certId").nullable();
       t.foreign("certId").references("id").inTable(TableName.Certificate).onDelete("CASCADE");
     });
-
-    await createOnUpdateTrigger(knex, TableName.PkiCollectionItem);
   }
+
+  await createOnUpdateTrigger(knex, TableName.PkiCollectionItem);
 
   if (!(await knex.schema.hasTable(TableName.PkiAlert))) {
     await knex.schema.createTable(TableName.PkiAlert, (t) => {
@@ -45,9 +45,9 @@ export async function up(knex: Knex): Promise<void> {
       t.string("recipientEmails").notNullable();
       t.unique(["name", "projectId"]);
     });
-
-    await createOnUpdateTrigger(knex, TableName.PkiAlert);
   }
+
+  await createOnUpdateTrigger(knex, TableName.PkiAlert);
 }
 
 export async function down(knex: Knex): Promise<void> {


### PR DESCRIPTION
# Description 📣

We were creating triggers even if they were already created. This fix only creates triggers on new tables. The error this addresses is:

```
 migration file "20240818024923_cert-alerting.ts" failed
infisical-db-migration  | migration failed with error: 
infisical-db-migration  | CREATE TRIGGER "pki_collections_updatedAt"
infisical-db-migration  | BEFORE UPDATE ON pki_collections
infisical-db-migration  | FOR EACH ROW
infisical-db-migration  | EXECUTE PROCEDURE on_update_timestamp();
infisical-db-migration  |  - trigger "pki_collections_updatedAt" for relation "pki_collections" already exists
infisical-db-migration  | 
infisical-db-migration  | CREATE TRIGGER "pki_collections_updatedAt"
infisical-db-migration  | BEFORE UPDATE ON pki_collections
infisical-db-migration  | FOR EACH ROW
infisical-db-migration  | EXECUTE PROCEDURE on_update_timestamp();
infisical-db-migration  |  - trigger "pki_collections_updatedAt" for relation "pki_collections" already exists
infisical-db-migration  | error: 
infisical-db-migration  | CREATE TRIGGER "pki_collections_updatedAt"
infisical-db-migration  | BEFORE UPDATE ON pki_collections
infisical-db-migration  | FOR EACH ROW
infisical-db-migration  | EXECUTE PROCEDURE on_update_timestamp();
infisical-db-migration  |  - trigger "pki_collections_updatedAt" for relation "pki_collections" already exists
infisical-db-migration  |     at Parser.parseErrorMessage (/backend/node_modules/pg-protocol/src/parser.ts:369:69)
infisical-db-migration  |     at Parser.handlePacket (/backend/node_modules/pg-protocol/src/parser.ts:188:21)
infisical-db-migration  |     at Parser.parse (/backend/node_modules/pg-protocol/src/parser.ts:103:30)
infisical-db-migration  |     at TLSSocket.<anonymous> (/backend/node_modules/pg-protocol/src/index.ts:7:48)
infisical-db-migration  |     at TLSSocket.emit (node:events:519:28)
infisical-db-migration  |     at TLSSocket.emit (node:domain:488:12)
infisical-db-migration  |     at addChunk (node:internal/streams/readable:559:12)
infisical-db-migration  |     at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
infisical-db-migration  |     at TLSSocket.Readable.push (node:internal/streams/readable:390:5)
infisical-db-migration  |     at TLSWrap.onStreamRead (node:internal/stream_base_commons:191:23)
```
