### PR TITLE
Add sort to Github integration dropdown box

### DIFF
--- a/frontend/src/hooks/api/integrationAuth/queries.tsx
+++ b/frontend/src/hooks/api/integrationAuth/queries.tsx
@@ -157,7 +157,8 @@ const fetchIntegrationAuthApps = async ({
     `/api/v1/integration-auth/${integrationAuthId}/apps`,
     { params: searchParams }
   );
-  return data.apps;
+
+  return data.apps.sort((a, b) => a.name.localeCompare(b.name));
 };
 
 const fetchIntegrationAuthTeams = async (integrationAuthId: string) => {


### PR DESCRIPTION
# Description 📣

I was using the Github Oauth integration before and all my repositories were sorted, but when I switched to Github App integration, the list of repositories was not sorted anymore.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
Before change
![Screenshot 2024-11-15 at 10 20 07 AM](https://github.com/user-attachments/assets/19d6ae33-d240-461f-bb96-118a0e09cdfa)

After change
![Screenshot 2024-11-15 at 10 21 07 AM](https://github.com/user-attachments/assets/ac1557b4-1509-4a92-9f69-9fba3ebb2e8c)

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->