### PR TITLE
Fix: Handle Empty Secret Values in Update, Bulk Create and Bulk Update Secret(s)

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -414,12 +414,13 @@ export const secretV2BridgeServiceFactory = ({
       type: KmsDataKey.SecretManager,
       projectId
     });
-    const encryptedValue = secretValue
-      ? {
-          encryptedValue: secretManagerEncryptor({ plainText: Buffer.from(secretValue) }).cipherTextBlob,
-          references: getAllSecretReferences(secretValue).nestedReferences
-        }
-      : {};
+    const encryptedValue =
+      typeof secretValue === "string"
+        ? {
+            encryptedValue: secretManagerEncryptor({ plainText: Buffer.from(secretValue) }).cipherTextBlob,
+            references: getAllSecretReferences(secretValue).nestedReferences
+          }
+        : {};
 
     if (secretValue) {
       const { nestedReferences, localReferences } = getAllSecretReferences(secretValue);

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1166,7 +1166,7 @@ export const secretV2BridgeServiceFactory = ({
     const newSecrets = await secretDAL.transaction(async (tx) =>
       fnSecretBulkInsert({
         inputSecrets: inputSecrets.map((el) => {
-          const references = secretReferencesGroupByInputSecretKey[el.secretKey].nestedReferences;
+          const references = secretReferencesGroupByInputSecretKey[el.secretKey]?.nestedReferences;
 
           return {
             version: 1,
@@ -1373,7 +1373,7 @@ export const secretV2BridgeServiceFactory = ({
             typeof el.secretValue !== "undefined"
               ? {
                   encryptedValue: secretManagerEncryptor({ plainText: Buffer.from(el.secretValue) }).cipherTextBlob,
-                  references: secretReferencesGroupByInputSecretKey[el.secretKey].nestedReferences
+                  references: secretReferencesGroupByInputSecretKey[el.secretKey]?.nestedReferences
                 }
               : {};
 


### PR DESCRIPTION
# Description 📣

This PR addresses incorrect handling of empty values for secrets on update (value not updated), bulk create (threw error), and bulk update (threw error).

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝