### PR TITLE
improvement: composite index for identityId:authMethod on access tokens table

### DIFF
--- a/backend/src/db/migrations/20241119184509_access-tokens-auth-method-identity-id-index.ts
+++ b/backend/src/db/migrations/20241119184509_access-tokens-auth-method-identity-id-index.ts
@@ -1,0 +1,25 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasIdentityIdColumn = await knex.schema.hasColumn(TableName.IdentityAccessToken, "identityId");
+  const hasAuthMethodColumn = await knex.schema.hasColumn(TableName.IdentityAccessToken, "authMethod");
+
+  await knex.schema.alterTable(TableName.IdentityAccessToken, (t) => {
+    if (hasIdentityIdColumn && hasAuthMethodColumn) {
+      t.index(["authMethod", "identityId"]);
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasIdentityIdColumn = await knex.schema.hasColumn(TableName.IdentityAccessToken, "identityId");
+  const hasAuthMethodColumn = await knex.schema.hasColumn(TableName.IdentityAccessToken, "authMethod");
+
+  await knex.schema.alterTable(TableName.IdentityAccessToken, (t) => {
+    if (hasIdentityIdColumn && hasAuthMethodColumn) {
+      t.dropIndex(["authMethod", "identityId"]);
+    }
+  });
+}


### PR DESCRIPTION
This PR adds a composite index on `identityId` and `authMethod`, in the identity access tokens table. The reason for this is to improve deletion speeds of access tokens where we query for identityId and authMethod.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->