### PR TITLE
fix: allow preset domains for `infisical login`

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -111,7 +111,7 @@ var exportCmd = &cobra.Command{
 				accessToken = token.Token
 			} else {
 				log.Debug().Msg("GetAllEnvironmentVariables: Trying to fetch secrets using logged in details")
-				loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails()
+				loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 				if err != nil {
 					util.HandleError(err)
 				}

--- a/cli/packages/cmd/init.go
+++ b/cli/packages/cmd/init.go
@@ -41,7 +41,7 @@ var initCmd = &cobra.Command{
 			}
 		}
 
-		userCreds, err := util.GetCurrentLoggedInUserDetails()
+		userCreds, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {
 			util.HandleError(err, "Unable to get your login details")
 		}

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 			util.CheckForUpdate()
 		}
 
-		loggedInDetails, err := util.GetCurrentLoggedInUserDetails()
+		loggedInDetails, err := util.GetCurrentLoggedInUserDetails(false)
 
 		if !silent && err == nil && loggedInDetails.IsUserLoggedIn && !loggedInDetails.LoginExpired {
 			token, err := util.GetInfisicalToken(cmd)

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -194,7 +194,7 @@ var secretsSetCmd = &cobra.Command{
 				projectId = workspaceFile.WorkspaceId
 			}
 
-			loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails()
+			loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 			if err != nil {
 				util.HandleError(err, "unable to authenticate [err=%v]")
 			}
@@ -278,7 +278,7 @@ var secretsDeleteCmd = &cobra.Command{
 			util.RequireLogin()
 			util.RequireLocalWorkspaceFile()
 
-			loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails()
+			loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 			if err != nil {
 				util.HandleError(err, "Unable to authenticate")
 			}

--- a/cli/packages/cmd/tokens.go
+++ b/cli/packages/cmd/tokens.go
@@ -41,7 +41,7 @@ var tokensCreateCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// get plain text workspace key
-		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails()
+		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 
 		if err != nil {
 			util.HandleError(err, "Unable to retrieve your logged in your details. Please login in then try again")

--- a/cli/packages/util/credentials.go
+++ b/cli/packages/util/credentials.go
@@ -55,7 +55,7 @@ func GetUserCredsFromKeyRing(userEmail string) (credentials models.UserCredentia
 	return userCredentials, err
 }
 
-func GetCurrentLoggedInUserDetails() (LoggedInUserDetails, error) {
+func GetCurrentLoggedInUserDetails(setConfigVariables bool) (LoggedInUserDetails, error) {
 	if ConfigFileExists() {
 		configFile, err := GetConfigFile()
 		if err != nil {
@@ -75,17 +75,19 @@ func GetCurrentLoggedInUserDetails() (LoggedInUserDetails, error) {
 			}
 		}
 
+		if setConfigVariables {
+			config.INFISICAL_URL_MANUAL_OVERRIDE = config.INFISICAL_URL
+			//configFile.LoggedInUserDomain
+			//if not empty set as infisical url
+			if configFile.LoggedInUserDomain != "" {
+				config.INFISICAL_URL = AppendAPIEndpoint(configFile.LoggedInUserDomain)
+			}
+		}
+
 		// check to to see if the JWT is still valid
 		httpClient := resty.New().
 			SetAuthToken(userCreds.JTWToken).
 			SetHeader("Accept", "application/json")
-
-		config.INFISICAL_URL_MANUAL_OVERRIDE = config.INFISICAL_URL
-		//configFile.LoggedInUserDomain
-		//if not empty set as infisical url
-		if configFile.LoggedInUserDomain != "" {
-			config.INFISICAL_URL = AppendAPIEndpoint(configFile.LoggedInUserDomain)
-		}
 
 		isAuthenticated := api.CallIsAuthenticated(httpClient)
 		// TODO: add refresh token

--- a/cli/packages/util/folders.go
+++ b/cli/packages/util/folders.go
@@ -20,7 +20,7 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 
 		log.Debug().Msg("GetAllFolders: Trying to fetch folders using logged in details")
 
-		loggedInUserDetails, err := GetCurrentLoggedInUserDetails()
+		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func CreateFolder(params models.CreateFolderParameters) (models.SingleFolder, er
 	if params.InfisicalToken == "" {
 		RequireLogin()
 		RequireLocalWorkspaceFile()
-		loggedInUserDetails, err := GetCurrentLoggedInUserDetails()
+		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 
 		if err != nil {
 			return models.SingleFolder{}, err
@@ -224,7 +224,7 @@ func DeleteFolder(params models.DeleteFolderParameters) ([]models.SingleFolder, 
 		RequireLogin()
 		RequireLocalWorkspaceFile()
 
-		loggedInUserDetails, err := GetCurrentLoggedInUserDetails()
+		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 
 		if err != nil {
 			return nil, err

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -246,7 +246,7 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 
 		log.Debug().Msg("GetAllEnvironmentVariables: Trying to fetch secrets using logged in details")
 
-		loggedInUserDetails, err := GetCurrentLoggedInUserDetails()
+		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 		isConnected := ValidateInfisicalAPIConnection()
 
 		if isConnected {


### PR DESCRIPTION
# Description 📣

This PR adds support for the `--domain` flag or the `INFISICAL_API_URL` when users are logging in. Below I've attached a video that demonstrates the new functionality. This PR addresses https://github.com/Infisical/infisical/issues/2407

https://github.com/user-attachments/assets/5eb2d446-8f86-49d9-8ee8-66d32a9a298b


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->