### PR TITLE
fix(audit-logs): actor / actor ID mismatch

### DIFF
--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -9,7 +9,7 @@ export type TGetAuditLogsFilter = {
   eventMetadata?: Record<string, string>;
   actorType?: ActorType;
   projectId?: string;
-  actorId?: string; // user ID format
+  actor?: string; // user ID format
   startDate?: Date;
   endDate?: Date;
   limit: number;

--- a/frontend/src/views/Org/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/views/Org/AuditLogsPage/components/LogsSection.tsx
@@ -98,7 +98,7 @@ export const LogsSection = ({
           userAgentType,
           startDate,
           endDate,
-          actorId: actor
+          actor
         }}
       />
       <UpgradePlanModal


### PR DESCRIPTION
# Description 📣

This PR fixes an issue related to user audit logs. The API expects `actor` as the field for actor ID. But the frontend was sending `actorId` instead of `actor`.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->