### PR TITLE
fixing small typo in docs/integrations/platforms/kubernetes

### DIFF
--- a/docs/integrations/platforms/kubernetes.mdx
+++ b/docs/integrations/platforms/kubernetes.mdx
@@ -94,7 +94,7 @@ spec:
         projectSlug: new-ob-em
         envSlug: dev # "dev", "staging", "prod", etc..
         secretsPath: "/" # Root is "/"
-        recursive: true # Wether or not to use recursive mode (Fetches all secrets in an environment from a given secret path, and all folders inside the path) / defaults to false
+        recursive: true # Whether or not to use recursive mode (Fetches all secrets in an environment from a given secret path, and all folders inside the path) / defaults to false
       credentialsRef:
         secretName: universal-auth-credentials
         secretNamespace: default


### PR DESCRIPTION
# Description 📣

was reading [k8s integration docs](https://infisical.com/docs/integrations/platforms/kubernetes#sync-infisical-secrets-to-your-cluster) and found small typo in the `example-infisical-secret-crd.yaml` template

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [X] Documentation

# Tests 🛠️

N/A, just fixing typo

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->