### PR TITLE
feat(approvals): multi-path support `(draft)`

### DIFF
--- a/backend/src/db/migrations/20241120180442_multiple-approval-policy-secret-paths.ts
+++ b/backend/src/db/migrations/20241120180442_multiple-approval-policy-secret-paths.ts
@@ -1,0 +1,91 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  // ? ACCESS APPROVALS
+  const accessApprovalPolicyHasSecretPathColumn = await knex.schema.hasColumn(
+    TableName.AccessApprovalPolicy,
+    "secretPath"
+  );
+  const accessApprovalPolicyHasNewSecretPathsColumn = await knex.schema.hasColumn(
+    TableName.AccessApprovalPolicy,
+    "secretPaths"
+  );
+
+  await knex.schema.alterTable(TableName.AccessApprovalPolicy, (t) => {
+    if (!accessApprovalPolicyHasNewSecretPathsColumn) {
+      t.jsonb("secretPaths").notNullable().defaultTo("[]");
+    }
+  });
+
+  if (accessApprovalPolicyHasSecretPathColumn) {
+    // Move the existing secretPath values to the new secretPaths column
+    await knex(TableName.AccessApprovalPolicy)
+      .select("id", "secretPath")
+      .whereNotNull("secretPath")
+      .whereNot("secretPath", "")
+      .update({
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore -- secretPaths are not in the type definition yet
+        secretPaths: knex.raw("to_jsonb(ARRAY[??])", ["secretPath"])
+      });
+  }
+  // TODO(daniel): Drop the secretPath column in the future when this has stabilized
+
+  // ? SECRET CHANGE APPROVALS
+  const secretChangeApprovalPolicyHasSecretPathColumn = await knex.schema.hasColumn(
+    TableName.SecretApprovalPolicy,
+    "secretPath"
+  );
+  const secretChangeApprovalPolicyHasNewSecretPathsColumn = await knex.schema.hasColumn(
+    TableName.SecretApprovalPolicy,
+    "secretPaths"
+  );
+
+  await knex.schema.alterTable(TableName.SecretApprovalPolicy, (t) => {
+    if (!secretChangeApprovalPolicyHasNewSecretPathsColumn) {
+      t.jsonb("secretPaths").notNullable().defaultTo("[]");
+    }
+  });
+
+  if (secretChangeApprovalPolicyHasSecretPathColumn) {
+    // Move the existing secretPath values to the new secretPaths column
+    await knex(TableName.SecretApprovalPolicy)
+      .select("id", "secretPath")
+      .whereNotNull("secretPath")
+      .whereNot("secretPath", "")
+      .update({
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore -- secretPaths are not in the type definition yet
+        secretPaths: knex.raw("to_jsonb(ARRAY[??])", ["secretPath"])
+      });
+  }
+
+  // TODO(daniel): Drop the secretPath column in the future when this has stabilized.
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // TODO(daniel): Restore the secretPath columns when we add dropping in the up migration. (needs to be re-filled with data from the `secretPaths` column)
+
+  const accessApprovalPolicyHasNewSecretsPathsColumn = await knex.schema.hasColumn(
+    TableName.AccessApprovalPolicy,
+    "secretPaths"
+  );
+  const secretChangeApprovalPolicyHasSecretPathColumn = await knex.schema.hasColumn(
+    TableName.SecretApprovalPolicy,
+    "secretPaths"
+  );
+
+  await knex.schema.alterTable(TableName.AccessApprovalPolicy, (t) => {
+    if (accessApprovalPolicyHasNewSecretsPathsColumn) {
+      t.dropColumn("secretPaths");
+    }
+  });
+
+  await knex.schema.alterTable(TableName.SecretApprovalPolicy, (t) => {
+    if (secretChangeApprovalPolicyHasSecretPathColumn) {
+      t.dropColumn("secretPaths");
+    }
+  });
+}

--- a/backend/src/db/schemas/access-approval-policies.ts
+++ b/backend/src/db/schemas/access-approval-policies.ts
@@ -11,7 +11,7 @@ export const AccessApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   approvals: z.number().default(1),
-  secretPath: z.string().nullable().optional(),
+  secretPaths: z.unknown(),
   envId: z.string().uuid(),
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/backend/src/db/schemas/access-approval-policies.ts
+++ b/backend/src/db/schemas/access-approval-policies.ts
@@ -11,11 +11,12 @@ export const AccessApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   approvals: z.number().default(1),
-  secretPaths: z.unknown(),
+  secretPath: z.string().nullable().optional(),
   envId: z.string().uuid(),
   createdAt: z.date(),
   updatedAt: z.date(),
-  enforcementLevel: z.string().default("hard")
+  enforcementLevel: z.string().default("hard"),
+  secretPaths: z.unknown()
 });
 
 export type TAccessApprovalPolicies = z.infer<typeof AccessApprovalPoliciesSchema>;

--- a/backend/src/db/schemas/identity-metadata.ts
+++ b/backend/src/db/schemas/identity-metadata.ts
@@ -10,7 +10,7 @@ import { TImmutableDBKeys } from "./models";
 export const IdentityMetadataSchema = z.object({
   id: z.string().uuid(),
   key: z.string(),
-  value: z.string(),
+  value: z.string().nullable().optional(),
   orgId: z.string().uuid(),
   userId: z.string().uuid().nullable().optional(),
   identityId: z.string().uuid().nullable().optional(),

--- a/backend/src/db/schemas/kms-root-config.ts
+++ b/backend/src/db/schemas/kms-root-config.ts
@@ -12,7 +12,7 @@ import { TImmutableDBKeys } from "./models";
 export const KmsRootConfigSchema = z.object({
   id: z.string().uuid(),
   encryptedRootKey: zodBuffer,
-  encryptionStrategy: z.string(),
+  encryptionStrategy: z.string().default("SOFTWARE").nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date()
 });

--- a/backend/src/db/schemas/project-user-additional-privilege.ts
+++ b/backend/src/db/schemas/project-user-additional-privilege.ts
@@ -20,7 +20,8 @@ export const ProjectUserAdditionalPrivilegeSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   userId: z.string().uuid(),
-  projectId: z.string()
+  projectId: z.string(),
+  accessRequestId: z.string().uuid().nullable().optional()
 });
 
 export type TProjectUserAdditionalPrivilege = z.infer<typeof ProjectUserAdditionalPrivilegeSchema>;

--- a/backend/src/db/schemas/secret-approval-policies.ts
+++ b/backend/src/db/schemas/secret-approval-policies.ts
@@ -10,7 +10,7 @@ import { TImmutableDBKeys } from "./models";
 export const SecretApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  secretPath: z.string().nullable().optional(),
+  secretPaths: z.unknown(),
   approvals: z.number().default(1),
   envId: z.string().uuid(),
   createdAt: z.date(),

--- a/backend/src/db/schemas/secret-approval-policies.ts
+++ b/backend/src/db/schemas/secret-approval-policies.ts
@@ -10,12 +10,13 @@ import { TImmutableDBKeys } from "./models";
 export const SecretApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  secretPaths: z.unknown(),
+  secretPath: z.string().nullable().optional(),
   approvals: z.number().default(1),
   envId: z.string().uuid(),
   createdAt: z.date(),
   updatedAt: z.date(),
-  enforcementLevel: z.string().default("hard")
+  enforcementLevel: z.string().default("hard"),
+  secretPaths: z.unknown()
 });
 
 export type TSecretApprovalPolicies = z.infer<typeof SecretApprovalPoliciesSchema>;

--- a/backend/src/ee/routes/v1/access-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-request-router.ts
@@ -20,7 +20,14 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
     method: "POST",
     schema: {
       body: z.object({
-        permissions: z.any().array(),
+        requestedActions: z.object({
+          read: z.boolean(),
+          edit: z.boolean(),
+          create: z.boolean(),
+          delete: z.boolean()
+        }),
+        environment: z.string(),
+        secretPaths: z.string().array(),
         isTemporary: z.boolean(),
         temporaryRange: z.string().optional()
       }),
@@ -39,7 +46,9 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         actor: req.permission.type,
         actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
-        permissions: req.body.permissions,
+        environment: req.body.environment,
+        secretPaths: req.body.secretPaths,
+        requestedActions: req.body.requestedActions,
         actorOrgId: req.permission.orgId,
         projectSlug: req.query.projectSlug,
         temporaryRange: req.body.temporaryRange,
@@ -107,7 +116,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
               name: z.string(),
               approvals: z.number(),
               approvers: z.string().array(),
-              secretPath: z.string().nullish(),
+              secretPaths: z.string().array(),
               envId: z.string(),
               enforcementLevel: z.string()
             }),

--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -41,8 +41,8 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
       response: {
         200: z.object({
           approvals: SecretApprovalRequestsSchema.extend({
-            // secretPath: z.string(),
             policy: z.object({
+              secretPaths: z.string().array(),
               id: z.string(),
               name: z.string(),
               approvals: z.number(),
@@ -51,7 +51,6 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
                   userId: z.string().nullable().optional()
                 })
                 .array(),
-              secretPath: z.string().optional().nullable(),
               enforcementLevel: z.string()
             }),
             committerUser: approvalRequestUser,
@@ -253,13 +252,12 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         200: z.object({
           approval: SecretApprovalRequestsSchema.merge(
             z.object({
-              // secretPath: z.string(),
               policy: z.object({
                 id: z.string(),
                 name: z.string(),
                 approvals: z.number(),
                 approvers: approvalRequestUser.array(),
-                secretPath: z.string().optional().nullable(),
+                secretPaths: z.string().array(),
                 enforcementLevel: z.string()
               }),
               environment: z.string(),
@@ -308,6 +306,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         actorOrgId: req.permission.orgId,
         id: req.params.id
       });
+
       return { approval };
     }
   });

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
@@ -17,14 +17,20 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient) => {
     filter: TFindFilter<TAccessApprovalPolicies & { projectId: string }>,
     customFilter?: {
       policyId?: string;
+      secretPaths?: string[];
     }
   ) => {
-    const result = await tx(TableName.AccessApprovalPolicy)
+    const query = tx(TableName.AccessApprovalPolicy)
       // eslint-disable-next-line
       .where(buildFindFilter(filter))
       .where((qb) => {
         if (customFilter?.policyId) {
           void qb.where(`${TableName.AccessApprovalPolicy}.id`, "=", customFilter.policyId);
+        }
+        if (customFilter?.secretPaths) {
+          void qb.whereRaw(`${TableName.AccessApprovalPolicy}.secretPaths @> ?::jsonb`, [
+            JSON.stringify(customFilter.secretPaths)
+          ]);
         }
       })
       .join(TableName.Environment, `${TableName.AccessApprovalPolicy}.envId`, `${TableName.Environment}.id`)
@@ -42,6 +48,51 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient) => {
       .select(tx.ref("id").withSchema(TableName.Environment).as("envId"))
       .select(tx.ref("projectId").withSchema(TableName.Environment))
       .select(selectAllTableCols(TableName.AccessApprovalPolicy));
+
+    const result = await query;
+
+    return result;
+  };
+
+  const accessApprovalPolicyFindOneQuery = async (
+    tx: Knex,
+    filter: TFindFilter<TAccessApprovalPolicies & { projectId: string }>,
+    customFilter?: {
+      policyId?: string;
+      secretPaths?: string[];
+    }
+  ) => {
+    const query = tx(TableName.AccessApprovalPolicy)
+      // eslint-disable-next-line
+      .where(buildFindFilter(filter))
+      .where((qb) => {
+        if (customFilter?.policyId) {
+          void qb.where(`${TableName.AccessApprovalPolicy}.id`, "=", customFilter.policyId);
+        }
+        if (customFilter?.secretPaths) {
+          void qb.whereRaw(`${TableName.AccessApprovalPolicy}."secretPaths" = ?::jsonb`, [
+            JSON.stringify(customFilter.secretPaths)
+          ]);
+        }
+      })
+      .join(TableName.Environment, `${TableName.AccessApprovalPolicy}.envId`, `${TableName.Environment}.id`)
+      .leftJoin(
+        TableName.AccessApprovalPolicyApprover,
+        `${TableName.AccessApprovalPolicy}.id`,
+        `${TableName.AccessApprovalPolicyApprover}.policyId`
+      )
+      .leftJoin(TableName.Users, `${TableName.AccessApprovalPolicyApprover}.approverUserId`, `${TableName.Users}.id`)
+      .select(tx.ref("username").withSchema(TableName.Users).as("approverUsername"))
+      .select(tx.ref("approverUserId").withSchema(TableName.AccessApprovalPolicyApprover))
+      .select(tx.ref("approverGroupId").withSchema(TableName.AccessApprovalPolicyApprover))
+      .select(tx.ref("name").withSchema(TableName.Environment).as("envName"))
+      .select(tx.ref("slug").withSchema(TableName.Environment).as("envSlug"))
+      .select(tx.ref("id").withSchema(TableName.Environment).as("envId"))
+      .select(tx.ref("projectId").withSchema(TableName.Environment))
+      .select(selectAllTableCols(TableName.AccessApprovalPolicy))
+      .first();
+
+    const result = await query;
 
     return result;
   };
@@ -109,8 +160,8 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient) => {
             slug: data.envSlug
           },
           projectId: data.projectId,
-          ...AccessApprovalPoliciesSchema.parse(data)
-          // secretPath: data.secretPath || undefined,
+          ...AccessApprovalPoliciesSchema.parse(data),
+          secretPaths: data.secretPaths as string[]
         }),
         childrenMapper: [
           {
@@ -139,5 +190,52 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient) => {
     }
   };
 
-  return { ...accessApprovalPolicyOrm, find, findById };
+  const findOne = async (
+    filter: Partial<Omit<TAccessApprovalPolicies, "secretPaths">>,
+    customFilter?: { secretPaths?: string[] },
+    tx?: Knex
+  ) => {
+    const doc = await accessApprovalPolicyFindOneQuery(tx || db.replicaNode(), filter, customFilter);
+
+    if (!doc) {
+      return null;
+    }
+
+    const [formattedDoc] = sqlNestRelationships({
+      data: [doc],
+      key: "id",
+      parentMapper: (data) => ({
+        environment: {
+          id: data.envId,
+          name: data.envName,
+          slug: data.envSlug
+        },
+        projectId: data.projectId,
+        ...AccessApprovalPoliciesSchema.parse(data)
+      }),
+      childrenMapper: [
+        {
+          key: "approverUserId",
+          label: "approvers" as const,
+          mapper: ({ approverUserId: id, approverUsername }) => ({
+            id,
+            type: ApproverType.User,
+            name: approverUsername
+          })
+        },
+        {
+          key: "approverGroupId",
+          label: "approvers" as const,
+          mapper: ({ approverGroupId: id }) => ({
+            id,
+            type: ApproverType.Group
+          })
+        }
+      ]
+    });
+
+    return formattedDoc;
+  };
+
+  return { ...accessApprovalPolicyOrm, find, findById, findOne };
 };

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -48,7 +48,7 @@ export const accessApprovalPolicyServiceFactory = ({
     actor,
     actorId,
     actorOrgId,
-    secretPath,
+    secretPaths,
     actorAuthMethod,
     approvals,
     approvers,
@@ -138,7 +138,7 @@ export const accessApprovalPolicyServiceFactory = ({
         {
           envId: env.id,
           approvals,
-          secretPath,
+          secretPaths: JSON.stringify(secretPaths),
           name,
           enforcementLevel
         },
@@ -166,7 +166,7 @@ export const accessApprovalPolicyServiceFactory = ({
 
       return doc;
     });
-    return { ...accessApproval, environment: env, projectId: project.id };
+    return { ...accessApproval, environment: env, projectId: project.id, secretPaths };
   };
 
   const getAccessApprovalPolicyByProjectSlug = async ({
@@ -190,13 +190,14 @@ export const accessApprovalPolicyServiceFactory = ({
     // ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.SecretApproval);
 
     const accessApprovalPolicies = await accessApprovalPolicyDAL.find({ projectId: project.id });
+
     return accessApprovalPolicies;
   };
 
   const updateAccessApprovalPolicy = async ({
     policyId,
     approvers,
-    secretPath,
+    secretPaths,
     name,
     actorId,
     actor,
@@ -246,7 +247,7 @@ export const accessApprovalPolicyServiceFactory = ({
         accessApprovalPolicy.id,
         {
           approvals,
-          secretPath,
+          secretPaths: JSON.stringify(secretPaths),
           name,
           enforcementLevel
         },
@@ -321,13 +322,14 @@ export const accessApprovalPolicyServiceFactory = ({
       actorAuthMethod,
       actorOrgId
     );
+
     ForbiddenError.from(permission).throwUnlessCan(
       ProjectPermissionActions.Delete,
       ProjectPermissionSub.SecretApproval
     );
 
     await accessApprovalPolicyDAL.deleteById(policyId);
-    return policy;
+    return { ...policy, secretPaths: policy.secretPaths as string[] };
   };
 
   const getAccessPolicyCountByEnvSlug = async ({

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-types.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-types.ts
@@ -20,7 +20,7 @@ export enum ApproverType {
 
 export type TCreateAccessApprovalPolicy = {
   approvals: number;
-  secretPath: string;
+  secretPaths: string[];
   environment: string;
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; name?: string })[];
   projectSlug: string;
@@ -32,7 +32,7 @@ export type TUpdateAccessApprovalPolicy = {
   policyId: string;
   approvals?: number;
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; name?: string })[];
-  secretPath?: string;
+  secretPaths?: string[];
   name?: string;
   enforcementLevel?: EnforcementLevel;
 } & Omit<TProjectPermission, "projectId">;

--- a/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
@@ -59,7 +59,7 @@ export const accessApprovalRequestDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.AccessApprovalPolicy).as("policyId"),
           db.ref("name").withSchema(TableName.AccessApprovalPolicy).as("policyName"),
           db.ref("approvals").withSchema(TableName.AccessApprovalPolicy).as("policyApprovals"),
-          db.ref("secretPath").withSchema(TableName.AccessApprovalPolicy).as("policySecretPath"),
+          db.ref("secretPaths").withSchema(TableName.AccessApprovalPolicy).as("policySecretPaths"),
           db.ref("enforcementLevel").withSchema(TableName.AccessApprovalPolicy).as("policyEnforcementLevel"),
           db.ref("envId").withSchema(TableName.AccessApprovalPolicy).as("policyEnvId")
         )
@@ -78,7 +78,6 @@ export const accessApprovalRequestDALFactory = (db: TDbClient) => {
           db.ref("status").withSchema(TableName.AccessApprovalRequestReviewer).as("reviewerStatus")
         )
 
-        // TODO: ADD SUPPORT FOR GROUPS!!!!
         .select(
           db.ref("email").withSchema("requestedByUser").as("requestedByUserEmail"),
           db.ref("username").withSchema("requestedByUser").as("requestedByUserUsername"),
@@ -116,9 +115,9 @@ export const accessApprovalRequestDALFactory = (db: TDbClient) => {
             id: doc.policyId,
             name: doc.policyName,
             approvals: doc.policyApprovals,
-            secretPath: doc.policySecretPath,
             enforcementLevel: doc.policyEnforcementLevel,
-            envId: doc.policyEnvId
+            envId: doc.policyEnvId,
+            secretPaths: doc.policySecretPaths as string[]
           },
           requestedByUser: {
             userId: doc.requestedByUserId,
@@ -250,7 +249,7 @@ export const accessApprovalRequestDALFactory = (db: TDbClient) => {
         tx.ref("name").withSchema(TableName.AccessApprovalPolicy).as("policyName"),
         tx.ref("projectId").withSchema(TableName.Environment),
         tx.ref("slug").withSchema(TableName.Environment).as("environment"),
-        tx.ref("secretPath").withSchema(TableName.AccessApprovalPolicy).as("policySecretPath"),
+        tx.ref("secretPaths").withSchema(TableName.AccessApprovalPolicy).as("policySecretPaths"),
         tx.ref("enforcementLevel").withSchema(TableName.AccessApprovalPolicy).as("policyEnforcementLevel"),
         tx.ref("approvals").withSchema(TableName.AccessApprovalPolicy).as("policyApprovals")
       );
@@ -270,8 +269,8 @@ export const accessApprovalRequestDALFactory = (db: TDbClient) => {
             id: el.policyId,
             name: el.policyName,
             approvals: el.policyApprovals,
-            secretPath: el.policySecretPath,
-            enforcementLevel: el.policyEnforcementLevel
+            enforcementLevel: el.policyEnforcementLevel,
+            secretPaths: el.policySecretPaths as string[]
           },
           requestedByUser: {
             userId: el.requestedByUserId,

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -4,11 +4,7 @@ import { BadRequestError } from "@app/lib/errors";
 
 import { TVerifyPermission } from "./access-approval-request-types";
 
-function filterUnique(value: string, index: number, array: string[]) {
-  return array.indexOf(value) === index;
-}
-
-export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) => {
+export const verifyRequestedPermissions = ({ permissions, checkPath }: TVerifyPermission) => {
   const permission = unpackRules(
     permissions as PackRule<{
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,32 +18,20 @@ export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) =
     throw new BadRequestError({ message: "No permission provided" });
   }
 
-  const requestedPermissions: string[] = [];
+  for (const perm of permission) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment
+    const permissionEnv = perm.conditions?.environment;
 
-  for (const p of permission) {
-    if (p.action[0] === "read") requestedPermissions.push("Read Access");
-    if (p.action[0] === "create") requestedPermissions.push("Create Access");
-    if (p.action[0] === "delete") requestedPermissions.push("Delete Access");
-    if (p.action[0] === "edit") requestedPermissions.push("Edit Access");
+    if (!permissionEnv || typeof permissionEnv !== "string") {
+      throw new BadRequestError({ message: "Permission environment is not a string" });
+    }
+
+    if (checkPath) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const permissionSecretPath = perm.conditions?.secretPath?.$glob;
+      if (!permissionSecretPath || typeof permissionSecretPath !== "string") {
+        throw new BadRequestError({ message: "Permission path is not a string" });
+      }
+    }
   }
-
-  const firstPermission = permission[0];
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-  const permissionSecretPath = firstPermission.conditions?.secretPath?.$glob;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-unsafe-assignment
-  const permissionEnv = firstPermission.conditions?.environment;
-
-  if (!permissionEnv || typeof permissionEnv !== "string") {
-    throw new BadRequestError({ message: "Permission environment is not a string" });
-  }
-  if (!permissionSecretPath || typeof permissionSecretPath !== "string") {
-    throw new BadRequestError({ message: "Permission path is not a string" });
-  }
-
-  return {
-    envSlug: permissionEnv,
-    secretPath: permissionSecretPath,
-    accessTypes: requestedPermissions.filter(filterUnique)
-  };
 };

--- a/backend/src/ee/services/access-approval-request/access-approval-request-types.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-types.ts
@@ -8,6 +8,7 @@ export enum ApprovalStatus {
 
 export type TVerifyPermission = {
   permissions: unknown;
+  checkPath?: boolean;
 };
 
 export type TGetAccessRequestCountDTO = {
@@ -21,7 +22,15 @@ export type TReviewAccessRequestDTO = {
 
 export type TCreateAccessApprovalRequestDTO = {
   projectSlug: string;
-  permissions: unknown;
+  environment: string;
+  // permissions: unknown;
+  requestedActions: {
+    read: boolean;
+    edit: boolean;
+    create: boolean;
+    delete: boolean;
+  };
+  secretPaths: string[];
   isTemporary: boolean;
   temporaryRange?: string;
 } & Omit<TProjectPermission, "projectId">;

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -232,7 +232,7 @@ export const permissionServiceFactory = ({
       objectify(
         userProjectPermission.metadata,
         (i) => i.key,
-        (i) => i.value
+        (i) => i.value || ""
       )
     );
     const interpolateRules = templatedRules(
@@ -299,7 +299,7 @@ export const permissionServiceFactory = ({
       objectify(
         identityProjectPermission.metadata,
         (i) => i.key,
-        (i) => i.value
+        (i) => i.value || ""
       )
     );
 

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
@@ -135,7 +135,8 @@ export const secretApprovalPolicyDALFactory = (db: TDbClient) => {
         parentMapper: (data) => ({
           environment: { id: data.envId, name: data.envName, slug: data.envSlug },
           projectId: data.projectId,
-          ...SecretApprovalPoliciesSchema.parse(data)
+          ...SecretApprovalPoliciesSchema.parse(data),
+          secretPaths: data.secretPaths as string[]
         }),
         childrenMapper: [
           {

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-types.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-types.ts
@@ -4,7 +4,7 @@ import { ApproverType } from "../access-approval-policy/access-approval-policy-t
 
 export type TCreateSapDTO = {
   approvals: number;
-  secretPath?: string | null;
+  secretPaths: string[];
   environment: string;
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; name?: string })[];
   projectId: string;
@@ -15,7 +15,7 @@ export type TCreateSapDTO = {
 export type TUpdateSapDTO = {
   secretPolicyId: string;
   approvals?: number;
-  secretPath?: string | null;
+  secretPaths?: string[];
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; name?: string })[];
   name?: string;
   enforcementLevel?: EnforcementLevel;

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-dal.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-dal.ts
@@ -108,7 +108,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
         tx.ref("name").withSchema(TableName.SecretApprovalPolicy).as("policyName"),
         tx.ref("projectId").withSchema(TableName.Environment),
         tx.ref("slug").withSchema(TableName.Environment).as("environment"),
-        tx.ref("secretPath").withSchema(TableName.SecretApprovalPolicy).as("policySecretPath"),
+        tx.ref("secretPaths").withSchema(TableName.SecretApprovalPolicy).as("policySecretPaths"),
         tx.ref("envId").withSchema(TableName.SecretApprovalPolicy).as("policyEnvId"),
         tx.ref("enforcementLevel").withSchema(TableName.SecretApprovalPolicy).as("policyEnforcementLevel"),
         tx.ref("approvals").withSchema(TableName.SecretApprovalPolicy).as("policyApprovals")
@@ -145,7 +145,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
             id: el.policyId,
             name: el.policyName,
             approvals: el.policyApprovals,
-            secretPath: el.policySecretPath,
+            secretPaths: el.policySecretPaths as string[],
             enforcementLevel: el.policyEnforcementLevel,
             envId: el.policyEnvId
           }
@@ -323,7 +323,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
           db.raw(
             `DENSE_RANK() OVER (partition by ${TableName.Environment}."projectId" ORDER BY ${TableName.SecretApprovalRequest}."id" DESC) as rank`
           ),
-          db.ref("secretPath").withSchema(TableName.SecretApprovalPolicy).as("policySecretPath"),
+          db.ref("secretPaths").withSchema(TableName.SecretApprovalPolicy).as("policySecretPaths"),
           db.ref("enforcementLevel").withSchema(TableName.SecretApprovalPolicy).as("policyEnforcementLevel"),
           db.ref("approvals").withSchema(TableName.SecretApprovalPolicy).as("policyApprovals"),
           db.ref("approverUserId").withSchema(TableName.SecretApprovalPolicyApprover),
@@ -352,7 +352,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
             id: el.policyId,
             name: el.policyName,
             approvals: el.policyApprovals,
-            secretPath: el.policySecretPath,
+            secretPaths: el.policySecretPaths as string[],
             enforcementLevel: el.policyEnforcementLevel
           },
           committerUser: {
@@ -470,7 +470,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
           db.raw(
             `DENSE_RANK() OVER (partition by ${TableName.Environment}."projectId" ORDER BY ${TableName.SecretApprovalRequest}."id" DESC) as rank`
           ),
-          db.ref("secretPath").withSchema(TableName.SecretApprovalPolicy).as("policySecretPath"),
+          db.ref("secretPaths").withSchema(TableName.SecretApprovalPolicy).as("policySecretPaths"),
           db.ref("approvals").withSchema(TableName.SecretApprovalPolicy).as("policyApprovals"),
           db.ref("enforcementLevel").withSchema(TableName.SecretApprovalPolicy).as("policyEnforcementLevel"),
           db.ref("approverUserId").withSchema(TableName.SecretApprovalPolicyApprover),
@@ -499,7 +499,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
             id: el.policyId,
             name: el.policyName,
             approvals: el.policyApprovals,
-            secretPath: el.policySecretPath,
+            secretPaths: el.policySecretPaths as string[],
             enforcementLevel: el.policyEnforcementLevel
           },
           committerUser: {

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -831,7 +831,7 @@ export const secretApprovalRequestServiceFactory = ({
           requesterFullName: `${requestedByUser.firstName} ${requestedByUser.lastName}`,
           requesterEmail: requestedByUser.email,
           bypassReason,
-          secretPath: policy.secretPath,
+          secretPath: folder.path,
           environment: env.name,
           approvalUrl: `${cfg.SITE_URL}/project/${project.id}/approval`
         },

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -294,10 +294,10 @@ export const secretApprovalRequestServiceFactory = ({
           : undefined
       }));
     }
-    const secretPath = await folderDAL.findSecretPathByFolderIds(secretApprovalRequest.projectId, [
+    const [secretPath] = await folderDAL.findSecretPathByFolderIds(secretApprovalRequest.projectId, [
       secretApprovalRequest.folderId
     ]);
-    return { ...secretApprovalRequest, secretPath: secretPath?.[0]?.path || "/", commits: secrets };
+    return { ...secretApprovalRequest, secretPath: secretPath?.path || "/", commits: secrets };
   };
 
   const reviewApproval = async ({

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -56,16 +56,15 @@ export const DefaultResponseErrorsSchema = {
   })
 };
 
-export const sapPubSchema = SecretApprovalPoliciesSchema.merge(
-  z.object({
-    environment: z.object({
-      id: z.string(),
-      name: z.string(),
-      slug: z.string()
-    }),
-    projectId: z.string()
-  })
-);
+export const sapPubSchema = SecretApprovalPoliciesSchema.extend({
+  secretPaths: z.string().array(),
+  environment: z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string()
+  }),
+  projectId: z.string()
+});
 
 export const sanitizedServiceTokenUserSchema = UsersSchema.pick({
   authMethods: true,

--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -207,7 +207,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
               .object({
                 key: z.string().trim().min(1),
                 id: z.string().trim().min(1),
-                value: z.string().trim().min(1)
+                value: z.string().trim().min(1).nullable().optional()
               })
               .array()
               .optional(),

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -135,7 +135,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
               .object({
                 key: z.string().trim().min(1),
                 id: z.string().trim().min(1),
-                value: z.string().trim().min(1)
+                value: z.string().trim().min(1).nullable().optional()
               })
               .array()
               .optional(),

--- a/frontend/src/hooks/api/accessApproval/mutation.tsx
+++ b/frontend/src/hooks/api/accessApproval/mutation.tsx
@@ -1,4 +1,3 @@
-import { packRules } from "@casl/ability/extra";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
@@ -22,7 +21,7 @@ export const useCreateAccessApprovalPolicy = () => {
       approvals,
       approvers,
       name,
-      secretPath,
+      secretPaths,
       enforcementLevel
     }) => {
       const { data } = await apiRequest.post("/api/v1/access-approvals/policies", {
@@ -30,7 +29,7 @@ export const useCreateAccessApprovalPolicy = () => {
         projectSlug,
         approvals,
         approvers,
-        secretPath,
+        secretPaths,
         name,
         enforcementLevel
       });
@@ -46,11 +45,11 @@ export const useUpdateAccessApprovalPolicy = () => {
   const queryClient = useQueryClient();
 
   return useMutation<{}, {}, TUpdateAccessPolicyDTO>({
-    mutationFn: async ({ id, approvers, approvals, name, secretPath, enforcementLevel }) => {
+    mutationFn: async ({ id, approvers, approvals, name, secretPaths, enforcementLevel }) => {
       const { data } = await apiRequest.patch(`/api/v1/access-approvals/policies/${id}`, {
         approvals,
         approvers,
-        secretPath,
+        secretPaths,
         name,
         enforcementLevel
       });
@@ -83,8 +82,8 @@ export const useCreateAccessRequest = () => {
       const { data } = await apiRequest.post<TAccessApproval>(
         "/api/v1/access-approvals/requests",
         {
-          ...request,
-          permissions: request.permissions ? packRules(request.permissions) : undefined
+          ...request
+          // permissions: request.permissions ? packRules(request.permissions) : undefined
         },
         {
           params: {

--- a/frontend/src/hooks/api/accessApproval/queries.tsx
+++ b/frontend/src/hooks/api/accessApproval/queries.tsx
@@ -73,7 +73,7 @@ const fetchApprovalRequests = async ({
     { params: { projectSlug, envSlug, authorProjectMembershipId } }
   );
 
-  return data.requests.map((request) => ({
+  const result = data.requests.map((request) => ({
     ...request,
 
     privilege: request.privilege
@@ -86,6 +86,10 @@ const fetchApprovalRequests = async ({
       : null,
     permissions: unpackRules(request.permissions as unknown as PackRule<TProjectPermission>[])
   }));
+
+  console.log("after");
+
+  return result;
 };
 
 const fetchAccessRequestsCount = async (projectSlug: string) => {

--- a/frontend/src/hooks/api/accessApproval/types.ts
+++ b/frontend/src/hooks/api/accessApproval/types.ts
@@ -6,7 +6,7 @@ export type TAccessApprovalPolicy = {
   id: string;
   name: string;
   approvals: number;
-  secretPath: string;
+  secretPaths: string[];
   envId: string;
   workspace: string;
   environment: WorkspaceEnv;
@@ -18,15 +18,15 @@ export type TAccessApprovalPolicy = {
   approvers?: Approver[];
 };
 
-export enum ApproverType{
+export enum ApproverType {
   User = "user",
   Group = "group"
 }
 
-export type Approver ={
+export type Approver = {
   id: string;
   type: ApproverType;
-}
+};
 
 export type TAccessApprovalRequest = {
   id: string;
@@ -67,7 +67,7 @@ export type TAccessApprovalRequest = {
     name: string;
     approvals: number;
     approvers: string[];
-    secretPath?: string | null;
+    secretPaths?: string[] | null;
     envId: string;
     enforcementLevel: EnforcementLevel;
   };
@@ -116,7 +116,18 @@ export type TProjectUserPrivilege = {
 
 export type TCreateAccessRequestDTO = {
   projectSlug: string;
-} & Omit<TProjectUserPrivilege, "id" | "createdAt" | "updatedAt" | "slug" | "projectMembershipId">;
+  secretPaths: string[];
+  environment: string;
+  requestedActions: {
+    read: boolean;
+    edit: boolean;
+    create: boolean;
+    delete: boolean;
+  };
+} & Omit<
+  TProjectUserPrivilege,
+  "id" | "createdAt" | "updatedAt" | "slug" | "projectMembershipId" | "permissions"
+>;
 
 export type TGetAccessApprovalRequestsDTO = {
   projectSlug: string;
@@ -132,7 +143,7 @@ export type TGetAccessPolicyApprovalCountDTO = {
 export type TGetSecretApprovalPolicyOfBoardDTO = {
   workspaceId: string;
   environment: string;
-  secretPath: string;
+  secretPaths: string[];
 };
 
 export type TCreateAccessPolicyDTO = {
@@ -141,7 +152,7 @@ export type TCreateAccessPolicyDTO = {
   environment: string;
   approvers?: Approver[];
   approvals?: number;
-  secretPath?: string;
+  secretPaths?: string[];
   enforcementLevel?: EnforcementLevel;
 };
 
@@ -149,7 +160,7 @@ export type TUpdateAccessPolicyDTO = {
   id: string;
   name?: string;
   approvers?: Approver[];
-  secretPath?: string;
+  secretPaths?: string[];
   environment?: string;
   approvals?: number;
   enforcementLevel?: EnforcementLevel;

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -37,7 +37,7 @@ export type IdentityMembershipOrg = {
   id: string;
   identity: Identity;
   organization: string;
-  metadata: { key: string; value: string; id: string }[];
+  metadata: { key: string; value?: string | null; id: string }[];
   role: "admin" | "member" | "viewer" | "no-access" | "custom";
   customRole?: TOrgRole;
   createdAt: string;

--- a/frontend/src/hooks/api/secretApproval/mutation.tsx
+++ b/frontend/src/hooks/api/secretApproval/mutation.tsx
@@ -14,7 +14,7 @@ export const useCreateSecretApprovalPolicy = () => {
       workspaceId,
       approvals,
       approvers,
-      secretPath,
+      secretPaths,
       name,
       enforcementLevel
     }) => {
@@ -23,7 +23,7 @@ export const useCreateSecretApprovalPolicy = () => {
         workspaceId,
         approvals,
         approvers,
-        secretPath,
+        secretPaths,
         name,
         enforcementLevel
       });
@@ -39,11 +39,11 @@ export const useUpdateSecretApprovalPolicy = () => {
   const queryClient = useQueryClient();
 
   return useMutation<{}, {}, TUpdateSecretPolicyDTO>({
-    mutationFn: async ({ id, approvers, approvals, secretPath, name, enforcementLevel }) => {
+    mutationFn: async ({ id, approvers, approvals, secretPaths, name, enforcementLevel }) => {
       const { data } = await apiRequest.patch(`/api/v1/secret-approvals/${id}`, {
         approvals,
         approvers,
-        secretPath,
+        secretPaths,
         name,
         enforcementLevel
       });

--- a/frontend/src/hooks/api/secretApproval/types.ts
+++ b/frontend/src/hooks/api/secretApproval/types.ts
@@ -7,22 +7,22 @@ export type TSecretApprovalPolicy = {
   name: string;
   envId: string;
   environment: WorkspaceEnv;
-  secretPath?: string;
+  secretPaths: string[];
   approvals: number;
   approvers: Approver[];
   updatedAt: Date;
   enforcementLevel: EnforcementLevel;
 };
 
-export enum ApproverType{
+export enum ApproverType {
   User = "user",
   Group = "group"
 }
 
-export type Approver ={
+export type Approver = {
   id: string;
   type: ApproverType;
-}
+};
 
 export type TGetSecretApprovalPoliciesDTO = {
   workspaceId: string;
@@ -38,7 +38,7 @@ export type TCreateSecretPolicyDTO = {
   workspaceId: string;
   name?: string;
   environment: string;
-  secretPath?: string | null;
+  secretPaths: string[];
   approvers?: Approver[];
   approvals?: number;
   enforcementLevel: EnforcementLevel;
@@ -48,7 +48,7 @@ export type TUpdateSecretPolicyDTO = {
   id: string;
   name?: string;
   approvers?: Approver[];
-  secretPath?: string | null;
+  secretPaths?: string[];
   approvals?: number;
   enforcementLevel?: EnforcementLevel;
   // for invalidating list

--- a/frontend/src/hooks/api/secretApprovalRequest/types.ts
+++ b/frontend/src/hooks/api/secretApprovalRequest/types.ts
@@ -52,7 +52,7 @@ export type TSecretApprovalRequest = {
   workspace: string;
   environment: string;
   folderId: string;
-  secretPath: string;
+  secretPaths: string[];
   hasMerged: boolean;
   status: "open" | "close";
   policy: Omit<TSecretApprovalPolicy, "approvers"> & {

--- a/frontend/src/hooks/api/secretApprovalRequest/types.ts
+++ b/frontend/src/hooks/api/secretApprovalRequest/types.ts
@@ -52,7 +52,7 @@ export type TSecretApprovalRequest = {
   workspace: string;
   environment: string;
   folderId: string;
-  secretPaths: string[];
+  secretPath: string;
   hasMerged: boolean;
   status: "open" | "close";
   policy: Omit<TSecretApprovalPolicy, "approvers"> & {

--- a/frontend/src/hooks/api/users/types.ts
+++ b/frontend/src/hooks/api/users/types.ts
@@ -51,7 +51,7 @@ export type UserEnc = {
 
 export type OrgUser = {
   id: string;
-  metadata: { key: string; value: string; id: string }[];
+  metadata: { key: string; value?: string | null; id: string }[];
   user: {
     username: string;
     email?: string;

--- a/frontend/src/lib/fn/string.ts
+++ b/frontend/src/lib/fn/string.ts
@@ -4,7 +4,7 @@ export const formatReservedPaths = (paths: string | string[]) => {
   const secretPaths = Array.isArray(paths) ? paths : [paths];
 
   const formattedSecretPaths = secretPaths.map((secretPath) => {
-    const i = secretPath.indexOf(ReservedFolders.SecretReplication);
+    const i = secretPath?.indexOf(ReservedFolders.SecretReplication);
     if (i !== -1) {
       return `${secretPath.slice(0, i)} - (replication)`;
     }

--- a/frontend/src/lib/fn/string.ts
+++ b/frontend/src/lib/fn/string.ts
@@ -1,9 +1,15 @@
 import { ReservedFolders } from "@app/hooks/api/secretFolders/types";
 
-export const formatReservedPaths = (secretPath: string) => {
-  const i = secretPath.indexOf(ReservedFolders.SecretReplication);
-  if (i !== -1) {
-    return `${secretPath.slice(0, i)} - (replication)`;
-  }
-  return secretPath;
+export const formatReservedPaths = (paths: string | string[]) => {
+  const secretPaths = Array.isArray(paths) ? paths : [paths];
+
+  const formattedSecretPaths = secretPaths.map((secretPath) => {
+    const i = secretPath.indexOf(ReservedFolders.SecretReplication);
+    if (i !== -1) {
+      return `${secretPath.slice(0, i)} - (replication)`;
+    }
+    return secretPath;
+  });
+
+  return formattedSecretPaths.join(", ");
 };

--- a/frontend/src/views/SecretApprovalPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -16,7 +16,7 @@ export const RequestAccessModal = ({
       <ModalContent
         className="max-w-4xl"
         title="Request Access"
-        subTitle="Your role has limited permissions, please contact your administrator to gain access"
+        subTitle="Request access to specific environments and paths across the project."
       >
         <SpecificPrivilegeSecretForm onClose={() => onOpenChange(false)} policies={policies} />
       </ModalContent>

--- a/frontend/src/views/SecretApprovalPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
@@ -36,7 +36,7 @@ export const ReviewAccessRequestModal = ({
   const accessDetails = {
     env: request.environmentName,
     // secret path will be inside $glob operator
-    secretPath: request.policy.secretPath,
+    secretPaths: request.policy.secretPaths,
     read: request.permissions?.some(({ action }) => action.includes(ProjectPermissionActions.Read)),
     edit: request.permissions?.some(({ action }) => action.includes(ProjectPermissionActions.Edit)),
     create: request.permissions?.some(({ action }) =>
@@ -123,8 +123,16 @@ export const ReviewAccessRequestModal = ({
 
           <div className="mt-4 mb-2 border-l border-blue-500 bg-blue-500/20 px-3 py-2 text-mineshaft-200">
             <div className="mb-1 lowercase">
-              <span className="font-bold capitalize">Requested path: </span>
-              <Badge>{accessDetails.env + accessDetails.secretPath || ""}</Badge>
+              <span className="font-bold capitalize">Requested environment: </span>
+              <Badge>{accessDetails.env}</Badge>
+            </div>
+            <div className="mb-1 lowercase">
+              <span className="font-bold capitalize">Requested paths: </span>
+              <Badge>
+                {accessDetails?.secretPaths?.length
+                  ? accessDetails.secretPaths.join(", ")
+                  : "Entire environment"}
+              </Badge>
             </div>
 
             <div className="mb-1">
@@ -142,8 +150,7 @@ export const ReviewAccessRequestModal = ({
             <Button
               isLoading={isLoading === "approved"}
               isDisabled={
-                !!isLoading ||
-                (!request.isApprover && !byPassApproval && isSoftEnforcement)
+                !!isLoading || (!request.isApprover && !byPassApproval && isSoftEnforcement)
               }
               onClick={() => handleReview("approved")}
               className="mt-4"
@@ -169,9 +176,9 @@ export const ReviewAccessRequestModal = ({
                 isChecked={byPassApproval}
                 id="byPassApproval"
                 checkIndicatorBg="text-white"
-                className={byPassApproval ? "bg-red hover:bg-red-600 border-red" : ""}
+                className={byPassApproval ? "border-red bg-red hover:bg-red-600" : ""}
               >
-                <span className="text-red text-sm">
+                <span className="text-sm text-red">
                   Approve without waiting for requirements to be met (bypass policy protection)
                 </span>
               </Checkbox>

--- a/frontend/src/views/SecretApprovalPage/components/ApprovalPolicyList/ApprovalPolicyList.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/ApprovalPolicyList/ApprovalPolicyList.tsx
@@ -187,7 +187,7 @@ export const ApprovalPolicyList = ({ workspaceId }: IProps) => {
             <Tr>
               <Th>Name</Th>
               <Th>Environment</Th>
-              <Th>Secret Path</Th>
+              <Th>Secret Paths</Th>
               <Th>Eligible Approvers</Th>
               <Th>Eligible Group Approvers</Th>
               <Th>Approval Required</Th>

--- a/frontend/src/views/SecretApprovalPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
@@ -29,13 +29,13 @@ interface IPolicy {
   name: string;
   environment: WorkspaceEnv;
   projectId?: string;
-  secretPath?: string;
+  secretPaths?: string[];
   approvals: number;
   approvers?: Approver[];
   updatedAt: Date;
   policyType: PolicyType;
   enforcementLevel: EnforcementLevel;
-};
+}
 
 type Props = {
   policy: IPolicy;
@@ -56,10 +56,16 @@ export const ApprovalPolicyRow = ({
   onEdit,
   onDelete
 }: Props) => {
-  const [selectedApprovers, setSelectedApprovers] = useState<Approver[]>(policy.approvers?.filter((approver) => approver.type === ApproverType.User) || []);
-  const [selectedGroupApprovers, setSelectedGroupApprovers] = useState<Approver[]>(policy.approvers?.filter((approver) => approver.type === ApproverType.Group) || []);
-  const { mutate: updateAccessApprovalPolicy, isLoading: isAccessApprovalPolicyLoading } = useUpdateAccessApprovalPolicy();
-  const { mutate: updateSecretApprovalPolicy, isLoading: isSecretApprovalPolicyLoading } = useUpdateSecretApprovalPolicy();
+  const [selectedApprovers, setSelectedApprovers] = useState<Approver[]>(
+    policy.approvers?.filter((approver) => approver.type === ApproverType.User) || []
+  );
+  const [selectedGroupApprovers, setSelectedGroupApprovers] = useState<Approver[]>(
+    policy.approvers?.filter((approver) => approver.type === ApproverType.Group) || []
+  );
+  const { mutate: updateAccessApprovalPolicy, isLoading: isAccessApprovalPolicyLoading } =
+    useUpdateAccessApprovalPolicy();
+  const { mutate: updateSecretApprovalPolicy, isLoading: isSecretApprovalPolicyLoading } =
+    useUpdateSecretApprovalPolicy();
   const isLoading = isAccessApprovalPolicyLoading || isSecretApprovalPolicyLoading;
 
   const { permission } = useProjectPermission();
@@ -68,7 +74,7 @@ export const ApprovalPolicyRow = ({
     <Tr>
       <Td>{policy.name}</Td>
       <Td>{policy.environment.slug}</Td>
-      <Td>{policy.secretPath || "*"}</Td>
+      <Td>{policy.secretPaths?.length ? policy?.secretPaths.join(", ") : "Full Environment"}</Td>
       <Td>
         <DropdownMenu
           onOpenChange={(isOpen) => {
@@ -78,11 +84,15 @@ export const ApprovalPolicyRow = ({
                   {
                     projectSlug,
                     id: policy.id,
-                    approvers: selectedApprovers.concat(selectedGroupApprovers),
+                    approvers: selectedApprovers.concat(selectedGroupApprovers)
                   },
                   {
                     onError: () => {
-                      setSelectedApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.User) || []);
+                      setSelectedApprovers(
+                        policy?.approvers?.filter(
+                          (approver) => approver.type === ApproverType.User
+                        ) || []
+                      );
                     }
                   }
                 );
@@ -91,17 +101,23 @@ export const ApprovalPolicyRow = ({
                   {
                     workspaceId,
                     id: policy.id,
-                    approvers: selectedApprovers.concat(selectedGroupApprovers),
+                    approvers: selectedApprovers.concat(selectedGroupApprovers)
                   },
                   {
                     onError: () => {
-                      setSelectedApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.User) || []);
+                      setSelectedApprovers(
+                        policy?.approvers?.filter(
+                          (approver) => approver.type === ApproverType.User
+                        ) || []
+                      );
                     }
                   }
                 );
               }
             } else {
-              setSelectedApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.User) || []);
+              setSelectedApprovers(
+                policy?.approvers?.filter((approver) => approver.type === ApproverType.User) || []
+              );
             }
           }}
         >
@@ -127,13 +143,19 @@ export const ApprovalPolicyRow = ({
             </DropdownMenuLabel>
             {members?.map(({ user }) => {
               const userId = user.id;
-              const isChecked = selectedApprovers?.filter((el: { id: string, type: ApproverType }) => el.id === userId && el.type === ApproverType.User).length > 0;
+              const isChecked =
+                selectedApprovers?.filter(
+                  (el: { id: string; type: ApproverType }) =>
+                    el.id === userId && el.type === ApproverType.User
+                ).length > 0;
               return (
                 <DropdownMenuItem
                   onClick={(evt) => {
                     evt.preventDefault();
                     setSelectedApprovers((state) =>
-                      isChecked ? state.filter((el) => el.id !== userId || el.type !== ApproverType.User) : [...state, { id: userId, type: ApproverType.User }]
+                      isChecked
+                        ? state.filter((el) => el.id !== userId || el.type !== ApproverType.User)
+                        : [...state, { id: userId, type: ApproverType.User }]
                     );
                   }}
                   key={`create-policy-members-${userId}`}
@@ -156,37 +178,51 @@ export const ApprovalPolicyRow = ({
                   {
                     projectSlug,
                     id: policy.id,
-                    approvers: selectedApprovers.concat(selectedGroupApprovers),
+                    approvers: selectedApprovers.concat(selectedGroupApprovers)
                   },
                   {
                     onError: () => {
-                      setSelectedGroupApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.Group) || []);
+                      setSelectedGroupApprovers(
+                        policy?.approvers?.filter(
+                          (approver) => approver.type === ApproverType.Group
+                        ) || []
+                      );
                     }
-                  },
+                  }
                 );
               } else {
                 updateSecretApprovalPolicy(
                   {
                     workspaceId,
                     id: policy.id,
-                    approvers: selectedApprovers.concat(selectedGroupApprovers),
+                    approvers: selectedApprovers.concat(selectedGroupApprovers)
                   },
                   {
                     onError: () => {
-                      setSelectedGroupApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.Group) || []);
+                      setSelectedGroupApprovers(
+                        policy?.approvers?.filter(
+                          (approver) => approver.type === ApproverType.Group
+                        ) || []
+                      );
                     }
                   }
                 );
               }
             } else {
-              setSelectedGroupApprovers(policy?.approvers?.filter((approver) => approver.type === ApproverType.Group) || []);
+              setSelectedGroupApprovers(
+                policy?.approvers?.filter((approver) => approver.type === ApproverType.Group) || []
+              );
             }
           }}
         >
           <DropdownMenuTrigger asChild>
             <Input
               isReadOnly
-              value={selectedGroupApprovers?.length ? `${selectedGroupApprovers.length} selected` : "None"}
+              value={
+                selectedGroupApprovers?.length
+                  ? `${selectedGroupApprovers.length} selected`
+                  : "None"
+              }
               className="text-left"
             />
           </DropdownMenuTrigger>
@@ -197,27 +233,34 @@ export const ApprovalPolicyRow = ({
             <DropdownMenuLabel>
               Select groups that are allowed to approve requests
             </DropdownMenuLabel>
-            {groups && groups.map(({ group }) => {
-              const { id } = group;
-              const isChecked = selectedGroupApprovers?.filter((el: { id: string, type: ApproverType }) => el.id === id && el.type === ApproverType.Group).length > 0;
-              return (
-                <DropdownMenuItem
-                  onClick={(evt) => {
-                    evt.preventDefault();
-                    setSelectedGroupApprovers(
-                      isChecked
-                        ? selectedGroupApprovers?.filter((el) => el.id !== id || el.type !== ApproverType.Group)
-                        : [...(selectedGroupApprovers || []), { id, type: ApproverType.Group }]
-                    );
-                  }}
-                  key={`create-policy-groups-${id}`}
-                  iconPos="right"
-                  icon={isChecked && <FontAwesomeIcon icon={faCheckCircle} />}
-                >
-                  {group.name}
-                </DropdownMenuItem>
-              );
-            })}
+            {groups &&
+              groups.map(({ group }) => {
+                const { id } = group;
+                const isChecked =
+                  selectedGroupApprovers?.filter(
+                    (el: { id: string; type: ApproverType }) =>
+                      el.id === id && el.type === ApproverType.Group
+                  ).length > 0;
+                return (
+                  <DropdownMenuItem
+                    onClick={(evt) => {
+                      evt.preventDefault();
+                      setSelectedGroupApprovers(
+                        isChecked
+                          ? selectedGroupApprovers?.filter(
+                              (el) => el.id !== id || el.type !== ApproverType.Group
+                            )
+                          : [...(selectedGroupApprovers || []), { id, type: ApproverType.Group }]
+                      );
+                    }}
+                    key={`create-policy-groups-${id}`}
+                    iconPos="right"
+                    icon={isChecked && <FontAwesomeIcon icon={faCheckCircle} />}
+                  >
+                    {group.name}
+                  </DropdownMenuItem>
+                );
+              })}
           </DropdownMenuContent>
         </DropdownMenu>
       </Td>
@@ -229,12 +272,12 @@ export const ApprovalPolicyRow = ({
       </Td>
       <Td>
         <DropdownMenu>
-          <DropdownMenuTrigger asChild className="rounded-lg cursor-pointer">
-            <div className="flex justify-center items-center hover:text-primary-400 data-[state=open]:text-primary-400 hover:scale-125 data-[state=open]:scale-125 transition-transform duration-300 ease-in-out">
+          <DropdownMenuTrigger asChild className="cursor-pointer rounded-lg">
+            <div className="flex items-center justify-center transition-transform duration-300 ease-in-out hover:scale-125 hover:text-primary-400 data-[state=open]:scale-125 data-[state=open]:text-primary-400">
               <FontAwesomeIcon size="sm" icon={faEllipsis} />
             </div>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="center" className="p-1 min-w-[100%]">
+          <DropdownMenuContent align="center" className="min-w-[100%] p-1">
             <ProjectPermissionCan
               I={ProjectPermissionActions.Edit}
               a={ProjectPermissionSub.SecretApproval}

--- a/frontend/src/views/SecretApprovalPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -193,9 +193,9 @@ export const SecretApprovalRequestChanges = ({
                 <div className="border-r border-mineshaft-500 pr-1">
                   <FontAwesomeIcon icon={faFolder} className="text-primary" size="sm" />
                 </div>
-                <Tooltip content={formatReservedPaths(secretApprovalRequestDetails.secretPath)}>
+                <Tooltip content={formatReservedPaths(secretApprovalRequestDetails.secretPaths)}>
                   <div className="truncate pl-2 pb-0.5 text-sm" style={{ maxWidth: "10rem" }}>
-                    {formatReservedPaths(secretApprovalRequestDetails.secretPath)}
+                    {formatReservedPaths(secretApprovalRequestDetails.secretPaths)}
                   </div>
                 </Tooltip>
               </div>

--- a/frontend/src/views/SecretApprovalPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/views/SecretApprovalPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -193,9 +193,9 @@ export const SecretApprovalRequestChanges = ({
                 <div className="border-r border-mineshaft-500 pr-1">
                   <FontAwesomeIcon icon={faFolder} className="text-primary" size="sm" />
                 </div>
-                <Tooltip content={formatReservedPaths(secretApprovalRequestDetails.secretPaths)}>
+                <Tooltip content={formatReservedPaths(secretApprovalRequestDetails.secretPath)}>
                   <div className="truncate pl-2 pb-0.5 text-sm" style={{ maxWidth: "10rem" }}>
-                    {formatReservedPaths(secretApprovalRequestDetails.secretPaths)}
+                    {formatReservedPaths(secretApprovalRequestDetails.secretPath)}
                   </div>
                 </Tooltip>
               </div>


### PR DESCRIPTION
# Description 📣

This PR introduces some significant changes to approvals. We are now supporting multiple paths for policies. There are also smaller improvements in the PR, such as handing permission building entirely on the server-side for access approval requests.

I also fixed environment-wide access approvals. An empty array _(no selected paths)_ now means that the entire environment is scoped to the policy. No more need for nullable / optional fields.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->