### PR TITLE
Fix: Prevent Updating Identity/User Project Role to reserved "Custom" Slug

### DIFF
--- a/backend/src/services/identity-project/identity-project-service.ts
+++ b/backend/src/services/identity-project/identity-project-service.ts
@@ -182,7 +182,12 @@ export const identityProjectServiceFactory = ({
 
     // validate custom roles input
     const customInputRoles = roles.filter(
-      ({ role }) => !Object.values(ProjectMembershipRole).includes(role as ProjectMembershipRole)
+      ({ role }) =>
+        !Object.values(ProjectMembershipRole)
+          // we don't want to include custom in this check;
+          // this unintentionally lets users set slug to custom which is reserved
+          .filter((r) => r !== ProjectMembershipRole.Custom)
+          .includes(role as ProjectMembershipRole)
     );
     const hasCustomRole = Boolean(customInputRoles.length);
     const customRoles = hasCustomRole

--- a/backend/src/services/identity-project/identity-project-service.ts
+++ b/backend/src/services/identity-project/identity-project-service.ts
@@ -185,7 +185,7 @@ export const identityProjectServiceFactory = ({
       ({ role }) =>
         !Object.values(ProjectMembershipRole)
           // we don't want to include custom in this check;
-          // this unintentionally lets users set slug to custom which is reserved
+          // this unintentionally enables setting slug to custom which is reserved
           .filter((r) => r !== ProjectMembershipRole.Custom)
           .includes(role as ProjectMembershipRole)
     );

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -280,7 +280,12 @@ export const projectMembershipServiceFactory = ({
 
     // validate custom roles input
     const customInputRoles = roles.filter(
-      ({ role }) => !Object.values(ProjectMembershipRole).includes(role as ProjectMembershipRole)
+      ({ role }) =>
+        !Object.values(ProjectMembershipRole)
+          // we don't want to include custom in this check;
+          // this unintentionally enables setting slug to custom which is reserved
+          .filter((r) => r !== ProjectMembershipRole.Custom)
+          .includes(role as ProjectMembershipRole)
     );
     const hasCustomRole = Boolean(customInputRoles.length);
     if (hasCustomRole) {

--- a/frontend/src/views/Project/IdentityDetailsPage/components/IdentityRoleDetailsSection/IdentityRoleDetailsSection.tsx
+++ b/frontend/src/views/Project/IdentityDetailsPage/components/IdentityRoleDetailsSection/IdentityRoleDetailsSection.tsx
@@ -50,11 +50,34 @@ export const IdentityRoleDetailsSection = ({
   const handleRoleDelete = async () => {
     const { id } = popUp?.deleteRole?.data as TProjectRole;
     try {
-      const updatedRole = identityMembershipDetails?.roles?.filter((el) => el.id !== id);
+      const updatedRoles = identityMembershipDetails?.roles?.filter((el) => el.id !== id);
       await updateIdentityWorkspaceRole({
         workspaceId: currentWorkspace?.id || "",
         identityId: identityMembershipDetails.identity.id,
-        roles: updatedRole
+        roles: updatedRoles.map(
+          ({
+            role,
+            customRoleSlug,
+            isTemporary,
+            temporaryMode,
+            temporaryRange,
+            temporaryAccessStartTime,
+            temporaryAccessEndTime
+          }) => ({
+            role: role === "custom" ? customRoleSlug : role,
+            ...(isTemporary
+              ? {
+                  isTemporary,
+                  temporaryMode,
+                  temporaryRange,
+                  temporaryAccessStartTime,
+                  temporaryAccessEndTime
+                }
+              : {
+                  isTemporary
+                })
+          })
+        )
       });
       createNotification({ type: "success", text: "Successfully removed role" });
       handlePopUpClose("deleteRole");

--- a/frontend/src/views/Project/MemberDetailsPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
+++ b/frontend/src/views/Project/MemberDetailsPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
@@ -61,10 +61,33 @@ export const MemberRoleDetailsSection = ({
   const handleRoleDelete = async () => {
     const { id } = popUp?.deleteRole?.data as TProjectRole;
     try {
-      const updatedRole = membershipDetails?.roles?.filter((el) => el.id !== id);
+      const updatedRoles = membershipDetails?.roles?.filter((el) => el.id !== id);
       await updateUserWorkspaceRole({
         workspaceId: currentWorkspace?.id || "",
-        roles: updatedRole,
+        roles: updatedRoles.map(
+          ({
+            role,
+            customRoleSlug,
+            isTemporary,
+            temporaryMode,
+            temporaryRange,
+            temporaryAccessStartTime,
+            temporaryAccessEndTime
+          }) => ({
+            role: role === "custom" ? customRoleSlug : role,
+            ...(isTemporary
+              ? {
+                  isTemporary,
+                  temporaryMode,
+                  temporaryRange,
+                  temporaryAccessStartTime,
+                  temporaryAccessEndTime
+                }
+              : {
+                  isTemporary
+                })
+          })
+        ),
         membershipId: membershipDetails.id
       });
       createNotification({ type: "success", text: "Successfully removed role" });
@@ -215,7 +238,10 @@ export const MemberRoleDetailsSection = ({
           title="Roles"
           subTitle="Select one or more of the pre-defined or custom roles to configure project permissions."
         >
-          <MemberRoleModify projectMember={membershipDetails}  onOpenUpgradeModal={onOpenUpgradeModal} />
+          <MemberRoleModify
+            projectMember={membershipDetails}
+            onOpenUpgradeModal={onOpenUpgradeModal}
+          />
         </ModalContent>
       </Modal>
     </div>


### PR DESCRIPTION
# Description 📣

This PR prevents setting a project membership  role slug value to "custom" which is reserved. This PR also corrects mapping of updated roles for users/identities

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝