### PR TITLE
fix: improve project DAL error handling

### DIFF
--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -191,6 +191,10 @@ export const projectDALFactory = (db: TDbClient) => {
 
       return project;
     } catch (error) {
+      if (error instanceof NotFoundError) {
+        throw error;
+      }
+
       throw new DatabaseError({ error, name: "Find all projects" });
     }
   };
@@ -240,6 +244,10 @@ export const projectDALFactory = (db: TDbClient) => {
 
       return project;
     } catch (error) {
+      if (error instanceof NotFoundError || error instanceof UnauthorizedError) {
+        throw error;
+      }
+
       throw new DatabaseError({ error, name: "Find project by slug" });
     }
   };
@@ -260,7 +268,7 @@ export const projectDALFactory = (db: TDbClient) => {
       }
       throw new BadRequestError({ message: "Invalid filter type" });
     } catch (error) {
-      if (error instanceof BadRequestError) {
+      if (error instanceof BadRequestError || error instanceof NotFoundError || error instanceof UnauthorizedError) {
         throw error;
       }
       throw new DatabaseError({ error, name: `Failed to find project by ${filter.type}` });


### PR DESCRIPTION
# Description 📣

This PR fixes errors for finding projects. Previously it wouldn't factor in Not Found or Unauthorized errors. If a NotFound error was thrown from within the DAL, it would translate to a 500 / Database error.

This issue was especially visible when trying to fetch secrets with an invalid project slug (`workspaceSlug`). 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->