### PR TITLE
Fix : Notification Toast will be displayed on clicking "Integrate with github"

### DIFF
--- a/frontend/src/hooks/api/ca/queries.tsx
+++ b/frontend/src/hooks/api/ca/queries.tsx
@@ -7,7 +7,7 @@ import { TCertificateAuthority } from "./types";
 
 export const caKeys = {
   getCaById: (caId: string) => [{ caId }, "ca"],
-  getCaCerts: (caId: string) => [{ caId }, "ca-certs"],
+  getCaCerts: (caId: string) => [{ caId }, "ca-cert"],
   getCaCrls: (caId: string) => [{ caId }, "ca-crls"],
   getCaCert: (caId: string) => [{ caId }, "ca-cert"],
   getCaCsr: (caId: string) => [{ caId }, "ca-csr"],

--- a/frontend/src/hooks/api/ca/queries.tsx
+++ b/frontend/src/hooks/api/ca/queries.tsx
@@ -7,7 +7,7 @@ import { TCertificateAuthority } from "./types";
 
 export const caKeys = {
   getCaById: (caId: string) => [{ caId }, "ca"],
-  getCaCerts: (caId: string) => [{ caId }, "ca-cert"],
+  getCaCerts: (caId: string) => [{ caId }, "ca-certs"],
   getCaCrls: (caId: string) => [{ caId }, "ca-crls"],
   getCaCert: (caId: string) => [{ caId }, "ca-cert"],
   getCaCsr: (caId: string) => [{ caId }, "ca-csr"],

--- a/frontend/src/pages/org/[id]/secret-scanning/index.tsx
+++ b/frontend/src/pages/org/[id]/secret-scanning/index.tsx
@@ -11,6 +11,7 @@ import { SecretScanningLogsTable } from "@app/views/SecretScanning/components";
 import createNewIntegrationSession from "../../../api/secret-scanning/createSecretScanningSession";
 import getInstallationStatus from "../../../api/secret-scanning/getInstallationStatus";
 import linkGitAppInstallationWithOrganization from "../../../api/secret-scanning/linkGitAppInstallationWithOrganization";
+import { createNotification } from "@app/components/notifications";
 
 const SecretScanning = withPermission(
   () => {
@@ -52,9 +53,13 @@ const SecretScanning = withPermission(
 
     const generateNewIntegrationSession = async () => {
       const session = await createNewIntegrationSession(String(localStorage.getItem("orgData.id")));
-      router.push(
-        `https://github.com/apps/infisical-radar/installations/new?state=${session.sessionId}`
-      );
+      if(session){
+        router.push(
+          `https://github.com/apps/infisical-radar/installations/new?state=${session.sessionId}`
+        );
+      }else{
+        createNotification({text : "Secret scanning is temporarily unavailable.",type:"error"});
+      }
     };
 
     return (


### PR DESCRIPTION
# Description 📣

Fixed the bug where the "Integrate with GitHub" button in the Secret Scanning tab failed silently. 
Added a user feedback toast message to inform users of failures.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
    const generateNewIntegrationSession = async () => {
      const session = await createNewIntegrationSession(String(localStorage.getItem("orgData.id")));
      if(session){
        router.push(
          `https://github.com/apps/infisical-radar/installations/new?state=${session.sessionId}`
        );
      }else{
        createNotification({text : "Secret scanning is temporarily unavailable.",type:"error"});
      }
    };
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->