### PR TITLE
Fix Error When Clicking on CA Table Row After Viewing Certificate in Certificate Authorities Tab

### DIFF
--- a/frontend/src/hooks/api/ca/queries.tsx
+++ b/frontend/src/hooks/api/ca/queries.tsx
@@ -7,7 +7,7 @@ import { TCertificateAuthority } from "./types";
 
 export const caKeys = {
   getCaById: (caId: string) => [{ caId }, "ca"],
-  getCaCerts: (caId: string) => [{ caId }, "ca-cert"],
+  getCaCerts: (caId: string) => [{ caId }, "ca-certs"],
   getCaCrls: (caId: string) => [{ caId }, "ca-crls"],
   getCaCert: (caId: string) => [{ caId }, "ca-cert"],
   getCaCsr: (caId: string) => [{ caId }, "ca-csr"],


### PR DESCRIPTION
# Description 📣
Fixes [#2786](https://github.com/Infisical/infisical/issues/2786#issue-2687943170)

This pull request addresses a bug in the Certificate Authorities section where clicking on a CA table row after selecting View Certificate results in a page error. 

**Root Cause**
The issue arises due to two hooks, useGetCaCerts and useGetCaCert, which are both using the same query key ("ca-cert") for fetching data:

useGetCaCerts: Called when clicking on a CA table row, it fetches an array of objects.
useGetCaCert: Called when clicking on the three dots and selecting View Certificate, it fetches a single object.

Since both hooks are using the same query key, the cache will store only the most recent data fetched. On clicking on View Certificate the useGetCert hook is called which returns an object and this is stored in the cache, and now on clicking on the row (CA), the component tries to map over the data, since the object is in cache ,it cannot map over it resulting in the error.

**Solution**
The query key for useGetCaCerts has been updated from "ca-cert" to "ca-certs", ensuring that the two hooks use distinct cache keys and no longer conflict.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
getCaCerts: (caId: string) => [{ caId }, "ca-certs"],
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->