### PR TITLE
fix(dynamic-secrets): renewal 500 error

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/aws-elasticache.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/aws-elasticache.ts
@@ -212,7 +212,7 @@ export const AwsElastiCacheDatabaseProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (inputs: unknown, entityId: string) => {
-    // Do nothing
+    // No renewal necessary
     return { entityId };
   };
 

--- a/backend/src/ee/services/dynamic-secret/providers/aws-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/aws-iam.ts
@@ -179,9 +179,8 @@ export const AwsIamProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (_inputs: unknown, entityId: string) => {
-    // do nothing
-    const username = entityId;
-    return { entityId: username };
+    // No renewal necessary
+    return { entityId };
   };
 
   return {

--- a/backend/src/ee/services/dynamic-secret/providers/azure-entra-id.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-entra-id.ts
@@ -55,11 +55,6 @@ export const AzureEntraIDProvider = (): TDynamicProviderFns & {
     return data.success;
   };
 
-  const renew = async (inputs: unknown, entityId: string) => {
-    // Do nothing
-    return { entityId };
-  };
-
   const create = async (inputs: unknown) => {
     const providerInputs = await validateProviderInputs(inputs);
     const data = await getToken(providerInputs.tenantId, providerInputs.applicationId, providerInputs.clientSecret);
@@ -125,6 +120,11 @@ export const AzureEntraIDProvider = (): TDynamicProviderFns & {
       };
     });
     return users;
+  };
+
+  const renew = async (inputs: unknown, entityId: string) => {
+    // No renewal necessary
+    return { entityId };
   };
 
   return {

--- a/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
@@ -96,7 +96,7 @@ export const ElasticSearchProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (inputs: unknown, entityId: string) => {
-    // Do nothing
+    // No renewal necessary
     return { entityId };
   };
 

--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -268,7 +268,7 @@ export const LdapProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (inputs: unknown, entityId: string) => {
-    // Do nothing
+    // No renewal necessary
     return { entityId };
   };
 

--- a/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
@@ -88,6 +88,7 @@ export const MongoDBProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (_inputs: unknown, entityId: string) => {
+    // No renewal necessary
     return { entityId };
   };
 

--- a/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
@@ -142,7 +142,7 @@ export const RabbitMqProvider = (): TDynamicProviderFns => {
   };
 
   const renew = async (inputs: unknown, entityId: string) => {
-    // Do nothing
+    // No renewal necessary
     return { entityId };
   };
 

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -141,6 +141,8 @@ export const RedisDatabaseProvider = (): TDynamicProviderFns => {
 
   const renew = async (inputs: unknown, entityId: string, expireAt: number) => {
     const providerInputs = await validateProviderInputs(inputs);
+    if (!providerInputs.renewStatement) return { entityId };
+
     const connection = await getClient(providerInputs);
 
     const username = entityId;

--- a/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
@@ -135,13 +135,15 @@ export const SapHanaProvider = (): TDynamicProviderFns => {
     return { entityId: username };
   };
 
-  const renew = async (inputs: unknown, username: string, expireAt: number) => {
+  const renew = async (inputs: unknown, entityId: string, expireAt: number) => {
     const providerInputs = await validateProviderInputs(inputs);
+    if (!providerInputs.renewStatement) return { entityId };
+
     const client = await getClient(providerInputs);
     try {
       const expiration = new Date(expireAt).toISOString();
 
-      const renewStatement = handlebars.compile(providerInputs.renewStatement)({ username, expiration });
+      const renewStatement = handlebars.compile(providerInputs.renewStatement)({ username: entityId, expiration });
       const queries = renewStatement.toString().split(";").filter(Boolean);
       for await (const query of queries) {
         await new Promise((resolve, reject) => {
@@ -161,7 +163,7 @@ export const SapHanaProvider = (): TDynamicProviderFns => {
       client.disconnect();
     }
 
-    return { entityId: username };
+    return { entityId };
   };
 
   return {

--- a/backend/src/ee/services/dynamic-secret/providers/snowflake.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/snowflake.ts
@@ -131,17 +131,16 @@ export const SnowflakeProvider = (): TDynamicProviderFns => {
     return { entityId: username };
   };
 
-  const renew = async (inputs: unknown, username: string, expireAt: number) => {
+  const renew = async (inputs: unknown, entityId: string, expireAt: number) => {
     const providerInputs = await validateProviderInputs(inputs);
-
-    if (!providerInputs.renewStatement) return { entityId: username };
+    if (!providerInputs.renewStatement) return { entityId };
 
     const client = await getClient(providerInputs);
 
     try {
       const expiration = getDaysToExpiry(new Date(expireAt));
       const renewStatement = handlebars.compile(providerInputs.renewStatement)({
-        username,
+        username: entityId,
         expiration
       });
 
@@ -161,7 +160,7 @@ export const SnowflakeProvider = (): TDynamicProviderFns => {
       client.destroy(noop);
     }
 
-    return { entityId: username };
+    return { entityId };
   };
 
   return {

--- a/backend/src/ee/services/dynamic-secret/providers/totp.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/totp.ts
@@ -1,7 +1,6 @@
 import { authenticator } from "otplib";
 import { HashAlgorithms } from "otplib/core";
 
-import { BadRequestError } from "@app/lib/errors";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 
 import { DynamicSecretTotpSchema, TDynamicProviderFns, TotpConfigType } from "./models";
@@ -76,10 +75,9 @@ export const TotpProvider = (): TDynamicProviderFns => {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const renew = async (_inputs: unknown, _entityId: string) => {
-    throw new BadRequestError({
-      message: "Lease renewal is not supported for TOTPs"
-    });
+  const renew = async (_inputs: unknown, entityId: string) => {
+    // No renewal necessary
+    return { entityId };
   };
 
   return {


### PR DESCRIPTION
# Description 📣

I realized while doing some testing for dynamic secrets, that we have a recurring pattern in our dynamic secret providers that would in some cases cause a 500 error. This would happen when the renewal statement was empty.

Additionally, I also found a bug with Cassandra, that would make custom renewal statements break the dynamic secret. Cassandra was using the revocation statement in the renewal, which means when you would attempt to renew a Cassandra dynamic secret, it will actually revoke the credential.

I also did some general cleanup, nothing major though.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->