### PR TITLE
Fix(Azure Key Vault): Ignore disabled secrets

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -519,16 +519,11 @@ const syncSecretsAzureKeyVault = async ({
           lastSlashIndex = getAzureKeyVaultSecret.id.lastIndexOf("/");
         }
 
-        let azureKeyVaultSecret;
-        try {
-          azureKeyVaultSecret = await request.get(`${getAzureKeyVaultSecret.id}?api-version=7.3`, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`
-            }
-          });
-        } catch (err) {
-          throw new Error(`Failed to fetch Azure Key Vault secret: ${(err as Error).message}`);
-        }
+        const azureKeyVaultSecret = await request.get(`${getAzureKeyVaultSecret.id}?api-version=7.3`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        });
 
         return {
           ...azureKeyVaultSecret.data,

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -507,7 +507,9 @@ const syncSecretsAzureKeyVault = async ({
     return result;
   };
 
-  const getAzureKeyVaultSecrets = await paginateAzureKeyVaultSecrets(`${integration.app}/secrets?api-version=7.3`);
+  const getAzureKeyVaultSecrets = (
+    await paginateAzureKeyVaultSecrets(`${integration.app}/secrets?api-version=7.3`)
+  ).filter((secret) => secret.attributes.enabled);
 
   let lastSlashIndex: number;
   const res = (
@@ -516,7 +518,6 @@ const syncSecretsAzureKeyVault = async ({
         if (!lastSlashIndex) {
           lastSlashIndex = getAzureKeyVaultSecret.id.lastIndexOf("/");
         }
-        if (!getAzureKeyVaultSecret.attributes.enabled) return null;
 
         let azureKeyVaultSecret;
         try {
@@ -535,15 +536,13 @@ const syncSecretsAzureKeyVault = async ({
         };
       })
     )
-  )
-    .filter((secret) => secret !== null)
-    .reduce(
-      (obj, secret) => ({
-        ...obj,
-        [secret.key]: secret
-      }),
-      {}
-    );
+  ).reduce(
+    (obj, secret) => ({
+      ...obj,
+      [secret.key]: secret
+    }),
+    {}
+  );
 
   const setSecrets: {
     key: string;

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -473,7 +473,7 @@ const syncSecretsAzureKeyVault = async ({
     id: string; // secret URI
     value: string;
     attributes: {
-      enabled: true;
+      enabled: boolean;
       created: number;
       updated: number;
       recoveryLevel: string;
@@ -507,14 +507,21 @@ const syncSecretsAzureKeyVault = async ({
     return result;
   };
 
-  const getAzureKeyVaultSecrets = (
-    await paginateAzureKeyVaultSecrets(`${integration.app}/secrets?api-version=7.3`)
-  ).filter((secret) => secret.attributes.enabled);
+  const getAzureKeyVaultSecrets = await paginateAzureKeyVaultSecrets(`${integration.app}/secrets?api-version=7.3`);
+
+  const enabledAzureKeyVaultSecrets = getAzureKeyVaultSecrets.filter((secret) => secret.attributes.enabled);
+
+  // disabled keys to skip sending updates to
+  const disabledAzureKeyVaultSecretKeys = getAzureKeyVaultSecrets
+    .filter(({ attributes }) => !attributes.enabled)
+    .map((getAzureKeyVaultSecret) => {
+      return getAzureKeyVaultSecret.id.substring(getAzureKeyVaultSecret.id.lastIndexOf("/") + 1);
+    });
 
   let lastSlashIndex: number;
   const res = (
     await Promise.all(
-      getAzureKeyVaultSecrets.map(async (getAzureKeyVaultSecret) => {
+      enabledAzureKeyVaultSecrets.map(async (getAzureKeyVaultSecret) => {
         if (!lastSlashIndex) {
           lastSlashIndex = getAzureKeyVaultSecret.id.lastIndexOf("/");
         }
@@ -660,6 +667,7 @@ const syncSecretsAzureKeyVault = async ({
   }) => {
     let isSecretSet = false;
     let maxTries = 6;
+    if (disabledAzureKeyVaultSecretKeys.includes(key)) return;
 
     while (!isSecretSet && maxTries > 0) {
       // try to set secret


### PR DESCRIPTION
# Description 📣

This fix ensures we only attempt to sync Azure Key Vault secrets that are not disabled in Azure.

**Now:**
![CleanShot 2024-11-26 at 23 27 47@2x](https://github.com/user-attachments/assets/24036a15-9e86-443f-9fc9-8fc8ca28f43a)
![CleanShot 2024-11-26 at 23 28 38@2x](https://github.com/user-attachments/assets/725ae11f-86ec-4260-a81b-b048e567c426)

**Previously** fetching the disabled key would throw an error, and block remaining sync functions
![image](https://github.com/user-attachments/assets/3a122872-ec09-4813-856c-6603ff65ccbc)


## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Manually tested by creating disabled secrets in Azure and manually triggering sync to replicate issue and create fix
---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->