### PR TITLE
improve: Folder name input validation text

### DIFF
--- a/frontend/src/views/SecretMainPage/components/ActionBar/FolderForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/ActionBar/FolderForm.tsx
@@ -15,7 +15,10 @@ const formSchema = z.object({
   name: z
     .string()
     .trim()
-    .regex(/^[a-zA-Z0-9-_]+$/, "Folder name cannot contain spaces. Only underscore and dashes")
+    .regex(
+      /^[a-zA-Z0-9-_]+$/,
+      "Folder name can only contain letters, numbers, dashes, and underscores"
+    )
 });
 type TFormData = z.infer<typeof formSchema>;
 


### PR DESCRIPTION
# Description 📣

Simple fix
Error from: "Folder name cannot contain spaces. Only underscore and dashes"
Error to: "Folder name can only contain letters, numbers, dashes, and underscores"
![CleanShot 2024-11-27 at 15 49 05@2x](https://github.com/user-attachments/assets/b144e014-81b2-4638-9987-69e1fe72af13)


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

manual testing
---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->