### PR TITLE
fix(cli): CLI tests failing due to dynamic request ID

### DIFF
--- a/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
+++ b/cli/test/.snapshots/test-TestUniversalAuth_SecretsGetWrongEnvironment
@@ -1,4 +1,4 @@
-error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&expandSecretReferences=true&include_imports=true&recursive=true&secretPath=%2F&workspaceId=bef697d4-849b-4a75-b284-0922f87f8ba2] [status-code=404] [response={"statusCode":404,"message":"Environment with slug 'invalid-env' in project with ID bef697d4-849b-4a75-b284-0922f87f8ba2 not found","error":"NotFound"}]
+error: CallGetRawSecretsV3: Unsuccessful response [GET https://app.infisical.com/api/v3/secrets/raw?environment=invalid-env&expandSecretReferences=true&include_imports=true&recursive=true&secretPath=%2F&workspaceId=bef697d4-849b-4a75-b284-0922f87f8ba2] [status-code=404] [response={"error":"NotFound","message":"Environment with slug 'invalid-env' in project with ID bef697d4-849b-4a75-b284-0922f87f8ba2 not found","statusCode":404}]
 
 
 If this issue continues, get support at https://infisical.com/slack

--- a/cli/test/.snapshots/test-testUserAuth_SecretsGetAllWithoutConnection
+++ b/cli/test/.snapshots/test-testUserAuth_SecretsGetAllWithoutConnection
@@ -1,4 +1,4 @@
-Warning: Unable to fetch the latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug
+Warning: Unable to fetch the latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug 
 ┌───────────────┬──────────────┬─────────────┐
 │ SECRET NAME   │ SECRET VALUE │ SECRET TYPE │
 ├───────────────┼──────────────┼─────────────┤

--- a/cli/test/helper.go
+++ b/cli/test/helper.go
@@ -71,7 +71,7 @@ func SetupCli() {
 
 func FilterRequestID(input string) string {
 
-	if !strings.Contains(input, "requestId") && strings.Contains(input, "reqId") {
+	if !strings.Contains(input, "requestId") && !strings.Contains(input, "reqId") {
 		return input
 	}
 

--- a/cli/test/helper.go
+++ b/cli/test/helper.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -43,9 +44,9 @@ func ExecuteCliCommand(command string, args ...string) (string, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(fmt.Sprint(err) + ": " + string(output))
-		return strings.TrimSpace(string(output)), err
+		return FilterRequestID(strings.TrimSpace(string(output))), err
 	}
-	return strings.TrimSpace(string(output)), nil
+	return FilterRequestID(strings.TrimSpace(string(output))), nil
 }
 
 func SetupCli() {
@@ -66,4 +67,40 @@ func SetupCli() {
 		}
 	}
 
+}
+
+func FilterRequestID(input string) string {
+
+	if !strings.Contains(input, "requestId") && strings.Contains(input, "reqId") {
+		return input
+	}
+
+	// Find the JSON part of the error message
+	start := strings.Index(input, "{")
+	end := strings.LastIndex(input, "}") + 1
+
+	if start == -1 || end == -1 {
+		return input
+	}
+
+	jsonPart := input[:start] // Pre-JSON content
+
+	// Parse the JSON object
+	var errorObj map[string]interface{}
+	if err := json.Unmarshal([]byte(input[start:end]), &errorObj); err != nil {
+		return input
+	}
+
+	// Remove requestId field
+	delete(errorObj, "requestId")
+	delete(errorObj, "reqId")
+
+	// Convert back to JSON
+	filtered, err := json.Marshal(errorObj)
+	if err != nil {
+		return input
+	}
+
+	// Reconstruct the full string
+	return jsonPart + string(filtered) + input[end:]
 }

--- a/cli/test/secrets_test.go
+++ b/cli/test/secrets_test.go
@@ -96,7 +96,7 @@ func TestUserAuth_SecretsGetAll(t *testing.T) {
 	// testUserAuth_SecretsGetAllWithoutConnection(t)
 }
 
-func testUserAuth_SecretsGetAllWithoutConnection(t *testing.T) {
+func TestUserAuth_SecretsGetAllWithoutConnection(t *testing.T) {
 	originalConfigFile, err := util.GetConfigFile()
 	if err != nil {
 		t.Fatalf("error getting config file")


### PR DESCRIPTION
# Description 📣

This will resolve the CLI tests failing and blocking our release CI. I added a function which removes `reqId` and `requestId` from the error response. I added `reqId` because we will be modifying the response to be `reqId` in the near future.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->