### PR TITLE
fix: Schema validation errors correctly returned as 422

### DIFF
--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -66,9 +66,9 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         error: error.name
       });
     } else if (error instanceof ZodError) {
-      void res.status(HttpStatusCodes.Unauthorized).send({
+      void res.status(HttpStatusCodes.BadRequest).send({
         requestId: req.id,
-        statusCode: HttpStatusCodes.Unauthorized,
+        statusCode: HttpStatusCodes.BadRequest,
         error: "ValidationFailure",
         message: error.issues
       });

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -27,6 +27,7 @@ enum HttpStatusCodes {
   NotFound = 404,
   Unauthorized = 401,
   Forbidden = 403,
+  UnprocessableContent = 422,
   // eslint-disable-next-line @typescript-eslint/no-shadow
   InternalServerError = 500,
   GatewayTimeout = 504,
@@ -66,9 +67,9 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         error: error.name
       });
     } else if (error instanceof ZodError) {
-      void res.status(HttpStatusCodes.BadRequest).send({
+      void res.status(HttpStatusCodes.UnprocessableContent).send({
         requestId: req.id,
-        statusCode: HttpStatusCodes.BadRequest,
+        statusCode: HttpStatusCodes.UnprocessableContent,
         error: "ValidationFailure",
         message: error.issues
       });

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -32,7 +32,7 @@ export const DefaultResponseErrorsSchema = {
   400: z.object({
     requestId: z.string(),
     statusCode: z.literal(400),
-    message: z.any(),
+    message: z.string(),
     error: z.string()
   }),
   404: z.object({
@@ -52,6 +52,12 @@ export const DefaultResponseErrorsSchema = {
     statusCode: z.literal(403),
     message: z.string(),
     details: z.any().optional(),
+    error: z.string()
+  }),
+  422: z.object({
+    requestId: z.string(),
+    statusCode: z.literal(422),
+    message: z.any(),
     error: z.string()
   }),
   500: z.object({

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -44,7 +44,7 @@ export const DefaultResponseErrorsSchema = {
   401: z.object({
     requestId: z.string(),
     statusCode: z.literal(401),
-    message: z.any(),
+    message: z.string(),
     error: z.string()
   }),
   403: z.object({
@@ -54,6 +54,7 @@ export const DefaultResponseErrorsSchema = {
     details: z.any().optional(),
     error: z.string()
   }),
+  // Zod errors return a message of varying shapes and sizes, so z.any() is used here
   422: z.object({
     requestId: z.string(),
     statusCode: z.literal(422),

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -32,7 +32,7 @@ export const DefaultResponseErrorsSchema = {
   400: z.object({
     requestId: z.string(),
     statusCode: z.literal(400),
-    message: z.string(),
+    message: z.any(),
     error: z.string()
   }),
   404: z.object({

--- a/frontend/src/hooks/api/types.ts
+++ b/frontend/src/hooks/api/types.ts
@@ -54,7 +54,7 @@ export type TApiErrors =
       requestId: string;
       error: ApiErrorTypes.ValidationError;
       message: ZodIssue[];
-      statusCode: 401;
+      statusCode: 400;
     }
   | {
       requestId: string;

--- a/frontend/src/hooks/api/types.ts
+++ b/frontend/src/hooks/api/types.ts
@@ -54,7 +54,7 @@ export type TApiErrors =
       requestId: string;
       error: ApiErrorTypes.ValidationError;
       message: ZodIssue[];
-      statusCode: 400;
+      statusCode: 422;
     }
   | {
       requestId: string;


### PR DESCRIPTION
# Description 📣

When input schema validation failed, the server would return a HTTP code 401 which could in some cases break the client.
This PR changes the schema validation HTTP error code to be 422 (Unprocessable Content) to be inline with standards.

![CleanShot 2024-12-02 at 23 51 41@2x](https://github.com/user-attachments/assets/f8b13b1d-a118-4cbf-ad4b-a87be21404bf)


## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Manual Testing

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->