### PR TITLE
fix: resolved reduntant min membership check over project creation

### DIFF
--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError } from "@casl/ability";
 import slugify from "@sindresorhus/slugify";
 
-import { OrgMembershipRole, ProjectMembershipRole, ProjectVersion, TProjectEnvironments } from "@app/db/schemas";
+import { ProjectMembershipRole, ProjectVersion, TProjectEnvironments } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
@@ -9,7 +9,6 @@ import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services
 import { TProjectTemplateServiceFactory } from "@app/ee/services/project-template/project-template-service";
 import { InfisicalProjectTemplate } from "@app/ee/services/project-template/project-template-types";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
-import { isAtLeastAsPrivileged } from "@app/lib/casl";
 import { infisicalSymmetricEncypt } from "@app/lib/crypto/encryption";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
@@ -370,20 +369,6 @@ export const projectServiceFactory = ({
           });
         }
 
-        // Get the role permission for the identity
-        const { permission: rolePermission, role: customRole } = await permissionService.getOrgPermissionByRole(
-          OrgMembershipRole.Member,
-          organization.id
-        );
-
-        // Identity has to be at least a member in order to create projects
-        const hasPrivilege = isAtLeastAsPrivileged(permission, rolePermission);
-        if (!hasPrivilege)
-          throw new ForbiddenRequestError({
-            message: "Failed to add identity to project with more privileged role"
-          });
-        const isCustomRole = Boolean(customRole);
-
         const identityProjectMembership = await identityProjectDAL.create(
           {
             identityId: actorId,
@@ -395,8 +380,7 @@ export const projectServiceFactory = ({
         await identityProjectMembershipRoleDAL.create(
           {
             projectMembershipId: identityProjectMembership.id,
-            role: isCustomRole ? ProjectMembershipRole.Custom : ProjectMembershipRole.Admin,
-            customRoleId: customRole?.id
+            role: ProjectMembershipRole.Admin
           },
           tx
         );


### PR DESCRIPTION
# Description 📣

The project creation for identity was checking a minimum membership level requirement from organization level for being a part of project. The weird part is, if its custom role, it's assigned from organization custom role which was also failing. 

Now it automatically assign the machine identity as admin on project creation.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->