### PR TITLE
Improvement: Integration Error - Handle Response Data Empty String

### DIFF
--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -932,8 +932,12 @@ export const secretQueueFactory = ({
             );
 
             const message =
-              (err instanceof AxiosError ? JSON.stringify(err?.response?.data) : (err as Error)?.message) ||
-              "Unknown error occurred.";
+              // eslint-disable-next-line no-nested-ternary
+              (err instanceof AxiosError
+                ? err?.response?.data
+                  ? JSON.stringify(err?.response?.data)
+                  : err?.message
+                : (err as Error)?.message) || "Unknown error occurred.";
 
             await auditLogService.createAuditLog({
               projectId,


### PR DESCRIPTION
# Description 📣

This PR contains a minor improvement for integration error sync messages by checking if the response data on a sync error is present, otherwise defaulting to an error message.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝