### PR TITLE
improvement: Add email footer with instance URL

### DIFF
--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -54,10 +54,10 @@ export const smtpServiceFactory = (cfg: TSmtpConfig) => {
   const isSmtpOn = Boolean(cfg.host);
 
   handlebars.registerHelper("emailFooter", () => {
-    const { isCloud, SITE_URL } = getConfig();
-    const cloudFooterHtml = `<p style="font-size: 12px;">Infisical - a tool for managing secrets in your organization. <a href="${SITE_URL}">Learn more</a></p>`;
-    const selfHostedFooterHtml = `<p style="font-size: 12px;">Email sent via Infisical at <a href="${SITE_URL}">${SITE_URL}</a></p>`;
-    return new handlebars.SafeString(isCloud ? cloudFooterHtml : selfHostedFooterHtml);
+    const { SITE_URL } = getConfig();
+    return new handlebars.SafeString(
+      `<p style="font-size: 12px;">Email sent via Infisical at <a href="${SITE_URL}">${SITE_URL}</a></p>`
+    );
   });
 
   const sendMail = async ({ substitutions, recipients, template, subjectLine }: TSmtpSendMail) => {

--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -53,6 +53,13 @@ export const smtpServiceFactory = (cfg: TSmtpConfig) => {
   const smtp = createTransport(cfg);
   const isSmtpOn = Boolean(cfg.host);
 
+  handlebars.registerHelper("emailFooter", () => {
+    const { isCloud, SITE_URL } = getConfig();
+    const cloudFooterHtml = `<p style="font-size: 12px;">Infisical - a tool for managing secrets in your organization. <a href="${SITE_URL}">Learn more</a></p>`;
+    const selfHostedFooterHtml = `<p style="font-size: 12px;">Email sent via Infisical at <a href="${SITE_URL}">${SITE_URL}</a></p>`;
+    return new handlebars.SafeString(isCloud ? cloudFooterHtml : selfHostedFooterHtml);
+  });
+
   const sendMail = async ({ substitutions, recipients, template, subjectLine }: TSmtpSendMail) => {
     const appCfg = getConfig();
     const html = await fs.readFile(path.resolve(__dirname, "./templates/", template), "utf8");

--- a/backend/src/services/smtp/templates/accessApprovalRequest.handlebars
+++ b/backend/src/services/smtp/templates/accessApprovalRequest.handlebars
@@ -45,6 +45,8 @@
       View the request and approve or deny it
       <a href="{{approvalUrl}}">here</a>.
     </p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/accessSecretRequestBypassed.handlebars
+++ b/backend/src/services/smtp/templates/accessSecretRequestBypassed.handlebars
@@ -11,8 +11,11 @@
     <p>A secret approval request has been bypassed in the project "{{projectName}}".</p>
 
     <p>
-      {{requesterFullName}} ({{requesterEmail}}) has merged
-      a secret to environment {{environment}} at secret path {{secretPath}}
+      {{requesterFullName}}
+      ({{requesterEmail}}) has merged a secret to environment
+      {{environment}}
+      at secret path
+      {{secretPath}}
       without obtaining the required approvals.
     </p>
     <p>
@@ -24,5 +27,7 @@
       To review this action, please visit the request panel
       <a href="{{approvalUrl}}">here</a>.
     </p>
+
+    {{emailFooter}}
   </body>
 </html>

--- a/backend/src/services/smtp/templates/emailMfa.handlebars
+++ b/backend/src/services/smtp/templates/emailMfa.handlebars
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 
   <head>
@@ -14,6 +13,8 @@
     <h2>{{code}}</h2>
     <p>The MFA code will be valid for 2 minutes.</p>
     <p>Not you? Contact {{#if isCloud}}Infisical{{else}}your administrator{{/if}} immediately.</p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/emailVerification.handlebars
+++ b/backend/src/services/smtp/templates/emailVerification.handlebars
@@ -10,6 +10,8 @@
     <h2>Confirm your email address</h2>
     <p>Your confirmation code is below — enter it in the browser window where you've started confirming your email.</p>
     <h1>{{code}}</h1>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/externalImportFailed.handlebars
+++ b/backend/src/services/smtp/templates/externalImportFailed.handlebars
@@ -16,6 +16,7 @@
 
     <p>Error: {{error}}</p>
 
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/externalImportStarted.handlebars
+++ b/backend/src/services/smtp/templates/externalImportStarted.handlebars
@@ -12,6 +12,8 @@
       {{provider}}
       to Infisical is in progress. The import process may take up to 30 minutes, and you will receive once the import
       has finished or if it fails.</p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/externalImportSuccessful.handlebars
+++ b/backend/src/services/smtp/templates/externalImportSuccessful.handlebars
@@ -9,6 +9,8 @@
   <body>
     <h2>An import from {{provider}} to Infisical was successful</h2>
     <p>An import from {{provider}} was successful. Your data is now available in Infisical.</p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/historicalSecretLeakIncident.handlebars
+++ b/backend/src/services/smtp/templates/historicalSecretLeakIncident.handlebars
@@ -1,21 +1,21 @@
-<!DOCTYPE html>
 <html>
 
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Incident alert: secrets potentially leaked</title>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Incident alert: secrets potentially leaked</title>
+  </head>
 
-<body>
-  <h3>Infisical has uncovered {{numberOfSecrets}} secret(s) from historical commits to your repo</h3>
-  <p><a href="{{siteUrl}}/secret-scanning"><strong>View leaked secrets</strong></a></p>
+  <body>
+    <h3>Infisical has uncovered {{numberOfSecrets}} secret(s) from historical commits to your repo</h3>
+    <p><a href="{{siteUrl}}/secret-scanning"><strong>View leaked secrets</strong></a></p>
 
-  <p>If these are production secrets, please rotate them immediately.</p>
+    <p>If these are production secrets, please rotate them immediately.</p>
 
-  <p>Once you have taken action, be sure to update the status of the risk in your <a
-      href="{{siteUrl}}">Infisical
-      dashboard</a>.</p>
-</body>
+    <p>Once you have taken action, be sure to update the status of the risk in your
+      <a href="{{siteUrl}}">Infisical dashboard</a>.</p>
+
+    {{emailFooter}}
+  </body>
 
 </html>

--- a/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
+++ b/backend/src/services/smtp/templates/integrationSyncFailed.handlebars
@@ -26,6 +26,8 @@
     {{#if syncMessage}}
       <p><b>Reason: </b>{{syncMessage}}</p>
     {{/if}}
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/newDevice.handlebars
+++ b/backend/src/services/smtp/templates/newDevice.handlebars
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 
   <head>
@@ -13,7 +12,11 @@
     <p><strong>Timestamp</strong>: {{timestamp}}</p>
     <p><strong>IP address</strong>: {{ip}}</p>
     <p><strong>User agent</strong>: {{userAgent}}</p>
-    <p>If you believe that this login is suspicious, please contact {{#if isCloud}}Infisical{{else}}your administrator{{/if}} or reset your password immediately.</p>
+    <p>If you believe that this login is suspicious, please contact
+      {{#if isCloud}}Infisical{{else}}your administrator{{/if}}
+      or reset your password immediately.</p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/organizationInvitation.handlebars
+++ b/backend/src/services/smtp/templates/organizationInvitation.handlebars
@@ -12,5 +12,7 @@
     <a href="{{callback_url}}?token={{token}}{{#if metadata}}&metadata={{metadata}}{{/if}}&to={{email}}&organization_id={{organizationId}}">Click to join</a>
     <h3>What is Infisical?</h3>
     <p>Infisical is an easy-to-use end-to-end encrypted tool that enables developers to sync and manage their secrets and configs.</p>
+
+    {{emailFooter}}
 </body>
 </html>

--- a/backend/src/services/smtp/templates/passwordReset.handlebars
+++ b/backend/src/services/smtp/templates/passwordReset.handlebars
@@ -1,14 +1,16 @@
-<!DOCTYPE html>
 <html>
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>Account Recovery</title>
-</head>
-<body>
+  </head>
+  <body>
     <h2>Reset your password</h2>
     <p>Someone requested a password reset.</p>
     <a href="{{callback_url}}?token={{token}}&to={{email}}">Reset password</a>
-    <p>If you didn't initiate this request, please contact {{#if isCloud}}us immediately at team@infisical.com.{{else}}your administrator immediately.{{/if}}</p>
-</body>
+    <p>If you didn't initiate this request, please contact
+      {{#if isCloud}}us immediately at team@infisical.com.{{else}}your administrator immediately.{{/if}}</p>
+
+    {{emailFooter}}
+  </body>
 </html>

--- a/backend/src/services/smtp/templates/pkiExpirationAlert.handlebars
+++ b/backend/src/services/smtp/templates/pkiExpirationAlert.handlebars
@@ -27,5 +27,7 @@
     <p>Please take necessary actions to renew these items before they expire.</p>
 
     <p>For more details, please log in to your Infisical account and check your PKI management section.</p>
+
+    {{emailFooter}}
   </body>
 </html>

--- a/backend/src/services/smtp/templates/scimUserProvisioned.handlebars
+++ b/backend/src/services/smtp/templates/scimUserProvisioned.handlebars
@@ -1,16 +1,18 @@
-<!DOCTYPE html>
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>Organization Invitation</title>
-</head>
-<body>
+  </head>
+  <body>
     <h2>Join your organization on Infisical</h2>
     <p>You've been invited to join the Infisical organization — {{organizationName}}</p>
     <a href="{{callback_url}}">Join now</a>
     <h3>What is Infisical?</h3>
-    <p>Infisical is an easy-to-use end-to-end encrypted tool that enables developers to sync and manage their secrets and configs.</p>
-</body>
+    <p>Infisical is an easy-to-use end-to-end encrypted tool that enables developers to sync and manage their secrets
+      and configs.</p>
+
+    {{emailFooter}}
+  </body>
 </html>

--- a/backend/src/services/smtp/templates/secretApprovalRequestNeedsReview.handlebars
+++ b/backend/src/services/smtp/templates/secretApprovalRequestNeedsReview.handlebars
@@ -17,6 +17,8 @@
       View the request and approve or deny it
       <a href="{{approvalUrl}}">here</a>.
     </p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/secretLeakIncident.handlebars
+++ b/backend/src/services/smtp/templates/secretLeakIncident.handlebars
@@ -1,25 +1,27 @@
-<!DOCTYPE html>
 <html>
 
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Incident alert: secret leaked</title>
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Incident alert: secret leaked</title>
+  </head>
 
-<body>
-  <h3>Infisical has uncovered {{numberOfSecrets}} secret(s) from your recent push</h3>
-  <p><a href="{{siteUrl}}/secret-scanning"><strong>View leaked secrets</strong></a></p>
-  <p>You are receiving this notification because one or more secret leaks have been detected in a recent commit pushed
-    by {{pusher_name}} ({{pusher_email}}). If
-    these are test secrets, please add `infisical-scan:ignore` at the end of the line containing the secret as comment
-    in the given programming. This will prevent future notifications from being sent out for those secret(s).</p>
+  <body>
+    <h3>Infisical has uncovered {{numberOfSecrets}} secret(s) from your recent push</h3>
+    <p><a href="{{siteUrl}}/secret-scanning"><strong>View leaked secrets</strong></a></p>
+    <p>You are receiving this notification because one or more secret leaks have been detected in a recent commit pushed
+      by
+      {{pusher_name}}
+      ({{pusher_email}}). If these are test secrets, please add `infisical-scan:ignore` at the end of the line
+      containing the secret as comment in the given programming. This will prevent future notifications from being sent
+      out for those secret(s).</p>
 
-  <p>If these are production secrets, please rotate them immediately.</p>
+    <p>If these are production secrets, please rotate them immediately.</p>
 
-  <p>Once you have taken action, be sure to update the status of the risk in your <a
-      href="{{siteUrl}}">Infisical
-      dashboard</a>.</p>
-</body>
+    <p>Once you have taken action, be sure to update the status of the risk in your
+      <a href="{{siteUrl}}">Infisical dashboard</a>.</p>
+
+    {{emailFooter}}
+  </body>
 
 </html>

--- a/backend/src/services/smtp/templates/secretReminder.handlebars
+++ b/backend/src/services/smtp/templates/secretReminder.handlebars
@@ -13,6 +13,8 @@
     {{#if reminderNote}}
       <p>Here's the note included with the reminder: {{reminderNote}}</p>
     {{/if}}
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/signupEmailVerification.handlebars
+++ b/backend/src/services/smtp/templates/signupEmailVerification.handlebars
@@ -1,17 +1,19 @@
-<!DOCTYPE html>
 <html>
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>Code</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <h2>Confirm your email address</h2>
     <p>Your confirmation code is below — enter it in the browser window where you've started signing up for Infisical.</p>
     <h1>{{code}}</h1>
-    <p>Questions about setting up Infisical? {{#if isCloud}}Email us at support@infisical.com{{else}}Contact your administrator{{/if}}.</p>
-</body>
+    <p>Questions about setting up Infisical?
+      {{#if isCloud}}Email us at support@infisical.com{{else}}Contact your administrator{{/if}}.</p>
+
+    {{emailFooter}}
+  </body>
 
 </html>

--- a/backend/src/services/smtp/templates/unlockAccount.handlebars
+++ b/backend/src/services/smtp/templates/unlockAccount.handlebars
@@ -11,6 +11,8 @@
     <p>Your account has been temporarily locked due to multiple failed login attempts. </h2>
     <a href="{{callback_url}}?token={{token}}">To unlock your account, follow the link here</a>
     <p>If these attempts were not made by you, reset your password immediately.</p>
+
+    {{emailFooter}}
   </body>
 
 </html>

--- a/backend/src/services/smtp/templates/workspaceInvitation.handlebars
+++ b/backend/src/services/smtp/templates/workspaceInvitation.handlebars
@@ -11,5 +11,7 @@
     <h3>What is Infisical?</h3>
     <p>Infisical is an easy-to-use end-to-end encrypted tool that enables developers to sync and manage their secrets
       and configs.</p>
+
+    {{emailFooter}}
   </body>
 </html>


### PR DESCRIPTION
# Description 📣

Adds a simple email footer to all email templates.
`Email sent via Infisical at ${URL}`
<img width="739" alt="image" src="https://github.com/user-attachments/assets/9f556359-a76b-4885-b455-233a5af0f5c8">

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

manually sent emails and caught by mailhog

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->