### PR TITLE
feat(azure-app-integration): label & reference support

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1126,8 +1126,7 @@ export const INTEGRATION = {
       shouldAutoRedeploy: "Used by Render to trigger auto deploy.",
       secretGCPLabel: "The label for GCP secrets.",
       secretAWSTag: "The tags for AWS secrets.",
-      azureUseLabels:
-        "If enabled, each secret will be given a label that represents which Infisical environment they belong to.",
+      azureLabel: "Define which label to assign to secrets created in Azure App Configuration.",
       githubVisibility:
         "Define where the secrets from the Github Integration should be visible. Option 'selected' lets you directly define which repositories to sync secrets to.",
       githubVisibilityRepoIds:

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1126,6 +1126,8 @@ export const INTEGRATION = {
       shouldAutoRedeploy: "Used by Render to trigger auto deploy.",
       secretGCPLabel: "The label for GCP secrets.",
       secretAWSTag: "The tags for AWS secrets.",
+      azureUseLabels:
+        "If enabled, each secret will be given a label that represents which Infisical environment they belong to.",
       githubVisibility:
         "Define where the secrets from the Github Integration should be visible. Option 'selected' lets you directly define which repositories to sync secrets to.",
       githubVisibilityRepoIds:

--- a/backend/src/services/integration-auth/integration-sync-secret-fns.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret-fns.ts
@@ -1,0 +1,35 @@
+export const isAzureKeyVaultReference = (uri: string) => {
+  const tryJsonDecode = () => {
+    try {
+      return (JSON.parse(uri) as { uri: string }).uri || uri;
+    } catch {
+      return uri;
+    }
+  };
+
+  const cleanUri = tryJsonDecode();
+
+  if (!cleanUri.startsWith("https://")) {
+    return false;
+  }
+
+  if (!cleanUri.includes(".vault.azure.net/secrets/")) {
+    return false;
+  }
+
+  // 3. Check for non-empty string between https:// and .vault.azure.net/secrets/
+  const parts = cleanUri.split(".vault.azure.net/secrets/");
+  const vaultName = parts[0].replace("https://", "");
+  if (!vaultName) {
+    return false;
+  }
+
+  // 4. Check for non-empty secret name
+  const secretParts = parts[1].split("/");
+  const secretName = secretParts[0];
+  if (!secretName) {
+    return false;
+  }
+
+  return true;
+};

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -422,9 +422,9 @@ const syncSecretsAzureAppConfig = async ({
           })
         },
         {
-          ...(metadata.azureUseLabels && {
+          ...(metadata.azureLabel && {
             params: {
-              label: integration.environment.slug
+              label: metadata.azureLabel
             }
           }),
 
@@ -447,9 +447,9 @@ const syncSecretsAzureAppConfig = async ({
         headers: {
           Authorization: `Bearer ${accessToken}`
         },
-        ...(metadata.azureUseLabels && {
+        ...(metadata.azureLabel && {
           params: {
-            label: integration.environment.slug
+            label: metadata.azureLabel
           }
         }),
         // we force IPV4 because docker setup fails with ipv6

--- a/backend/src/services/integration/integration-schema.ts
+++ b/backend/src/services/integration/integration-schema.ts
@@ -35,6 +35,8 @@ export const IntegrationMetadataSchema = z.object({
     .optional()
     .describe(INTEGRATION.CREATE.metadata.secretAWSTag),
 
+  azureUseLabels: z.boolean().optional().describe(INTEGRATION.CREATE.metadata.azureUseLabels),
+
   githubVisibility: z
     .union([z.literal("selected"), z.literal("private"), z.literal("all")])
     .optional()

--- a/backend/src/services/integration/integration-schema.ts
+++ b/backend/src/services/integration/integration-schema.ts
@@ -35,7 +35,7 @@ export const IntegrationMetadataSchema = z.object({
     .optional()
     .describe(INTEGRATION.CREATE.metadata.secretAWSTag),
 
-  azureUseLabels: z.boolean().optional().describe(INTEGRATION.CREATE.metadata.azureUseLabels),
+  azureLabel: z.string().optional().describe(INTEGRATION.CREATE.metadata.azureLabel),
 
   githubVisibility: z
     .union([z.literal("selected"), z.literal("private"), z.literal("all")])

--- a/frontend/src/hooks/api/integrations/queries.tsx
+++ b/frontend/src/hooks/api/integrations/queries.tsx
@@ -80,6 +80,7 @@ export const useCreateIntegration = () => {
           key: string;
           value: string;
         }[];
+        azureUseLabels?: boolean;
         githubVisibility?: string;
         githubVisibilityRepoIds?: string[];
         kmsKeyId?: string;

--- a/frontend/src/hooks/api/integrations/queries.tsx
+++ b/frontend/src/hooks/api/integrations/queries.tsx
@@ -80,7 +80,7 @@ export const useCreateIntegration = () => {
           key: string;
           value: string;
         }[];
-        azureUseLabels?: boolean;
+        azureLabel?: string;
         githubVisibility?: string;
         githubVisibilityRepoIds?: string[];
         kmsKeyId?: string;

--- a/frontend/src/hooks/api/integrations/types.ts
+++ b/frontend/src/hooks/api/integrations/types.ts
@@ -41,6 +41,7 @@ export type TIntegration = {
       key: string;
       value: string;
     }[];
+    azureLabel?: string;
 
     kmsKeyId?: string;
     secretSuffix?: string;

--- a/frontend/src/pages/integrations/azure-app-configuration/create.tsx
+++ b/frontend/src/pages/integrations/azure-app-configuration/create.tsx
@@ -4,11 +4,7 @@ import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import {
-  faArrowUpRightFromSquare,
-  faBookOpen,
-  faQuestionCircle
-} from "@fortawesome/free-solid-svg-icons";
+import { faArrowUpRightFromSquare, faBookOpen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import queryString from "query-string";
@@ -24,11 +20,11 @@ import {
   Card,
   CardTitle,
   FormControl,
+  FormLabel,
   Input,
   Select,
   SelectItem,
-  Switch,
-  Tooltip
+  Switch
 } from "../../../components/v2";
 import { useGetIntegrationAuthById } from "../../../hooks/api/integrationAuth";
 import { useGetWorkspaceById } from "../../../hooks/api/workspace";
@@ -209,7 +205,7 @@ export default function AzureAppConfigurationCreateIntegration() {
               )}
             />
 
-            <div className="flex w-full flex-col gap-1">
+            <div className="mb-2 flex w-full flex-col gap-1">
               <Controller
                 control={control}
                 name="useLabels"
@@ -219,12 +215,7 @@ export default function AzureAppConfigurationCreateIntegration() {
                     onCheckedChange={(isChecked) => onChange(isChecked)}
                     isChecked={value}
                   >
-                    <div className="flex w-full items-center gap-1">
-                      Use Labels
-                      <Tooltip content="Assign a label to each key-value pair that gets synced to your Azure App Configuration.">
-                        <FontAwesomeIcon icon={faQuestionCircle} size="1x" />
-                      </Tooltip>
-                    </div>
+                    <FormLabel label="Use Labels" />
                   </Switch>
                 )}
               />

--- a/frontend/src/views/IntegrationsPage/IntegrationDetailsPage/components/IntegrationSettingsSection.tsx
+++ b/frontend/src/views/IntegrationsPage/IntegrationDetailsPage/components/IntegrationSettingsSection.tsx
@@ -14,6 +14,7 @@ const metadataMappings: Record<keyof NonNullable<TIntegrationWithEnv["metadata"]
   githubVisibilityRepoIds: "Github Visibility Repo Ids",
   shouldAutoRedeploy: "Auto Redeploy Target Application When Secrets Change",
   secretAWSTag: "Tags For Secrets Stored In AWS",
+  azureLabel: "Azure Label",
   kmsKeyId: "AWS KMS Key ID",
   secretSuffix: "Secret Suffix",
   secretPrefix: "Secret Prefix",
@@ -86,7 +87,7 @@ export const IntegrationSettingsSection = ({ integration }: Props) => {
           Object.entries(integration.metadata).map(([key, value]) => (
             <div key={key} className="flex flex-col">
               <p className="text-sm text-gray-400">
-                {metadataMappings[key as keyof typeof metadataMappings]}
+                {!!value && metadataMappings[key as keyof typeof metadataMappings]}
               </p>
               <p className="text-sm text-gray-200">{renderValue(key as MetadataKey, value)}</p>
             </div>


### PR DESCRIPTION
# Description 📣

This PR adds support for environment labeling and references as secret values.

The labeling is necessary incase there are multiple integrations for multiple environments, and the keys are overlapping. Azure supports multiple secrets with the same key, with different labels.

Reference support allows for users to set the secret value to an azure reference. If this happens, we set the content type of the azure key, to `application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8`, which indicates that the secret should be treated as a reference in Azure App Config. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->