### PR TITLE
fix(dashboard): pasting secrets into create secret modal

### DIFF
--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -15,7 +15,10 @@ export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
     }
   });
 
-  if (firstDelimiterIndex === -1) {
+  // Check if there's any content after the delimiter
+  const hasValueAfterDelimiter = pastedContent.length > firstDelimiterIndex + foundDelimiter.length;
+
+  if (firstDelimiterIndex === -1 || !hasValueAfterDelimiter) {
     return { key: pastedContent.trim(), value: "" };
   }
 

--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -15,7 +15,6 @@ export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
     }
   });
 
-  // Check if there's any content after the delimiter
   const hasValueAfterDelimiter = pastedContent.length > firstDelimiterIndex + foundDelimiter.length;
 
   if (firstDelimiterIndex === -1 || !hasValueAfterDelimiter) {

--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -1,14 +1,29 @@
 /** Extracts the key and value from a passed in env string based on the provided delimiters. */
 export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
-  const foundDelimiter = delimiters.find((delimiter) => pastedContent.includes(delimiter));
+  if (!pastedContent) {
+    return { key: "", value: "" };
+  }
 
-  if (!foundDelimiter) {
+  let firstDelimiterIndex = -1;
+  let foundDelimiter = "";
+
+  delimiters.forEach((delimiter) => {
+    const index = pastedContent.indexOf(delimiter);
+    if (index !== -1 && (firstDelimiterIndex === -1 || index < firstDelimiterIndex)) {
+      firstDelimiterIndex = index;
+      foundDelimiter = delimiter;
+    }
+  });
+
+  if (firstDelimiterIndex === -1) {
     return { key: pastedContent.trim(), value: "" };
   }
 
-  const [key, value] = pastedContent.split(foundDelimiter);
+  const key = pastedContent.substring(0, firstDelimiterIndex);
+  const value = pastedContent.substring(firstDelimiterIndex + foundDelimiter.length);
+
   return {
     key: key.trim(),
-    value: (value ?? "").trim()
+    value: value.trim()
   };
 };

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -143,11 +143,8 @@ export const CreateSecretForm = ({
           {...secretKeyRegisterRest}
           ref={(e) => {
             setSecretKeyHookRef(e);
-            // Can't directly set secretKeyInputRef.current = e, because of read-only property definitions
-            Object.defineProperty(secretKeyInputRef, "current", {
-              value: e,
-              writable: true
-            });
+            // @ts-expect-error this is for multiple ref single component
+            secretKeyInputRef.current = e;
           }}
           placeholder="Type your secret name"
           onPaste={handlePaste}

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -61,6 +61,8 @@ export const CreateSecretForm = ({
   );
 
   const secretKeyInputRef = useRef<HTMLInputElement>(null);
+  const { ref: setSecretKeyHookRef, ...secretKeyRegisterRest } = register("key");
+
   const secretKey = watch("key");
 
   const slugSchema = z.string().trim().toLowerCase().min(1);
@@ -122,11 +124,10 @@ export const CreateSecretForm = ({
       secretKeyInputRef.current.selectionEnd === secretKeyInputRef.current.value.length;
 
     if (!secretKey || isWholeKeyHighlighted) {
+      e.preventDefault();
+
       setValue("key", key);
       setValue("value", value);
-    }
-    if (!secretKey) {
-      e.preventDefault();
     }
   };
 
@@ -139,8 +140,15 @@ export const CreateSecretForm = ({
         errorText={errors?.key?.message}
       >
         <Input
-          {...register("key")}
-          ref={secretKeyInputRef}
+          {...secretKeyRegisterRest}
+          ref={(e) => {
+            setSecretKeyHookRef(e);
+            // Can't directly set secretKeyInputRef.current = e, because of read-only property definitions
+            Object.defineProperty(secretKeyInputRef, "current", {
+              value: e,
+              writable: true
+            });
+          }}
           placeholder="Type your secret name"
           onPaste={handlePaste}
           autoCapitalization={autoCapitalize}

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -1,4 +1,4 @@
-import { ClipboardEvent } from "react";
+import { ClipboardEvent, useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -60,7 +60,7 @@ export const CreateSecretForm = ({
     canReadTags ? workspaceId : ""
   );
 
-  const secretValue = watch("value");
+  const secretKeyInputRef = useRef<HTMLInputElement>(null);
   const secretKey = watch("key");
 
   const slugSchema = z.string().trim().toLowerCase().min(1);
@@ -116,13 +116,15 @@ export const CreateSecretForm = ({
     const pastedContent = e.clipboardData.getData("text");
     const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    if (!secretKey) {
+    const isWholeKeyHighlighted =
+      secretKeyInputRef.current &&
+      secretKeyInputRef.current.selectionStart === 0 &&
+      secretKeyInputRef.current.selectionEnd === secretKeyInputRef.current.value.length;
+
+    if (!secretKey || isWholeKeyHighlighted) {
       setValue("key", key);
-    }
-    if (!secretValue) {
       setValue("value", value);
     }
-
     if (!secretKey) {
       e.preventDefault();
     }
@@ -138,6 +140,7 @@ export const CreateSecretForm = ({
       >
         <Input
           {...register("key")}
+          ref={secretKeyInputRef}
           placeholder="Type your secret name"
           onPaste={handlePaste}
           autoCapitalization={autoCapitalize}

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -46,6 +46,7 @@ export const CreateSecretForm = ({
     control,
     reset,
     setValue,
+    watch,
     formState: { errors, isSubmitting }
   } = useForm<TFormSchema>({ resolver: zodResolver(typeSchema) });
   const { closePopUp } = usePopUpAction();
@@ -58,6 +59,9 @@ export const CreateSecretForm = ({
   const { data: projectTags, isLoading: isTagsLoading } = useGetWsTags(
     canReadTags ? workspaceId : ""
   );
+
+  const secretValue = watch("value");
+  const secretKey = watch("key");
 
   const slugSchema = z.string().trim().toLowerCase().min(1);
   const createNewTag = async (slug: string) => {
@@ -108,13 +112,20 @@ export const CreateSecretForm = ({
   };
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
     const delimitters = [":", "="];
     const pastedContent = e.clipboardData.getData("text");
     const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    setValue("key", key);
-    setValue("value", value);
+    if (!secretKey) {
+      setValue("key", key);
+    }
+    if (!secretValue) {
+      setValue("value", value);
+    }
+
+    if (!secretKey) {
+      e.preventDefault();
+    }
   };
 
   return (

--- a/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretMainPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -127,7 +127,9 @@ export const CreateSecretForm = ({
       e.preventDefault();
 
       setValue("key", key);
-      setValue("value", value);
+      if (value) {
+        setValue("value", value);
+      }
     }
   };
 

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -1,4 +1,4 @@
-import { ClipboardEvent } from "react";
+import { ClipboardEvent, useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { subject } from "@casl/ability";
 import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
@@ -62,7 +62,7 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
     canReadTags ? workspaceId : ""
   );
 
-  const secretValue = watch("value");
+  const secretKeyInputRef = useRef<HTMLInputElement>(null);
   const secretKey = watch("key");
 
   const handleFormSubmit = async ({ key, value, environments: selectedEnv, tags }: TFormSchema) => {
@@ -160,13 +160,15 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
     const pastedContent = e.clipboardData.getData("text");
     const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    if (!secretKey) {
+    const isWholeKeyHighlighted =
+      secretKeyInputRef.current &&
+      secretKeyInputRef.current.selectionStart === 0 &&
+      secretKeyInputRef.current.selectionEnd === secretKeyInputRef.current.value.length;
+
+    if (!secretKey || isWholeKeyHighlighted) {
       setValue("key", key);
-    }
-    if (!secretValue) {
       setValue("value", value);
     }
-
     if (!secretKey) {
       e.preventDefault();
     }
@@ -201,6 +203,7 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
       >
         <Input
           {...register("key")}
+          ref={secretKeyInputRef}
           placeholder="Type your secret name"
           onPaste={handlePaste}
           autoCapitalization={currentWorkspace?.autoCapitalization}

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -63,6 +63,8 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
   );
 
   const secretKeyInputRef = useRef<HTMLInputElement>(null);
+  const { ref: setSecretKeyHookRef, ...secretKeyRegisterRest } = register("key");
+
   const secretKey = watch("key");
 
   const handleFormSubmit = async ({ key, value, environments: selectedEnv, tags }: TFormSchema) => {
@@ -166,11 +168,10 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
       secretKeyInputRef.current.selectionEnd === secretKeyInputRef.current.value.length;
 
     if (!secretKey || isWholeKeyHighlighted) {
+      e.preventDefault();
+
       setValue("key", key);
       setValue("value", value);
-    }
-    if (!secretKey) {
-      e.preventDefault();
     }
   };
 
@@ -202,8 +203,15 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
         errorText={errors?.key?.message}
       >
         <Input
-          {...register("key")}
-          ref={secretKeyInputRef}
+          {...secretKeyRegisterRest}
+          ref={(e) => {
+            setSecretKeyHookRef(e);
+            // Can't directly set secretKeyInputRef.current = e, because of read-only property definitions
+            Object.defineProperty(secretKeyInputRef, "current", {
+              value: e,
+              writable: true
+            });
+          }}
           placeholder="Type your secret name"
           onPaste={handlePaste}
           autoCapitalization={currentWorkspace?.autoCapitalization}

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -46,6 +46,7 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
     control,
     reset,
     setValue,
+    watch,
     formState: { isSubmitting, errors }
   } = useForm<TFormSchema>({ resolver: zodResolver(typeSchema) });
 
@@ -60,6 +61,9 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
   const { data: projectTags, isLoading: isTagsLoading } = useGetWsTags(
     canReadTags ? workspaceId : ""
   );
+
+  const secretValue = watch("value");
+  const secretKey = watch("key");
 
   const handleFormSubmit = async ({ key, value, environments: selectedEnv, tags }: TFormSchema) => {
     const promises = selectedEnv.map(async (env) => {
@@ -152,13 +156,20 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
   };
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
-    e.preventDefault();
     const delimitters = [":", "="];
     const pastedContent = e.clipboardData.getData("text");
     const { key, value } = getKeyValue(pastedContent, delimitters);
 
-    setValue("key", key);
-    setValue("value", value);
+    if (!secretKey) {
+      setValue("key", key);
+    }
+    if (!secretValue) {
+      setValue("value", value);
+    }
+
+    if (!secretKey) {
+      e.preventDefault();
+    }
   };
 
   const createWsTag = useCreateWsTag();

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -206,11 +206,8 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
           {...secretKeyRegisterRest}
           ref={(e) => {
             setSecretKeyHookRef(e);
-            // Can't directly set secretKeyInputRef.current = e, because of read-only property definitions
-            Object.defineProperty(secretKeyInputRef, "current", {
-              value: e,
-              writable: true
-            });
+            // @ts-expect-error this is for multiple ref single component
+            secretKeyInputRef.current = e;
           }}
           placeholder="Type your secret name"
           onPaste={handlePaste}

--- a/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/views/SecretOverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -171,7 +171,9 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
       e.preventDefault();
 
       setValue("key", key);
-      setValue("value", value);
+      if (value) {
+        setValue("value", value);
+      }
     }
   };
 


### PR DESCRIPTION
# Description 📣

Fixed pasting secrets into the create secret modal. Previously the paste behavior was very buggy, and caused the value to be wiped if you pasted again. It would also wipe the secret key if you pasted a new value. All in all it felt very unnatural to use the secret paste feature.

Additionally I also fixed the splitter, so the value becomes everything after the FIRST splitter (such as `:` or `=`), instead of the last.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->