### PR TITLE
fix(dashboard): improved project creation speed

### DIFF
--- a/frontend/src/components/v2/projects/NewProjectModal.tsx
+++ b/frontend/src/components/v2/projects/NewProjectModal.tsx
@@ -36,7 +36,8 @@ import {
   fetchOrgUsers,
   useAddUserToWsNonE2EE,
   useCreateWorkspace,
-  useGetExternalKmsList
+  useGetExternalKmsList,
+  useGetUserWorkspaces
 } from "@app/hooks/api";
 import { INTERNAL_KMS_KEY_ID } from "@app/hooks/api/kms/types";
 import { InfisicalProjectTemplate, useListProjectTemplates } from "@app/hooks/api/projectTemplates";
@@ -68,6 +69,7 @@ const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
   const { permission } = useOrgPermission();
   const { user } = useUser();
   const createWs = useCreateWorkspace();
+  const { refetch: refetchWorkspaces } = useGetUserWorkspaces();
   const addUsersToProject = useAddUserToWsNonE2EE();
   const { subscription } = useSubscription();
 
@@ -137,8 +139,8 @@ const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
           orgId: currentOrg.id
         });
       }
-      // eslint-disable-next-line no-promise-executor-return -- We do this because the function returns too fast, which sometimes causes an error when the user is redirected.
-      await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+      await refetchWorkspaces();
 
       createNotification({ text: "Project created", type: "success" });
       reset();


### PR DESCRIPTION
# Description 📣

Removed the previously necessary 2 second delay when creating projects, and instead added a forceful refetch of projects. We are already invalidating the get all projects query after creating a new project, so this seems redundant right? No. When we invalidate queries, it doesn't wait for them to invalidate. It starts the invalidation, and then redirects to the project page, which causes the UI to glitch out. To completely fix this, we do a manual refetch and await it.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->