### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ We're on a mission to make security tooling more accessible to everyone, not jus
 
 ### Key Management (KMS):
 
-- **[Cryptograhic Keys](https://infisical.com/docs/documentation/platform/kms)**: Centrally manage keys across projects through a user-friendly interface or via the API.
+- **[Cryptographic Keys](https://infisical.com/docs/documentation/platform/kms)**: Centrally manage keys across projects through a user-friendly interface or via the API.
 - **[Encrypt and Decrypt Data](https://infisical.com/docs/documentation/platform/kms#guide-to-encrypting-data)**: Use symmetric keys to encrypt and decrypt data.
 
 ### General Platform:


### PR DESCRIPTION
Corrected the typo "Cryptograhic" to "Cryptographic" in the README.md file.
