### PR TITLE
misc: address cpu usage issue of secret version query

### DIFF
--- a/backend/src/db/migrations/20241213122320_add-index-for-secret-version-v2-folder.ts
+++ b/backend/src/db/migrations/20241213122320_add-index-for-secret-version-v2-folder.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.SecretVersionV2, "folderId")) {
+    await knex.schema.alterTable(TableName.SecretVersionV2, (t) => {
+      t.index("folderId");
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.SecretVersionV2, "folderId")) {
+    await knex.schema.alterTable(TableName.SecretVersionV2, (t) => {
+      t.dropIndex("folderId");
+    });
+  }
+}

--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -20,7 +20,8 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
         .join(TableName.SecretV2, `${TableName.SecretV2}.id`, `${TableName.SecretVersionV2}.secretId`)
         .join<TSecretVersionsV2, TSecretVersionsV2 & { secretId: string; max: number }>(
           (tx || db)(TableName.SecretVersionV2)
-            .groupBy("folderId", "secretId")
+            .where(`${TableName.SecretVersionV2}.folderId`, folderId)
+            .groupBy("secretId")
             .max("version")
             .select("secretId")
             .as("latestVersion"),


### PR DESCRIPTION
# Description 📣
This PR addresses the high CPU usage issue of the following query:
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/c58ddfac-52f6-451c-af31-fa14cfe4145b" />

Explain result before optimization:
![image](https://github.com/user-attachments/assets/4428aa3c-4125-4d90-8226-139aabf3c283)

Explain result after optimization:
![image](https://github.com/user-attachments/assets/f2650a52-f11e-431e-821f-a7ec42540e3a)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->