### PR TITLE
Fix : TeamCty Integration error

### DIFF
--- a/frontend/src/pages/integrations/teamcity/create.tsx
+++ b/frontend/src/pages/integrations/teamcity/create.tsx
@@ -98,16 +98,12 @@ export default function TeamCityCreateIntegrationPage() {
     }
   };
 
-  const filteredBuildConfigs = targetBuildConfigs?.concat({
-    name: "",
-    buildConfigId: ""
-  });
 
   return integrationAuth &&
     workspace &&
     selectedSourceEnvironment &&
     integrationAuthApps &&
-    filteredBuildConfigs &&
+    targetBuildConfigs &&
     targetAppId ? (
     <div className="flex h-full w-full items-center justify-center">
       <Head>
@@ -195,7 +191,7 @@ export default function TeamCityCreateIntegrationPage() {
             onValueChange={(val) => setTargetBuildConfigId(val)}
             className="w-full border border-mineshaft-500"
           >
-            {filteredBuildConfigs.map((buildConfig: any) => (
+            {targetBuildConfigs.map((buildConfig: any) => (
               <SelectItem
                 value={buildConfig.buildConfigId}
                 key={`target-build-config-${buildConfig.buildConfigId}`}


### PR DESCRIPTION
# Description 📣

**Problem:**
When performing a TeamCity integration, after entering the access token and server URL, the page errors out upon clicking the "Connect" button.

**Root Cause:**
In the create.tsx file, the targetBuildConfigs array is being concatenated with an object containing configId and configName initialized to empty strings (filteredBuildConfigs). This modified array is then passed to the Select component. However, the SelectItem component does not accept empty strings as valid values, which leads to the error.

**Solution:**
Removed the addition of the empty configId and configName object to the targetBuildConfigs array.
This ensures that only valid build configurations are passed to the Select component, preventing the error from occurring.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️


https://github.com/user-attachments/assets/12425b12-6408-400b-a650-73e6a2cb113e



```sh
            {targetBuildConfigs.map((buildConfig: any) => (
              <SelectItem
                value={buildConfig.buildConfigId}
                key={`target-build-config-${buildConfig.buildConfigId}`}
              >
                {buildConfig.name}
              </SelectItem>
            ))}
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->