### PR TITLE
fix: group only access to project failing

### DIFF
--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -51,7 +51,7 @@ export const projectDALFactory = (db: TDbClient) => {
         .join(TableName.Project, `${TableName.GroupProjectMembership}.projectId`, `${TableName.Project}.id`)
         .where(`${TableName.Project}.orgId`, orgId)
         .andWhere((qb) => {
-          if (projectType) {
+          if (projectType !== "all") {
             void qb.where(`${TableName.Project}.type`, projectType);
           }
         })


### PR DESCRIPTION
# Description 📣

This PR fixes failing access to projects when there are only part of it via groups. This was because of the temporary all filter missing for group project access listing.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->