### PR TITLE
fix: resolves a false org not logged in error

### DIFF
--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -441,7 +441,12 @@ export const projectServiceFactory = ({
     const workspaces = await projectDAL.findAllProjects(actorId, actorOrgId, type);
 
     if (includeRoles) {
-      const { permission } = await permissionService.getUserOrgPermission(actorId, actorOrgId, actorAuthMethod);
+      const { permission } = await permissionService.getUserOrgPermission(
+        actorId,
+        actorOrgId,
+        actorAuthMethod,
+        actorOrgId
+      );
 
       // `includeRoles` is specifically used by organization admins when inviting new users to the organizations to avoid looping redundant api calls.
       ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Create, OrgPermissionSubjects.Member);


### PR DESCRIPTION
# Description 📣

This PR fixes a false `User not logged into org` error from the backend when they access `Access Control` page in organization. This was due to missing actorOrgId

![Screenshot 2024-12-17 at 2 39 37 PM](https://github.com/user-attachments/assets/2581c432-5c9a-4b07-981d-78ee6697111e)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->