### PR TITLE
improv ui: don't close "Create Secrets" modal when clicking outside it

### DIFF
--- a/frontend/src/components/v2/Modal/Modal.tsx
+++ b/frontend/src/components/v2/Modal/Modal.tsx
@@ -72,7 +72,7 @@ ModalContent.displayName = "ModalContent";
 
 export type ModalProps = Omit<DialogPrimitive.DialogProps, "open"> & { isOpen?: boolean };
 export const Modal = ({ isOpen, ...props }: ModalProps) => (
-  <DialogPrimitive.Root open={isOpen} {...props} />
+  <DialogPrimitive.Root open={isOpen} {...props} modal/>
 );
 
 export const ModalTrigger = DialogPrimitive.Trigger;

--- a/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
+++ b/frontend/src/views/SecretOverviewPage/SecretOverviewPage.tsx
@@ -1125,6 +1125,7 @@ export const SecretOverviewPage = () => {
           bodyClassName="overflow-visible"
           title="Create Secrets"
           subTitle="Create a secret across multiple environments"
+          onPointerDownOutside={(e) => e.preventDefault()}
         >
           <CreateSecretForm
             secretPath={secretPath}


### PR DESCRIPTION
# Description 📣

- As mentioned in #2845, it can be frustrating for the user to see their data being lost when they mistakenly click outside
the modal while adding secrets.
This PR provides a probable fix for this by ensuring that the modal remains open.
**Note:** This is just one of the ways of fixing this problem. We need to decide an uniform way of handling modals throughout the product ( should modals close when clicked outside? ). This PR serves as a starting point for starting this discussion.
- This PR also includes a commit to enable the `modal` mode for radix dialogs. This ensures that interaction with outside elements is disabled and only dialog content is visible to screen readers. ( [Ref](https://www.radix-ui.com/primitives/docs/components/dialog) )

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
- Tested manually by opening the "Create Secrets" modal and ensuring that it doesn't close after this change

## Possible Improvements
- Abstract away the `onPointerDownOutside` prop to decide whether a modal closes on clicking outside

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝