### PR TITLE
ci: add slack notification message on success

### DIFF
--- a/.github/actions/notify-slack/action.yaml
+++ b/.github/actions/notify-slack/action.yaml
@@ -1,0 +1,42 @@
+name: notify-slack
+description: notify slack
+inputs:
+  channel:
+    description: channel to send message
+    required: true
+  token:
+    description: token with chat:write and chat:write.public permissions
+    required: true
+  message:
+    description: message formatted in Markdown
+    required: true
+runs:
+  using: composite
+  steps:
+    # see https://api.slack.com/tutorials/tracks/posting-messages-with-curl#let-us-hello-then__making-your-messages-more-fantastic
+    - name: notify-slack
+      shell: bash
+      run: |
+        curl https://slack.com/api/chat.postMessage \
+        -X POST --fail --silent --show-error \
+        -H "Authorization: Bearer ${SLACK_TOKEN}" \
+        -H "Content-type: application/json; charset=utf-8" \
+        --data @<(yq -pjson -ojson '.channel = env(SLACK_CHANNEL) | .blocks[0].text.text = env(MESSAGE)' <<'EOF'
+        {
+          "channel": "<replace me>",
+          "blocks": [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "<replace me>"
+              }
+            }
+          ]
+        }
+        EOF
+        ) >/dev/null
+      env:
+        SLACK_CHANNEL: ${{ inputs.channel }}
+        SLACK_TOKEN: ${{ inputs.token }}
+        MESSAGE: ${{ inputs.message }}

--- a/.github/workflows/deployment-pipeline.yml
+++ b/.github/workflows/deployment-pipeline.yml
@@ -103,6 +103,12 @@ jobs:
           service: infisical-core-gamma-stage
           cluster: infisical-gamma-stage
           wait-for-service-stability: true
+      # only notify of success because continue-on-error is so tricky, see https://www.kenmuse.com/blog/how-to-handle-step-and-job-errors-in-github-actions/
+      - uses: ./.github/actions/notify-slack
+        with:
+          token: ${{ secrets.SLACK_TOKEN }}
+          channel: ${{ secrets.SLACK_CHANNEL }}
+          message: deployed infisical/staging_infisical:${{ steps.commit.outputs.short }} to ${{ vars.ENVIRONMENT }}
 
   production-us:
     name: US production deploy 
@@ -159,6 +165,12 @@ jobs:
           service: infisical-core-platform
           cluster: infisical-core-platform
           wait-for-service-stability: true
+      # only notify of success because continue-on-error is so tricky, see https://www.kenmuse.com/blog/how-to-handle-step-and-job-errors-in-github-actions/
+      - uses: ./.github/actions/notify-slack
+        with:
+          token: ${{ secrets.SLACK_TOKEN }}
+          channel: ${{ secrets.SLACK_CHANNEL }}
+          message: deployed infisical/staging_infisical:${{ steps.commit.outputs.short }} to ${{ vars.ENVIRONMENT }}
 
   production-eu:
       name: EU production deploy
@@ -210,3 +222,9 @@ jobs:
             service: infisical-core-platform
             cluster: infisical-core-platform
             wait-for-service-stability: true
+      # only notify of success because continue-on-error is so tricky, see https://www.kenmuse.com/blog/how-to-handle-step-and-job-errors-in-github-actions/
+      - uses: ./.github/actions/notify-slack
+        with:
+          token: ${{ secrets.SLACK_TOKEN }}
+          channel: ${{ secrets.SLACK_CHANNEL }}
+          message: deployed infisical/staging_infisical:${{ steps.commit.outputs.short }} to ${{ vars.ENVIRONMENT }}


### PR DESCRIPTION
# Description 📣

Add slack notification message on success. Also, there's a few additional details:

1. I only notify of success because continue-on-error is so tricky, see https://www.kenmuse.com/blog/how-to-handle-step-and-job-errors-in-github-actions/ post.
2. I still need to update the SLACK_TOKEN, SLACK_CHANNEL secrets and the ENVIRONMENT environment-level env var.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

see the runs at https://github.com/max-infisical/myrepo
