### PR TITLE
ui-improve: replace Next.js Link with <a> for external demo booking link

### DIFF
--- a/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
+++ b/frontend/src/views/Settings/BillingSettingsPage/components/BillingCloudTab/PreviewSection.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -108,15 +107,18 @@ export const PreviewSection = () => {
                 Want to learn more?{" "}
               </div>
               <div className="flex w-full justify-center">
-                <Link href="https://infisical.com/schedule-demo">
-                  <span className="cursor-pointer rounded-full border border-mineshaft-500 bg-mineshaft-600 px-4 py-2 duration-200 hover:border-primary/40 hover:bg-primary/10">
-                    Book a demo{" "}
-                    <FontAwesomeIcon
-                      icon={faArrowUpRightFromSquare}
-                      className="mb-[0.06rem] ml-1 text-xs"
-                    />
-                  </span>
-                </Link>
+                <a
+                  href="https://infisical.com/schedule-demo"
+                  target="_blank"
+                  className="cursor-pointer rounded-full border border-mineshaft-500 bg-mineshaft-600 px-4 py-2 duration-200 hover:border-primary/40 hover:bg-primary/10"
+                  rel="noreferrer"
+                >
+                  Book a demo{" "}
+                  <FontAwesomeIcon
+                    icon={faArrowUpRightFromSquare}
+                    className="mb-[0.06rem] ml-1 text-xs"
+                  />
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Description 📣
This pull request updates the demo booking link by replacing the `Next.js` `Link` component with a standard `<a>` tag. The change ensures that the link opens in a new tab, which is appropriate for external resources.


# Reasoning
The Next.js Link component is ideal for client-side navigation but is not suitable for external links that should open in a new tab. This change aligns with the expected behavior of external links and improves the user experience.

# Demo
https://github.com/user-attachments/assets/491b96d3-960a-4b61-aeee-9970764832b8


- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->