### PR TITLE
--domain not working correctly

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -60,6 +60,12 @@ func handleUniversalAuthLogin(cmd *cobra.Command, infisicalClient infisicalSdk.I
 		return infisicalSdk.MachineIdentityCredential{}, err
 	}
 
+	// Update the infisicalClient with the domain flag
+	domain, err := cmd.Flags().GetString("domain")
+	if err == nil && domain != "" {
+		infisicalClient.SetSiteUrl(domain)
+	}
+
 	return infisicalClient.Auth().UniversalAuthLogin(clientId, clientSecret)
 }
 

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Infisical/infisical-merge/packages/api"
+	"github.com/Infisical/infisical-merge/packages/config"
 	"github.com/Infisical/infisical-merge/packages/models"
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Related to #2659

Update the `--domain` flag functionality in infisical CLI version 0.31.4 to correctly point to the specified domain.

* **cli/packages/util/helper.go**
  - Import `config` package.
* **cli/packages/cmd/login.go**
  - Update the `handleUniversalAuthLogin` function to consider the `--domain` flag and update the `infisicalClient` with the domain flag.

