### PR TITLE
Fix: Propagate sub-command exit status

### DIFF
--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -279,8 +279,11 @@ func execBasicCmd(cmd *exec.Cmd) error {
 	}()
 
 	if err := cmd.Wait(); err != nil {
-		_ = cmd.Process.Signal(os.Kill)
-		return fmt.Errorf("failed to wait for command termination: %v", err)
+		if cmd.ProcessState != nil {
+			waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus()) // Exit with the command's exit code
+		}
+		return fmt.Errorf("error while waiting for command to terminate: %w", err)
 	}
 
 	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)


### PR DESCRIPTION
## Description 📣

This PR fixes the handling of subcommand exit statuses to ensure the Go program propagates the exit code correctly. Previously, subcommands returning non-zero exit codes were treated as errors, which could lead to misleading error messages and incorrect behavior. This update ensures the Go program exits with the same status code as the executed subcommand, aligning with expected behavior.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

## Tests 🛠️

The following tests were performed to verify the changes:
	1.	Successful Subcommand: Verified that the Go program exits with 0 for subcommands that finish successfully.
	2.	Non-Zero Exit Code: Verified that the Go program exits with the same non-zero code as subcommands that terminate with a specific exit status.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->