### PR TITLE
Fix: Set Force Flag on Delete Secret Command for AWS Secrets Manager

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -1167,7 +1167,8 @@ const syncSecretsAWSSecretManager = async ({
         } else {
           await secretsManager.send(
             new DeleteSecretCommand({
-              SecretId: secretId
+              SecretId: secretId,
+              ForceDeleteWithoutRecovery: true
             })
           );
         }


### PR DESCRIPTION
# Description 📣

This PR sets the `ForceDeleteWithoutRecovery` flag to `true` when deleting secrets from AWS Secrets Manager on integration sync. This resolves a bug where deleted secrets in AWS (because removed or set to an empty value within Infisical) still within their recovery window would cause an error to be thrown on subsequent syncs if the value was set or a new secret was added with the same name.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝