### PR TITLE
fix: k8's manifest out of sync

### DIFF
--- a/k8-operator/kubectl-install/install-secrets-operator.yaml
+++ b/k8-operator/kubectl-install/install-secrets-operator.yaml
@@ -79,7 +79,6 @@ spec:
                     - identityId
                     type: object
                   kubernetesAuth:
-                    description: Rest of your types should be defined similarly...
                     properties:
                       identityId:
                         type: string
@@ -120,18 +119,19 @@ spec:
                 type: string
               destination:
                 properties:
-                  envSlug:
+                  environmentSlug:
                     type: string
                   projectId:
                     type: string
                   secretsPath:
                     type: string
                 required:
-                - envSlug
+                - environmentSlug
                 - projectId
                 - secretsPath
                 type: object
               hostAPI:
+                description: Infisical host to pull secrets from
                 type: string
               push:
                 properties:
@@ -152,6 +152,26 @@ spec:
                 type: object
               resyncInterval:
                 type: string
+              tls:
+                properties:
+                  caRef:
+                    description: Reference to secret containing CA cert
+                    properties:
+                      key:
+                        description: The name of the secret property with the CA certificate value
+                        type: string
+                      secretName:
+                        description: The name of the Kubernetes Secret
+                        type: string
+                      secretNamespace:
+                        description: The namespace where the Kubernetes Secret is located
+                        type: string
+                    required:
+                    - key
+                    - secretName
+                    - secretNamespace
+                    type: object
+                type: object
               updatePolicy:
                 type: string
             required:
@@ -491,6 +511,18 @@ spec:
                     default: Opaque
                     description: 'The Kubernetes Secret type (experimental feature). More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types'
                     type: string
+                  template:
+                    description: The template to transform the secret data
+                    properties:
+                      data:
+                        additionalProperties:
+                          type: string
+                        description: The template key values
+                        type: object
+                      includeAllSecrets:
+                        description: This injects all retrieved secrets into the top level of your template. Secrets defined in the template will take precedence over the injected ones.
+                        type: boolean
+                    type: object
                 required:
                 - secretName
                 - secretNamespace
@@ -692,6 +724,32 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - secrets.infisical.com
+  resources:
+  - infisicalpushsecrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - secrets.infisical.com
+  resources:
+  - infisicalpushsecrets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - secrets.infisical.com
+  resources:
+  - infisicalpushsecrets/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - secrets.infisical.com
   resources:


### PR DESCRIPTION
# Description 📣

This PR updates the k8's manifest to be in sync with the operator.

Generated with
```
./bin/kustomize build ./config/default > ./kubectl-install/install-secrets-operator.yaml
```

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->