### PR TITLE
fix: allow users to expose project ID as env

### DIFF
--- a/cli/packages/cmd/dynamic_secrets.go
+++ b/cli/packages/cmd/dynamic_secrets.go
@@ -45,7 +45,7 @@ func getDynamicSecretList(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -143,7 +143,7 @@ func createDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -270,7 +270,7 @@ func renewDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -373,7 +373,7 @@ func revokeDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -470,7 +470,7 @@ func listDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -51,9 +51,9 @@ var exportCmd = &cobra.Command{
 			util.HandleError(err)
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
-			util.HandleError(err)
+			util.HandleError(err, "Unable to parse flag")
 		}
 
 		token, err := util.GetInfisicalToken(cmd)

--- a/cli/packages/cmd/folder.go
+++ b/cli/packages/cmd/folder.go
@@ -33,7 +33,7 @@ var getCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -86,7 +86,7 @@ var createCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -158,7 +158,7 @@ var deleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/run.go
+++ b/cli/packages/cmd/run.go
@@ -77,7 +77,7 @@ var runCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -38,7 +38,7 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -162,7 +162,7 @@ var secretsSetCmd = &cobra.Command{
 			}
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -246,7 +246,7 @@ var secretsDeleteCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		projectId, err := cmd.Flags().GetString("projectId")
+		projectId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}
@@ -335,7 +335,7 @@ func getSecretsByNames(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}
@@ -447,7 +447,7 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 		util.HandleError(err, "Unable to parse flag")
 	}
 
-	projectId, err := cmd.Flags().GetString("projectId")
+	projectId, err := util.GetProjectId(cmd)
 	if err != nil {
 		util.HandleError(err, "Unable to parse flag")
 	}

--- a/cli/packages/cmd/tokens.go
+++ b/cli/packages/cmd/tokens.go
@@ -56,7 +56,7 @@ var tokensCreateCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		workspaceId, err := cmd.Flags().GetString("projectId")
+		workspaceId, err := util.GetProjectId(cmd)
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
 		}

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -119,6 +119,19 @@ func GetInfisicalToken(cmd *cobra.Command) (token *models.TokenDetails, err erro
 
 }
 
+func GetProjectId(cmd *cobra.Command) (string, error) {
+	projectId, err := cmd.Flags().GetString("projectId")
+	if err != nil {
+		return "", err
+	}
+
+	if projectId == "" {
+		projectId = os.Getenv("INFISICAL_PROJECT_ID")
+	}
+
+	return projectId, nil
+}
+
 func UniversalAuthLogin(clientId string, clientSecret string) (api.UniversalAuthLoginResponse, error) {
 	httpClient := resty.New()
 	httpClient.SetRetryCount(10000).


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Closes #2912

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [X] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
export INFISICAL_PROJECT_ID="non-exist-projectId"

infisical run --env=prod --path=/app/backend -- flask run --port=8080  # should fail with error message "message":"Project with ID 'non-exist-projectId' not found during bot lookup. Are you sure you are using the correct project ID?
```

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->