### PR TITLE
misc: resolve shared secret within org and added login redirect

### DIFF
--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -206,8 +206,13 @@ export const secretSharingServiceFactory = ({
 
     const orgName = sharedSecret.orgId ? (await orgDAL.findOrgById(sharedSecret.orgId))?.name : "";
 
-    if (accessType === SecretSharingAccessType.Organization && orgId !== sharedSecret.orgId)
+    if (accessType === SecretSharingAccessType.Organization && orgId === undefined) {
+      throw new UnauthorizedError();
+    }
+
+    if (accessType === SecretSharingAccessType.Organization && orgId !== sharedSecret.orgId) {
       throw new ForbiddenRequestError();
+    }
 
     // all secrets pass through here, meaning we check if its expired first and then check if it needs verification
     // or can be safely sent to the client.

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -58,7 +58,8 @@ export const leaveConfirmDefaultMessage =
   "Your changes will be lost if you leave the page. Are you sure you want to continue?";
 
 export enum SessionStorageKeys {
-  CLI_TERMINAL_TOKEN = "CLI_TERMINAL_TOKEN"
+  CLI_TERMINAL_TOKEN = "CLI_TERMINAL_TOKEN",
+  ORG_LOGIN_SUCCESS_REDIRECT_URL = "ORG_LOGIN_SUCCESS_REDIRECT_URL"
 }
 
 export const secretTagsColors = [

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/route.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/route.tsx
@@ -2,6 +2,8 @@ import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
+import { authKeys, fetchAuthToken } from "@app/hooks/api/auth/queries";
+
 import { ViewSharedSecretByIDPage } from "./ViewSharedSecretByIDPage";
 
 const SharedSecretByIDPageQuerySchema = z.object({
@@ -9,9 +11,18 @@ const SharedSecretByIDPageQuerySchema = z.object({
 });
 
 export const Route = createFileRoute("/shared/secret/$secretId")({
-  component: ViewSharedSecretByIDPage,
   validateSearch: zodValidator(SharedSecretByIDPageQuerySchema),
+  component: ViewSharedSecretByIDPage,
   search: {
     middlewares: [stripSearchParams({ key: "" })]
+  },
+  beforeLoad: async ({ context }) => {
+    // we load the auth token because the view shared secret screen serves both public and authenticated users
+    await context.queryClient
+      .ensureQueryData({
+        queryKey: authKeys.getAuthToken,
+        queryFn: fetchAuthToken
+      })
+      .catch(() => undefined);
   }
 });


### PR DESCRIPTION
# Description 📣
This PR addresses the issue where users cannot view secrets shared within the organization. This also adds a login redirect for shared secrets requiring org authentication.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->