### PR TITLE
fix(audit-logs): time conversion bug

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -100,10 +100,10 @@ export const auditLogDALFactory = (db: TDbClient) => {
 
       // Filter by date range
       if (startDate) {
-        void sqlQuery.where(`${TableName.AuditLog}.createdAt`, ">=", startDate);
+        void sqlQuery.whereRaw(`"${TableName.AuditLog}"."createdAt" >= ?::timestamptz`, [startDate]);
       }
       if (endDate) {
-        void sqlQuery.where(`${TableName.AuditLog}.createdAt`, "<=", endDate);
+        void sqlQuery.whereRaw(`"${TableName.AuditLog}"."createdAt" <= ?::timestamptz`, [endDate]);
       }
 
       // we timeout long running queries to prevent DB resource issues (2 minutes)

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -3,6 +3,7 @@ import { EventType, UserAgentType } from "./enums";
 export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.GET_SECRETS]: "List secrets",
   [EventType.GET_SECRET]: "Read secret",
+  [EventType.DELETE_SECRETS]: "Delete secrets",
   [EventType.CREATE_SECRET]: "Create secret",
   [EventType.UPDATE_SECRET]: "Update secret",
   [EventType.DELETE_SECRET]: "Delete secret",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -17,6 +17,7 @@ export enum UserAgentType {
 
 export enum EventType {
   GET_SECRETS = "get-secrets",
+  DELETE_SECRETS = "delete-secrets",
   GET_SECRET = "get-secret",
   CREATE_SECRET = "create-secret",
   UPDATE_SECRET = "update-secret",


### PR DESCRIPTION
# Description 📣

This PR aims to resolve a time conversion bug happening in the audit logs. The frontend sends an ISO 8601 formatted timestamp to the API. This PR tells Postgres to explicitly handle timezone conversion on our behalf.

Additionally I also added the deleted-secrets event type to the frontend. Previously it was displaying `undefined`.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->