### PR TITLE
misc: add support for array values in OIDC aud field

### DIFF
--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-fns.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-fns.ts
@@ -2,3 +2,11 @@ import picomatch from "picomatch";
 
 export const doesFieldValueMatchOidcPolicy = (fieldValue: string, policyValue: string) =>
   policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue);
+
+export const doesAudValueMatchOidcPolicy = (fieldValue: string | string[], policyValue: string) => {
+  if (Array.isArray(fieldValue)) {
+    return fieldValue.some((entry) => entry === policyValue || picomatch.isMatch(entry, policyValue));
+  }
+
+  return policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue);
+};

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -27,7 +27,7 @@ import { TIdentityAccessTokenDALFactory } from "../identity-access-token/identit
 import { TIdentityAccessTokenJwtPayload } from "../identity-access-token/identity-access-token-types";
 import { TOrgBotDALFactory } from "../org/org-bot-dal";
 import { TIdentityOidcAuthDALFactory } from "./identity-oidc-auth-dal";
-import { doesFieldValueMatchOidcPolicy } from "./identity-oidc-auth-fns";
+import { doesAudValueMatchOidcPolicy, doesFieldValueMatchOidcPolicy } from "./identity-oidc-auth-fns";
 import {
   TAttachOidcAuthDTO,
   TGetOidcAuthDTO,
@@ -148,7 +148,7 @@ export const identityOidcAuthServiceFactory = ({
       if (
         !identityOidcAuth.boundAudiences
           .split(", ")
-          .some((policyValue) => doesFieldValueMatchOidcPolicy(tokenData.aud, policyValue))
+          .some((policyValue) => doesAudValueMatchOidcPolicy(tokenData.aud, policyValue))
       ) {
         throw new UnauthorizedError({
           message: "Access denied: OIDC audience not allowed."


### PR DESCRIPTION
# Description 📣
This PR ensures that the OIDC auth method can be used with Kubernetes setups by enabling the aud field to support an array input (which some systems do)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->