### PR TITLE
feat(audit-logs): shared secrets audit logs

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -31,7 +31,7 @@ export type TListProjectAuditLogDTO = {
 
 export type TCreateAuditLogDTO = {
   event: Event;
-  actor: UserActor | IdentityActor | ServiceActor | ScimClientActor | PlatformActor;
+  actor: UserActor | IdentityActor | ServiceActor | ScimClientActor | PlatformActor | UnknownUserActor;
   orgId?: string;
   projectId?: string;
 } & BaseAuthData;
@@ -229,7 +229,10 @@ export enum EventType {
   GET_APP_CONNECTION = "get-app-connection",
   CREATE_APP_CONNECTION = "create-app-connection",
   UPDATE_APP_CONNECTION = "update-app-connection",
-  DELETE_APP_CONNECTION = "delete-app-connection"
+  DELETE_APP_CONNECTION = "delete-app-connection",
+  CREATE_SHARED_SECRET = "create-shared-secret",
+  DELETE_SHARED_SECRET = "delete-shared-secret",
+  READ_SHARED_SECRET = "read-shared-secret"
 }
 
 interface UserActorMetadata {
@@ -252,6 +255,8 @@ interface ScimClientActorMetadata {}
 
 interface PlatformActorMetadata {}
 
+interface UnknownUserActorMetadata {}
+
 export interface UserActor {
   type: ActorType.USER;
   metadata: UserActorMetadata;
@@ -265,6 +270,11 @@ export interface ServiceActor {
 export interface PlatformActor {
   type: ActorType.PLATFORM;
   metadata: PlatformActorMetadata;
+}
+
+export interface UnknownUserActor {
+  type: ActorType.UNKNOWN_USER;
+  metadata: UnknownUserActorMetadata;
 }
 
 export interface IdentityActor {
@@ -1907,6 +1917,35 @@ interface DeleteAppConnectionEvent {
   };
 }
 
+interface CreateSharedSecretEvent {
+  type: EventType.CREATE_SHARED_SECRET;
+  metadata: {
+    id: string;
+    accessType: string;
+    name?: string;
+    expiresAfterViews?: number;
+    usingPassword: boolean;
+    expiresAt: string;
+  };
+}
+
+interface DeleteSharedSecretEvent {
+  type: EventType.DELETE_SHARED_SECRET;
+  metadata: {
+    id: string;
+    name?: string;
+  };
+}
+
+interface ReadSharedSecretEvent {
+  type: EventType.READ_SHARED_SECRET;
+  metadata: {
+    id: string;
+    name?: string;
+    accessType: string;
+  };
+}
+
 export type Event =
   | GetSecretsEvent
   | GetSecretEvent
@@ -2083,4 +2122,7 @@ export type Event =
   | GetAppConnectionEvent
   | CreateAppConnectionEvent
   | UpdateAppConnectionEvent
-  | DeleteAppConnectionEvent;
+  | DeleteAppConnectionEvent
+  | CreateSharedSecretEvent
+  | DeleteSharedSecretEvent
+  | ReadSharedSecretEvent;

--- a/backend/src/services/auth/auth-type.ts
+++ b/backend/src/services/auth/auth-type.ts
@@ -39,7 +39,8 @@ export enum ActorType { // would extend to AWS, Azure, ...
   SERVICE = "service",
   IDENTITY = "identity",
   Machine = "machine",
-  SCIM_CLIENT = "scimClient"
+  SCIM_CLIENT = "scimClient",
+  UNKNOWN_USER = "unknownUser"
 }
 
 // This will be null unless the token-type is JWT

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -82,7 +82,10 @@ export const eventToNameMap: { [K in EventType]: string } = {
     "Update certificate template EST configuration",
   [EventType.UPDATE_PROJECT_SLACK_CONFIG]: "Update project slack configuration",
   [EventType.GET_PROJECT_SLACK_CONFIG]: "Get project slack configuration",
-  [EventType.INTEGRATION_SYNCED]: "Integration sync"
+  [EventType.INTEGRATION_SYNCED]: "Integration sync",
+  [EventType.CREATE_SHARED_SECRET]: "Create shared secret",
+  [EventType.DELETE_SHARED_SECRET]: "Delete shared secret",
+  [EventType.READ_SHARED_SECRET]: "Read shared secret"
 };
 
 export const userAgentTTypeoNameMap: { [K in UserAgentType]: string } = {

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -2,7 +2,8 @@ export enum ActorType {
   PLATFORM = "platform",
   USER = "user",
   SERVICE = "service",
-  IDENTITY = "identity"
+  IDENTITY = "identity",
+  UNKNOWN_USER = "unknownUser"
 }
 
 export enum UserAgentType {
@@ -95,5 +96,8 @@ export enum EventType {
   GET_CERTIFICATE_TEMPLATE_EST_CONFIG = "get-certificate-template-est-config",
   UPDATE_PROJECT_SLACK_CONFIG = "update-project-slack-config",
   GET_PROJECT_SLACK_CONFIG = "get-project-slack-config",
-  INTEGRATION_SYNCED = "integration-synced"
+  INTEGRATION_SYNCED = "integration-synced",
+  CREATE_SHARED_SECRET = "create-shared-secret",
+  DELETE_SHARED_SECRET = "delete-shared-secret",
+  READ_SHARED_SECRET = "read-shared-secret"
 }

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -50,7 +50,11 @@ export interface PlatformActor {
   metadata: object;
 }
 
-export type Actor = UserActor | ServiceActor | IdentityActor | PlatformActor;
+export interface UnknownUserActor {
+  type: ActorType.UNKNOWN_USER;
+}
+
+export type Actor = UserActor | ServiceActor | IdentityActor | PlatformActor | UnknownUserActor;
 
 interface GetSecretsEvent {
   type: EventType.GET_SECRETS;

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Control, Controller, UseFormReset, UseFormSetValue, UseFormWatch } from "react-hook-form";
 import { faCaretDown, faCheckCircle, faFilterCircleXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -49,7 +49,6 @@ export const LogsFilter = ({
   isOrgAuditLogs,
   className,
   control,
-  setValue,
   reset,
   watch
 }: Props) => {
@@ -62,12 +61,6 @@ export const LogsFilter = ({
   const workspacesInOrg = workspaces.filter((ws) => ws.orgId === currentOrg?.id);
 
   const { data, isPending } = useGetAuditLogActorFilterOpts(workspaces?.[0]?.id ?? "");
-
-  useEffect(() => {
-    if (workspacesInOrg.length) {
-      setValue("project", workspacesInOrg[0]);
-    }
-  }, [workspaces]);
 
   const renderActorSelectItem = (actor: Actor) => {
     switch (actor.type) {
@@ -129,6 +122,7 @@ export const LogsFilter = ({
             >
               <FilterableSelect
                 value={value}
+                isClearable
                 onChange={onChange}
                 placeholder="Select a project..."
                 options={workspacesInOrg.map(({ name, id }) => ({ name, id }))}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
@@ -1,4 +1,7 @@
-import { Td, Tr } from "@app/components/v2";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { Td, Tooltip, Tr } from "@app/components/v2";
 import { eventToNameMap, userAgentTTypeoNameMap } from "@app/hooks/api/auditLogs/constants";
 import { ActorType, EventType } from "@app/hooks/api/auditLogs/enums";
 import { Actor, AuditLog } from "@app/hooks/api/auditLogs/types";
@@ -35,6 +38,17 @@ export const LogsTableRow = ({ auditLog, isOrgAuditLogs, showActorColumn }: Prop
           <Td>
             <p>{`${actor.metadata.name}`}</p>
             <p>Machine Identity</p>
+          </Td>
+        );
+      case ActorType.UNKNOWN_USER:
+        return (
+          <Td>
+            <div className="flex items-center gap-2">
+              <p>Unknown User</p>
+              <Tooltip content="This action was performed by a user who was not authenticated at the time.">
+                <FontAwesomeIcon className="text-mineshaft-400" icon={faQuestionCircle} />
+              </Tooltip>
+            </div>
           </Td>
         );
       default:


### PR DESCRIPTION
# Description 📣

This PR introduces support for secret sharing audit logs. The 3 new events are:

1. Shared secret created
2. Shared secret deleted
3. Shared secret read

The created/deleted events will only happen if the secret is created within an organization. And the read event will be logged regardless if it's a public user, or an authenticated organization member reading the secret. This means we now have a new actor type called `Unknown User`. The Unknown user actor type will be used when the actor isn't authenticated.

**Smaller:**
I also added `isClearable` to the project selector in the audit logs tab, and removed the useEffect that made it default to a project on load.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->