### PR TITLE
fix: PROJECT_ID exposed as an env value just like INFISICA_TOKEN #2912

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -38,9 +38,19 @@ var secretsCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
+		// Using GetProjectID utility function
+		projectDetails, err := util.GetProjectID(cmd)
+		if err != nil {
+			util.HandleError(err, "Unable to determine project ID")
+		}
+
 		projectId, err := cmd.Flags().GetString("projectId")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
+		}
+
+		if projectDetails != nil {
+			projectId = projectDetails.ID
 		}
 
 		secretsPath, err := cmd.Flags().GetString("path")

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -69,6 +69,12 @@ type TokenDetails struct {
 	Source string
 }
 
+// ProjectDetails contains the project ID and its source
+type ProjectDetails struct {
+	ID     string
+	Source string
+}
+
 type SingleFolder struct {
 	ID   string `json:"_id"`
 	Name string `json:"name"`

--- a/cli/packages/util/constants.go
+++ b/cli/packages/util/constants.go
@@ -7,6 +7,7 @@ const (
 	INFISICAL_DEFAULT_EU_URL                   = "https://eu.infisical.com"
 	INFISICAL_WORKSPACE_CONFIG_FILE_NAME       = ".infisical.json"
 	INFISICAL_TOKEN_NAME                       = "INFISICAL_TOKEN"
+	INFISICAL_PROJECT_ID                       = "INFISICAL_PROJECT_ID"
 	INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN_NAME = "INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN"
 	INFISICAL_VAULT_FILE_PASSPHRASE_ENV_NAME   = "INFISICAL_VAULT_FILE_PASSPHRASE" // This works because we've forked the keyring package and added support for this env variable. This explains why you won't find any occurrences of it in the CLI codebase.
 


### PR DESCRIPTION
# What does this PR do?
This PR addresses issue #2912 by exposing PROJECT_ID as an environment variable, similar to how INFISICAL_TOKEN is handled. This enhancement improves the developer experience by enabling users to configure the PROJECT_ID through environment variables, streamlining workflows and making it easier to manage configurations in CI/CD pipelines.

## Type ✨

- [ ✅] Improvement


# Tests 🛠️

The following tests were conducted to verify the changes:

Default Behavior:
Verified that the application continues to function as expected when PROJECT_ID is not set as an environment variable.

Environment Variable Usage:
Set the PROJECT_ID as an environment variable and ensured that the application correctly utilized the value.

Priority Check:
Tested scenarios where both the environment variable and CLI flag for projectId were provided to confirm that the CLI flag takes precedence.

Invalid Inputs:
Verified that invalid or missing PROJECT_ID values are properly handled with relevant error messages.

