### PR TITLE
fix: fix the problem of secret tags attribute missing

### DIFF
--- a/cli/packages/api/model.go
+++ b/cli/packages/api/model.go
@@ -593,10 +593,16 @@ type GetRawSecretsV3Request struct {
 
 type GetRawSecretsV3Response struct {
 	Secrets []struct {
-		ID            string `json:"_id"`
-		Version       int    `json:"version"`
-		Workspace     string `json:"workspace"`
-		Type          string `json:"type"`
+		ID        string `json:"_id"`
+		Version   int    `json:"version"`
+		Workspace string `json:"workspace"`
+		Type      string `json:"type"`
+		Tags      []struct {
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Slug  string `json:"slug"`
+			Color string `json:"color"`
+		} `json:"tags"`
 		Environment   string `json:"environment"`
 		SecretKey     string `json:"secretKey"`
 		SecretValue   string `json:"secretValue"`

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -486,10 +486,10 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 	type TagsAndSecrets struct {
 		Secrets []models.SingleEnvironmentVariable
 		Tags    []struct {
-			ID        string `json:"_id"`
-			Name      string `json:"name"`
-			Slug      string `json:"slug"`
-			Workspace string `json:"workspace"`
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Slug  string `json:"slug"`
+			Color string `json:"color"`
 		}
 	}
 
@@ -500,10 +500,10 @@ func generateExampleEnv(cmd *cobra.Command, args []string) {
 
 	for i, secret := range secrets {
 		filteredTag := []struct {
-			ID        string "json:\"_id\""
-			Name      string "json:\"name\""
-			Slug      string "json:\"slug\""
-			Workspace string "json:\"workspace\""
+			ID    string "json:\"id\""
+			Name  string "json:\"name\""
+			Slug  string "json:\"slug\""
+			Color string "json:\"color\""
 		}{}
 
 		for _, secretTag := range secret.Tags {

--- a/cli/packages/models/cli.go
+++ b/cli/packages/models/cli.go
@@ -32,10 +32,10 @@ type SingleEnvironmentVariable struct {
 	ID          string `json:"_id"`
 	SecretPath  string `json:"secretPath"`
 	Tags        []struct {
-		ID        string `json:"_id"`
-		Name      string `json:"name"`
-		Slug      string `json:"slug"`
-		Workspace string `json:"workspace"`
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Slug  string `json:"slug"`
+		Color string `json:"color"`
 	} `json:"tags"`
 	Comment string `json:"comment"`
 	Etag    string `json:"Etag"`

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -104,7 +104,14 @@ func GetPlainTextSecretsV3(accessToken string, workspaceId string, environmentNa
 	plainTextSecrets := []models.SingleEnvironmentVariable{}
 
 	for _, secret := range rawSecrets.Secrets {
-		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{Key: secret.SecretKey, Value: secret.SecretValue, Type: secret.Type, WorkspaceId: secret.Workspace, SecretPath: secret.SecretPath})
+		plainTextSecrets = append(plainTextSecrets, models.SingleEnvironmentVariable{
+			Key:         secret.SecretKey,
+			Value:       secret.SecretValue,
+			Type:        secret.Type,
+			Tags:        secret.Tags,
+			WorkspaceId: secret.Workspace,
+			SecretPath:  secret.SecretPath,
+		})
 	}
 
 	if includeImports {


### PR DESCRIPTION
# Description 📣

The API model in the CLI is not compatible with the latest API response, resulting in the loss of the tags attribute when converting the API response into a Go struct.
If the user specifies `--tags` in the CLI, all Secrets will be filtered out.

## Type ✨

- [X] Bug fix

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->