### PR TITLE
feat(radar): pagination and filtering

### DIFF
--- a/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
@@ -1,4 +1,4 @@
-import { Knex, KnexTimeoutError } from "knex";
+import knex, { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
 import { TableName, TSecretScanningGitRisksInsert } from "@app/db/schemas";
@@ -76,7 +76,7 @@ export const secretScanningDALFactory = (db: TDbClient) => {
           .sort((a, b) => a.localeCompare(b))
       };
     } catch (error) {
-      if (error instanceof KnexTimeoutError) {
+      if (error instanceof knex.KnexTimeoutError) {
         throw new GatewayTimeoutError({
           error,
           message: "Failed to fetch audit logs due to timeout. Add more search filters."

--- a/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
@@ -1,9 +1,12 @@
-import { Knex } from "knex";
+import { Knex, KnexTimeoutError } from "knex";
 
 import { TDbClient } from "@app/db";
 import { TableName, TSecretScanningGitRisksInsert } from "@app/db/schemas";
-import { DatabaseError } from "@app/lib/errors";
-import { ormify } from "@app/lib/knex";
+import { DatabaseError, GatewayTimeoutError } from "@app/lib/errors";
+import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { OrderByDirection } from "@app/lib/types";
+
+import { SecretScanningResolvedStatus, TGetOrgRisksDTO } from "./secret-scanning-types";
 
 export type TSecretScanningDALFactory = ReturnType<typeof secretScanningDALFactory>;
 
@@ -19,5 +22,70 @@ export const secretScanningDALFactory = (db: TDbClient) => {
     }
   };
 
-  return { ...gitRiskOrm, upsert };
+  const findByOrgId = async (orgId: string, filter: TGetOrgRisksDTO["filter"], tx?: Knex) => {
+    try {
+      // Find statements
+      const sqlQuery = (tx || db.replicaNode())(TableName.SecretScanningGitRisk)
+        // eslint-disable-next-line func-names
+        .where(`${TableName.SecretScanningGitRisk}.orgId`, orgId);
+
+      if (filter.repositoryNames) {
+        void sqlQuery.whereIn(`${TableName.SecretScanningGitRisk}.repositoryFullName`, filter.repositoryNames);
+      }
+
+      if (filter.resolvedStatus) {
+        if (filter.resolvedStatus !== SecretScanningResolvedStatus.All) {
+          const isResolved = filter.resolvedStatus === SecretScanningResolvedStatus.Resolved;
+
+          void sqlQuery.where(`${TableName.SecretScanningGitRisk}.isResolved`, isResolved);
+        }
+      }
+
+      // Select statements
+      void sqlQuery
+        .select(selectAllTableCols(TableName.SecretScanningGitRisk))
+        .limit(filter.limit)
+        .offset(filter.offset);
+
+      if (filter.orderBy) {
+        const orderDirection = filter.orderDirection || OrderByDirection.ASC;
+
+        void sqlQuery.orderBy(filter.orderBy, orderDirection);
+      }
+
+      const countQuery = (tx || db.replicaNode())(TableName.SecretScanningGitRisk)
+        .where(`${TableName.SecretScanningGitRisk}.orgId`, orgId)
+        .count();
+
+      const uniqueReposQuery = (tx || db.replicaNode())(TableName.SecretScanningGitRisk)
+        .where(`${TableName.SecretScanningGitRisk}.orgId`, orgId)
+        .distinct("repositoryFullName")
+        .select("repositoryFullName");
+
+      // we timeout long running queries to prevent DB resource issues (2 minutes)
+      const docs = await sqlQuery.timeout(1000 * 120);
+      const uniqueRepos = await uniqueReposQuery.timeout(1000 * 120);
+      const totalCount = await countQuery;
+
+      return {
+        risks: docs,
+        totalCount: Number(totalCount?.[0].count),
+        repos: uniqueRepos
+          .filter(Boolean)
+          .map((r) => r.repositoryFullName!)
+          .sort((a, b) => a.localeCompare(b))
+      };
+    } catch (error) {
+      if (error instanceof KnexTimeoutError) {
+        throw new GatewayTimeoutError({
+          error,
+          message: "Failed to fetch audit logs due to timeout. Add more search filters."
+        });
+      }
+
+      throw new DatabaseError({ error });
+    }
+  };
+
+  return { ...gitRiskOrm, upsert, findByOrgId };
 };

--- a/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-dal.ts
@@ -79,7 +79,7 @@ export const secretScanningDALFactory = (db: TDbClient) => {
       if (error instanceof knex.KnexTimeoutError) {
         throw new GatewayTimeoutError({
           error,
-          message: "Failed to fetch audit logs due to timeout. Add more search filters."
+          message: "Failed to fetch secret leaks due to timeout. Add more search filters."
         });
       }
 

--- a/backend/src/ee/services/secret-scanning/secret-scanning-service.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-service.ts
@@ -122,7 +122,6 @@ export const secretScanningServiceFactory = ({
   const getRisksByOrg = async ({ actor, orgId, actorId, actorAuthMethod, actorOrgId, filter }: TGetOrgRisksDTO) => {
     const { permission } = await permissionService.getOrgPermission(actor, actorId, orgId, actorAuthMethod, actorOrgId);
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.SecretScanning);
-    // const risks = await secretScanningDAL.find({ orgId }, { sort: [["createdAt", "desc"]] });
 
     const results = await secretScanningDAL.findByOrgId(orgId, filter);
 

--- a/backend/src/ee/services/secret-scanning/secret-scanning-service.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-service.ts
@@ -15,6 +15,7 @@ import { TSecretScanningDALFactory } from "./secret-scanning-dal";
 import { TSecretScanningQueueFactory } from "./secret-scanning-queue";
 import {
   SecretScanningRiskStatus,
+  TGetAllOrgRisksDTO,
   TGetOrgInstallStatusDTO,
   TGetOrgRisksDTO,
   TInstallAppSessionDTO,
@@ -118,11 +119,22 @@ export const secretScanningServiceFactory = ({
     return Boolean(appInstallation);
   };
 
-  const getRisksByOrg = async ({ actor, orgId, actorId, actorAuthMethod, actorOrgId }: TGetOrgRisksDTO) => {
+  const getRisksByOrg = async ({ actor, orgId, actorId, actorAuthMethod, actorOrgId, filter }: TGetOrgRisksDTO) => {
     const { permission } = await permissionService.getOrgPermission(actor, actorId, orgId, actorAuthMethod, actorOrgId);
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.SecretScanning);
+    // const risks = await secretScanningDAL.find({ orgId }, { sort: [["createdAt", "desc"]] });
+
+    const results = await secretScanningDAL.findByOrgId(orgId, filter);
+
+    return results;
+  };
+
+  const getAllRisksByOrg = async ({ actor, orgId, actorId, actorAuthMethod, actorOrgId }: TGetAllOrgRisksDTO) => {
+    const { permission } = await permissionService.getOrgPermission(actor, actorId, orgId, actorAuthMethod, actorOrgId);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.SecretScanning);
+
     const risks = await secretScanningDAL.find({ orgId }, { sort: [["createdAt", "desc"]] });
-    return { risks };
+    return risks;
   };
 
   const updateRiskStatus = async ({
@@ -189,6 +201,7 @@ export const secretScanningServiceFactory = ({
     linkInstallationToOrg,
     getOrgInstallationStatus,
     getRisksByOrg,
+    getAllRisksByOrg,
     updateRiskStatus,
     handleRepoPushEvent,
     handleRepoDeleteEvent

--- a/backend/src/ee/services/secret-scanning/secret-scanning-types.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-types.ts
@@ -1,10 +1,16 @@
-import { TOrgPermission } from "@app/lib/types";
+import { OrderByDirection, TOrgPermission } from "@app/lib/types";
 
 export enum SecretScanningRiskStatus {
   FalsePositive = "RESOLVED_FALSE_POSITIVE",
   Revoked = "RESOLVED_REVOKED",
   NotRevoked = "RESOLVED_NOT_REVOKED",
   Unresolved = "UNRESOLVED"
+}
+
+export enum SecretScanningResolvedStatus {
+  All = "all",
+  Resolved = "resolved",
+  Unresolved = "unresolved"
 }
 
 export type TInstallAppSessionDTO = TOrgPermission;
@@ -16,7 +22,22 @@ export type TLinkInstallSessionDTO = {
 
 export type TGetOrgInstallStatusDTO = TOrgPermission;
 
-export type TGetOrgRisksDTO = TOrgPermission;
+type RiskFilter = {
+  offset: number;
+  limit: number;
+  orderBy?: "createdAt" | "name";
+  orderDirection?: OrderByDirection;
+  repositoryNames?: string[];
+  resolvedStatus?: SecretScanningResolvedStatus;
+};
+
+export type TGetOrgRisksDTO = {
+  filter: RiskFilter;
+} & TOrgPermission;
+
+export type TGetAllOrgRisksDTO = {
+  filter: Omit<RiskFilter, "offset" | "limit" | "orderBy" | "orderDirection">;
+} & TOrgPermission;
 
 export type TUpdateRiskStatusDTO = {
   riskId: string;

--- a/frontend/src/hooks/api/secretScanning/index.tsx
+++ b/frontend/src/hooks/api/secretScanning/index.tsx
@@ -1,5 +1,6 @@
 export {
   useCreateNewInstallationSession,
+  useExportSecretScanningRisks,
   useLinkGitAppInstallationWithOrg,
   useUpdateRiskStatus
 } from "./mutation";

--- a/frontend/src/hooks/api/secretScanning/mutation.ts
+++ b/frontend/src/hooks/api/secretScanning/mutation.ts
@@ -2,7 +2,12 @@ import { useMutation } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
-import { RiskStatus, TGitAppOrg, TSecretScanningGitRisks } from "./types";
+import {
+  RiskStatus,
+  SecretScanningResolvedStatus,
+  TGitAppOrg,
+  TSecretScanningGitRisks
+} from "./types";
 
 export const useCreateNewInstallationSession = () => {
   return useMutation<{ sessionId: string }, object, { organizationId: string }>({
@@ -40,6 +45,34 @@ export const useLinkGitAppInstallationWithOrg = () => {
         opt
       );
       return data;
+    }
+  });
+};
+
+export const useExportSecretScanningRisks = () => {
+  return useMutation<
+    TSecretScanningGitRisks[],
+    object,
+    {
+      orgId: string;
+      filter: {
+        repositoryNames?: string[];
+        resolvedStatus?: SecretScanningResolvedStatus;
+      };
+    }
+  >({
+    mutationFn: async ({ filter, orgId }) => {
+      const params = new URLSearchParams({
+        ...(filter.resolvedStatus && { resolvedStatus: filter.resolvedStatus }),
+        ...(filter.repositoryNames && { repositoryNames: filter.repositoryNames.join(",") })
+      });
+
+      const { data } = await apiRequest.get<{
+        risks: TSecretScanningGitRisks[];
+      }>(`/api/v1/secret-scanning/organization/${orgId}/risks/export`, {
+        params
+      });
+      return data.risks;
     }
   });
 };

--- a/frontend/src/hooks/api/secretScanning/types.ts
+++ b/frontend/src/hooks/api/secretScanning/types.ts
@@ -5,6 +5,21 @@ export enum RiskStatus {
   UNRESOLVED = "UNRESOLVED"
 }
 
+export enum SecretScanningOrderBy {
+  CreatedAt = "createdAt"
+}
+
+export enum SecretScanningResolvedStatus {
+  All = "all",
+  Resolved = "resolved",
+  Unresolved = "unresolved"
+}
+
+export type SecretScanningRiskFilter = {
+  repositoryNames?: string[];
+  resolvedStatus?: SecretScanningResolvedStatus;
+};
+
 export type TSecretScanningGitRisks = {
   id: string;
   description: string;

--- a/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
+++ b/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
@@ -173,13 +173,15 @@ export const SecretScanningPage = withPermission(
               )}
             </div>
             <div className="mt-8 space-y-3">
-              <div className="flex w-full items-center justify-end">
-                <SecretScanningFilter
-                  repositories={risksData?.repos || []}
-                  handlePopUpToggle={handlePopUpToggle}
-                  control={control}
-                />
-              </div>
+              {integrationEnabled && (
+                <div className="flex w-full items-center justify-end">
+                  <SecretScanningFilter
+                    repositories={risksData?.repos || []}
+                    handlePopUpToggle={handlePopUpToggle}
+                    control={control}
+                  />
+                </div>
+              )}
               <SecretScanningLogsTable gitRisks={risksData?.risks} isPending={isPending} />
               {!isPending &&
                 risksData?.totalCount !== undefined &&

--- a/frontend/src/pages/organization/SecretScanningPage/components/SecretScanningFilters.tsx
+++ b/frontend/src/pages/organization/SecretScanningPage/components/SecretScanningFilters.tsx
@@ -1,0 +1,89 @@
+import { Control, Controller } from "react-hook-form";
+import { twMerge } from "tailwind-merge";
+
+import { Button, FilterableSelect, FormControl, Select, SelectItem } from "@app/components/v2";
+import { SecretScanningResolvedStatus } from "@app/hooks/api/secretScanning/types";
+import { UsePopUpState } from "@app/hooks/usePopUp";
+
+import { SecretScanningFilterFormData } from "./types";
+
+type Props = {
+  control: Control<SecretScanningFilterFormData>;
+  repositories: string[];
+  handlePopUpToggle: (
+    popUpName: keyof UsePopUpState<["exportSecretScans"]>,
+    state?: boolean
+  ) => void;
+};
+
+export const SecretScanningFilter = ({ repositories, control, handlePopUpToggle }: Props) => {
+  return (
+    <div className={twMerge("flex w-full flex-wrap items-center justify-between bg-bunker-800")}>
+      <div className="flex items-center -space-x-8">
+        <Controller
+          control={control}
+          name="repositoryNames"
+          render={({ field: { onChange, value }, fieldState: { error } }) => (
+            <FormControl
+              label="Repository"
+              errorText={error?.message}
+              isError={Boolean(error)}
+              className="mr-12 w-96"
+            >
+              <FilterableSelect
+                value={value}
+                isClearable
+                isMulti
+                onChange={onChange}
+                placeholder="Select a repository..."
+                options={repositories.map((repository) => ({
+                  name: repository
+                }))}
+                getOptionValue={(option) => option.name}
+                getOptionLabel={(option) => option.name}
+              />
+            </FormControl>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="resolved"
+          render={({ field: { onChange, value }, fieldState: { error } }) => (
+            <FormControl
+              label="Status"
+              errorText={error?.message}
+              isError={Boolean(error)}
+              className="mr-12 w-44"
+            >
+              <Select
+                defaultValue={SecretScanningResolvedStatus.All}
+                placeholder={SecretScanningResolvedStatus.All}
+                value={value}
+                onValueChange={onChange}
+                className="w-full"
+              >
+                {Object.values(SecretScanningResolvedStatus).map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status.charAt(0).toUpperCase() + status.slice(1)} risks
+                  </SelectItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+      </div>
+
+      <div>
+        <Button
+          className="mt-[0.45rem]"
+          onClick={() => handlePopUpToggle("exportSecretScans", true)}
+          variant="solid"
+          colorSchema="secondary"
+        >
+          Export
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/organization/SecretScanningPage/components/types.ts
+++ b/frontend/src/pages/organization/SecretScanningPage/components/types.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+import { SecretScanningResolvedStatus } from "@app/hooks/api/secretScanning/types";
+
+export const secretScanningFilterFormSchema = z.object({
+  repositoryNames: z.array(z.object({ name: z.string() })),
+  resolved: z
+    .nativeEnum(SecretScanningResolvedStatus)
+    .default(SecretScanningResolvedStatus.All)
+    .optional()
+});
+
+export type SecretScanningFilterFormData = z.infer<typeof secretScanningFilterFormSchema>;
+
+export type SetValueType = (
+  name: keyof SecretScanningFilterFormData,
+  value: any,
+  options?: {
+    shouldValidate?: boolean;
+    shouldDirty?: boolean;
+  }
+) => void;


### PR DESCRIPTION
# Description 📣

This PR adds pagination and filtering support to the Infisical Radar. Users can now select which repositories they wish to view leaks for, and what status they want to view.

This PR builds on top of #2981, which added exporting ability. I had to tweak the export logic slightly to work with pagination, as you'll notice in this PR.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->