### PR TITLE
misc: added missing install CRD flag for multi-installation

### DIFF
--- a/helm-charts/secrets-operator/templates/infisicaldynamicsecret-crd.yaml
+++ b/helm-charts/secrets-operator/templates/infisicaldynamicsecret-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -308,3 +309,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/helm-charts/secrets-operator/templates/infisicalpushsecret-crd.yaml
+++ b/helm-charts/secrets-operator/templates/infisicalpushsecret-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -265,3 +266,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}


### PR DESCRIPTION
# Description 📣
- This PR will make it so that the installation of the dynamicsecret and pushsecret CRDs can be controlled by setting a flag value. This will allow multiple installations of a chart in differet namespaces.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->