### PR TITLE
Added region flag for eu in cli

### DIFF
--- a/cli/packages/cmd/login.go
+++ b/cli/packages/cmd/login.go
@@ -315,7 +315,11 @@ var loginCmd = &cobra.Command{
 			credential, err := authStrategies[strategy](cmd, infisicalClient)
 
 			if err != nil {
-				util.HandleError(fmt.Errorf("unable to authenticate with %s [err=%v]", formatAuthMethod(loginMethod), err))
+				euErrorMessage := ""
+				if strings.HasPrefix(config.INFISICAL_URL, util.INFISICAL_DEFAULT_US_URL) {
+					euErrorMessage = "\nIf you are using the Infisical Cloud Europe Region, please switch to it by using the \"--region eu\" flag."
+				}
+				util.HandleError(fmt.Errorf("unable to authenticate with %s [err=%v].%s", formatAuthMethod(loginMethod), err, euErrorMessage))
 			}
 
 			if plainOutput {

--- a/cli/packages/cmd/root.go
+++ b/cli/packages/cmd/root.go
@@ -39,6 +39,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initLog)
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")
+	rootCmd.PersistentFlags().StringP("region", "r", "us", "Select the Infisical Cloud Region (us or eu). If the domain option is provided, this setting will be ignored.")
 	rootCmd.PersistentFlags().Bool("telemetry", true, "Infisical collects non-sensitive telemetry data to enhance features and improve user experience. Participation is voluntary")
 	rootCmd.PersistentFlags().StringVar(&config.INFISICAL_URL, "domain", fmt.Sprintf("%s/api", util.INFISICAL_DEFAULT_US_URL), "Point the CLI to your own backend [can also set via environment variable name: INFISICAL_API_URL]")
 	rootCmd.PersistentFlags().Bool("silent", false, "Disable output of tip/info messages. Useful when running in scripts or CI/CD pipelines.")
@@ -46,6 +47,15 @@ func init() {
 		silent, err := cmd.Flags().GetBool("silent")
 		if err != nil {
 			util.HandleError(err)
+		}
+
+		region, err := cmd.Flags().GetString("region")
+		if err != nil {
+			util.HandleError(err)
+		}
+
+		if region == "eu" {
+			config.INFISICAL_URL = util.INFISICAL_DEFAULT_EU_URL
 		}
 
 		config.INFISICAL_URL = util.AppendAPIEndpoint(config.INFISICAL_URL)

--- a/docs/cli/commands/commands.mdx
+++ b/docs/cli/commands/commands.mdx
@@ -11,11 +11,13 @@ description: "Infisical CLI command overview"
 | `init`  | Used to link a local project to the platform.                        |
 | `run`   | Used to inject envars from the platform into an application process. |
 | `vault` | Used to manage where your login credentials are stored at rest       |
+
 ## Global options
 
-| Option            | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| `--help`, `-h`    | List help for any command                       |
-| `--debug`, `-d`   | Enable verbose logging                          |
-| `--domain`        | Use to direct Infisical to a self-hosted domain |
-| `--version`, `-v` | Print version information and quit              |
+| Option            | Description                                                                                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--help`, `-h`    | List help for any command                                                                                                                                            |
+| `--debug`, `-d`   | Enable verbose logging                                                                                                                                               |
+| `--domain`        | Use to direct Infisical to a self-hosted domain                                                                                                                      |
+| `--version`, `-v` | Print version information and quit                                                                                                                                   |
+| `--region`, `-r`  | By default, the Infisical domain points to the US cloud region at https://app.infisical.com. Setting the region flag to eu switches it to https://eu.infisical.com." |


### PR DESCRIPTION
# Description 📣

This PR introduces an additional flag `region` to switch between us and eu. Additional we have also added on identity auth failure and in us cloud domain, we give them a europe region note.

<img width="1554" alt="Screenshot 2025-01-17 at 6 39 11 PM" src="https://github.com/user-attachments/assets/265f7eda-0413-4147-beff-ac9eae489376" />


## Type ✨

- [x]  Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->