### PR TITLE
fix: resolved failing project delete

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -895,7 +895,8 @@ export const registerRoutes = async (
     certificateTemplateDAL,
     projectSlackConfigDAL,
     slackIntegrationDAL,
-    projectTemplateService
+    projectTemplateService,
+    groupProjectDAL
   });
 
   const projectEnvService = projectEnvServiceFactory({


### PR DESCRIPTION
# Description 📣

This PR fixes project delete failing due to multiple reasons
1. When project delete triggers a cascade, the project role table is tried to delete. But this causes the project group and user table to throw a foreign key error.
2. When the same secret manager key id is in two projects, causes foreign key error. Happened due to project split.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->