### PR TITLE
feat: updated ui validation for env to 64 like api

### DIFF
--- a/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
@@ -19,7 +19,7 @@ const schema = z.object({
   environmentName: z
     .string()
     .min(1, { message: "Environment Name field must be at least 1 character" }),
-  environmentSlug: slugSchema()
+  environmentSlug: slugSchema({ max: 64 })
 });
 
 export type FormData = z.infer<typeof schema>;

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/UpdateEnvironmentModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/UpdateEnvironmentModal.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const schema = z.object({
   name: z.string(),
-  slug: slugSchema({ min: 1 })
+  slug: slugSchema({ min: 1, max: 64 })
 });
 
 export type FormData = z.infer<typeof schema>;


### PR DESCRIPTION
# Description 📣

Our backend API env router has env slug max length as `64`. It seems for some reason frontend is validating it as `32` max. 

Updated to `64`

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->