### PR TITLE
fix: approvals triggering for personal secrets

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -288,7 +288,12 @@ export const SecretListView = ({
         text: "Failed to delete secret"
       });
     }
-  }, [(popUp.deleteSecret?.data as SecretV3RawSanitized)?.key, environment, secretPath]);
+  }, [
+    (popUp.deleteSecret?.data as SecretV3RawSanitized)?.key,
+    environment,
+    secretPath,
+    isProtectedBranch
+  ]);
 
   // for optimization on minimise re-rendering of secret items
   const onCreateTag = useCallback(() => handlePopUpOpen("createTag"), []);

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -180,10 +180,12 @@ export const SecretListView = ({
 
       try {
         // personal secret change
+        let personalAction = false;
         if (overrideAction === "deleted") {
           await handleSecretOperation("delete", SecretType.Personal, oldKey, {
             secretId: orgSecret.idOverride
           });
+          personalAction = true;
         } else if (overrideAction && idOverride) {
           await handleSecretOperation("update", SecretType.Personal, oldKey, {
             value: valueOverride,
@@ -191,14 +193,16 @@ export const SecretListView = ({
             secretId: orgSecret.idOverride,
             skipMultilineEncoding: modSecret.skipMultilineEncoding
           });
+          personalAction = true;
         } else if (overrideAction) {
           await handleSecretOperation("create", SecretType.Personal, oldKey, {
             value: valueOverride
           });
+          personalAction = true;
         }
 
         // shared secret change
-        if (!isSharedSecUnchanged) {
+        if (!isSharedSecUnchanged && !personalAction) {
           await handleSecretOperation("update", SecretType.Shared, oldKey, {
             value,
             tags: tagIds,
@@ -232,10 +236,11 @@ export const SecretListView = ({
         });
         handlePopUpClose("secretDetail");
         createNotification({
-          type: isProtectedBranch ? "info" : "success",
-          text: isProtectedBranch
-            ? "Requested changes have been sent for review"
-            : "Successfully saved secrets"
+          type: isProtectedBranch && !personalAction ? "info" : "success",
+          text:
+            isProtectedBranch && !personalAction
+              ? "Requested changes have been sent for review"
+              : "Successfully saved secrets"
         });
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
# Description 📣

When updating a personal secret, it was triggering an update for shared secrets as well. This was purely a frontend issue, and no changes were needed on the backend. It was sending out multiple requests, one for personal and one for shared. In reality it's only supposed to send a request to update the personal secret. 



## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->