### PR TITLE
feat(audit-logs): query by secret path

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -39,11 +39,13 @@ export const auditLogDALFactory = (db: TDbClient) => {
       offset = 0,
       actorId,
       actorType,
+      secretPath,
       eventType,
       eventMetadata
     }: Omit<TFindQuery, "actor" | "eventType"> & {
       actorId?: string;
       actorType?: ActorType;
+      secretPath?: string;
       eventType?: EventType[];
       eventMetadata?: Record<string, string>;
     },
@@ -86,6 +88,10 @@ export const auditLogDALFactory = (db: TDbClient) => {
         Object.entries(eventMetadata).forEach(([key, value]) => {
           void sqlQuery.whereRaw(`"eventMetadata" @> jsonb_build_object(?::text, ?::text)`, [key, value]);
         });
+      }
+
+      if (projectId && secretPath) {
+        void sqlQuery.whereRaw(`"eventMetadata" @> jsonb_build_object('secretPath', ?::text)`, [secretPath]);
       }
 
       // Filter by actor type

--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -46,10 +46,6 @@ export const auditLogServiceFactory = ({
         actorOrgId
       );
 
-      /**
-       * NOTE (dangtony98): Update this to organization-level audit log permission check once audit logs are moved
-       * to the organization level ✅
-       */
       ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.AuditLogs);
     }
 
@@ -64,6 +60,7 @@ export const auditLogServiceFactory = ({
       actorId: filter.auditLogActorId,
       actorType: filter.actorType,
       eventMetadata: filter.eventMetadata,
+      secretPath: filter.secretPath,
       ...(filter.projectId ? { projectId: filter.projectId } : { orgId: actorOrgId })
     });
 

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -32,6 +32,7 @@ export type TListProjectAuditLogDTO = {
     projectId?: string;
     auditLogActorId?: string;
     actorType?: ActorType;
+    secretPath?: string;
     eventMetadata?: Record<string, string>;
   };
 } & Omit<TProjectPermission, "projectId">;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -828,6 +828,8 @@ export const AUDIT_LOGS = {
     projectId:
       "Optionally filter logs by project ID. If not provided, logs from the entire organization will be returned.",
     eventType: "The type of the event to export.",
+    secretPath:
+      "The path of the secret to query audit logs for. Note that the projectId parameter must also be provided.",
     userAgentType: "Choose which consuming application to export audit logs for.",
     eventMetadata:
       "Filter by event metadata key-value pairs. Formatted as `key1=value1,key2=value2`, with comma-separation.",

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/db/schemas";
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { AUDIT_LOGS, ORGANIZATIONS } from "@app/lib/api-docs";
-import { getLastMidnightDateISO } from "@app/lib/fn";
+import { getLastMidnightDateISO, removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -113,6 +113,12 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
       querystring: z.object({
         projectId: z.string().optional().describe(AUDIT_LOGS.EXPORT.projectId),
         actorType: z.nativeEnum(ActorType).optional(),
+        secretPath: z
+          .string()
+          .optional()
+          .transform((val) => (!val ? val : removeTrailingSlash(val)))
+          .describe(AUDIT_LOGS.EXPORT.secretPath),
+
         // eventType is split with , for multiple values, we need to transform it to array
         eventType: z
           .string()

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -10,6 +10,7 @@ export type TGetAuditLogsFilter = {
   actorType?: ActorType;
   projectId?: string;
   actor?: string; // user ID format
+  secretPath?: string;
   startDate?: Date;
   endDate?: Date;
   limit: number;

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuTrigger,
   FilterableSelect,
   FormControl,
+  Input,
   Select,
   SelectItem
 } from "@app/components/v2";
@@ -50,6 +51,7 @@ export const LogsFilter = ({
   className,
   control,
   reset,
+  setValue,
   watch
 }: Props) => {
   const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
@@ -101,6 +103,7 @@ export const LogsFilter = ({
   };
 
   const selectedEventTypes = watch("eventType") as EventType[] | undefined;
+  const selectedProjectId = watch("project")?.id;
 
   return (
     <div
@@ -109,30 +112,49 @@ export const LogsFilter = ({
         className
       )}
     >
-      {isOrgAuditLogs && workspacesInOrg.length > 0 && (
-        <Controller
-          control={control}
-          name="project"
-          render={({ field: { onChange, value }, fieldState: { error } }) => (
-            <FormControl
-              label="Project"
-              errorText={error?.message}
-              isError={Boolean(error)}
-              className="mr-12 w-64"
-            >
-              <FilterableSelect
-                value={value}
-                isClearable
-                onChange={onChange}
-                placeholder="Select a project..."
-                options={workspacesInOrg.map(({ name, id }) => ({ name, id }))}
-                getOptionValue={(option) => option.id}
-                getOptionLabel={(option) => option.name}
-              />
-            </FormControl>
-          )}
-        />
-      )}
+      <div className="flex items-center gap-4">
+        {isOrgAuditLogs && workspacesInOrg.length > 0 && (
+          <Controller
+            control={control}
+            name="project"
+            render={({ field: { onChange, value }, fieldState: { error } }) => (
+              <FormControl
+                label="Project"
+                errorText={error?.message}
+                isError={Boolean(error)}
+                className="w-64"
+              >
+                <FilterableSelect
+                  value={value}
+                  isClearable
+                  onChange={(e) => {
+                    console.log(e);
+                    if (e === null) {
+                      setValue("secretPath", "");
+                    }
+                    onChange(e);
+                  }}
+                  placeholder="Select a project..."
+                  options={workspacesInOrg.map(({ name, id }) => ({ name, id }))}
+                  getOptionValue={(option) => option.id}
+                  getOptionLabel={(option) => option.name}
+                />
+              </FormControl>
+            )}
+          />
+        )}
+        {selectedProjectId && (
+          <Controller
+            control={control}
+            name="secretPath"
+            render={({ field: { onChange, value, ...field } }) => (
+              <FormControl label="Secret path" className="w-40">
+                <Input {...field} value={value} onChange={(e) => onChange(e.target.value)} />
+              </FormControl>
+            )}
+          />
+        )}
+      </div>
       <div className="mt-1 flex items-center space-x-2">
         <Controller
           control={control}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -23,6 +23,7 @@ import { useGetAuditLogActorFilterOpts, useGetUserWorkspaces } from "@app/hooks/
 import { eventToNameMap, userAgentTTypeoNameMap } from "@app/hooks/api/auditLogs/constants";
 import { ActorType, EventType } from "@app/hooks/api/auditLogs/enums";
 import { Actor } from "@app/hooks/api/auditLogs/types";
+import { ProjectType } from "@app/hooks/api/workspace/types";
 
 import { AuditLogFilterFormData } from "./types";
 
@@ -103,7 +104,7 @@ export const LogsFilter = ({
   };
 
   const selectedEventTypes = watch("eventType") as EventType[] | undefined;
-  const selectedProjectId = watch("project")?.id;
+  const selectedProject = watch("project");
 
   return (
     <div
@@ -134,7 +135,7 @@ export const LogsFilter = ({
                     onChange(e);
                   }}
                   placeholder="Select a project..."
-                  options={workspacesInOrg.map(({ name, id }) => ({ name, id }))}
+                  options={workspacesInOrg.map(({ name, id, type }) => ({ name, id, type }))}
                   getOptionValue={(option) => option.id}
                   getOptionLabel={(option) => option.name}
                 />
@@ -142,7 +143,7 @@ export const LogsFilter = ({
             )}
           />
         )}
-        {selectedProjectId && (
+        {selectedProject?.type === ProjectType.SecretManager && (
           <Controller
             control={control}
             name="secretPath"

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -128,7 +128,6 @@ export const LogsFilter = ({
                   value={value}
                   isClearable
                   onChange={(e) => {
-                    console.log(e);
                     if (e === null) {
                       setValue("secretPath", "");
                     }

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { OrgPermissionActions, OrgPermissionSubjects, useSubscription } from "@app/context";
 import { withPermission } from "@app/hoc";
+import { useDebounce } from "@app/hooks";
 import { ActorType, EventType, UserAgentType } from "@app/hooks/api/auditLogs/enums";
 import { usePopUp } from "@app/hooks/usePopUp";
 
@@ -67,9 +68,12 @@ export const LogsSection = withPermission(
     const userAgentType = watch("userAgentType") as UserAgentType | undefined;
     const actor = watch("actor");
     const projectId = watch("project")?.id;
+    const secretPath = watch("secretPath");
 
     const startDate = watch("startDate");
     const endDate = watch("endDate");
+
+    const [debouncedSecretPath] = useDebounce<string>(secretPath!, 500);
 
     return (
       <div>
@@ -90,6 +94,7 @@ export const LogsSection = withPermission(
           isOrgAuditLogs={isOrgAuditLogs}
           showActorColumn={!!showActorColumn}
           filter={{
+            secretPath: debouncedSecretPath || undefined,
             eventMetadata: presets?.eventMetadata,
             projectId,
             actorType: presets?.actorType,

--- a/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
@@ -9,11 +9,11 @@ export const auditLogFilterFormSchema = z
     eventType: z.nativeEnum(EventType).array(),
     actor: z.string().optional(),
     userAgentType: z.nativeEnum(UserAgentType),
+    secretPath: z.string().optional(),
     startDate: z.date().optional(),
     endDate: z.date().optional(),
     page: z.coerce.number().optional(),
-    perPage: z.coerce.number().optional(),
-    secretPath: z.string().optional()
+    perPage: z.coerce.number().optional()
   })
   .superRefine((el, ctx) => {
     if (el.endDate && el.startDate && el.endDate < el.startDate) {

--- a/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
@@ -12,7 +12,8 @@ export const auditLogFilterFormSchema = z
     startDate: z.date().optional(),
     endDate: z.date().optional(),
     page: z.coerce.number().optional(),
-    perPage: z.coerce.number().optional()
+    perPage: z.coerce.number().optional(),
+    secretPath: z.string().optional()
   })
   .superRefine((el, ctx) => {
     if (el.endDate && el.startDate && el.endDate < el.startDate) {

--- a/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
@@ -1,11 +1,15 @@
 import { z } from "zod";
 
 import { EventType, UserAgentType } from "@app/hooks/api/auditLogs/enums";
+import { ProjectType } from "@app/hooks/api/workspace/types";
 
 export const auditLogFilterFormSchema = z
   .object({
     eventMetadata: z.object({}).optional(),
-    project: z.object({ id: z.string(), name: z.string() }).optional().nullable(),
+    project: z
+      .object({ id: z.string(), name: z.string(), type: z.nativeEnum(ProjectType) })
+      .optional()
+      .nullable(),
     eventType: z.nativeEnum(EventType).array(),
     actor: z.string().optional(),
     userAgentType: z.nativeEnum(UserAgentType),


### PR DESCRIPTION
# Description 📣

This PR adds the ability to query audit logs by secret path. The user will need to select a project first, and then they can query by secret path.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->