### PR TITLE
Improve Visibility and Alignment of Tooltips and Copy Secret Key Icon

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
@@ -195,7 +195,7 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
                       ariaLabel="copy-value"
                       variant="plain"
                       size="sm"
-                      className="p-0 opacity-0 group-hover:opacity-100"
+                      className="p-0 opacity-100"
                       onClick={copyTokenToClipboard}
                     >
                       <FontAwesomeIcon icon={isSecNameCopied ? faCheck : faCopy} />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
@@ -189,17 +189,19 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: 10, opacity: 0 }}
               >
-                <Tooltip content="Copy secret name">
-                  <IconButton
-                    ariaLabel="copy-value"
-                    variant="plain"
-                    size="sm"
-                    className="p-0 opacity-0 group-hover:opacity-100"
-                    onClick={copyTokenToClipboard}
-                  >
-                    <FontAwesomeIcon icon={isSecNameCopied ? faCheck : faCopy} />
-                  </IconButton>
-                </Tooltip>
+                <div className="relative">
+                  <Tooltip content="Copy secret name">
+                    <IconButton
+                      ariaLabel="copy-value"
+                      variant="plain"
+                      size="sm"
+                      className="p-0 opacity-0 group-hover:opacity-100"
+                      onClick={copyTokenToClipboard}
+                    >
+                      <FontAwesomeIcon icon={isSecNameCopied ? faCheck : faCopy} />
+                    </IconButton>
+                  </Tooltip>
+                </div>
               </motion.div>
             ) : (
               <motion.div
@@ -209,44 +211,48 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
                 animate={{ x: 0, opacity: 1 }}
                 exit={{ x: -10, opacity: 0 }}
               >
-                <Tooltip content={errors.key ? errors.key.message : "Save"}>
-                  <IconButton
-                    ariaLabel="more"
-                    variant="plain"
-                    type="submit"
-                    size="md"
-                    className={twMerge(
-                      "p-0 text-primary opacity-0 group-hover:opacity-100",
-                      isDirty && "opacity-100"
-                    )}
-                    isDisabled={isSubmitting || Boolean(errors.key)}
-                  >
-                    {isSubmitting ? (
-                      <Spinner className="m-0 h-4 w-4 p-0" />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faCheck}
-                        size="lg"
-                        className={twMerge("text-primary", errors.key && "text-mineshaft-400")}
-                      />
-                    )}
-                  </IconButton>
-                </Tooltip>
-                <Tooltip content="Cancel">
-                  <IconButton
-                    ariaLabel="more"
-                    variant="plain"
-                    size="md"
-                    className={twMerge(
-                      "p-0 opacity-0 group-hover:opacity-100",
-                      isDirty && "opacity-100"
-                    )}
-                    onClick={() => reset()}
-                    isDisabled={isSubmitting}
-                  >
-                    <FontAwesomeIcon icon={faClose} size="lg" />
-                  </IconButton>
-                </Tooltip>
+                <div className="relative">
+                  <Tooltip content={errors.key ? errors.key.message : "Save"}>
+                    <IconButton
+                      ariaLabel="more"
+                      variant="plain"
+                      type="submit"
+                      size="md"
+                      className={twMerge(
+                        "p-0 text-primary opacity-0 group-hover:opacity-100",
+                        isDirty && "opacity-100"
+                      )}
+                      isDisabled={isSubmitting || Boolean(errors.key)}
+                    >
+                      {isSubmitting ? (
+                        <Spinner className="m-0 h-4 w-4 p-0" />
+                      ) : (
+                        <FontAwesomeIcon
+                          icon={faCheck}
+                          size="lg"
+                          className={twMerge("text-primary", errors.key && "text-mineshaft-400")}
+                        />
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                </div>
+                <div className="relative">
+                  <Tooltip content="Cancel">
+                    <IconButton
+                      ariaLabel="more"
+                      variant="plain"
+                      size="md"
+                      className={twMerge(
+                        "p-0 opacity-0 group-hover:opacity-100",
+                        isDirty && "opacity-100"
+                      )}
+                      onClick={() => reset()}
+                      isDisabled={isSubmitting}
+                    >
+                      <FontAwesomeIcon icon={faClose} size="lg" />
+                    </IconButton>
+                  </Tooltip>
+                </div>
               </motion.div>
             )}
           </AnimatePresence>


### PR DESCRIPTION
# Description 📣

issue: #3047 

In this PR, I updated two things. The first is to make the `Copy Secret Key` icon visible at all times instead of only on hover. I think this will improve usability, being a user myself, I didn't know this would happen until I accidentally hovered over it. In addition, I noticed that the tooltips were not inline with the Copy icon, and when you change the secret name, the Save and Cancel icon tooltips were also not aligned.

### Changes made in `SecretRenameRow.tsx`
In line 198, I simply changed the opacity to 100 and removed the hover property.
I addressed the alignment issue by wrapping each Tooltip with a `div` that has the `relative` property, which fixed the offset bug.



## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

I tested my changes by running the dev environment and making sure that the tooltips were centered over the icons. I also resized the window width to ensure that they didn't revert back to being offset.

## Note
If you believe that the `Copy Secret Key` icon should only show up on hover, please inform me, and I can change it back to how it was previously.
	
- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->