### PR TITLE
feat(integrations/vercel): custom environments support

### DIFF
--- a/backend/src/server/routes/v1/integration-auth-router.ts
+++ b/backend/src/server/routes/v1/integration-auth-router.ts
@@ -1153,6 +1153,50 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
 
   server.route({
     method: "GET",
+    url: "/:integrationAuthId/vercel/custom-environments",
+    config: {
+      rateLimit: readLimit
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    schema: {
+      querystring: z.object({
+        teamId: z.string().trim()
+      }),
+      params: z.object({
+        integrationAuthId: z.string().trim()
+      }),
+      response: {
+        200: z.object({
+          environments: z
+            .object({
+              appId: z.string(),
+              customEnvironments: z
+                .object({
+                  id: z.string(),
+                  slug: z.string()
+                })
+                .array()
+            })
+            .array()
+        })
+      }
+    },
+    handler: async (req) => {
+      const environments = await server.services.integrationAuth.getVercelCustomEnvironments({
+        actorId: req.permission.id,
+        actor: req.permission.type,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        id: req.params.integrationAuthId,
+        teamId: req.query.teamId
+      });
+
+      return { environments };
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/:integrationAuthId/octopus-deploy/spaces",
     config: {
       rateLimit: readLimit

--- a/backend/src/services/integration-auth/integration-app-list.ts
+++ b/backend/src/services/integration-auth/integration-app-list.ts
@@ -180,10 +180,6 @@ export const getAppsVercel = async ({ accessToken, teamId }: { teamId?: string |
       }
     });
 
-    for (const project of data.projects) {
-      console.log(project.customEnvironments);
-    }
-
     data.projects.forEach((a) => {
       apps.push({
         name: a.name,

--- a/backend/src/services/integration-auth/integration-app-list.ts
+++ b/backend/src/services/integration-auth/integration-app-list.ts
@@ -132,16 +132,26 @@ const getAppsHeroku = async ({ accessToken }: { accessToken: string }) => {
 
 /**
  * Return list of names of apps for Vercel integration
+ * This is re-used for getting custom environments for Vercel
  */
-const getAppsVercel = async ({ accessToken, teamId }: { teamId?: string | null; accessToken: string }) => {
-  const apps: Array<{ name: string; appId: string }> = [];
+export const getAppsVercel = async ({ accessToken, teamId }: { teamId?: string | null; accessToken: string }) => {
+  const apps: Array<{ name: string; appId: string; customEnvironments: Array<{ slug: string; id: string }> }> = [];
 
   const limit = "20";
   let hasMorePages = true;
   let next: number | null = null;
 
   interface Response {
-    projects: { name: string; id: string }[];
+    projects: {
+      name: string;
+      id: string;
+      customEnvironments?: {
+        id: string;
+        type: string;
+        description: string;
+        slug: string;
+      }[];
+    }[];
     pagination: {
       count: number;
       next: number | null;
@@ -170,10 +180,19 @@ const getAppsVercel = async ({ accessToken, teamId }: { teamId?: string | null; 
       }
     });
 
+    for (const project of data.projects) {
+      console.log(project.customEnvironments);
+    }
+
     data.projects.forEach((a) => {
       apps.push({
         name: a.name,
-        appId: a.id
+        appId: a.id,
+        customEnvironments:
+          a.customEnvironments?.map((env) => ({
+            slug: env.slug,
+            id: env.id
+          })) ?? []
       });
     });
 

--- a/backend/src/services/integration-auth/integration-auth-types.ts
+++ b/backend/src/services/integration-auth/integration-auth-types.ts
@@ -284,3 +284,8 @@ export type TOctopusDeployVariableSet = {
     Self: string;
   };
 };
+
+export type GetVercelCustomEnvironmentsDTO = {
+  teamId: string;
+  id: string;
+} & Omit<TProjectPermission, "projectId">;

--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -1636,7 +1636,7 @@ const syncSecretsVercel = async ({
                 }
               : {
                   customEnvironmentIds: res[key].customEnvironmentIds?.includes(integration.targetEnvironment as string)
-                    ? [...res[key].customEnvironmentIds]
+                    ? [...(res[key].customEnvironmentIds || [])]
                     : [...(res[key]?.customEnvironmentIds || []), integration.targetEnvironment as string]
                 }),
 

--- a/backend/src/services/integration-auth/integration-token.ts
+++ b/backend/src/services/integration-auth/integration-token.ts
@@ -5,7 +5,6 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError, ForbiddenRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 
 import { Integrations, IntegrationUrls } from "./integration-list";
-import { AxiosError } from "axios";
 
 type ExchangeCodeAzureResponse = {
   token_type: string;
@@ -198,22 +197,15 @@ const exchangeCodeVercel = async ({ code }: { code: string }) => {
   }
 
   const res = (
-    await request
-      .post<ExchangeCodeVercelResponse>(
-        IntegrationUrls.VERCEL_TOKEN_URL,
-        new URLSearchParams({
-          code,
-          client_id: appCfg.CLIENT_ID_VERCEL,
-          client_secret: appCfg.CLIENT_SECRET_VERCEL,
-          redirect_uri: `${appCfg.SITE_URL}/integrations/vercel/oauth2/callback`
-        })
-      )
-      .catch((e) => {
-        if (e instanceof AxiosError) {
-          console.log(e.response?.data);
-        }
-        throw e;
+    await request.post<ExchangeCodeVercelResponse>(
+      IntegrationUrls.VERCEL_TOKEN_URL,
+      new URLSearchParams({
+        code,
+        client_id: appCfg.CLIENT_ID_VERCEL,
+        client_secret: appCfg.CLIENT_SECRET_VERCEL,
+        redirect_uri: `${appCfg.SITE_URL}/integrations/vercel/oauth2/callback`
       })
+    )
   ).data;
 
   return {

--- a/backend/src/services/integration-auth/integration-token.ts
+++ b/backend/src/services/integration-auth/integration-token.ts
@@ -5,6 +5,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError, ForbiddenRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 
 import { Integrations, IntegrationUrls } from "./integration-list";
+import { AxiosError } from "axios";
 
 type ExchangeCodeAzureResponse = {
   token_type: string;
@@ -197,15 +198,22 @@ const exchangeCodeVercel = async ({ code }: { code: string }) => {
   }
 
   const res = (
-    await request.post<ExchangeCodeVercelResponse>(
-      IntegrationUrls.VERCEL_TOKEN_URL,
-      new URLSearchParams({
-        code,
-        client_id: appCfg.CLIENT_ID_VERCEL,
-        client_secret: appCfg.CLIENT_SECRET_VERCEL,
-        redirect_uri: `${appCfg.SITE_URL}/integrations/vercel/oauth2/callback`
+    await request
+      .post<ExchangeCodeVercelResponse>(
+        IntegrationUrls.VERCEL_TOKEN_URL,
+        new URLSearchParams({
+          code,
+          client_id: appCfg.CLIENT_ID_VERCEL,
+          client_secret: appCfg.CLIENT_SECRET_VERCEL,
+          redirect_uri: `${appCfg.SITE_URL}/integrations/vercel/oauth2/callback`
+        })
+      )
+      .catch((e) => {
+        if (e instanceof AxiosError) {
+          console.log(e.response?.data);
+        }
+        throw e;
       })
-    )
   ).data;
 
   return {

--- a/frontend/src/hooks/api/integrationAuth/index.tsx
+++ b/frontend/src/hooks/api/integrationAuth/index.tsx
@@ -16,5 +16,6 @@ export {
   useGetIntegrationAuthTeamCityBuildConfigs,
   useGetIntegrationAuthTeams,
   useGetIntegrationAuthVercelBranches,
+  useGetIntegrationAuthVercelCustomEnvironments,
   useSaveIntegrationAccessToken
 } from "./queries";

--- a/frontend/src/hooks/api/integrationAuth/types.ts
+++ b/frontend/src/hooks/api/integrationAuth/types.ts
@@ -43,6 +43,11 @@ export type Environment = {
   environmentId: string;
 };
 
+export type VercelEnvironment = {
+  id: string;
+  slug: string;
+};
+
 export type ChecklyGroup = {
   name: string;
   groupId: number;

--- a/frontend/src/pages/secret-manager/integrations/VercelConfigurePage/VercelConfigurePage.tsx
+++ b/frontend/src/pages/secret-manager/integrations/VercelConfigurePage/VercelConfigurePage.tsx
@@ -164,8 +164,6 @@ export const VercelConfigurePage = () => {
     return selectedEnvironments;
   }, [targetAppId, customEnvironments]);
 
-  console.log("selectedVercelEnvironments", selectedVercelEnvironments);
-
   return integrationAuth &&
     selectedSourceEnvironment &&
     integrationAuthApps &&

--- a/frontend/src/pages/secret-manager/integrations/VercelConfigurePage/VercelConfigurePage.tsx
+++ b/frontend/src/pages/secret-manager/integrations/VercelConfigurePage/VercelConfigurePage.tsx
@@ -142,9 +142,6 @@ export const VercelConfigurePage = () => {
   };
 
   const selectedVercelEnvironments = useMemo(() => {
-    // Structure looks like:
-    // {appId: string, environments: [{id: string, name: string}]}[]
-
     let selectedEnvironments = vercelEnvironments;
 
     const environments = customEnvironments?.find(
@@ -240,12 +237,11 @@ export const VercelConfigurePage = () => {
           <Select
             value={targetAppId}
             onValueChange={(val) => {
-              setTargetAppId(val);
-
-              // Reset the target environment if it's not a default environment
               if (vercelEnvironments.every((env) => env.slug !== targetEnvironment)) {
                 setTargetEnvironment(vercelEnvironments[0].slug);
               }
+
+              setTargetAppId(val);
             }}
             className="w-full border border-mineshaft-500"
             isDisabled={integrationAuthApps.length === 0}


### PR DESCRIPTION
# Description 📣

This PR aims to add support for custom environments for our Vercel Integration. Previously, the user wasn't able to select custom environments. The sync logic is slightly different for custom environments, requiring the usage of the `customEnvironmentIds` field.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->