### PR TITLE
k8s: bug fixes and better prints

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.8.7
+version: v0.8.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.7"
+appVersion: "v0.8.8"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
           - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.8.7
+      tag: v0.8.8
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/controllers/infisicalsecret/conditions.go
+++ b/k8-operator/controllers/infisicalsecret/conditions.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *InfisicalSecretReconciler) SetReadyToSyncSecretsConditions(ctx context.Context, infisicalSecret *v1alpha1.InfisicalSecret, errorToConditionOn error) error {
+func (r *InfisicalSecretReconciler) SetReadyToSyncSecretsConditions(ctx context.Context, infisicalSecret *v1alpha1.InfisicalSecret, secretsCount int, errorToConditionOn error) error {
 	if infisicalSecret.Status.Conditions == nil {
 		infisicalSecret.Status.Conditions = []metav1.Condition{}
 	}
@@ -35,7 +35,7 @@ func (r *InfisicalSecretReconciler) SetReadyToSyncSecretsConditions(ctx context.
 			Type:    "secrets.infisical.com/ReadyToSyncSecrets",
 			Status:  metav1.ConditionTrue,
 			Reason:  "OK",
-			Message: "Infisical controller has started syncing your secrets",
+			Message: fmt.Sprintf("Infisical controller has started syncing your secrets. Last reconcile synced %d secrets", secretsCount),
 		})
 	}
 


### PR DESCRIPTION
# Description 📣

This PR contains a few fixes for the K8's operator.

1. InfisicalSecret CRD now prints the amount of secrets that were synced.
   2. Example output: `Successfully synced 5 secrets. Operator will requeue after [10s]`
   3. This is also added to the successful sync status condition.
2. Fixed the InfisicalSecret CRD trying to reconcile when condition status's are updated. This was causing the operator to requeue far more often than necessary. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->