### PR TITLE
feat(api): list secrets filter by metadata

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -688,7 +688,9 @@ export const RAW_SECRETS = {
     environment: "The slug of the environment to list secrets from.",
     secretPath: "The secret path to list secrets from.",
     includeImports: "Weather to include imported secrets or not.",
-    tagSlugs: "The comma separated tag slugs to filter secrets."
+    tagSlugs: "The comma separated tag slugs to filter secrets.",
+    secretMetadata:
+      "The secret metadata key-value pairs to filter secrets by. When querying for multiple metadata pairs, the query is treated as an AND operation. Secret metadata format is key1:value1,key2:value2."
   },
   CREATE: {
     secretName: "The name of the secret to create.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -689,8 +689,8 @@ export const RAW_SECRETS = {
     secretPath: "The secret path to list secrets from.",
     includeImports: "Weather to include imported secrets or not.",
     tagSlugs: "The comma separated tag slugs to filter secrets.",
-    secretMetadata:
-      "The secret metadata key-value pairs to filter secrets by. When querying for multiple metadata pairs, the query is treated as an AND operation. Secret metadata format is key1:value1,key2:value2."
+    metadataFilter:
+      "The secret metadata key-value pairs to filter secrets by. When querying for multiple metadata pairs, the query is treated as an AND operation. Secret metadata format is key=value1,value=value2|key=value3,value=value4."
   },
   CREATE: {
     secretName: "The name of the secret to create.",

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -181,7 +181,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         }
       ],
       querystring: z.object({
-        secretMetadata: z
+        metadataFilter: z
           .string()
           .optional()
           .transform((val) => {
@@ -343,7 +343,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         actorAuthMethod: req.permission.authMethod,
         projectId: workspaceId,
         path: secretPath,
-        secretMetadata: req.query.secretMetadata,
+        secretMetadata: req.query.metadataFilter,
         includeImports: req.query.include_imports,
         recursive: req.query.recursive,
         tagSlugs: req.query.tagSlugs

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -343,7 +343,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         actorAuthMethod: req.permission.authMethod,
         projectId: workspaceId,
         path: secretPath,
-        secretMetadata: req.query.metadataFilter,
+        metadataFilter: req.query.metadataFilter,
         includeImports: req.query.include_imports,
         recursive: req.query.recursive,
         tagSlugs: req.query.tagSlugs

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -216,7 +216,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
             if (metadata && !Array.isArray(metadata)) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
-                message: "Invalid secretMetadata format. Correct format is key1:value1,key2:value2"
+                message:
+                  "Invalid secretMetadata format. Correct format is key=value1,value=value2|key=value3,value=value4."
               });
             }
 
@@ -233,13 +234,13 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
                   ctx.addIssue({
                     code: z.ZodIssueCode.custom,
                     message:
-                      "Invalid secretMetadata format, key or value must be provided. Correct format is key1:value1,key2:value2"
+                      "Invalid secretMetadata format, key or value must be provided. Correct format is key=value1,value=value2|key=value3,value=value4."
                   });
                 }
               }
             }
           })
-          .describe(RAW_SECRETS.LIST.secretMetadata),
+          .describe(RAW_SECRETS.LIST.metadataFilter),
         workspaceId: z.string().trim().optional().describe(RAW_SECRETS.LIST.workspaceId),
         workspaceSlug: z.string().trim().optional().describe(RAW_SECRETS.LIST.workspaceSlug),
         environment: z.string().trim().optional().describe(RAW_SECRETS.LIST.environment),

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -188,32 +188,29 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
             if (!val) return undefined;
 
             const result: { key?: string; value?: string }[] = [];
-            const pairs = val.split(",");
+            const pairs = val.split("|");
 
             for (const pair of pairs) {
-              const pairResult: { key?: string; value?: string } = {};
-              const parts = pair.split(/[:=]/).map((part) => part.trim());
+              const keyValuePair: { key?: string; value?: string } = {};
+              const parts = pair.split(/[,=]/);
 
-              for (let i = 0; i < parts.length - 1; i += 1) {
-                const current = parts[i].toLowerCase();
-                const next = parts[i + 1];
+              for (let i = 0; i < parts.length; i += 2) {
+                const identifier = parts[i].trim().toLowerCase();
+                const value = parts[i + 1]?.trim();
 
-                if (current === "key" && next) {
-                  pairResult.key = next;
-                } else if (current === "value" && next) {
-                  pairResult.value = next;
+                if (identifier === "key" && value) {
+                  keyValuePair.key = value;
+                } else if (identifier === "value" && value) {
+                  keyValuePair.value = value;
                 }
               }
 
-              // Only add pair if at least one of key or value is present
-              if (pairResult.key || pairResult.value) {
-                result.push(pairResult);
+              if (keyValuePair.key && keyValuePair.value) {
+                result.push(keyValuePair);
               }
             }
 
-            if (!result.length) return undefined;
-
-            return result;
+            return result.length ? result : undefined;
           })
           .superRefine((metadata, ctx) => {
             if (metadata && !Array.isArray(metadata)) {

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -194,16 +194,23 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
 
             return metadata;
           })
-          .superRefine((el, ctx) => {
-            if (el && !Array.isArray(el)) {
+          .superRefine((metadata, ctx) => {
+            if (metadata && !Array.isArray(metadata)) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 message: "Invalid secretMetadata format. Correct format is key1:value1,key2:value2"
               });
             }
 
-            if (el) {
-              for (const item of el) {
+            if (metadata) {
+              if (metadata.length > 10) {
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: "You can only filter by up to 10 metadata fields"
+                });
+              }
+
+              for (const item of metadata) {
                 if (!item.key || !item.value) {
                   ctx.addIssue({
                     code: z.ZodIssueCode.custom,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -414,18 +414,12 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           `${TableName.SecretTag}.id`
         )
         .leftJoin(TableName.ResourceMetadata, `${TableName.SecretV2}.id`, `${TableName.ResourceMetadata}.secretId`)
-        .where((bd) => {
-          if (filters?.secretMetadata && filters.secretMetadata?.length > 0) {
+        .where((qb) => {
+          if (filters?.secretMetadata && filters.secretMetadata.length > 0) {
             filters.secretMetadata.forEach((meta) => {
-              void bd.whereExists((qb) => {
-                void qb
-                  .select("secretId")
-                  .from(TableName.ResourceMetadata)
-                  .whereRaw(`"${TableName.ResourceMetadata}"."secretId" = "${TableName.SecretV2}"."id"`)
-                  .where({
-                    [`${TableName.ResourceMetadata}.key` as string]: meta.key,
-                    [`${TableName.ResourceMetadata}.value` as string]: meta.value
-                  });
+              void qb.where({
+                [`${TableName.ResourceMetadata}.key` as string]: meta.key,
+                [`${TableName.ResourceMetadata}.value` as string]: meta.value
               });
             });
           }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -418,8 +418,8 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           if (filters?.secretMetadata && filters.secretMetadata.length > 0) {
             filters.secretMetadata.forEach((meta) => {
               void qb.where({
-                [`${TableName.ResourceMetadata}.key` as string]: meta.key,
-                [`${TableName.ResourceMetadata}.value` as string]: meta.value
+                ...(meta.key ? { [`${TableName.ResourceMetadata}.key` as string]: meta.key } : {}),
+                ...(meta.value ? { [`${TableName.ResourceMetadata}.value` as string]: meta.value } : {})
               });
             });
           }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -415,8 +415,8 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
         )
         .leftJoin(TableName.ResourceMetadata, `${TableName.SecretV2}.id`, `${TableName.ResourceMetadata}.secretId`)
         .where((qb) => {
-          if (filters?.secretMetadata && filters.secretMetadata.length > 0) {
-            filters.secretMetadata.forEach((meta) => {
+          if (filters?.metadataFilter && filters.metadataFilter.length > 0) {
+            filters.metadataFilter.forEach((meta) => {
               void qb.where({
                 ...(meta.key ? { [`${TableName.ResourceMetadata}.key` as string]: meta.key } : {}),
                 ...(meta.value ? { [`${TableName.ResourceMetadata}.value` as string]: meta.value } : {})

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -498,18 +498,6 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
         ]
       });
 
-      // if (secretMetadata) {
-      //   return data.filter((s) => {
-      //     if (!s.secretMetadata.length) return false;
-
-      //     return secretMetadata.every((m) => {
-      //       const secretMeta = s.secretMetadata.find((sm) => sm.key === m.key);
-      //       if (!secretMeta) return false;
-      //       return secretMeta.value === m.value;
-      //     });
-      //   });
-      // }
-
       return data;
     } catch (error) {
       throw new DatabaseError({ error, name: "get all secret" });

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -417,9 +417,13 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
         .where((qb) => {
           if (filters?.metadataFilter && filters.metadataFilter.length > 0) {
             filters.metadataFilter.forEach((meta) => {
-              void qb.where({
-                ...(meta.key ? { [`${TableName.ResourceMetadata}.key` as string]: meta.key } : {}),
-                ...(meta.value ? { [`${TableName.ResourceMetadata}.value` as string]: meta.value } : {})
+              void qb.whereExists((subQuery) => {
+                void subQuery
+                  .select("secretId")
+                  .from(TableName.ResourceMetadata)
+                  .whereRaw(`"${TableName.ResourceMetadata}"."secretId" = "${TableName.SecretV2}"."id"`)
+                  .where(`${TableName.ResourceMetadata}.key`, meta.key)
+                  .where(`${TableName.ResourceMetadata}.value`, meta.value);
               });
             });
           }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -30,6 +30,10 @@ export type TGetSecretsDTO = {
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
+  secretMetadata?: {
+    key: string;
+    value: string;
+  }[];
   orderBy?: SecretsOrderBy;
   orderDirection?: OrderByDirection;
   offset?: number;
@@ -310,6 +314,7 @@ export type TFindSecretsByFolderIdsFilter = {
   orderDirection?: OrderByDirection;
   search?: string;
   tagSlugs?: string[];
+  secretMetadata?: { key: string; value: string }[];
   includeTagsInSearch?: boolean;
   keys?: string[];
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -30,7 +30,7 @@ export type TGetSecretsDTO = {
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
-  secretMetadata?: {
+  metadataFilter?: {
     key?: string;
     value?: string;
   }[];
@@ -314,7 +314,7 @@ export type TFindSecretsByFolderIdsFilter = {
   orderDirection?: OrderByDirection;
   search?: string;
   tagSlugs?: string[];
-  secretMetadata?: { key?: string; value?: string }[];
+  metadataFilter?: { key?: string; value?: string }[];
   includeTagsInSearch?: boolean;
   keys?: string[];
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -31,8 +31,8 @@ export type TGetSecretsDTO = {
   recursive?: boolean;
   tagSlugs?: string[];
   secretMetadata?: {
-    key: string;
-    value: string;
+    key?: string;
+    value?: string;
   }[];
   orderBy?: SecretsOrderBy;
   orderDirection?: OrderByDirection;
@@ -314,7 +314,7 @@ export type TFindSecretsByFolderIdsFilter = {
   orderDirection?: OrderByDirection;
   search?: string;
   tagSlugs?: string[];
-  secretMetadata?: { key: string; value: string }[];
+  secretMetadata?: { key?: string; value?: string }[];
   includeTagsInSearch?: boolean;
   keys?: string[];
 };

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -1263,7 +1263,7 @@ export const secretServiceFactory = ({
         name: "bot_not_found_error"
       });
 
-    if (paramsV2.secretMetadata) {
+    if (paramsV2.metadataFilter) {
       throw new BadRequestError({
         message: "Please upgrade your project to filter secrets by metadata",
         name: "SecretMetadataNotSupported"

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -1263,6 +1263,13 @@ export const secretServiceFactory = ({
         name: "bot_not_found_error"
       });
 
+    if (paramsV2.secretMetadata) {
+      throw new BadRequestError({
+        message: "Please upgrade your project to filter secrets by metadata",
+        name: "SecretMetadataNotSupported"
+      });
+    }
+
     const { secrets, imports } = await getSecrets({
       actorId,
       projectId,

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -183,8 +183,8 @@ export type TGetSecretsRawDTO = {
   recursive?: boolean;
   tagSlugs?: string[];
   secretMetadata?: {
-    key: string;
-    value: string;
+    key?: string;
+    value?: string;
   }[];
   orderBy?: SecretsOrderBy;
   orderDirection?: OrderByDirection;

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -182,7 +182,7 @@ export type TGetSecretsRawDTO = {
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
-  secretMetadata?: {
+  metadataFilter?: {
     key?: string;
     value?: string;
   }[];

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -182,6 +182,10 @@ export type TGetSecretsRawDTO = {
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
+  secretMetadata?: {
+    key: string;
+    value: string;
+  }[];
   orderBy?: SecretsOrderBy;
   orderDirection?: OrderByDirection;
   offset?: number;


### PR DESCRIPTION
# Description 📣

This PR adds support for filtering secrets by their metadata. If multiple metadata fields are passed in, the operation will work as an `AND` operator, which means the secrets returned will match all the metadata fields.

The format for the `secretMetadata` query parameter is `key1:value1,key2:value2`.

The metadata filter is limited to max 10 metadata key-value pairs. This is to avoid overloading the backend, and to avoid bad actors passing into a list with millions of key-value pairs, which could result in a DoS attack.
```typescript
if (metadata.length > 10) {
                ctx.addIssue({
                  code: z.ZodIssueCode.custom,
                  message: "You can only filter by up to 10 metadata fields"
                });
              }
```

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->