### PR TITLE
feat: added validation for secret path in permission

### DIFF
--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -163,6 +163,30 @@ export type ProjectPermissionSet =
   | [ProjectPermissionActions.Create, ProjectPermissionSub.SecretRollback]
   | [ProjectPermissionActions.Edit, ProjectPermissionSub.Kms];
 
+const SECRET_PATH_MISSING_SLASH_ERR_MSG = "Invalid Secret Path; it must start with a '/'";
+const SECRET_PATH_PERMISSION_OPERATOR_SCHEMA = z.union([
+  z.string().refine((val) => val.startsWith("/"), SECRET_PATH_MISSING_SLASH_ERR_MSG),
+  z
+    .object({
+      [PermissionConditionOperators.$EQ]: PermissionConditionSchema[PermissionConditionOperators.$EQ].refine(
+        (val) => val.startsWith("/"),
+        SECRET_PATH_MISSING_SLASH_ERR_MSG
+      ),
+      [PermissionConditionOperators.$NEQ]: PermissionConditionSchema[PermissionConditionOperators.$NEQ].refine(
+        (val) => val.startsWith("/"),
+        SECRET_PATH_MISSING_SLASH_ERR_MSG
+      ),
+      [PermissionConditionOperators.$IN]: PermissionConditionSchema[PermissionConditionOperators.$IN].refine(
+        (val) => val.every((el) => el.startsWith("/")),
+        SECRET_PATH_MISSING_SLASH_ERR_MSG
+      ),
+      [PermissionConditionOperators.$GLOB]: PermissionConditionSchema[PermissionConditionOperators.$GLOB].refine(
+        (val) => val.startsWith("/"),
+        SECRET_PATH_MISSING_SLASH_ERR_MSG
+      )
+    })
+    .partial()
+]);
 // akhilmhdh: don't modify this for v2
 // if you want to update create a new schema
 const SecretConditionV1Schema = z
@@ -177,17 +201,7 @@ const SecretConditionV1Schema = z
         })
         .partial()
     ]),
-    secretPath: z.union([
-      z.string(),
-      z
-        .object({
-          [PermissionConditionOperators.$EQ]: PermissionConditionSchema[PermissionConditionOperators.$EQ],
-          [PermissionConditionOperators.$NEQ]: PermissionConditionSchema[PermissionConditionOperators.$NEQ],
-          [PermissionConditionOperators.$IN]: PermissionConditionSchema[PermissionConditionOperators.$IN],
-          [PermissionConditionOperators.$GLOB]: PermissionConditionSchema[PermissionConditionOperators.$GLOB]
-        })
-        .partial()
-    ])
+    secretPath: SECRET_PATH_PERMISSION_OPERATOR_SCHEMA
   })
   .partial();
 
@@ -204,17 +218,7 @@ const SecretConditionV2Schema = z
         })
         .partial()
     ]),
-    secretPath: z.union([
-      z.string(),
-      z
-        .object({
-          [PermissionConditionOperators.$EQ]: PermissionConditionSchema[PermissionConditionOperators.$EQ],
-          [PermissionConditionOperators.$NEQ]: PermissionConditionSchema[PermissionConditionOperators.$NEQ],
-          [PermissionConditionOperators.$IN]: PermissionConditionSchema[PermissionConditionOperators.$IN],
-          [PermissionConditionOperators.$GLOB]: PermissionConditionSchema[PermissionConditionOperators.$GLOB]
-        })
-        .partial()
-    ]),
+    secretPath: SECRET_PATH_PERMISSION_OPERATOR_SCHEMA,
     secretName: z.union([
       z.string(),
       z

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -180,10 +180,7 @@ const SECRET_PATH_PERMISSION_OPERATOR_SCHEMA = z.union([
         (val) => val.every((el) => el.startsWith("/")),
         SECRET_PATH_MISSING_SLASH_ERR_MSG
       ),
-      [PermissionConditionOperators.$GLOB]: PermissionConditionSchema[PermissionConditionOperators.$GLOB].refine(
-        (val) => val.startsWith("/"),
-        SECRET_PATH_MISSING_SLASH_ERR_MSG
-      )
+      [PermissionConditionOperators.$GLOB]: PermissionConditionSchema[PermissionConditionOperators.$GLOB]
     })
     .partial()
 ]);

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -82,7 +82,14 @@ const ConditionSchema = z
     { message: "Duplicate operator found for a condition" }
   )
   .refine(
-    (val) => val.filter((el) => el.lhs === "secretPath").every((el) => el.rhs.startsWith("/")),
+    (val) =>
+      val
+        .filter((el) => el.lhs === "secretPath")
+        .every((el) =>
+          el.operator === PermissionConditionOperators.$IN
+            ? el.rhs.split(",").every((i) => i.trim().startsWith("/"))
+            : el.rhs.trim().startsWith("/")
+        ),
     { message: "Invalid Secret Path. Must start with '/'" }
   );
 

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -84,7 +84,9 @@ const ConditionSchema = z
   .refine(
     (val) =>
       val
-        .filter((el) => el.lhs === "secretPath")
+        .filter(
+          (el) => el.lhs === "secretPath" && el.operator !== PermissionConditionOperators.$GLOB
+        )
         .every((el) =>
           el.operator === PermissionConditionOperators.$IN
             ? el.rhs.split(",").every((i) => i.trim().startsWith("/"))

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -80,6 +80,10 @@ const ConditionSchema = z
       return true;
     },
     { message: "Duplicate operator found for a condition" }
+  )
+  .refine(
+    (val) => val.filter((el) => el.lhs === "secretPath").every((el) => el.rhs.startsWith("/")),
+    { message: "Invalid Secret Path. Must start with '/'" }
   );
 
 export const projectRoleFormSchema = z.object({

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/SecretPermissionConditions.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/SecretPermissionConditions.tsx
@@ -36,6 +36,10 @@ export const SecretPermissionConditions = ({ position = 0, isDisabled }: Props) 
     name: `permissions.secrets.${position}.conditions`
   });
 
+  const conditionErrorMessage =
+    errors?.permissions?.secrets?.[position]?.conditions?.message ||
+    errors?.permissions?.secrets?.[position]?.conditions?.root?.message;
+
   return (
     <div className="mt-6 border-t border-t-mineshaft-600 bg-mineshaft-800 pt-2">
       <p className="mt-2 text-gray-300">Conditions</p>
@@ -147,10 +151,10 @@ export const SecretPermissionConditions = ({ position = 0, isDisabled }: Props) 
           );
         })}
       </div>
-      {errors?.permissions?.secrets?.[position]?.conditions?.message && (
+      {conditionErrorMessage && (
         <div className="flex items-center space-x-2 py-2 text-sm text-gray-400">
           <FontAwesomeIcon icon={faWarning} className="text-red" />
-          <span>{errors?.permissions?.secrets?.[position]?.conditions?.message}</span>
+          <span>{conditionErrorMessage}</span>
         </div>
       )}
       <div>


### PR DESCRIPTION
# Description 📣

This PR adds secret path validation in project permission for both ui and server when the path doesn't start with `/`

![Screenshot 2025-01-29 at 4 26 38 PM](https://github.com/user-attachments/assets/137c64f6-1820-4b04-b054-4be0f0afc5fe)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->