### PR TITLE
fix: wrong client variable in c# code example

### DIFF
--- a/docs/sdks/languages/csharp.mdx
+++ b/docs/sdks/languages/csharp.mdx
@@ -42,7 +42,7 @@ namespace Example
                 ProjectId = "PROJECT_ID",
                 Environment = "dev",
             };
-            var secret = infisical.GetSecret(getSecretOptions);
+            var secret = infisicalClient.GetSecret(getSecretOptions);
 
 
             Console.WriteLine($"The value of secret '{secret.SecretKey}', is: {secret.SecretValue}");


### PR DESCRIPTION
The InfisicalClient variable was wrong in the Basic Usage code block

# Description 📣

A copy/paste of the Basic Usage code block doesn't compile. It's because the infisical client variable was wrongly spelled

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [X] Documentation

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
