### PR TITLE
feature: added export dotenv-plain

### DIFF
--- a/cli/packages/cmd/export.go
+++ b/cli/packages/cmd/export.go
@@ -23,6 +23,7 @@ const (
 	FormatCSV          string = "csv"
 	FormatYaml         string = "yaml"
 	FormatDotEnvExport string = "dotenv-export"
+	FormatDotEnvPlain  string = "dotenv-plain"
 )
 
 // exportCmd represents the export command
@@ -173,6 +174,8 @@ func formatEnvs(envs []models.SingleEnvironmentVariable, format string) (string,
 		return formatAsDotEnv(envs), nil
 	case FormatDotEnvExport:
 		return formatAsDotEnvExport(envs), nil
+	case FormatDotEnvPlain:
+		return formatAsDotEnvPlain(envs), nil
 	case FormatJson:
 		return formatAsJson(envs), nil
 	case FormatCSV:
@@ -180,7 +183,7 @@ func formatEnvs(envs []models.SingleEnvironmentVariable, format string) (string,
 	case FormatYaml:
 		return formatAsYaml(envs)
 	default:
-		return "", fmt.Errorf("invalid format type: %s. Available format types are [%s]", format, []string{FormatDotenv, FormatJson, FormatCSV, FormatYaml, FormatDotEnvExport})
+		return "", fmt.Errorf("invalid format type: %s. Available format types are [%s]", format, []string{FormatDotenv, FormatJson, FormatCSV, FormatYaml, FormatDotEnvExport, FormatDotEnvPlain})
 	}
 }
 
@@ -210,6 +213,15 @@ func formatAsDotEnvExport(envs []models.SingleEnvironmentVariable) string {
 	var dotenv string
 	for _, env := range envs {
 		dotenv += fmt.Sprintf("export %s='%s'\n", env.Key, env.Value)
+	}
+	return dotenv
+}
+
+// Format environment variables as a dotenv file with no single quotes
+func formatAsDotEnvPlain(envs []models.SingleEnvironmentVariable) string {
+	var dotenv string
+	for _, env := range envs {
+		dotenv += fmt.Sprintf("%s=%s\n", env.Key, env.Value)
 	}
 	return dotenv
 }


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This PR adds a new format option to the CLI: `infisical export -f dotenv-plain`.

The default dotenv format wraps the values in singles quotes (`KEY='value'`) which can cause issues when feeding secrets from Infisical into a Docker container using the `--env-file` flag of `docker run` command. For example, when running the `bluenviron/mediamtx` container, I received the following error message (notice the extraneous single quotes wrapping the value):

```sh
$ docker run --rm -it --network=host --env-file <(infisical export) bluenviron/mediamtx
ERR: invalid source: ''rtsp://server/mystream''
```

Currently, I am using the `--template` flag to workaround this issue:

```sh
$ docker run --rm -it --network=host --env-file <(infisical export --template="/path/to/template/file") bluenviron/mediamtx
```

my-template-file:

```
{{$secrets := secret "<infisical-project-id>" "<environment-slug>" "<folder-path>"}}
{{- with $secrets }}
{{- range $index, $secret := . }}
{{ $secret.Key }}={{ $secret.Value }}
{{- end }}
{{- end }}
```

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

The changes have been tested by running the application and confirming the expected output.

```sh
$ go run main.go export -f dotenv-plain
...
KEY_1=value_1
KEY_2=value_2
...
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->