### PR TITLE
Batch upsert operation

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -352,6 +352,7 @@ interface CreateSecretBatchEvent {
     secrets: Array<{
       secretId: string;
       secretKey: string;
+      secretPath?: string;
       secretVersion: number;
       secretMetadata?: TSecretMetadata;
     }>;
@@ -374,8 +375,14 @@ interface UpdateSecretBatchEvent {
   type: EventType.UPDATE_SECRETS;
   metadata: {
     environment: string;
-    secretPath: string;
-    secrets: Array<{ secretId: string; secretKey: string; secretVersion: number; secretMetadata?: TSecretMetadata }>;
+    secretPath?: string;
+    secrets: Array<{
+      secretId: string;
+      secretKey: string;
+      secretVersion: number;
+      secretMetadata?: TSecretMetadata;
+      secretPath?: string;
+    }>;
   };
 }
 

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -721,6 +721,7 @@ export const RAW_SECRETS = {
     secretName: "The name of the secret to update.",
     secretComment: "Update comment to the secret.",
     environment: "The slug of the environment where the secret is located.",
+    mode: "Defines how the system should handle missing secrets during an update.",
     secretPath: "The path of the secret to update.",
     secretValue: "The new value of the secret.",
     skipMultilineEncoding: "Skip multiline encoding for the secret value.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -722,7 +722,7 @@ export const RAW_SECRETS = {
     secretComment: "Update comment to the secret.",
     environment: "The slug of the environment where the secret is located.",
     mode: "Defines how the system should handle missing secrets during an update.",
-    secretPath: "The path of the secret to update.",
+    secretPath: "The default path for secrets to update or upsert, if not provided in the secret details.",
     secretValue: "The new value of the secret.",
     skipMultilineEncoding: "Skip multiline encoding for the secret value.",
     type: "The type of the secret to update.",

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -20,6 +20,7 @@ import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 import { ProjectFilterType } from "@app/services/project/project-types";
 import { ResourceMetadataSchema } from "@app/services/resource-metadata/resource-metadata-schema";
 import { SecretOperations, SecretProtectionType } from "@app/services/secret/secret-types";
+import { SecretUpdateMode } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { secretRawSchema } from "../sanitizedSchemas";
@@ -2030,6 +2031,11 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
           .default("/")
           .transform(removeTrailingSlash)
           .describe(RAW_SECRETS.UPDATE.secretPath),
+        mode: z
+          .nativeEnum(SecretUpdateMode)
+          .optional()
+          .default(SecretUpdateMode.FailOnNotFound)
+          .describe(RAW_SECRETS.UPDATE.environment),
         secrets: z
           .object({
             secretKey: SecretNameSchema.describe(RAW_SECRETS.UPDATE.secretName),
@@ -2037,6 +2043,12 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
               .string()
               .transform((val) => (val.at(-1) === "\n" ? `${val.trim()}\n` : val.trim()))
               .describe(RAW_SECRETS.UPDATE.secretValue),
+            secretPath: z
+              .string()
+              .trim()
+              .transform(removeTrailingSlash)
+              .optional()
+              .describe(RAW_SECRETS.UPDATE.secretPath),
             secretComment: z.string().trim().optional().describe(RAW_SECRETS.UPDATE.secretComment),
             skipMultilineEncoding: z.boolean().optional().describe(RAW_SECRETS.UPDATE.skipMultilineEncoding),
             newSecretName: SecretNameSchema.optional().describe(RAW_SECRETS.UPDATE.newSecretName),
@@ -2073,7 +2085,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         environment,
         projectSlug,
         projectId: req.body.workspaceId,
-        secrets: inputSecrets
+        secrets: inputSecrets,
+        mode: req.body.mode
       });
       if (secretOperation.type === SecretProtectionType.Approval) {
         return { approval: secretOperation.approval };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1294,9 +1294,8 @@ export const secretV2BridgeServiceFactory = ({
       await kmsService.createCipherPairWithDataKey({ type: KmsDataKey.SecretManager, projectId });
 
     const updatedSecrets: Array<TSecretsV2 & { secretPath: string }> = [];
-    /* eslint-disable no-await-in-loop */
     await secretDAL.transaction(async (tx) => {
-      for (const folder of folders) {
+      for await (const folder of folders) {
         if (!folder) throw new NotFoundError({ message: "Folder not found" });
 
         const folderId = folder.id;
@@ -1336,7 +1335,7 @@ export const secretV2BridgeServiceFactory = ({
             message: `Secret does not exist: ${diff(
               secretsToUpdate.map((el) => el.secretKey),
               secretsToUpdateInDB.map((el) => el.key)
-            ).join(",")} in path ${folder.path}`
+            ).join(", ")} in path ${folder.path}`
           });
 
         const secretsToUpdateInDBGroupedByKey = groupBy(secretsToUpdateInDB, (i) => i.key);
@@ -1426,7 +1425,7 @@ export const secretV2BridgeServiceFactory = ({
             throw new BadRequestError({
               message: `Secret with new name already exists: ${secretsWithNewName
                 .map((el) => el.newSecretName)
-                .join(",")}`
+                .join(", ")}`
             });
 
           secretsWithNewName.forEach((el) => {
@@ -1530,7 +1529,6 @@ export const secretV2BridgeServiceFactory = ({
       }
     });
 
-    /* eslint-enable */
     await Promise.allSettled(folders.map((el) => (el?.id ? snapshotService.performSnapshot(el.id) : undefined)));
     await Promise.allSettled(
       folders.map((el) =>

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -23,6 +23,12 @@ export type TSecretReferenceDTO = {
   secretKey: string;
 };
 
+export enum SecretUpdateMode {
+  Ignore = "ignore",
+  Upsert = "upsert",
+  FailOnNotFound = "failOnNotFound"
+}
+
 export type TGetSecretsDTO = {
   expandSecretReferences?: boolean;
   path: string;
@@ -113,6 +119,7 @@ export type TUpdateManySecretDTO = Omit<TProjectPermission, "projectId"> & {
   secretPath: string;
   projectId: string;
   environment: string;
+  mode: SecretUpdateMode;
   secrets: {
     secretKey: string;
     newSecretName?: string;
@@ -123,6 +130,7 @@ export type TUpdateManySecretDTO = Omit<TProjectPermission, "projectId"> & {
     secretReminderRepeatDays?: number | null;
     secretReminderNote?: string | null;
     secretMetadata?: ResourceMetadataDTO;
+    secretPath?: string;
   }[];
 };
 

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -30,7 +30,10 @@ import { groupBy, pick } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { OrgServiceActor } from "@app/lib/types";
-import { TGetSecretsRawByFolderMappingsDTO } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
+import {
+  SecretUpdateMode,
+  TGetSecretsRawByFolderMappingsDTO
+} from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 
 import { ActorType } from "../auth/auth-type";
 import { TProjectDALFactory } from "../project/project-dal";
@@ -2012,6 +2015,7 @@ export const secretServiceFactory = ({
     actorOrgId,
     actorAuthMethod,
     secretPath,
+    mode = SecretUpdateMode.FailOnNotFound,
     secrets: inputSecrets = []
   }: TUpdateManySecretRawDTO) => {
     if (!projectSlug && !optionalProjectId)
@@ -2076,7 +2080,8 @@ export const secretServiceFactory = ({
         actorOrgId,
         actor,
         actorId,
-        secrets: inputSecrets
+        secrets: inputSecrets,
+        mode
       });
       return { type: SecretProtectionType.Direct as const, secrets };
     }

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -17,6 +17,7 @@ import { TKmsServiceFactory } from "../kms/kms-service";
 import { TResourceMetadataDALFactory } from "../resource-metadata/resource-metadata-dal";
 import { ResourceMetadataDTO } from "../resource-metadata/resource-metadata-schema";
 import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-dal";
+import { SecretUpdateMode } from "../secret-v2-bridge/secret-v2-bridge-types";
 import { TSecretVersionV2DALFactory } from "../secret-v2-bridge/secret-version-dal";
 import { TSecretVersionV2TagDALFactory } from "../secret-v2-bridge/secret-version-tag-dal";
 
@@ -274,6 +275,7 @@ export type TUpdateManySecretRawDTO = Omit<TProjectPermission, "projectId"> & {
   projectId?: string;
   projectSlug?: string;
   environment: string;
+  mode: SecretUpdateMode;
   secrets: {
     secretKey: string;
     newSecretName?: string;


### PR DESCRIPTION
# Description 📣

The PR adds support for bulk update operation to have multiple modes to determine when secret not found
1. `failOnNotFound`: If secret not found throw error
2. `ignore`: ignore missing secrets
3. `upsert`: Create missing secrets

Another change would be bulk update support passing secrets path to secrets - to update secrets in multiple path. If not provided the root level secret path is found. If root level secret path is missing, then default `/` is picked

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bulk secret management: Efficiently update or add multiple secrets in one operation, now supporting single and multiple secret paths.
  - Flexible update modes: Choose from different update behaviors for handling missing secrets, enhancing control and reliability.
  
- **Bug Fixes**
  - Improved handling of optional fields in bulk operations, ensuring flexibility and robustness in secret management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->