### PR TITLE
Resolved base64 decode saving file as ansii

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.8.9
+version: v0.8.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.9"
+appVersion: "v0.8.10"

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
           - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.8.8
+      tag: v0.8.10
     resources:
       limits:
         cpu: 500m

--- a/k8-operator/config/samples/crd/infisicalsecret/infisical-secret-crd-with-template.yml
+++ b/k8-operator/config/samples/crd/infisicalsecret/infisical-secret-crd-with-template.yml
@@ -104,7 +104,7 @@ spec:
       includeAllSecrets: true
       data:
         SSH_KEY: "{{ .KEY.SecretPath }} {{ .KEY.Value }}"
-        BINARY_KEY: "{{ toBase64DecodedString .BINARY_KEY_BASE64.Value }}"
+        BINARY_KEY: "{{ decodeBase64ToBytes .BINARY_KEY_BASE64.Value }}"
     creationPolicy: "Orphan" ## Owner | Orphan
     # secretType: kubernetes.io/dockerconfigjson
 

--- a/k8-operator/controllers/infisicalsecret/infisicalsecret_helper.go
+++ b/k8-operator/controllers/infisicalsecret/infisicalsecret_helper.go
@@ -156,12 +156,12 @@ func (r *InfisicalSecretReconciler) getInfisicalServiceAccountCredentialsFromKub
 }
 
 var infisicalSecretTemplateFunctions = template.FuncMap{
-	"decodeBase64ToBytes": func(encodedString string) []byte {
+	"decodeBase64ToBytes": func(encodedString string) string {
 		decoded, err := base64.StdEncoding.DecodeString(encodedString)
 		if err != nil {
 			panic(fmt.Sprintf("Error: %v", err))
 		}
-		return decoded
+		return string(decoded)
 	},
 }
 
@@ -222,7 +222,6 @@ func (r *InfisicalSecretReconciler) createInfisicalManagedKubeSecret(ctx context
 	}
 
 	annotations[constants.SECRET_VERSION_ANNOTATION] = ETag
-
 	// create a new secret as specified by the managed secret spec of CRD
 	newKubeSecretInstance := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Description 📣

This PR fixes an issue with k8s operator template function `decodeBase64ToBytes` to save files as ansii format instead of making it binary. This was because golang templating engine when it gets as bytes it's encoding it as ansii.

We fixed this by stating that type is string, so the templating engine of golang doesn't do any encoding and save it as it is.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->