### PR TITLE
Fix: Exclude Reserved Folders from Deep Search Folder Query

### DIFF
--- a/backend/src/services/secret-folder/secret-folder-dal.ts
+++ b/backend/src/services/secret-folder/secret-folder-dal.ts
@@ -493,6 +493,7 @@ export const secretFolderDALFactory = (db: TDbClient) => {
                   db.ref("parents.environment")
                 )
                 .from(TableName.SecretFolder)
+                .where(`${TableName.SecretFolder}.isReserved`, false)
                 .join("parents", `${TableName.SecretFolder}.parentId`, "parents.id");
             })
         )


### PR DESCRIPTION
# Description 📣

This PR excludes folders with `isReserved` equal to `true` to prevent displaying reserved folders in deep search / moving secrets.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->