### PR TITLE
Improvement: Increase Max Error Message Size for Secret Syncs

### DIFF
--- a/backend/src/db/migrations/20250207002643_secret-syncs-increase-message-length.ts
+++ b/backend/src/db/migrations/20250207002643_secret-syncs-increase-message-length.ts
@@ -1,0 +1,31 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.SecretSync)) {
+    const hasLastSyncMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastSyncMessage");
+    const hasLastImportMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastImportMessage");
+    const hasLastRemoveMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastRemoveMessage");
+
+    await knex.schema.alterTable(TableName.SecretSync, (t) => {
+      if (hasLastSyncMessage) t.string("lastSyncMessage", 1024).alter();
+      if (hasLastImportMessage) t.string("lastImportMessage", 1024).alter();
+      if (hasLastRemoveMessage) t.string("lastRemoveMessage", 1024).alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.SecretSync)) {
+    const hasLastSyncMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastSyncMessage");
+    const hasLastImportMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastImportMessage");
+    const hasLastRemoveMessage = await knex.schema.hasColumn(TableName.SecretSync, "lastRemoveMessage");
+
+    await knex.schema.alterTable(TableName.SecretSync, (t) => {
+      if (hasLastSyncMessage) t.string("lastSyncMessage").alter();
+      if (hasLastImportMessage) t.string("lastImportMessage").alter();
+      if (hasLastRemoveMessage) t.string("lastRemoveMessage").alter();
+    });
+  }
+}

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/SecretSyncRow.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/SecretSyncRow.tsx
@@ -208,7 +208,9 @@ export const SecretSyncRow = ({
                           <FontAwesomeIcon icon={faXmark} className="ml-1 pr-1.5 pt-0.5 text-sm" />
                           <div className="text-xs">Failure Reason</div>
                         </div>
-                        <div className="rounded bg-mineshaft-600 p-2 text-xs">{failureMessage}</div>
+                        <div className="break-words rounded bg-mineshaft-600 p-2 text-xs">
+                          {failureMessage}
+                        </div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
# Description 📣

This PR increases that max message length for job failure messages on Secret Syncs, and handles truncation if a message exceeds this limit.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝