### PR TITLE
Improvement: Remove Capitalizion from Breadcrumbs Container

### DIFF
--- a/frontend/src/components/v2/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/components/v2/Breadcrumb/Breadcrumb.tsx
@@ -126,7 +126,7 @@ export type TBreadcrumbFormat =
     };
 
 const BreadcrumbContainer = ({ breadcrumbs }: { breadcrumbs: TBreadcrumbFormat[] }) => (
-  <div className="mx-auto max-w-7xl py-4 capitalize text-white">
+  <div className="mx-auto max-w-7xl py-4 text-white">
     <Breadcrumb>
       <BreadcrumbList>
         {(breadcrumbs as TBreadcrumbFormat[]).map((el, index) => {


### PR DESCRIPTION
# Description 📣

This PR removes `capitalize` from the breadcrumbs container to prevent casing changes of user named resources.

![CleanShot 2025-02-10 at 19 16 34@2x](https://github.com/user-attachments/assets/d6b89d8b-de90-4f7f-84b3-884c18907acf)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝