### PR TITLE
fix(api): disallow colon in secret name & allow updating malformed secret name

### DIFF
--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -36,11 +36,12 @@ const SecretReferenceNodeTree: z.ZodType<TSecretReferenceNode> = SecretReference
   children: z.lazy(() => SecretReferenceNodeTree.array())
 });
 
-const SecretNameSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .refine((el) => !el.includes(" "), "Secret name cannot contain spaces.");
+const BaseSecretNameSchema = z.string().trim().min(1);
+
+const SecretNameSchema = BaseSecretNameSchema.refine(
+  (el) => !el.includes(" "),
+  "Secret name cannot contain spaces."
+).refine((el) => !el.includes(":"), "Secret name cannot contain colon.");
 
 export const registerSecretRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -618,7 +619,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        secretName: SecretNameSchema.describe(RAW_SECRETS.UPDATE.secretName)
+        secretName: BaseSecretNameSchema.describe(RAW_SECRETS.UPDATE.secretName)
       }),
       body: z.object({
         workspaceId: z.string().trim().describe(RAW_SECRETS.UPDATE.workspaceId),


### PR DESCRIPTION
# Description 📣

This PR restricts the usage of colons in secret key. Additionally it fixes not being able to update already incorrectly formatted secret keys to a correctly formatted key

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->