### PR TITLE
fix: octopus deploy integration error

### DIFF
--- a/frontend/src/pages/secret-manager/integrations/OctopusDeployConfigurePage/OctopusDeployConfigurePage.tsx
+++ b/frontend/src/pages/secret-manager/integrations/OctopusDeployConfigurePage/OctopusDeployConfigurePage.tsx
@@ -88,7 +88,7 @@ export const OctopusDeployConfigurePage = () => {
       {
         integrationAuthId,
         spaceId: currentSpace?.Id,
-        resourceId: currentResource.appId!,
+        resourceId: currentResource?.appId || "",
         scope: currentScope
       },
       { enabled: Boolean(currentSpace && currentResource) }


### PR DESCRIPTION
# Description 📣

This PR fixes the octopus deploy integration crashing after entering in authentication credentials. This is because the `currentResource` is not defined at first, and crashes when trying to access the appId on it.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced handling of integration configuration data to prevent potential runtime disruptions, ensuring a more reliable experience when managing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->