### PR TITLE
Fix (temp): Wrap Integrations beforeLoad in Try/Catch and RenderBannerGuard if order

### DIFF
--- a/frontend/src/components/permissions/ProjectPermissionCan.tsx
+++ b/frontend/src/components/permissions/ProjectPermissionCan.tsx
@@ -57,16 +57,16 @@ export const ProjectPermissionCan: FunctionComponent<Props<ProjectPermissionSet>
         const finalChild =
           typeof children === "function" ? children(isAllowed, ability as any) : children;
 
+        if (!isAllowed && renderGuardBanner) {
+          return <ProjectPermissionGuardBanner />;
+        }
+
         if (!isAllowed && passThrough) {
           return <Tooltip content={label}>{finalChild}</Tooltip>;
         }
 
         if (isAllowed && renderTooltip && allowedLabel) {
           return <Tooltip content={allowedLabel}>{finalChild}</Tooltip>;
-        }
-
-        if (!isAllowed && renderGuardBanner) {
-          return <ProjectPermissionGuardBanner />;
         }
 
         if (!isAllowed) return null;

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/IntegrationsListPage.tsx
@@ -8,6 +8,7 @@ import { ProjectPermissionCan } from "@app/components/permissions";
 import { Badge, PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { ProjectPermissionActions, ProjectPermissionSub, useWorkspace } from "@app/context";
+import { ProjectPermissionSecretSyncActions } from "@app/context/ProjectPermissionContext/types";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
 import {
@@ -100,8 +101,7 @@ export const IntegrationsListPage = () => {
             <TabPanel value={IntegrationsListPageTabs.SecretSyncs}>
               <ProjectPermissionCan
                 renderGuardBanner
-                passThrough={false}
-                I={ProjectPermissionActions.Read}
+                I={ProjectPermissionSecretSyncActions.Read}
                 a={ProjectPermissionSub.SecretSyncs}
               >
                 <SecretSyncsTab />
@@ -110,7 +110,6 @@ export const IntegrationsListPage = () => {
             <TabPanel value={IntegrationsListPageTabs.NativeIntegrations}>
               <ProjectPermissionCan
                 renderGuardBanner
-                passThrough={false}
                 I={ProjectPermissionActions.Read}
                 a={ProjectPermissionSub.Integrations}
               >

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/route.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/route.tsx
@@ -3,7 +3,12 @@ import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
 import { workspaceKeys } from "@app/hooks/api";
-import { fetchSecretSyncsByProjectId, secretSyncKeys } from "@app/hooks/api/secretSyncs";
+import { TIntegration } from "@app/hooks/api/integrations/types";
+import {
+  fetchSecretSyncsByProjectId,
+  secretSyncKeys,
+  TSecretSync
+} from "@app/hooks/api/secretSyncs";
 import { fetchWorkspaceIntegrations } from "@app/hooks/api/workspace/queries";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
@@ -20,43 +25,12 @@ export const Route = createFileRoute(
   validateSearch: zodValidator(IntegrationsListPageQuerySchema),
   beforeLoad: async ({ context, search, params: { projectId } }) => {
     if (!search.selectedTab) {
+      let secretSyncs: TSecretSync[];
+
       try {
-        const secretSyncs = await context.queryClient.ensureQueryData({
+        secretSyncs = await context.queryClient.ensureQueryData({
           queryKey: secretSyncKeys.list(projectId),
           queryFn: () => fetchSecretSyncsByProjectId(projectId)
-        });
-
-        if (secretSyncs.length) {
-          throw redirect({
-            to: "/secret-manager/$projectId/integrations",
-            params: {
-              projectId
-            },
-            search: { selectedTab: IntegrationsListPageTabs.SecretSyncs }
-          });
-        }
-
-        const integrations = await context.queryClient.ensureQueryData({
-          queryKey: workspaceKeys.getWorkspaceIntegrations(projectId),
-          queryFn: () => fetchWorkspaceIntegrations(projectId)
-        });
-
-        if (integrations.length) {
-          throw redirect({
-            to: "/secret-manager/$projectId/integrations",
-            params: {
-              projectId
-            },
-            search: { selectedTab: IntegrationsListPageTabs.NativeIntegrations }
-          });
-        }
-
-        throw redirect({
-          to: "/secret-manager/$projectId/integrations",
-          params: {
-            projectId
-          },
-          search: { selectedTab: IntegrationsListPageTabs.SecretSyncs }
         });
       } catch {
         throw redirect({
@@ -67,6 +41,50 @@ export const Route = createFileRoute(
           search: { selectedTab: IntegrationsListPageTabs.NativeIntegrations }
         });
       }
+
+      if (secretSyncs.length) {
+        throw redirect({
+          to: "/secret-manager/$projectId/integrations",
+          params: {
+            projectId
+          },
+          search: { selectedTab: IntegrationsListPageTabs.SecretSyncs }
+        });
+      }
+
+      let integrations: TIntegration[];
+      try {
+        integrations = await context.queryClient.ensureQueryData({
+          queryKey: workspaceKeys.getWorkspaceIntegrations(projectId),
+          queryFn: () => fetchWorkspaceIntegrations(projectId)
+        });
+      } catch {
+        throw redirect({
+          to: "/secret-manager/$projectId/integrations",
+          params: {
+            projectId
+          },
+          search: { selectedTab: IntegrationsListPageTabs.SecretSyncs }
+        });
+      }
+
+      if (integrations.length) {
+        throw redirect({
+          to: "/secret-manager/$projectId/integrations",
+          params: {
+            projectId
+          },
+          search: { selectedTab: IntegrationsListPageTabs.NativeIntegrations }
+        });
+      }
+
+      throw redirect({
+        to: "/secret-manager/$projectId/integrations",
+        params: {
+          projectId
+        },
+        search: { selectedTab: IntegrationsListPageTabs.SecretSyncs }
+      });
     }
 
     return {


### PR DESCRIPTION

# Description 📣

This PR wraps the beforeLoad on the integrations list page in a try/catch to handle permission failure (temporary). Also adjusts if statements in permission banner guard to properly display

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the logic for displaying an access warning, ensuring that users without permission are notified immediately.
  
- **New Features**
  - Updated the secret management interface to enforce refined access controls on the Secret Syncs tab.
  
- **Bug Fixes**
  - Enhanced error handling during data retrieval, ensuring smooth redirections in case of data load issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->