### PR TITLE
Improvement: Use isPending Over isLoading

### DIFF
--- a/frontend/src/components/secret-syncs/SecretSyncSelect.tsx
+++ b/frontend/src/components/secret-syncs/SecretSyncSelect.tsx
@@ -10,9 +10,9 @@ type Props = {
 };
 
 export const SecretSyncSelect = ({ onSelect }: Props) => {
-  const { isLoading, data: secretSyncOptions } = useSecretSyncOptions();
+  const { isPending, data: secretSyncOptions } = useSecretSyncOptions();
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <div className="flex h-full flex-col items-center justify-center py-2.5">
         <Spinner size="lg" className="text-mineshaft-500" />

--- a/frontend/src/components/secret-syncs/forms/SecretSyncConnectionField.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncConnectionField.tsx
@@ -23,7 +23,7 @@ export const SecretSyncConnectionField = ({ onChange: callback }: Props) => {
   const destination = watch("destination");
   const app = SECRET_SYNC_CONNECTION_MAP[destination];
 
-  const { data: availableConnections, isLoading } = useListAvailableAppConnections(app);
+  const { data: availableConnections, isPending } = useListAvailableAppConnections(app);
 
   const connectionName = APP_CONNECTION_MAP[app].name;
 
@@ -54,7 +54,7 @@ export const SecretSyncConnectionField = ({ onChange: callback }: Props) => {
                 onChange(newValue);
                 if (callback) callback();
               }}
-              isLoading={isLoading}
+              isLoading={isPending}
               options={availableConnections}
               placeholder="Select connection..."
               getOptionLabel={(option) => option.name}

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
@@ -11,9 +11,9 @@ type Props = {
 };
 
 export const AppConnectionsSelect = ({ onSelect }: Props) => {
-  const { isLoading, data: appConnectionOptions } = useAppConnectionOptions();
+  const { isPending, data: appConnectionOptions } = useAppConnectionOptions();
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <div className="flex h-full flex-col items-center justify-center py-2.5">
         <Spinner size="lg" className="text-mineshaft-500" />

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionsTable.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionsTable.tsx
@@ -51,7 +51,7 @@ type AppConnectionFilters = {
 };
 
 export const AppConnectionsTable = () => {
-  const { isLoading, data: appConnections = [] } = useListAppConnections();
+  const { isPending, data: appConnections = [] } = useListAppConnections();
 
   const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp([
     "deleteConnection",
@@ -262,7 +262,7 @@ export const AppConnectionsTable = () => {
             </Tr>
           </THead>
           <TBody>
-            {isLoading && (
+            {isPending && (
               <TableSkeleton innerKey="app-connections-table" columns={4} key="app-connections" />
             )}
             {filteredAppConnections.slice(offset, perPage * page).map((connection) => (
@@ -285,7 +285,7 @@ export const AppConnectionsTable = () => {
             onChangePerPage={setPerPage}
           />
         )}
-        {!isLoading && !filteredAppConnections?.length && (
+        {!isPending && !filteredAppConnections?.length && (
           <EmptyState
             title={
               appConnections.length


### PR DESCRIPTION
# Description 📣

This PR corrects a few usages of `useQuery` `isLoading` to `isPending`

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Harmonized the loading indications across components (for secret syncs and app connections) to ensure a consistent display when data is being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->