### PR TITLE
feat(api/secrets): view secret value permission

### DIFF
--- a/backend/e2e-test/routes/v2/service-token.spec.ts
+++ b/backend/e2e-test/routes/v2/service-token.spec.ts
@@ -496,7 +496,7 @@ describe("Service token fail cases", async () => {
   test("Unauthorized secret path access", async () => {
     const serviceToken = await createServiceToken(
       [{ secretPath: "/", environment: seedData1.environment.slug }],
-      ["read", "write"]
+      ["read", "readValue", "write"]
     );
     const fetchSecrets = await testServer.inject({
       method: "GET",
@@ -518,7 +518,7 @@ describe("Service token fail cases", async () => {
   test("Unauthorized secret environment access", async () => {
     const serviceToken = await createServiceToken(
       [{ secretPath: "/", environment: seedData1.environment.slug }],
-      ["read", "write"]
+      ["read", "readValue", "write"]
     );
     const fetchSecrets = await testServer.inject({
       method: "GET",
@@ -540,7 +540,7 @@ describe("Service token fail cases", async () => {
   test("Unauthorized write operation", async () => {
     const serviceToken = await createServiceToken(
       [{ secretPath: "/", environment: seedData1.environment.slug }],
-      ["read"]
+      ["read", "readValue"]
     );
     const writeSecrets = await testServer.inject({
       method: "POST",

--- a/backend/e2e-test/routes/v2/service-token.spec.ts
+++ b/backend/e2e-test/routes/v2/service-token.spec.ts
@@ -6,7 +6,7 @@ import { decryptAsymmetric, decryptSymmetric128BitHexKeyUTF8, encryptSymmetric12
 
 const createServiceToken = async (
   scopes: { environment: string; secretPath: string }[],
-  permissions: ("read" | "write")[]
+  permissions: ("read" | "write" | "readValue")[]
 ) => {
   const projectKeyRes = await testServer.inject({
     method: "GET",
@@ -139,7 +139,7 @@ describe("Service token secret ops", async () => {
   beforeAll(async () => {
     serviceToken = await createServiceToken(
       [{ secretPath: "/**", environment: seedData1.environment.slug }],
-      ["read", "write"]
+      ["read", "write", "readValue"]
     );
 
     // this is ensure cli service token decryptiong working fine

--- a/backend/e2e-test/vitest-environment-knex.ts
+++ b/backend/e2e-test/vitest-environment-knex.ts
@@ -120,4 +120,3 @@ export default {
     };
   }
 };
-

--- a/backend/src/db/migrations/20250218020306_backfill-secret-permissions-with-readvalue.ts
+++ b/backend/src/db/migrations/20250218020306_backfill-secret-permissions-with-readvalue.ts
@@ -62,8 +62,10 @@ const $updatePermissionsDown = (permissions: unknown) => {
     const { subject, action } = parsedPermission;
 
     if (subject === ProjectPermissionSub.Secrets) {
-      if (action.includes(SecretActions.ReadValue)) {
-        action.splice(action.indexOf(SecretActions.ReadValue));
+      const readValueIndex = action.indexOf(SecretActions.ReadValue);
+
+      if (action.includes(SecretActions.ReadValue) && readValueIndex !== -1) {
+        action.splice(readValueIndex, 1);
         parsedPermissions[i] = { ...parsedPermission, action };
 
         shouldUpdate = true;

--- a/backend/src/db/migrations/20250218020306_backfill-secret-permissions-with-readvalue.ts
+++ b/backend/src/db/migrations/20250218020306_backfill-secret-permissions-with-readvalue.ts
@@ -1,0 +1,36 @@
+import { selectAllTableCols } from "@app/lib/knex";
+import { Knex } from "knex";
+import { TableName } from "../schemas";
+
+// [["read,create","secrets",{"environment":{"$eq":"dev"}}],
+//  ["read,edit,create","secrets",{"environment":{"$eq":"staging"}}],
+//  ["read,create","secrets",{"environment":{"$eq":"prod"}},1],
+//  ["edit,delete,create","secret-folders",{}],
+//  ["read,edit,delete,create","secret-imports",{}],
+//  ["read,edit,delete,create","member"],
+//  ["read,edit,delete,create","role"],
+//  ["read,edit,delete,create","integrations"],
+//  ["read,edit","settings"],
+//  ["edit,delete","workspace"],
+//  ["read,edit,delete,create","tags"],
+//  ["read,create,edit,delete,sync-secrets,import-secrets,remove-secrets","secret-syncs"]]
+
+// enum ProjectPermissionSub {
+//   Secrets = "secrets"
+// }
+
+export async function up(knex: Knex): Promise<void> {
+  const projectRoles = await knex(TableName.ProjectRoles).select(selectAllTableCols(TableName.ProjectRoles));
+
+  for (const projectRole of projectRoles) {
+    const { _, permissions } = projectRole;
+
+    const parsedPermissions = JSON.parse(permissions as string) as Record<string, string>[]; // contains array of permissions.
+
+    for (const parsedPermission of parsedPermissions) {
+      console.log(parsedPermission);
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {}

--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -10,7 +10,7 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApprovalStatus, RequestState } from "@app/ee/services/secret-approval-request/secret-approval-request-types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
-import { secretRawSchema } from "@app/server/routes/sanitizedSchemas";
+import { SanitizedTagSchema, secretRawSchema } from "@app/server/routes/sanitizedSchemas";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { ResourceMetadataSchema } from "@app/services/resource-metadata/resource-metadata-schema";
 
@@ -250,14 +250,6 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
     }
   });
 
-  const tagSchema = SecretTagsSchema.pick({
-    id: true,
-    slug: true,
-    color: true
-  })
-    .array()
-    .optional();
-
   server.route({
     method: "GET",
     url: "/:id",
@@ -291,7 +283,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
                 .omit({ _id: true, environment: true, workspace: true, type: true, version: true })
                 .extend({
                   op: z.string(),
-                  tags: tagSchema,
+                  tags: SanitizedTagSchema.array().optional(),
                   secretMetadata: ResourceMetadataSchema.nullish(),
                   secret: z
                     .object({
@@ -310,7 +302,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
                       secretKey: z.string(),
                       secretValue: z.string().optional(),
                       secretComment: z.string().optional(),
-                      tags: tagSchema,
+                      tags: SanitizedTagSchema.array().optional(),
                       secretMetadata: ResourceMetadataSchema.nullish()
                     })
                     .optional()

--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -1,11 +1,6 @@
 import { z } from "zod";
 
-import {
-  SecretApprovalRequestsReviewersSchema,
-  SecretApprovalRequestsSchema,
-  SecretTagsSchema,
-  UsersSchema
-} from "@app/db/schemas";
+import { SecretApprovalRequestsReviewersSchema, SecretApprovalRequestsSchema, UsersSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApprovalStatus, RequestState } from "@app/ee/services/secret-approval-request/secret-approval-request-types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";

--- a/backend/src/ee/routes/v1/secret-router.ts
+++ b/backend/src/ee/routes/v1/secret-router.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 
-import { ProjectPermissionActions } from "@app/ee/services/permission/project-permission";
+import { ProjectPermissionSecretActions } from "@app/ee/services/permission/project-permission";
 import { RAW_SECRETS } from "@app/lib/api-docs";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { readLimit } from "@app/server/config/rateLimiter";
@@ -9,7 +9,7 @@ import { AuthMode } from "@app/services/auth/auth-type";
 
 const AccessListEntrySchema = z
   .object({
-    allowedActions: z.nativeEnum(ProjectPermissionActions).array(),
+    allowedActions: z.nativeEnum(ProjectPermissionSecretActions).array(),
     id: z.string(),
     membershipId: z.string(),
     name: z.string()

--- a/backend/src/ee/routes/v1/secret-version-router.ts
+++ b/backend/src/ee/routes/v1/secret-version-router.ts
@@ -22,7 +22,11 @@ export const registerSecretVersionRouter = async (server: FastifyZodProvider) =>
       }),
       response: {
         200: z.object({
-          secretVersions: secretRawSchema.array()
+          secretVersions: secretRawSchema
+            .extend({
+              secretValueHidden: z.boolean()
+            })
+            .array()
         })
       }
     },
@@ -37,6 +41,7 @@ export const registerSecretVersionRouter = async (server: FastifyZodProvider) =>
         offset: req.query.offset,
         secretId: req.params.secretId
       });
+
       return { secretVersions };
     }
   });

--- a/backend/src/ee/routes/v1/snapshot-router.ts
+++ b/backend/src/ee/routes/v1/snapshot-router.ts
@@ -31,6 +31,7 @@ export const registerSnapshotRouter = async (server: FastifyZodProvider) => {
             secretVersions: secretRawSchema
               .omit({ _id: true, environment: true, workspace: true, type: true })
               .extend({
+                secretValueHidden: z.boolean(),
                 secretId: z.string(),
                 tags: SecretTagsSchema.pick({
                   id: true,
@@ -55,6 +56,7 @@ export const registerSnapshotRouter = async (server: FastifyZodProvider) => {
         actorOrgId: req.permission.orgId,
         id: req.params.secretSnapshotId
       });
+
       return { secretSnapshot };
     }
   });

--- a/backend/src/ee/routes/v1/snapshot-router.ts
+++ b/backend/src/ee/routes/v1/snapshot-router.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
-import { SecretSnapshotsSchema, SecretTagsSchema } from "@app/db/schemas";
+import { SecretSnapshotsSchema } from "@app/db/schemas";
 import { PROJECTS } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
-import { secretRawSchema } from "@app/server/routes/sanitizedSchemas";
+import { SanitizedTagSchema, secretRawSchema } from "@app/server/routes/sanitizedSchemas";
 import { AuthMode } from "@app/services/auth/auth-type";
 
 export const registerSnapshotRouter = async (server: FastifyZodProvider) => {
@@ -33,11 +33,7 @@ export const registerSnapshotRouter = async (server: FastifyZodProvider) => {
               .extend({
                 secretValueHidden: z.boolean(),
                 secretId: z.string(),
-                tags: SecretTagsSchema.pick({
-                  id: true,
-                  slug: true,
-                  color: true
-                }).array()
+                tags: SanitizedTagSchema.array()
               })
               .array(),
             folderVersion: z.object({ id: z.string(), name: z.string() }).array(),

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -437,11 +437,12 @@ const GeneralPermissionSchema = [
   })
 ];
 
+// Do not update this schema anymore, as it's kept purely for backwards compatability. Update V2 schema only.
 export const ProjectPermissionV1Schema = z.discriminatedUnion("subject", [
   z.object({
     subject: z.literal(ProjectPermissionSub.Secrets).describe("The entity this permission pertains to."),
     inverted: z.boolean().optional().describe("Whether rule allows or forbids."),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretActions).describe(
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions).describe(
       "Describe what action an entity can take."
     ),
     conditions: SecretConditionV1Schema.describe(

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -442,7 +442,7 @@ export const ProjectPermissionV1Schema = z.discriminatedUnion("subject", [
   z.object({
     subject: z.literal(ProjectPermissionSub.Secrets).describe("The entity this permission pertains to."),
     inverted: z.boolean().optional().describe("Whether rule allows or forbids."),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretActions).describe(
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions).describe(
       "Describe what action an entity can take."
     ),
     conditions: SecretConditionV1Schema.describe(

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -808,8 +808,8 @@ export const projectMemberPermissions = buildMemberPermissionRules();
 const buildViewerPermissionRules = () => {
   const { can, rules } = new AbilityBuilder<MongoAbility<ProjectPermissionSet>>(createMongoAbility);
 
-  // ? Q(Daniel): Should the viewer role be allowed to read values? Currently not allowed in permission below.
   can(ProjectPermissionSecretActions.DescribeSecret, ProjectPermissionSub.Secrets);
+  can(ProjectPermissionSecretActions.ReadValue, ProjectPermissionSub.Secrets);
   can(ProjectPermissionActions.Read, ProjectPermissionSub.SecretFolders);
   can(ProjectPermissionDynamicSecretActions.ReadRootCredential, ProjectPermissionSub.DynamicSecrets);
   can(ProjectPermissionActions.Read, ProjectPermissionSub.SecretImports);

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -58,7 +58,7 @@ import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { TLicenseServiceFactory } from "../license/license-service";
 import { TPermissionServiceFactory } from "../permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "../permission/project-permission";
+import { ProjectPermissionSecretActions, ProjectPermissionSub } from "../permission/project-permission";
 import { TSecretApprovalPolicyDALFactory } from "../secret-approval-policy/secret-approval-policy-dal";
 import { TSecretSnapshotServiceFactory } from "../secret-snapshot/secret-snapshot-service";
 import { TSecretApprovalRequestDALFactory } from "./secret-approval-request-dal";
@@ -88,7 +88,12 @@ type TSecretApprovalRequestServiceFactoryDep = {
   secretDAL: TSecretDALFactory;
   secretTagDAL: Pick<
     TSecretTagDALFactory,
-    "findManyTagsById" | "saveTagsToSecret" | "deleteTagsManySecret" | "saveTagsToSecretV2" | "deleteTagsToSecretV2"
+    | "findManyTagsById"
+    | "saveTagsToSecret"
+    | "deleteTagsManySecret"
+    | "saveTagsToSecretV2"
+    | "deleteTagsToSecretV2"
+    | "find"
   >;
   secretBlindIndexDAL: Pick<TSecretBlindIndexDALFactory, "findOne">;
   snapshotService: Pick<TSecretSnapshotServiceFactory, "performSnapshot">;
@@ -914,7 +919,7 @@ export const secretApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath })
     );
 
@@ -1001,6 +1006,7 @@ export const secretApprovalRequestServiceFactory = ({
               : keyName2BlindIndex[secretName];
           // add tags
           if (tagIds?.length) commitTagIds[keyName2BlindIndex[secretName]] = tagIds;
+
           return {
             ...latestSecretVersions[secretId],
             ...el,
@@ -1363,9 +1369,9 @@ export const secretApprovalRequestServiceFactory = ({
     const tagsGroupById = groupBy(tags, (i) => i.id);
 
     commits.forEach((commit) => {
-      let action = ProjectPermissionActions.Create;
-      if (commit.op === SecretOperations.Update) action = ProjectPermissionActions.Edit;
-      if (commit.op === SecretOperations.Delete) action = ProjectPermissionActions.Delete;
+      let action = ProjectPermissionSecretActions.Create;
+      if (commit.op === SecretOperations.Update) action = ProjectPermissionSecretActions.Edit;
+      if (commit.op === SecretOperations.Delete) action = ProjectPermissionSecretActions.Delete;
 
       ForbiddenError.from(permission).throwUnlessCan(
         action,

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -111,7 +111,7 @@ type TSecretApprovalRequestServiceFactoryDep = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey" | "encryptWithInputKey" | "decryptWithInputKey">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany"
+    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany" | "find"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;

--- a/backend/src/ee/services/secret-replication/secret-replication-service.ts
+++ b/backend/src/ee/services/secret-replication/secret-replication-service.ts
@@ -265,6 +265,7 @@ export const secretReplicationServiceFactory = ({
         folderDAL,
         secretImportDAL,
         decryptor: (value) => (value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : ""),
+        viewSecretValue: true,
         hasSecretAccess: () => true
       });
       // secrets that gets replicated across imports

--- a/backend/src/ee/services/secret-rotation/secret-rotation-service.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-service.ts
@@ -15,7 +15,11 @@ import { TSecretV2BridgeDALFactory } from "@app/services/secret-v2-bridge/secret
 
 import { TLicenseServiceFactory } from "../license/license-service";
 import { TPermissionServiceFactory } from "../permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "../permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "../permission/project-permission";
 import { TSecretRotationDALFactory } from "./secret-rotation-dal";
 import { TSecretRotationQueueFactory } from "./secret-rotation-queue";
 import { TSecretRotationEncData } from "./secret-rotation-queue/secret-rotation-queue-types";
@@ -106,7 +110,7 @@ export const secretRotationServiceFactory = ({
       });
     }
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Edit,
+      ProjectPermissionSecretActions.Edit,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath })
     );
 

--- a/backend/src/ee/services/secret-snapshot/secret-snapshot-service.ts
+++ b/backend/src/ee/services/secret-snapshot/secret-snapshot-service.ts
@@ -102,7 +102,7 @@ export const secretSnapshotServiceFactory = ({
 
     // We need to check if the user has access to the secrets in the folder. If we don't do this, a user could theoretically access snapshot secret values even if they don't have read access to the secrets in the folder.
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeSecret,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
     );
 
@@ -139,7 +139,7 @@ export const secretSnapshotServiceFactory = ({
 
     // We need to check if the user has access to the secrets in the folder. If we don't do this, a user could theoretically access snapshot secret values even if they don't have read access to the secrets in the folder.
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeSecret,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
     );
 

--- a/backend/src/ee/services/secret-snapshot/secret-snapshot-service.ts
+++ b/backend/src/ee/services/secret-snapshot/secret-snapshot-service.ts
@@ -22,7 +22,11 @@ import { TSecretVersionV2TagDALFactory } from "@app/services/secret-v2-bridge/se
 
 import { TLicenseServiceFactory } from "../license/license-service";
 import { TPermissionServiceFactory } from "../permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "../permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "../permission/project-permission";
 import {
   TGetSnapshotDataDTO,
   TProjectSnapshotCountDTO,
@@ -97,7 +101,7 @@ export const secretSnapshotServiceFactory = ({
 
     // We need to check if the user has access to the secrets in the folder. If we don't do this, a user could theoretically access snapshot secret values even if they don't have read access to the secrets in the folder.
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
     );
 
@@ -134,7 +138,7 @@ export const secretSnapshotServiceFactory = ({
 
     // We need to check if the user has access to the secrets in the folder. If we don't do this, a user could theoretically access snapshot secret values even if they don't have read access to the secrets in the folder.
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, { environment, secretPath: path })
     );
 
@@ -224,7 +228,7 @@ export const secretSnapshotServiceFactory = ({
 
     // We need to check if the user has access to the secrets in the folder. If we don't do this, a user could theoretically access snapshot secret values even if they don't have read access to the secrets in the folder.
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, {
         environment: snapshotDetails.environment.slug,
         secretPath: fullFolderPath

--- a/backend/src/ee/services/ssh-certificate/ssh-certificate-schema.ts
+++ b/backend/src/ee/services/ssh-certificate/ssh-certificate-schema.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import { SshCertificatesSchema } from "@app/db/schemas";
 
 export const sanitizedSshCertificate = SshCertificatesSchema.pick({

--- a/backend/src/ee/services/ssh-certificate/ssh-certificate-schema.ts
+++ b/backend/src/ee/services/ssh-certificate/ssh-certificate-schema.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { SshCertificatesSchema } from "@app/db/schemas";
 
 export const sanitizedSshCertificate = SshCertificatesSchema.pick({

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -666,6 +666,7 @@ export const SECRETS = {
     secretPath: "The path of the secret to attach tags to.",
     type: "The type of the secret to attach tags to. (shared/personal)",
     environment: "The slug of the environment where the secret is located",
+    viewSecretValue: "Whether or not to retrieve the secret value.",
     projectSlug: "The slug of the project where the secret is located.",
     tagSlugs: "An array of existing tag slugs to attach to the secret."
   },
@@ -689,6 +690,7 @@ export const RAW_SECRETS = {
       "The slug of the project to list secrets from. This parameter is only applicable by machine identities.",
     environment: "The slug of the environment to list secrets from.",
     secretPath: "The secret path to list secrets from.",
+    viewSecretValue: "Whether or not to retrieve the secret value.",
     includeImports: "Weather to include imported secrets or not.",
     tagSlugs: "The comma separated tag slugs to filter secrets.",
     metadataFilter:
@@ -717,6 +719,7 @@ export const RAW_SECRETS = {
     secretPath: "The path of the secret to get.",
     version: "The version of the secret to get.",
     type: "The type of the secret to get.",
+    viewSecretValue: "Whether or not to retrieve the secret value.",
     includeImports: "Weather to include imported secrets or not."
   },
   UPDATE: {

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line max-classes-per-file
+import { AnyAbility, ForbiddenError } from "@casl/ability";
+
 /* eslint-disable max-classes-per-file */
 export class DatabaseError extends Error {
   name: string;
@@ -56,6 +59,13 @@ export class ForbiddenRequestError extends Error {
     super(message ?? "You are not allowed to access this resource");
     this.name = name || "ForbiddenError";
     this.error = error;
+  }
+}
+
+export class ForbiddenReadSecretError extends ForbiddenRequestError {
+  constructor({ error, message }: { message?: string; error?: unknown } = {}) {
+    super({ message, error });
+    this.name = "ForbiddenReadSecretError";
   }
 }
 

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -1,7 +1,5 @@
-// eslint-disable-next-line max-classes-per-file
-import { AnyAbility, ForbiddenError } from "@casl/ability";
-
 /* eslint-disable max-classes-per-file */
+
 export class DatabaseError extends Error {
   name: string;
 

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -60,13 +60,6 @@ export class ForbiddenRequestError extends Error {
   }
 }
 
-export class ForbiddenReadSecretError extends ForbiddenRequestError {
-  constructor({ error, message }: { message?: string; error?: unknown } = {}) {
-    super({ message, error });
-    this.name = "ForbiddenReadSecretError";
-  }
-}
-
 export class BadRequestError extends Error {
   name: string;
 

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -7,6 +7,7 @@ import {
   ProjectRolesSchema,
   ProjectsSchema,
   SecretApprovalPoliciesSchema,
+  SecretTagsSchema,
   UsersSchema
 } from "@app/db/schemas";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
@@ -231,4 +232,12 @@ export const SanitizedProjectSchema = ProjectsSchema.pick({
   pitVersionLimit: true,
   kmsCertificateKeyId: true,
   auditLogsRetentionDays: true
+});
+
+export const SanitizedTagSchema = SecretTagsSchema.pick({
+  id: true,
+  slug: true,
+  color: true
+}).extend({
+  name: z.string()
 });

--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -604,14 +604,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
             tagSlugs: tags
           });
 
-          console.log("totalSecretCount", totalSecretCount);
-          console.log("adjustedOffset", adjustedOffset);
-          console.log("remainingLimit", remainingLimit);
-
-          console.log("will resolve to true", remainingLimit > 0 && totalSecretCount > adjustedOffset);
-
           if (remainingLimit > 0 && totalSecretCount > adjustedOffset) {
-            console.log("before running");
             const secretsRaw = await server.services.secret.getSecretsRaw({
               actorId: req.permission.id,
               actor: req.permission.type,
@@ -629,7 +622,6 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
               tagSlugs: tags
             });
 
-            console.log("secretsRaw", secretsRaw);
             secrets = secretsRaw.secrets;
 
             await server.services.auditLog.createAuditLog({
@@ -662,7 +654,6 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
           }
         }
       } catch (error) {
-        console.log(error);
         if (!(error instanceof ForbiddenError)) {
           throw error;
         }

--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -5,6 +5,7 @@ import { ActionProjectType, SecretFoldersSchema, SecretImportsSchema } from "@ap
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import {
   ProjectPermissionDynamicSecretActions,
+  ProjectPermissionSecretActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { DASHBOARD } from "@app/lib/api-docs";
@@ -688,6 +689,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
             .optional(),
           secrets: secretRawSchema
             .extend({
+              secretValueHidden: z.boolean(),
               secretPath: z.string().optional(),
               secretMetadata: ResourceMetadataSchema.optional(),
               tags: SanitizedTagSchema.array().optional()
@@ -734,6 +736,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
 
       const secrets = await server.services.secret.getSecretsRawByFolderMappings(
         {
+          filterByAction: ProjectPermissionSecretActions.DescribeSecret,
           projectId,
           folderMappings,
           filters: {

--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError, subject } from "@casl/ability";
 import { z } from "zod";
 
-import { ActionProjectType, SecretFoldersSchema, SecretImportsSchema, SecretTagsSchema } from "@app/db/schemas";
+import { ActionProjectType, SecretFoldersSchema, SecretImportsSchema } from "@app/db/schemas";
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import {
   ProjectPermissionDynamicSecretActions,

--- a/backend/src/server/routes/v2/service-token-router.ts
+++ b/backend/src/server/routes/v2/service-token-router.ts
@@ -94,7 +94,7 @@ export const registerServiceTokenRouter = async (server: FastifyZodProvider) => 
         iv: z.string().trim(),
         tag: z.string().trim(),
         expiresIn: z.number().nullable(),
-        permissions: z.enum(["read", "write"]).array()
+        permissions: z.enum(["read", "write", "readValue"]).array()
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -77,8 +77,6 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
         secure: cfg.HTTPS_ENABLED
       });
 
-      console.log("access token", tokens.access);
-
       return { token: tokens.access, isMfaEnabled: false };
     }
   });

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -77,6 +77,8 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
         secure: cfg.HTTPS_ENABLED
       });
 
+      console.log("access token", tokens.access);
+
       return { token: tokens.access, isMfaEnabled: false };
     }
   });

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -292,7 +292,8 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
               secrets: secretRawSchema
                 .omit({ createdAt: true, updatedAt: true })
                 .extend({
-                  // secretValueHidden: z.boolean(),
+                  // No `secretValueHidden` on imports, because imported secrets that the user doesn't have read value permission on, will be filtered out.
+                  // Therefore all returned secret imports will have the value present.
                   secretMetadata: ResourceMetadataSchema.optional()
                 })
                 .array()
@@ -2322,7 +2323,6 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
     }
   });
 
-  // ? No work needed, does not expose secret value.
   server.route({
     method: "POST",
     url: "/backfill-secret-references",

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -1,13 +1,7 @@
 import picomatch from "picomatch";
 import { z } from "zod";
 
-import {
-  SecretApprovalRequestsSchema,
-  SecretsSchema,
-  SecretTagsSchema,
-  SecretType,
-  ServiceTokenScopes
-} from "@app/db/schemas";
+import { SecretApprovalRequestsSchema, SecretsSchema, SecretType, ServiceTokenScopes } from "@app/db/schemas";
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { RAW_SECRETS, SECRETS } from "@app/lib/api-docs";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";

--- a/backend/src/services/external-migration/external-migration-fns.ts
+++ b/backend/src/services/external-migration/external-migration-fns.ts
@@ -33,7 +33,7 @@ export type TImportDataIntoInfisicalDTO = {
 
   secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "create">;
-  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create">;
+  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany" | "create">;
 
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany">;

--- a/backend/src/services/external-migration/external-migration-fns.ts
+++ b/backend/src/services/external-migration/external-migration-fns.ts
@@ -31,7 +31,7 @@ export type TImportDataIntoInfisicalDTO = {
   projectEnvDAL: Pick<TProjectEnvDALFactory, "find" | "findLastEnvPosition" | "create" | "findOne">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
 
-  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys">;
+  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "find">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "create">;
   secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany" | "create">;

--- a/backend/src/services/external-migration/external-migration-queue.ts
+++ b/backend/src/services/external-migration/external-migration-queue.ts
@@ -27,7 +27,7 @@ export type TExternalMigrationQueueFactoryDep = {
   projectEnvDAL: Pick<TProjectEnvDALFactory, "find" | "findLastEnvPosition" | "create" | "findOne">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
 
-  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys">;
+  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "find">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "create">;
   secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany" | "create">;

--- a/backend/src/services/external-migration/external-migration-queue.ts
+++ b/backend/src/services/external-migration/external-migration-queue.ts
@@ -29,7 +29,7 @@ export type TExternalMigrationQueueFactoryDep = {
 
   secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "findBySecretKeys">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "create">;
-  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create">;
+  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "create" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany" | "create">;
 
   folderDAL: Pick<TSecretFolderDALFactory, "create" | "findBySecretPath" | "findOne" | "findById">;

--- a/backend/src/services/integration-auth/integration-delete-secret.ts
+++ b/backend/src/services/integration-auth/integration-delete-secret.ts
@@ -68,7 +68,8 @@ const getIntegrationSecretsV2 = async (
     secretDAL: secretV2BridgeDAL,
     secretImportDAL,
     secretImports,
-    hasSecretAccess: () => true
+    hasSecretAccess: () => true,
+    viewSecretValue: true
   });
 
   for (let i = importedSecrets.length - 1; i >= 0; i -= 1) {

--- a/backend/src/services/integration/integration-service.ts
+++ b/backend/src/services/integration/integration-service.ts
@@ -2,7 +2,11 @@ import { ForbiddenError, subject } from "@casl/ability";
 
 import { ActionProjectType } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
 import { NotFoundError } from "@app/lib/errors";
 import { TProjectPermission } from "@app/lib/types";
 
@@ -92,7 +96,7 @@ export const integrationServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.Integrations);
 
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, {
         environment: sourceEnvironment,
         secretPath
@@ -175,7 +179,7 @@ export const integrationServiceFactory = ({
 
     if (environment || secretPath) {
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
+        ProjectPermissionSecretActions.ReadValue,
         subject(ProjectPermissionSub.Secrets, {
           environment: newEnvironment,
           secretPath: newSecretPath

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -11,7 +11,11 @@ import {
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
 import { TProjectTemplateServiceFactory } from "@app/ee/services/project-template/project-template-service";
 import { InfisicalProjectTemplate } from "@app/ee/services/project-template/project-template-types";
 import { TSshCertificateAuthorityDALFactory } from "@app/ee/services/ssh/ssh-certificate-authority-dal";
@@ -747,7 +751,10 @@ export const projectServiceFactory = ({
       actorOrgId,
       actionProjectType: ActionProjectType.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Secrets);
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionSecretActions.DescribeSecret,
+      ProjectPermissionSub.Secrets
+    );
 
     const project = await projectDAL.findProjectById(projectId);
 

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -183,7 +183,7 @@ export const fnSecretsV2FromImports = async ({
     depth: number;
     parentImportedSecrets: (TSecretsV2 & {
       secretValueHidden: boolean;
-      secretTags: { slug: string; name: string; id: string; color: string }[];
+      secretTags: { slug: string; name: string; id: string; color?: string | null }[];
     })[];
   }[] = [{ secretImports: rootSecretImports, depth: 0, parentImportedSecrets: [] }];
 

--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -94,7 +94,7 @@ export const secretImportServiceFactory = ({
 
     // check if user has permission to import from target path
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeSecret,
       subject(ProjectPermissionSub.Secrets, {
         environment: data.environment,
         secretPath: data.path
@@ -406,7 +406,7 @@ export const secretImportServiceFactory = ({
 
     // check if user has permission to import from target path
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeSecret,
       subject(ProjectPermissionSub.Secrets, {
         environment: secretImportDoc.importEnv.slug,
         secretPath: secretImportDoc.importPath
@@ -646,6 +646,7 @@ export const secretImportServiceFactory = ({
       const importedSecrets = await fnSecretsV2FromImports({
         secretImports,
         folderDAL,
+        viewSecretValue: true,
         secretDAL: secretV2BridgeDAL,
         secretImportDAL,
         decryptor: (value) => (value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : ""),

--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -5,7 +5,11 @@ import { ForbiddenError, subject } from "@casl/ability";
 import { ActionProjectType, TableName } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
 import { getReplicationFolderName } from "@app/ee/services/secret-replication/secret-replication-service";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 
@@ -90,7 +94,7 @@ export const secretImportServiceFactory = ({
 
     // check if user has permission to import from target path
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, {
         environment: data.environment,
         secretPath: data.path
@@ -402,7 +406,7 @@ export const secretImportServiceFactory = ({
 
     // check if user has permission to import from target path
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, {
         environment: secretImportDoc.importEnv.slug,
         secretPath: secretImportDoc.importPath
@@ -596,7 +600,7 @@ export const secretImportServiceFactory = ({
     const secretImports = await secretImportDAL.find({ folderId: folder.id, isReplication: false });
     const allowedImports = secretImports.filter((el) =>
       permission.can(
-        ProjectPermissionActions.Read,
+        ProjectPermissionSecretActions.ReadValue,
         subject(ProjectPermissionSub.Secrets, {
           environment: el.importEnv.slug,
           secretPath: el.importPath
@@ -647,7 +651,7 @@ export const secretImportServiceFactory = ({
         decryptor: (value) => (value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : ""),
         hasSecretAccess: (expandEnvironment, expandSecretPath, expandSecretKey, expandSecretTags) =>
           permission.can(
-            ProjectPermissionActions.Read,
+            ProjectPermissionSecretActions.ReadValue,
             subject(ProjectPermissionSub.Secrets, {
               environment: expandEnvironment,
               secretPath: expandSecretPath,
@@ -667,7 +671,7 @@ export const secretImportServiceFactory = ({
 
     const allowedImports = secretImports.filter((el) =>
       permission.can(
-        ProjectPermissionActions.Read,
+        ProjectPermissionSecretActions.ReadValue,
         subject(ProjectPermissionSub.Secrets, {
           environment: el.importEnv.slug,
           secretPath: el.importPath
@@ -683,7 +687,10 @@ export const secretImportServiceFactory = ({
     return importedSecrets.map((el) => ({
       ...el,
       secrets: el.secrets.map((encryptedSecret) =>
-        decryptSecretRaw({ ...encryptedSecret, workspace: projectId, environment, secretPath }, botKey)
+        decryptSecretRaw(
+          { ...encryptedSecret, workspace: projectId, environment, secretPath, secretValueHidden: false },
+          botKey
+        )
       )
     }));
   };

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -249,7 +249,8 @@ export const secretSyncQueueFactory = ({
         expandSecretReferences,
         secretImportDAL,
         secretImports,
-        hasSecretAccess: () => true
+        hasSecretAccess: () => true,
+        viewSecretValue: true
       });
 
       for (let i = importedSecrets.length - 1; i >= 0; i -= 1) {

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -3,7 +3,7 @@ import { ForbiddenError, subject } from "@casl/ability";
 import { ActionProjectType } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
 import {
-  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
   ProjectPermissionSecretSyncActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
@@ -179,7 +179,7 @@ export const secretSyncServiceFactory = ({
     );
 
     ForbiddenError.from(projectPermission).throwUnlessCan(
-      ProjectPermissionActions.Read,
+      ProjectPermissionSecretActions.ReadValue,
       subject(ProjectPermissionSub.Secrets, {
         environment,
         secretPath
@@ -270,7 +270,7 @@ export const secretSyncServiceFactory = ({
         throw new BadRequestError({ message: "Must specify both source environment and secret path" });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Read,
+        ProjectPermissionSecretActions.ReadValue,
         subject(ProjectPermissionSub.Secrets, {
           environment: updatedEnvironment,
           secretPath: updatedSecretPath

--- a/backend/src/services/secret-tag/secret-tag-dal.ts
+++ b/backend/src/services/secret-tag/secret-tag-dal.ts
@@ -47,6 +47,7 @@ export const secretTagDALFactory = (db: TDbClient) => {
       throw new DatabaseError({ error, name: "Find all by ids" });
     }
   };
+
   return {
     ...secretTagOrm,
     saveTagsToSecret: secretJnTagOrm.insertMany,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -103,18 +103,6 @@ export const fnSecretBulkInsert = async ({
     }))
   );
 
-  const secretTags = await secretTagDAL.find({
-    $in: {
-      id: newSecretTags.map((el) => el.secret_tagsId)
-    }
-  });
-
-  const secretTagsWithSlugs = await secretTagDAL.find({
-    $in: {
-      id: secretTags.map((el) => el.id)
-    }
-  });
-
   const secretVersions = await secretVersionDAL.insertMany(
     sanitizedInputSecrets.map((el) => ({
       ...el,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -148,7 +148,16 @@ export const fnSecretBulkInsert = async ({
     await secretVersionTagDAL.insertMany(newSecretVersionTags, tx);
   }
 
-  return newSecrets.map((secret) => ({ ...secret, _id: secret.id }));
+  const secretsWithTags = await secretDAL.find(
+    {
+      $in: {
+        [`${TableName.SecretV2}.id` as "id"]: newSecrets.map((s) => s.id)
+      }
+    },
+    { tx }
+  );
+
+  return secretsWithTags.map((secret) => ({ ...secret, _id: secret.id }));
 };
 
 export const fnSecretBulkUpdate = async ({
@@ -286,7 +295,15 @@ export const fnSecretBulkUpdate = async ({
     tx
   );
 
-  return newSecrets.map((secret) => ({ ...secret, _id: secret.id }));
+  const secretsWithTags = await secretDAL.find(
+    {
+      $in: {
+        [`${TableName.SecretV2}.id` as "id"]: newSecrets.map((s) => s.id)
+      }
+    },
+    { tx }
+  );
+  return secretsWithTags.map((secret) => ({ ...secret, _id: secret.id }));
 };
 
 export const fnSecretBulkDelete = async ({
@@ -627,7 +644,7 @@ export const reshapeBridgeSecret = (
     }[];
     secretMetadata?: ResourceMetadataDTO;
   },
-  secretValueHidden?: boolean
+  secretValueHidden: boolean
 ) => ({
   secretKey: secret.key,
   secretPath,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -519,7 +519,7 @@ export const expandSecretReferencesFactory = ({
             const referredValue = await fetchSecret(environment, secretPath, secretKey);
             if (!canExpandValue(environment, secretPath, secretKey, referredValue.tags))
               throw new ForbiddenRequestError({
-                message: `You are attempting to reference secret named ${secretKey} from environment ${environment} in path ${secretPath} which you do not have access to.`
+                message: `You are attempting to reference secret named ${secretKey} from environment ${environment} in path ${secretPath} which you do not have access to read value on.`
               });
 
             const cacheKey = getCacheUniqueKey(environment, secretPath);
@@ -538,7 +538,7 @@ export const expandSecretReferencesFactory = ({
             const referedValue = await fetchSecret(secretReferenceEnvironment, secretReferencePath, secretReferenceKey);
             if (!canExpandValue(secretReferenceEnvironment, secretReferencePath, secretReferenceKey, referedValue.tags))
               throw new ForbiddenRequestError({
-                message: `You are attempting to reference secret named ${secretReferenceKey} from environment ${secretReferenceEnvironment} in path ${secretReferencePath} which you do not have access to.`
+                message: `You are attempting to reference secret named ${secretReferenceKey} from environment ${secretReferenceEnvironment} in path ${secretReferencePath} which you do not have access to read value on.`
               });
 
             const cacheKey = getCacheUniqueKey(secretReferenceEnvironment, secretReferencePath);

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -7,6 +7,7 @@ import { logger } from "@app/lib/logger";
 
 import { TProjectEnvDALFactory } from "../project-env/project-env-dal";
 import { ResourceMetadataDTO } from "../resource-metadata/resource-metadata-schema";
+import { INFISICAL_SECRET_VALUE_HIDDEN_MASK } from "../secret/secret-fns";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretV2BridgeDALFactory } from "./secret-v2-bridge-dal";
 import { TFnSecretBulkDelete, TFnSecretBulkInsert, TFnSecretBulkUpdate } from "./secret-v2-bridge-types";
@@ -649,7 +650,7 @@ export const reshapeBridgeSecret = (
 
   ...(secretValueHidden
     ? {
-        secretValue: "<hidden-by-infisical>",
+        secretValue: INFISICAL_SECRET_VALUE_HIDDEN_MASK,
         secretValueHidden: true
       }
     : {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -20,7 +20,7 @@ import { TSecretApprovalPolicyServiceFactory } from "@app/ee/services/secret-app
 import { TSecretApprovalRequestDALFactory } from "@app/ee/services/secret-approval-request/secret-approval-request-dal";
 import { TSecretApprovalRequestSecretDALFactory } from "@app/ee/services/secret-approval-request/secret-approval-request-secret-dal";
 import { TSecretSnapshotServiceFactory } from "@app/ee/services/secret-snapshot/secret-snapshot-service";
-import { BadRequestError, ForbiddenReadSecretError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { diff, groupBy } from "@app/lib/fn";
 import { setKnexStringValue } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
@@ -987,7 +987,6 @@ export const secretV2BridgeServiceFactory = ({
       secretDAL,
       decryptSecretValue: (value) => (value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : undefined),
       canExpandValue: (expandEnvironment, expandSecretPath, expandSecretKey, expandSecretTags) =>
-        // ? Question(Daniel): Will throw an error if the user doesn't have access to any of the expanded secrets.
         permission.can(
           ProjectPermissionSecretActions.ReadValue,
           subject(ProjectPermissionSub.Secrets, {
@@ -1249,8 +1248,9 @@ export const secretV2BridgeServiceFactory = ({
         ) &&
         secretType !== SecretType.Personal
       ) {
-        throw new ForbiddenReadSecretError({
-          message: `You do not have permission to view secret value on secret with name '${secretName}'`
+        throw new ForbiddenRequestError({
+          message: `You do not have permission to view secret value on secret with name '${secretName}'`,
+          name: "ForbiddenReadSecretError"
         });
       }
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1400,7 +1400,7 @@ export const secretV2BridgeServiceFactory = ({
       const secs = await secretDAL.find(
         {
           $in: {
-            id: createdSecrets.map((el) => el.id)
+            [`${TableName.SecretV2}.id` as "id"]: createdSecrets.map((el) => el.id)
           }
         },
         { tx }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1697,7 +1697,7 @@ export const secretV2BridgeServiceFactory = ({
         const bulkUpdatedSecrets = await secretDAL.find(
           {
             $in: {
-              id: bulkUpdatedSecretsRes.map((el) => el.id)
+              [`${TableName.SecretV2}.id` as "id"]: bulkUpdatedSecretsRes.map((el) => el.id)
             }
           },
           {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -950,6 +950,8 @@ export const secretV2BridgeServiceFactory = ({
         );
       })
       .map((secret) => {
+        const isPersonalSecret = secret.userId === actorId && secret.type === SecretType.Personal;
+
         const secretValueHidden =
           !viewSecretValue ||
           !permission.can(
@@ -975,7 +977,7 @@ export const secretV2BridgeServiceFactory = ({
               ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedComment }).toString()
               : ""
           },
-          secretValueHidden
+          secretValueHidden && !isPersonalSecret
         );
       });
 
@@ -1244,7 +1246,8 @@ export const secretV2BridgeServiceFactory = ({
             secretName,
             secretTags: (secret?.tags || []).map((el) => el.slug)
           })
-        )
+        ) &&
+        secretType !== SecretType.Personal
       ) {
         throw new ForbiddenReadSecretError({
           message: `You do not have permission to view secret value on secret with name '${secretName}'`

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1741,7 +1741,7 @@ export const secretV2BridgeServiceFactory = ({
           const bulkInsertedSecrets = await secretDAL.find(
             {
               $in: {
-                id: bulkInsertedSecretsRes.map((el) => el.id)
+                [`${TableName.SecretV2}.id` as "id"]: bulkInsertedSecretsRes.map((el) => el.id)
               }
             },
             { tx }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -981,6 +981,8 @@ export const secretV2BridgeServiceFactory = ({
               })
             );
           }
+          // Else, we do nothing. Because we don't want to filter out the secret, OR throw an error.
+          // If the user doesn't have access to read the value, in the below map function, we mask the secret value and return the secret with a hidden value.
         }
 
         return canDescribeSecret;

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -38,6 +38,7 @@ export type TGetSecretsDTO = {
   recursive?: boolean;
   tagSlugs?: string[];
   viewSecretValue: boolean;
+  throwOnMissingReadValuePermission?: boolean;
   metadataFilter?: {
     key?: string;
     value?: string;
@@ -49,6 +50,11 @@ export type TGetSecretsDTO = {
   search?: string;
   keys?: string[];
 } & TProjectPermission;
+
+export type TGetSecretsMissingReadValuePermissionDTO = Omit<
+  TGetSecretsDTO,
+  "viewSecretValue" | "recursive" | "expandSecretReferences"
+>;
 
 export type TGetASecretDTO = {
   secretName: string;
@@ -167,7 +173,7 @@ export type TFnSecretBulkInsert = {
     }
   >;
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany">;
-  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences">;
+  secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences" | "find">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
   secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -191,7 +197,7 @@ export type TFnSecretBulkUpdate = {
     data: TRequireReferenceIfValue & { tags?: string[]; secretMetadata?: ResourceMetadataDTO };
   }[];
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete">;
-  secretDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "upsertSecretReferences">;
+  secretDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "upsertSecretReferences" | "find">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
   secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "deleteTagsToSecretV2" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -1,6 +1,7 @@
 import { Knex } from "knex";
 
 import { SecretType, TSecretsV2, TSecretsV2Insert, TSecretsV2Update } from "@app/db/schemas";
+import { ProjectPermissionSecretActions } from "@app/ee/services/permission/project-permission";
 import { OrderByDirection, TProjectPermission } from "@app/lib/types";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { SecretsOrderBy } from "@app/services/secret/secret-types";
@@ -36,6 +37,7 @@ export type TGetSecretsDTO = {
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
+  viewSecretValue: boolean;
   metadataFilter?: {
     key?: string;
     value?: string;
@@ -57,6 +59,7 @@ export type TGetASecretDTO = {
   includeImports?: boolean;
   version?: number;
   projectId: string;
+  viewSecretValue: boolean;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TCreateSecretDTO = TProjectPermission & {
@@ -166,7 +169,7 @@ export type TFnSecretBulkInsert = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany">;
   secretDAL: Pick<TSecretV2BridgeDALFactory, "insertMany" | "upsertSecretReferences">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
-  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2">;
+  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
 };
 
@@ -190,7 +193,7 @@ export type TFnSecretBulkUpdate = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete">;
   secretDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "upsertSecretReferences">;
   secretVersionDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
-  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "deleteTagsToSecretV2">;
+  secretTagDAL: Pick<TSecretTagDALFactory, "saveTagsToSecretV2" | "deleteTagsToSecretV2" | "find">;
   secretVersionTagDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
   tx?: Knex;
 };
@@ -332,4 +335,5 @@ export type TGetSecretsRawByFolderMappingsDTO = {
   folderMappings: { folderId: string; path: string; environment: string }[];
   userId: string;
   filters: TFindSecretsByFolderIdsFilter;
+  filterByAction?: ProjectPermissionSecretActions;
 };

--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -1,9 +1,9 @@
 import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
-import { TableName, TSecretVersionsV2, TSecretVersionsV2Update } from "@app/db/schemas";
+import { SecretVersionsV2Schema, TableName, TSecretVersionsV2, TSecretVersionsV2Update } from "@app/db/schemas";
 import { BadRequestError, DatabaseError } from "@app/lib/errors";
-import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { ormify, selectAllTableCols, sqlNestRelationships, TFindOpt } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
 import { QueueName } from "@app/queue";
 
@@ -11,6 +11,58 @@ export type TSecretVersionV2DALFactory = ReturnType<typeof secretVersionV2Bridge
 
 export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
   const secretVersionV2Orm = ormify(db, TableName.SecretVersionV2);
+
+  const findBySecretId = async (secretId: string, { offset, limit, sort, tx }: TFindOpt<TSecretVersionsV2> = {}) => {
+    try {
+      const query = (tx || db.replicaNode())(TableName.SecretVersionV2)
+        .where(`${TableName.SecretVersionV2}.secretId`, secretId)
+        .leftJoin(TableName.SecretV2, `${TableName.SecretVersionV2}.secretId`, `${TableName.SecretV2}.id`)
+        .leftJoin(
+          TableName.SecretV2JnTag,
+          `${TableName.SecretV2}.id`,
+          `${TableName.SecretV2JnTag}.${TableName.SecretV2}Id`
+        )
+        .leftJoin(
+          TableName.SecretTag,
+          `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`,
+          `${TableName.SecretTag}.id`
+        )
+        .select(selectAllTableCols(TableName.SecretVersionV2))
+        .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
+        .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
+        .select(db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"));
+
+      if (limit) void query.limit(limit);
+      if (offset) void query.offset(offset);
+      if (sort) {
+        void query.orderBy(sort.map(([column, order, nulls]) => ({ column: column as string, order, nulls })));
+      }
+
+      const docs = await query;
+
+      const data = sqlNestRelationships({
+        data: docs,
+        key: "id",
+        parentMapper: (el) => ({ _id: el.id, ...SecretVersionsV2Schema.parse(el) }),
+        childrenMapper: [
+          {
+            key: "tagId",
+            label: "tags" as const,
+            mapper: ({ tagId: id, tagColor: color, tagSlug: slug }) => ({
+              id,
+              color,
+              slug,
+              name: slug
+            })
+          }
+        ]
+      });
+
+      return data;
+    } catch (error) {
+      throw new DatabaseError({ error, name: `${TableName.SecretVersionV2}: FindBySecretId` });
+    }
+  };
 
   // This will fetch all latest secret versions from a folder
   const findLatestVersionByFolderId = async (folderId: string, tx?: Knex) => {
@@ -124,6 +176,7 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
     pruneExcessVersions,
     findLatestVersionMany,
     bulkUpdate,
-    findLatestVersionByFolderId
+    findLatestVersionByFolderId,
+    findBySecretId
   };
 };

--- a/backend/src/services/secret/secret-dal.ts
+++ b/backend/src/services/secret/secret-dal.ts
@@ -169,6 +169,48 @@ export const secretDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findManySecretsWithTags = async (
+    filter: {
+      secretIds: string[];
+      type: SecretType;
+    },
+    tx?: Knex
+  ) => {
+    try {
+      const secrets = await (tx || db.replicaNode())(TableName.Secret)
+        .whereIn(`${TableName.Secret}.id` as "id", filter.secretIds)
+        .where("type", filter.type)
+        .leftJoin(TableName.JnSecretTag, `${TableName.Secret}.id`, `${TableName.JnSecretTag}.${TableName.Secret}Id`)
+        .leftJoin(TableName.SecretTag, `${TableName.JnSecretTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
+        .select(selectAllTableCols(TableName.Secret))
+        .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
+        .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
+        .select(db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"));
+
+      const data = sqlNestRelationships({
+        data: secrets,
+        key: "id",
+        parentMapper: (el) => ({ _id: el.id, ...SecretsSchema.parse(el) }),
+        childrenMapper: [
+          {
+            key: "tagId",
+            label: "tags" as const,
+            mapper: ({ tagId: id, tagColor: color, tagSlug: slug }) => ({
+              id,
+              color,
+              slug,
+              name: slug
+            })
+          }
+        ]
+      });
+
+      return data;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "get many secrets with tags" });
+    }
+  };
+
   const findByFolderIds = async (folderIds: string[], userId?: string, tx?: Knex) => {
     try {
       // check if not uui then userId id is null (corner case because service token's ID is not UUI in effort to keep backwards compatibility from mongo)
@@ -443,6 +485,7 @@ export const secretDALFactory = (db: TDbClient) => {
     upsertSecretReferences,
     findReferencedSecretReferences,
     findAllProjectSecretValues,
-    pruneSecretReminders
+    pruneSecretReminders,
+    findManySecretsWithTags
   };
 };

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -51,6 +51,8 @@ import {
   TUpdateManySecretsRawFnFactory
 } from "./secret-types";
 
+export const INFISICAL_SECRET_VALUE_HIDDEN_MASK = "<hidden-by-infisical>";
+
 export const generateSecretBlindIndexBySalt = async (secretName: string, secretBlindIndexDoc: TSecretBlindIndexes) => {
   const appCfg = getConfig();
   const secretBlindIndex = await buildSecretBlindIndexFromName({
@@ -370,7 +372,7 @@ export const decryptSecretRaw = (
         tag: secret.secretValueTag,
         key
       })
-    : "<hidden-by-infisical>";
+    : INFISICAL_SECRET_VALUE_HIDDEN_MASK;
 
   let secretComment = "";
 
@@ -1214,12 +1216,10 @@ export const conditionallyHideSecretValue = (
     secretValueTag: string;
   }
 ) => {
-  const hiddenPlaceholder = "hidden-by-infisical>";
-
   return {
-    secretValueCiphertext: shouldHideValue ? hiddenPlaceholder : secretValueCiphertext,
-    secretValueIV: shouldHideValue ? hiddenPlaceholder : secretValueIV,
-    secretValueTag: shouldHideValue ? hiddenPlaceholder : secretValueTag,
+    secretValueCiphertext: shouldHideValue ? INFISICAL_SECRET_VALUE_HIDDEN_MASK : secretValueCiphertext,
+    secretValueIV: shouldHideValue ? INFISICAL_SECRET_VALUE_HIDDEN_MASK : secretValueIV,
+    secretValueTag: shouldHideValue ? INFISICAL_SECRET_VALUE_HIDDEN_MASK : secretValueTag,
     secretValueHidden: shouldHideValue
   };
 };

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -402,7 +402,8 @@ export const secretQueueFactory = ({
       expandSecretReferences,
       secretImportDAL,
       secretImports,
-      hasSecretAccess: () => true
+      hasSecretAccess: () => true,
+      viewSecretValue: true
     });
 
     for (let i = importedSecrets.length - 1; i >= 0; i -= 1) {

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -2814,11 +2814,7 @@ export const secretServiceFactory = ({
           destinationAction,
           subject(ProjectPermissionSub.Secrets, {
             environment: destinationEnvironment,
-            secretPath: destinationSecretPath,
-            secretName: secretKey,
-            ...(secret.tags.length && {
-              secretTags: secret.tags.map((t) => t.id)
-            })
+            secretPath: destinationSecretPath
           })
         );
       }
@@ -2828,11 +2824,7 @@ export const secretServiceFactory = ({
           sourceAction,
           subject(ProjectPermissionSub.Secrets, {
             environment: sourceEnvironment,
-            secretPath: sourceSecretPath,
-            secretName: secretKey,
-            ...(secret.tags.length && {
-              secretTags: secret.tags.map((t) => t.id)
-            })
+            secretPath: sourceSecretPath
           })
         );
       }

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -180,6 +180,7 @@ export type TGetSecretsRawDTO = {
   expandSecretReferences?: boolean;
   path: string;
   environment: string;
+  viewSecretValue: boolean;
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
@@ -205,6 +206,7 @@ export type TGetASecretRawDTO = {
   secretName: string;
   path: string;
   environment: string;
+  viewSecretValue: boolean;
   expandSecretReferences?: boolean;
   type: "shared" | "personal";
   includeImports?: boolean;

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -181,6 +181,7 @@ export type TGetSecretsRawDTO = {
   path: string;
   environment: string;
   viewSecretValue: boolean;
+  throwOnMissingReadValuePermission?: boolean;
   includeImports?: boolean;
   recursive?: boolean;
   tagSlugs?: string[];
@@ -411,7 +412,7 @@ export type TCreateManySecretsRawFnFactory = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany"
+    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany" | "find"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -448,7 +449,7 @@ export type TUpdateManySecretsRawFnFactory = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany"
+    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany" | "find"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -1,9 +1,9 @@
 import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
-import { TableName, TSecretVersions, TSecretVersionsUpdate } from "@app/db/schemas";
+import { SecretVersionsSchema, TableName, TSecretVersions, TSecretVersionsUpdate } from "@app/db/schemas";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
-import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { ormify, selectAllTableCols, sqlNestRelationships, TFindOpt } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
 import { QueueName } from "@app/queue";
 
@@ -11,6 +11,50 @@ export type TSecretVersionDALFactory = ReturnType<typeof secretVersionDALFactory
 
 export const secretVersionDALFactory = (db: TDbClient) => {
   const secretVersionOrm = ormify(db, TableName.SecretVersion);
+
+  const findBySecretId = async (secretId: string, { offset, limit, sort, tx }: TFindOpt<TSecretVersions> = {}) => {
+    try {
+      const query = (tx || db.replicaNode())(TableName.SecretVersion)
+        .where(`${TableName.SecretVersion}.secretId`, secretId)
+        .leftJoin(TableName.Secret, `${TableName.SecretVersion}.secretId`, `${TableName.Secret}.id`)
+        .leftJoin(TableName.JnSecretTag, `${TableName.Secret}.id`, `${TableName.JnSecretTag}.${TableName.Secret}Id`)
+        .leftJoin(TableName.SecretTag, `${TableName.JnSecretTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
+        .select(selectAllTableCols(TableName.SecretVersion))
+        .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
+        .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
+        .select(db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"));
+
+      if (limit) void query.limit(limit);
+      if (offset) void query.offset(offset);
+      if (sort) {
+        void query.orderBy(sort.map(([column, order, nulls]) => ({ column: column as string, order, nulls })));
+      }
+
+      const docs = await query;
+
+      const data = sqlNestRelationships({
+        data: docs,
+        key: "id",
+        parentMapper: (el) => ({ _id: el.id, ...SecretVersionsSchema.parse(el) }),
+        childrenMapper: [
+          {
+            key: "tagId",
+            label: "tags" as const,
+            mapper: ({ tagId: id, tagColor: color, tagSlug: slug }) => ({
+              id,
+              color,
+              slug,
+              name: slug
+            })
+          }
+        ]
+      });
+
+      return data;
+    } catch (error) {
+      throw new DatabaseError({ error, name: `${TableName.SecretVersion}: FindBySecretId` });
+    }
+  };
 
   // This will fetch all latest secret versions from a folder
   const findLatestVersionByFolderId = async (folderId: string, tx?: Knex) => {
@@ -149,6 +193,7 @@ export const secretVersionDALFactory = (db: TDbClient) => {
     findLatestVersionMany,
     bulkUpdate,
     findLatestVersionByFolderId,
+    findBySecretId,
     bulkUpdateNoVersionIncrement
   };
 };

--- a/backend/src/services/service-token/service-token-service.ts
+++ b/backend/src/services/service-token/service-token-service.ts
@@ -5,7 +5,11 @@ import bcrypt from "bcrypt";
 
 import { ActionProjectType } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
 import { getConfig } from "@app/lib/config/env";
 import { ForbiddenRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
 
@@ -67,7 +71,7 @@ export const serviceTokenServiceFactory = ({
 
     scopes.forEach(({ environment, secretPath }) => {
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionActions.Create,
+        ProjectPermissionSecretActions.Create,
         subject(ProjectPermissionSub.Secrets, { environment, secretPath })
       );
     });

--- a/backend/src/services/service-token/service-token-types.ts
+++ b/backend/src/services/service-token/service-token-types.ts
@@ -7,7 +7,7 @@ export type TCreateServiceTokenDTO = {
   iv: string;
   tag: string;
   expiresIn?: number | null;
-  permissions: ("read" | "write")[];
+  permissions: ("read" | "write" | "readValue")[];
 } & TProjectPermission;
 
 export type TGetServiceTokenInfoDTO = Omit<TProjectPermission, "projectId">;

--- a/frontend/src/components/secrets/SecretReferenceDetails/SecretReferenceDetails.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/SecretReferenceDetails.tsx
@@ -1,13 +1,21 @@
-import { useState } from "react";
-import { faChevronRight, faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+/* eslint-disable no-nested-ternary */
+import { useEffect, useState } from "react";
+import {
+  faChevronRight,
+  faExclamationTriangle,
+  faEye,
+  faEyeSlash
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Collapsible from "@radix-ui/react-collapsible";
+import { AxiosError } from "axios";
 import { twMerge } from "tailwind-merge";
 
+import { createNotification } from "@app/components/notifications";
 import { FormControl, FormLabel, SecretInput, Spinner, Tooltip } from "@app/components/v2";
 import { useWorkspace } from "@app/context";
 import { useGetSecretReferenceTree } from "@app/hooks/api";
-import { TSecretReferenceTraceNode } from "@app/hooks/api/types";
+import { ApiErrorTypes, TApiErrors, TSecretReferenceTraceNode } from "@app/hooks/api/types";
 
 import style from "./SecretReferenceDetails.module.css";
 
@@ -84,7 +92,7 @@ export const SecretReferenceTree = ({ secretPath, environment, secretKey }: Prop
   const { currentWorkspace } = useWorkspace();
   const projectId = currentWorkspace?.id || "";
 
-  const { data, isPending } = useGetSecretReferenceTree({
+  const { data, isPending, isError, error } = useGetSecretReferenceTree({
     secretPath,
     environmentSlug: environment,
     projectId,
@@ -93,6 +101,26 @@ export const SecretReferenceTree = ({ secretPath, environment, secretKey }: Prop
 
   const tree = data?.tree;
   const secretValue = data?.value;
+
+  useEffect(() => {
+    if (error instanceof AxiosError) {
+      const err = error?.response?.data as TApiErrors;
+
+      if (err?.error === ApiErrorTypes.CustomForbiddenError) {
+        createNotification({
+          title: "You don't have permission to view reference tree",
+          text: "You don't have permission to view one or more of the referenced secrets.",
+          type: "error"
+        });
+        return;
+      }
+      createNotification({
+        title: "Error fetching secret reference tree",
+        text: "Please try again later.",
+        type: "error"
+      });
+    }
+  }, [error]);
 
   if (isPending) {
     return (
@@ -114,11 +142,16 @@ export const SecretReferenceTree = ({ secretPath, environment, secretKey }: Prop
       </FormControl>
       <FormLabel className="mb-2" label="Reference Tree" />
       <div className="thin-scrollbar relative max-h-96 overflow-auto rounded-md border border-mineshaft-600 bg-bunker-700 py-6 text-sm text-mineshaft-200">
-        {tree && (
+        {isError ? (
+          <div className="flex items-center justify-center py-4">
+            <FontAwesomeIcon icon={faExclamationTriangle} className="mr-2 text-red-500" />
+            <p className="text-red-500">Error fetching secret reference tree</p>
+          </div>
+        ) : tree ? (
           <ul className={style.tree}>
             <SecretReferenceNode node={tree} isRoot secretKey={secretKey} />
           </ul>
-        )}
+        ) : null}
       </div>
       <div className="mt-2 text-sm text-mineshaft-400">
         Click a secret key to view its sub-references.

--- a/frontend/src/components/v2/Blur/Blur.tsx
+++ b/frontend/src/components/v2/Blur/Blur.tsx
@@ -1,0 +1,22 @@
+import { twMerge } from "tailwind-merge";
+
+import { Tooltip } from "../Tooltip/Tooltip";
+
+interface IProps {
+  className?: string;
+  tooltipText?: string;
+}
+
+export const Blur = ({ className, tooltipText }: IProps) => {
+  return (
+    <Tooltip content={tooltipText} isDisabled={!tooltipText}>
+      <div
+        className={twMerge("flex w-80 flex-grow items-center py-1 pl-4 pr-2", className)}
+        tabIndex={0}
+        role="button"
+      >
+        <span className="blur">********</span>
+      </div>
+    </Tooltip>
+  );
+};

--- a/frontend/src/components/v2/Blur/index.tsx
+++ b/frontend/src/components/v2/Blur/index.tsx
@@ -1,0 +1,1 @@
+export { Blur } from "./Blur";

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -120,6 +120,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
 
     const isPopupOpen = Boolean(suggestionSource.isOpen) && isFocused;
     const { data: secrets } = useGetProjectSecrets({
+      viewSecretValue: false,
       environment: suggestionSource.environment || "",
       secretPath: suggestionSource.secretPath || "",
       workspaceId,

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -2,7 +2,6 @@ import { forwardRef, TextareaHTMLAttributes, useCallback, useMemo, useRef, useSt
 import { faCircle, faFolder, faKey } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Popover from "@radix-ui/react-popover";
-import { twMerge } from "tailwind-merge";
 
 import { useWorkspace } from "@app/context";
 import { useDebounce, useToggle } from "@app/hooks";
@@ -283,7 +282,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
                 setIsFocused.off();
             }}
             onChange={(e) => onChange?.(e.target.value)}
-            containerClassName={twMerge(containerClassName)}
+            containerClassName={containerClassName}
           />
         </Popover.Trigger>
         <Popover.Content

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -2,6 +2,7 @@ import { forwardRef, TextareaHTMLAttributes, useCallback, useMemo, useRef, useSt
 import { faCircle, faFolder, faKey } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Popover from "@radix-ui/react-popover";
+import { twMerge } from "tailwind-merge";
 
 import { useWorkspace } from "@app/context";
 import { useDebounce, useToggle } from "@app/hooks";
@@ -54,6 +55,7 @@ type Props = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange" | "val
   secretPath?: string;
   environment?: string;
   containerClassName?: string;
+  secretValueHidden?: boolean;
 };
 
 type ReferenceItem = {
@@ -70,6 +72,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
       containerClassName,
       secretPath: propSecretPath,
       environment: propEnvironment,
+      secretValueHidden,
       ...props
     },
     ref
@@ -275,6 +278,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
             ref={handleRef}
             onKeyDown={handleKeyDown}
             value={value}
+            valueHidden={secretValueHidden}
             onFocus={() => setIsFocused.on()}
             onBlur={(evt) => {
               // should not on blur when its mouse down selecting a item from suggestion
@@ -282,7 +286,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
                 setIsFocused.off();
             }}
             onChange={(e) => onChange?.(e.target.value)}
-            containerClassName={containerClassName}
+            containerClassName={twMerge(containerClassName)}
           />
         </Popover.Trigger>
         <Popover.Content

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -55,7 +55,6 @@ type Props = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange" | "val
   secretPath?: string;
   environment?: string;
   containerClassName?: string;
-  secretValueHidden?: boolean;
 };
 
 type ReferenceItem = {
@@ -72,7 +71,6 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
       containerClassName,
       secretPath: propSecretPath,
       environment: propEnvironment,
-      secretValueHidden,
       ...props
     },
     ref
@@ -278,7 +276,6 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
             ref={handleRef}
             onKeyDown={handleKeyDown}
             value={value}
-            valueHidden={secretValueHidden}
             onFocus={() => setIsFocused.on()}
             onBlur={(evt) => {
               // should not on blur when its mouse down selecting a item from suggestion

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/no-danger */
 import { forwardRef, TextareaHTMLAttributes } from "react";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { twMerge } from "tailwind-merge";
 
 import { useToggle } from "@app/hooks";
+
+import { Tooltip } from "../Tooltip";
 
 const REGEX = /(\${([a-zA-Z0-9-_.]+)})/g;
 const replaceContentWithDot = (str: string) => {
@@ -14,7 +18,26 @@ const replaceContentWithDot = (str: string) => {
   return finalStr;
 };
 
-const syntaxHighlight = (content?: string | null, isVisible?: boolean, isImport?: boolean) => {
+const syntaxHighlight = (
+  content?: string | null,
+  isVisible?: boolean,
+  isImport?: boolean,
+  valueHidden?: boolean
+) => {
+  if (valueHidden && !content)
+    return (
+      <div className="flex items-center gap-2">
+        <span className="opacity-60">VALUE HIDDEN</span>
+        <div className="relative z-50">
+          <Tooltip
+            className="!relative !z-50 !break-normal !font-inter"
+            content="You do not have permission to read the value of this secret."
+          >
+            <FontAwesomeIcon icon={faQuestionCircle} className="text-xs" />
+          </Tooltip>
+        </div>
+      </div>
+    );
   if (isImport && !content) return "IMPORTED";
   if (content === "") return "EMPTY";
   if (!content) return "EMPTY";
@@ -50,6 +73,7 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   isImport?: boolean;
   isReadOnly?: boolean;
   isDisabled?: boolean;
+  valueHidden?: boolean;
   containerClassName?: string;
 };
 
@@ -61,6 +85,7 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
       value,
       isVisible,
       isImport,
+      valueHidden,
       containerClassName,
       onBlur,
       isDisabled,
@@ -81,7 +106,7 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
           <pre aria-hidden className="m-0">
             <code className={`inline-block w-full ${commonClassName}`}>
               <span style={{ whiteSpace: "break-spaces" }}>
-                {syntaxHighlight(value, isVisible || isSecretFocused, isImport)}
+                {syntaxHighlight(value, isVisible || isSecretFocused, isImport, valueHidden)}
               </span>
             </code>
           </pre>

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -50,7 +50,6 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   isImport?: boolean;
   isReadOnly?: boolean;
   isDisabled?: boolean;
-  valueHidden?: boolean;
   containerClassName?: string;
 };
 
@@ -62,7 +61,6 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
       value,
       isVisible,
       isImport,
-      valueHidden,
       containerClassName,
       onBlur,
       isDisabled,

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-danger */
 import { forwardRef, TextareaHTMLAttributes } from "react";
-
 import { twMerge } from "tailwind-merge";
 
 import { useToggle } from "@app/hooks";

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -1,12 +1,9 @@
 /* eslint-disable react/no-danger */
 import { forwardRef, TextareaHTMLAttributes } from "react";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
 import { twMerge } from "tailwind-merge";
 
 import { useToggle } from "@app/hooks";
-
-import { Tooltip } from "../Tooltip";
 
 const REGEX = /(\${([a-zA-Z0-9-_.]+)})/g;
 const replaceContentWithDot = (str: string) => {
@@ -18,26 +15,7 @@ const replaceContentWithDot = (str: string) => {
   return finalStr;
 };
 
-const syntaxHighlight = (
-  content?: string | null,
-  isVisible?: boolean,
-  isImport?: boolean,
-  valueHidden?: boolean
-) => {
-  if (valueHidden && !content)
-    return (
-      <div className="flex items-center gap-2">
-        <span className="opacity-60">VALUE HIDDEN</span>
-        <div className="relative z-50">
-          <Tooltip
-            className="!relative !z-50 !break-normal !font-inter"
-            content="You do not have permission to read the value of this secret."
-          >
-            <FontAwesomeIcon icon={faQuestionCircle} className="text-xs" />
-          </Tooltip>
-        </div>
-      </div>
-    );
+const syntaxHighlight = (content?: string | null, isVisible?: boolean, isImport?: boolean) => {
   if (isImport && !content) return "IMPORTED";
   if (content === "") return "EMPTY";
   if (!content) return "EMPTY";
@@ -106,7 +84,7 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
           <pre aria-hidden className="m-0">
             <code className={`inline-block w-full ${commonClassName}`}>
               <span style={{ whiteSpace: "break-spaces" }}>
-                {syntaxHighlight(value, isVisible || isSecretFocused, isImport, valueHidden)}
+                {syntaxHighlight(value, isVisible || isSecretFocused, isImport)}
               </span>
             </code>
           </pre>

--- a/frontend/src/context/ProjectPermissionContext/types.ts
+++ b/frontend/src/context/ProjectPermissionContext/types.ts
@@ -7,6 +7,14 @@ export enum ProjectPermissionActions {
   Delete = "delete"
 }
 
+export enum ProjectPermissionSecretActions {
+  DescribeSecret = "read",
+  ReadValue = "readValue",
+  Create = "create",
+  Edit = "edit",
+  Delete = "delete"
+}
+
 export enum ProjectPermissionDynamicSecretActions {
   ReadRootCredential = "read-root-credential",
   CreateRootCredential = "create-root-credential",
@@ -138,7 +146,7 @@ export type SecretImportSubjectFields = {
 
 export type ProjectPermissionSet =
   | [
-      ProjectPermissionActions,
+      ProjectPermissionSecretActions,
       (
         | ProjectPermissionSub.Secrets
         | (ForcedSubject<ProjectPermissionSub.Secrets> & SecretSubjectFields)

--- a/frontend/src/hooks/api/dashboard/queries.tsx
+++ b/frontend/src/hooks/api/dashboard/queries.tsx
@@ -207,6 +207,7 @@ export const useGetProjectSecretsDetails = (
     search = "",
     includeSecrets,
     includeFolders,
+    viewSecretValue,
     includeImports,
     includeDynamicSecrets,
     tags
@@ -231,6 +232,7 @@ export const useGetProjectSecretsDetails = (
       limit,
       orderBy,
       orderDirection,
+      viewSecretValue,
       offset,
       projectId,
       environment,
@@ -247,6 +249,7 @@ export const useGetProjectSecretsDetails = (
         limit,
         orderBy,
         orderDirection,
+        viewSecretValue,
         offset,
         projectId,
         environment,

--- a/frontend/src/hooks/api/dashboard/types.ts
+++ b/frontend/src/hooks/api/dashboard/types.ts
@@ -69,6 +69,7 @@ export type TGetDashboardProjectSecretsDetailsDTO = Omit<
   TGetDashboardProjectSecretsOverviewDTO,
   "environments"
 > & {
+  viewSecretValue: boolean;
   environment: string;
   includeImports?: boolean;
   tags: Record<string, boolean>;

--- a/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
@@ -79,6 +79,7 @@ export const decryptSecrets = (
       id: encSecret.id,
       env: encSecret.environment,
       key: secretKey,
+      secretValueHidden: encSecret.secretValueHidden,
       value: secretValue,
       tags: encSecret.tags,
       comment: secretComment,

--- a/frontend/src/hooks/api/secretImports/queries.tsx
+++ b/frontend/src/hooks/api/secretImports/queries.tsx
@@ -176,6 +176,7 @@ export const useGetImportedSecretsAllEnvs = ({
                 env: encSecret.environment,
                 key: encSecret.secretKey,
                 value: encSecret.secretValue,
+                secretValueHidden: encSecret.secretValueHidden,
                 tags: encSecret.tags,
                 comment: encSecret.secretComment,
                 createdAt: encSecret.createdAt,

--- a/frontend/src/hooks/api/secretImports/queries.tsx
+++ b/frontend/src/hooks/api/secretImports/queries.tsx
@@ -137,6 +137,7 @@ export const useGetImportedSecretsSingleEnv = ({
             env: encSecret.environment,
             key: encSecret.secretKey,
             value: encSecret.secretValue,
+            secretValueHidden: encSecret.secretValueHidden,
             tags: encSecret.tags,
             comment: encSecret.secretComment,
             createdAt: encSecret.createdAt,

--- a/frontend/src/hooks/api/secretSnapshots/queries.tsx
+++ b/frontend/src/hooks/api/secretSnapshots/queries.tsx
@@ -75,7 +75,7 @@ export const useGetSnapshotSecrets = ({ snapshotId }: TSnapshotDataProps) =>
           id: secretVersion.secretId,
           env: data.environment.slug,
           key: secretVersion.secretKey,
-          secretValueHidden: false,
+          secretValueHidden: secretVersion.secretValueHidden,
           value: secretVersion.secretValue || "",
           tags: secretVersion.tags,
           comment: secretVersion.secretComment,

--- a/frontend/src/hooks/api/secretSnapshots/queries.tsx
+++ b/frontend/src/hooks/api/secretSnapshots/queries.tsx
@@ -75,6 +75,7 @@ export const useGetSnapshotSecrets = ({ snapshotId }: TSnapshotDataProps) =>
           id: secretVersion.secretId,
           env: data.environment.slug,
           key: secretVersion.secretKey,
+          secretValueHidden: false,
           value: secretVersion.secretValue || "",
           tags: secretVersion.tags,
           comment: secretVersion.secretComment,

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -26,8 +26,13 @@ import {
 
 export const secretKeys = {
   // this is also used in secretSnapshot part
-  getProjectSecret: ({ workspaceId, environment, secretPath }: TGetProjectSecretsKey) =>
-    [{ workspaceId, environment, secretPath }, "secrets"] as const,
+  getProjectSecret: ({
+    workspaceId,
+    environment,
+    secretPath,
+    viewSecretValue
+  }: TGetProjectSecretsKey) =>
+    [{ workspaceId, environment, secretPath, viewSecretValue }, "secrets"] as const,
   getSecretVersion: (secretId: string) => [{ secretId }, "secret-versions"] as const,
   getSecretAccessList: ({
     workspaceId,
@@ -44,13 +49,15 @@ export const fetchProjectSecrets = async ({
   environment,
   secretPath,
   includeImports,
-  expandSecretReferences
+  expandSecretReferences,
+  viewSecretValue
 }: TGetProjectSecretsKey) => {
   const { data } = await apiRequest.get<SecretV3RawResponse>("/api/v3/secrets/raw", {
     params: {
       environment,
       workspaceId,
       secretPath,
+      viewSecretValue,
       expandSecretReferences,
       include_imports: includeImports
     }
@@ -108,6 +115,7 @@ export const useGetProjectSecrets = ({
   workspaceId,
   environment,
   secretPath,
+  viewSecretValue,
   options
 }: TGetProjectSecretsDTO & {
   options?: Omit<
@@ -124,8 +132,13 @@ export const useGetProjectSecrets = ({
     ...options,
     // wait for all values to be available
     enabled: Boolean(workspaceId && environment) && (options?.enabled ?? true),
-    queryKey: secretKeys.getProjectSecret({ workspaceId, environment, secretPath }),
-    queryFn: () => fetchProjectSecrets({ workspaceId, environment, secretPath }),
+    queryKey: secretKeys.getProjectSecret({
+      workspaceId,
+      environment,
+      secretPath,
+      viewSecretValue
+    }),
+    queryFn: () => fetchProjectSecrets({ workspaceId, environment, secretPath, viewSecretValue }),
     select: useCallback(
       (data: Awaited<ReturnType<typeof fetchProjectSecrets>>) => mergePersonalSecrets(data.secrets),
       []

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -68,6 +68,7 @@ export const mergePersonalSecrets = (rawSecrets: SecretV3Raw[]) => {
       env: el.environment,
       key: el.secretKey,
       value: el.secretValue,
+      secretValueHidden: el.secretValueHidden,
       tags: el.tags || [],
       comment: el.secretComment || "",
       reminderRepeatDays: el.secretReminderRepeatDays,

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -113,6 +113,7 @@ export type TGetProjectSecretsKey = {
   environment: string;
   secretPath?: string;
   includeImports?: boolean;
+  viewSecretValue?: boolean;
   expandSecretReferences?: boolean;
 };
 

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -98,6 +98,7 @@ export type SecretVersions = {
   envId: string;
   secretKey: string;
   secretValue?: string;
+  secretValueHidden: boolean;
   secretComment?: string;
   tags: WsTag[];
   __v: number;

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -19,6 +19,7 @@ export type EncryptedSecret = {
   secretValueCiphertext: string;
   secretValueIV: string;
   secretValueTag: string;
+  secretValueHidden: boolean;
   __v: number;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -37,6 +37,7 @@ export type SecretV3RawSanitized = {
   version: number;
   key: string;
   value?: string;
+  secretValueHidden: boolean;
   comment?: string;
   reminderRepeatDays?: number | null;
   reminderNote?: string | null;
@@ -61,6 +62,7 @@ export type SecretV3Raw = {
   environment: string;
   version: number;
   type: string;
+  secretValueHidden: boolean;
   secretKey: string;
   secretPath: string;
   secretValue?: string;

--- a/frontend/src/hooks/api/types.ts
+++ b/frontend/src/hooks/api/types.ts
@@ -46,7 +46,8 @@ export enum ApiErrorTypes {
   ValidationError = "ValidationFailure",
   BadRequestError = "BadRequest",
   UnauthorizedError = "UnauthorizedError",
-  ForbiddenError = "PermissionDenied"
+  ForbiddenError = "PermissionDenied",
+  CustomForbiddenError = "ForbiddenError"
 }
 
 export type TApiErrors =
@@ -67,6 +68,12 @@ export type TApiErrors =
       error: ApiErrorTypes.ForbiddenError;
       message: string;
       details: PureAbility["rules"];
+      statusCode: 403;
+    }
+  | {
+      reqId: string;
+      error: ApiErrorTypes.CustomForbiddenError;
+      message: string;
       statusCode: 403;
     }
   | {

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -58,6 +58,7 @@ const schema = z.object({
   permissions: z
     .object({
       read: z.boolean(),
+      readValue: z.boolean(),
       write: z.boolean()
     })
     .required()
@@ -296,13 +297,18 @@ export const AddServiceTokenModal = ({ popUp, handlePopUpToggle }: Props) => {
               name="permissions"
               defaultValue={{
                 read: true,
+                readValue: false,
                 write: false
               }}
               render={({ field: { onChange, value }, fieldState: { error } }) => {
                 const options = [
                   {
-                    label: "Read (default)",
+                    label: "Describe Secret (default)",
                     value: "read"
+                  },
+                  {
+                    label: "Read Value (optional)",
+                    value: "readValue"
                   },
                   {
                     label: "Write (optional)",

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -35,6 +35,11 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
   title,
   isDisabled
 }: Props<T>) => {
+  if (subject === "secrets") {
+    console.log("secret subject");
+    console.log(actions);
+  }
+
   const { control } = useFormContext<TFormSchema>();
   const items = useFieldArray({
     control,
@@ -116,25 +121,36 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
                 <div className="w-1/4">Actions</div>
                 <div className="flex flex-grow flex-wrap justify-start gap-8">
                   {actions.map(({ label, value }) => {
+                    if (subject === "secrets") {
+                      console.log("value", value);
+                    }
+
                     if (typeof value !== "string") return undefined;
+
                     return (
                       <Controller
                         key={`${el.id}-${label}`}
                         name={`permissions.${subject}.${rootIndex}.${value}` as any}
                         control={control}
                         defaultValue={false}
-                        render={({ field }) => (
-                          <div className="flex items-center justify-center">
-                            <Checkbox
-                              isDisabled={isDisabled}
-                              isChecked={Boolean(field.value)}
-                              onCheckedChange={field.onChange}
-                              id={`permissions.${subject}.${rootIndex}.${String(value)}`}
-                            >
-                              {label}
-                            </Checkbox>
-                          </div>
-                        )}
+                        render={({ field }) => {
+                          if (subject === "secrets") {
+                            console.log("field", field);
+                          }
+
+                          return (
+                            <div className="flex items-center justify-center">
+                              <Checkbox
+                                isDisabled={isDisabled}
+                                isChecked={Boolean(field.value)}
+                                onCheckedChange={field.onChange}
+                                id={`permissions.${subject}.${rootIndex}.${String(value)}`}
+                              >
+                                {label}
+                              </Checkbox>
+                            </div>
+                          );
+                        }}
                       />
                     );
                   })}

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -35,11 +35,6 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
   title,
   isDisabled
 }: Props<T>) => {
-  if (subject === "secrets") {
-    console.log("secret subject");
-    console.log(actions);
-  }
-
   const { control } = useFormContext<TFormSchema>();
   const items = useFieldArray({
     control,
@@ -121,10 +116,6 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
                 <div className="w-1/4">Actions</div>
                 <div className="flex flex-grow flex-wrap justify-start gap-8">
                   {actions.map(({ label, value }) => {
-                    if (subject === "secrets") {
-                      console.log("value", value);
-                    }
-
                     if (typeof value !== "string") return undefined;
 
                     return (
@@ -134,10 +125,6 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
                         control={control}
                         defaultValue={false}
                         render={({ field }) => {
-                          if (subject === "secrets") {
-                            console.log("field", field);
-                          }
-
                           return (
                             <div className="flex items-center justify-center">
                               <Checkbox

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -19,6 +19,7 @@ import {
 import { getKeyValue } from "@app/helpers/parseEnvVar";
 import { useCreateFolder, useCreateSecretV3, useCreateWsTag, useGetWsTags } from "@app/hooks/api";
 import { SecretType } from "@app/hooks/api/types";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 
 const typeSchema = z
   .object({
@@ -275,7 +276,7 @@ export const CreateSecretForm = ({ secretPath = "/", onClose }: Props) => {
               isMulti
               options={environments.filter((environment) =>
                 permission.can(
-                  ProjectPermissionActions.Create,
+                  ProjectPermissionSecretActions.Create,
                   subject(ProjectPermissionSub.Secrets, {
                     environment: environment.slug,
                     secretPath,

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -142,24 +142,35 @@ export const SecretEditRow = ({
       />
 
       <div className="flex-grow border-r border-r-mineshaft-600 pl-1 pr-2">
-        <Controller
-          disabled={isImportedSecret && !defaultValue}
-          control={control}
-          name="value"
-          render={({ field }) => (
-            <InfisicalSecretInput
-              {...field}
-              isReadOnly={isImportedSecret}
-              value={field.value as string}
-              key="secret-input"
-              isVisible={isVisible}
-              secretValueHidden={secretValueHidden}
-              secretPath={secretPath}
-              environment={environment}
-              isImport={isImportedSecret}
-            />
-          )}
-        />
+        {secretValueHidden ? (
+          <Tooltip content="You do not have permission to read the value of this secret.">
+            <div
+              className="flex w-80 flex-grow items-center py-1 pl-4 pr-2"
+              tabIndex={0}
+              role="button"
+            >
+              <span className="blur">********</span>
+            </div>
+          </Tooltip>
+        ) : (
+          <Controller
+            disabled={isImportedSecret && !defaultValue}
+            control={control}
+            name="value"
+            render={({ field }) => (
+              <InfisicalSecretInput
+                {...field}
+                isReadOnly={isImportedSecret}
+                value={field.value as string}
+                key="secret-input"
+                isVisible={isVisible}
+                secretPath={secretPath}
+                environment={environment}
+                isImport={isImportedSecret}
+              />
+            )}
+          />
+        )}
       </div>
 
       <div

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -25,6 +25,7 @@ import {
   ModalTrigger,
   Tooltip
 } from "@app/components/v2";
+import { Blur } from "@app/components/v2/Blur";
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
 import { useToggle } from "@app/hooks";
@@ -143,11 +144,7 @@ export const SecretEditRow = ({
 
       <div className="flex-grow border-r border-r-mineshaft-600 pl-1 pr-2">
         {secretValueHidden ? (
-          <Tooltip content="You do not have permission to read the value of this secret.">
-            <div className="flex w-80 flex-grow items-center py-1 pl-4 pr-2">
-              <span className="blur">********</span>
-            </div>
-          </Tooltip>
+          <Blur tooltipText="You do not have permission to read the value of this secret." />
         ) : (
           <Controller
             disabled={isImportedSecret && !defaultValue}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -219,6 +219,7 @@ export const SecretEditRow = ({
             <div className="opacity-0 group-hover:opacity-100">
               <Tooltip content="Copy Secret">
                 <IconButton
+                  isDisabled={secretValueHidden}
                   ariaLabel="copy-value"
                   onClick={handleCopySecretToClipboard}
                   variant="plain"

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -144,11 +144,7 @@ export const SecretEditRow = ({
       <div className="flex-grow border-r border-r-mineshaft-600 pl-1 pr-2">
         {secretValueHidden ? (
           <Tooltip content="You do not have permission to read the value of this secret.">
-            <div
-              className="flex w-80 flex-grow items-center py-1 pl-4 pr-2"
-              tabIndex={0}
-              role="button"
-            >
+            <div className="flex w-80 flex-grow items-center py-1 pl-4 pr-2">
               <span className="blur">********</span>
             </div>
           </Tooltip>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -39,6 +39,7 @@ type Props = {
   isVisible?: boolean;
   isImportedSecret: boolean;
   environment: string;
+  secretValueHidden: boolean;
   secretPath: string;
   onSecretCreate: (env: string, key: string, value: string) => Promise<void>;
   onSecretUpdate: (
@@ -58,6 +59,7 @@ export const SecretEditRow = ({
   isImportedSecret,
   onSecretUpdate,
   secretName,
+  secretValueHidden,
   onSecretCreate,
   onSecretDelete,
   environment,
@@ -151,6 +153,7 @@ export const SecretEditRow = ({
               value={field.value as string}
               key="secret-input"
               isVisible={isVisible}
+              secretValueHidden={secretValueHidden}
               secretPath={secretPath}
               environment={environment}
               isImport={isImportedSecret}
@@ -158,6 +161,7 @@ export const SecretEditRow = ({
           )}
         />
       </div>
+
       <div
         className={twMerge(
           "flex w-24 justify-center space-x-3 pl-2 transition-all",

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretNoAccessOverviewTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretNoAccessOverviewTableRow.tsx
@@ -3,6 +3,7 @@ import { faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { Td, Tooltip, Tr } from "@app/components/v2";
+import { Blur } from "@app/components/v2/Blur";
 
 type Props = {
   environments: { name: string; slug: string }[];
@@ -25,7 +26,7 @@ export const SecretNoAccessOverviewTableRow = ({ environments = [], count }: Pro
                   <div className="text-bunker-300">
                     <FontAwesomeIcon className="block" icon={faLock} />
                   </div>
-                  <div className="blur-sm">NO ACCESS</div>
+                  <Blur />
                 </div>
               </Tooltip>
             </div>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -221,10 +221,13 @@ export const SecretOverviewTableRow = ({
                               secretPath={secretPath}
                               isVisible={isSecretVisible}
                               secretName={secretKey}
+                              secretValueHidden={secret?.secretValueHidden || false}
                               defaultValue={
-                                secret?.valueOverride ||
-                                secret?.value ||
-                                importedSecret?.secret?.value
+                                secret?.secretValueHidden
+                                  ? ""
+                                  : secret?.valueOverride ||
+                                    secret?.value ||
+                                    importedSecret?.secret?.value
                               }
                               secretId={secret?.id}
                               isOverride={Boolean(secret?.valueOverride)}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretRenameRow.tsx
@@ -10,12 +10,8 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { IconButton, Input, Spinner, Tooltip } from "@app/components/v2";
-import {
-  ProjectPermissionActions,
-  ProjectPermissionSub,
-  useProjectPermission,
-  useWorkspace
-} from "@app/context";
+import { ProjectPermissionSub, useProjectPermission, useWorkspace } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useToggle } from "@app/hooks";
 import { useUpdateSecretV3 } from "@app/hooks/api";
 import { SecretType, SecretV3RawSanitized } from "@app/hooks/api/types";
@@ -55,8 +51,8 @@ function SecretRenameRow({ environments, getSecretByKey, secretKey, secretPath }
       secretTags: (secretDetails?.tags || []).map((i) => i.slug)
     });
     const isSecretInEnvReadOnly =
-      permission.can(ProjectPermissionActions.Read, secretPermissionSubject) &&
-      permission.cannot(ProjectPermissionActions.Edit, secretPermissionSubject);
+      permission.can(ProjectPermissionSecretActions.DescribeSecret, secretPermissionSubject) &&
+      permission.cannot(ProjectPermissionSecretActions.Edit, secretPermissionSubject);
     if (isSecretInEnvReadOnly) {
       return true;
     }

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
@@ -110,21 +110,31 @@ export const QuickSearchSecretItem = ({
             </Badge>
           )}
           {isSingleEnv ? (
-            <IconButton
-              size="md"
-              variant="plain"
-              colorSchema="secondary"
-              ariaLabel="Copy secret value"
-              onClick={(e) => {
-                e.stopPropagation();
-                const el = envSlugMap.get(groupSecret.env)?.name;
-                if (el) {
-                  handleCopy(groupSecret.value!, el);
-                }
-              }}
+            <Tooltip
+              isDisabled={!groupSecret?.secretValueHidden}
+              content={
+                groupSecret?.secretValueHidden
+                  ? "You do not have permission to view this secret value"
+                  : ""
+              }
             >
-              <FontAwesomeIcon icon={isUrlCopied ? faCheck : faCopy} />
-            </IconButton>
+              <IconButton
+                size="md"
+                isDisabled={groupSecret?.secretValueHidden}
+                variant="plain"
+                colorSchema="secondary"
+                ariaLabel="Copy secret value"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const el = envSlugMap.get(groupSecret.env)?.name;
+                  if (el) {
+                    handleCopy(groupSecret.value!, el);
+                  }
+                }}
+              >
+                <FontAwesomeIcon icon={isUrlCopied ? faCheck : faCopy} />
+              </IconButton>
+            </Tooltip>
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -158,14 +168,24 @@ export const QuickSearchSecretItem = ({
           )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton
-                size="md"
-                variant="plain"
-                colorSchema="secondary"
-                ariaLabel="View secret value"
+              <Tooltip
+                isDisabled={!groupSecret?.secretValueHidden}
+                content={
+                  groupSecret?.secretValueHidden
+                    ? "You do not have permission to view this secret value"
+                    : ""
+                }
               >
-                <FontAwesomeIcon icon={faEye} />
-              </IconButton>
+                <IconButton
+                  size="md"
+                  isDisabled={groupSecret?.secretValueHidden}
+                  variant="plain"
+                  colorSchema="secondary"
+                  ariaLabel="View secret value"
+                >
+                  <FontAwesomeIcon icon={faEye} />
+                </IconButton>
+              </Tooltip>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Hover to Reveal...</DropdownMenuLabel>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
@@ -11,6 +11,7 @@ import {
   useProjectPermission,
   useWorkspace
 } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { usePopUp } from "@app/hooks";
 import { useDeleteFolder, useDeleteSecretBatch } from "@app/hooks/api";
 import {
@@ -58,7 +59,7 @@ export const SelectionPanel = ({ secretPath, resetSelectedEntries, selectedEntri
   // user should have the ability to delete secrets/folders in at least one of the envs
   const shouldShowDelete = userAvailableEnvs.some((env) =>
     permission.can(
-      ProjectPermissionActions.Delete,
+      ProjectPermissionSecretActions.Delete,
       subject(ProjectPermissionSub.Secrets, {
         environment: env.slug,
         secretPath,
@@ -110,7 +111,7 @@ export const SelectionPanel = ({ secretPath, resetSelectedEntries, selectedEntri
         (accum: TDeleteSecretBatchDTO["secrets"], secretRecord) => {
           const entry = secretRecord[env.slug];
           const canDeleteSecret = permission.can(
-            ProjectPermissionActions.Delete,
+            ProjectPermissionSecretActions.Delete,
             subject(ProjectPermissionSub.Secrets, {
               environment: env.slug,
               secretPath,

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/MoveSecretsDialog/MoveSecretsDialog.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/MoveSecretsDialog/MoveSecretsDialog.tsx
@@ -25,7 +25,8 @@ import {
   Spinner,
   Switch
 } from "@app/components/v2";
-import { ProjectPermissionActions, ProjectPermissionSub, useProjectPermission } from "@app/context";
+import { ProjectPermissionSub, useProjectPermission } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useDebounce } from "@app/hooks";
 import { useMoveSecrets } from "@app/hooks/api";
 import { useGetProjectSecretsQuickSearch } from "@app/hooks/api/dashboard";
@@ -95,7 +96,7 @@ const Content = ({
         env.slug,
         {
           missingPermissions: permission.cannot(
-            ProjectPermissionActions.Delete,
+            ProjectPermissionSecretActions.Delete,
             subject(ProjectPermissionSub.Secrets, {
               environment: env.slug,
               secretPath: sourceSecretPath,

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
@@ -122,8 +122,6 @@ const Page = () => {
     })
   );
 
-  console.log("Can read secret value", canReadSecret);
-
   const canReadSecretImports = permission.can(
     ProjectPermissionActions.Read,
     subject(ProjectPermissionSub.SecretImports, { environment, secretPath })

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
@@ -58,6 +58,7 @@ import {
   useSelectedSecrets
 } from "./SecretMainPage.store";
 import { Filter, RowType } from "./SecretMainPage.types";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 
 const LOADER_TEXT = [
   "Retrieving your encrypted secrets...",
@@ -103,7 +104,7 @@ const Page = () => {
   const projectSlug = currentWorkspace?.slug || "";
   const secretPath = (routerQueryParams.secretPath as string) || "/";
   const canReadSecret = permission.can(
-    ProjectPermissionActions.Read,
+    ProjectPermissionSecretActions.DescribeSecret,
     subject(ProjectPermissionSub.Secrets, {
       environment,
       secretPath,
@@ -111,6 +112,17 @@ const Page = () => {
       secretTags: ["*"]
     })
   );
+  const canReadSecretValue = permission.can(
+    ProjectPermissionSecretActions.ReadValue,
+    subject(ProjectPermissionSub.Secrets, {
+      environment,
+      secretPath,
+      secretName: "*",
+      secretTags: ["*"]
+    })
+  );
+
+  console.log("Can read secret value", canReadSecret);
 
   const canReadSecretImports = permission.can(
     ProjectPermissionActions.Read,
@@ -176,6 +188,7 @@ const Page = () => {
     orderDirection,
     includeImports: canReadSecretImports && filter.include.import,
     includeFolders: filter.include.folder,
+    viewSecretValue: canReadSecretValue,
     includeDynamicSecrets: canReadDynamicSecret && filter.include.dynamic,
     includeSecrets: canReadSecret && filter.include.secret,
     tags: filter.tags

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/SecretDashboardPage.tsx
@@ -25,6 +25,7 @@ import {
   useProjectPermission,
   useWorkspace
 } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useDebounce, usePagination, usePopUp, useResetPageHelper } from "@app/hooks";
 import {
   useGetImportedSecretsSingleEnv,
@@ -58,7 +59,6 @@ import {
   useSelectedSecrets
 } from "./SecretMainPage.store";
 import { Filter, RowType } from "./SecretMainPage.types";
-import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 
 const LOADER_TEXT = [
   "Retrieving your encrypted secrets...",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -21,6 +21,7 @@ import {
   faTrash
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { AxiosError } from "axios";
 import FileSaver from "file-saver";
 import { twMerge } from "tailwind-merge";
 
@@ -54,7 +55,7 @@ import {
 import { usePopUp } from "@app/hooks";
 import { useCreateFolder, useDeleteSecretBatch, useMoveSecrets } from "@app/hooks/api";
 import { fetchProjectSecrets } from "@app/hooks/api/secrets/queries";
-import { SecretType, WsTag } from "@app/hooks/api/types";
+import { ApiErrorTypes, SecretType, TApiErrors, WsTag } from "@app/hooks/api/types";
 import { SecretSearchInput } from "@app/pages/secret-manager/OverviewPage/components/SecretSearchInput";
 
 import {
@@ -152,51 +153,71 @@ export const ActionBar = ({
   };
 
   const handleSecretDownload = async () => {
-    const { secrets: localSecrets, imports: localImportedSecrets } = await fetchProjectSecrets({
-      workspaceId,
-      expandSecretReferences: true,
-      includeImports: true,
-      environment,
-      secretPath
-    });
-    const secretsPicked = new Set<string>();
-    const secretsToDownload: { key: string; value?: string; comment?: string }[] = [];
-    localSecrets.forEach((el) => {
-      secretsPicked.add(el.secretKey);
-      secretsToDownload.push({
-        key: el.secretKey,
-        value: el.secretValue,
-        comment: el.secretComment
+    try {
+      const { secrets: localSecrets, imports: localImportedSecrets } = await fetchProjectSecrets({
+        workspaceId,
+        expandSecretReferences: true,
+        includeImports: true,
+        environment,
+        secretPath
       });
-    });
+      const secretsPicked = new Set<string>();
+      const secretsToDownload: { key: string; value?: string; comment?: string }[] = [];
+      localSecrets.forEach((el) => {
+        secretsPicked.add(el.secretKey);
+        secretsToDownload.push({
+          key: el.secretKey,
+          value: el.secretValue,
+          comment: el.secretComment
+        });
+      });
 
-    for (let i = localImportedSecrets.length - 1; i >= 0; i -= 1) {
-      for (let j = localImportedSecrets[i].secrets.length - 1; j >= 0; j -= 1) {
-        const secret = localImportedSecrets[i].secrets[j];
-        if (!secretsPicked.has(secret.secretKey)) {
-          secretsToDownload.push({
-            key: secret.secretKey,
-            value: secret.secretValue,
-            comment: secret.secretComment
-          });
+      for (let i = localImportedSecrets.length - 1; i >= 0; i -= 1) {
+        for (let j = localImportedSecrets[i].secrets.length - 1; j >= 0; j -= 1) {
+          const secret = localImportedSecrets[i].secrets[j];
+          if (!secretsPicked.has(secret.secretKey)) {
+            secretsToDownload.push({
+              key: secret.secretKey,
+              value: secret.secretValue,
+              comment: secret.secretComment
+            });
+          }
+          secretsPicked.add(secret.secretKey);
         }
-        secretsPicked.add(secret.secretKey);
       }
+
+      const file = secretsToDownload
+        .sort((a, b) => a.key.toLowerCase().localeCompare(b.key.toLowerCase()))
+        .reduce(
+          (prev, { key, comment, value }, index) =>
+            prev +
+            (comment
+              ? `${index === 0 ? "#" : "\n#"} ${comment}\n${key}=${value}\n`
+              : `${key}=${value}\n`),
+          ""
+        );
+
+      const blob = new Blob([file], { type: "text/plain;charset=utf-8" });
+      FileSaver.saveAs(blob, `${environment}.env`);
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        const error = err?.response?.data as TApiErrors;
+
+        if (error?.error === ApiErrorTypes.ForbiddenError && error.message.includes("readValue")) {
+          createNotification({
+            title: "You don't have permission to download secrets",
+            text: "You don't have permission to view one or more of the secrets in the current folder. Please contact your administrator.",
+            type: "error"
+          });
+          return;
+        }
+      }
+      createNotification({
+        title: "Failed to download secrets",
+        text: "Please try again later.",
+        type: "error"
+      });
     }
-
-    const file = secretsToDownload
-      .sort((a, b) => a.key.toLowerCase().localeCompare(b.key.toLowerCase()))
-      .reduce(
-        (prev, { key, comment, value }, index) =>
-          prev +
-          (comment
-            ? `${index === 0 ? "#" : "\n#"} ${comment}\n${key}=${value}\n`
-            : `${key}=${value}\n`),
-        ""
-      );
-
-    const blob = new Blob([file], { type: "text/plain;charset=utf-8" });
-    FileSaver.saveAs(blob, `${environment}.env`);
   };
 
   const handleSecretBulkDelete = async () => {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -276,53 +276,55 @@ export const SecretDetailSidebar = ({
                         key="secret-value"
                         control={control}
                         render={({ field }) => (
-                          <FormControl
-                            helperText={
-                              cannotReadSecretValue ? (
-                                <div className="flex space-x-2">
-                                  <FontAwesomeIcon
-                                    icon={faTriangleExclamation}
-                                    className="mt-0.5 text-yellow-400"
-                                  />
-                                  <span>
-                                    The value of this secret is hidden because you do not have the
-                                    read secret value permission.
-                                  </span>
-                                </div>
-                              ) : undefined
-                            }
-                            label="Value"
-                          >
-                            <InfisicalSecretInput
-                              isReadOnly={isReadOnly}
-                              environment={environment}
-                              secretPath={secretPath}
-                              key="secret-value"
-                              isDisabled={isOverridden || !isAllowed}
-                              containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-800 px-2 py-1.5"
-                              {...field}
-                              autoFocus={false}
-                            />
-                          </FormControl>
+                          <div className="flex items-center gap-2">
+                            <FormControl
+                              helperText={
+                                cannotReadSecretValue ? (
+                                  <div className="flex space-x-2">
+                                    <FontAwesomeIcon
+                                      icon={faTriangleExclamation}
+                                      className="mt-0.5 text-yellow-400"
+                                    />
+                                    <span>
+                                      The value of this secret is hidden because you do not have the
+                                      read secret value permission.
+                                    </span>
+                                  </div>
+                                ) : undefined
+                              }
+                              label="Value"
+                            >
+                              <div className="flex items-center gap-2">
+                                <InfisicalSecretInput
+                                  isReadOnly={isReadOnly}
+                                  environment={environment}
+                                  secretPath={secretPath}
+                                  key="secret-value"
+                                  isDisabled={isOverridden || !isAllowed}
+                                  containerClassName="text-bunker-300 w-full hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-800 px-2 py-1.5"
+                                  {...field}
+                                  autoFocus={false}
+                                />
+                                <Button
+                                  className="px-2 py-[0.43rem] font-normal"
+                                  variant="outline_bg"
+                                  leftIcon={<FontAwesomeIcon icon={faShare} />}
+                                  onClick={() => {
+                                    const value = secret?.valueOverride ?? secret?.value;
+                                    if (value) {
+                                      handleSecretShare(value);
+                                    }
+                                  }}
+                                >
+                                  Share
+                                </Button>
+                              </div>
+                            </FormControl>
+                          </div>
                         )}
                       />
                     )}
                   </ProjectPermissionCan>
-                </div>
-                <div className="ml-1 mt-1.5 flex items-center">
-                  <Button
-                    className="w-full px-2 py-[0.43rem] font-normal"
-                    variant="outline_bg"
-                    leftIcon={<FontAwesomeIcon icon={faShare} />}
-                    onClick={() => {
-                      const value = secret?.valueOverride ?? secret?.value;
-                      if (value) {
-                        handleSecretShare(value);
-                      }
-                    }}
-                  >
-                    Share
-                  </Button>
                 </div>
               </div>
               <div className="mb-2 rounded border border-mineshaft-600 bg-mineshaft-900 p-4 px-0 pb-0">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Link } from "@tanstack/react-router";
 import { format } from "date-fns";
+import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
@@ -207,9 +208,16 @@ export const SecretDetailSidebar = ({
     await onSaveSecret(secret, { ...secret, ...data }, () => reset());
   };
 
-  const handleReminderSubmit = async (reminderRepeatDays: number | null | undefined, reminderNote: string | null | undefined) => {
-    await onSaveSecret(secret, { ...secret, reminderRepeatDays, reminderNote, isReminderEvent: true }, () => { });
-  }
+  const handleReminderSubmit = async (
+    reminderRepeatDays: number | null | undefined,
+    reminderNote: string | null | undefined
+  ) => {
+    await onSaveSecret(
+      secret,
+      { ...secret, reminderRepeatDays, reminderNote, isReminderEvent: true },
+      () => {}
+    );
+  };
 
   const [createReminderFormOpen, setCreateReminderFormOpen] = useToggle(false);
 
@@ -228,7 +236,7 @@ export const SecretDetailSidebar = ({
           if (data) {
             setValue("reminderRepeatDays", data.days, { shouldDirty: false });
             setValue("reminderNote", data.note, { shouldDirty: false });
-            handleReminderSubmit(data.days, data.note)
+            handleReminderSubmit(data.days, data.note);
           }
         }}
       />
@@ -278,6 +286,7 @@ export const SecretDetailSidebar = ({
                         render={({ field }) => (
                           <div className="flex items-center gap-2">
                             <FormControl
+                              className="flex-1"
                               helperText={
                                 cannotReadSecretValue ? (
                                   <div className="flex space-x-2">
@@ -651,51 +660,34 @@ export const SecretDetailSidebar = ({
               <div className="mb-4flex-grow dark cursor-default text-sm text-bunker-300">
                 <div className="mb-2 pl-1">Version History</div>
                 <div className="thin-scrollbar flex h-48 flex-col space-y-2 overflow-y-auto overflow-x-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 p-4 dark:[color-scheme:dark]">
-                  {secretVersion?.map(({ createdAt, secretValue, version, id }) => (
-                    <div className="flex flex-row">
-                      <div key={id} className="flex w-full flex-col space-y-1">
-                        <div className="flex items-center">
-                          <div className="w-10">
-                            <div className="w-fit rounded-md border border-mineshaft-600 bg-mineshaft-700 px-1 text-sm text-mineshaft-300">
-                              v{version}
+                  {secretVersion?.map(
+                    ({ createdAt, secretValue, version, id, secretValueHidden }) => (
+                      <div className="flex flex-row">
+                        <div key={id} className="flex w-full flex-col space-y-1">
+                          <div className="flex items-center">
+                            <div className="w-10">
+                              <div className="w-fit rounded-md border border-mineshaft-600 bg-mineshaft-700 px-1 text-sm text-mineshaft-300">
+                                v{version}
+                              </div>
                             </div>
+                            <div>{format(new Date(createdAt), "Pp")}</div>
                           </div>
-                          <div>{format(new Date(createdAt), "Pp")}</div>
-                        </div>
-                        <div className="flex w-full cursor-default">
-                          <div className="relative w-10">
-                            <div className="absolute bottom-0 left-3 top-0 mt-0.5 border-l border-mineshaft-400/60" />
-                          </div>
-                          <div className="flex flex-row">
-                            <div className="h-min w-fit rounded-sm bg-primary-500/10 px-1 text-primary-300/70">
-                              Value:
+                          <div className="flex w-full cursor-default">
+                            <div className="relative w-10">
+                              <div className="absolute bottom-0 left-3 top-0 mt-0.5 border-l border-mineshaft-400/60" />
                             </div>
-                            <div className="group break-all pl-1 font-mono">
-                              <div className="relative hidden cursor-pointer transition-all duration-200 group-[.show-value]:inline">
-                                <button
-                                  type="button"
-                                  className="select-none"
-                                  onClick={(e) => {
-                                    navigator.clipboard.writeText(secretValue || "");
-                                    const target = e.currentTarget;
-                                    target.style.borderBottom = "1px dashed";
-                                    target.style.paddingBottom = "-1px";
+                            <div className="flex flex-row">
+                              <div className="h-min w-fit rounded-sm bg-primary-500/10 px-1 text-primary-300/70">
+                                Value:
+                              </div>
+                              <div className="group break-all pl-1 font-mono">
+                                <div className="relative hidden cursor-pointer transition-all duration-200 group-[.show-value]:inline">
+                                  <button
+                                    type="button"
+                                    className="select-none"
+                                    onClick={(e) => {
+                                      if (secretValueHidden) return;
 
-                                    // Create and insert popup
-                                    const popup = document.createElement("div");
-                                    popup.className =
-                                      "w-16 flex justify-center absolute top-6 left-0 text-xs text-primary-100 bg-mineshaft-800 px-1 py-0.5 rounded-md border border-primary-500/50";
-                                    popup.textContent = "Copied!";
-                                    target.parentElement?.appendChild(popup);
-
-                                    // Remove popup and border after delay
-                                    setTimeout(() => {
-                                      popup.remove();
-                                      target.style.borderBottom = "none";
-                                    }, 3000);
-                                  }}
-                                  onKeyDown={(e) => {
-                                    if (e.key === "Enter" || e.key === " ") {
                                       navigator.clipboard.writeText(secretValue || "");
                                       const target = e.currentTarget;
                                       target.style.borderBottom = "1px dashed";
@@ -713,72 +705,109 @@ export const SecretDetailSidebar = ({
                                         popup.remove();
                                         target.style.borderBottom = "none";
                                       }, 3000);
-                                    }
-                                  }}
-                                >
-                                  {secretValue}
-                                </button>
-                                <button
-                                  type="button"
-                                  className="ml-1 cursor-pointer"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    e.currentTarget
-                                      .closest(".group")
-                                      ?.classList.remove("show-value");
-                                  }}
-                                  onKeyDown={(e) => {
-                                    if (e.key === "Enter" || e.key === " ") {
+                                    }}
+                                    onKeyDown={(e) => {
+                                      if (secretValueHidden) return;
+
+                                      if (e.key === "Enter" || e.key === " ") {
+                                        navigator.clipboard.writeText(secretValue || "");
+                                        const target = e.currentTarget;
+                                        target.style.borderBottom = "1px dashed";
+                                        target.style.paddingBottom = "-1px";
+
+                                        // Create and insert popup
+                                        const popup = document.createElement("div");
+                                        popup.className =
+                                          "w-16 flex justify-center absolute top-6 left-0 text-xs text-primary-100 bg-mineshaft-800 px-1 py-0.5 rounded-md border border-primary-500/50";
+                                        popup.textContent = "Copied!";
+                                        target.parentElement?.appendChild(popup);
+
+                                        // Remove popup and border after delay
+                                        setTimeout(() => {
+                                          popup.remove();
+                                          target.style.borderBottom = "none";
+                                        }, 3000);
+                                      }
+                                    }}
+                                  >
+                                    <Tooltip
+                                      className="break-normal text-xs"
+                                      content="You do not have permission to view this secret value"
+                                      isDisabled={!secretValueHidden}
+                                    >
+                                      <span
+                                        className={twMerge(
+                                          secretValueHidden && "text-xs text-bunker-300 opacity-40"
+                                        )}
+                                      >
+                                        {secretValueHidden ? "Hidden" : secretValue}
+                                      </span>
+                                    </Tooltip>
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="ml-1 cursor-pointer"
+                                    onClick={(e) => {
                                       e.stopPropagation();
                                       e.currentTarget
                                         .closest(".group")
                                         ?.classList.remove("show-value");
-                                    }
-                                  }}
-                                >
-                                  <FontAwesomeIcon icon={faEyeSlash} />
-                                </button>
-                              </div>
-                              <span className="group-[.show-value]:hidden">
-                                {secretValue?.replace(/./g, "*")}
-                                <button
-                                  type="button"
-                                  className="ml-1 cursor-pointer"
-                                  onClick={(e) => {
-                                    e.currentTarget.closest(".group")?.classList.add("show-value");
-                                  }}
-                                  onKeyDown={(e) => {
-                                    if (e.key === "Enter" || e.key === " ") {
+                                    }}
+                                    onKeyDown={(e) => {
+                                      if (e.key === "Enter" || e.key === " ") {
+                                        e.stopPropagation();
+                                        e.currentTarget
+                                          .closest(".group")
+                                          ?.classList.remove("show-value");
+                                      }
+                                    }}
+                                  >
+                                    <FontAwesomeIcon icon={faEyeSlash} />
+                                  </button>
+                                </div>
+                                <span className="group-[.show-value]:hidden">
+                                  {secretValueHidden ? "******" : secretValue?.replace(/./g, "*")}
+                                  <button
+                                    type="button"
+                                    className="ml-1 cursor-pointer"
+                                    onClick={(e) => {
                                       e.currentTarget
                                         .closest(".group")
                                         ?.classList.add("show-value");
-                                    }
-                                  }}
-                                >
-                                  <FontAwesomeIcon icon={faEye} />
-                                </button>
-                              </span>
+                                    }}
+                                    onKeyDown={(e) => {
+                                      if (e.key === "Enter" || e.key === " ") {
+                                        e.currentTarget
+                                          .closest(".group")
+                                          ?.classList.add("show-value");
+                                      }
+                                    }}
+                                  >
+                                    <FontAwesomeIcon icon={faEye} />
+                                  </button>
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </div>
+                        <div
+                          className={`flex items-center justify-center ${version === secretVersion.length ? "hidden" : ""}`}
+                        >
+                          <Tooltip content="Restore Secret Value">
+                            <IconButton
+                              ariaLabel="Restore"
+                              variant="outline_bg"
+                              size="sm"
+                              className="h-8 w-8 rounded-md"
+                              onClick={() => setValue("value", secretValue)}
+                            >
+                              <FontAwesomeIcon icon={faArrowRotateRight} />
+                            </IconButton>
+                          </Tooltip>
+                        </div>
                       </div>
-                      <div
-                        className={`flex items-center justify-center ${version === secretVersion.length ? "hidden" : ""}`}
-                      >
-                        <Tooltip content="Restore Secret Value">
-                          <IconButton
-                            ariaLabel="Restore"
-                            variant="outline_bg"
-                            size="sm"
-                            className="h-8 w-8 rounded-md"
-                            onClick={() => setValue("value", secretValue)}
-                          >
-                            <FontAwesomeIcon icon={faArrowRotateRight} />
-                          </IconButton>
-                        </Tooltip>
-                      </div>
-                    </div>
-                  ))}
+                    )
+                  )}
                 </div>
               </div>
               <div className="dark mb-4 flex-grow text-sm text-bunker-300">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -9,7 +9,8 @@ import {
   faPlus,
   faShare,
   faTag,
-  faTrash
+  faTrash,
+  faTriangleExclamation
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -44,6 +45,7 @@ import {
   useProjectPermission,
   useWorkspace
 } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { usePopUp, useToggle } from "@app/hooks";
 import { useGetSecretVersion } from "@app/hooks/api";
 import { useGetSecretAccessList } from "@app/hooks/api/secrets/queries";
@@ -52,8 +54,6 @@ import { ProjectType } from "@app/hooks/api/workspace/types";
 
 import { CreateReminderForm } from "./CreateReminderForm";
 import { formSchema, SecretActionType, TFormSchema } from "./SecretListView.utils";
-import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
-import { useEffect } from "react";
 
 type Props = {
   isOpen?: boolean;
@@ -155,8 +155,6 @@ export const SecretDetailSidebar = ({
     ) &&
     cannotEditSecret &&
     cannotReadSecretValue;
-
-  console.log("cannotReadSecretValue", cannotReadSecretValue);
 
   const overrideAction = watch("overrideAction");
   const isOverridden =
@@ -280,9 +278,18 @@ export const SecretDetailSidebar = ({
                         render={({ field }) => (
                           <FormControl
                             helperText={
-                              cannotReadSecretValue
-                                ? "The value of this secret is hidden because you don't have the read secret value permission."
-                                : undefined
+                              cannotReadSecretValue ? (
+                                <div className="flex space-x-2">
+                                  <FontAwesomeIcon
+                                    icon={faTriangleExclamation}
+                                    className="mt-0.5 text-yellow-400"
+                                  />
+                                  <span>
+                                    The value of this secret is hidden because you do not have the
+                                    read secret value permission.
+                                  </span>
+                                </div>
+                              ) : undefined
                             }
                             label="Value"
                           >

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -314,19 +314,25 @@ export const SecretDetailSidebar = ({
                                   {...field}
                                   autoFocus={false}
                                 />
-                                <Button
-                                  className="px-2 py-[0.43rem] font-normal"
-                                  variant="outline_bg"
-                                  leftIcon={<FontAwesomeIcon icon={faShare} />}
-                                  onClick={() => {
-                                    const value = secret?.valueOverride ?? secret?.value;
-                                    if (value) {
-                                      handleSecretShare(value);
-                                    }
-                                  }}
+                                <Tooltip
+                                  content="You don't have permission to view the secret value."
+                                  isDisabled={!secret?.secretValueHidden}
                                 >
-                                  Share
-                                </Button>
+                                  <Button
+                                    isDisabled={secret?.secretValueHidden}
+                                    className="px-2 py-[0.43rem] font-normal"
+                                    variant="outline_bg"
+                                    leftIcon={<FontAwesomeIcon icon={faShare} />}
+                                    onClick={() => {
+                                      const value = secret?.valueOverride ?? secret?.value;
+                                      if (value) {
+                                        handleSecretShare(value);
+                                      }
+                                    }}
+                                  >
+                                    Share
+                                  </Button>
+                                </Tooltip>
                               </div>
                             </FormControl>
                           </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -661,8 +661,8 @@ export const SecretDetailSidebar = ({
                 <div className="mb-2 pl-1">Version History</div>
                 <div className="thin-scrollbar flex h-48 flex-col space-y-2 overflow-y-auto overflow-x-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 p-4 dark:[color-scheme:dark]">
                   {secretVersion?.map(
-                    ({ createdAt, secretValue, version, id, secretValueHidden }) => (
-                      <div className="flex flex-row">
+                    ({ createdAt, secretValue, version, id, secretValueHidden }, index) => (
+                      <div key={`secret-version-${index + 1}`} className="flex flex-row">
                         <div key={id} className="flex w-full flex-col space-y-1">
                           <div className="flex items-center">
                             <div className="w-10">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -150,7 +150,6 @@ export const SecretItem = memo(
       );
 
     const { secretValueHidden } = secret;
-    console.log(`Secret Key: ${secret.key}, hidden: ${secretValueHidden}`);
 
     const [isSecValueCopied, setIsSecValueCopied] = useToggle(false);
     useEffect(() => {
@@ -283,6 +282,16 @@ export const SecretItem = memo(
                     />
                   )}
                 />
+              ) : secretValueHidden ? (
+                <Tooltip content="You do not have permission to read the value of this secret.">
+                  <div
+                    className="flex w-80 flex-grow items-center py-1 pl-4 pr-2"
+                    tabIndex={0}
+                    role="button"
+                  >
+                    <span className="blur">********</span>
+                  </div>
+                </Tooltip>
               ) : (
                 <Controller
                   name="value"
@@ -290,7 +299,6 @@ export const SecretItem = memo(
                   control={control}
                   render={({ field }) => (
                     <InfisicalSecretInput
-                      secretValueHidden={secretValueHidden}
                       isReadOnly={isReadOnly}
                       key="secret-value"
                       isVisible={isVisible}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -46,6 +46,7 @@ import {
 } from "@app/components/secrets/SecretReferenceDetails";
 
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
+import { Blur } from "@app/components/v2/Blur";
 import {
   FontAwesomeSpriteName,
   formSchema,
@@ -283,15 +284,7 @@ export const SecretItem = memo(
                   )}
                 />
               ) : secretValueHidden ? (
-                <Tooltip content="You do not have permission to read the value of this secret.">
-                  <div
-                    className="flex w-80 flex-grow items-center py-1 pl-4 pr-2"
-                    tabIndex={0}
-                    role="button"
-                  >
-                    <span className="blur">********</span>
-                  </div>
-                </Tooltip>
+                <Blur tooltipText="You do not have permission to read the value of this secret." />
               ) : (
                 <Controller
                   name="value"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -307,6 +307,7 @@ export const SecretItem = memo(
               <div key="actions" className="flex h-8 flex-shrink-0 self-start transition-all">
                 <Tooltip content="Copy secret">
                   <IconButton
+                    isDisabled={secret.secretValueHidden}
                     ariaLabel="copy-value"
                     variant="plain"
                     size="sm"
@@ -514,6 +515,7 @@ export const SecretItem = memo(
                     )}
                   </ProjectPermissionCan>
                   <IconButton
+                    isDisabled={secret.secretValueHidden}
                     className="w-0 overflow-hidden p-0 group-hover:mr-2 group-hover:w-5 data-[state=open]:w-6"
                     variant="plain"
                     size="md"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 /* eslint-disable simple-import-sort/imports */
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
@@ -44,6 +45,7 @@ import {
   SecretReferenceTree
 } from "@app/components/secrets/SecretReferenceDetails";
 
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import {
   FontAwesomeSpriteName,
   formSchema,
@@ -99,8 +101,14 @@ export const SecretItem = memo(
       trigger,
       formState: { isDirty, isSubmitting, errors }
     } = useForm<TFormSchema>({
-      defaultValues: secret,
-      values: secret,
+      defaultValues: {
+        ...secret,
+        value: secret.secretValueHidden ? "" : secret.value
+      },
+      values: {
+        ...secret,
+        value: secret.secretValueHidden ? "" : secret.value
+      },
       resolver: zodResolver(formSchema)
     });
 
@@ -123,7 +131,7 @@ export const SecretItem = memo(
 
     const isReadOnly =
       permission.can(
-        ProjectPermissionActions.Read,
+        ProjectPermissionSecretActions.DescribeSecret,
         subject(ProjectPermissionSub.Secrets, {
           environment,
           secretPath,
@@ -132,7 +140,7 @@ export const SecretItem = memo(
         })
       ) &&
       permission.cannot(
-        ProjectPermissionActions.Edit,
+        ProjectPermissionSecretActions.Edit,
         subject(ProjectPermissionSub.Secrets, {
           environment,
           secretPath,
@@ -140,6 +148,9 @@ export const SecretItem = memo(
           secretTags: selectedTagSlugs
         })
       );
+
+    const { secretValueHidden } = secret;
+    console.log(`Secret Key: ${secret.key}, hidden: ${secretValueHidden}`);
 
     const [isSecValueCopied, setIsSecValueCopied] = useToggle(false);
     useEffect(() => {
@@ -279,12 +290,14 @@ export const SecretItem = memo(
                   control={control}
                   render={({ field }) => (
                     <InfisicalSecretInput
+                      secretValueHidden={secretValueHidden}
                       isReadOnly={isReadOnly}
                       key="secret-value"
                       isVisible={isVisible}
                       environment={environment}
                       secretPath={secretPath}
                       {...field}
+                      defaultValue={secretValueHidden ? "" : undefined}
                       containerClassName="py-1.5 rounded-md transition-all group-hover:mr-2"
                     />
                   )}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretNoAccessListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretNoAccessListView.tsx
@@ -1,4 +1,5 @@
 import { FontAwesomeSymbol, Input, Tooltip } from "@app/components/v2";
+import { Blur } from "@app/components/v2/Blur";
 
 import { FontAwesomeSpriteName } from "./SecretListView.utils";
 
@@ -34,13 +35,7 @@ export const SecretNoAccessListView = ({ count }: Props) => {
                 className="w-full px-0 blur-sm placeholder:text-red-500 focus:text-bunker-100 focus:ring-transparent"
               />
             </div>
-            <div
-              className="flex w-80 flex-grow items-center border-x border-mineshaft-600 py-1 pl-4 pr-2"
-              tabIndex={0}
-              role="button"
-            >
-              <span className="blur">********</span>
-            </div>
+            <Blur />
           </div>
         </Tooltip>
       ))}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SnapshotView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SnapshotView/SecretItem.tsx
@@ -20,6 +20,7 @@ import {
   Tooltip,
   Tr
 } from "@app/components/v2";
+import { Blur } from "@app/components/v2/Blur";
 import { useToggle } from "@app/hooks";
 import { SecretV3RawSanitized } from "@app/hooks/api/secrets/types";
 
@@ -120,11 +121,25 @@ export const SecretItem = ({ mode, preSecret, postSecret }: Props) => {
                   <Td className="border-r border-mineshaft-600">Value</Td>
                   {isModified && (
                     <Td className="border-r border-mineshaft-600">
-                      <SecretInput value={preSecret?.value} />
+                      {preSecret?.secretValueHidden ? (
+                        <Blur
+                          className="w-min"
+                          tooltipText="You do not have permission to read the value of this secret."
+                        />
+                      ) : (
+                        <SecretInput value={preSecret?.value} />
+                      )}
                     </Td>
                   )}
                   <Td>
-                    <SecretInput value={postSecret?.value} />
+                    {postSecret?.secretValueHidden ? (
+                      <Blur
+                        className="w-min"
+                        tooltipText="You do not have permission to read the value of this secret."
+                      />
+                    ) : (
+                      <SecretInput value={postSecret?.value} />
+                    )}
                   </Td>
                 </Tr>
                 {Boolean(preSecret?.idOverride || postSecret?.idOverride) && (


### PR DESCRIPTION
# Description 📣

This PR adds a new permission on the secrets subject, called `read value`. This aims to make secret value access more granular, and to allow users to specify weather or not a role should have access to purely describe a secret, or reveal it's value entirely.

A few important notes:
1. Users will still be able to fetch their personal secrets, even without the `Read Value` permission.
2. We are backfilling all existing permissions for roles, identity additional privileges, and user additional privileges.
3. The `POST` secret endpoints (endpoints used to create new secrets), will still expose the secret value regardless if the user has the `Read Value` permission or not. This is because the person creating the secret will already know the value that they're creating, therefore there's no point trying to enforce the `Read Value` permission here.
4. The Get Secret By Name and List Secrets endpoints now have a new `viewSecretValue` parameter (**which defaults to `true`**). If this parameter is set to `true`, and the user doesn't have the `Read Value` permission, it will throw an API error. If it's set to `false`, the API will return the secret without the value. The value is masked with `<hidden-by-infisical>`. 
5. Secret import secrets are filtered out if the user doesn't have the `Read Value` permission on the secret(s). This is inline with our current logic for secret imports.
   a. The same thing applies to recursive mode.
6. If there are secret references and `expandSecretReferences` is true and the user doesn't have the `Read Value` permission, it will result in an API error. 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded secret permissions with a new "readValue" option and enhanced service token capabilities.
  - Introduced new API and UI parameters to control secret visibility, allowing refined management of sensitive data.
  - Added a new `Blur` component for better visual representation of access restrictions.
  - New `secretValueHidden` property added to various schemas and components to manage secret visibility.

- **Refactor & Security Improvements**
  - Streamlined permission checks and secret management logic for more granular and secure access control.
  - UI components now conditionally mask secret values when users lack access, enhancing security.
  - Enhanced error handling in the `ActionBar` component for improved user feedback regarding permission issues.

- **Database Migrations**
  - Updated underlying data structures to support the expanded secret permissions model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->