### PR TITLE
Fix: AWS Secrets Manager Remove Deletion of other Secrets from Many-to-One Mapping

### DIFF
--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -272,22 +272,6 @@ export const AwsSecretsManagerSyncFns = {
           SecretString: secretValue
         });
       }
-
-      for await (const secretKey of Object.keys(awsSecretsRecord)) {
-        if (secretKey === destinationConfig.secretName) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-
-        try {
-          await deleteSecret(client, secretKey);
-        } catch (error) {
-          throw new SecretSyncError({
-            error,
-            secretKey
-          });
-        }
-      }
     }
   },
   getSecrets: async (secretSync: TAwsSecretsManagerSyncWithCredentials): Promise<TSecretMap> => {


### PR DESCRIPTION
# Description 📣

This PR removes deletion of other secrets during syncing for AWS Secrets Manager Sync when mapping behavior is Many-to-One.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the secret synchronization process to prevent unintended removal of secrets, ensuring a more stable management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->