### PR TITLE
Fix: Propagate Set Secrets Errors for Flyio Integration

### DIFF
--- a/backend/src/services/integration-auth/integration-sync-secret.ts
+++ b/backend/src/services/integration-auth/integration-sync-secret.ts
@@ -2257,7 +2257,9 @@ const syncSecretsFlyio = async ({
     }
   `;
 
-  await request.post(
+  type TFlyioErrors = { message: string }[];
+
+  const setSecretsResp = await request.post<{ errors?: TFlyioErrors }>(
     IntegrationUrls.FLYIO_API_URL,
     {
       query: SetSecrets,
@@ -2278,6 +2280,10 @@ const syncSecretsFlyio = async ({
       }
     }
   );
+
+  if (setSecretsResp.data.errors?.length) {
+    throw new Error(JSON.stringify(setSecretsResp.data.errors));
+  }
 
   // get secrets
   interface FlyioSecret {


### PR DESCRIPTION
# Description 📣

This PR propagates set secrets errors for our Flyio integration so that the sync properly fails and provides users with error context.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error reporting for third-party integration, ensuring that issues encountered during the secret-setting process are clearly identified, which improves system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->