### PR TITLE
docs: remove service token deprecation warning

### DIFF
--- a/docs/api-reference/overview/authentication.mdx
+++ b/docs/api-reference/overview/authentication.mdx
@@ -11,13 +11,6 @@ To interact with the Infisical API, you will need to obtain an access token. Fol
 **FAQ**
 
 <AccordionGroup>
-<Accordion title="What happened to the Service Token and API Key authentication modes?">
-    The Service Token and API Key authentication modes are being deprecated out in favor of [Identities](/documentation/platform/identity).
-    We expect to make a deprecation notice in the coming months alongside a larger deprecation initiative planned for Q1/Q2 2024.
-
-    With identities, we're improving significantly over the shortcomings of Service Tokens and API Keys. Amongst many differences, identities provide broader access over the Infisical API, utilizes the same role-based
-    permission system used by users, and comes with ample more configurable security measures.
-</Accordion>
 <Accordion title="Why can I not create, read, update, or delete an identity?">
   There are a few reasons for why this might happen:
   


### PR DESCRIPTION
# Description 📣

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API documentation by removing outdated guidance on previous authentication methods, ensuring that users only see current information focused on identity management and API credential support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->