### PR TITLE
use serviceName in helm chart.

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -120,5 +120,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "infisical.redisConnectionString" -}}
 {{- $password := .Values.redis.auth.password -}}
 {{- $serviceName := include "infisical.redisServiceName" . -}}
-{{- printf "redis://default:%s@%s:6379" $password "redis-master" -}}
+{{- printf "redis://default:%s@%s:6379" $password $serviceName -}}
 {{- end -}}


### PR DESCRIPTION
trying to use not the default service name doesnt work

# Description 📣

use the serviceName variable instead of an old default value. i assume this is what is intended

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [ x ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the connection configuration to dynamically use your defined service settings, enhancing flexibility and adaptability for deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->