### PR TITLE
Improvement: Increase Secret v2 Reminder Note Max Length

### DIFF
--- a/backend/src/db/migrations/20250228022604_increase-secret-reminder-note-max-length.ts
+++ b/backend/src/db/migrations/20250228022604_increase-secret-reminder-note-max-length.ts
@@ -1,0 +1,35 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  for await (const tableName of [
+    TableName.SecretV2,
+    TableName.SecretVersionV2,
+    TableName.SecretApprovalRequestSecretV2
+  ]) {
+    const hasReminderNoteCol = await knex.schema.hasColumn(tableName, "reminderNote");
+
+    if (hasReminderNoteCol) {
+      await knex.schema.alterTable(tableName, (t) => {
+        t.string("reminderNote", 1024).alter();
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for await (const tableName of [
+    TableName.SecretV2,
+    TableName.SecretVersionV2,
+    TableName.SecretApprovalRequestSecretV2
+  ]) {
+    const hasReminderNoteCol = await knex.schema.hasColumn(tableName, "reminderNote");
+
+    if (hasReminderNoteCol) {
+      await knex.schema.alterTable(tableName, (t) => {
+        t.string("reminderNote").alter();
+      });
+    }
+  }
+}

--- a/backend/src/server/routes/v3/secret-router.ts
+++ b/backend/src/server/routes/v3/secret-router.ts
@@ -537,7 +537,12 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
           .optional()
           .nullable()
           .describe(RAW_SECRETS.CREATE.secretReminderRepeatDays),
-        secretReminderNote: z.string().optional().nullable().describe(RAW_SECRETS.CREATE.secretReminderNote)
+        secretReminderNote: z
+          .string()
+          .max(1024, "Secret reminder note cannot exceed 1024 characters")
+          .optional()
+          .nullable()
+          .describe(RAW_SECRETS.CREATE.secretReminderNote)
       }),
       response: {
         200: z.union([
@@ -640,7 +645,12 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         tagIds: z.string().array().optional().describe(RAW_SECRETS.UPDATE.tagIds),
         metadata: z.record(z.string()).optional(),
         secretMetadata: ResourceMetadataSchema.optional(),
-        secretReminderNote: z.string().optional().nullable().describe(RAW_SECRETS.UPDATE.secretReminderNote),
+        secretReminderNote: z
+          .string()
+          .max(1024, "Secret reminder note cannot exceed 1024 characters")
+          .optional()
+          .nullable()
+          .describe(RAW_SECRETS.UPDATE.secretReminderNote),
         secretReminderRepeatDays: z
           .number()
           .optional()
@@ -2053,7 +2063,12 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
             skipMultilineEncoding: z.boolean().optional().describe(RAW_SECRETS.UPDATE.skipMultilineEncoding),
             newSecretName: SecretNameSchema.optional().describe(RAW_SECRETS.UPDATE.newSecretName),
             tagIds: z.string().array().optional().describe(RAW_SECRETS.UPDATE.tagIds),
-            secretReminderNote: z.string().optional().nullable().describe(RAW_SECRETS.UPDATE.secretReminderNote),
+            secretReminderNote: z
+              .string()
+              .max(1024, "Secret reminder note cannot exceed 1024 characters")
+              .optional()
+              .nullable()
+              .describe(RAW_SECRETS.UPDATE.secretReminderNote),
             secretMetadata: ResourceMetadataSchema.optional(),
             secretReminderRepeatDays: z
               .number()


### PR DESCRIPTION
# Description 📣

This PR increases the max length of secret v2 reminder notes from 255 characters to 1024 characters. The API has also been updated to provide max length error messaging rather than failing at the service level.


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Secret reminder notes now support up to 1024 characters.
  - Added clear, descriptive error messaging to guide users when the character limit is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->