### PR TITLE
Fix: Use New Secret Key for Approval Policy Generation for Tag Resolution

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1294,7 +1294,7 @@ export const secretApprovalRequestServiceFactory = ({
             secretMetadata
           }) => {
             const secretId = updatingSecretsGroupByKey[secretKey][0].id;
-            if (tagIds?.length) commitTagIds[secretKey] = tagIds;
+            if (tagIds?.length) commitTagIds[newSecretName ?? secretKey] = tagIds;
             return {
               ...latestSecretVersions[secretId],
               secretMetadata,


### PR DESCRIPTION
# Description 📣

This PR fixes an error being thrown when generating secret approval policies for updating a secret with a new key name and existing tags.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of tag associations during secret updates so that when a secret’s name is changed, the correct tag is applied for enhanced consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->