### PR TITLE
Save Secret Reminder from Modal

### DIFF
--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -51,6 +51,7 @@ export type SecretV3RawSanitized = {
   folderId?: string;
   skipMultilineEncoding?: boolean;
   secretMetadata?: { key: string; value: string }[];
+  isReminderEvent?: boolean;
 };
 
 export type SecretV3Raw = {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -192,8 +192,8 @@ export const SecretDetailSidebar = ({
     await onSaveSecret(secret, { ...secret, ...data }, () => reset());
   };
 
-  const handleReminderSubmit = async (reminderRepeatDays: number | null, reminderNote: string | null) => {
-    await onSaveSecret(secret, { ...secret, reminderRepeatDays, reminderNote, isReminderEvent: true }, () => {});
+  const handleReminderSubmit = async (reminderRepeatDays: number | null | undefined, reminderNote: string | null | undefined) => {
+    await onSaveSecret(secret, { ...secret, reminderRepeatDays, reminderNote, isReminderEvent: true }, () => { });
   }
 
   const [createReminderFormOpen, setCreateReminderFormOpen] = useToggle(false);

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -192,6 +192,10 @@ export const SecretDetailSidebar = ({
     await onSaveSecret(secret, { ...secret, ...data }, () => reset());
   };
 
+  const handleReminderSubmit = async (reminderRepeatDays: number | null, reminderNote: string | null) => {
+    await onSaveSecret(secret, { ...secret, reminderRepeatDays, reminderNote, isReminderEvent: true }, () => {});
+  }
+
   const [createReminderFormOpen, setCreateReminderFormOpen] = useToggle(false);
 
   const secretReminderRepeatDays = watch("reminderRepeatDays");
@@ -207,8 +211,9 @@ export const SecretDetailSidebar = ({
           setCreateReminderFormOpen.toggle();
 
           if (data) {
-            setValue("reminderRepeatDays", data.days, { shouldDirty: true });
-            setValue("reminderNote", data.note, { shouldDirty: true });
+            setValue("reminderRepeatDays", data.days, { shouldDirty: false });
+            setValue("reminderNote", data.note, { shouldDirty: false });
+            handleReminderSubmit(data.days, data.note)
           }
         }}
       />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -158,7 +158,8 @@ export const SecretListView = ({
         comment,
         reminderRepeatDays,
         reminderNote,
-        secretMetadata
+        secretMetadata,
+        isReminderEvent
       } = modSecret;
       const hasKeyChanged = oldKey !== key && key;
 
@@ -234,7 +235,9 @@ export const SecretListView = ({
         queryClient.invalidateQueries({
           queryKey: secretApprovalRequestKeys.count({ workspaceId })
         });
-        handlePopUpClose("secretDetail");
+        if (!isReminderEvent) {
+          handlePopUpClose("secretDetail");
+        }
         createNotification({
           type: isProtectedBranch && !personalAction ? "info" : "success",
           text:

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -238,12 +238,13 @@ export const SecretListView = ({
         if (!isReminderEvent) {
           handlePopUpClose("secretDetail");
         }
+        const successMessage = isReminderEvent ? "secret reminder" : "secrets";
         createNotification({
           type: isProtectedBranch && !personalAction ? "info" : "success",
           text:
             isProtectedBranch && !personalAction
               ? "Requested changes have been sent for review"
-              : "Successfully saved secrets"
+              : `Successfully saved ${successMessage}`
         });
       } catch (error) {
         console.log(error);

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -238,13 +238,20 @@ export const SecretListView = ({
         if (!isReminderEvent) {
           handlePopUpClose("secretDetail");
         }
-        const successMessage = isReminderEvent ? "secret reminder" : "secrets";
+        
+        let successMessage;
+        if (isReminderEvent) {
+          successMessage = reminderRepeatDays ? "Successfully saved secret reminder" : "Successfully deleted secret reminder";
+        } else {
+          successMessage = "Successfully saved secrets";
+        }
+
         createNotification({
           type: isProtectedBranch && !personalAction ? "info" : "success",
           text:
             isProtectedBranch && !personalAction
               ? "Requested changes have been sent for review"
-              : `Successfully saved ${successMessage}`
+              : successMessage
         });
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This PR enhances the secret reminder flow in the UI by requiring users to click 'Save' on the sidebar after the modal closes, making the process more intuitive.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

https://github.com/user-attachments/assets/fa163df4-7639-4c57-82d7-d05f60d7e9db


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the reminder functionality in the Secret Dashboard by introducing a new submission process that saves reminder details effectively.
  - Improved the interface behavior to conditionally maintain the reminder dialog, ensuring that interactions with the reminder form remain smooth and intuitive.
  - Added an optional property to represent whether a secret is associated with a reminder event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->