### PR TITLE
Improvement: Clear Secret Scanning Query Params after Setup

### DIFF
--- a/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
+++ b/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
@@ -72,8 +72,11 @@ export const SecretScanningPage = withPermission(
     const { mutateAsync: linkGitAppInstallationWithOrganization } =
       useLinkGitAppInstallationWithOrg();
     const { mutateAsync: createNewIntegrationSession } = useCreateNewInstallationSession();
-    const { data: installationStatus, isPending: isSecretScanningInstatllationStatusLoading } =
-      useGetSecretScanningInstallationStatus(organizationId);
+    const {
+      data: installationStatus,
+      isPending: isSecretScanningInstatllationStatusLoading,
+      refetch: refetchSecretScanningInstallationStatus
+    } = useGetSecretScanningInstallationStatus(organizationId);
     const integrationEnabled =
       !isSecretScanningInstatllationStatusLoading && installationStatus?.appInstallationCompleted;
 
@@ -91,7 +94,7 @@ export const SecretScanningPage = withPermission(
               await navigate({
                 to: "/organization/secret-scanning"
               });
-              window.location.reload();
+              refetchSecretScanningInstallationStatus();
             }
 
             console.log("installation verification complete");

--- a/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
+++ b/frontend/src/pages/organization/SecretScanningPage/SecretScanningPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import { Button, NoticeBanner, PageHeader, Pagination } from "@app/components/v2";
@@ -35,6 +35,8 @@ export const SecretScanningPage = withPermission(
     const queryParams = useSearch({
       from: ROUTE_PATHS.Organization.SecretScanning.id
     });
+
+    const navigate = useNavigate();
 
     const { control, watch } = useForm<SecretScanningFilterFormData>({
       resolver: zodResolver(secretScanningFilterFormSchema),
@@ -86,6 +88,9 @@ export const SecretScanningPage = withPermission(
               sessionId: String(queryParams.state)
             });
             if (isLinked) {
+              await navigate({
+                to: "/organization/secret-scanning"
+              });
               window.location.reload();
             }
 


### PR DESCRIPTION
This PR clears setup query params after initial secret scanning setup to prevent setup hook running again and failing after page reload.

# Description 📣

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the post-installation flow: After connecting the GitHub app, users are now automatically redirected to the Secret Scanning page for a smoother navigation experience.
	- Added functionality to refresh the installation status after navigation to ensure users have the latest information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->