### PR TITLE
feat: get secret by ID

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1073,7 +1073,6 @@ export const registerRoutes = async (
   const secretService = secretServiceFactory({
     folderDAL,
     secretVersionDAL,
-    secretV2BridgeDAL,
     secretVersionTagDAL,
     secretBlindIndexDAL,
     permissionService,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1073,6 +1073,7 @@ export const registerRoutes = async (
   const secretService = secretServiceFactory({
     folderDAL,
     secretVersionDAL,
+    secretV2BridgeDAL,
     secretVersionTagDAL,
     secretBlindIndexDAL,
     permissionService,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -613,6 +613,9 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`,
           `${TableName.SecretTag}.id`
         )
+
+        .leftJoin(TableName.SecretFolder, `${TableName.SecretV2}.folderId`, `${TableName.SecretFolder}.id`)
+        .leftJoin(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
         .leftJoin(TableName.ResourceMetadata, `${TableName.SecretV2}.id`, `${TableName.ResourceMetadata}.secretId`)
         .select(selectAllTableCols(TableName.SecretV2))
         .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
@@ -622,12 +625,13 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.ResourceMetadata).as("metadataId"),
           db.ref("key").withSchema(TableName.ResourceMetadata).as("metadataKey"),
           db.ref("value").withSchema(TableName.ResourceMetadata).as("metadataValue")
-        );
+        )
+        .select(db.ref("projectId").withSchema(TableName.Environment).as("projectId"));
 
       const docs = sqlNestRelationships({
         data: rawDocs,
         key: "id",
-        parentMapper: (el) => ({ _id: el.id, ...SecretsV2Schema.parse(el) }),
+        parentMapper: (el) => ({ _id: el.id, projectId: el.projectId, ...SecretsV2Schema.parse(el) }),
         childrenMapper: [
           {
             key: "tagId",

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -28,6 +28,7 @@ import { KmsDataKey } from "../kms/kms-types";
 import { TProjectEnvDALFactory } from "../project-env/project-env-dal";
 import { TResourceMetadataDALFactory } from "../resource-metadata/resource-metadata-dal";
 import { TSecretQueueFactory } from "../secret/secret-queue";
+import { TGetASecretByIdDTO } from "../secret/secret-types";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretImportDALFactory } from "../secret-import/secret-import-dal";
 import { fnSecretsV2FromImports } from "../secret-import/secret-import-fns";
@@ -73,7 +74,13 @@ type TSecretV2BridgeServiceFactoryDep = {
   projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne" | "findBySlugs">;
   folderDAL: Pick<
     TSecretFolderDALFactory,
-    "findBySecretPath" | "updateById" | "findById" | "findByManySecretPath" | "find" | "findBySecretPathMultiEnv"
+    | "findBySecretPath"
+    | "updateById"
+    | "findById"
+    | "findByManySecretPath"
+    | "find"
+    | "findBySecretPathMultiEnv"
+    | "findSecretPathByFolderIds"
   >;
   secretImportDAL: Pick<TSecretImportDALFactory, "find" | "findByFolderIds">;
   secretQueueService: Pick<TSecretQueueFactory, "syncSecrets" | "handleSecretReminder" | "removeSecretReminder">;
@@ -953,6 +960,70 @@ export const secretV2BridgeServiceFactory = ({
       secrets: decryptedSecrets,
       imports: importedSecrets
     };
+  };
+
+  const getSecretById = async ({ actorId, actor, actorOrgId, actorAuthMethod, secret }: TGetASecretByIdDTO) => {
+    const folder = await folderDAL.findById(secret.folderId);
+    if (!folder) {
+      throw new NotFoundError({
+        message: `Folder with id '${secret.folderId}' not found`,
+        name: "GetSecretById"
+      });
+    }
+
+    const [folderWithPath] = await folderDAL.findSecretPathByFolderIds(folder.projectId, [folder.id]);
+
+    if (!folderWithPath) {
+      throw new NotFoundError({
+        message: `Folder with id '${folder.id}' not found`,
+        name: "GetSecretById"
+      });
+    }
+
+    const { permission } = await permissionService.getProjectPermission({
+      actor,
+      actorId,
+      projectId: folder.projectId,
+      actorAuthMethod,
+      actorOrgId,
+      actionProjectType: ActionProjectType.SecretManager
+    });
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionActions.Read,
+      subject(ProjectPermissionSub.Secrets, {
+        environment: folder.environment.envSlug,
+        secretPath: folderWithPath.path,
+        secretName: secret.key,
+        secretTags: secret.tags.map((i) => i.slug)
+      })
+    );
+
+    if (secret.type === SecretType.Personal && secret.userId !== actorId) {
+      throw new ForbiddenRequestError({
+        message: "You are not allowed to access this secret",
+        name: "GetSecretById"
+      });
+    }
+
+    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId: folder.projectId
+    });
+
+    const secretValue = secret.encryptedValue
+      ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedValue }).toString()
+      : "";
+
+    const secretComment = secret.encryptedComment
+      ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedComment }).toString()
+      : "";
+
+    return reshapeBridgeSecret(folder.projectId, folder.environment.envSlug, folderWithPath.path, {
+      ...secret,
+      value: secretValue,
+      comment: secretComment
+    });
   };
 
   const getSecretByName = async ({
@@ -2237,6 +2308,7 @@ export const secretV2BridgeServiceFactory = ({
     getSecretsCountMultiEnv,
     getSecretsMultiEnv,
     getSecretReferenceTree,
-    getSecretsByFolderMappings
+    getSecretsByFolderMappings,
+    getSecretById
   };
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -964,7 +964,7 @@ export const secretV2BridgeServiceFactory = ({
 
   const getSecretById = async ({ actorId, actor, actorOrgId, actorAuthMethod, secretId }: TGetASecretByIdDTO) => {
     const secret = await secretDAL.findOneWithTags({
-      id: secretId
+      [`${TableName.SecretV2}.id` as "id"]: secretId
     });
 
     if (!secret) {

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex";
 import { z } from "zod";
 
-import { SecretType, TSecretBlindIndexes, TSecrets, TSecretsInsert, TSecretsUpdate, TSecretsV2 } from "@app/db/schemas";
+import { SecretType, TSecretBlindIndexes, TSecrets, TSecretsInsert, TSecretsUpdate } from "@app/db/schemas";
 import { OrderByDirection, TProjectPermission } from "@app/lib/types";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotDALFactory } from "@app/services/project-bot/project-bot-dal";
@@ -122,14 +122,7 @@ export type TGetASecretDTO = {
 } & TProjectPermission;
 
 export type TGetASecretByIdDTO = {
-  secret: TSecretsV2 & {
-    tags: {
-      id: string;
-      color?: string | null;
-      slug: string;
-      name: string;
-    }[];
-  };
+  secretId: string;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TCreateBulkSecretDTO = {

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex";
 import { z } from "zod";
 
-import { SecretType, TSecretBlindIndexes, TSecrets, TSecretsInsert, TSecretsUpdate } from "@app/db/schemas";
+import { SecretType, TSecretBlindIndexes, TSecrets, TSecretsInsert, TSecretsUpdate, TSecretsV2 } from "@app/db/schemas";
 import { OrderByDirection, TProjectPermission } from "@app/lib/types";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotDALFactory } from "@app/services/project-bot/project-bot-dal";
@@ -121,6 +121,17 @@ export type TGetASecretDTO = {
   version?: number;
 } & TProjectPermission;
 
+export type TGetASecretByIdDTO = {
+  secret: TSecretsV2 & {
+    tags: {
+      id: string;
+      color?: string | null;
+      slug: string;
+      name: string;
+    }[];
+  };
+} & Omit<TProjectPermission, "projectId">;
+
 export type TCreateBulkSecretDTO = {
   path: string;
   environment: string;
@@ -211,6 +222,10 @@ export type TGetASecretRawDTO = {
   version?: number;
   projectSlug?: string;
   projectId?: string;
+} & Omit<TProjectPermission, "projectId">;
+
+export type TGetASecretByIdRawDTO = {
+  secretId: string;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TCreateSecretRawDTO = TProjectPermission & {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -5,6 +5,7 @@ import {
   faArrowRotateRight,
   faCheckCircle,
   faClock,
+  faCopy,
   faDesktop,
   faEyeSlash,
   faPlus,
@@ -990,29 +991,49 @@ export const SecretDetailSidebar = ({
                       </Button>
                     )}
                   </ProjectPermissionCan>
-                  <ProjectPermissionCan
-                    I={ProjectPermissionActions.Delete}
-                    a={subject(ProjectPermissionSub.Secrets, {
-                      environment,
-                      secretPath,
-                      secretName: secretKey,
-                      secretTags: selectTagSlugs
-                    })}
-                  >
-                    {(isAllowed) => (
+                  <div className="flex items-center gap-2">
+                    <Tooltip content="Copy Secret ID">
                       <IconButton
-                        colorSchema="danger"
-                        ariaLabel="Delete Secret"
-                        className="border border-mineshaft-600 bg-mineshaft-700 hover:border-red-500/70 hover:bg-red-600/20"
-                        isDisabled={!isAllowed}
-                        onClick={onDeleteSecret}
+                        variant="outline_bg"
+                        ariaLabel="Copy Secret ID"
+                        onClick={async () => {
+                          await navigator.clipboard.writeText(secret.id);
+
+                          createNotification({
+                            title: "Secret ID Copied",
+                            text: "The secret ID has been copied to your clipboard.",
+                            type: "success"
+                          });
+                        }}
                       >
-                        <Tooltip content="Delete Secret">
-                          <FontAwesomeIcon icon={faTrash} />
-                        </Tooltip>
+                        <FontAwesomeIcon icon={faCopy} />
                       </IconButton>
-                    )}
-                  </ProjectPermissionCan>
+                    </Tooltip>
+                    <ProjectPermissionCan
+                      I={ProjectPermissionActions.Delete}
+                      a={subject(ProjectPermissionSub.Secrets, {
+                        environment,
+                        secretPath,
+                        secretName: secretKey,
+                        secretTags: selectTagSlugs
+                      })}
+                    >
+                      {(isAllowed) => (
+                        <Tooltip content="Delete Secret">
+                          <IconButton
+                            colorSchema="danger"
+                            variant="outline_bg"
+                            ariaLabel="Delete Secret"
+                            className="border border-mineshaft-600 bg-mineshaft-700 hover:border-red-500/70 hover:bg-red-600/20"
+                            isDisabled={!isAllowed}
+                            onClick={onDeleteSecret}
+                          >
+                            <FontAwesomeIcon icon={faTrash} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </ProjectPermissionCan>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description 📣

This PR allows for fetching secrets by ID. This endpoint is intended for internal usage, specifically for terraform import support for the infisical_secret resource.

This PR serves as prerequisite for https://github.com/Infisical/terraform-provider-infisical/pull/102 

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Launched a secure method for retrieving secrets by their identifier, now returning enriched metadata with robust access controls.
	- Enhanced the secret management interface with a new copy-to-clipboard button for secret IDs, complete with tooltip feedback for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->