### PR TITLE
Fix: Handle Audit Log Query Duration

### DIFF
--- a/backend/src/server/lib/utils.ts
+++ b/backend/src/server/lib/utils.ts
@@ -1,0 +1,6 @@
+export const extendTimeout =
+  (timeoutMs: number) =>
+  (request: { raw: { socket: { setTimeout: (ms: number) => void } } }, reply: unknown, done: () => void) => {
+    request.raw.socket.setTimeout(timeoutMs);
+    done();
+  };

--- a/backend/src/server/lib/utils.ts
+++ b/backend/src/server/lib/utils.ts
@@ -1,3 +1,5 @@
+export const QUERY_TIMEOUT = 121000; // 2 mins (query timeout) with padding
+
 export const extendTimeout =
   (timeoutMs: number) =>
   (request: { raw: { socket: { setTimeout: (ms: number) => void } } }, reply: unknown, done: () => void) => {

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -14,6 +14,7 @@ import { AUDIT_LOGS, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getLastMidnightDateISO, removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
+import { extendTimeout } from "@app/server/lib/utils";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode, MfaMethod } from "@app/services/auth/auth-type";
 import { sanitizedOrganizationSchema } from "@app/services/org/org-schema";
@@ -108,6 +109,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
+    preHandler: extendTimeout(121000), // 2 mins (query timeout) with padding
     schema: {
       description: "Get all audit logs for an organization",
       querystring: z.object({

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -14,7 +14,7 @@ import { AUDIT_LOGS, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getLastMidnightDateISO, removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
-import { extendTimeout } from "@app/server/lib/utils";
+import { extendTimeout, QUERY_TIMEOUT } from "@app/server/lib/utils";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode, MfaMethod } from "@app/services/auth/auth-type";
 import { sanitizedOrganizationSchema } from "@app/services/org/org-schema";
@@ -109,7 +109,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    preHandler: extendTimeout(121000), // 2 mins (query timeout) with padding
+    preHandler: extendTimeout(QUERY_TIMEOUT),
     schema: {
       description: "Get all audit logs for an organization",
       querystring: z.object({

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
@@ -106,7 +106,7 @@ export const LogsTable = ({
           className="mb-20 mt-4 px-4 py-3 text-sm"
           isFullWidth
           variant="star"
-          isLoading={isFetchingNextPage}
+          isLoading={isFetchingNextPage || isPending}
           isDisabled={isFetchingNextPage || !hasNextPage}
           onClick={() => fetchNextPage()}
         >

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -15,6 +15,21 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+     location /api/v1/organization/audit-logs {
+        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+
+        proxy_read_timeout 121s; # query timeout with padding
+     }
+
     location /api/v3/migrate {
         client_max_body_size 25M;
 

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -17,6 +17,21 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+     location /api/v1/organization/audit-logs {
+        proxy_set_header X-Real-RIP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+
+        proxy_read_timeout 121s; # query timeout with padding
+    }
+
 		location /runtime-ui-env.js {
         proxy_set_header X-Real-RIP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
# Description 📣

This PR increases the audit log endpoint and nginx config timeout to handle query max duration of 2 minutes which was previously timing out at 30 seconds due to server config. Also fixes empty audit log error notifcation.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The audit logs functionality now supports extended processing times for long-running queries.
  - The audit logs interface has been updated to provide a more accurate loading indicator during data fetching.
  - A new endpoint for audit logs has been introduced, enhancing server API capabilities.
  
- **Bug Fixes**
  - Improved loading state indication for the button in the audit logs interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->