### PR TITLE
Added webhook trigger for secret reminder

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -503,7 +503,7 @@ export const secretApprovalRequestServiceFactory = ({
     if (!hasMinApproval && !isSoftEnforcement)
       throw new BadRequestError({ message: "Doesn't have minimum approvals needed" });
 
-    const { botKey, shouldUseSecretV2Bridge } = await projectBotService.getBotKey(projectId);
+    const { botKey, shouldUseSecretV2Bridge, project } = await projectBotService.getBotKey(projectId);
     let mergeStatus;
     if (shouldUseSecretV2Bridge) {
       // this cycle if for bridged secrets
@@ -861,7 +861,6 @@ export const secretApprovalRequestServiceFactory = ({
 
     if (isSoftEnforcement) {
       const cfg = getConfig();
-      const project = await projectDAL.findProjectById(projectId);
       const env = await projectEnvDAL.findOne({ id: policy.envId });
       const requestedByUser = await userDAL.findOne({ id: actorId });
       const approverUsers = await userDAL.find({

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -21,6 +21,7 @@ import {
   TQueueSecretSyncSyncSecretsByIdDTO,
   TQueueSendSecretSyncActionFailedNotificationsDTO
 } from "@app/services/secret-sync/secret-sync-types";
+import { TWebhookPayloads } from "@app/services/webhook/webhook-types";
 
 export enum QueueName {
   SecretRotation = "secret-rotation",
@@ -107,7 +108,7 @@ export type TQueueJobTypes = {
   };
   [QueueName.SecretWebhook]: {
     name: QueueJobs.SecWebhook;
-    payload: { projectId: string; environment: string; secretPath: string; depth?: number };
+    payload: TWebhookPayloads;
   };
 
   [QueueName.AccessTokenStatusUpdate]:

--- a/backend/src/services/webhook/webhook-service.ts
+++ b/backend/src/services/webhook/webhook-service.ts
@@ -16,7 +16,8 @@ import {
   TDeleteWebhookDTO,
   TListWebhookDTO,
   TTestWebhookDTO,
-  TUpdateWebhookDTO
+  TUpdateWebhookDTO,
+  WebhookEvents
 } from "./webhook-types";
 
 type TWebhookServiceFactoryDep = {
@@ -144,12 +145,15 @@ export const webhookServiceFactory = ({
       await triggerWebhookRequest(
         webhook,
         (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString(),
-        getWebhookPayload("test", {
-          workspaceName: project.name,
-          workspaceId: webhook.projectId,
-          environment: webhook.environment.slug,
-          secretPath: webhook.secretPath,
-          type: webhook.type
+        getWebhookPayload({
+          type: "test" as WebhookEvents.SecretModified,
+          payload: {
+            projectName: project.name,
+            projectId: webhook.projectId,
+            environment: webhook.environment.slug,
+            secretPath: webhook.secretPath,
+            type: webhook.type
+          }
         })
       );
     } catch (err) {

--- a/backend/src/services/webhook/webhook-types.ts
+++ b/backend/src/services/webhook/webhook-types.ts
@@ -30,3 +30,36 @@ export enum WebhookType {
   GENERAL = "general",
   SLACK = "slack"
 }
+
+export enum WebhookEvents {
+  SecretModified = "secrets.modified",
+  SecretReminderExpired = "secrets.reminder-expired",
+  TestEvent = "test"
+}
+
+type TWebhookSecretModifiedEventPayload = {
+  type: WebhookEvents.SecretModified;
+  payload: {
+    projectName?: string;
+    projectId: string;
+    environment: string;
+    secretPath?: string;
+    type?: string | null;
+  };
+};
+
+type TWebhookSecretReminderEventPayload = {
+  type: WebhookEvents.SecretReminderExpired;
+  payload: {
+    projectName?: string;
+    projectId: string;
+    environment: string;
+    secretPath?: string;
+    type?: string | null;
+    secretName: string;
+    secretId: string;
+    reminderNote?: string | null;
+  };
+};
+
+export type TWebhookPayloads = TWebhookSecretModifiedEventPayload | TWebhookSecretReminderEventPayload;

--- a/docs/documentation/platform/webhooks.mdx
+++ b/docs/documentation/platform/webhooks.mdx
@@ -36,3 +36,18 @@ If the signature in the header matches the signature that you generated, then yo
   "timestamp": ""
 }
 ```
+
+```json
+{
+  "event": "secrets.reminder-expired",
+  "project": {
+    "workspaceId": "the workspace id",
+    "environment": "project environment",
+    "secretPath": "project folder path",
+    "secretName": "name of the secret",
+    "secretId": "id of the secret",
+    "reminderNote": "reminder note of the secret"
+  },
+  "timestamp": ""
+}
+```


### PR DESCRIPTION
# Description 📣

PR to trigger webhook event for secret reminder expiry

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized secret approval processing by consolidating data retrieval and reducing redundant backend operations.
  - Enhanced secret event queuing through a restructured payload format that clarifies event types and improves data handling.
  - Updated webhook notification logic for more consistent event processing.

- **New Features**
  - Introduced refined webhook event classifications, including detailed payloads for secret modifications and reminders.

- **Documentation**
  - Expanded the webhook documentation with a new JSON payload format for secret reminder events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->