### PR TITLE
add system md service for gateway

### DIFF
--- a/cli/packages/cmd/gateway.go
+++ b/cli/packages/cmd/gateway.go
@@ -1,28 +1,93 @@
 package cmd
 
 import (
-	// "fmt"
-
-	// "github.com/Infisical/infisical-merge/packages/api"
-	// "github.com/Infisical/infisical-merge/packages/models"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
 	"github.com/Infisical/infisical-merge/packages/gateway"
 	"github.com/Infisical/infisical-merge/packages/util"
 	"github.com/rs/zerolog/log"
-
-	// "github.com/Infisical/infisical-merge/packages/visualize"
-	// "github.com/rs/zerolog/log"
-
-	// "github.com/go-resty/resty/v2"
 	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
 )
+
+const systemdServiceTemplate = `[Unit]
+Description=Infisical Gateway Service
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/infisical/gateway.conf
+ExecStart=/usr/local/bin/infisical gateway
+Restart=on-failure
+InaccessibleDirectories=/home
+PrivateTmp=yes
+LimitCORE=infinity
+LimitNOFILE=1000000
+LimitNPROC=60000
+LimitRTPRIO=infinity
+LimitRTTIME=7000000
+
+[Install]
+WantedBy=multi-user.target
+`
+
+func installSystemdService(token string, domain string) error {
+	if runtime.GOOS != "linux" {
+		log.Info().Msg("Skipping systemd service installation - not on Linux")
+		return nil
+	}
+
+	if os.Geteuid() != 0 {
+		log.Info().Msg("Skipping systemd service installation - not running as root/sudo")
+		return nil
+	}
+
+	configDir := "/etc/infisical"
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %v", err)
+	}
+
+	configContent := fmt.Sprintf("INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN=%s\n", token)
+	if domain != "" {
+		configContent += fmt.Sprintf("INFISICAL_API_URL=%s\n", domain)
+	} else {
+		configContent += "INFISICAL_API_URL=\n"
+	}
+
+	configPath := filepath.Join(configDir, "gateway.conf")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		return fmt.Errorf("failed to write config file: %v", err)
+	}
+
+	servicePath := "/etc/systemd/system/infisical-gateway.service"
+	if _, err := os.Stat(servicePath); err == nil {
+		log.Info().Msg("Systemd service file already exists")
+		return nil
+	}
+
+	if err := os.WriteFile(servicePath, []byte(systemdServiceTemplate), 0644); err != nil {
+		return fmt.Errorf("failed to write systemd service file: %v", err)
+	}
+
+	reloadCmd := exec.Command("systemctl", "daemon-reload")
+	if err := reloadCmd.Run(); err != nil {
+		return fmt.Errorf("failed to reload systemd: %v", err)
+	}
+
+	log.Info().Msg("Successfully installed systemd service")
+	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
+	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
+
+	return nil
+}
 
 var gatewayCmd = &cobra.Command{
 	Example:               `infisical gateway`,
@@ -38,6 +103,16 @@ var gatewayCmd = &cobra.Command{
 
 		if token == nil {
 			util.HandleError(fmt.Errorf("Token not found"))
+		}
+
+		domain, err := cmd.Flags().GetString("domain")
+		if err != nil {
+			util.HandleError(err, "Unable to parse domain flag")
+		}
+
+		// Try to install systemd service if possible
+		if err := installSystemdService(token.Token, domain); err != nil {
+			log.Warn().Msgf("Failed to install systemd service: %v", err)
 		}
 
 		Telemetry.CaptureEvent("cli-command:gateway", posthog.NewProperties().Set("version", util.CLI_VERSION))


### PR DESCRIPTION
Will create a system md service and save the the --domain flag and --token flag into a config file for use during restart. 
- this will ignore systemmd for non linux distros 
- if there are errors, it will ignore them for the install installSystemdService since these aren't hard blockers.

Need to install this on a linux to test since on mac there is no system md 