### PR TITLE
fix: change dd-mm-yy to mm-dd-yy

### DIFF
--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
@@ -28,7 +28,7 @@ type Props = {
 
 const AUDIT_LOG_LIMIT = 15;
 
-const TABLE_HEADERS = ["Timestamp", "Event", "Project", "Actor", "Source", "Metadata"] as const;
+const TABLE_HEADERS = ["Timestamp (MM/DD/YYYY)", "Event", "Project", "Actor", "Source", "Metadata"] as const;
 export type TAuditLogTableHeader = (typeof TABLE_HEADERS)[number];
 
 export const LogsTable = ({

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
@@ -83,7 +83,7 @@ export const LogsTableRow = ({ auditLog, isOrgAuditLogs, showActorColumn }: Prop
     hours %= 12;
     hours = hours || 12; // the hour '0' should be '12'
 
-    const formattedDate = `${day}-${month}-${year} at ${hours}:${minutes} ${period}`;
+    const formattedDate = `${month}-${day}-${year} at ${hours}:${minutes} ${period}`;
     return formattedDate;
   };
 


### PR DESCRIPTION
# Description 📣

Changed the date format from `DD-MM-YYYYY` to `MM-DD-YYYY` on Audit Logs page.

![image](https://github.com/user-attachments/assets/b4680008-4141-4e14-a743-a5a8718554a9)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

No tests needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated the date display format on the Audit Logs page to show month-first ordering for improved clarity.
	- Changed the header for the timestamp in the logs table to specify the format as "Timestamp (MM/DD/YYYY)" for clearer user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->