### PR TITLE
docs: replace yum with dnf

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -85,7 +85,7 @@ You can use it across various environments, whether it's local development, CI/C
 
     	Then install CLI
     	```bash
-    	sudo yum install infisical
+    	sudo dnf install infisical
     	```
 		###
 		<Tip>


### PR DESCRIPTION
Resolves: #3209 

# Description 📣

This PR will replace yum with dnf for the CLI installation on RedHat, CentOS, and Amazon installation guide documentation, as dnf is faster and supports better modular management than yum. it's the recommended package manager for RHEL 8+ systems.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->