### PR TITLE
fix: list secrets permissioning bug

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -909,11 +909,7 @@ export const secretV2BridgeServiceFactory = ({
       actorOrgId,
       actionProjectType: ActionProjectType.SecretManager
     });
-    throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
-      environment,
-      secretPath: path,
-      secretTags: params.tagSlugs
-    });
+    throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret);
 
     let paths: { folderId: string; path: string }[] = [];
 


### PR DESCRIPTION
# Description 📣

Fix for permissioning bug causing list secrets to fail for tag-based permissions.

`params.tagSlugs` will always be an empty string when listing secrets through the dashboard, which will cause `ForbiddenError: Cannot execute "describeSecret" on "secrets"`. This check is a top-level permission check to ensure the permission includes DescribeSecret. We are doing more granular checks further down in the function.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal validation process for secure access. The permission checks now use fewer contextual parameters, leading to a more consistent and maintainable system.
  - No changes affect the public interface or externally visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->