### PR TITLE
Add dynamic secrets modal form on secrets overview page

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -187,10 +187,8 @@ export const OverviewPage = () => {
     permission.can(
       ProjectPermissionDynamicSecretActions.CreateRootCredential,
       subject(ProjectPermissionSub.DynamicSecrets, {
-        environment: env.id,
-        secretPath,
-        secretName: "*",
-        secretTags: ["*"]
+        environment: env.slug,
+        secretPath
       })
     )
   );
@@ -863,42 +861,49 @@ export const OverviewPage = () => {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <div className="flex flex-col space-y-1 p-1.5">
-                      <Button
-                        leftIcon={<FontAwesomeIcon icon={faFingerprint} className="pr-2" />}
-                        onClick={() => {
-                          if (subscription?.dynamicSecret) {
-                            handlePopUpOpen("addDynamicSecret");
-                            return;
-                          }
-                          handlePopUpOpen("upgradePlan");
-                        }}
-                        isDisabled={userAvailableDynamicSecretEnvs.length === 0}
-                        variant="outline_bg"
-                        className="h-10 text-left"
-                        isFullWidth
-                      >
-                        Add Dynamic Secret
-                      </Button>
                       <ProjectPermissionCan
                         I={ProjectPermissionActions.Create}
                         a={ProjectPermissionSub.SecretFolders}
                       >
                         {(isAllowed) => (
                           <Button
-                            leftIcon={<FontAwesomeIcon icon={faFolderPlus} />}
+                            leftIcon={<FontAwesomeIcon icon={faFolderPlus} className="pr-2" />}
                             onClick={() => {
                               handlePopUpOpen("addFolder");
                               handlePopUpClose("misc");
                             }}
                             isDisabled={!isAllowed}
                             variant="outline_bg"
-                            className="h-10"
+                            className="h-10 text-left"
                             isFullWidth
                           >
                             Add Folder
                           </Button>
                         )}
                       </ProjectPermissionCan>
+                      <Tooltip
+                        content={
+                          userAvailableDynamicSecretEnvs.length === 0 ? "Access restricted" : ""
+                        }
+                      >
+                        <Button
+                          leftIcon={<FontAwesomeIcon icon={faFingerprint} className="pr-2" />}
+                          onClick={() => {
+                            if (subscription?.dynamicSecret) {
+                              handlePopUpOpen("addDynamicSecret");
+                              handlePopUpClose("misc");
+                              return;
+                            }
+                            handlePopUpOpen("upgradePlan");
+                          }}
+                          isDisabled={userAvailableDynamicSecretEnvs.length === 0}
+                          variant="outline_bg"
+                          className="h-10 text-left"
+                          isFullWidth
+                        >
+                          Add Dynamic Secret
+                        </Button>
+                      </Tooltip>
                     </div>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link, useNavigate, useRouter, useSearch } from "@tanstack/react-router";
 import { twMerge } from "tailwind-merge";
 
+import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
@@ -49,8 +50,10 @@ import {
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
   ProjectPermissionActions,
+  ProjectPermissionDynamicSecretActions,
   ProjectPermissionSub,
   useProjectPermission,
+  useSubscription,
   useWorkspace
 } from "@app/context";
 import { useDebounce, usePagination, usePopUp, useResetPageHelper } from "@app/hooks";
@@ -71,6 +74,7 @@ import { SecretType, SecretV3RawSanitized, TSecretFolder } from "@app/hooks/api/
 import { ProjectType, ProjectVersion } from "@app/hooks/api/workspace/types";
 import { useDynamicSecretOverview, useFolderOverview, useSecretOverview } from "@app/hooks/utils";
 
+import { CreateDynamicSecretForm } from "../SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm";
 import { FolderForm } from "../SecretDashboardPage/components/ActionBar/FolderForm";
 import { CreateSecretForm } from "./components/CreateSecretForm";
 import { FolderBreadCrumbs } from "./components/FolderBreadCrumbs";
@@ -131,6 +135,7 @@ export const OverviewPage = () => {
   const [searchFilter, setSearchFilter] = useState("");
   const [debouncedSearchFilter, setDebouncedSearchFilter] = useDebounce(searchFilter);
   const secretPath = (routerSearch?.secretPath as string) || "/";
+  const { subscription } = useSubscription();
 
   const [filter, setFilter] = useState<Filter>(DEFAULT_FILTER_STATE);
   const [filterHistory, setFilterHistory] = useState<
@@ -178,6 +183,17 @@ export const OverviewPage = () => {
   }, []);
 
   const userAvailableEnvs = currentWorkspace?.environments || [];
+  const userAvailableDynamicSecretEnvs = userAvailableEnvs.filter((env) =>
+    permission.can(
+      ProjectPermissionDynamicSecretActions.CreateRootCredential,
+      subject(ProjectPermissionSub.DynamicSecrets, {
+        environment: env.id,
+        secretPath,
+        secretName: "*",
+        secretTags: ["*"]
+      })
+    )
+  );
 
   const [visibleEnvs, setVisibleEnvs] = useState(userAvailableEnvs);
 
@@ -249,7 +265,9 @@ export const OverviewPage = () => {
     "addSecretsInAllEnvs",
     "addFolder",
     "misc",
-    "updateFolder"
+    "updateFolder",
+    "addDynamicSecret",
+    "upgradePlan"
   ] as const);
 
   const handleFolderCreate = async (folderName: string, description: string | null) => {
@@ -845,6 +863,22 @@ export const OverviewPage = () => {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <div className="flex flex-col space-y-1 p-1.5">
+                      <Button
+                        leftIcon={<FontAwesomeIcon icon={faFingerprint} className="pr-2" />}
+                        onClick={() => {
+                          if (subscription && subscription.dynamicSecret) {
+                            handlePopUpOpen("addDynamicSecret");
+                            return;
+                          }
+                          handlePopUpOpen("upgradePlan");
+                        }}
+                        isDisabled={userAvailableDynamicSecretEnvs.length === 0}
+                        variant="outline_bg"
+                        className="h-10 text-left"
+                        isFullWidth
+                      >
+                        Add Dynamic Secret
+                      </Button>
                       <ProjectPermissionCan
                         I={ProjectPermissionActions.Create}
                         a={ProjectPermissionSub.SecretFolders}
@@ -1170,6 +1204,24 @@ export const OverviewPage = () => {
           />
         </ModalContent>
       </Modal>
+      <CreateDynamicSecretForm
+        isOpen={popUp.addDynamicSecret.isOpen}
+        onToggle={(isOpen) => handlePopUpToggle("addDynamicSecret", isOpen)}
+        projectSlug={projectSlug}
+        environments={userAvailableDynamicSecretEnvs}
+        secretPath={secretPath}
+      />
+      {subscription && (
+        <UpgradePlanModal
+          isOpen={popUp.upgradePlan.isOpen}
+          onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+          text={
+            subscription.slug === null
+              ? "You can perform this action under an Enterprise license"
+              : "You can perform this action if you switch to Infisical's Team plan"
+          }
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -866,7 +866,7 @@ export const OverviewPage = () => {
                       <Button
                         leftIcon={<FontAwesomeIcon icon={faFingerprint} className="pr-2" />}
                         onClick={() => {
-                          if (subscription && subscription.dynamicSecret) {
+                          if (subscription?.dynamicSecret) {
                             handlePopUpOpen("addDynamicSecret");
                             return;
                           }

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -657,6 +657,7 @@ export const ActionBar = ({
         projectSlug={projectSlug}
         environments={[{ slug: environment, name: environment, id: "not-used" }]}
         secretPath={secretPath}
+        isSingleEnvironmentMode
       />
       <Modal
         isOpen={popUp.addFolder.isOpen}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -655,7 +655,7 @@ export const ActionBar = ({
         isOpen={popUp.addDynamicSecret.isOpen}
         onToggle={(isOpen) => handlePopUpToggle("addDynamicSecret", isOpen)}
         projectSlug={projectSlug}
-        environments={[{ slug: environment, name: "not-used", id: "not-used" }]}
+        environments={[{ slug: environment, name: environment, id: "not-used" }]}
         secretPath={secretPath}
       />
       <Modal

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -655,7 +655,7 @@ export const ActionBar = ({
         isOpen={popUp.addDynamicSecret.isOpen}
         onToggle={(isOpen) => handlePopUpToggle("addDynamicSecret", isOpen)}
         projectSlug={projectSlug}
-        environment={environment}
+        environments={[{ slug: environment, name: "not-used", id: "not-used" }]}
         secretPath={secretPath}
       />
       <Modal

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -127,7 +127,7 @@ export const AwsElastiCacheInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -53,7 +53,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -91,7 +91,7 @@ export const AwsElastiCacheInputForm = ({
         "UserId": "{{username}}"
 }`
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -102,33 +102,26 @@ export const AwsElastiCacheInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.AwsElastiCache, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        hasErrors = true;
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.AwsElastiCache, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -319,19 +312,18 @@ export const AwsElastiCacheInputForm = ({
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                         />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -11,6 +11,7 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
+  FilterableSelect,
   FormControl,
   Input,
   SecretInput,
@@ -18,6 +19,7 @@ import {
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -50,7 +52,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -59,13 +62,13 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 export const AwsElastiCacheInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -87,32 +90,42 @@ export const AwsElastiCacheInputForm = ({
         revocationStatement: `{
         "UserId": "{{username}}"
 }`
-      }
+      },
+      environments: environments.length === 1 ? environments : []
     }
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.AwsElastiCache, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (env) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.AwsElastiCache, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: env.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   return (
@@ -299,6 +312,29 @@ export const AwsElastiCacheInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
+                {environments.length > 1 && (
+                  <Controller
+                    control={control}
+                    name="environments"
+                    render={({ field: { value, onChange }, fieldState: { error } }) => (
+                      <FormControl
+                        label="Environments"
+                        isError={Boolean(error)}
+                        errorText={error?.message}
+                      >
+                        <FilterableSelect
+                          isMulti
+                          options={environments}
+                          value={value}
+                          onChange={onChange}
+                          placeholder="Select environments to create secret in..."
+                          getOptionLabel={(option) => option.name}
+                          getOptionValue={(option) => option.slug}
+                        />
+                      </FormControl>
+                    )}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -63,6 +63,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const AwsElastiCacheInputForm = ({
@@ -70,7 +71,8 @@ export const AwsElastiCacheInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -91,7 +93,7 @@ export const AwsElastiCacheInputForm = ({
         "UserId": "{{username}}"
 }`
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -309,7 +311,7 @@ export const AwsElastiCacheInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -106,6 +106,7 @@ export const AwsElastiCacheInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
+    let hasErrors = false;
     const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
@@ -117,15 +118,18 @@ export const AwsElastiCacheInputForm = ({
           projectSlug,
           environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
+        hasErrors = true;
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
@@ -83,7 +83,8 @@ export const AwsIamInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.AwsIam, inputs: provider },
@@ -92,17 +93,20 @@ export const AwsIamInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
+        hasErrors = true;
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
@@ -52,6 +52,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const AwsIamInputForm = ({
@@ -59,7 +60,8 @@ export const AwsIamInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -68,7 +70,7 @@ export const AwsIamInputForm = ({
   } = useForm<TForm>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -298,7 +300,7 @@ export const AwsIamInputForm = ({
                   </FormControl>
                 )}
               />
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
@@ -104,7 +104,7 @@ export const AwsIamInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
@@ -72,6 +72,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const AzureEntraIdInputForm = ({
@@ -79,7 +80,8 @@ export const AzureEntraIdInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -89,7 +91,7 @@ export const AzureEntraIdInputForm = ({
   } = useForm<TForm>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
   const tenantId = watch("provider.tenantId");
@@ -379,7 +381,7 @@ export const AzureEntraIdInputForm = ({
               </div>
             </div>
           </div>
-          {environments.length > 1 && (
+          {!isSingleEnvironmentMode && (
             <Controller
               control={control}
               name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
@@ -149,7 +149,7 @@ export const AzureEntraIdInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -11,6 +11,7 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
+  FilterableSelect,
   FormControl,
   Input,
   SecretInput,
@@ -18,6 +19,7 @@ import {
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -52,7 +54,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -61,7 +64,7 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 const getSqlStatements = () => {
@@ -76,7 +79,7 @@ const getSqlStatements = () => {
 export const CassandraInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -87,32 +90,42 @@ export const CassandraInputForm = ({
   } = useForm<TForm>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      provider: getSqlStatements()
+      provider: getSqlStatements(),
+      environments: environments.length === 1 ? environments : []
     }
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.Cassandra, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (environment) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.Cassandra, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: environment.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   return (
@@ -345,6 +358,30 @@ export const CassandraInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
+                {environments.length > 1 && (
+                  <Controller
+                    control={control}
+                    name="environments"
+                    render={({ field: { value, onChange }, fieldState: { error } }) => (
+                      <FormControl
+                        label="Environments"
+                        isError={Boolean(error)}
+                        errorText={error?.message}
+                      >
+                        <FilterableSelect
+                          isMulti
+                          options={environments}
+                          value={value}
+                          onChange={onChange}
+                          placeholder="Select environments to create secret in..."
+                          getOptionLabel={(option) => option.name}
+                          getOptionValue={(option) => option.slug}
+                          menuPlacement="top"
+                        />
+                      </FormControl>
+                    )}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -127,7 +127,7 @@ export const CassandraInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -106,7 +106,8 @@ export const CassandraInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.Cassandra, inputs: provider },
@@ -115,17 +116,20 @@ export const CassandraInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -65,6 +65,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 const getSqlStatements = () => {
@@ -81,7 +82,8 @@ export const CassandraInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -91,7 +93,7 @@ export const CassandraInputForm = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       provider: getSqlStatements(),
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -356,7 +358,7 @@ export const CassandraInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -55,7 +55,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -91,7 +91,7 @@ export const CassandraInputForm = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       provider: getSqlStatements(),
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -102,33 +102,27 @@ export const CassandraInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.Cassandra, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.Cassandra, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -365,19 +359,18 @@ export const CassandraInputForm = ({
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CreateDynamicSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CreateDynamicSecretForm.tsx
@@ -17,6 +17,7 @@ import { AnimatePresence, motion } from "framer-motion";
 
 import { Modal, ModalContent } from "@app/components/v2";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 import { AwsElastiCacheInputForm } from "./AwsElastiCacheInputForm";
 import { AwsIamInputForm } from "./AwsIamInputForm";
@@ -38,7 +39,7 @@ type Props = {
   isOpen?: boolean;
   onToggle: (isOpen: boolean) => void;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
   secretPath: string;
 };
 
@@ -129,7 +130,7 @@ export const CreateDynamicSecretForm = ({
   isOpen,
   onToggle,
   projectSlug,
-  environment,
+  environments,
   secretPath
 }: Props) => {
   const [wizardStep, setWizardStep] = useState(WizardSteps.SelectProvider);
@@ -197,7 +198,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -215,7 +216,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -233,7 +234,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -251,7 +252,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -269,7 +270,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -287,7 +288,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -305,7 +306,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -323,7 +324,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -341,7 +342,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -359,7 +360,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -377,7 +378,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -395,7 +396,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -413,7 +414,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -432,7 +433,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}
@@ -450,7 +451,7 @@ export const CreateDynamicSecretForm = ({
                   onCancel={handleFormReset}
                   projectSlug={projectSlug}
                   secretPath={secretPath}
-                  environment={environment}
+                  environments={environments}
                 />
               </motion.div>
             )}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CreateDynamicSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CreateDynamicSecretForm.tsx
@@ -41,6 +41,7 @@ type Props = {
   projectSlug: string;
   environments: WorkspaceEnv[];
   secretPath: string;
+  isSingleEnvironmentMode?: boolean;
 };
 
 enum WizardSteps {
@@ -131,7 +132,8 @@ export const CreateDynamicSecretForm = ({
   onToggle,
   projectSlug,
   environments,
-  secretPath
+  secretPath,
+  isSingleEnvironmentMode
 }: Props) => {
   const [wizardStep, setWizardStep] = useState(WizardSteps.SelectProvider);
   const [selectedProvider, setSelectedProvider] = useState<DynamicSecretProviders | null>(null);
@@ -199,6 +201,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -217,6 +220,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -235,6 +239,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -253,6 +258,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -271,6 +277,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -289,6 +296,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -307,6 +315,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -325,6 +334,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -343,6 +353,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -361,6 +372,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -379,6 +391,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -397,6 +410,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -415,6 +429,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -434,6 +449,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}
@@ -452,6 +468,7 @@ export const CreateDynamicSecretForm = ({
                   projectSlug={projectSlug}
                   secretPath={secretPath}
                   environments={environments}
+                  isSingleEnvironmentMode={isSingleEnvironmentMode}
                 />
               </motion.div>
             )}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
@@ -126,7 +126,8 @@ export const ElasticSearchInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.ElasticSearch, inputs: provider },
@@ -135,17 +136,20 @@ export const ElasticSearchInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   const selectedAuthType = watch("provider.auth.type");

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
@@ -76,7 +76,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -111,7 +111,7 @@ export const ElasticSearchInputForm = ({
         roles: ["superuser"],
         port: 443
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -122,33 +122,26 @@ export const ElasticSearchInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.ElasticSearch, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.ElasticSearch, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -426,19 +419,18 @@ export const ElasticSearchInputForm = ({
               {environments.length > 1 && (
                 <Controller
                   control={control}
-                  name="environments"
+                  name="environment"
                   render={({ field: { value, onChange }, fieldState: { error } }) => (
                     <FormControl
-                      label="Environments"
+                      label="Environment"
                       isError={Boolean(error)}
                       errorText={error?.message}
                     >
                       <FilterableSelect
-                        isMulti
                         options={environments}
                         value={value}
                         onChange={onChange}
-                        placeholder="Select environments to create secret in..."
+                        placeholder="Select the environment to create secret in..."
                         getOptionLabel={(option) => option.name}
                         getOptionValue={(option) => option.slug}
                         menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
@@ -86,6 +86,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const ElasticSearchInputForm = ({
@@ -93,7 +94,8 @@ export const ElasticSearchInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -111,7 +113,7 @@ export const ElasticSearchInputForm = ({
         roles: ["superuser"],
         port: 443
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -416,7 +418,7 @@ export const ElasticSearchInputForm = ({
                   )}
                 />
               </div>
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
@@ -147,7 +147,7 @@ export const ElasticSearchInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -156,7 +156,7 @@ export const LdapInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -79,7 +79,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 
 type TForm = z.infer<typeof formSchema>;
@@ -118,7 +118,7 @@ export const LdapInputForm = ({
         rollbackLdif: "",
         credentialType: CredentialType.Dynamic
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -131,33 +131,26 @@ export const LdapInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.Ldap, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.Ldap, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -396,19 +389,18 @@ export const LdapInputForm = ({
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -135,7 +135,8 @@ export const LdapInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.Ldap, inputs: provider },
@@ -144,17 +145,20 @@ export const LdapInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -90,6 +90,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const LdapInputForm = ({
@@ -97,7 +98,8 @@ export const LdapInputForm = ({
   onCancel,
   secretPath,
   projectSlug,
-  environments
+  environments,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -118,7 +120,7 @@ export const LdapInputForm = ({
         rollbackLdif: "",
         credentialType: CredentialType.Dynamic
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -386,7 +388,7 @@ export const LdapInputForm = ({
                     )}
                   />
                 )}
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
@@ -137,7 +137,8 @@ export const MongoAtlasInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.MongoAtlas, inputs: provider },
@@ -146,17 +147,20 @@ export const MongoAtlasInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
@@ -158,7 +158,7 @@ export const MongoAtlasInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
@@ -76,6 +76,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 const ATLAS_SCOPE_TYPES = [
@@ -98,7 +99,8 @@ export const MongoAtlasInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -112,7 +114,7 @@ export const MongoAtlasInputForm = ({
       provider: {
         roles: [{ databaseName: "", roleName: "" }]
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -448,7 +450,7 @@ export const MongoAtlasInputForm = ({
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
@@ -13,6 +13,7 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
+  FilterableSelect,
   FormControl,
   FormLabel,
   IconButton,
@@ -22,6 +23,7 @@ import {
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -63,7 +65,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -72,7 +75,7 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 const ATLAS_SCOPE_TYPES = [
@@ -93,7 +96,7 @@ const ATLAS_SCOPE_TYPES = [
 export const MongoAtlasInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -108,7 +111,8 @@ export const MongoAtlasInputForm = ({
     defaultValues: {
       provider: {
         roles: [{ databaseName: "", roleName: "" }]
-      }
+      },
+      environments: environments.length === 1 ? environments : []
     }
   });
 
@@ -124,26 +128,35 @@ export const MongoAtlasInputForm = ({
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.MongoAtlas, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (environment) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.MongoAtlas, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: environment.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   return (
@@ -438,6 +451,30 @@ export const MongoAtlasInputForm = ({
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
+              {environments.length > 1 && (
+                <Controller
+                  control={control}
+                  name="environments"
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl
+                      label="Environments"
+                      isError={Boolean(error)}
+                      errorText={error?.message}
+                    >
+                      <FilterableSelect
+                        isMulti
+                        options={environments}
+                        value={value}
+                        onChange={onChange}
+                        placeholder="Select environments to create secret in..."
+                        getOptionLabel={(option) => option.name}
+                        getOptionValue={(option) => option.slug}
+                        menuPlacement="top"
+                      />
+                    </FormControl>
+                  )}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoAtlasInputForm.tsx
@@ -66,7 +66,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -112,7 +112,7 @@ export const MongoAtlasInputForm = ({
       provider: {
         roles: [{ databaseName: "", roleName: "" }]
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -133,33 +133,26 @@ export const MongoAtlasInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.MongoAtlas, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.MongoAtlas, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -458,19 +451,18 @@ export const MongoAtlasInputForm = ({
               {environments.length > 1 && (
                 <Controller
                   control={control}
-                  name="environments"
+                  name="environment"
                   render={({ field: { value, onChange }, fieldState: { error } }) => (
                     <FormControl
-                      label="Environments"
+                      label="Environment"
                       isError={Boolean(error)}
                       errorText={error?.message}
                     >
                       <FilterableSelect
-                        isMulti
                         options={environments}
                         value={value}
                         onChange={onChange}
-                        placeholder="Select environments to create secret in..."
+                        placeholder="Select the environment to create secret in..."
                         getOptionLabel={(option) => option.name}
                         getOptionValue={(option) => option.slug}
                         menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
@@ -135,7 +135,7 @@ export const MongoDBDatabaseInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
@@ -66,6 +66,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const MongoDBDatabaseInputForm = ({
@@ -73,7 +74,8 @@ export const MongoDBDatabaseInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -87,7 +89,7 @@ export const MongoDBDatabaseInputForm = ({
       provider: {
         roles: [{ roleName: "readWrite" }]
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -338,7 +340,7 @@ export const MongoDBDatabaseInputForm = ({
                   )}
                 />
               </div>
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
@@ -107,7 +107,8 @@ export const MongoDBDatabaseInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: {
@@ -123,17 +124,20 @@ export const MongoDBDatabaseInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -60,7 +60,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -100,7 +100,7 @@ export const RabbitMqInputForm = ({
         },
         tags: []
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -111,33 +111,26 @@ export const RabbitMqInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.RabbitMq, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.RabbitMq, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -432,19 +425,18 @@ export const RabbitMqInputForm = ({
               {environments.length > 1 && (
                 <Controller
                   control={control}
-                  name="environments"
+                  name="environment"
                   render={({ field: { value, onChange }, fieldState: { error } }) => (
                     <FormControl
-                      label="Environments"
+                      label="Environment"
                       isError={Boolean(error)}
                       errorText={error?.message}
                     >
                       <FilterableSelect
-                        isMulti
                         options={environments}
                         value={value}
                         onChange={onChange}
-                        placeholder="Select environments to create secret in..."
+                        placeholder="Select the environment to create secret in..."
                         getOptionLabel={(option) => option.name}
                         getOptionValue={(option) => option.slug}
                         menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -136,7 +136,7 @@ export const RabbitMqInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -115,7 +115,8 @@ export const RabbitMqInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.RabbitMq, inputs: provider },
@@ -124,17 +125,20 @@ export const RabbitMqInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   const selectedTags = watch("provider.tags");

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -7,9 +7,18 @@ import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, FormLabel, IconButton, Input, SecretInput } from "@app/components/v2";
+import {
+  Button,
+  FilterableSelect,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Input,
+  SecretInput
+} from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -50,7 +59,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -59,13 +69,13 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 export const RabbitMqInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -89,32 +99,42 @@ export const RabbitMqInputForm = ({
           }
         },
         tags: []
-      }
+      },
+      environments: environments.length === 1 ? environments : []
     }
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.RabbitMq, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (environment) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.RabbitMq, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: environment.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   const selectedTags = watch("provider.tags");
@@ -405,6 +425,30 @@ export const RabbitMqInputForm = ({
                   )}
                 />
               </div>
+              {environments.length > 1 && (
+                <Controller
+                  control={control}
+                  name="environments"
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl
+                      label="Environments"
+                      isError={Boolean(error)}
+                      errorText={error?.message}
+                    >
+                      <FilterableSelect
+                        isMulti
+                        options={environments}
+                        value={value}
+                        onChange={onChange}
+                        placeholder="Select environments to create secret in..."
+                        getOptionLabel={(option) => option.name}
+                        getOptionValue={(option) => option.slug}
+                        menuPlacement="top"
+                      />
+                    </FormControl>
+                  )}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -70,6 +70,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const RabbitMqInputForm = ({
@@ -77,7 +78,8 @@ export const RabbitMqInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -100,7 +102,7 @@ export const RabbitMqInputForm = ({
         },
         tags: []
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -422,7 +424,7 @@ export const RabbitMqInputForm = ({
                   )}
                 />
               </div>
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
@@ -121,7 +121,7 @@ export const RedisInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
@@ -53,7 +53,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -85,7 +85,7 @@ export const RedisInputForm = ({
         creationStatement: "ACL SETUSER {{username}} on >{{password}} ~* &* +@all",
         revocationStatement: "ACL DELUSER {{username}}"
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -96,33 +96,26 @@ export const RedisInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.Redis, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.Redis, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -333,19 +326,18 @@ export const RedisInputForm = ({
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
@@ -63,6 +63,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const RedisInputForm = ({
@@ -70,7 +71,8 @@ export const RedisInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -85,7 +87,7 @@ export const RedisInputForm = ({
         creationStatement: "ACL SETUSER {{username}} on >{{password}} ~* &* +@all",
         revocationStatement: "ACL DELUSER {{username}}"
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -323,7 +325,7 @@ export const RedisInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
@@ -100,7 +100,8 @@ export const RedisInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.Redis, inputs: provider },
@@ -109,17 +110,20 @@ export const RedisInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
@@ -122,7 +122,7 @@ sp_droplogin '{{username}}';`
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
@@ -51,7 +51,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -86,7 +86,7 @@ sp_role 'grant', 'mon_role', '{{username}}';`,
         revocationStatement: `sp_dropuser '{{username}}';
 sp_droplogin '{{username}}';`
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -97,33 +97,26 @@ sp_droplogin '{{username}}';`
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.SapAse, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.SapAse, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -311,19 +304,18 @@ sp_droplogin '{{username}}';`
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
@@ -11,12 +11,14 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
+  FilterableSelect,
   FormControl,
   Input,
   TextArea
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -48,7 +50,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -57,13 +60,13 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 export const SapAseInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -82,32 +85,42 @@ sp_adduser '{{username}}', '{{username}}', null;
 sp_role 'grant', 'mon_role', '{{username}}';`,
         revocationStatement: `sp_dropuser '{{username}}';
 sp_droplogin '{{username}}';`
-      }
+      },
+      environments: environments.length === 1 ? environments : []
     }
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.SapAse, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (environment) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.SapAse, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: environment.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   return (
@@ -291,6 +304,30 @@ sp_droplogin '{{username}}';`
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
+                {environments.length > 1 && (
+                  <Controller
+                    control={control}
+                    name="environments"
+                    render={({ field: { value, onChange }, fieldState: { error } }) => (
+                      <FormControl
+                        label="Environments"
+                        isError={Boolean(error)}
+                        errorText={error?.message}
+                      >
+                        <FilterableSelect
+                          isMulti
+                          options={environments}
+                          value={value}
+                          onChange={onChange}
+                          placeholder="Select environments to create secret in..."
+                          getOptionLabel={(option) => option.name}
+                          getOptionValue={(option) => option.slug}
+                          menuPlacement="top"
+                        />
+                      </FormControl>
+                    )}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
@@ -61,6 +61,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const SapAseInputForm = ({
@@ -68,7 +69,8 @@ export const SapAseInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -86,7 +88,7 @@ sp_role 'grant', 'mon_role', '{{username}}';`,
         revocationStatement: `sp_dropuser '{{username}}';
 sp_droplogin '{{username}}';`
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -301,7 +303,7 @@ sp_droplogin '{{username}}';`
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapAseInputForm.tsx
@@ -101,7 +101,8 @@ sp_droplogin '{{username}}';`
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.SapAse, inputs: provider },
@@ -110,17 +111,20 @@ sp_droplogin '{{username}}';`
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -53,7 +53,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -86,7 +86,7 @@ GRANT "MONITORING" TO {{username}};`,
 DROP USER {{username}};`,
         renewStatement: "ALTER USER {{username}} VALID UNTIL '{{expiration}}';"
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -97,33 +97,26 @@ DROP USER {{username}};`,
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.SapHana, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret in environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.SapHana, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -331,19 +324,18 @@ DROP USER {{username}};`,
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -101,7 +101,8 @@ DROP USER {{username}};`,
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.SapHana, inputs: provider },
@@ -110,17 +111,20 @@ DROP USER {{username}};`,
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret in environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -122,7 +122,7 @@ DROP USER {{username}};`,
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -11,6 +11,7 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
+  FilterableSelect,
   FormControl,
   Input,
   SecretInput,
@@ -18,6 +19,7 @@ import {
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { WorkspaceEnv } from "@app/hooks/api/types";
 
 const formSchema = z.object({
   provider: z.object({
@@ -50,7 +52,8 @@ const formSchema = z.object({
       if (valMs > 24 * 60 * 60 * 1000)
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
-  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase")
+  name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
+  environments: z.object({ name: z.string(), slug: z.string() }).array()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -59,13 +62,13 @@ type Props = {
   onCancel: () => void;
   secretPath: string;
   projectSlug: string;
-  environment: string;
+  environments: WorkspaceEnv[];
 };
 
 export const SapHanaInputForm = ({
   onCompleted,
   onCancel,
-  environment,
+  environments,
   secretPath,
   projectSlug
 }: Props) => {
@@ -82,32 +85,42 @@ GRANT "MONITORING" TO {{username}};`,
         revocationStatement: `REVOKE "MONITORING" FROM {{username}};
 DROP USER {{username}};`,
         renewStatement: "ALTER USER {{username}} VALID UNTIL '{{expiration}}';"
-      }
+      },
+      environments: environments.length === 1 ? environments : []
     }
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
 
-  const handleCreateDynamicSecret = async ({ name, maxTTL, provider, defaultTTL }: TForm) => {
+  const handleCreateDynamicSecret = async ({
+    name,
+    maxTTL,
+    provider,
+    defaultTTL,
+    environments: selectedEnvs
+  }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    try {
-      await createDynamicSecret.mutateAsync({
-        provider: { type: DynamicSecretProviders.SapHana, inputs: provider },
-        maxTTL,
-        name,
-        path: secretPath,
-        defaultTTL,
-        projectSlug,
-        environmentSlug: environment
-      });
-      onCompleted();
-    } catch {
-      createNotification({
-        type: "error",
-        text: "Failed to create dynamic secret"
-      });
-    }
+    const promises = selectedEnvs.map(async (environment) => {
+      try {
+        await createDynamicSecret.mutateAsync({
+          provider: { type: DynamicSecretProviders.SapHana, inputs: provider },
+          maxTTL,
+          name,
+          path: secretPath,
+          defaultTTL,
+          projectSlug,
+          environmentSlug: environment.slug
+        });
+        onCompleted();
+      } catch {
+        createNotification({
+          type: "error",
+          text: "Failed to create dynamic secret"
+        });
+      }
+    });
+    await Promise.all(promises);
   };
 
   return (
@@ -311,6 +324,30 @@ DROP USER {{username}};`,
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
+                {environments.length > 1 && (
+                  <Controller
+                    control={control}
+                    name="environments"
+                    render={({ field: { value, onChange }, fieldState: { error } }) => (
+                      <FormControl
+                        label="Environments"
+                        isError={Boolean(error)}
+                        errorText={error?.message}
+                      >
+                        <FilterableSelect
+                          isMulti
+                          options={environments}
+                          value={value}
+                          onChange={onChange}
+                          placeholder="Select environments to create secret in..."
+                          getOptionLabel={(option) => option.name}
+                          getOptionValue={(option) => option.slug}
+                          menuPlacement="top"
+                        />
+                      </FormControl>
+                    )}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -63,6 +63,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const SapHanaInputForm = ({
@@ -70,7 +71,8 @@ export const SapHanaInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -86,7 +88,7 @@ GRANT "MONITORING" TO {{username}};`,
 DROP USER {{username}};`,
         renewStatement: "ALTER USER {{username}} VALID UNTIL '{{expiration}}';"
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -321,7 +323,7 @@ DROP USER {{username}};`,
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
@@ -67,6 +67,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const SnowflakeInputForm = ({
@@ -74,7 +75,8 @@ export const SnowflakeInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -89,7 +91,7 @@ export const SnowflakeInputForm = ({
         revocationStatement: "DROP USER {{username}};",
         renewStatement: "ALTER USER {{username}} SET DAYS_TO_EXPIRY = {{expiration}};"
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -324,7 +326,7 @@ export const SnowflakeInputForm = ({
                   </AccordionContent>
                 </AccordionItem>
               </Accordion>
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
@@ -104,7 +104,8 @@ export const SnowflakeInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.Snowflake, inputs: provider },
@@ -113,17 +114,20 @@ export const SnowflakeInputForm = ({
           path: secretPath,
           defaultTTL,
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch (err) {
         createNotification({
           type: "error",
           text: err instanceof Error ? err.message : "Failed to create dynamic secret"
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SnowflakeInputForm.tsx
@@ -125,7 +125,7 @@ export const SnowflakeInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -215,7 +215,7 @@ export const SqlDatabaseInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -82,7 +82,7 @@ const formSchema = z.object({
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than a day" });
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
-  environments: z.object({ name: z.string(), slug: z.string() }).array()
+  environment: z.object({ name: z.string(), slug: z.string() })
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -176,7 +176,7 @@ export const SqlDatabaseInputForm = ({
           allowedSymbols: "-_.~!*"
         }
       },
-      environments: environments.length === 1 ? environments : []
+      environment: environments.length === 1 ? environments[0] : undefined
     }
   });
 
@@ -190,33 +190,27 @@ export const SqlDatabaseInputForm = ({
     maxTTL,
     provider,
     defaultTTL,
-    environments: selectedEnvs
+    environment
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    let hasErrors = false;
-    const promises = selectedEnvs.map(async (env) => {
-      try {
-        await createDynamicSecret.mutateAsync({
-          provider: { type: DynamicSecretProviders.SqlDatabase, inputs: provider },
-          maxTTL,
-          name,
-          path: secretPath,
-          defaultTTL,
-          projectSlug,
-          environmentSlug: env.slug
-        });
-      } catch {
-        createNotification({
-          type: "error",
-          text: `Failed to create dynamic secret for environment ${env.name}`
-        });
-        hasErrors = true;
-      }
-    });
-    await Promise.all(promises);
-    if (!hasErrors) {
+
+    try {
+      await createDynamicSecret.mutateAsync({
+        provider: { type: DynamicSecretProviders.SqlDatabase, inputs: provider },
+        maxTTL,
+        name,
+        path: secretPath,
+        defaultTTL,
+        projectSlug,
+        environmentSlug: environment.slug
+      });
       onCompleted();
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to create dynamic secret"
+      });
     }
   };
 
@@ -669,19 +663,18 @@ export const SqlDatabaseInputForm = ({
                 {environments.length > 1 && (
                   <Controller
                     control={control}
-                    name="environments"
+                    name="environment"
                     render={({ field: { value, onChange }, fieldState: { error } }) => (
                       <FormControl
-                        label="Environments"
+                        label="Environment"
                         isError={Boolean(error)}
                         errorText={error?.message}
                       >
                         <FilterableSelect
-                          isMulti
                           options={environments}
                           value={value}
                           onChange={onChange}
-                          placeholder="Select environments to create secret in..."
+                          placeholder="Select the environment to create secret in..."
                           getOptionLabel={(option) => option.name}
                           getOptionValue={(option) => option.slug}
                           menuPlacement="top"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -194,6 +194,7 @@ export const SqlDatabaseInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
+    let hasErrors = false;
     const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
@@ -205,15 +206,18 @@ export const SqlDatabaseInputForm = ({
           projectSlug,
           environmentSlug: env.slug
         });
-        onCompleted();
       } catch {
         createNotification({
           type: "error",
-          text: "Failed to create dynamic secret"
+          text: `Failed to create dynamic secret for environment ${env.name}`
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   const handleDatabaseChange = (type: SqlProviders) => {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -92,6 +92,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 const getSqlStatements = (provider: SqlProviders) => {
@@ -150,7 +151,8 @@ export const SqlDatabaseInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const { currentWorkspace } = useWorkspace();
 
@@ -176,7 +178,7 @@ export const SqlDatabaseInputForm = ({
           allowedSymbols: "-_.~!*"
         }
       },
-      environment: environments.length === 1 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -660,7 +662,7 @@ export const SqlDatabaseInputForm = ({
                     </AccordionContent>
                   </AccordionItem>
                 </Accordion>
-                {environments.length > 1 && (
+                {!isSingleEnvironmentMode && (
                   <Controller
                     control={control}
                     name="environment"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
@@ -128,7 +128,7 @@ export const TotpInputForm = ({
       }
     });
     await Promise.all(promises);
-    if (hasErrors) {
+    if (!hasErrors) {
       onCompleted();
     }
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
@@ -107,7 +107,8 @@ export const TotpInputForm = ({
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
-    const promises = selectedEnvs.map(async (environment) => {
+    let hasErrors = false;
+    const promises = selectedEnvs.map(async (env) => {
       try {
         await createDynamicSecret.mutateAsync({
           provider: { type: DynamicSecretProviders.Totp, inputs: provider },
@@ -116,17 +117,20 @@ export const TotpInputForm = ({
           path: secretPath,
           defaultTTL: "1m",
           projectSlug,
-          environmentSlug: environment.slug
+          environmentSlug: env.slug
         });
-        onCompleted();
       } catch (err) {
         createNotification({
           type: "error",
           text: err instanceof Error ? err.message : "Failed to create dynamic secret"
         });
+        hasErrors = true;
       }
     });
     await Promise.all(promises);
+    if (hasErrors) {
+      onCompleted();
+    }
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/TotpInputForm.tsx
@@ -72,6 +72,7 @@ type Props = {
   secretPath: string;
   projectSlug: string;
   environments: WorkspaceEnv[];
+  isSingleEnvironmentMode?: boolean;
 };
 
 export const TotpInputForm = ({
@@ -79,7 +80,8 @@ export const TotpInputForm = ({
   onCancel,
   environments,
   secretPath,
-  projectSlug
+  projectSlug,
+  isSingleEnvironmentMode
 }: Props) => {
   const {
     control,
@@ -92,7 +94,7 @@ export const TotpInputForm = ({
       provider: {
         configType: ConfigType.URL
       },
-      environment: environments.length === 1 ? environments[0] : environments[0]
+      environment: isSingleEnvironmentMode ? environments[0] : undefined
     }
   });
 
@@ -305,7 +307,7 @@ export const TotpInputForm = ({
                   </p>
                 </>
               )}
-              {environments.length > 1 && (
+              {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}
                   name="environment"


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Add an option on the Secrets Overview page to create dynamic secrets, enabling users to choose which environments should be included.

https://github.com/user-attachments/assets/99475650-6403-4a51-b1f5-ad4e4ab0e887



## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - **Dynamic Secret Management:** Users can now create dynamic secrets across multiple environments, enhancing flexibility when managing credentials.
  - **Subscription Enhancements:** The secret management page now checks subscription status and conditionally displays an upgrade prompt, ensuring that users on different plans access the appropriate features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->