### PR TITLE
Fix: Handle Disabled/Destroyed Values in GCP Sync

### DIFF
--- a/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
@@ -71,8 +71,13 @@ const getGcpSecrets = async (accessToken: string, secretSync: TGcpSyncWithCreden
 
       res[key] = Buffer.from(secretLatest.payload.data, "base64").toString("utf-8");
     } catch (error) {
-      // when a secret in GCP has no versions, we treat it as if it's a blank value
-      if (error instanceof AxiosError && error.response?.status === 404) {
+      // when a secret in GCP has no versions, or is disabled/destroyed, we treat it as if it's a blank value
+      if (
+        error instanceof AxiosError &&
+        (error.response?.status === 404 ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          (error.response?.status === 400 && error.response.data.error.status === "FAILED_PRECONDITION"))
+      ) {
         res[key] = "";
       } else {
         throw new SecretSyncError({

--- a/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
@@ -75,8 +75,11 @@ const getGcpSecrets = async (accessToken: string, secretSync: TGcpSyncWithCreden
       if (
         error instanceof AxiosError &&
         (error.response?.status === 404 ||
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          (error.response?.status === 400 && error.response.data.error.status === "FAILED_PRECONDITION"))
+          (error.response?.status === 400 &&
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            error.response.data.error.status === "FAILED_PRECONDITION" &&
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+            error.response.data.error.message.match(/(?:disabled|destroyed)/i)))
       ) {
         res[key] = "";
       } else {


### PR DESCRIPTION
# Description 📣

This PR updates GCP sync functionality to handle disabled/destroyed secret values and treat them as empty secrets.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for GCP secrets access, now accounting for additional error conditions to improve robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->