### PR TITLE
Grammar fixes to local-development.mdx

### DIFF
--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -6,7 +6,7 @@ description: "Learn how to manage secrets in local development environments."
 
 ## Problem at hand
 
-There is a number of issues that arise with secret management in local development environment: 
+There are a number of issues that arise with secret management in local development environment: 
 1. **Getting secrets onto local machines**. When new developers join or a new project is created, the process of getting the development set of secrets onto local machines is often unclear. As a result, developers end up spending a lot of time onboarding and risk potentially following insecure practices when sharing secrets from one developer to another.
 2. **Syncing secrets with teammates**. One of the problems with .env files is that they become unsynced when one of the developers updates a secret or configuration. Even if the rest of the team is notified, developers don't make all the right changes immediately, and later on end up spending a lot of time debugging an issue due to missing environment variables. This leads to a lot of inefficiencies and lost time. 
 3. **Accidentally leaking secrets**. When developing locally, it's common for developers to accidentally leak a hardcoded secret as part of a commit. As soon as the secret is part of the git history, it becomes hard to get it removed and create a security vulnerability.


### PR DESCRIPTION
# Description 📣

Minor grammer typo on [Quikstart page](https://infisical.com/docs/documentation/guides/local-development).

**Before** - There ~~is~~ a number of issues that arise with secret management in local development environment

**After** - There `are` a number of issues that arise with secret management in local development environment

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

Validated changes using a spell checker.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the local development guide with improved grammatical accuracy for clearer content presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->