### PR TITLE
fix: k8s installation failing

### DIFF
--- a/helm-charts/secrets-operator/templates/infisicalsecret-crd.yaml
+++ b/helm-charts/secrets-operator/templates/infisicalsecret-crd.yaml
@@ -505,3 +505,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
+{{- end }}


### PR DESCRIPTION
# Description 📣

This PR resolves the helm installation error seen below. And end statement was missing from the infisicalsecret CRD 
template. This issue was mentioned in the discussion https://github.com/Infisical/infisical/discussions/3250

```
helm install --generate-name infisical-helm-charts/secrets-operator
Error: INSTALLATION FAILED: parse error at (secrets-operator/templates/infisicalsecret-crd.yaml:507): unexpected EOF
```

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted configuration templating to ensure smooth and accurate rendering of deployment charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->