### PR TITLE
feat(helm): custom volume support

### DIFF
--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1 (March 19, 2025)
+
+Changes:
+* Added support for supplying extra volume mounts and volumes via `infisical.extraVolumeMounts` and `infisical.extraVolumes`
+
 ## 1.4.0 (November 06, 2024)
 
 Changes:

--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -77,6 +77,14 @@ spec:
         {{- if  $infisicalValues.resources }}
         resources: {{- toYaml $infisicalValues.resources | nindent 12 }}
         {{- end }}
+        {{- with $infisicalValues.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with $infisicalValues.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 
 apiVersion: v1


### PR DESCRIPTION
# Description 📣

We currently don't support specifying your own volumes for k8 deployments, which is needed in order to use an HSM client with k8's, otherwise users will need to build their own docker image with the client files pre-packaged.

Instead with this PR, people will be able to persistent volumes like so: 
```yaml
  extraVolumeMounts:
    - name: hsm-data
      mountPath: /hsm-client
      subPath: ./hsm-client

  extraVolumes:
    - name: hsm-data
      persistentVolumeClaim:
        claimName: infisical-data-pvc # volume created which is not a part of the deployment itself
```

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release version to 1.4.1.

- **New Features**
  - Introduced additional configuration options to enable flexible customization of volume mounts and volumes during deployments.
  - Added support for supplying extra volume mounts and volumes via `infisical.extraVolumeMounts` and `infisical.extraVolumes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->