### PR TITLE
Bulk Delete Secret Incorrectly says lacking permission

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
@@ -110,6 +110,7 @@ export const SelectionPanel = ({ secretPath, resetSelectedEntries, selectedEntri
       const secretsToDelete = Object.values(selectedEntries.secret).reduce(
         (accum: TDeleteSecretBatchDTO["secrets"], secretRecord) => {
           const entry = secretRecord[env.slug];
+          if (!entry) return accum;
           const canDeleteSecret = permission.can(
             ProjectPermissionSecretActions.Delete,
             subject(ProjectPermissionSub.Secrets, {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

**Issue**
When attempting to bulk delete secrets across multiple environments on the secrets overview page, users received a permission error, even though they had the necessary permissions.

**Root Cause**
The problem was in the handleBulkDelete reducer logic. Specifically, `const entry = secretRecord[env.slug];` could return undefined. When that happened, the permissions check (permission.can) failed, and the reducer loop would break, causing only the first selected secret to be processed and skipping the rest.

**Solution**
Added a conditional check to skip entries where entry is undefined by simply returning the accumulator. This prevents unnecessary permission checks for invalid entries and ensures the reducer continues processing all selected secrets correctly.

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the bulk deletion process in the Secret Manager by ensuring that only valid secret entries are processed. This update prevents potential errors when handling missing or invalid entries, resulting in a more reliable and stable deletion experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->