### PR TITLE
fix(k8s): remove required field from helm

### DIFF
--- a/helm-charts/secrets-operator/Chart.yaml
+++ b/helm-charts/secrets-operator/Chart.yaml
@@ -13,9 +13,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.8.14
+version: v0.8.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.14"
+appVersion: "v0.8.15"

--- a/helm-charts/secrets-operator/templates/infisicalsecret-crd.yaml
+++ b/helm-charts/secrets-operator/templates/infisicalsecret-crd.yaml
@@ -417,7 +417,6 @@ spec:
                 - secretNamespace
                 type: object
             required:
-            - managedKubeConfigMapReferences
             - resyncInterval
             type: object
           status:

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -32,7 +32,7 @@ controllerManager:
           - ALL
     image:
       repository: infisical/kubernetes-operator
-      tag: v0.8.14
+      tag: v0.8.15
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
# Description 📣

This PR resolves an issue with `managedKubeConfigMapReferences` being a required field in helm, but not in the operator itself. This field should not be required. This PR resolves #3273

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the release to version v0.8.15, ensuring the operator and its container image are aligned with the latest release.

- **Refactor**
  - Simplified configuration by removing a previously mandatory setting, streamlining the setup process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->