### PR TITLE
K8s reviewer jwt optional and self client method

### DIFF
--- a/backend/src/db/migrations/20250321100157_k8s-self-reviewer-jwt.ts
+++ b/backend/src/db/migrations/20250321100157_k8s-self-reviewer-jwt.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasReviewerJwtCol = await knex.schema.hasColumn(
+    TableName.IdentityKubernetesAuth,
+    "encryptedKubernetesTokenReviewerJwt"
+  );
+  if (hasReviewerJwtCol) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
+      t.binary("encryptedKubernetesTokenReviewerJwt").nullable().alter();
+    });
+  }
+}
+
+export async function down(): Promise<void> {
+  // we can't make it back to non nullable, it will fail
+}

--- a/backend/src/db/schemas/identity-kubernetes-auths.ts
+++ b/backend/src/db/schemas/identity-kubernetes-auths.ts
@@ -28,7 +28,7 @@ export const IdentityKubernetesAuthsSchema = z.object({
   allowedNamespaces: z.string(),
   allowedNames: z.string(),
   allowedAudience: z.string(),
-  encryptedKubernetesTokenReviewerJwt: zodBuffer,
+  encryptedKubernetesTokenReviewerJwt: zodBuffer.nullable().optional(),
   encryptedKubernetesCaCertificate: zodBuffer.nullable().optional()
 });
 

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -244,7 +244,7 @@ export const KUBERNETES_AUTH = {
     kubernetesHost: "The host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert: "The PEM-encoded CA cert for the Kubernetes API server.",
     tokenReviewerJwt:
-      "The long-lived service account JWT token for Infisical to access the TokenReview API to validate other service account JWT tokens submitted by applications/pods.",
+      "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     allowedNamespaces:
       "The comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.",
     allowedNames: "The comma-separated list of trusted service account names that can authenticate with Infisical.",
@@ -260,7 +260,7 @@ export const KUBERNETES_AUTH = {
     kubernetesHost: "The new host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert: "The new PEM-encoded CA cert for the Kubernetes API server.",
     tokenReviewerJwt:
-      "The new long-lived service account JWT token for Infisical to access the TokenReview API to validate other service account JWT tokens submitted by applications/pods.",
+      "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     allowedNamespaces:
       "The new comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.",
     allowedNames: "The new comma-separated list of trusted service account names that can authenticate with Infisical.",

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -24,7 +24,7 @@ const IdentityKubernetesAuthResponseSchema = IdentityKubernetesAuthsSchema.pick(
   allowedAudience: true
 }).extend({
   caCert: z.string(),
-  tokenReviewerJwt: z.string()
+  tokenReviewerJwt: z.string().optional().nullable()
 });
 
 export const registerIdentityKubernetesRouter = async (server: FastifyZodProvider) => {
@@ -98,7 +98,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z.string().trim().min(1).describe(KUBERNETES_AUTH.ATTACH.kubernetesHost),
           caCert: z.string().trim().default("").describe(KUBERNETES_AUTH.ATTACH.caCert),
-          tokenReviewerJwt: z.string().trim().min(1).describe(KUBERNETES_AUTH.ATTACH.tokenReviewerJwt),
+          tokenReviewerJwt: z.string().trim().optional().describe(KUBERNETES_AUTH.ATTACH.tokenReviewerJwt),
           allowedNamespaces: z.string().describe(KUBERNETES_AUTH.ATTACH.allowedNamespaces), // TODO: validation
           allowedNames: z.string().describe(KUBERNETES_AUTH.ATTACH.allowedNames),
           allowedAudience: z.string().describe(KUBERNETES_AUTH.ATTACH.allowedAudience),
@@ -195,7 +195,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z.string().trim().min(1).optional().describe(KUBERNETES_AUTH.UPDATE.kubernetesHost),
           caCert: z.string().trim().optional().describe(KUBERNETES_AUTH.UPDATE.caCert),
-          tokenReviewerJwt: z.string().trim().min(1).optional().describe(KUBERNETES_AUTH.UPDATE.tokenReviewerJwt),
+          tokenReviewerJwt: z.string().trim().nullable().optional().describe(KUBERNETES_AUTH.UPDATE.tokenReviewerJwt),
           allowedNamespaces: z.string().optional().describe(KUBERNETES_AUTH.UPDATE.allowedNamespaces), // TODO: validation
           allowedNames: z.string().optional().describe(KUBERNETES_AUTH.UPDATE.allowedNames),
           allowedAudience: z.string().optional().describe(KUBERNETES_AUTH.UPDATE.allowedAudience),

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
@@ -9,7 +9,7 @@ export type TAttachKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost: string;
   caCert: string;
-  tokenReviewerJwt: string;
+  tokenReviewerJwt?: string;
   allowedNamespaces: string;
   allowedNames: string;
   allowedAudience: string;
@@ -24,7 +24,7 @@ export type TUpdateKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost?: string;
   caCert?: string;
-  tokenReviewerJwt?: string;
+  tokenReviewerJwt?: string | null;
   allowedNamespaces?: string;
   allowedNames?: string;
   allowedAudience?: string;

--- a/docs/documentation/platform/identities/kubernetes-auth.mdx
+++ b/docs/documentation/platform/identities/kubernetes-auth.mdx
@@ -37,7 +37,8 @@ then Infisical returns a short-lived access token that can be used to make authe
 To be more specific:
 
 1. The application deployed on Kubernetes retrieves its [service account credential](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) that is a JWT token at the `/var/run/secrets/kubernetes.io/serviceaccount/token` pod path.
-2. The application sends the JWT token to Infisical at the `/api/v1/auth/kubernetes-auth/login` endpoint after which Infisical forwards the JWT token to the Kubernetes API Server at the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) for verification and to obtain the service account information associated with the JWT token. Infisical is able to authenticate and interact with the TokenReview API by using a long-lived service account JWT token itself (referred to onward as the token reviewer JWT token).
+2. The application sends the JWT token to Infisical at the `/api/v1/auth/kubernetes-auth/login` endpoint after which Infisical forwards the JWT token to the Kubernetes API Server at the TokenReview API for verification and to obtain the service account information associated with the JWT token.
+Infisical is able to authenticate and interact with the TokenReview API by using either the long lived JWT token set while configuring this authentication method or by using the incoming token itself. The JWT token mentioned in this context is referred as the token reviewer JWT token.
 3. Infisical checks the service account properties against set criteria such **Allowed Service Account Names** and **Allowed Namespaces**.
 4. If all is well, Infisical returns a short-lived access token that the application can use to make authenticated requests to the Infisical API.
 
@@ -54,11 +55,14 @@ In the following steps, we explore how to create and use identities for your app
 <Steps>
     <Step title="Obtaining the token reviewer JWT for Infisical">
 				<Tabs>
-								<Tab title="Reviewer JWT">
+					<Tab title="Option 1: Reviewer JWT Token">
+        
+        <Note>
+        **When to use this option**: Choose this approach when you want centralized authentication management. Only one service account needs special permissions, and your application service accounts remain unchanged.
+        </Note>
         1.1. Start by creating a service account in your Kubernetes cluster that will be used by Infisical to authenticate with the Kubernetes API Server.
 
-        ```yaml
-    			infisical-service-account.yaml
+        ```yaml infisical-service-account.yaml
         apiVersion: v1
         kind: ServiceAccount
         metadata:
@@ -124,23 +128,36 @@ In the following steps, we explore how to create and use identities for your app
         Keep this JWT token handy as you will need it for the **Token Reviewer JWT** field when configuring the Kubernetes Auth authentication method for the identity in step 2.
 
 </Tab>
-<Tab title="Client JWT as Self Reviewer JWT">
+<Tab title="Option 2: Client JWT as Reviewer JWT Token">
 
-The self-validation method eliminates the need for a separate long-lived reviewer JWT by using the same token for both authentication and validation. This approach:
+    <Note>
+    **When to use this option**: Choose this approach to eliminate long-lived tokens. This option simplifies Infisical configuration but requires each application service account to have elevated permissions.
+    </Note>
 
-1. Reduces the number of long-lived credentials in your system
-2. Allows you to use short-lived tokens throughout your authentication flow
+    The self-validation method eliminates the need for a separate long-lived reviewer JWT by using the same token for both authentication and validation. Instead of creating a dedicated reviewer service account, you'll grant the necessary permissions to each application service account.
 
-Requires maintaining `system:auth-delegator` role bindings for all authenticating service accounts, which increases the operational overhead on the client side.
+    For each service account that needs to authenticate with Infisical, add the `system:auth-delegator` role:
 
-```bash
-kubectl create clusterrolebinding infisical-client \
-    --clusterrole=system:auth-delegator \
-    --group=group1 \
-    --serviceaccount=default:svcaccount1 \
-    ...
-```
+    ```yaml client-role-binding.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: infisical-client-binding-[your-app-name]
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+      - kind: ServiceAccount
+        name: [your-app-service-account]
+        namespace: [your-app-namespace]
+    ```
 
+    ```
+    kubectl apply -f client-role-binding.yaml
+    ```
+
+    When configuring Kubernetes Auth in Infisical, leave the **Token Reviewer JWT** field empty. Infisical will use the client's own token for validation.
 </Tab>
 </Tabs>
 </Step>
@@ -173,7 +190,8 @@ kubectl create clusterrolebinding infisical-client \
     Here's some more guidance on each field:
 
     - Kubernetes Host / Base Kubernetes API URL: The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running `kubectl cluster-info`.
-    - Token Reviewer JWT: A long-lived service account JWT token for Infisical to access the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to validate other service account JWT tokens submitted by applications/pods. This is the JWT token obtained from step 1.5(Reviewer Tab). If omitted, the client's own JWT will be used instead, which requires the client to have the `system:auth-delegator` ClusterRole binding. This is shown in step 1(Client JWT as Self Reviewer JWT).
+    - Token Reviewer JWT: A long-lived service account JWT token for Infisical to access the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to validate other service account JWT tokens submitted by applications/pods. This is the JWT token obtained from step 1.5(Reviewer Tab). If omitted, the client's own JWT will be used instead, which requires the client to have the `system:auth-delegator` ClusterRole binding. 
+      This is shown in step 1, option 2.
     - Allowed Service Account Names: A comma-separated list of trusted service account names that are allowed to authenticate with Infisical.
     - Allowed Namespaces: A comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.
     - Allowed Audience: An optional audience claim that the service account JWT token must have to authenticate with Infisical.

--- a/docs/documentation/platform/identities/kubernetes-auth.mdx
+++ b/docs/documentation/platform/identities/kubernetes-auth.mdx
@@ -53,15 +53,17 @@ In the following steps, we explore how to create and use identities for your app
 
 <Steps>
     <Step title="Obtaining the token reviewer JWT for Infisical">
+				<Tabs>
+								<Tab title="Reviewer JWT">
         1.1. Start by creating a service account in your Kubernetes cluster that will be used by Infisical to authenticate with the Kubernetes API Server.
 
-        ```yaml infisical-service-account.yaml
+        ```yaml
+    			infisical-service-account.yaml
         apiVersion: v1
         kind: ServiceAccount
         metadata:
           name: infisical-auth
           namespace: default
-
         ```
 
         ```
@@ -121,7 +123,27 @@ In the following steps, we explore how to create and use identities for your app
 
         Keep this JWT token handy as you will need it for the **Token Reviewer JWT** field when configuring the Kubernetes Auth authentication method for the identity in step 2.
 
-    </Step>
+</Tab>
+<Tab title="Client JWT as Self Reviewer JWT">
+
+The self-validation method eliminates the need for a separate long-lived reviewer JWT by using the same token for both authentication and validation. This approach:
+
+1. Reduces the number of long-lived credentials in your system
+2. Allows you to use short-lived tokens throughout your authentication flow
+
+Requires maintaining `system:auth-delegator` role bindings for all authenticating service accounts, which increases the operational overhead on the client side.
+
+```bash
+kubectl create clusterrolebinding infisical-client \
+    --clusterrole=system:auth-delegator \
+    --group=group1 \
+    --serviceaccount=default:svcaccount1 \
+    ...
+```
+
+</Tab>
+</Tabs>
+</Step>
 
   <Step title="Creating an identity">
     To create an identity, head to your Organization Settings > Access Control > Machine Identities and press **Create identity**.
@@ -151,7 +173,7 @@ In the following steps, we explore how to create and use identities for your app
     Here's some more guidance on each field:
 
     - Kubernetes Host / Base Kubernetes API URL: The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running `kubectl cluster-info`.
-    - Token Reviewer JWT: A long-lived service account JWT token for Infisical to access the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to validate other service account JWT tokens submitted by applications/pods. This is the JWT token obtained from step 1.5.
+    - Token Reviewer JWT: A long-lived service account JWT token for Infisical to access the [TokenReview API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-review-v1/) to validate other service account JWT tokens submitted by applications/pods. This is the JWT token obtained from step 1.5(Reviewer Tab). If omitted, the client's own JWT will be used instead, which requires the client to have the `system:auth-delegator` ClusterRole binding. This is shown in step 1(Client JWT as Self Reviewer JWT).
     - Allowed Service Account Names: A comma-separated list of trusted service account names that are allowed to authenticate with Infisical.
     - Allowed Namespaces: A comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.
     - Allowed Audience: An optional audience claim that the service account JWT token must have to authenticate with Infisical.
@@ -176,18 +198,19 @@ In the following steps, we explore how to create and use identities for your app
   </Step>
   <Step title="Accessing the Infisical API with the identity">
     To access the Infisical API as the identity, you should first make sure that the pod running your application is bound to a service account specified in the **Allowed Service Account Names** field of the identity's Kubernetes Auth authentication method configuration in step 2.
-    
+
     Once bound, the pod will receive automatically mounted service account credentials that is a JWT token at the `/var/run/secrets/kubernetes.io/serviceaccount/token` path. This token should be used to authenticate with Infisical at the `/api/v1/auth/kubernetes-auth/login` endpoint.
-    
+
     For information on how to configure sevice accounts for pods, refer to the guide [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
-    
+
     We provide a code example below of how you might retrieve the JWT token and use it to authenticate with Infisical to gain access to the [Infisical API](/api-reference/overview/introduction).
+
    <Accordion
         title="Sample code for inside an application"
-    > 
+    >
         The shown example uses Node.js but you can use any other language to retrieve the service account JWT token and use it to authenticate with Infisical.
-        
-        ```javascript   
+
+        ```javascript
         const fs = require("fs");
         try {
             const tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token";
@@ -237,15 +260,16 @@ In the following steps, we explore how to create and use identities for your app
 </Accordion>
 <Accordion title="Why is the Infisical API rejecting my access token?">
   There are a few reasons for why this might happen:
-  
-  - The access token has expired.
-  - The identity is insufficently permissioned to interact with the resources you wish to access.
-  - The client access token is being used from an untrusted IP.
+
+- The access token has expired.
+- The identity is insufficently permissioned to interact with the resources you wish to access.
+- The client access token is being used from an untrusted IP.
+
 </Accordion>
 <Accordion title="What is access token renewal and TTL/Max TTL?">
-  A identity access token can have a time-to-live (TTL) or incremental lifetime after which it expires.
-  
-  In certain cases, you may want to extend the lifespan of an access token; to do so, you must set a max TTL parameter.
+A identity access token can have a time-to-live (TTL) or incremental lifetime after which it expires.
+
+In certain cases, you may want to extend the lifespan of an access token; to do so, you must set a max TTL parameter.
 
 A token can be renewed any number of times where each call to renew it can extend the token's lifetime by increments of the access token's TTL.
 Regardless of how frequently an access token is renewed, its lifespan remains bound to the maximum TTL determined at its creation.

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -350,7 +350,7 @@ export type AddIdentityKubernetesAuthDTO = {
   organizationId: string;
   identityId: string;
   kubernetesHost: string;
-  tokenReviewerJwt: string;
+  tokenReviewerJwt?: string;
   allowedNamespaces: string;
   allowedNames: string;
   allowedAudience: string;
@@ -367,7 +367,7 @@ export type UpdateIdentityKubernetesAuthDTO = {
   organizationId: string;
   identityId: string;
   kubernetesHost?: string;
-  tokenReviewerJwt?: string;
+  tokenReviewerJwt?: string | null;
   allowedNamespaces?: string;
   allowedNames?: string;
   allowedAudience?: string;

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -31,7 +31,7 @@ import { IdentityFormTab } from "./types";
 const schema = z
   .object({
     kubernetesHost: z.string().min(1),
-    tokenReviewerJwt: z.string().min(1),
+    tokenReviewerJwt: z.string().optional(),
     allowedNames: z.string(),
     allowedNamespaces: z.string(),
     allowedAudience: z.string(),
@@ -166,7 +166,7 @@ export const IdentityKubernetesAuthForm = ({
         await updateMutateAsync({
           organizationId: orgId,
           kubernetesHost,
-          tokenReviewerJwt,
+          tokenReviewerJwt: tokenReviewerJwt || null,
           allowedNames,
           allowedNamespaces,
           allowedAudience,
@@ -182,7 +182,7 @@ export const IdentityKubernetesAuthForm = ({
           organizationId: orgId,
           identityId,
           kubernetesHost: kubernetesHost || "",
-          tokenReviewerJwt,
+          tokenReviewerJwt: tokenReviewerJwt || undefined,
           allowedNames: allowedNames || "",
           allowedNamespaces: allowedNamespaces || "",
           allowedAudience: allowedAudience || "",
@@ -255,11 +255,11 @@ export const IdentityKubernetesAuthForm = ({
             name="tokenReviewerJwt"
             render={({ field, fieldState: { error } }) => (
               <FormControl
+                tooltipClassName="max-w-md"
                 label="Token Reviewer JWT"
                 isError={Boolean(error)}
                 errorText={error?.message}
-                tooltipText="A long-lived service account JWT token for Infisical to access the TokenReview API to validate other service account JWT tokens submitted by applications/pods."
-                isRequired
+                tooltipText="Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding."
               >
                 <Input {...field} placeholder="" type="password" />
               </FormControl>

--- a/frontend/src/pages/organization/IdentityDetailsByIDPage/components/ViewIdentityAuthModal/ViewIdentityKubernetesAuthContent.tsx
+++ b/frontend/src/pages/organization/IdentityDetailsByIDPage/components/ViewIdentityAuthModal/ViewIdentityKubernetesAuthContent.tsx
@@ -70,20 +70,26 @@ export const ViewIdentityKubernetesAuthContent = ({
         {data.kubernetesHost}
       </IdentityAuthFieldDisplay>
       <IdentityAuthFieldDisplay className="col-span-2" label="Token Reviewer JWT">
-        <Tooltip
-          side="right"
-          className="max-w-xl p-2"
-          content={
-            <p className="break-words rounded bg-mineshaft-600 p-2">{data.tokenReviewerJwt}</p>
-          }
-        >
-          <div className="w-min">
-            <Badge className="flex h-5 w-min items-center gap-1.5 whitespace-nowrap bg-mineshaft-400/50 text-bunker-300">
-              <FontAwesomeIcon icon={faEye} />
-              <span>Reveal</span>
-            </Badge>
-          </div>
-        </Tooltip>
+        {data.tokenReviewerJwt ? (
+          <Tooltip
+            side="right"
+            className="max-w-xl p-2"
+            content={
+              <p className="break-words rounded bg-mineshaft-600 p-2">
+                {data.tokenReviewerJwt || "Not provided"}
+              </p>
+            }
+          >
+            <div className="w-min">
+              <Badge className="flex h-5 w-min items-center gap-1.5 whitespace-nowrap bg-mineshaft-400/50 text-bunker-300">
+                <FontAwesomeIcon icon={faEye} />
+                <span>Reveal</span>
+              </Badge>
+            </div>
+          </Tooltip>
+        ) : (
+          <p className="text-base italic leading-4 text-bunker-400">Not set</p>
+        )}
       </IdentityAuthFieldDisplay>
       <IdentityAuthFieldDisplay className="col-span-2" label="Allowed Service Account Names">
         {data.allowedNames


### PR DESCRIPTION
# Description 📣

This PR updates reviewer jwt to be optional in k8s auth for identity and enables the client to have it's reviewer role.

This allows k8s auth to have short lived token and not rely on a long live reviewer token

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Kubernetes authentication configuration now supports an optional Token Reviewer JWT. When omitted, the system automatically defaults to using the client’s own token. UI forms provide clearer tooltips and feedback regarding the field status.
  
- **Documentation**
  - Updated guides and API documentation now explain the optional token approach and introduce an alternative setup using the client’s JWT, offering improved clarity on authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->