### PR TITLE
Add recursive flag to folders get endpoint to retrieve all nested folders

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -631,7 +631,8 @@ export const FOLDERS = {
     workspaceId: "The ID of the project to list folders from.",
     environment: "The slug of the environment to list folders from.",
     path: "The path to list folders from.",
-    directory: "The directory to list folders from. (Deprecated in favor of path)"
+    directory: "The directory to list folders from. (Deprecated in favor of path)",
+    recursive: "Whether or not to fetch all folders from the specified base path, and all of its subdirectories."
   },
   GET_BY_ID: {
     folderId: "The ID of the folder to get details."

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -81,7 +81,7 @@ export const booleanSchema = z
     return value;
   })
   .optional()
-  .default(false);
+  .default(true);
 
 export const sapPubSchema = SecretApprovalPoliciesSchema.merge(
   z.object({

--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -70,6 +70,19 @@ export const DefaultResponseErrorsSchema = {
   })
 };
 
+export const booleanSchema = z
+  .union([z.boolean(), z.string().trim()])
+  .transform((value) => {
+    if (typeof value === "string") {
+      // ie if not empty, 0 or false, return true
+      return Boolean(value) && Number(value) !== 0 && value.toLowerCase() !== "false";
+    }
+
+    return value;
+  })
+  .optional()
+  .default(false);
+
 export const sapPubSchema = SecretApprovalPoliciesSchema.merge(
   z.object({
     environment: z.object({

--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -16,27 +16,18 @@ import { secretsLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { getUserAgentType } from "@app/server/plugins/audit-log";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
-import { SanitizedDynamicSecretSchema, SanitizedTagSchema, secretRawSchema } from "@app/server/routes/sanitizedSchemas";
+import {
+  booleanSchema,
+  SanitizedDynamicSecretSchema,
+  SanitizedTagSchema,
+  secretRawSchema
+} from "@app/server/routes/sanitizedSchemas";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { ResourceMetadataSchema } from "@app/services/resource-metadata/resource-metadata-schema";
 import { SecretsOrderBy } from "@app/services/secret/secret-types";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 const MAX_DEEP_SEARCH_LIMIT = 500; // arbitrary limit to prevent excessive results
-
-// handle querystring boolean values
-const booleanSchema = z
-  .union([z.boolean(), z.string().trim()])
-  .transform((value) => {
-    if (typeof value === "string") {
-      // ie if not empty, 0 or false, return true
-      return Boolean(value) && Number(value) !== 0 && value.toLowerCase() !== "false";
-    }
-
-    return value;
-  })
-  .optional()
-  .default(true);
 
 const parseSecretPathSearch = (search?: string) => {
   if (!search)

--- a/backend/src/server/routes/v1/secret-folder-router.ts
+++ b/backend/src/server/routes/v1/secret-folder-router.ts
@@ -9,18 +9,7 @@ import { readLimit, secretsLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
-const booleanSchema = z
-  .union([z.boolean(), z.string().trim()])
-  .transform((value) => {
-    if (typeof value === "string") {
-      // ie if not empty, 0 or false, return true
-      return Boolean(value) && Number(value) !== 0 && value.toLowerCase() !== "false";
-    }
-
-    return value;
-  })
-  .optional()
-  .default(false);
+import { booleanSchema } from "../sanitizedSchemas";
 
 export const registerSecretFolderRouter = async (server: FastifyZodProvider) => {
   server.route({

--- a/backend/src/server/routes/v1/secret-folder-router.ts
+++ b/backend/src/server/routes/v1/secret-folder-router.ts
@@ -350,7 +350,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
           .transform(prefixWithSlash)
           .transform(removeTrailingSlash)
           .describe(FOLDERS.LIST.directory),
-        recursive: booleanSchema.describe(FOLDERS.LIST.recursive)
+        recursive: booleanSchema.default(false).describe(FOLDERS.LIST.recursive)
       }),
       response: {
         200: z.object({

--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -401,7 +401,8 @@ export const secretFolderServiceFactory = ({
     orderBy,
     orderDirection,
     limit,
-    offset
+    offset,
+    recursive
   }: TGetFolderDTO) => {
     // folder list is allowed to be read by anyone
     // permission to check does user has access
@@ -419,6 +420,17 @@ export const secretFolderServiceFactory = ({
 
     const parentFolder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
     if (!parentFolder) return [];
+
+    if (recursive) {
+      const recursiveFolders = await folderDAL.findByEnvsDeep({ parentIds: [parentFolder.id] });
+      // remove the parent folder
+      return recursiveFolders
+        .filter((folder) => folder.id !== parentFolder.id)
+        .map((folder) => ({
+          ...folder,
+          relativePath: folder.path
+        }));
+    }
 
     const folders = await folderDAL.find(
       {

--- a/backend/src/services/secret-folder/secret-folder-types.ts
+++ b/backend/src/services/secret-folder/secret-folder-types.ts
@@ -45,6 +45,7 @@ export type TGetFolderDTO = {
   orderDirection?: OrderByDirection;
   limit?: number;
   offset?: number;
+  recursive?: boolean;
 } & TProjectPermission;
 
 export type TGetFolderByIdDTO = {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Add a new recursive flag to the GET /folders endpoint to retrieve all nested folders within the provided path. Introduced a relativePath field in the response to make folder hierarchy clearer and help distinguish between the requested path and its nested folders, avoiding potential misunderstandings.
![CleanShot 2025-03-21 at 18 12 57](https://github.com/user-attachments/assets/19150ea4-3fe6-41fe-b3a4-8ef115f1c118)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Tested with over 1,500 folders and a case with folder nesting up to 200 levels deep.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a recursive option for folder retrieval that enables fetching all nested directories from a specified base path.
	- Enhanced folder query responses to include additional details about the folder structure, such as relative paths, offering a clearer view of folder hierarchies.
	- Added a new boolean schema for improved validation of boolean values in API requests.

- **Bug Fixes**
	- Deprecated the `directory` property in favor of the new `path` property for better clarity in folder retrieval.

- **Chores**
	- Removed local definition of `booleanSchema` in favor of a centralized import from the sanitized schemas module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->