### PR TITLE
Gateway minor fixes

### DIFF
--- a/backend/src/lib/gateway/index.ts
+++ b/backend/src/lib/gateway/index.ts
@@ -93,6 +93,7 @@ export const pingGatewayAndVerify = async ({
   let lastError: Error | null = null;
   const quicClient = await createQuicConnection(relayHost, relayPort, tlsOptions, identityId, orgId).catch((err) => {
     throw new BadRequestError({
+      message: (err as Error)?.message,
       error: err as Error
     });
   });

--- a/cli/packages/gateway/systemd.go
+++ b/cli/packages/gateway/systemd.go
@@ -15,7 +15,8 @@ Description=Infisical Gateway Service
 After=network.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=all
 EnvironmentFile=/etc/infisical/gateway.conf
 ExecStart=infisical gateway
 Restart=on-failure
@@ -50,8 +51,6 @@ func InstallGatewaySystemdService(token string, domain string) error {
 	configContent := fmt.Sprintf("INFISICAL_UNIVERSAL_AUTH_ACCESS_TOKEN=%s\n", token)
 	if domain != "" {
 		configContent += fmt.Sprintf("INFISICAL_API_URL=%s\n", domain)
-	} else {
-		configContent += "INFISICAL_API_URL=\n"
 	}
 
 	configPath := filepath.Join(configDir, "gateway.conf")
@@ -60,11 +59,6 @@ func InstallGatewaySystemdService(token string, domain string) error {
 	}
 
 	servicePath := "/etc/systemd/system/infisical-gateway.service"
-	if _, err := os.Stat(servicePath); err == nil {
-		log.Info().Msg("Systemd service file already exists")
-		return nil
-	}
-
 	if err := os.WriteFile(servicePath, []byte(systemdServiceTemplate), 0644); err != nil {
 		return fmt.Errorf("failed to write systemd service file: %v", err)
 	}
@@ -78,5 +72,50 @@ func InstallGatewaySystemdService(token string, domain string) error {
 	log.Info().Msg("To start the service, run: sudo systemctl start infisical-gateway")
 	log.Info().Msg("To enable the service on boot, run: sudo systemctl enable infisical-gateway")
 
+	return nil
+}
+
+func UninstallGatewaySystemdService() error {
+	if runtime.GOOS != "linux" {
+		log.Info().Msg("Skipping systemd service uninstallation - not on Linux")
+		return nil
+	}
+
+	if os.Geteuid() != 0 {
+		log.Info().Msg("Skipping systemd service uninstallation - not running as root/sudo")
+		return nil
+	}
+
+	// Stop the service if it's running
+	stopCmd := exec.Command("systemctl", "stop", "infisical-gateway")
+	if err := stopCmd.Run(); err != nil {
+		log.Warn().Msgf("Failed to stop service: %v", err)
+	}
+
+	// Disable the service
+	disableCmd := exec.Command("systemctl", "disable", "infisical-gateway")
+	if err := disableCmd.Run(); err != nil {
+		log.Warn().Msgf("Failed to disable service: %v", err)
+	}
+
+	// Remove the service file
+	servicePath := "/etc/systemd/system/infisical-gateway.service"
+	if err := os.Remove(servicePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove systemd service file: %v", err)
+	}
+
+	// Remove the configuration file
+	configPath := "/etc/infisical/gateway.conf"
+	if err := os.Remove(configPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove config file: %v", err)
+	}
+
+	// Reload systemd to apply changes
+	reloadCmd := exec.Command("systemctl", "daemon-reload")
+	if err := reloadCmd.Run(); err != nil {
+		return fmt.Errorf("failed to reload systemd: %v", err)
+	}
+
+	log.Info().Msg("Successfully uninstalled Infisical Gateway systemd service")
 	return nil
 }

--- a/cli/packages/util/helper.go
+++ b/cli/packages/util/helper.go
@@ -245,8 +245,9 @@ func getCurrentBranch() (string, error) {
 }
 
 func AppendAPIEndpoint(address string) string {
+	// if it's empty return as it is
 	// Ensure the address does not already end with "/api"
-	if strings.HasSuffix(address, "/api") {
+	if address == "" || strings.HasSuffix(address, "/api") {
 		return address
 	}
 


### PR DESCRIPTION
# Description 📣

This PR adds couple of improvement for gateway
1. CLI command to uninstall gateway service
2. Updated systemd command to use notify instead of simple and made install idempotent so any systemd changes in updates get effective on next cli install. Notify also gives better failure message on start failed in systemd
3. The gateway config file won't add API domain environment variable if it's missing
4. The append api endpoint exits if empty string previously it would throw error

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduces a CLI command to uninstall and remove the gateway service, enhancing management capabilities.
  - Enhances service readiness with improved notification support.

- **Bug Fixes**
  - Improves error reporting with explicit messages during connection failures.
  - Refines network connectivity by updating binding behavior and error handling logic.
  - Adjusts input processing to gracefully handle empty API endpoint entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->