### PR TITLE
Keep Domains on writeInitalConfig for CLI login

### DIFF
--- a/cli/packages/util/config.go
+++ b/cli/packages/util/config.go
@@ -56,6 +56,7 @@ func WriteInitalConfig(userCredentials *models.UserCredentials) error {
 		LoggedInUsers:          existingConfigFile.LoggedInUsers,
 		VaultBackendType:       existingConfigFile.VaultBackendType,
 		VaultBackendPassphrase: existingConfigFile.VaultBackendPassphrase,
+		Domains:                existingConfigFile.Domains,
 	}
 
 	configFileMarshalled, err := json.Marshal(configFile)


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Issue:
The WriteInitialConfig function was overwriting the CLI config file and unintentionally removing the Domains field. As a result, users had to manually re-enter the domain URL each time their session expired.

Improvement:
Now, the function preserves the Domains field, allowing the domain to be pre-filled on subsequent logins. This makes re-authentication faster and more convenient for users.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration setup to now include additional domain details, ensuring more complete and consistent data during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->