### PR TITLE
feat(audit-logs): filter audit logs by secret key

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -106,16 +106,9 @@ export const auditLogDALFactory = (db: TDbClient) => {
         }
         if (secretKey) {
           void sqlQuery.whereRaw(
-            `(
-            "eventMetadata"->>'secretKey' = ?
-            OR
-            EXISTS (
-              SELECT 1 
-              FROM jsonb_array_elements("eventMetadata"->'secrets') AS element
-              WHERE element->>'secretKey' = ?
-            )
-          )`,
-            [secretKey, secretKey]
+            `("eventMetadata"->>'secretKey' = ? 
+             OR "eventMetadata"->'secrets' @> ?::jsonb)`,
+            [secretKey, JSON.stringify([{ secretKey }])]
           );
         }
       }

--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -64,6 +64,7 @@ export const auditLogServiceFactory = ({
       eventMetadata: filter.eventMetadata,
       secretPath: filter.secretPath,
       secretKey: filter.secretKey,
+      environment: filter.environment,
       ...(filter.projectId ? { projectId: filter.projectId } : { orgId: actorOrgId })
     });
 

--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -63,6 +63,7 @@ export const auditLogServiceFactory = ({
       actorType: filter.actorType,
       eventMetadata: filter.eventMetadata,
       secretPath: filter.secretPath,
+      secretKey: filter.secretKey,
       ...(filter.projectId ? { projectId: filter.projectId } : { orgId: actorOrgId })
     });
 

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -33,6 +33,7 @@ export type TListProjectAuditLogDTO = {
     endDate?: string;
     startDate?: string;
     projectId?: string;
+    environment?: string;
     auditLogActorId?: string;
     actorType?: ActorType;
     secretPath?: string;

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -287,6 +287,16 @@ export enum EventType {
   KMIP_OPERATION_REGISTER = "kmip-operation-register"
 }
 
+export const filterableSecretEvents: EventType[] = [
+  EventType.GET_SECRET,
+  EventType.DELETE_SECRETS,
+  EventType.CREATE_SECRETS,
+  EventType.UPDATE_SECRETS,
+  EventType.CREATE_SECRET,
+  EventType.UPDATE_SECRET,
+  EventType.DELETE_SECRET
+];
+
 interface UserActorMetadata {
   userId: string;
   email?: string | null;

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -36,6 +36,7 @@ export type TListProjectAuditLogDTO = {
     auditLogActorId?: string;
     actorType?: ActorType;
     secretPath?: string;
+    secretKey?: string;
     eventMetadata?: Record<string, string>;
   };
 } & Omit<TProjectPermission, "projectId">;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -843,6 +843,8 @@ export const AUDIT_LOGS = {
     eventType: "The type of the event to export.",
     secretPath:
       "The path of the secret to query audit logs for. Note that the projectId parameter must also be provided.",
+    secretKey:
+      "The key of the secret to query audit logs for. Note that the projectId parameter must also be provided.",
     userAgentType: "Choose which consuming application to export audit logs for.",
     eventMetadata:
       "Filter by event metadata key-value pairs. Formatted as `key1=value1,key2=value2`, with comma-separation.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -840,6 +840,8 @@ export const AUDIT_LOGS = {
   EXPORT: {
     projectId:
       "Optionally filter logs by project ID. If not provided, logs from the entire organization will be returned.",
+    environment:
+      "The environment to filter logs by. If not provided, logs from all environments will be returned. Note that the projectId parameter must also be provided.",
     eventType: "The type of the event to export.",
     secretPath:
       "The path of the secret to query audit logs for. Note that the projectId parameter must also be provided.",

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -112,6 +112,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
       description: "Get all audit logs for an organization",
       querystring: z.object({
         projectId: z.string().optional().describe(AUDIT_LOGS.EXPORT.projectId),
+        environment: z.string().optional().describe(AUDIT_LOGS.EXPORT.environment),
         actorType: z.nativeEnum(ActorType).optional(),
         secretPath: z
           .string()

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -118,6 +118,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
           .optional()
           .transform((val) => (!val ? val : removeTrailingSlash(val)))
           .describe(AUDIT_LOGS.EXPORT.secretPath),
+        secretKey: z.string().optional().describe(AUDIT_LOGS.EXPORT.secretKey),
 
         // eventType is split with , for multiple values, we need to transform it to array
         eventType: z

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -1,5 +1,16 @@
 import { EventType, UserAgentType } from "./enums";
 
+export const secretEvents: EventType[] = [
+  EventType.GET_SECRETS,
+  EventType.GET_SECRET,
+  EventType.DELETE_SECRETS,
+  EventType.CREATE_SECRETS,
+  EventType.UPDATE_SECRETS,
+  EventType.CREATE_SECRET,
+  EventType.UPDATE_SECRET,
+  EventType.DELETE_SECRET
+];
+
 export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.GET_SECRETS]: "List secrets",
   [EventType.GET_SECRET]: "Read secret",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -12,8 +12,8 @@ export enum UserAgentType {
   CLI = "cli",
   K8_OPERATOR = "k8-operator",
   TERRAFORM = "terraform",
-  NODE_SDK = "node-sdk",
-  PYTHON_SDK = "python-sdk",
+  NODE_SDK = "InfisicalNodeSDK",
+  PYTHON_SDK = "InfisicalPythonSDK",
   OTHER = "other"
 }
 

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -11,6 +11,7 @@ export type TGetAuditLogsFilter = {
   projectId?: string;
   actor?: string; // user ID format
   secretPath?: string;
+  secretKey?: string;
   startDate?: Date;
   endDate?: Date;
   limit: number;

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -9,6 +9,7 @@ export type TGetAuditLogsFilter = {
   eventMetadata?: Record<string, string>;
   actorType?: ActorType;
   projectId?: string;
+  environment?: string;
   actor?: string; // user ID format
   secretPath?: string;
   secretKey?: string;

--- a/frontend/src/pages/organization/AuditLogsPage/AuditLogsPage.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/AuditLogsPage.tsx
@@ -18,7 +18,7 @@ export const AuditLogsPage = () => {
             title="Audit logs"
             description="Audit logs for security and compliance teams to monitor information access."
           />
-          <LogsSection filterClassName="static py-2" showFilters />
+          <LogsSection />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogFilterItem.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogFilterItem.tsx
@@ -1,0 +1,32 @@
+import { twMerge } from "tailwind-merge";
+
+import { Button, Tooltip } from "@app/components/v2";
+
+type Props = {
+  hoverTooltip?: string;
+  className?: string;
+  label: string;
+  onClear: () => void;
+  children: React.ReactNode;
+};
+
+export const LogFilterItem = ({ label, onClear, hoverTooltip, children, className }: Props) => {
+  return (
+    <Tooltip className="relative top-4" content={hoverTooltip} isDisabled={!hoverTooltip}>
+      <div className={twMerge("flex flex-col justify-between", className)}>
+        <div className="flex items-center justify-between pr-1">
+          <p className="text-xs opacity-60">{label}</p>
+          <Button
+            onClick={() => onClear()}
+            variant="link"
+            className="font-normal text-mineshaft-400 transition-all duration-75 hover:text-mineshaft-300"
+            size="xs"
+          >
+            Clear
+          </Button>
+        </div>
+        {children}
+      </div>
+    </Tooltip>
+  );
+};

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -157,7 +157,24 @@ export const LogsFilter = ({
             control={control}
             name="secretPath"
             render={({ field: { onChange, value, ...field } }) => (
-              <FormControl label="Secret path" className="w-40">
+              <FormControl label="Secret Path" className="w-40">
+                <Input
+                  placeholder="/folder"
+                  {...field}
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                />
+              </FormControl>
+            )}
+          />
+        )}
+
+        {selectedProject?.type === ProjectType.SecretManager && (
+          <Controller
+            control={control}
+            name="secretKey"
+            render={({ field: { onChange, value, ...field } }) => (
+              <FormControl label="Secret Key" className="w-40">
                 <Input {...field} value={value} onChange={(e) => onChange(e.target.value)} />
               </FormControl>
             )}
@@ -289,7 +306,7 @@ export const LogsFilter = ({
           control={control}
           render={({ field: { onChange, ...field }, fieldState: { error } }) => {
             return (
-              <FormControl label="Start date" errorText={error?.message} isError={Boolean(error)}>
+              <FormControl label="Start Date" errorText={error?.message} isError={Boolean(error)}>
                 <DatePicker
                   value={field.value || undefined}
                   onChange={onChange}
@@ -309,7 +326,7 @@ export const LogsFilter = ({
           control={control}
           render={({ field: { onChange, ...field }, fieldState: { error } }) => {
             return (
-              <FormControl label="End date" errorText={error?.message} isError={Boolean(error)}>
+              <FormControl label="End Date" errorText={error?.message} isError={Boolean(error)}>
                 <DatePicker
                   value={field.value || undefined}
                   onChange={onChange}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -1,10 +1,26 @@
-import { useState } from "react";
-import { Control, Controller, UseFormReset, UseFormSetValue, UseFormWatch } from "react-hook-form";
-import { faCaretDown, faCheckCircle, faFilterCircleXmark } from "@fortawesome/free-solid-svg-icons";
+/* eslint-disable no-nested-ternary */
+import { useMemo, useState } from "react";
+import {
+  Control,
+  Controller,
+  UseFormGetFieldState,
+  UseFormReset,
+  UseFormResetField,
+  UseFormSetValue,
+  UseFormWatch
+} from "react-hook-form";
+import {
+  faArrowRight,
+  faCaretDown,
+  faCheckCircle,
+  faFilterCircleXmark
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { AnimatePresence, motion } from "framer-motion";
 import { twMerge } from "tailwind-merge";
 
 import {
+  Badge,
   Button,
   DatePicker,
   DropdownMenu,
@@ -18,13 +34,17 @@ import {
   SelectItem
 } from "@app/components/v2";
 import { useOrganization } from "@app/context";
-import { useGetAuditLogActorFilterOpts, useGetUserWorkspaces } from "@app/hooks/api";
-import { eventToNameMap, userAgentTTypeoNameMap } from "@app/hooks/api/auditLogs/constants";
-import { ActorType, EventType } from "@app/hooks/api/auditLogs/enums";
-import { Actor } from "@app/hooks/api/auditLogs/types";
-import { ProjectType } from "@app/hooks/api/workspace/types";
+import { useGetUserWorkspaces } from "@app/hooks/api";
+import {
+  eventToNameMap,
+  secretEvents,
+  userAgentTTypeoNameMap
+} from "@app/hooks/api/auditLogs/constants";
+import { EventType } from "@app/hooks/api/auditLogs/enums";
+import { UserAgentType } from "@app/hooks/api/auth/types";
 
-import { AuditLogFilterFormData } from "./types";
+import { LogFilterItem } from "./LogFilterItem";
+import { AuditLogFilterFormData, Presets } from "./types";
 
 const eventTypes = Object.entries(eventToNameMap).map(([value, label]) => ({ label, value }));
 const userAgentTypes = Object.entries(userAgentTTypeoNameMap).map(([value, label]) => ({
@@ -33,26 +53,70 @@ const userAgentTypes = Object.entries(userAgentTTypeoNameMap).map(([value, label
 }));
 
 type Props = {
-  presets?: {
-    actorId?: string;
-    eventType?: EventType[];
-  };
-  className?: string;
-  isOrgAuditLogs?: boolean;
-  setValue: UseFormSetValue<AuditLogFilterFormData>;
+  presets?: Presets;
   control: Control<AuditLogFilterFormData>;
   reset: UseFormReset<AuditLogFilterFormData>;
+  resetField: UseFormResetField<AuditLogFilterFormData>;
   watch: UseFormWatch<AuditLogFilterFormData>;
+  getFieldState: UseFormGetFieldState<AuditLogFilterFormData>;
+  setValue: UseFormSetValue<AuditLogFilterFormData>;
+};
+
+const getActiveFilterCount = (
+  getFieldState: UseFormGetFieldState<AuditLogFilterFormData>,
+  watch: UseFormWatch<AuditLogFilterFormData>
+) => {
+  const fields = [
+    "actor",
+    "project",
+    "eventType",
+    "startDate",
+    "endDate",
+    "environment",
+    "secretPath",
+    "userAgentType",
+    "secretKey"
+  ] as Partial<keyof AuditLogFilterFormData>[];
+
+  let filterCount = 0;
+
+  // either start or end date should only be counted as one filter
+  let dateProcessed = false;
+
+  fields.forEach((field) => {
+    const fieldState = getFieldState(field);
+
+    if (
+      field === "userAgentType" ||
+      field === "environment" ||
+      field === "secretKey" ||
+      field === "secretPath"
+    ) {
+      const value = watch(field);
+
+      if (value !== undefined && value !== "") {
+        filterCount += 1;
+      }
+    } else if (fieldState.isDirty && !dateProcessed) {
+      filterCount += 1;
+
+      if (field === "startDate" || field === "endDate") {
+        dateProcessed = true;
+      }
+    }
+  });
+
+  return filterCount;
 };
 
 export const LogsFilter = ({
   presets,
-  isOrgAuditLogs,
-  className,
   control,
   reset,
-  setValue,
-  watch
+  resetField,
+  watch,
+  getFieldState,
+  setValue
 }: Props) => {
   const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
   const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
@@ -62,317 +126,423 @@ export const LogsFilter = ({
 
   const workspacesInOrg = workspaces.filter((ws) => ws.orgId === currentOrg?.id);
 
-  const { data, isPending } = useGetAuditLogActorFilterOpts(workspaces?.[0]?.id ?? "");
-
-  const renderActorSelectItem = (actor: Actor) => {
-    switch (actor.type) {
-      case ActorType.USER:
-        return (
-          <SelectItem
-            value={`${actor.type}-${actor.metadata.userId}`}
-            key={`user-actor-filter-${actor.metadata.userId}`}
-          >
-            {actor.metadata.email}
-          </SelectItem>
-        );
-      case ActorType.SERVICE:
-        return (
-          <SelectItem
-            value={`${actor.type}-${actor.metadata.serviceId}`}
-            key={`service-actor-filter-${actor.metadata.serviceId}`}
-          >
-            {actor.metadata.name}
-          </SelectItem>
-        );
-      case ActorType.IDENTITY:
-        return (
-          <SelectItem
-            value={`${actor.type}-${actor.metadata.identityId}`}
-            key={`identity-filter-${actor.metadata.identityId}`}
-          >
-            {actor.metadata.name}
-          </SelectItem>
-        );
-      case ActorType.KMIP_CLIENT:
-        return (
-          <SelectItem
-            value={`${actor.type}-${actor.metadata.clientId}`}
-            key={`kmip-client-filter-${actor.metadata.clientId}`}
-          >
-            {actor.metadata.name}
-          </SelectItem>
-        );
-      default:
-        return (
-          <SelectItem value="actor-none" key="actor-none">
-            N/A
-          </SelectItem>
-        );
-    }
-  };
-
   const selectedEventTypes = watch("eventType") as EventType[] | undefined;
   const selectedProject = watch("project");
 
+  const showSecretsSection =
+    selectedEventTypes?.some(
+      (eventType) => secretEvents.includes(eventType) && eventType !== EventType.GET_SECRETS
+    ) || selectedEventTypes?.length === 0;
+
+  const availableEnvironments = useMemo(() => {
+    if (!selectedProject) return [];
+
+    return workspacesInOrg.find((ws) => ws.id === selectedProject.id)?.environments ?? [];
+  }, [selectedProject, workspacesInOrg]);
+
+  const activeFilterCount = getActiveFilterCount(getFieldState, watch);
+
   return (
-    <div className={twMerge("sticky top-20 z-10 flex flex-col bg-bunker-800", className)}>
-      <div className="flex items-center gap-4">
-        {isOrgAuditLogs && workspacesInOrg.length > 0 && (
-          <Controller
-            control={control}
-            name="project"
-            render={({ field: { onChange, value }, fieldState: { error } }) => (
-              <FormControl
-                label="Project"
-                errorText={error?.message}
-                isError={Boolean(error)}
-                className="w-64"
-              >
-                <FilterableSelect
-                  value={value}
-                  isClearable
-                  onChange={(e) => {
-                    if (e === null) {
-                      setValue("secretPath", "");
-                    }
-                    onChange(e);
-                  }}
-                  placeholder="Select a project..."
-                  options={workspacesInOrg.map(({ name, id, type }) => ({ name, id, type }))}
-                  getOptionValue={(option) => option.id}
-                  getOptionLabel={(option) => option.name}
-                />
-              </FormControl>
-            )}
-          />
-        )}
-        {selectedProject?.type === ProjectType.SecretManager && (
-          <Controller
-            control={control}
-            name="secretPath"
-            render={({ field: { onChange, value, ...field } }) => (
-              <FormControl
-                tooltipText="Filter audit logs related to events that occurred on a specific secret path."
-                label="Secret Path"
-                className="w-40"
-              >
-                <Input
-                  placeholder="/folder"
-                  {...field}
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
-            )}
-          />
-        )}
-
-        {selectedProject?.type === ProjectType.SecretManager && (
-          <Controller
-            control={control}
-            name="secretKey"
-            render={({ field: { onChange, value, ...field } }) => (
-              <FormControl
-                tooltipText="Filter audit logs related to a specific secret."
-                label="Secret Name"
-                className="w-40"
-              >
-                <Input
-                  {...field}
-                  placeholder="API_KEY"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
-            )}
-          />
-        )}
-      </div>
-      <div className="mt-1 flex w-full justify-start">
-        <div className="flex items-center space-x-2">
-          <Controller
-            control={control}
-            name="eventType"
-            render={({ field }) => (
-              <FormControl label="Events">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <div className="inline-flex w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border border-mineshaft-500 bg-mineshaft-700 px-3 py-2 font-inter text-sm font-normal text-bunker-200 outline-none data-[placeholder]:text-mineshaft-200">
-                      {selectedEventTypes?.length === 1
-                        ? eventTypes.find((eventType) => eventType.value === selectedEventTypes[0])
-                            ?.label
-                        : selectedEventTypes?.length === 0
-                          ? "All events"
-                          : `${selectedEventTypes?.length} events selected`}
-                      <FontAwesomeIcon icon={faCaretDown} className="ml-2 text-xs" />
-                    </div>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="z-[100] max-h-80 overflow-hidden">
-                    <div className="max-h-80 overflow-y-auto">
-                      {eventTypes && eventTypes.length > 0 ? (
-                        eventTypes.map((eventType) => {
-                          const isSelected = selectedEventTypes?.includes(
-                            eventType.value as EventType
-                          );
-
-                          return (
-                            <DropdownMenuItem
-                              onSelect={(event) => eventTypes.length > 1 && event.preventDefault()}
-                              onClick={() => {
-                                if (selectedEventTypes?.includes(eventType.value as EventType)) {
-                                  field.onChange(
-                                    selectedEventTypes?.filter((e: string) => e !== eventType.value)
-                                  );
-                                } else {
-                                  field.onChange([...(selectedEventTypes || []), eventType.value]);
-                                }
-                              }}
-                              key={`event-type-${eventType.value}`}
-                              icon={
-                                isSelected ? (
-                                  <FontAwesomeIcon
-                                    icon={faCheckCircle}
-                                    className="pr-0.5 text-primary"
-                                  />
-                                ) : (
-                                  <div className="pl-[1.01rem]" />
-                                )
-                              }
-                              iconPos="left"
-                              className="w-[28.4rem] text-sm"
-                            >
-                              {eventType.label}
-                            </DropdownMenuItem>
-                          );
-                        })
-                      ) : (
-                        <div />
-                      )}
-                    </div>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </FormControl>
-            )}
-          />
-
-          {!isPending && data && data.length > 0 && !presets?.actorId && (
-            <Controller
-              control={control}
-              name="actor"
-              render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                <FormControl
-                  label="Actor"
-                  errorText={error?.message}
-                  isError={Boolean(error)}
-                  className="w-40"
-                >
-                  <Select
-                    {...(field.value ? { value: field.value } : { placeholder: "Select" })}
-                    {...field}
-                    onValueChange={(e) => onChange(e)}
-                    className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
-                  >
-                    {data.map((actor) => renderActorSelectItem(actor))}
-                  </Select>
-                </FormControl>
-              )}
-            />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline_bg" colorSchema="primary">
+          <FontAwesomeIcon icon={faFilterCircleXmark} className="mr-3 px-[0.1rem]" />
+          Filters
+          {activeFilterCount > 0 && (
+            <Badge className="ml-2 px-1.5 py-0.5" variant="primary">
+              {activeFilterCount}
+            </Badge>
           )}
-          <Controller
-            control={control}
-            name="userAgentType"
-            render={({ field: { onChange, value, ...field }, fieldState: { error } }) => (
-              <FormControl
-                label="Source"
-                errorText={error?.message}
-                isError={Boolean(error)}
-                className="w-40"
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="mt-4 py-4">
+        <div className="flex min-w-64 flex-col font-inter">
+          <div className="mb-3 flex items-center border-b border-b-mineshaft-500 px-3 pb-2">
+            <div className="flex w-full items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span>Filters</span>
+                <Badge className="px-1.5 py-0.5" variant="primary">
+                  {activeFilterCount}
+                </Badge>
+              </div>
+              <Button
+                onClick={() => {
+                  reset({
+                    eventType: presets?.eventType || [],
+                    actor: presets?.actorId,
+                    userAgentType: undefined,
+                    startDate: undefined,
+                    endDate: undefined,
+                    project: null,
+                    secretPath: undefined,
+                    secretKey: undefined
+                  });
+                }}
+                variant="link"
+                className="text-mineshaft-400"
+                size="xs"
               >
-                <Select
-                  value={value === undefined ? "all" : value}
-                  {...field}
-                  onValueChange={(e) => {
-                    if (e === "all") onChange(undefined);
-                    else onChange(e);
+                Clear filters
+              </Button>
+            </div>
+          </div>
+
+          <div className="px-3">
+            <LogFilterItem
+              label="Events"
+              onClear={() => {
+                resetField("eventType");
+              }}
+            >
+              <Controller
+                control={control}
+                name="eventType"
+                render={({ field }) => (
+                  <FormControl>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <div className="thin-scrollbar inline-flex w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border border-mineshaft-500 bg-mineshaft-700 px-3 py-2 font-inter text-sm font-normal text-bunker-200 outline-none data-[placeholder]:text-mineshaft-200">
+                          {selectedEventTypes?.length === 1
+                            ? eventTypes.find(
+                                (eventType) => eventType.value === selectedEventTypes[0]
+                              )?.label
+                            : selectedEventTypes?.length === 0
+                              ? "All events"
+                              : `${selectedEventTypes?.length} events selected`}
+                          <FontAwesomeIcon icon={faCaretDown} className="ml-2 text-xs" />
+                        </div>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="start"
+                        className="thin-scrollbar z-[100] max-h-80 overflow-hidden"
+                      >
+                        <div className="max-h-80 overflow-y-auto">
+                          {eventTypes && eventTypes.length > 0 ? (
+                            eventTypes.map((eventType) => {
+                              const isSelected = selectedEventTypes?.includes(
+                                eventType.value as EventType
+                              );
+
+                              return (
+                                <DropdownMenuItem
+                                  onSelect={(event) =>
+                                    eventTypes.length > 1 && event.preventDefault()
+                                  }
+                                  onClick={() => {
+                                    if (
+                                      selectedEventTypes?.includes(eventType.value as EventType)
+                                    ) {
+                                      field.onChange(
+                                        selectedEventTypes?.filter(
+                                          (e: string) => e !== eventType.value
+                                        )
+                                      );
+                                    } else {
+                                      field.onChange([
+                                        ...(selectedEventTypes || []),
+                                        eventType.value
+                                      ]);
+                                    }
+                                  }}
+                                  key={`event-type-${eventType.value}`}
+                                  icon={
+                                    isSelected ? (
+                                      <FontAwesomeIcon
+                                        icon={faCheckCircle}
+                                        className="pr-0.5 text-primary"
+                                      />
+                                    ) : (
+                                      <div className="pl-[1.01rem]" />
+                                    )
+                                  }
+                                  iconPos="left"
+                                  className="w-[28.4rem] text-sm"
+                                >
+                                  {eventType.label}
+                                </DropdownMenuItem>
+                              );
+                            })
+                          ) : (
+                            <div />
+                          )}
+                        </div>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </FormControl>
+                )}
+              />
+            </LogFilterItem>
+            <LogFilterItem
+              label="Source"
+              onClear={() => {
+                resetField("userAgentType");
+              }}
+            >
+              <Controller
+                control={control}
+                name="userAgentType"
+                render={({ field: { onChange, value, ...field }, fieldState: { error } }) => (
+                  <FormControl
+                    errorText={error?.message}
+                    isError={Boolean(error)}
+                    className="w-full"
+                  >
+                    <Select
+                      value={value === undefined ? "all" : value}
+                      {...field}
+                      onValueChange={(e) => {
+                        if (e === "all") onChange(undefined);
+                        else setValue("userAgentType", e as UserAgentType, { shouldDirty: true });
+                      }}
+                      className={twMerge("w-full border border-mineshaft-500 bg-mineshaft-700")}
+                    >
+                      <SelectItem value="all" key="all">
+                        All sources
+                      </SelectItem>
+                      {userAgentTypes.map(({ label, value: userAgent }) => (
+                        <SelectItem value={userAgent} key={label}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+              />
+            </LogFilterItem>
+
+            <LogFilterItem
+              label="Date"
+              onClear={() => {
+                resetField("startDate");
+                resetField("endDate");
+              }}
+            >
+              <div className="flex h-10 w-full items-center justify-between gap-2">
+                <Controller
+                  name="startDate"
+                  control={control}
+                  render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+                    return (
+                      <FormControl
+                        className="relative top-2"
+                        errorText={error?.message}
+                        isError={Boolean(error)}
+                      >
+                        <DatePicker
+                          value={field.value || undefined}
+                          onChange={onChange}
+                          dateFormat="P"
+                          popUpProps={{
+                            open: isStartDatePickerOpen,
+                            onOpenChange: setIsStartDatePickerOpen
+                          }}
+                          popUpContentProps={{}}
+                        />
+                      </FormControl>
+                    );
                   }}
-                  className={twMerge("w-full border border-mineshaft-500 bg-mineshaft-700")}
+                />
+
+                <div className="flex items-center -space-x-3">
+                  <div className="h-[2px] w-[20px] rounded-full bg-mineshaft-500" />
+                  <FontAwesomeIcon icon={faArrowRight} className="text-mineshaft-500" />
+                </div>
+
+                <Controller
+                  name="endDate"
+                  control={control}
+                  render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+                    return (
+                      <FormControl
+                        className="relative top-2"
+                        errorText={error?.message}
+                        isError={Boolean(error)}
+                      >
+                        <DatePicker
+                          value={field.value || undefined}
+                          onChange={onChange}
+                          dateFormat="P"
+                          popUpProps={{
+                            open: isEndDatePickerOpen,
+                            onOpenChange: setIsEndDatePickerOpen
+                          }}
+                          popUpContentProps={{}}
+                        />
+                      </FormControl>
+                    );
+                  }}
+                />
+              </div>
+            </LogFilterItem>
+            <AnimatePresence initial={false}>
+              {showSecretsSection && (
+                <motion.div
+                  className="mt-2 overflow-hidden"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.3 }}
                 >
-                  <SelectItem value="all" key="all">
-                    All sources
-                  </SelectItem>
-                  {userAgentTypes.map(({ label, value: userAgent }) => (
-                    <SelectItem value={userAgent} key={label}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-          />
-          <Controller
-            name="startDate"
-            control={control}
-            render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-              return (
-                <FormControl label="Start Date" errorText={error?.message} isError={Boolean(error)}>
-                  <DatePicker
-                    value={field.value || undefined}
-                    onChange={onChange}
-                    dateFormat="P"
-                    popUpProps={{
-                      open: isStartDatePickerOpen,
-                      onOpenChange: setIsStartDatePickerOpen
+                  <div className="mb-3 mt-2">
+                    <p className="text-xs opacity-60">Secrets</p>
+                    <div className="h-[1px] w-full rounded-full bg-mineshaft-500" />
+                  </div>
+
+                  <LogFilterItem
+                    label="Project"
+                    onClear={() => {
+                      resetField("project");
+                      resetField("environment");
+                      setValue("secretPath", "");
+                      setValue("secretKey", "");
                     }}
-                    popUpContentProps={{}}
-                  />
-                </FormControl>
-              );
-            }}
-          />
-          <Controller
-            name="endDate"
-            control={control}
-            render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-              return (
-                <FormControl label="End Date" errorText={error?.message} isError={Boolean(error)}>
-                  <DatePicker
-                    value={field.value || undefined}
-                    onChange={onChange}
-                    dateFormat="P"
-                    popUpProps={{
-                      open: isEndDatePickerOpen,
-                      onOpenChange: setIsEndDatePickerOpen
+                  >
+                    <Controller
+                      control={control}
+                      name="project"
+                      render={({ field: { onChange, value }, fieldState: { error } }) => (
+                        <FormControl
+                          errorText={error?.message}
+                          isError={Boolean(error)}
+                          className="w-full"
+                        >
+                          <FilterableSelect
+                            value={value}
+                            isClearable
+                            onChange={(e) => {
+                              if (e === null) {
+                                setValue("secretPath", "");
+                                setValue("secretKey", "");
+                              }
+                              resetField("environment");
+                              onChange(e);
+                            }}
+                            placeholder="All projects"
+                            options={workspacesInOrg.map(({ name, id, type }) => ({
+                              name,
+                              id,
+                              type
+                            }))}
+                            getOptionValue={(option) => option.id}
+                            getOptionLabel={(option) => option.name}
+                          />
+                        </FormControl>
+                      )}
+                    />
+                  </LogFilterItem>
+
+                  <LogFilterItem
+                    label="Environment"
+                    hoverTooltip={
+                      !selectedProject
+                        ? "Select a project before filtering by environment."
+                        : undefined
+                    }
+                    className={twMerge(!selectedProject && "opacity-50")}
+                    onClear={() => {
+                      resetField("environment");
                     }}
-                    popUpContentProps={{}}
-                  />
-                </FormControl>
-              );
-            }}
-          />
-          <Button
-            isLoading={false}
-            colorSchema="primary"
-            variant="outline_bg"
-            className="mt-[0.45rem]"
-            type="submit"
-            leftIcon={<FontAwesomeIcon icon={faFilterCircleXmark} />}
-            onClick={() =>
-              reset({
-                eventType: presets?.eventType || [],
-                actor: presets?.actorId,
-                userAgentType: undefined,
-                startDate: undefined,
-                endDate: undefined,
-                project: null,
-                secretPath: undefined,
-                secretKey: undefined
-              })
-            }
-          >
-            Clear filters
-          </Button>
+                  >
+                    <Controller
+                      control={control}
+                      name="environment"
+                      render={({ field: { onChange, value }, fieldState: { error } }) => (
+                        <FormControl
+                          errorText={error?.message}
+                          isError={Boolean(error)}
+                          className="w-full"
+                        >
+                          <FilterableSelect
+                            value={value}
+                            key={value?.name || "filter-environment"}
+                            isClearable
+                            isDisabled={!selectedProject}
+                            onChange={(e) => onChange(e)}
+                            placeholder="All environments"
+                            options={availableEnvironments.map(({ name, slug }) => ({
+                              name,
+                              slug
+                            }))}
+                            getOptionValue={(option) => option.slug}
+                            getOptionLabel={(option) => option.name}
+                          />
+                        </FormControl>
+                      )}
+                    />
+                  </LogFilterItem>
+                  <LogFilterItem
+                    label="Secret Path"
+                    hoverTooltip={
+                      !selectedProject
+                        ? "Select a project before filtering by secret path."
+                        : undefined
+                    }
+                    className={twMerge(!selectedProject && "opacity-50")}
+                    onClear={() => {
+                      setValue("secretPath", "");
+                    }}
+                  >
+                    <Controller
+                      control={control}
+                      name="secretPath"
+                      render={({ field: { onChange, value, ...field } }) => (
+                        <FormControl
+                          tooltipText="Filter audit logs related to events that occurred on a specific secret path."
+                          className="w-full"
+                        >
+                          <Input
+                            placeholder="Enter secret path"
+                            className="disabled:cursor-not-allowed"
+                            isDisabled={!selectedProject}
+                            {...field}
+                            value={value}
+                            onChange={(e) => onChange(e.target.value)}
+                          />
+                        </FormControl>
+                      )}
+                    />
+                  </LogFilterItem>
+
+                  <LogFilterItem
+                    hoverTooltip={
+                      !selectedProject
+                        ? "Select a project before filtering by secret key."
+                        : undefined
+                    }
+                    className={twMerge(!selectedProject && "opacity-50")}
+                    label="Secret Key"
+                    onClear={() => {
+                      setValue("secretKey", "");
+                    }}
+                  >
+                    <Controller
+                      control={control}
+                      name="secretKey"
+                      render={({ field: { onChange, value, ...field } }) => (
+                        <FormControl
+                          tooltipText="Filter audit logs related to a specific secret."
+                          className="w-full"
+                        >
+                          <Input
+                            isDisabled={!selectedProject}
+                            {...field}
+                            placeholder="Enter secret key"
+                            className="disabled:cursor-not-allowed"
+                            value={value}
+                            onChange={(e) =>
+                              setValue("secretKey", e.target.value, { shouldDirty: true })
+                            }
+                          />
+                        </FormControl>
+                      )}
+                    />
+                  </LogFilterItem>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
         </div>
-      </div>
-    </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsFilter.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { useState } from "react";
 import { Control, Controller, UseFormReset, UseFormSetValue, UseFormWatch } from "react-hook-form";
 import { faCaretDown, faCheckCircle, faFilterCircleXmark } from "@fortawesome/free-solid-svg-icons";
@@ -116,12 +115,7 @@ export const LogsFilter = ({
   const selectedProject = watch("project");
 
   return (
-    <div
-      className={twMerge(
-        "sticky top-20 z-10 flex flex-wrap items-center justify-between bg-bunker-800",
-        className
-      )}
-    >
+    <div className={twMerge("sticky top-20 z-10 flex flex-col bg-bunker-800", className)}>
       <div className="flex items-center gap-4">
         {isOrgAuditLogs && workspacesInOrg.length > 0 && (
           <Controller
@@ -157,7 +151,11 @@ export const LogsFilter = ({
             control={control}
             name="secretPath"
             render={({ field: { onChange, value, ...field } }) => (
-              <FormControl label="Secret Path" className="w-40">
+              <FormControl
+                tooltipText="Filter audit logs related to events that occurred on a specific secret path."
+                label="Secret Path"
+                className="w-40"
+              >
                 <Input
                   placeholder="/folder"
                   {...field}
@@ -174,193 +172,206 @@ export const LogsFilter = ({
             control={control}
             name="secretKey"
             render={({ field: { onChange, value, ...field } }) => (
-              <FormControl label="Secret Key" className="w-40">
-                <Input {...field} value={value} onChange={(e) => onChange(e.target.value)} />
+              <FormControl
+                tooltipText="Filter audit logs related to a specific secret."
+                label="Secret Name"
+                className="w-40"
+              >
+                <Input
+                  {...field}
+                  placeholder="API_KEY"
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                />
               </FormControl>
             )}
           />
         )}
       </div>
-      <div className="mt-1 flex items-center space-x-2">
-        <Controller
-          control={control}
-          name="eventType"
-          render={({ field }) => (
-            <FormControl label="Events">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <div className="inline-flex w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border border-mineshaft-500 bg-mineshaft-700 px-3 py-2 font-inter text-sm font-normal text-bunker-200 outline-none data-[placeholder]:text-mineshaft-200">
-                    {selectedEventTypes?.length === 1
-                      ? eventTypes.find((eventType) => eventType.value === selectedEventTypes[0])
-                          ?.label
-                      : selectedEventTypes?.length === 0
-                        ? "All events"
-                        : `${selectedEventTypes?.length} events selected`}
-                    <FontAwesomeIcon icon={faCaretDown} className="ml-2 text-xs" />
-                  </div>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start" className="z-[100] max-h-80 overflow-hidden">
-                  <div className="max-h-80 overflow-y-auto">
-                    {eventTypes && eventTypes.length > 0 ? (
-                      eventTypes.map((eventType) => {
-                        const isSelected = selectedEventTypes?.includes(
-                          eventType.value as EventType
-                        );
-
-                        return (
-                          <DropdownMenuItem
-                            onSelect={(event) => eventTypes.length > 1 && event.preventDefault()}
-                            onClick={() => {
-                              if (selectedEventTypes?.includes(eventType.value as EventType)) {
-                                field.onChange(
-                                  selectedEventTypes?.filter((e: string) => e !== eventType.value)
-                                );
-                              } else {
-                                field.onChange([...(selectedEventTypes || []), eventType.value]);
-                              }
-                            }}
-                            key={`event-type-${eventType.value}`}
-                            icon={
-                              isSelected ? (
-                                <FontAwesomeIcon
-                                  icon={faCheckCircle}
-                                  className="pr-0.5 text-primary"
-                                />
-                              ) : (
-                                <div className="pl-[1.01rem]" />
-                              )
-                            }
-                            iconPos="left"
-                            className="w-[28.4rem] text-sm"
-                          >
-                            {eventType.label}
-                          </DropdownMenuItem>
-                        );
-                      })
-                    ) : (
-                      <div />
-                    )}
-                  </div>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </FormControl>
-          )}
-        />
-
-        {!isPending && data && data.length > 0 && !presets?.actorId && (
+      <div className="mt-1 flex w-full justify-start">
+        <div className="flex items-center space-x-2">
           <Controller
             control={control}
-            name="actor"
-            render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+            name="eventType"
+            render={({ field }) => (
+              <FormControl label="Events">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <div className="inline-flex w-full cursor-pointer items-center justify-between whitespace-nowrap rounded-md border border-mineshaft-500 bg-mineshaft-700 px-3 py-2 font-inter text-sm font-normal text-bunker-200 outline-none data-[placeholder]:text-mineshaft-200">
+                      {selectedEventTypes?.length === 1
+                        ? eventTypes.find((eventType) => eventType.value === selectedEventTypes[0])
+                            ?.label
+                        : selectedEventTypes?.length === 0
+                          ? "All events"
+                          : `${selectedEventTypes?.length} events selected`}
+                      <FontAwesomeIcon icon={faCaretDown} className="ml-2 text-xs" />
+                    </div>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="z-[100] max-h-80 overflow-hidden">
+                    <div className="max-h-80 overflow-y-auto">
+                      {eventTypes && eventTypes.length > 0 ? (
+                        eventTypes.map((eventType) => {
+                          const isSelected = selectedEventTypes?.includes(
+                            eventType.value as EventType
+                          );
+
+                          return (
+                            <DropdownMenuItem
+                              onSelect={(event) => eventTypes.length > 1 && event.preventDefault()}
+                              onClick={() => {
+                                if (selectedEventTypes?.includes(eventType.value as EventType)) {
+                                  field.onChange(
+                                    selectedEventTypes?.filter((e: string) => e !== eventType.value)
+                                  );
+                                } else {
+                                  field.onChange([...(selectedEventTypes || []), eventType.value]);
+                                }
+                              }}
+                              key={`event-type-${eventType.value}`}
+                              icon={
+                                isSelected ? (
+                                  <FontAwesomeIcon
+                                    icon={faCheckCircle}
+                                    className="pr-0.5 text-primary"
+                                  />
+                                ) : (
+                                  <div className="pl-[1.01rem]" />
+                                )
+                              }
+                              iconPos="left"
+                              className="w-[28.4rem] text-sm"
+                            >
+                              {eventType.label}
+                            </DropdownMenuItem>
+                          );
+                        })
+                      ) : (
+                        <div />
+                      )}
+                    </div>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </FormControl>
+            )}
+          />
+
+          {!isPending && data && data.length > 0 && !presets?.actorId && (
+            <Controller
+              control={control}
+              name="actor"
+              render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+                <FormControl
+                  label="Actor"
+                  errorText={error?.message}
+                  isError={Boolean(error)}
+                  className="w-40"
+                >
+                  <Select
+                    {...(field.value ? { value: field.value } : { placeholder: "Select" })}
+                    {...field}
+                    onValueChange={(e) => onChange(e)}
+                    className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
+                  >
+                    {data.map((actor) => renderActorSelectItem(actor))}
+                  </Select>
+                </FormControl>
+              )}
+            />
+          )}
+          <Controller
+            control={control}
+            name="userAgentType"
+            render={({ field: { onChange, value, ...field }, fieldState: { error } }) => (
               <FormControl
-                label="Actor"
+                label="Source"
                 errorText={error?.message}
                 isError={Boolean(error)}
                 className="w-40"
               >
                 <Select
-                  {...(field.value ? { value: field.value } : { placeholder: "Select" })}
+                  value={value === undefined ? "all" : value}
                   {...field}
-                  onValueChange={(e) => onChange(e)}
-                  className="w-full border border-mineshaft-500 bg-mineshaft-700 text-mineshaft-100"
+                  onValueChange={(e) => {
+                    if (e === "all") onChange(undefined);
+                    else onChange(e);
+                  }}
+                  className={twMerge("w-full border border-mineshaft-500 bg-mineshaft-700")}
                 >
-                  {data.map((actor) => renderActorSelectItem(actor))}
+                  <SelectItem value="all" key="all">
+                    All sources
+                  </SelectItem>
+                  {userAgentTypes.map(({ label, value: userAgent }) => (
+                    <SelectItem value={userAgent} key={label}>
+                      {label}
+                    </SelectItem>
+                  ))}
                 </Select>
               </FormControl>
             )}
           />
-        )}
-        <Controller
-          control={control}
-          name="userAgentType"
-          render={({ field: { onChange, value, ...field }, fieldState: { error } }) => (
-            <FormControl
-              label="Source"
-              errorText={error?.message}
-              isError={Boolean(error)}
-              className="w-40"
-            >
-              <Select
-                value={value === undefined ? "all" : value}
-                {...field}
-                onValueChange={(e) => {
-                  if (e === "all") onChange(undefined);
-                  else onChange(e);
-                }}
-                className={twMerge("w-full border border-mineshaft-500 bg-mineshaft-700")}
-              >
-                <SelectItem value="all" key="all">
-                  All sources
-                </SelectItem>
-                {userAgentTypes.map(({ label, value: userAgent }) => (
-                  <SelectItem value={userAgent} key={label}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
-        />
-        <Controller
-          name="startDate"
-          control={control}
-          render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-            return (
-              <FormControl label="Start Date" errorText={error?.message} isError={Boolean(error)}>
-                <DatePicker
-                  value={field.value || undefined}
-                  onChange={onChange}
-                  dateFormat="P"
-                  popUpProps={{
-                    open: isStartDatePickerOpen,
-                    onOpenChange: setIsStartDatePickerOpen
-                  }}
-                  popUpContentProps={{}}
-                />
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          name="endDate"
-          control={control}
-          render={({ field: { onChange, ...field }, fieldState: { error } }) => {
-            return (
-              <FormControl label="End Date" errorText={error?.message} isError={Boolean(error)}>
-                <DatePicker
-                  value={field.value || undefined}
-                  onChange={onChange}
-                  dateFormat="P"
-                  popUpProps={{
-                    open: isEndDatePickerOpen,
-                    onOpenChange: setIsEndDatePickerOpen
-                  }}
-                  popUpContentProps={{}}
-                />
-              </FormControl>
-            );
-          }}
-        />
-        <Button
-          isLoading={false}
-          colorSchema="primary"
-          variant="outline_bg"
-          className="mt-[0.45rem]"
-          type="submit"
-          leftIcon={<FontAwesomeIcon icon={faFilterCircleXmark} />}
-          onClick={() =>
-            reset({
-              eventType: presets?.eventType || [],
-              actor: presets?.actorId,
-              userAgentType: undefined,
-              startDate: undefined,
-              endDate: undefined,
-              project: null
-            })
-          }
-        >
-          Clear filters
-        </Button>
+          <Controller
+            name="startDate"
+            control={control}
+            render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+              return (
+                <FormControl label="Start Date" errorText={error?.message} isError={Boolean(error)}>
+                  <DatePicker
+                    value={field.value || undefined}
+                    onChange={onChange}
+                    dateFormat="P"
+                    popUpProps={{
+                      open: isStartDatePickerOpen,
+                      onOpenChange: setIsStartDatePickerOpen
+                    }}
+                    popUpContentProps={{}}
+                  />
+                </FormControl>
+              );
+            }}
+          />
+          <Controller
+            name="endDate"
+            control={control}
+            render={({ field: { onChange, ...field }, fieldState: { error } }) => {
+              return (
+                <FormControl label="End Date" errorText={error?.message} isError={Boolean(error)}>
+                  <DatePicker
+                    value={field.value || undefined}
+                    onChange={onChange}
+                    dateFormat="P"
+                    popUpProps={{
+                      open: isEndDatePickerOpen,
+                      onOpenChange: setIsEndDatePickerOpen
+                    }}
+                    popUpContentProps={{}}
+                  />
+                </FormControl>
+              );
+            }}
+          />
+          <Button
+            isLoading={false}
+            colorSchema="primary"
+            variant="outline_bg"
+            className="mt-[0.45rem]"
+            type="submit"
+            leftIcon={<FontAwesomeIcon icon={faFilterCircleXmark} />}
+            onClick={() =>
+              reset({
+                eventType: presets?.eventType || [],
+                actor: presets?.actorId,
+                userAgentType: undefined,
+                startDate: undefined,
+                endDate: undefined,
+                project: null,
+                secretPath: undefined,
+                secretKey: undefined
+              })
+            }
+          >
+            Clear filters
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
@@ -58,11 +58,13 @@ export const LogsSection = withPermission(
     const actor = watch("actor");
     const projectId = watch("project")?.id;
     const secretPath = watch("secretPath");
+    const secretKey = watch("secretKey");
 
     const startDate = watch("startDate");
     const endDate = watch("endDate");
 
     const [debouncedSecretPath] = useDebounce<string>(secretPath!, 500);
+    const [debouncedSecretKey] = useDebounce<string>(secretKey!, 500);
 
     return (
       <div>
@@ -81,6 +83,7 @@ export const LogsSection = withPermission(
           refetchInterval={refetchInterval}
           filter={{
             secretPath: debouncedSecretPath || undefined,
+            secretKey: debouncedSecretKey || undefined,
             eventMetadata: presets?.eventMetadata,
             projectId,
             actorType: presets?.actorType,

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
@@ -98,7 +98,7 @@ export const LogsTable = ({ filter, refetchInterval }: Props) => {
         <Button
           className="mb-20 mt-4 px-4 py-3 text-sm"
           isFullWidth
-          variant="star"
+          variant="outline_bg"
           isLoading={isFetchingNextPage}
           isDisabled={isFetchingNextPage || !hasNextPage}
           onClick={() => fetchNextPage()}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
@@ -1,10 +1,12 @@
 import { Fragment } from "react";
 import { faFile, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { twMerge } from "tailwind-merge";
 
 import {
   Button,
   EmptyState,
+  Spinner,
   Table,
   TableContainer,
   TableSkeleton,
@@ -52,7 +54,9 @@ export const LogsTable = ({ filter, refetchInterval }: Props) => {
         <Table>
           <THead>
             <Tr>
-              <Th className="w-24" />
+              <Th className="w-24">
+                <Spinner size="xs" className={twMerge(isPending ? "opacity-100" : "opacity-0")} />
+              </Th>
               <Th className="w-64">
                 Timestamp
                 <Tooltip

--- a/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { EventType, UserAgentType } from "@app/hooks/api/auditLogs/enums";
+import { ActorType, EventType, UserAgentType } from "@app/hooks/api/auditLogs/enums";
 import { ProjectType } from "@app/hooks/api/workspace/types";
 
 export const auditLogFilterFormSchema = z
@@ -10,6 +10,7 @@ export const auditLogFilterFormSchema = z
       .object({ id: z.string(), name: z.string(), type: z.nativeEnum(ProjectType) })
       .optional()
       .nullable(),
+    environment: z.object({ name: z.string(), slug: z.string() }).optional().nullable(),
     eventType: z.nativeEnum(EventType).array(),
     actor: z.string().optional(),
     userAgentType: z.nativeEnum(UserAgentType),
@@ -40,3 +41,12 @@ export type SetValueType = (
     shouldDirty?: boolean;
   }
 ) => void;
+
+export type Presets = {
+  actorId?: string;
+  eventType?: EventType[];
+  actorType?: ActorType;
+  startDate?: Date;
+  endDate?: Date;
+  eventMetadata?: Record<string, string>;
+};

--- a/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/types.tsx
@@ -14,6 +14,7 @@ export const auditLogFilterFormSchema = z
     actor: z.string().optional(),
     userAgentType: z.nativeEnum(UserAgentType),
     secretPath: z.string().optional(),
+    secretKey: z.string().optional(),
     startDate: z.date().optional(),
     endDate: z.date().optional(),
     page: z.coerce.number().optional(),

--- a/frontend/src/pages/organization/UserDetailsByIDPage/components/UserProjectsSection/UserAuditLogsSection.tsx
+++ b/frontend/src/pages/organization/UserDetailsByIDPage/components/UserProjectsSection/UserAuditLogsSection.tsx
@@ -1,8 +1,3 @@
-import { useState } from "react";
-import { faFilter } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
-import { IconButton, Tooltip } from "@app/components/v2";
 import { OrgPermissionActions, OrgPermissionSubjects, useSubscription } from "@app/context";
 import { withPermission } from "@app/hoc";
 import { OrgUser } from "@app/hooks/api/types";
@@ -14,7 +9,6 @@ type Props = {
 
 export const UserAuditLogsSection = withPermission(
   ({ orgMembership }: Props) => {
-    const [showFilter, setShowFilter] = useState(false);
     const { subscription } = useSubscription();
 
     // eslint-disable-next-line no-nested-ternary
@@ -23,25 +17,8 @@ export const UserAuditLogsSection = withPermission(
         <div className="w-full rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
           <div className="mb-4 flex items-center justify-between border-b border-mineshaft-400 pb-4">
             <p className="text-lg font-semibold text-gray-200">Audit Logs</p>
-
-            <Tooltip content="Show audit log filters">
-              <IconButton
-                colorSchema="primary"
-                ariaLabel="copy icon"
-                variant="plain"
-                className="group relative"
-                onClick={() => setShowFilter(!showFilter)}
-              >
-                <div className="flex items-center space-x-2">
-                  <p>Filter</p>
-                  <FontAwesomeIcon icon={faFilter} />
-                </div>
-              </IconButton>
-            </Tooltip>
           </div>
           <LogsSection
-            showFilters={showFilter}
-            filterClassName="bg-mineshaft-900 static"
             presets={{
               actorId: orgMembership.user.id
             }}

--- a/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
@@ -35,7 +35,6 @@ export const IntegrationAuditLogsSection = ({ integration }: Props) => {
           startDate: new Date(new Date().setDate(new Date().getDate() - auditLogsRetentionDays)),
           eventType: INTEGRATION_EVENTS
         }}
-        filterClassName="bg-mineshaft-900 static"
       />
     </div>
   ) : (

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncAuditLogsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncAuditLogsSection.tsx
@@ -41,7 +41,6 @@ export const SecretSyncAuditLogsSection = ({ secretSync }: Props) => {
             startDate: new Date(new Date().setDate(new Date().getDate() - auditLogsRetentionDays)),
             eventType: INTEGRATION_EVENTS
           }}
-          filterClassName="bg-mineshaft-900 static"
         />
       ) : (
         <div className="flex h-full items-center justify-center rounded-lg bg-mineshaft-800 text-sm text-mineshaft-200">


### PR DESCRIPTION
# Description 📣

This PR extends our audit log filtering to support filtering by secret keys. We currently support filtering by project and secret path, so allowing for filtering by secret keys serves as a natural extension to the existing audit logs filtering.


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced audit log filtering to allow filtering by a secret key and environment, providing more granular control over log queries.
  - The audit logs UI now supports secret key and environment input alongside existing filters.
  - Introduced a new `LogFilterItem` component for better filter management.

- **Style**
  - Updated field labels for consistency and clarity in audit log filtering forms.
  - Improved visual feedback in the logs table with a loading spinner.

- **Bug Fixes**
  - Removed unnecessary filter-related functionality from the `UserAuditLogsSection`, streamlining the component.
  - Removed `filterClassName` prop from multiple components, simplifying their implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->