### PR TITLE
Folder last secret commit feature

### DIFF
--- a/backend/src/db/migrations/20250326171707_folder-last-secret-modified.ts
+++ b/backend/src/db/migrations/20250326171707_folder-last-secret-modified.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.SecretFolder, "lastSecretModified");
+  if (!hasCol) {
+    await knex.schema.alterTable(TableName.SecretFolder, (t) => {
+      t.datetime("lastSecretModified");
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.SecretFolder, "lastSecretModified");
+  if (hasCol) {
+    await knex.schema.alterTable(TableName.SecretFolder, (t) => {
+      t.dropColumn("lastSecretModified");
+    });
+  }
+}

--- a/backend/src/db/schemas/secret-folders.ts
+++ b/backend/src/db/schemas/secret-folders.ts
@@ -16,7 +16,8 @@ export const SecretFoldersSchema = z.object({
   envId: z.string().uuid(),
   parentId: z.string().uuid().nullable().optional(),
   isReserved: z.boolean().default(false).nullable().optional(),
-  description: z.string().nullable().optional()
+  description: z.string().nullable().optional(),
+  lastSecretModified: z.date().nullable().optional()
 });
 
 export type TSecretFolders = z.infer<typeof SecretFoldersSchema>;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -633,7 +633,7 @@ export const FOLDERS = {
     path: "The path to list folders from.",
     directory: "The directory to list folders from. (Deprecated in favor of path)",
     recursive: "Whether or not to fetch all folders from the specified base path, and all of its subdirectories.",
-    lastSecretModified: "The timestamp filters folders with secrets modified after the specified date."
+    lastSecretModified: "The ISO 8601 timestamp filters folders with secrets modified after the specified date."
   },
   GET_BY_ID: {
     folderId: "The ID of the folder to get details."

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -632,7 +632,8 @@ export const FOLDERS = {
     environment: "The slug of the environment to list folders from.",
     path: "The path to list folders from.",
     directory: "The directory to list folders from. (Deprecated in favor of path)",
-    recursive: "Whether or not to fetch all folders from the specified base path, and all of its subdirectories."
+    recursive: "Whether or not to fetch all folders from the specified base path, and all of its subdirectories.",
+    lastSecretModified: "The timestamp filters folders with secrets modified after the specified date."
   },
   GET_BY_ID: {
     folderId: "The ID of the folder to get details."

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -633,7 +633,7 @@ export const FOLDERS = {
     path: "The path to list folders from.",
     directory: "The directory to list folders from. (Deprecated in favor of path)",
     recursive: "Whether or not to fetch all folders from the specified base path, and all of its subdirectories.",
-    lastSecretModified: "The ISO 8601 timestamp filters folders with secrets modified after the specified date."
+    lastSecretModified: "The timestamp used to filter folders with secrets modified after the specified date. The format for this timestamp is ISO 8601 (e.g. 2025-04-01T09:41:45-04:00)"
   },
   GET_BY_ID: {
     folderId: "The ID of the folder to get details."

--- a/backend/src/server/routes/v1/secret-folder-router.ts
+++ b/backend/src/server/routes/v1/secret-folder-router.ts
@@ -335,6 +335,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
       querystring: z.object({
         workspaceId: z.string().trim().describe(FOLDERS.LIST.workspaceId),
         environment: z.string().trim().describe(FOLDERS.LIST.environment),
+        lastSecretModified: z.string().datetime().trim().optional().describe(FOLDERS.LIST.lastSecretModified),
         path: z
           .string()
           .trim()

--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -402,7 +402,8 @@ export const secretFolderServiceFactory = ({
     orderDirection,
     limit,
     offset,
-    recursive
+    recursive,
+    lastSecretModified
   }: TGetFolderDTO) => {
     // folder list is allowed to be read by anyone
     // permission to check does user has access
@@ -425,7 +426,16 @@ export const secretFolderServiceFactory = ({
       const recursiveFolders = await folderDAL.findByEnvsDeep({ parentIds: [parentFolder.id] });
       // remove the parent folder
       return recursiveFolders
-        .filter((folder) => folder.id !== parentFolder.id)
+        .filter((folder) => {
+          if (lastSecretModified) {
+            if (!folder.lastSecretModified) return false;
+
+            if (folder.lastSecretModified < new Date(lastSecretModified)) {
+              return false;
+            }
+          }
+          return folder.id !== parentFolder.id;
+        })
         .map((folder) => ({
           ...folder,
           relativePath: folder.path
@@ -445,6 +455,11 @@ export const secretFolderServiceFactory = ({
         offset
       }
     );
+    if (lastSecretModified) {
+      return folders.filter((el) =>
+        el.lastSecretModified ? el.lastSecretModified >= new Date(lastSecretModified) : false
+      );
+    }
     return folders;
   };
 

--- a/backend/src/services/secret-folder/secret-folder-types.ts
+++ b/backend/src/services/secret-folder/secret-folder-types.ts
@@ -46,6 +46,7 @@ export type TGetFolderDTO = {
   limit?: number;
   offset?: number;
   recursive?: boolean;
+  lastSecretModified?: string;
 } & TProjectPermission;
 
 export type TGetFolderByIdDTO = {

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -646,6 +646,10 @@ export const secretQueueFactory = ({
       }
     );
 
+    const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
+    if (!folder) return;
+    await folderDAL.updateById(folder.id, { lastSecretModified: new Date() });
+
     await secretSyncQueue.queueSecretSyncsSyncSecretsByPath({ projectId, environmentSlug: environment, secretPath });
 
     await syncIntegrations({ secretPath, projectId, environment, deDupeQueue, isManual: false });


### PR DESCRIPTION
# Description 📣

This PR provides a new feature for folder api that records  a timestamp whenever the secret inside changes or imported secret changes. You can then filter folder by the timestamp. The folders will be listed with the ones modified later for a given time

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled tracking of folder modifications by adding a new "last secret modified" timestamp.
  - Enhanced folder retrieval functionality with optional filtering based on the modification date.
  - Improved secret synchronization to automatically update the folder’s last modified timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->