### PR TITLE
Add file support to secrets set key=value command

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -139,7 +140,7 @@ var secretsGenerateExampleEnvCmd = &cobra.Command{
 }
 
 var secretsSetCmd = &cobra.Command{
-	Example:               `secrets set <secretName=secretValue> <secretName=secretValue>..."`,
+	Example:               `secrets set <secretName=secretValue> <secretName=secretValue> <secretName=@/path/to/file>..."`,
 	Short:                 "Used set secrets",
 	Use:                   "set [secrets]",
 	DisableFlagsInUseLine: true,
@@ -185,6 +186,30 @@ var secretsSetCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse secret type")
 		}
 
+		processedArgs := []string{}
+		for _, arg := range args {
+			splitKeyValue := strings.SplitN(arg, "=", 2)
+			if len(splitKeyValue) != 2 {
+				util.HandleError(fmt.Errorf("invalid argument format: %s. Expected format: key=value or key=@filepath", arg), "")
+			}
+
+			key := splitKeyValue[0]
+			value := splitKeyValue[1]
+
+			if strings.HasPrefix(value, "\\@") {
+				value = "@" + value[2:]
+			} else if strings.HasPrefix(value, "@") {
+				filePath := strings.TrimPrefix(value, "@")
+				content, err := os.ReadFile(filePath)
+				if err != nil {
+					util.HandleError(err, fmt.Sprintf("Unable to read file %s", filePath))
+				}
+				value = string(content)
+			}
+
+			processedArgs = append(processedArgs, fmt.Sprintf("%s=%s", key, value))
+		}
+
 		file, err := cmd.Flags().GetString("file")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
@@ -216,7 +241,7 @@ var secretsSetCmd = &cobra.Command{
 				util.PrintErrorMessageAndExit("Your login session has expired, please run [infisical login] and try again")
 			}
 
-			secretOperations, err = util.SetRawSecrets(args, secretType, environmentName, secretsPath, projectId, &models.TokenDetails{
+			secretOperations, err = util.SetRawSecrets(processedArgs, secretType, environmentName, secretsPath, projectId, &models.TokenDetails{
 				Type:  "",
 				Token: loggedInUserDetails.UserCredentials.JTWToken,
 			}, file)


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
On `secrets set key=value` add support to use the content of a file as the value of a key using the format: `key=@filepath` [For cases where the value of a key starts with "**@**" but it's not a file it, it can be set using `key="\@.....restOfTheValue"` and will store `key=@.....restOfTheValue`.
Used curl as reference to set the file reference using "**@**": https://curl.se/docs/manpage.html#-F

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->