### PR TITLE
Added provider oidc claim in audit log event

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -968,6 +968,7 @@ interface LoginIdentityOidcAuthEvent {
     identityId: string;
     identityOidcAuthId: string;
     identityAccessTokenId: string;
+    oidcClaimsReceived: Record<string, unknown>;
   };
 }
 

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -213,7 +213,7 @@ export const identityOidcAuthServiceFactory = ({
           }
     );
 
-    return { accessToken, identityOidcAuth, identityAccessToken, identityMembershipOrg };
+    return { accessToken, identityOidcAuth, identityAccessToken, identityMembershipOrg, oidcTokenData: tokenData };
   };
 
   const attachOidcAuth = async ({


### PR DESCRIPTION
# Description 📣

This PR adds the oidc claim provided by the server to be included in oidc identity login audit event

![Screenshot 2025-03-27 at 2 57 57 PM](https://github.com/user-attachments/assets/be934982-a6c4-4d45-9b06-33b4f3115dca)

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication events now capture additional OIDC claim data to provide a more comprehensive record.
  - OIDC token payloads are now size-validated to ensure secure handling of authentication data.
  - Authentication responses have been enhanced to include enriched OIDC token information, offering improved transparency during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->