### PR TITLE
docs: add new secret actions to permission doc

### DIFF
--- a/docs/internals/permissions/project-permissions.mdx
+++ b/docs/internals/permissions/project-permissions.mdx
@@ -140,12 +140,14 @@ Below is a comprehensive list of all available project-level subjects and their 
 #### Subject: `secrets`
 
 Supports conditions and permission inversion
-| Action | Description |
-| -------- | ------------------------------- |
-| `read` | View secrets and their values |
-| `create` | Add new secrets to the project |
-| `edit` | Modify existing secret values |
-| `delete` | Remove secrets from the project |
+| Action | Description | Notes |
+| -------- | ------------------------------- | ----- |
+| `read` | View secrets and their values     | This action is the equivalent of granting both `describeSecret` and `readValue`. The `read` action is considered **legacy**. You should use the `describeSecret` and/or `readValue` actions instead.       |
+| `describeSecret` | View secret details such as key, path, metadata, tags, and more | If you are using the API, you can pass `viewSecretValue: false` to the API call to retrieve secrets without their values. |
+| `readValue` | View the value of a secret.| In order to read secret values, the `describeSecret` action must also be granted. |
+| `create` | Add new secrets to the project  |       |
+| `edit` | Modify existing secret values     |       |
+| `delete` | Remove secrets from the project |       |
 
 #### Subject: `secret-folders`
 


### PR DESCRIPTION
# Description 📣

This PR adds our new secret permission actions to our permission doc. It also outlines the `read` permission as legacy.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the permissions documentation to provide clearer guidance on secret actions.
  - Introduced two new permission actions that allow for more detailed secret information access.
  - Updated the "read" action with legacy status and suggestions for alternative approaches.
  - Restructured the actions table to incorporate additional context and notes for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->