### PR TITLE
Set modal=false on DropdownMenu on MinimizedOrgSidebar orgDetails option

### DIFF
--- a/frontend/src/layouts/OrganizationLayout/components/MinimizedOrgSidebar/MinimizedOrgSidebar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/MinimizedOrgSidebar/MinimizedOrgSidebar.tsx
@@ -176,7 +176,7 @@ export const MinimizedOrgSidebar = () => {
         <nav className="items-between flex h-full flex-col justify-between overflow-y-auto dark:[color-scheme:dark]">
           <div>
             <div className="flex items-center hover:bg-mineshaft-700">
-              <DropdownMenu open={openOrg} onOpenChange={setOpenOrg} modal>
+              <DropdownMenu open={openOrg} onOpenChange={setOpenOrg} modal={false}>
                 <DropdownMenuTrigger
                   onMouseEnter={() => setOpenOrg(true)}
                   onMouseLeave={() => setOpenOrg(false)}


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Fix flickering in the left sidebar's "Org" option for Safari users. The first part of the video shows the fix applied, while the second part demonstrates the previous issue.

Root cause: 
When using the modal option, the following setting was applied to the dropdown menu:

`"The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled, and only menu content will be visible to screen readers."`

This caused the icon to lose focus, leading to the flickering issue in Safari. Since the dropdown is rendered on top of the rest of the content and is hidden when it loses focus, this setting is unnecessary.

https://github.com/user-attachments/assets/0612edc4-1603-48b9-aa03-d1a0eca03680


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->