### PR TITLE
fix: add permissions to k8s release

### DIFF
--- a/.github/workflows/release_docker_k8_operator.yaml
+++ b/.github/workflows/release_docker_k8_operator.yaml
@@ -4,6 +4,10 @@ on:
         tags:
             - "infisical-k8-operator/v*.*.*"
 
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
     release-image:
         name: Generate Helm Chart PR


### PR DESCRIPTION
# Description 📣

This PR fixes our k8s release step by adding the required permissions to the workflow.

Failed workflow example: https://github.com/Infisical/infisical/actions/runs/14182290011/job/39730940713

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->