### PR TITLE
fix: remove users with capitalized usernames from projects

### DIFF
--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -423,7 +423,7 @@ export const projectMembershipServiceFactory = ({
     const usernamesAndEmails = [...emails, ...usernames];
 
     const projectMembers = await projectMembershipDAL.findMembershipsByUsername(projectId, [
-      ...new Set(usernamesAndEmails.map((element) => element.toLowerCase()))
+      ...new Set(usernamesAndEmails.map((element) => element))
     ]);
 
     if (projectMembers.length !== usernamesAndEmails.length) {


### PR DESCRIPTION
# Description 📣

This PR fixes not being able to remove users with capitalized usernames from projects. When removing users from projects it would result in a 400 error because we were forcefully setting usernames to lowercase on the API, which would result in an error because we allow capitalized usernames.

```json
{
  "usernames": [
    "DANIEL+2@infisiCAL.com"
  ]
}
```
![CleanShot 2025-04-01 at 04 27 21](https://github.com/user-attachments/assets/4c235bdc-ed1e-4c4e-8c62-d692542e57b4)


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the project membership removal process to preserve the original case of usernames and emails, ensuring matching now honors case sensitivity.  
  This update means that when managing project members, the inputs must match the stored case exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->