### PR TITLE
Fix issue with missing token on secrets set command CLI

### DIFF
--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -694,7 +694,7 @@ func SetRawSecrets(secretArgs []string, secretType string, environmentName strin
 	if err != nil {
 		return nil, fmt.Errorf("unable to get client with custom headers [err=%v]", err)
 	}
-
+	httpClient.SetAuthToken(tokenDetails.Token)
 	httpClient.SetHeader("Accept", "application/json")
 
 	// pull current secrets


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Fix for missing auth token on secrets set command on CLI
## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the secure token configuration to ensure reliable authentication for remote service interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->