### PR TITLE
misc: add missing version filter in get secret by name

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1252,21 +1252,24 @@ export const secretV2BridgeServiceFactory = ({
       : secretVersionDAL
           .findOne({
             folderId,
+            version,
             type: secretType,
             userId: secretType === SecretType.Personal ? actorId : null,
             key: secretName
           })
           .then((el) =>
-            SecretsV2Schema.extend({
-              tags: z
-                .object({ slug: z.string(), name: z.string(), id: z.string(), color: z.string() })
-                .array()
-                .default([])
-                .optional()
-            }).parse({
-              ...el,
-              id: el.secretId
-            })
+            el
+              ? SecretsV2Schema.extend({
+                  tags: z
+                    .object({ slug: z.string(), name: z.string(), id: z.string(), color: z.string() })
+                    .array()
+                    .default([])
+                    .optional()
+                }).parse({
+                  ...el,
+                  id: el.secretId
+                })
+              : undefined
           ));
 
     throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -1558,6 +1558,7 @@ export const secretServiceFactory = ({
         actorOrgId,
         actor,
         actorId,
+        version,
         expandSecretReferences,
         type,
         secretName


### PR DESCRIPTION
# Description 📣
- This PR adds support for filtering fetch raw secret by name using `version`

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a secret version during retrieval, enabling more precise management of versioned secrets.

- **Bug Fixes**
  - Improved error handling to prevent issues when a requested secret is not found, thereby enhancing overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->