### PR TITLE
feat(project-identity): get project identity by membership ID

### DIFF
--- a/backend/src/server/routes/v2/identity-project-router.ts
+++ b/backend/src/server/routes/v2/identity-project-router.ts
@@ -351,4 +351,56 @@ export const registerIdentityProjectRouter = async (server: FastifyZodProvider) 
       return { identityMembership };
     }
   });
+
+  server.route({
+    method: "GET",
+    url: "/identity-memberships/:identityMembershipId",
+    config: {
+      rateLimit: readLimit
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    schema: {
+      params: z.object({
+        identityMembershipId: z.string().trim()
+      }),
+      response: {
+        200: z.object({
+          identityMembership: z.object({
+            id: z.string(),
+            identityId: z.string(),
+            createdAt: z.date(),
+            updatedAt: z.date(),
+            roles: z.array(
+              z.object({
+                id: z.string(),
+                role: z.string(),
+                customRoleId: z.string().optional().nullable(),
+                customRoleName: z.string().optional().nullable(),
+                customRoleSlug: z.string().optional().nullable(),
+                isTemporary: z.boolean(),
+                temporaryMode: z.string().optional().nullable(),
+                temporaryRange: z.string().nullable().optional(),
+                temporaryAccessStartTime: z.date().nullable().optional(),
+                temporaryAccessEndTime: z.date().nullable().optional()
+              })
+            ),
+            identity: IdentitiesSchema.pick({ name: true, id: true }).extend({
+              authMethods: z.array(z.string())
+            }),
+            project: SanitizedProjectSchema.pick({ name: true, id: true })
+          })
+        })
+      }
+    },
+    handler: async (req) => {
+      const identityMembership = await server.services.identityProject.getProjectIdentityByMembershipId({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        identityMembershipId: req.params.identityMembershipId
+      });
+      return { identityMembership };
+    }
+  });
 };

--- a/backend/src/services/identity-project/identity-project-service.ts
+++ b/backend/src/services/identity-project/identity-project-service.ts
@@ -380,6 +380,12 @@ export const identityProjectServiceFactory = ({
   }: TGetProjectIdentityByMembershipIdDTO) => {
     const membership = await identityProjectDAL.findOne({ id: identityMembershipId });
 
+    if (!membership) {
+      throw new NotFoundError({
+        message: `Project membership with ID '${identityMembershipId}' not found`
+      });
+    }
+
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -388,12 +394,6 @@ export const identityProjectServiceFactory = ({
       actorOrgId,
       actionProjectType: ActionProjectType.Any
     });
-
-    if (!membership) {
-      throw new NotFoundError({
-        message: `Project membership with ID '${identityMembershipId}' not found`
-      });
-    }
 
     ForbiddenError.from(permission).throwUnlessCan(
       ProjectPermissionIdentityActions.Read,

--- a/backend/src/services/identity-project/identity-project-types.ts
+++ b/backend/src/services/identity-project/identity-project-types.ts
@@ -52,6 +52,10 @@ export type TGetProjectIdentityByIdentityIdDTO = {
   identityId: string;
 } & TProjectPermission;
 
+export type TGetProjectIdentityByMembershipIdDTO = {
+  identityMembershipId: string;
+} & Omit<TProjectPermission, "projectId">;
+
 export enum ProjectIdentityOrderBy {
   Name = "name"
 }

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
@@ -86,7 +86,20 @@ const Page = () => {
             title={identityMembershipDetails?.identity?.name}
             description={`Identity joined on ${identityMembershipDetails?.createdAt && formatRelative(new Date(identityMembershipDetails?.createdAt || ""), new Date())}`}
           >
-            <div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline_bg"
+                size="xs"
+                onClick={() => {
+                  navigator.clipboard.writeText(identityMembershipDetails.id);
+                  createNotification({
+                    text: "Membership ID copied to clipboard",
+                    type: "success"
+                  });
+                }}
+              >
+                Copy Membership ID
+              </Button>
               <ProjectPermissionCan
                 I={ProjectPermissionActions.Delete}
                 a={subject(ProjectPermissionSub.Identity, {


### PR DESCRIPTION
# Description 📣

This PR adds support for getting a identity project membership directly by the membership ID itself. This is an internal endpoint that won't be exposed for the time being, as it will be used for allowing Terraform imports project identity memberships.

This PR serves a prerequisite for the Terraform Import Project Identity Memberships PR. (https://github.com/Infisical/terraform-provider-infisical/pull/124)

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Copy Membership ID" button on the Identity Details page. Users can now quickly copy their membership ID to the clipboard and receive immediate confirmation through a notification.
	- Added a new route to retrieve identity membership details based on membership ID.
  
- **Bug Fixes**
	- Improved error handling for identity membership retrieval, ensuring proper feedback for not found or permission errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->