### PR TITLE
Add condition to avoid secret names that contain forward slashes

### DIFF
--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -45,4 +45,6 @@ export const BaseSecretNameSchema = z.string().trim().min(1);
 export const SecretNameSchema = BaseSecretNameSchema.refine(
   (el) => !el.includes(" "),
   "Secret name cannot contain spaces."
-).refine((el) => !el.includes(":"), "Secret name cannot contain colon.");
+)
+  .refine((el) => !el.includes(":"), "Secret name cannot contain colon.")
+  .refine((el) => !el.includes("/"), "Secret name cannot contain forward slash.");


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Prevent slashes in secret names to avoid API failures

When renaming secrets, our validation previously checked for spaces and colons but not slashes. Secret names with slashes pass initial request body validation but break API endpoints that use them as path parameters (for example: "secrets/raw/secret/name/with/slashes").

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced secret name validation by adding a check to disallow forward slashes alongside colons, improving input consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->