### PR TITLE
Added caching for secret dal

### DIFF
--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -9,6 +9,7 @@ export const mockKeyStore = (): TKeyStoreFactory => {
       store[key] = value;
       return "OK";
     },
+    setExpiry: async () => 0,
     setItemWithExpiry: async (key, value) => {
       store[key] = value;
       return "OK";

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -113,7 +113,13 @@ type TSecretApprovalRequestServiceFactoryDep = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey" | "encryptWithInputKey" | "decryptWithInputKey">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "insertMany" | "upsertSecretReferences" | "findBySecretKeys" | "bulkUpdate" | "deleteMany" | "find"
+    | "insertMany"
+    | "upsertSecretReferences"
+    | "findBySecretKeys"
+    | "bulkUpdate"
+    | "deleteMany"
+    | "find"
+    | "cacheInvalidateSecretByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -864,6 +870,7 @@ export const secretApprovalRequestServiceFactory = ({
       });
     }
 
+    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
     await snapshotService.performSnapshot(folderId);
     const [folder] = await folderDAL.findSecretPathByFolderIds(projectId, [folderId]);
     if (!folder) {

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -119,7 +119,7 @@ type TSecretApprovalRequestServiceFactoryDep = {
     | "bulkUpdate"
     | "deleteMany"
     | "find"
-    | "cacheInvalidateSecretByProjectId"
+    | "invalidateSecretCacheByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -870,7 +870,7 @@ export const secretApprovalRequestServiceFactory = ({
       });
     }
 
-    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
     await snapshotService.performSnapshot(folderId);
     const [folder] = await folderDAL.findSecretPathByFolderIds(projectId, [folderId]);
     if (!folder) {

--- a/backend/src/ee/services/secret-replication/secret-replication-service.ts
+++ b/backend/src/ee/services/secret-replication/secret-replication-service.ts
@@ -52,7 +52,7 @@ type TSecretReplicationServiceFactoryDep = {
     | "delete"
     | "upsertSecretReferences"
     | "transaction"
-    | "cacheInvalidateSecretByProjectId"
+    | "invalidateSecretCacheByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<
     TSecretVersionV2DALFactory,
@@ -505,7 +505,7 @@ export const secretReplicationServiceFactory = ({
                 }
               });
 
-              await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+              await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
               await secretQueueService.syncSecrets({
                 projectId,
                 orgId,

--- a/backend/src/ee/services/secret-replication/secret-replication-service.ts
+++ b/backend/src/ee/services/secret-replication/secret-replication-service.ts
@@ -45,7 +45,14 @@ type TSecretReplicationServiceFactoryDep = {
   secretVersionDAL: Pick<TSecretVersionDALFactory, "find" | "insertMany" | "update" | "findLatestVersionMany">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "find" | "findBySecretKeys" | "insertMany" | "bulkUpdate" | "delete" | "upsertSecretReferences" | "transaction"
+    | "find"
+    | "findBySecretKeys"
+    | "insertMany"
+    | "bulkUpdate"
+    | "delete"
+    | "upsertSecretReferences"
+    | "transaction"
+    | "cacheInvalidateSecretByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<
     TSecretVersionV2DALFactory,
@@ -260,6 +267,7 @@ export const secretReplicationServiceFactory = ({
       const sourceLocalSecrets = await secretV2BridgeDAL.find({ folderId: folder.id, type: SecretType.Shared });
       const sourceSecretImports = await secretImportDAL.find({ folderId: folder.id });
       const sourceImportedSecrets = await fnSecretsV2FromImports({
+        projectId,
         secretImports: sourceSecretImports,
         secretDAL: secretV2BridgeDAL,
         folderDAL,
@@ -783,6 +791,7 @@ export const secretReplicationServiceFactory = ({
               }
             });
 
+            await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
             await secretQueueService.syncSecrets({
               projectId,
               orgId,

--- a/backend/src/ee/services/secret-replication/secret-replication-service.ts
+++ b/backend/src/ee/services/secret-replication/secret-replication-service.ts
@@ -505,6 +505,7 @@ export const secretReplicationServiceFactory = ({
                 }
               });
 
+              await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
               await secretQueueService.syncSecrets({
                 projectId,
                 orgId,
@@ -791,7 +792,6 @@ export const secretReplicationServiceFactory = ({
               }
             });
 
-            await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
             await secretQueueService.syncSecrets({
               projectId,
               orgId,

--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
@@ -88,7 +88,7 @@ export type TSecretRotationV2ServiceFactoryDep = {
   folderDAL: Pick<TSecretFolderDALFactory, "findBySecretPath" | "findBySecretPathMultiEnv">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "bulkUpdate" | "insertMany" | "deleteMany" | "upsertSecretReferences" | "find"
+    "bulkUpdate" | "insertMany" | "deleteMany" | "upsertSecretReferences" | "find" | "cacheInvalidateSecretByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -515,6 +515,7 @@ export const secretRotationV2ServiceFactory = ({
         });
       });
 
+      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,
@@ -651,6 +652,7 @@ export const secretRotationV2ServiceFactory = ({
       });
 
       if (secretsMappingUpdated) {
+        await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
         await snapshotService.performSnapshot(folder.id);
         await secretQueueService.syncSecrets({
           orgId: connection.orgId,
@@ -777,6 +779,7 @@ export const secretRotationV2ServiceFactory = ({
     }
 
     if (deleteSecrets) {
+      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,
@@ -935,6 +938,7 @@ export const secretRotationV2ServiceFactory = ({
         }
       });
 
+      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,

--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
@@ -88,7 +88,7 @@ export type TSecretRotationV2ServiceFactoryDep = {
   folderDAL: Pick<TSecretFolderDALFactory, "findBySecretPath" | "findBySecretPathMultiEnv">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "bulkUpdate" | "insertMany" | "deleteMany" | "upsertSecretReferences" | "find" | "cacheInvalidateSecretByProjectId"
+    "bulkUpdate" | "insertMany" | "deleteMany" | "upsertSecretReferences" | "find" | "invalidateSecretCacheByProjectId"
   >;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany">;
   secretVersionTagV2BridgeDAL: Pick<TSecretVersionV2TagDALFactory, "insertMany">;
@@ -515,7 +515,7 @@ export const secretRotationV2ServiceFactory = ({
         });
       });
 
-      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,
@@ -652,7 +652,7 @@ export const secretRotationV2ServiceFactory = ({
       });
 
       if (secretsMappingUpdated) {
-        await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+        await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
         await snapshotService.performSnapshot(folder.id);
         await secretQueueService.syncSecrets({
           orgId: connection.orgId,
@@ -779,7 +779,7 @@ export const secretRotationV2ServiceFactory = ({
     }
 
     if (deleteSecrets) {
-      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,
@@ -938,7 +938,7 @@ export const secretRotationV2ServiceFactory = ({
         }
       });
 
-      await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
       await snapshotService.performSnapshot(folder.id);
       await secretQueueService.syncSecrets({
         orgId: connection.orgId,

--- a/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
@@ -48,7 +48,7 @@ type TSecretRotationQueueFactoryDep = {
   secretRotationDAL: TSecretRotationDALFactory;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
   secretDAL: Pick<TSecretDALFactory, "bulkUpdate" | "find">;
-  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "find" | "cacheInvalidateSecretByProjectId">;
+  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "find" | "invalidateSecretCacheByProjectId">;
   secretVersionDAL: Pick<TSecretVersionDALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
@@ -340,7 +340,7 @@ export const secretRotationQueueFactory = ({
           );
         });
 
-        await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(secretRotation.projectId);
+        await secretV2BridgeDAL.invalidateSecretCacheByProjectId(secretRotation.projectId);
       } else {
         if (!botKey)
           throw new NotFoundError({

--- a/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
@@ -48,7 +48,7 @@ type TSecretRotationQueueFactoryDep = {
   secretRotationDAL: TSecretRotationDALFactory;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
   secretDAL: Pick<TSecretDALFactory, "bulkUpdate" | "find">;
-  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "find">;
+  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "bulkUpdate" | "find" | "cacheInvalidateSecretByProjectId">;
   secretVersionDAL: Pick<TSecretVersionDALFactory, "insertMany" | "findLatestVersionMany">;
   secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "insertMany" | "findLatestVersionMany">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
@@ -339,6 +339,8 @@ export const secretRotationQueueFactory = ({
             tx
           );
         });
+
+        await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(secretRotation.projectId);
       } else {
         if (!botKey)
           throw new NotFoundError({

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -77,6 +77,8 @@ export const keyStoreFactory = (redisUrl: string) => {
 
   const incrementBy = async (key: string, value: number) => redis.incrby(key, value);
 
+  const setExpiry = async (key: string, expiryInSeconds: number) => redis.expire(key, expiryInSeconds);
+
   const waitTillReady = async ({
     key,
     waitingCb,
@@ -103,6 +105,7 @@ export const keyStoreFactory = (redisUrl: string) => {
   return {
     setItem,
     getItem,
+    setExpiry,
     setItemWithExpiry,
     deleteItem,
     incrementBy,

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -10,6 +10,7 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
       store[key] = value;
       return "OK";
     },
+    setExpiry: async () => 0,
     setItemWithExpiry: async (key, value) => {
       store[key] = value;
       return "OK";

--- a/backend/src/lib/crypto/cache.ts
+++ b/backend/src/lib/crypto/cache.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-export const getCacheKey = (data: unknown) =>
+export const generateCacheKeyFromData = (data: unknown) =>
   crypto
     .createHash("md5")
     .update(JSON.stringify(data))

--- a/backend/src/lib/crypto/cache.ts
+++ b/backend/src/lib/crypto/cache.ts
@@ -1,0 +1,10 @@
+import crypto from "node:crypto";
+
+export const getCacheKey = (data: unknown) =>
+  crypto
+    .createHash("md5")
+    .update(JSON.stringify(data))
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");

--- a/backend/src/lib/types/index.ts
+++ b/backend/src/lib/types/index.ts
@@ -41,6 +41,18 @@ export type RequiredKeys<T> = {
   [K in keyof T]-?: undefined extends T[K] ? never : K;
 }[keyof T];
 
+export type BufferKeysToString<T> = {
+  [K in keyof T]: T[K] extends Buffer
+    ? string
+    : T[K] extends Buffer | null
+      ? string | null
+      : T[K] extends Buffer | undefined
+        ? string | undefined
+        : T[K] extends Buffer | null | undefined
+          ? string | null | undefined
+          : T[K];
+};
+
 export type PickRequired<T> = Pick<T, RequiredKeys<T>>;
 
 export type DiscriminativePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : never;

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -315,7 +315,7 @@ export const registerRoutes = async (
   const secretVersionTagDAL = secretVersionTagDALFactory(db);
   const secretBlindIndexDAL = secretBlindIndexDALFactory(db);
 
-  const secretV2BridgeDAL = secretV2BridgeDALFactory(db);
+  const secretV2BridgeDAL = secretV2BridgeDALFactory({ db, keyStore });
   const secretVersionV2BridgeDAL = secretVersionV2BridgeDALFactory(db);
   const secretVersionTagV2BridgeDAL = secretVersionV2TagBridgeDALFactory(db);
 

--- a/backend/src/services/integration-auth/integration-delete-secret.ts
+++ b/backend/src/services/integration-auth/integration-delete-secret.ts
@@ -50,7 +50,7 @@ const getIntegrationSecretsV2 = async (
   }
 
   // process secrets in current folder
-  const secrets = await secretV2BridgeDAL.findByFolderId(dto.folderId);
+  const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId, projectId: dto.projectId });
 
   secrets.forEach((secret) => {
     const secretKey = secret.key;
@@ -63,6 +63,7 @@ const getIntegrationSecretsV2 = async (
   // if no imports then return secrets in the current folder
   if (!secretImports.length) return content;
   const importedSecrets = await fnSecretsV2FromImports({
+    projectId: dto.projectId,
     decryptor: dto.decryptor,
     folderDAL,
     secretDAL: secretV2BridgeDAL,

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -159,7 +159,8 @@ export const fnSecretsV2FromImports = async ({
   decryptor,
   expandSecretReferences,
   hasSecretAccess,
-  viewSecretValue
+  viewSecretValue,
+  projectId
 }: {
   secretImports: (Omit<TSecretImports, "importEnv"> & {
     importEnv: { id: string; slug: string; name: string };
@@ -176,6 +177,7 @@ export const fnSecretsV2FromImports = async ({
     environment: string;
   }) => Promise<string | undefined>;
   hasSecretAccess: (environment: string, secretPath: string, secretName: string, secretTagSlugs: string[]) => boolean;
+  projectId: string;
 }) => {
   const cyclicDetector = new Set();
   const stack: {
@@ -216,7 +218,8 @@ export const fnSecretsV2FromImports = async ({
         type: SecretType.Shared
       },
       {
-        sort: [["id", "asc"]]
+        sort: [["id", "asc"]],
+        useCache: { projectId }
       }
     );
     const importedSecretsGroupByFolderId = groupBy(importedSecrets, (i) => i.folderId);

--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -43,7 +43,7 @@ type TSecretImportServiceFactoryDep = {
   secretImportDAL: TSecretImportDALFactory;
   folderDAL: TSecretFolderDALFactory;
   secretDAL: Pick<TSecretDALFactory, "find">;
-  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "find" | "cacheInvalidateSecretByProjectId">;
+  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "find" | "invalidateSecretCacheByProjectId">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
   projectDAL: Pick<TProjectDALFactory, "checkProjectUpgradeStatus">;
   projectEnvDAL: TProjectEnvDALFactory;
@@ -184,7 +184,7 @@ export const secretImportServiceFactory = ({
       });
     }
 
-    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
     return { ...secImport, importEnv };
   };
 
@@ -283,7 +283,7 @@ export const secretImportServiceFactory = ({
       return doc;
     });
 
-    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
     return { ...updatedSecImport, importEnv: importedEnv };
   };
 
@@ -358,7 +358,7 @@ export const secretImportServiceFactory = ({
       actorId
     });
 
-    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretV2BridgeDAL.invalidateSecretCacheByProjectId(projectId);
     return secImport;
   };
 

--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -43,7 +43,7 @@ type TSecretImportServiceFactoryDep = {
   secretImportDAL: TSecretImportDALFactory;
   folderDAL: TSecretFolderDALFactory;
   secretDAL: Pick<TSecretDALFactory, "find">;
-  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "find">;
+  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "find" | "cacheInvalidateSecretByProjectId">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
   projectDAL: Pick<TProjectDALFactory, "checkProjectUpgradeStatus">;
   projectEnvDAL: TProjectEnvDALFactory;
@@ -184,6 +184,7 @@ export const secretImportServiceFactory = ({
       });
     }
 
+    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
     return { ...secImport, importEnv };
   };
 
@@ -281,6 +282,8 @@ export const secretImportServiceFactory = ({
       );
       return doc;
     });
+
+    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
     return { ...updatedSecImport, importEnv: importedEnv };
   };
 
@@ -355,6 +358,7 @@ export const secretImportServiceFactory = ({
       actorId
     });
 
+    await secretV2BridgeDAL.cacheInvalidateSecretByProjectId(projectId);
     return secImport;
   };
 
@@ -693,6 +697,7 @@ export const secretImportServiceFactory = ({
         projectId
       });
       const importedSecrets = await fnSecretsV2FromImports({
+        projectId,
         secretImports,
         folderDAL,
         viewSecretValue: true,

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -213,7 +213,7 @@ export const secretSyncQueueFactory = ({
       canExpandValue: () => true
     });
 
-    const secrets = await secretV2BridgeDAL.findByFolderId(folderId);
+    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId, projectId });
 
     await Promise.allSettled(
       secrets.map(async (secret) => {
@@ -243,6 +243,7 @@ export const secretSyncQueueFactory = ({
 
     if (secretImports.length) {
       const importedSecrets = await fnSecretsV2FromImports({
+        projectId,
         decryptor: decryptSecretValue,
         folderDAL,
         secretDAL: secretV2BridgeDAL,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -2,7 +2,10 @@ import { Knex } from "knex";
 import { validate as uuidValidate } from "uuid";
 
 import { TDbClient } from "@app/db";
-import { SecretsV2Schema, SecretType, TableName, TSecretsV2, TSecretsV2Update } from "@app/db/schemas";
+import { ProjectType, SecretsV2Schema, SecretType, TableName, TSecretsV2, TSecretsV2Update } from "@app/db/schemas";
+import { TKeyStoreFactory } from "@app/keystore/keystore";
+import { getConfig } from "@app/lib/config/env";
+import { getCacheKey } from "@app/lib/crypto/cache";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import {
   buildFindFilter,
@@ -12,14 +15,63 @@ import {
   TFindFilter,
   TFindOpt
 } from "@app/lib/knex";
-import { OrderByDirection } from "@app/lib/types";
+import { BufferKeysToString, OrderByDirection } from "@app/lib/types";
 import { SecretsOrderBy } from "@app/services/secret/secret-types";
-import { TFindSecretsByFolderIdsFilter } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
+import type { TFindSecretsByFolderIdsFilter } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
+
+export const SecretDalCacheKeys = {
+  get productKey() {
+    const { INFISICAL_PLATFORM_VERSION } = getConfig();
+    return `${ProjectType.SecretManager}:${INFISICAL_PLATFORM_VERSION || 0}`;
+  },
+  getSecretDalVersion: (projectId: string) => {
+    return `${SecretDalCacheKeys.productKey}:${projectId}:${TableName.SecretV2}-dal-version`;
+  },
+  findByFolderIds: (
+    projectId: string,
+    version: number,
+    { useCache, tx, ...cacheKey }: Parameters<TSecretV2BridgeDALFactory["findByFolderIds"]>[0]
+  ) => {
+    return `${SecretDalCacheKeys.productKey}:${projectId}:${
+      TableName.SecretV2
+    }-dal:v${version}:find-by-folder-ids:${getCacheKey(cacheKey)}`;
+  },
+  findByFolderId: (
+    projectId: string,
+    version: number,
+    { useCache, tx, ...cacheKey }: Parameters<TSecretV2BridgeDALFactory["findByFolderId"]>[0]
+  ) => {
+    return `${SecretDalCacheKeys.productKey}:${projectId}:${
+      TableName.SecretV2
+    }-dal:v${version}:find-by-folder-id:${getCacheKey(cacheKey)}`;
+  },
+  find: (projectId: string, version: number, ...args: Parameters<TSecretV2BridgeDALFactory["find"]>) => {
+    const [filter, opts] = args;
+    delete opts?.tx;
+    delete opts?.useCache;
+    return `${SecretDalCacheKeys.productKey}:${projectId}:${TableName.SecretV2}-dal:v${version}:find:${getCacheKey({
+      filter,
+      opts
+    })}`;
+  }
+};
 
 export type TSecretV2BridgeDALFactory = ReturnType<typeof secretV2BridgeDALFactory>;
+interface TSecretV2DalArg {
+  db: TDbClient;
+  keyStore: TKeyStoreFactory;
+}
 
-export const secretV2BridgeDALFactory = (db: TDbClient) => {
+const SECRET_DAL_TTL = 5 * 60;
+const SECRET_DAL_VERSION_TTL = 15 * 60;
+export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
   const secretOrm = ormify(db, TableName.SecretV2);
+
+  const cacheInvalidateSecretByProjectId = async (projectId: string) => {
+    const secretDalVersionKey = SecretDalCacheKeys.getSecretDalVersion(projectId);
+    await keyStore.incrementBy(secretDalVersionKey, 1);
+    await keyStore.setExpiry(secretDalVersionKey, SECRET_DAL_VERSION_TTL);
+  };
 
   const findOne = async (filter: Partial<TSecretsV2>, tx?: Knex) => {
     try {
@@ -73,8 +125,35 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
     }
   };
 
-  const find = async (filter: TFindFilter<TSecretsV2>, { offset, limit, sort, tx }: TFindOpt<TSecretsV2> = {}) => {
+  const find = async (
+    filter: TFindFilter<TSecretsV2>,
+    opts: TFindOpt<TSecretsV2> & { useCache?: { projectId: string } } = {}
+  ) => {
+    const { offset, limit, sort, tx, useCache } = opts;
     try {
+      let secretDalVersion = 0;
+      if (useCache) {
+        const cachedSecretDalVersion = await keyStore.getItem(
+          SecretDalCacheKeys.getSecretDalVersion(useCache.projectId)
+        );
+        secretDalVersion = Number(cachedSecretDalVersion || 0);
+        const cacheKey = SecretDalCacheKeys.find(useCache.projectId, secretDalVersion, filter, opts);
+        const cachedSecrets = await keyStore.getItem(cacheKey);
+        if (cachedSecrets) {
+          await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL);
+
+          const unsanitizedSecrets = JSON.parse(cachedSecrets) as BufferKeysToString<(typeof data)[number]>[];
+          const sanitizedSecrets = unsanitizedSecrets.map((el) => {
+            const encryptedValue = el.encryptedValue ? Buffer.from(el.encryptedValue, "base64") : null;
+            const encryptedComment = el.encryptedComment ? Buffer.from(el.encryptedComment, "base64") : null;
+            const createdAt = new Date(el.createdAt);
+            const updatedAt = new Date(el.updatedAt);
+            return { ...el, encryptedComment, encryptedValue, createdAt, updatedAt };
+          });
+          return sanitizedSecrets;
+        }
+      }
+
       const query = (tx || db)(TableName.SecretV2)
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         .where(buildFindFilter(filter))
@@ -142,6 +221,20 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           }
         ]
       });
+
+      if (useCache) {
+        const cachedSecrets = data.map((el) => {
+          const encryptedValue = el.encryptedValue ? el.encryptedValue.toString("base64") : null;
+          const encryptedComment = el.encryptedComment ? el.encryptedComment.toString("base64") : null;
+          return { ...el, encryptedValue, encryptedComment };
+        });
+        await keyStore.setItemWithExpiry(
+          SecretDalCacheKeys.find(useCache.projectId, secretDalVersion, filter, opts),
+          SECRET_DAL_TTL,
+          JSON.stringify(cachedSecrets)
+        );
+      }
+
       return data;
     } catch (error) {
       throw new DatabaseError({ error, name: `${TableName.SecretV2}: Find` });
@@ -246,12 +339,41 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findByFolderId = async (folderId: string, userId?: string, tx?: Knex) => {
+  const findByFolderId = async (dto: {
+    folderId: string;
+    userId?: string;
+    tx?: Knex;
+    projectId: string;
+    useCache?: boolean;
+  }) => {
     try {
-      // check if not uui then userId id is null (corner case because service token's ID is not UUI in effort to keep backwards compatibility from mongo)
+      const { folderId, tx, projectId } = dto;
+      let { userId } = dto;
+      // check if not uui then userId id is null (corner case because service token's ID is not UUI in effort to keep backwards compatibility from mongo
       if (userId && !uuidValidate(userId)) {
         // eslint-disable-next-line
         userId = undefined;
+      }
+
+      const cachedSecretDalVersion = await keyStore.getItem(SecretDalCacheKeys.getSecretDalVersion(projectId));
+      const secretDalVersion = Number(cachedSecretDalVersion || 0);
+
+      if (dto.useCache) {
+        const cacheKey = SecretDalCacheKeys.findByFolderId(projectId, secretDalVersion, dto);
+        const cachedSecrets = await keyStore.getItem(cacheKey);
+        if (cachedSecrets) {
+          await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL);
+
+          const unsanitizedSecrets = JSON.parse(cachedSecrets) as BufferKeysToString<(typeof data)[number]>[];
+          const sanitizedSecrets = unsanitizedSecrets.map((el) => {
+            const encryptedValue = el.encryptedValue ? Buffer.from(el.encryptedValue, "base64") : null;
+            const encryptedComment = el.encryptedComment ? Buffer.from(el.encryptedComment, "base64") : null;
+            const createdAt = new Date(el.createdAt);
+            const updatedAt = new Date(el.updatedAt);
+            return { ...el, encryptedComment, encryptedValue, createdAt, updatedAt };
+          });
+          return sanitizedSecrets;
+        }
       }
 
       const secs = await (tx || db.replicaNode())(TableName.SecretV2)
@@ -309,6 +431,18 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           }
         ]
       });
+      if (dto.useCache) {
+        const newCachedSecrets = data.map((el) => {
+          const encryptedValue = el.encryptedValue ? el.encryptedValue.toString("base64") : null;
+          const encryptedComment = el.encryptedComment ? el.encryptedComment.toString("base64") : null;
+          return { ...el, encryptedValue, encryptedComment };
+        });
+        await keyStore.setItemWithExpiry(
+          SecretDalCacheKeys.findByFolderId(projectId, secretDalVersion, dto),
+          SECRET_DAL_TTL,
+          JSON.stringify(newCachedSecrets)
+        );
+      }
       return data;
     } catch (error) {
       throw new DatabaseError({ error, name: "get all secret" });
@@ -394,17 +528,41 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findByFolderIds = async (
-    folderIds: string[],
-    userId?: string,
-    tx?: Knex,
-    filters?: TFindSecretsByFolderIdsFilter
-  ) => {
+  const findByFolderIds = async (dto: {
+    folderIds: string[];
+    userId?: string;
+    tx?: Knex;
+    projectId: string;
+    filters?: TFindSecretsByFolderIdsFilter;
+    useCache?: boolean;
+  }) => {
+    const { folderIds, tx, filters, useCache, projectId } = dto;
+    let { userId } = dto;
     try {
       // check if not uui then userId id is null (corner case because service token's ID is not UUI in effort to keep backwards compatibility from mongo)
       if (userId && !uuidValidate(userId)) {
         // eslint-disable-next-line no-param-reassign
         userId = undefined;
+      }
+
+      const cachedSecretDalVersion = await keyStore.getItem(SecretDalCacheKeys.getSecretDalVersion(projectId));
+      const secretDalVersion = Number(cachedSecretDalVersion || 0);
+      if (useCache) {
+        const cacheKey = SecretDalCacheKeys.findByFolderIds(projectId, secretDalVersion, dto);
+        const cachedSecrets = await keyStore.getItem(cacheKey);
+        if (cachedSecrets) {
+          await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL);
+
+          const unsanitizedSecrets = JSON.parse(cachedSecrets) as BufferKeysToString<(typeof data)[number]>[];
+          const sanitizedSecrets = unsanitizedSecrets.map((el) => {
+            const encryptedValue = el.encryptedValue ? Buffer.from(el.encryptedValue, "base64") : null;
+            const encryptedComment = el.encryptedComment ? Buffer.from(el.encryptedComment, "base64") : null;
+            const createdAt = new Date(el.createdAt);
+            const updatedAt = new Date(el.updatedAt);
+            return { ...el, encryptedComment, encryptedValue, createdAt, updatedAt };
+          });
+          return sanitizedSecrets;
+        }
       }
 
       const query = (tx || db.replicaNode())(TableName.SecretV2)
@@ -532,6 +690,18 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
           }
         ]
       });
+      if (useCache) {
+        const cachedSecrets = data.map((el) => {
+          const encryptedValue = el.encryptedValue ? el.encryptedValue.toString("base64") : null;
+          const encryptedComment = el.encryptedComment ? el.encryptedComment.toString("base64") : null;
+          return { ...el, encryptedValue, encryptedComment };
+        });
+        await keyStore.setItemWithExpiry(
+          SecretDalCacheKeys.findByFolderIds(projectId, secretDalVersion, dto),
+          SECRET_DAL_TTL,
+          JSON.stringify(cachedSecrets)
+        );
+      }
 
       return data;
     } catch (error) {
@@ -724,6 +894,7 @@ export const secretV2BridgeDALFactory = (db: TDbClient) => {
     findAllProjectSecretValues,
     countByFolderIds,
     findOne,
-    find
+    find,
+    cacheInvalidateSecretByProjectId
   };
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -501,7 +501,7 @@ export const expandSecretReferencesFactory = ({
 
     const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
     if (!folder) return { value: "", tags: [] };
-    const secrets = await secretDAL.findByFolderId(folder.id);
+    const secrets = await secretDAL.findByFolderId({ folderId: folder.id, projectId, useCache: true });
 
     const decryptedSecret = secrets.reduce<Record<string, { value: string; tags: string[] }>>((prev, secret) => {
       // eslint-disable-next-line no-param-reassign

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -331,7 +331,7 @@ export const secretV2BridgeServiceFactory = ({
       return createdSecret;
     });
 
-    await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretDAL.invalidateSecretCacheByProjectId(projectId);
     if (inputSecret.type === SecretType.Shared) {
       await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
@@ -540,7 +540,7 @@ export const secretV2BridgeServiceFactory = ({
       projectId
     });
 
-    await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretDAL.invalidateSecretCacheByProjectId(projectId);
     if (inputSecret.type === SecretType.Shared) {
       await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
@@ -649,7 +649,7 @@ export const secretV2BridgeServiceFactory = ({
         })
       );
 
-      await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretDAL.invalidateSecretCacheByProjectId(projectId);
       if (inputSecret.type === SecretType.Shared) {
         await snapshotService.performSnapshot(folderId);
         await secretQueueService.syncSecrets({
@@ -1552,7 +1552,7 @@ export const secretV2BridgeServiceFactory = ({
         tx
       })
     );
-    await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretDAL.invalidateSecretCacheByProjectId(projectId);
     await snapshotService.performSnapshot(folderId);
     await secretQueueService.syncSecrets({
       actor,
@@ -1892,7 +1892,7 @@ export const secretV2BridgeServiceFactory = ({
       }
     });
 
-    await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+    await secretDAL.invalidateSecretCacheByProjectId(projectId);
     await Promise.allSettled(folders.map((el) => (el?.id ? snapshotService.performSnapshot(el.id) : undefined)));
     await Promise.allSettled(
       folders.map((el) =>
@@ -2024,7 +2024,7 @@ export const secretV2BridgeServiceFactory = ({
         })
       );
 
-      await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretDAL.invalidateSecretCacheByProjectId(projectId);
       await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         actor,
@@ -2549,7 +2549,7 @@ export const secretV2BridgeServiceFactory = ({
     });
 
     if (isDestinationUpdated || isSourceUpdated) {
-      await secretDAL.cacheInvalidateSecretByProjectId(projectId);
+      await secretDAL.invalidateSecretCacheByProjectId(projectId);
     }
     if (isDestinationUpdated) {
       await snapshotService.performSnapshot(destinationFolder.id);
@@ -2729,7 +2729,7 @@ export const secretV2BridgeServiceFactory = ({
       generatePaths(folderMap).map(({ folderId, path }) => [folderId, path === "/" ? path : path.substring(1)])
     );
 
-    const secrets = await secretDAL.findByFolderIds({ folderIds: folders.map((f) => f.id), projectId });
+    const secrets = await secretDAL.findByFolderIds({ folderIds: folders.map((f) => f.id), projectId, useCache: true });
 
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.SecretManager,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -279,6 +279,13 @@ export type TUpdateManySecretsFnFactory = {
   folderDAL: TSecretFolderDALFactory;
 };
 
+export type TFindByFolderIdDALDTO = {
+  folderId: string;
+  userId?: string;
+  tx?: Knex;
+  projectId: string;
+};
+
 export type TUpdateManySecretsFn = {
   projectId: string;
   environment: string;

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -367,7 +367,7 @@ export const secretQueueFactory = ({
       canExpandValue: () => true
     });
     // process secrets in current folder
-    const secrets = await secretV2BridgeDAL.findByFolderId(dto.folderId);
+    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId, projectId: dto.projectId });
 
     await Promise.allSettled(
       secrets.map(async (secret) => {
@@ -397,6 +397,7 @@ export const secretQueueFactory = ({
     // if no imports then return secrets in the current folder
     if (!secretImports.length) return content;
     const importedSecrets = await fnSecretsV2FromImports({
+      projectId: dto.projectId,
       decryptor: dto.decryptor,
       folderDAL,
       secretDAL: secretV2BridgeDAL,


### PR DESCRIPTION
# Description 📣

This PR adds redis caching to secrets to make endpoint faster and reduce load on db

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced caching across secret operations now automatically refreshes data to ensure up-to-date information.
	- Added key expiry management for improved security and controlled key lifetimes.
	- Introduced project-specific handling in secret-related functions for more precise and consistent data management.
	- New method for generating cache keys for improved cache management.
	- New functionality for invalidating cached secrets based on project ID.

- **Bug Fixes**
	- Adjusted secret retrieval methods to include project context, enhancing accuracy in data access.

- **Documentation**
	- Updated type definitions to reflect new parameters and methods for better clarity in usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->