### PR TITLE
Add go-sdk version parameter to RetrieveSecretOptions docs

### DIFF
--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -373,6 +373,9 @@ secret, err := client.Secrets().Retrieve(infisical.RetrieveSecretOptions{
       The type of the secret. Valid options are "shared" or "personal". If not
       specified, the default value is "shared".
     </ParamField>
+    <ParamField query="Version" type="number" optional>
+      The version of the secret to retrieve.
+    </ParamField>
   </Expandable>
 </ParamField>
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Add missing `Version` parameter to go-sdk RetrieveSecretOptions
![CleanShot 2025-04-11 at 17 39 15@2x](https://github.com/user-attachments/assets/f4a75dd5-06dc-44ea-bcbd-9f50af3610bc)


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced secret retrieval by allowing users to optionally specify the version when accessing secrets, providing more granular control over secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->