### PR TITLE
Typo correction in the go-sdk example

### DIFF
--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -28,7 +28,7 @@ func main() {
     AutoTokenRefresh: true, // Wether or not to let the SDK handle the access token lifecycle. Defaults to true if not specified.
 	})
 
-	_, err = client.Auth().UniversalAuthLogin("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET")
+	_, err := client.Auth().UniversalAuthLogin("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET")
 
 	if err != nil {
 		fmt.Printf("Authentication failed: %v", err)


### PR DESCRIPTION
# Description 📣

The ‘:’ is missing to automatically define the type of ‘err’. Without it, the example code cannot function correctly.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Go SDK documentation sample to demonstrate improved variable initialization practices, ensuring clear variable scope while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->