### PR TITLE
[feature] improve helm chart templating to dynamically create connection url for postgresql and redis from credential secrets

### DIFF
--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -54,18 +54,17 @@ A helm chart to deploy Infisical
 | postgresql.enabled | bool | `true` | Enables an in-cluster PostgreSQL deployment. To achieve HA for Postgres, we recommend deploying https://github.com/zalando/postgres-operator instead. |
 | postgresql.fullnameOverride | string | `"postgresql"` | Full name override for PostgreSQL resources |
 | postgresql.name | string | `"postgresql"` | PostgreSQL resource name |
+| postgresql.customURIParameters.enabled | bool | `false` | Set to true if using custom URI parameters for PostgreSQL connection |
+| postgresql.customURIParameters.username | string | `""` | Username for PostgreSQL connection |
+| postgresql.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the PostgreSQL password |
+| postgresql.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL password |
+| postgresql.customURIParameters.host | string | `""` | Hostname for PostgreSQL connection |
+| postgresql.customURIParameters.port | string | `"5432"` | Port for PostgreSQL connection. Default is 5432 |
+| postgresql.customURIParameters.database | string | `""` | Database name for PostgreSQL connection |
+| postgresql.customURIParameters.ssl.enabled | bool | `false` | Set to true if using SSL for PostgreSQL connection |
+| postgresql.customURIParameters.ssl.mode | string | `"verify-ca"` | SSL mode for PostgreSQL connection. Default is "verify-ca" |
+| postgresql.customURIParameters.ssl.rootCertPath | string | `""` | Path to the Root CA certificate file for SSL connection |
 | postgresql.useExistingPostgresSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string |
-| postgresql.useExistingPostgresSecret.customURIParameters.enabled | bool | `false` | Set to true if using a custom PostgreSQL connection string |
-| postgresql.useExistingPostgresSecret.customURIParameters.usernameSecret.key | string | `""` | Key name in the Kubernetes secret that holds the PostgreSQL username |
-| postgresql.useExistingPostgresSecret.customURIParameters.usernameSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL username |
-| postgresql.useExistingPostgresSecret.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the PostgreSQL password |
-| postgresql.useExistingPostgresSecret.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL password |
-| postgresql.useExistingPostgresSecret.customURIParameters.host | string | `""` | PostgreSQL host |
-| postgresql.useExistingPostgresSecret.customURIParameters.port | string | `"5432"` | PostgreSQL port |
-| postgresql.useExistingPostgresSecret.customURIParameters.database | string | `""` | PostgreSQL database name |
-| postgresql.useExistingPostgresSecret.customURIParameters.ssl.enabled | bool | `false` | Set to true if using SSL for PostgreSQL connection |
-| postgresql.useExistingPostgresSecret.customURIParameters.ssl.mode | string | `"verify-ca"` | SSL mode for PostgreSQL connection |
-| postgresql.useExistingPostgresSecret.customURIParameters.ssl.rootCertPath | string | `""` | Path to the Root CA certificate file for SSL connection |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key | string | `""` | Key name in the Kubernetes secret that holds the connection string |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL connection string |
 | redis.architecture | string | `"standalone"` | Redis deployment type (e.g., standalone or cluster) |
@@ -75,9 +74,10 @@ A helm chart to deploy Infisical
 | redis.fullnameOverride | string | `"redis"` | Full name override for Redis resources |
 | redis.name | string | `"redis"` | Redis resource name |
 | redis.usePassword | bool | `true` | Requires a password for Redis authentication |
+| redis.customURIParameters.enabled | bool | `false` | Set to true if using custom URI parameters for Redis connection |
+| redis.customURIParameters.username | string | `""` | Optional username for Redis authentication |
+| redis.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the Redis password |
+| redis.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the Redis password |
+| redis.customURIParameters.host | string | `""` | Redis host |
+| redis.customURIParameters.port | number | `6379` | Port for Redis connection. Default is 6379 |
 | redis.useExistingRedisSecret.enabled | bool | `false` | Set to true if using a custom Redis connection |
-| redis.useExistingRedisSecret.customURIParameters.username | string | `""` | Optional username for Redis authentication |
-| redis.useExistingRedisSecret.customURIParameters.host | string | `""` | Redis host |
-| redis.useExistingRedisSecret.customURIParameters.port | string | `"6379"` | Redis port |
-| redis.useExistingRedisSecret.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the Redis password |
-| redis.useExistingRedisSecret.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the Redis password |

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -55,6 +55,17 @@ A helm chart to deploy Infisical
 | postgresql.fullnameOverride | string | `"postgresql"` | Full name override for PostgreSQL resources |
 | postgresql.name | string | `"postgresql"` | PostgreSQL resource name |
 | postgresql.useExistingPostgresSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string |
+| postgresql.useExistingPostgresSecret.customURIParameters.enabled | bool | `false` | Set to true if using a custom PostgreSQL connection string |
+| postgresql.useExistingPostgresSecret.customURIParameters.usernameSecret.key | string | `""` | Key name in the Kubernetes secret that holds the PostgreSQL username |
+| postgresql.useExistingPostgresSecret.customURIParameters.usernameSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL username |
+| postgresql.useExistingPostgresSecret.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the PostgreSQL password |
+| postgresql.useExistingPostgresSecret.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL password |
+| postgresql.useExistingPostgresSecret.customURIParameters.host | string | `""` | PostgreSQL host |
+| postgresql.useExistingPostgresSecret.customURIParameters.port | string | `"5432"` | PostgreSQL port |
+| postgresql.useExistingPostgresSecret.customURIParameters.database | string | `""` | PostgreSQL database name |
+| postgresql.useExistingPostgresSecret.customURIParameters.ssl.enabled | bool | `false` | Set to true if using SSL for PostgreSQL connection |
+| postgresql.useExistingPostgresSecret.customURIParameters.ssl.mode | string | `"verify-ca"` | SSL mode for PostgreSQL connection |
+| postgresql.useExistingPostgresSecret.customURIParameters.ssl.rootCertPath | string | `""` | Path to the Root CA certificate file for SSL connection |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key | string | `""` | Key name in the Kubernetes secret that holds the connection string |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL connection string |
 | redis.architecture | string | `"standalone"` | Redis deployment type (e.g., standalone or cluster) |
@@ -64,3 +75,9 @@ A helm chart to deploy Infisical
 | redis.fullnameOverride | string | `"redis"` | Full name override for Redis resources |
 | redis.name | string | `"redis"` | Redis resource name |
 | redis.usePassword | bool | `true` | Requires a password for Redis authentication |
+| redis.useExistingRedisSecret.enabled | bool | `false` | Set to true if using a custom Redis connection |
+| redis.useExistingRedisSecret.customURIParameters.username | string | `""` | Optional username for Redis authentication |
+| redis.useExistingRedisSecret.customURIParameters.host | string | `""` | Redis host |
+| redis.useExistingRedisSecret.customURIParameters.port | string | `"6379"` | Redis port |
+| redis.useExistingRedisSecret.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the Redis password |
+| redis.useExistingRedisSecret.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the Redis password |

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -75,7 +75,6 @@ A helm chart to deploy Infisical
 | redis.name | string | `"redis"` | Redis resource name |
 | redis.usePassword | bool | `true` | Requires a password for Redis authentication |
 | redis.customURIParameters.enabled | bool | `false` | Set to true if using custom URI parameters for Redis connection |
-| redis.customURIParameters.username | string | `""` | Optional username for Redis authentication |
 | redis.customURIParameters.passwordSecret.key | string | `""` | Key name in the Kubernetes secret that holds the Redis password |
 | redis.customURIParameters.passwordSecret.name | string | `""` | Kubernetes secret name containing the Redis password |
 | redis.customURIParameters.host | string | `""` | Redis host |

--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Create a PostgreSQL connection string from custom URI parameters
 {{- else -}}
 {{- $sslParams = printf "?sslmode=disable" -}}
 {{- end -}}
-{{- printf "postgresql://%s:${DB_PASSWORD}@%s:%v/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
+{{- printf "postgresql://%s:$(DB_PASSWORD)@%s:%v/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
 {{- else -}}
 {{- fail "PostgreSQL custom URI parameters missing required fields (username, host, port, database)" -}}
 {{- end -}}
@@ -156,11 +156,7 @@ Create a Redis connection string from custom URI parameters
 {{- if .Values.redis.customURIParameters.enabled -}}
 {{- $redisParams := .Values.redis.customURIParameters -}}
 {{- if and $redisParams.host $redisParams.port -}}
-{{- if $redisParams.username -}}
-{{- printf "redis://%s:${REDIS_PASSWORD}@%s:%v" $redisParams.username $redisParams.host $redisParams.port -}}
-{{- else -}}
-{{- printf "redis://${REDIS_PASSWORD}@%s:%v" $redisParams.host $redisParams.port -}}
-{{- end -}}
+{{- printf "redis://default:$(REDIS_PASSWORD)@%s:%v" $redisParams.host $redisParams.port -}}
 {{- else -}}
 {{- fail "Redis custom URI parameters missing required fields (host, port)" -}}
 {{- end -}}

--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -91,6 +91,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a PostgreSQL connection string from custom URI parameters
+*/}}
+{{- define "infisical.customPostgresDBConnectionString" -}}
+{{- if .Values.postgresql.customURIParameters.enabled -}}
+{{- $pgParams := .Values.postgresql.customURIParameters -}}
+{{- $sslParams := "" -}}
+{{- if $pgParams.ssl.enabled -}}
+{{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath -}}
+{{- end -}}
+{{- printf "postgresql://%s:${DB_PASSWORD}@%s:%s/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
+{{- else -}}
+{{- print "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a fully qualified redis name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -121,4 +137,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $password := .Values.redis.auth.password -}}
 {{- $serviceName := include "infisical.redisServiceName" . -}}
 {{- printf "redis://default:%s@%s:6379" $password "redis-master" -}}
+{{- end -}}
+
+{{/*
+Create a Redis connection string from custom URI parameters
+*/}}
+{{- define "infisical.customRedisConnectionString" -}}
+{{- if .Values.redis.customURIParameters.enabled -}}
+{{- $redisParams := .Values.redis.customURIParameters -}}
+{{- $usernameSegment := "" -}}
+{{- if $redisParams.username -}}
+{{- $usernameSegment = printf "%s" $redisParams.username -}}
+{{- end -}}
+{{- printf "redis://%s:${REDIS_PASSWORD}@%s:%v" $usernameSegment $redisParams.host $redisParams.port -}}
+{{- else -}}
+{{- print "" -}}
+{{- end -}}
 {{- end -}}

--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Create a PostgreSQL connection string from custom URI parameters
 {{- if $pgParams.ssl.enabled -}}
 {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath -}}
 {{- end -}}
-{{- printf "postgresql://%s:${DB_PASSWORD}@%s:%s/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
+{{- printf "postgresql://%s:${DB_PASSWORD}@%s:%v/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
 {{- else -}}
 {{- print "" -}}
 {{- end -}}

--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -96,11 +96,21 @@ Create a PostgreSQL connection string from custom URI parameters
 {{- define "infisical.customPostgresDBConnectionString" -}}
 {{- if .Values.postgresql.customURIParameters.enabled -}}
 {{- $pgParams := .Values.postgresql.customURIParameters -}}
+{{- if and $pgParams.username $pgParams.host $pgParams.port $pgParams.database -}}
 {{- $sslParams := "" -}}
 {{- if $pgParams.ssl.enabled -}}
+{{- if and $pgParams.ssl.mode $pgParams.ssl.rootCertPath -}}
 {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath -}}
+{{- else -}}
+{{- $sslParams = printf "?sslmode=disable" -}}
+{{- end -}}
+{{- else -}}
+{{- $sslParams = printf "?sslmode=disable" -}}
 {{- end -}}
 {{- printf "postgresql://%s:${DB_PASSWORD}@%s:%v/%s%s" $pgParams.username $pgParams.host $pgParams.port $pgParams.database $sslParams -}}
+{{- else -}}
+{{- fail "PostgreSQL custom URI parameters missing required fields (username, host, port, database)" -}}
+{{- end -}}
 {{- else -}}
 {{- print "" -}}
 {{- end -}}
@@ -145,11 +155,15 @@ Create a Redis connection string from custom URI parameters
 {{- define "infisical.customRedisConnectionString" -}}
 {{- if .Values.redis.customURIParameters.enabled -}}
 {{- $redisParams := .Values.redis.customURIParameters -}}
-{{- $usernameSegment := "" -}}
+{{- if and $redisParams.host $redisParams.port -}}
 {{- if $redisParams.username -}}
-{{- $usernameSegment = printf "%s" $redisParams.username -}}
+{{- printf "redis://%s:${REDIS_PASSWORD}@%s:%v" $redisParams.username $redisParams.host $redisParams.port -}}
+{{- else -}}
+{{- printf "redis://${REDIS_PASSWORD}@%s:%v" $redisParams.host $redisParams.port -}}
 {{- end -}}
-{{- printf "redis://%s:${REDIS_PASSWORD}@%s:%v" $usernameSegment $redisParams.host $redisParams.port -}}
+{{- else -}}
+{{- fail "Redis custom URI parameters missing required fields (host, port)" -}}
+{{- end -}}
 {{- else -}}
 {{- print "" -}}
 {{- end -}}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -64,7 +64,25 @@ spec:
         ports: 
         - containerPort: 8080
         env:
-        {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
+        {{- if and .Values.postgresql.useExistingPostgresSecret.enabled .Values.postgresql.useExistingPostgresSecret.customURIParameters.enabled }}
+        {{- $pgParams := .Values.postgresql.useExistingPostgresSecret.customURIParameters }}
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pgParams.usernameSecret.name }}
+              key: {{ $pgParams.usernameSecret.key }}
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $pgParams.passwordSecret.name }}
+              key: {{ $pgParams.passwordSecret.key }}
+        - name: DB_CONNECTION_URI
+          {{- $sslParams := "" }}
+          {{- if and $pgParams.ssl.enabled $pgParams.ssl.mode }}
+          {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath }}
+          {{- end }}
+          value: "postgresql://$(DB_USER):$(DB_PASSWORD)@{{ $pgParams.host }}:{{ $pgParams.port }}/{{ $pgParams.database }}{{ $sslParams }}"
+        {{- else if .Values.postgresql.useExistingPostgresSecret.enabled }}
         - name: DB_CONNECTION_URI
           valueFrom:
             secretKeyRef:
@@ -74,6 +92,20 @@ spec:
         {{- if .Values.postgresql.enabled }}
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
+        {{- end }}
+        {{- if .Values.redis.useExistingRedisSecret.enabled }}
+        {{- $redisParams := .Values.redis.useExistingRedisSecret.customURIParameters }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $redisParams.passwordSecret.name }}
+              key: {{ $redisParams.passwordSecret.key }}
+        - name: REDIS_URL
+          {{- $usernameSegment := "default" }}
+          {{- if $redisParams.username }}
+          {{- $usernameSegment = printf "%s" $redisParams.username }}
+          {{- end }}
+          value: "redis://{{ $usernameSegment }}:$(REDIS_PASSWORD)@{{ $redisParams.host }}:{{ $redisParams.port }}"
         {{- end }}
         {{- if .Values.redis.enabled }}
         - name: REDIS_URL

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -64,25 +64,17 @@ spec:
         ports: 
         - containerPort: 8080
         env:
-        {{- if and .Values.postgresql.useExistingPostgresSecret.enabled .Values.postgresql.useExistingPostgresSecret.customURIParameters.enabled }}
-        {{- $pgParams := .Values.postgresql.useExistingPostgresSecret.customURIParameters }}
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ $pgParams.usernameSecret.name }}
-              key: {{ $pgParams.usernameSecret.key }}
+        {{- if .Values.postgresql.customURIParameters.enabled }}
+        {{- $pgParams := .Values.postgresql.customURIParameters }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ $pgParams.passwordSecret.name }}
               key: {{ $pgParams.passwordSecret.key }}
         - name: DB_CONNECTION_URI
-          {{- $sslParams := "" }}
-          {{- if and $pgParams.ssl.enabled $pgParams.ssl.mode }}
-          {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath }}
-          {{- end }}
-          value: "postgresql://$(DB_USER):$(DB_PASSWORD)@{{ $pgParams.host }}:{{ $pgParams.port }}/{{ $pgParams.database }}{{ $sslParams }}"
-        {{- else if .Values.postgresql.useExistingPostgresSecret.enabled }}
+          value: {{ include "infisical.customPostgresDBConnectionString" . }}
+        {{- end }}
+        {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
         - name: DB_CONNECTION_URI
           valueFrom:
             secretKeyRef:
@@ -93,19 +85,15 @@ spec:
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
         {{- end }}
-        {{- if .Values.redis.useExistingRedisSecret.enabled }}
-        {{- $redisParams := .Values.redis.useExistingRedisSecret.customURIParameters }}
+        {{- if .Values.redis.customURIParameters.enabled }}
+        {{- $redisParams := .Values.redis.customURIParameters }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ $redisParams.passwordSecret.name }}
               key: {{ $redisParams.passwordSecret.key }}
         - name: REDIS_URL
-          {{- $usernameSegment := "default" }}
-          {{- if $redisParams.username }}
-          {{- $usernameSegment = printf "%s" $redisParams.username }}
-          {{- end }}
-          value: "redis://{{ $usernameSegment }}:$(REDIS_PASSWORD)@{{ $redisParams.host }}:{{ $redisParams.port }}"
+          value: {{ include "infisical.customRedisConnectionString" . }}
         {{- end }}
         {{- if .Values.redis.enabled }}
         - name: REDIS_URL

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -35,25 +35,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          {{- if and .Values.postgresql.useExistingPostgresSecret.enabled .Values.postgresql.useExistingPostgresSecret.customURIParameters.enabled }}
-          {{- $pgParams := .Values.postgresql.useExistingPostgresSecret.customURIParameters }}
-          - name: DB_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ $pgParams.usernameSecret.name }}
-                key: {{ $pgParams.usernameSecret.key }}
+          {{- if .Values.postgresql.customURIParameters.enabled }}
+          {{- $pgParams := .Values.postgresql.customURIParameters }}
           - name: DB_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ $pgParams.passwordSecret.name }}
                 key: {{ $pgParams.passwordSecret.key }}
           - name: DB_CONNECTION_URI
-            {{- $sslParams := "" }}
-            {{- if and $pgParams.ssl.enabled $pgParams.ssl.mode }}
-            {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath }}
-            {{- end }}
-            value: "postgresql://$(DB_USER):$(DB_PASSWORD)@{{ $pgParams.host }}:{{ $pgParams.port }}/{{ $pgParams.database }}{{ $sslParams }}"
-          {{- else if .Values.postgresql.useExistingPostgresSecret.enabled }}
+            value: {{ include "infisical.customPostgresDBConnectionString" . }}
+          {{- end }}
+          {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
           - name: DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -22,12 +22,38 @@ spec:
         {{- toYaml $infisicalValues.image.imagePullSecrets | nindent 6 }}
     {{- end }}
       restartPolicy: OnFailure
+      {{- with $infisicalValues.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: infisical-schema-migration
           image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
           command: ["npm", "run", "migration:latest"]
+          {{- with $infisicalValues.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
-          {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
+          {{- if and .Values.postgresql.useExistingPostgresSecret.enabled .Values.postgresql.useExistingPostgresSecret.customURIParameters.enabled }}
+          {{- $pgParams := .Values.postgresql.useExistingPostgresSecret.customURIParameters }}
+          - name: DB_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ $pgParams.usernameSecret.name }}
+                key: {{ $pgParams.usernameSecret.key }}
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ $pgParams.passwordSecret.name }}
+                key: {{ $pgParams.passwordSecret.key }}
+          - name: DB_CONNECTION_URI
+            {{- $sslParams := "" }}
+            {{- if and $pgParams.ssl.enabled $pgParams.ssl.mode }}
+            {{- $sslParams = printf "?sslmode=%s&sslrootcert=%s" $pgParams.ssl.mode $pgParams.ssl.rootCertPath }}
+            {{- end }}
+            value: "postgresql://$(DB_USER):$(DB_PASSWORD)@{{ $pgParams.host }}:{{ $pgParams.port }}/{{ $pgParams.database }}{{ $sslParams }}"
+          {{- else if .Values.postgresql.useExistingPostgresSecret.enabled }}
           - name: DB_CONNECTION_URI
             valueFrom:
               secretKeyRef:

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -192,8 +192,6 @@ redis:
   customURIParameters:
     # -- Set to true if using custom URI parameters for Redis connection
     enabled: false
-    # -- Optional username for Redis authentication
-    username: ""
     # -- Redis host
     host: ""
     # -- Port for Redis connection. Default is 6379

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -72,6 +72,25 @@ infisical:
       # -- CPU request for Infisical container
       cpu: 350m
 
+  # -- Additional volumes to mount to the Infisical pod
+  # Use this to mount custom CA certificates for PostgreSQL TLS connections
+  # Example: Mount a root CA certificate from a secret to verify PostgreSQL server certificate
+  extraVolumes: []
+    # - name: postgres-ca-cert
+    #   secret:
+    #     secretName: postgres-ca-certificate
+    #     items:
+    #       - key: ca.crt
+    #         path: postgres-ca.crt
+  
+  # -- Volume mount points for the additional volumes
+  # Use this to specify where CA certificates should be mounted in the container
+  # Example: Mount the PostgreSQL CA certificate to be referenced in connection string
+  extraVolumeMounts: []
+    # - name: postgres-ca-cert
+    #   mountPath: /etc/postgres-certs
+    #   readOnly: true
+
 ingress:
   # -- Enable or disable ingress configuration
   enabled: true
@@ -120,6 +139,36 @@ postgresql:
       # -- Key name in the Kubernetes secret that holds the connection string
       key: ""
 
+    customURIParameters:
+      # -- Set to true if using custom URI parameters for PostgreSQL connection
+      enabled: false
+      # -- Hostname for PostgreSQL connection
+      host: ""
+      # -- Port for PostgreSQL connection. Default is 5432
+      port: 5432
+      # -- Database name for PostgreSQL connection
+      database: ""
+
+      usernameSecret:
+        # -- Kubernetes secret name containing the PostgreSQL username
+        name: ""
+        # -- Key name in the Kubernetes secret that holds the PostgreSQL username
+        key: ""
+
+      passwordSecret:
+        # -- Kubernetes secret name containing the PostgreSQL password
+        name: ""
+        # -- Key name in the Kubernetes secret that holds the PostgreSQL password
+        key: ""
+
+      ssl:
+        # -- Set to true if using SSL for PostgreSQL connection
+        enabled: false
+        # -- SSL mode for PostgreSQL connection. Default is "verify-ca"
+        mode: "verify-ca"
+        # -- Path to the Root CA certificate file for SSL connection
+        rootCertPath: ""
+
 redis:
   # -- Enables an in-cluster Redis deployment
   enabled: true
@@ -141,3 +190,22 @@ redis:
 
   # -- Redis deployment type (e.g., standalone or cluster)
   architecture: standalone
+
+  useExistingRedisSecret:
+    # -- Set to true if using a custom Redis connection
+    enabled: false
+    
+    # -- Build a custom Redis connection string from parameters
+    customURIParameters:
+      # -- Optional username for Redis authentication
+      username: ""
+      # -- Redis host
+      host: ""
+      # -- Port for Redis connection. Default is 6379
+      port: 6379
+      # -- Secret containing Redis password
+      passwordSecret:
+        # -- Kubernetes secret name containing the Redis password
+        name: ""
+        # -- Key name in the Kubernetes secret that holds the Redis password
+        key: ""

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -82,7 +82,7 @@ infisical:
     #     items:
     #       - key: ca.crt
     #         path: postgres-ca.crt
-  
+
   # -- Volume mount points for the additional volumes
   # Use this to specify where CA certificates should be mounted in the container
   # Example: Mount the PostgreSQL CA certificate to be referenced in connection string
@@ -139,35 +139,32 @@ postgresql:
       # -- Key name in the Kubernetes secret that holds the connection string
       key: ""
 
-    customURIParameters:
-      # -- Set to true if using custom URI parameters for PostgreSQL connection
+  customURIParameters:
+    # -- Set to true if using custom URI parameters for PostgreSQL connection
+    enabled: false
+    # -- Hostname for PostgreSQL connection
+    host: ""
+    # -- Port for PostgreSQL connection. Default is 5432
+    port: 5432
+    # -- Database name for PostgreSQL connection
+    database: ""
+
+      # -- Database Username
+    username: ""
+    # -- Database Password
+    passwordSecret:
+      # -- Kubernetes secret name containing the PostgreSQL password
+      name: ""
+      # -- Key name in the Kubernetes secret that holds the PostgreSQL password
+      key: ""
+
+    ssl:
+      # -- Set to true if using SSL for PostgreSQL connection
       enabled: false
-      # -- Hostname for PostgreSQL connection
-      host: ""
-      # -- Port for PostgreSQL connection. Default is 5432
-      port: 5432
-      # -- Database name for PostgreSQL connection
-      database: ""
-
-      usernameSecret:
-        # -- Kubernetes secret name containing the PostgreSQL username
-        name: ""
-        # -- Key name in the Kubernetes secret that holds the PostgreSQL username
-        key: ""
-
-      passwordSecret:
-        # -- Kubernetes secret name containing the PostgreSQL password
-        name: ""
-        # -- Key name in the Kubernetes secret that holds the PostgreSQL password
-        key: ""
-
-      ssl:
-        # -- Set to true if using SSL for PostgreSQL connection
-        enabled: false
-        # -- SSL mode for PostgreSQL connection. Default is "verify-ca"
-        mode: "verify-ca"
-        # -- Path to the Root CA certificate file for SSL connection
-        rootCertPath: ""
+      # -- SSL mode for PostgreSQL connection. Default is "verify-ca"
+      mode: "verify-ca"
+      # -- Path to the Root CA certificate file for SSL connection
+      rootCertPath: ""
 
 redis:
   # -- Enables an in-cluster Redis deployment
@@ -191,21 +188,19 @@ redis:
   # -- Redis deployment type (e.g., standalone or cluster)
   architecture: standalone
 
-  useExistingRedisSecret:
-    # -- Set to true if using a custom Redis connection
+  # -- Build a custom Redis connection string from parameters
+  customURIParameters:
+    # -- Set to true if using custom URI parameters for Redis connection
     enabled: false
-    
-    # -- Build a custom Redis connection string from parameters
-    customURIParameters:
-      # -- Optional username for Redis authentication
-      username: ""
-      # -- Redis host
-      host: ""
-      # -- Port for Redis connection. Default is 6379
-      port: 6379
-      # -- Secret containing Redis password
-      passwordSecret:
-        # -- Kubernetes secret name containing the Redis password
-        name: ""
-        # -- Key name in the Kubernetes secret that holds the Redis password
-        key: ""
+    # -- Optional username for Redis authentication
+    username: ""
+    # -- Redis host
+    host: ""
+    # -- Port for Redis connection. Default is 6379
+    port: 6379
+    # -- Secret containing Redis password
+    passwordSecret:
+      # -- Kubernetes secret name containing the Redis password
+      name: ""
+      # -- Key name in the Kubernetes secret that holds the Redis password
+      key: ""


### PR DESCRIPTION
# Description 📣

#3408
This change addresses new improvements with the PostgreSQL and Redis connection configuration in the Infisical Helm chart:

1. Added support for building PostgreSQL & Redis connection URI string from secrets
2. Added SSL connection support with configurable SSL mode and root certificate path for Postgres
3. Added documentation to the helm-chart which identifies the new configureable parameters


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

First test is to do a dry-run with the new `values.yaml` and inspect the deployment and the job variables to see if the postgres and redis URIs have been populated correctly


<details>
<Summary>
  <strong>values.yaml</strong>
</Summary>

```
infisical:
  enabled: true # -- Enable Infisical chart deployment
  name: infisical # -- Sets the name of the deployment within this chart

  # -- Number of pod replicas for high availability
  replicaCount: 3

  image:
    repository: infisical/infisical
    # -- Specific version tag of the Infisical image. View the latest version here https://hub.docker.com/r/infisical/infisical
    tag: "v0.122.0-postgres"

  kubeSecretRef: "infisical-secrets"

  resources:
    limits:
      memory: 600Mi
    requests:
      cpu: 350m

  extraVolumes:
    - name: postgres-ca-cert
      secret:
        secretName: self-signed-ca-key-pair
        items:
          - key: ca.crt
            path: postgres-ca.crt
  
  extraVolumeMounts:
    - name: postgres-ca-cert
      mountPath: /etc/custom-certs
      readOnly: true

ingress:
  enabled: false
  nginx:
    enabled: false

postgresql:
  # -- Enables an in-cluster PostgreSQL deployment. To achieve HA for Postgres, we recommend deploying https://github.com/zalando/postgres-operator instead.
  enabled: false

  customURIParameters:
    enabled: true
    host: "pg-infisical-rw.infisical.svc.cluster.local"
    port: "5432"
    database: "pg-infisical"
    username:"pg-infisical-admin"
    passwordSecret:
      name: "infisical-pg-admin-credentials-secret"
      key: "password"
    ssl:
      enabled: true
      mode: "verify-ca"
      rootCertPath: "/etc/custom-certs/postgres-ca.crt"

redis:
  enabled: false
  
  # -- Build a custom Redis connection string from parameters
  customURIParameters:
  # -- Set to true if using custom URI parameters for Redis connection
    enabled: true
    # -- Redis host
    host: "redis-infisical-master.infisical.svc.cluster.local"
    # -- Port for Redis connection. Default is 6379
    port: 6379
    # -- Secret containing Redis password
    passwordSecret:
      # -- Kubernetes secret name containing the Redis password
      name: "infisical-redis-admin-credentials-secret"
      # -- Key name in the Kubernetes secret that holds the Redis password
      key: "redis-password"
```
</details>

Then run:
```sh
helm install infisical-test ./infisical-standalone --dry-run --debug -f values.yaml > rendered.yaml
```

Then inspect:
<details>
<Summary>
  <strong>rendered.yaml - Deployment</strong>
</Summary>

```
# Source: infisical-standalone/templates/infisical.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: infisical-test-infisical-standalone-infisical
  ...
  labels:
    component: "infisical"
    app: infisical-standalone
    release: infisical-test
    chart: infisical-standalone-1.5.0
    heritage: Helm
spec:
  replicas: 3
  ...
  template:
    ...
    spec:
      serviceAccountName: infisical-test-infisical
      initContainers:
      - name: "migration-init"
        image: "ghcr.io/groundnuty/k8s-wait-for:no-root-v2.0"
        imagePullPolicy: IfNotPresent
        args: 
        - "job"
        - "infisical-test-schema-migration-1"
        volumeMounts:
          - mountPath: /etc/custom-certs
            name: postgres-ca-cert
            readOnly: true
      containers:
      - name: infisical-standalone-infisical
        image: "infisical/infisical:v0.122.0-postgres"
        ...
        env:
        - name: DB_PASSWORD
          valueFrom:
            secretKeyRef:
              name: infisical-pg-admin-credentials-secret
              key: password
        - name: DB_CONNECTION_URI
          value: "postgresql://pg-infisical-admin:$(DB_PASSWORD)@pg-infisical-rw.infisical.svc.cluster.local:5432/pg-infisical?sslmode=verify-ca&sslrootcert=/etc/custom-certs/postgres-ca.crt"
        - name: REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
              name: infisical-redis-admin-credentials-secret
              key: redis-password
        - name: REDIS_URL
          value: "redis://default:$(REDIS_PASSWORD)@redis-infisical-master.infisical.svc.cluster.local:6379"
        envFrom:
        - secretRef:
            name: infisical-secrets
        ...
        volumeMounts:
          - mountPath: /etc/custom-certs
            name: postgres-ca-cert
            readOnly: true
      volumes:
        - name: postgres-ca-cert
          secret:
            items:
            - key: ca.crt
              path: postgres-ca.crt
            secretName: self-signed-ca-key-pair
```
</details>


<details>
<Summary>
  <strong>rendered.yaml - Job</strong>
</Summary>

```
# Source: infisical-standalone/templates/schema-migration-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "infisical-test-schema-migration-1"
  labels:
    helm.sh/chart: "infisical-standalone-1.5.0"
spec:
  ...
  template:
    metadata:
      name: "infisical-test-create-tables"
      ...
    spec:
      serviceAccountName: infisical-test-infisical
      restartPolicy: OnFailure
      volumes:
        - name: postgres-ca-cert
          secret:
            items:
            - key: ca.crt
              path: postgres-ca.crt
            secretName: self-signed-ca-key-pair
      containers:
        - name: infisical-schema-migration
          image: "infisical/infisical:v0.122.0-postgres"
          command: ["npm", "run", "migration:latest"]
          volumeMounts:
            - mountPath: /etc/custom-certs
              name: postgres-ca-cert
              readOnly: true
          env:
          - name: DB_PASSWORD
            valueFrom:
              secretKeyRef:
                name: infisical-pg-admin-credentials-secret
                key: password
          - name: DB_CONNECTION_URI
            value: "postgresql://pg-infisical-admin:$(DB_PASSWORD)@pg-infisical-rw.infisical.svc.cluster.local:5432/pg-infisical?sslmode=verify-ca&sslrootcert=/etc/custom-certs/postgres-ca.crt"
          envFrom:
          - secretRef:
              name: infisical-secrets
```

</details>


### Additional Tests
Follow my [documentation](https://github.com/chakraborty29/Home-Lab/tree/develop/templates/k3s/infisical) on how to get Infisical up and running with `cloudnative-pg` with TLS support and proper secret management with the helm chart from this PR.

Following these steps yields me to be able to open Infisical in my browser:
![image](https://github.com/user-attachments/assets/3e72ea8c-34e0-4afd-86d7-0e5329e3e361)

After creating an account:
![image](https://github.com/user-attachments/assets/b5d9fd18-2b2b-4d5a-93ce-4167d2f9ee39)

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added customizable connection settings for PostgreSQL and Redis, including credential management, host/port, and SSL/TLS options.
  - Enabled mounting of additional volumes for enhanced security, such as custom CA certificates.
  - Enhanced environment variable configuration for deployment and migration jobs to support flexible connection strings.

- **Documentation**
  - Updated Helm chart README with detailed instructions and examples for new database and cache configuration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->