### PR TITLE
Improvement: Rollback Secret V1 Create Deprecation

### DIFF
--- a/backend/src/ee/routes/v1/secret-rotation-provider-router.ts
+++ b/backend/src/ee/routes/v1/secret-rotation-provider-router.ts
@@ -23,7 +23,8 @@ export const registerSecretRotationProviderRouter = async (server: FastifyZodPro
               title: z.string(),
               image: z.string().optional(),
               description: z.string().optional(),
-              template: z.any()
+              template: z.any(),
+              isDeprecated: z.boolean().optional()
             })
             .array()
         })

--- a/backend/src/ee/services/secret-rotation/secret-rotation-service.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-service.ts
@@ -127,6 +127,13 @@ export const secretRotationServiceFactory = ({
       });
       if (selectedSecrets.length !== Object.values(outputs).length)
         throw new NotFoundError({ message: `Secrets not found in folder with ID '${folder.id}'` });
+      const rotatedSecrets = selectedSecrets.filter(({ isRotatedSecret }) => isRotatedSecret);
+      if (rotatedSecrets.length)
+        throw new BadRequestError({
+          message: `Selected secrets are already used for rotation: ${rotatedSecrets
+            .map((secret) => secret.key)
+            .join(", ")}`
+        });
     } else {
       const selectedSecrets = await secretDAL.find({
         folderId: folder.id,

--- a/backend/src/ee/services/secret-rotation/templates/index.ts
+++ b/backend/src/ee/services/secret-rotation/templates/index.ts
@@ -18,7 +18,8 @@ export const rotationTemplates: TSecretRotationProviderTemplate[] = [
     title: "PostgreSQL",
     image: "postgres.png",
     description: "Rotate PostgreSQL/CockroachDB user credentials",
-    template: POSTGRES_TEMPLATE
+    template: POSTGRES_TEMPLATE,
+    isDeprecated: true
   },
   {
     name: "mysql",
@@ -32,7 +33,8 @@ export const rotationTemplates: TSecretRotationProviderTemplate[] = [
     title: "Microsoft SQL Server",
     image: "mssqlserver.png",
     description: "Rotate Microsoft SQL server user credentials",
-    template: MSSQL_TEMPLATE
+    template: MSSQL_TEMPLATE,
+    isDeprecated: true
   },
   {
     name: "aws-iam",

--- a/backend/src/ee/services/secret-rotation/templates/types.ts
+++ b/backend/src/ee/services/secret-rotation/templates/types.ts
@@ -50,6 +50,7 @@ export type TSecretRotationProviderTemplate = {
   image?: string;
   description?: string;
   template: THttpProviderTemplate | TDbProviderTemplate | TAwsProviderTemplate;
+  isDeprecated?: boolean;
 };
 
 export type THttpProviderTemplate = {

--- a/backend/src/services/project/project-types.ts
+++ b/backend/src/services/project/project-types.ts
@@ -1,11 +1,11 @@
 import { Knex } from "knex";
 
-import { ProjectType, TProjectKeys, SortDirection } from "@app/db/schemas";
+import { ProjectType, SortDirection, TProjectKeys } from "@app/db/schemas";
 import { TSshCertificateAuthorityDALFactory } from "@app/ee/services/ssh/ssh-certificate-authority-dal";
 import { TSshCertificateAuthoritySecretDALFactory } from "@app/ee/services/ssh/ssh-certificate-authority-secret-dal";
+import { OrgServiceActor, TProjectPermission } from "@app/lib/types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectSshConfigDALFactory } from "@app/services/project/project-ssh-config-dal";
-import { OrgServiceActor, TProjectPermission } from "@app/lib/types";
 
 import { ActorAuthMethod, ActorType } from "../auth/auth-type";
 

--- a/frontend/src/hooks/api/secretRotation/types.ts
+++ b/frontend/src/hooks/api/secretRotation/types.ts
@@ -45,6 +45,7 @@ export type TSecretRotationProviderTemplate = {
   image?: string;
   description?: string;
   template: THttpProviderTemplate | TDbProviderTemplate;
+  isDeprecated?: boolean;
 };
 
 export type THttpProviderTemplate = {


### PR DESCRIPTION
# Description 📣

This PR reverts full deprecation on Secret Rotation V1 create and only deprecates PG/MSSQL through the UI.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now create secret rotations via a new modal interface that checks permissions and subscription status.
- **Enhancements**
  - Improved validation prevents duplicate secret rotations.
  - Rotation providers and templates now clearly indicate deprecated options for a more informed experience.
- **Chores**
  - Internal refinements and organization updates bolster overall consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->