### PR TITLE
Feature: Add General Env Var for Allowing Internal IP Connections

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
@@ -42,7 +42,7 @@ export const verifyHostInputValidity = async (host: string, isGateway = false) =
     inputHostIps.push(...resolvedIps);
   }
 
-  if (!isGateway && !appCfg.DYNAMIC_SECRET_ALLOW_INTERNAL_IP) {
+  if (!isGateway && !(appCfg.DYNAMIC_SECRET_ALLOW_INTERNAL_IP || appCfg.ALLOW_INTERNAL_IP_CONNECTIONS)) {
     const isInternalIp = inputHostIps.some((el) => isPrivateIp(el));
     if (isInternalIp) throw new BadRequestError({ message: "Invalid db host" });
   }

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -197,6 +197,7 @@ const envSchema = z
     /* ----------------------------------------------------------------------------- */
 
     /* App Connections ----------------------------------------------------------------------------- */
+    ALLOW_INTERNAL_IP_CONNECTIONS: zodStrBool.default("false"),
 
     // aws
     INF_APP_CONNECTION_AWS_ACCESS_KEY_ID: zpStr(z.string().optional()),

--- a/docs/integrations/app-connections/mssql.mdx
+++ b/docs/integrations/app-connections/mssql.mdx
@@ -51,6 +51,10 @@ Infisical supports connecting to Microsoft SQL Server using database principals.
         - `username` - The username of the login created in the steps above
         - `password` - The password of the login created in the steps above
         - `sslCertificate` (optional) - The SSL certificate required for connection (if configured)
+
+        <Note>
+            If you are self-hosting Infisical and intend to connect to an internal/private IP address, be sure to set the `ALLOW_INTERNAL_IP_CONNECTIONS` environment variable to `true`.
+        </Note>
     </Step>
 </Steps>
 

--- a/docs/integrations/app-connections/postgres.mdx
+++ b/docs/integrations/app-connections/postgres.mdx
@@ -41,6 +41,10 @@ Infisical supports connecting to PostgreSQL using a database role.
         - `username` - The role name of the login created in the steps above
         - `password` - The role password of the login created in the steps above
         - `sslCertificate` (optional) - The SSL certificate required for connection (if configured)
+
+        <Note>
+            If you are self-hosting Infisical and intend to connect to an internal/private IP address, be sure to set the `ALLOW_INTERNAL_IP_CONNECTIONS` environment variable to `true`.
+        </Note>
     </Step>
 </Steps>
 

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -34,6 +34,10 @@ Used to configure platform-specific security and operational settings
   this to `false`.
 </ParamField>
 
+<ParamField query="ALLOW_INTERNAL_IP_CONNECTIONS" type="bool" default="false" optional>
+    Determines whether App Connections and Dynamic Secrets are permitted to connect with internal/private IP addresses.
+</ParamField>
+
 ## CORS
 
 Cross-Origin Resource Sharing (CORS) is a security feature that allows web applications running on one domain to access resources from another domain.


### PR DESCRIPTION
# Description 📣

This PR adds a general environment variable for permitting internal IP connections for App Connections and Dynamic Secrets. Defaults to false. Updated relevant docs.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment variable, ALLOW_INTERNAL_IP_CONNECTIONS, to enable connections to internal or private IP addresses for App Connections and Dynamic Secrets.

- **Documentation**
  - Updated configuration and integration guides to include instructions for using the ALLOW_INTERNAL_IP_CONNECTIONS variable when connecting to internal or private IPs for self-hosted deployments.
  - Added details about the new environment variable in the general platform configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->