### PR TITLE
fix: rename `isDigest` to `preDigested`

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1719,7 +1719,7 @@ export const KMS = {
   SIGN: {
     keyId: "The ID of the key to sign the data with.",
     data: "The data in string format to be signed (base64 encoded).",
-    isDigest:
+    preDigested:
       "Whether the data is already digested or not. Please be aware that if you are passing a digest the algorithm used to create the digest must match the signing algorithm used to sign the digest.",
     signingAlgorithm: "The algorithm to use when performing cryptographic operations with the key."
   },
@@ -1727,7 +1727,7 @@ export const KMS = {
     keyId: "The ID of the key to verify the data with.",
     data: "The data in string format to be verified (base64 encoded). For data larger than 4096 bytes you must first create a digest of the data and then pass the digest in the data parameter.",
     signature: "The signature to be verified (base64 encoded).",
-    isDigest: "Whether the data is already digested or not."
+    preDigested: "Whether the data is already digested or not."
   }
 };
 

--- a/backend/src/lib/crypto/sign/signing.ts
+++ b/backend/src/lib/crypto/sign/signing.ts
@@ -339,13 +339,13 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     data: Buffer,
     privateKey: Buffer,
     signingAlgorithm: SigningAlgorithm,
-    isDigest: boolean
+    preDigested: boolean
   ): Promise<Buffer> => {
     $validateAlgorithmWithKeyType(signingAlgorithm);
 
     const { hashAlgorithm, padding, saltLength } = $getSigningParams(signingAlgorithm);
 
-    if (isDigest) {
+    if (preDigested) {
       if (signingAlgorithm.startsWith("RSASSA_PSS")) {
         throw new BadRequestError({
           message: "RSA PSS does not support digested input"
@@ -400,14 +400,14 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     signature: Buffer,
     publicKey: Buffer,
     signingAlgorithm: SigningAlgorithm,
-    isDigest: boolean
+    preDigested: boolean
   ): Promise<boolean> => {
     try {
       $validateAlgorithmWithKeyType(signingAlgorithm);
 
       const { hashAlgorithm, padding, saltLength } = $getSigningParams(signingAlgorithm);
 
-      if (isDigest) {
+      if (preDigested) {
         if (signingAlgorithm.startsWith("RSASSA_PSS")) {
           throw new BadRequestError({
             message: "RSA PSS does not support digested input"

--- a/backend/src/lib/crypto/sign/types.ts
+++ b/backend/src/lib/crypto/sign/types.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 export type TAsymmetricSignVerifyFns = {
-  sign: (data: Buffer, key: Buffer, signingAlgorithm: SigningAlgorithm, isDigest: boolean) => Promise<Buffer>;
+  sign: (data: Buffer, key: Buffer, signingAlgorithm: SigningAlgorithm, preDigested: boolean) => Promise<Buffer>;
   verify: (
     data: Buffer,
     signature: Buffer,
     key: Buffer,
     signingAlgorithm: SigningAlgorithm,
-    isDigest: boolean
+    preDigested: boolean
   ) => Promise<boolean>;
   generateAsymmetricPrivateKey: () => Promise<Buffer>;
   getPublicKeyFromPrivateKey: (privateKey: Buffer) => Buffer;

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -501,7 +501,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
       }),
       body: z.object({
         signingAlgorithm: z.nativeEnum(SigningAlgorithm),
-        isDigest: z.boolean().optional().default(false).describe(KMS.SIGN.isDigest),
+        preDigested: z.boolean().optional().default(false).describe(KMS.SIGN.preDigested),
         data: base64Schema.describe(KMS.SIGN.data)
       }),
       response: {
@@ -516,12 +516,12 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
     handler: async (req) => {
       const {
         params: { keyId: inputKeyId },
-        body: { data, signingAlgorithm, isDigest },
+        body: { data, signingAlgorithm, preDigested },
         permission
       } = req;
 
       const { projectId, ...result } = await server.services.cmek.cmekSign(
-        { keyId: inputKeyId, data, signingAlgorithm, isDigest },
+        { keyId: inputKeyId, data, signingAlgorithm, preDigested },
         permission
       );
 
@@ -553,7 +553,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         keyId: z.string().uuid().describe(KMS.VERIFY.keyId)
       }),
       body: z.object({
-        isDigest: z.boolean().optional().default(false).describe(KMS.VERIFY.isDigest),
+        preDigested: z.boolean().optional().default(false).describe(KMS.VERIFY.preDigested),
         data: base64Schema.describe(KMS.VERIFY.data),
         signature: base64Schema.describe(KMS.VERIFY.signature),
         signingAlgorithm: z.nativeEnum(SigningAlgorithm)
@@ -570,12 +570,12 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
     handler: async (req) => {
       const {
         params: { keyId },
-        body: { data, signature, signingAlgorithm, isDigest },
+        body: { data, signature, signingAlgorithm, preDigested },
         permission
       } = req;
 
       const { projectId, ...result } = await server.services.cmek.cmekVerify(
-        { keyId, data, signature, signingAlgorithm, isDigest },
+        { keyId, data, signature, signingAlgorithm, preDigested },
         permission
       );
 

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -304,7 +304,7 @@ export const cmekServiceFactory = ({ kmsService, kmsDAL, permissionService, proj
     return { publicKey: publicKey.toString("base64"), projectId: key.projectId };
   };
 
-  const cmekSign = async ({ keyId, data, signingAlgorithm, isDigest }: TCmekSignDTO, actor: OrgServiceActor) => {
+  const cmekSign = async ({ keyId, data, signingAlgorithm, preDigested }: TCmekSignDTO, actor: OrgServiceActor) => {
     const key = await kmsDAL.findCmekById(keyId);
 
     if (!key) throw new NotFoundError({ message: `Key with ID "${keyId}" not found` });
@@ -326,7 +326,7 @@ export const cmekServiceFactory = ({ kmsService, kmsDAL, permissionService, proj
 
     const sign = await kmsService.signWithKmsKey({ kmsId: keyId });
 
-    const { signature, algorithm } = await sign({ data: Buffer.from(data, "base64"), signingAlgorithm, isDigest });
+    const { signature, algorithm } = await sign({ data: Buffer.from(data, "base64"), signingAlgorithm, preDigested });
 
     return {
       signature: signature.toString("base64"),
@@ -337,7 +337,7 @@ export const cmekServiceFactory = ({ kmsService, kmsDAL, permissionService, proj
   };
 
   const cmekVerify = async (
-    { keyId, data, signature, signingAlgorithm, isDigest }: TCmekVerifyDTO,
+    { keyId, data, signature, signingAlgorithm, preDigested }: TCmekVerifyDTO,
     actor: OrgServiceActor
   ) => {
     const key = await kmsDAL.findCmekById(keyId);
@@ -362,7 +362,7 @@ export const cmekServiceFactory = ({ kmsService, kmsDAL, permissionService, proj
     const verify = await kmsService.verifyWithKmsKey({ kmsId: keyId, signingAlgorithm });
 
     const { signatureValid, algorithm } = await verify({
-      isDigest,
+      preDigested,
       data: Buffer.from(data, "base64"),
       signature: Buffer.from(signature, "base64")
     });

--- a/backend/src/services/cmek/cmek-types.ts
+++ b/backend/src/services/cmek/cmek-types.ts
@@ -57,7 +57,7 @@ export type TCmekSignDTO = {
   keyId: string;
   data: string;
   signingAlgorithm: SigningAlgorithm;
-  isDigest: boolean;
+  preDigested: boolean;
 };
 
 export type TCmekVerifyDTO = {
@@ -65,5 +65,5 @@ export type TCmekVerifyDTO = {
   data: string;
   signature: string;
   signingAlgorithm: SigningAlgorithm;
-  isDigest: boolean;
+  preDigested: boolean;
 };

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -469,10 +469,10 @@ export const kmsServiceFactory = ({
     return async ({
       data,
       signingAlgorithm,
-      isDigest
-    }: Pick<TSignWithKmsDTO, "data" | "signingAlgorithm" | "isDigest">) => {
+      preDigested
+    }: Pick<TSignWithKmsDTO, "data" | "signingAlgorithm" | "preDigested">) => {
       const kmsKey = keyCipher.decrypt(kmsDoc.internalKms?.encryptedKey as Buffer, ROOT_ENCRYPTION_KEY);
-      const signature = await sign(data, kmsKey, signingAlgorithm, isDigest);
+      const signature = await sign(data, kmsKey, signingAlgorithm, preDigested);
 
       return Promise.resolve({ signature, algorithm: signingAlgorithm });
     };
@@ -494,11 +494,11 @@ export const kmsServiceFactory = ({
 
     const keyCipher = symmetricCipherService(SymmetricKeyAlgorithm.AES_GCM_256);
     const { verify, getPublicKeyFromPrivateKey } = signingService(encryptionAlgorithm);
-    return async ({ data, signature, isDigest }: Pick<TVerifyWithKmsDTO, "data" | "signature" | "isDigest">) => {
+    return async ({ data, signature, preDigested }: Pick<TVerifyWithKmsDTO, "data" | "signature" | "preDigested">) => {
       const kmsKey = keyCipher.decrypt(kmsDoc.internalKms?.encryptedKey as Buffer, ROOT_ENCRYPTION_KEY);
 
       const publicKey = getPublicKeyFromPrivateKey(kmsKey);
-      const signatureValid = await verify(data, signature, publicKey, signingAlgorithm, isDigest);
+      const signatureValid = await verify(data, signature, publicKey, signingAlgorithm, preDigested);
       return Promise.resolve({ signatureValid, algorithm: signingAlgorithm });
     };
   };

--- a/backend/src/services/kms/kms-types.ts
+++ b/backend/src/services/kms/kms-types.ts
@@ -52,7 +52,7 @@ export type TSignWithKmsDTO = {
   kmsId: string;
   data: Buffer;
   signingAlgorithm: SigningAlgorithm;
-  isDigest: boolean;
+  preDigested: boolean;
 };
 
 export type TVerifyWithKmsDTO = {
@@ -60,7 +60,7 @@ export type TVerifyWithKmsDTO = {
   data: Buffer;
   signature: Buffer;
   signingAlgorithm: SigningAlgorithm;
-  isDigest: boolean;
+  preDigested: boolean;
 };
 
 export type TEncryptionWithKeyDTO = {


### PR DESCRIPTION
# Description 📣

This PR renames API parameters from `isDigest` to `preDigested` for new KMS sign/verify endpoints.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the parameter and property name indicating pre-digested data from `isDigest` to `preDigested` across all relevant signing and verification APIs, request schemas, and documentation. This change affects API endpoints, request/response bodies, and related documentation for key management operations. No changes to functionality or logic were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->