### PR TITLE
Increase Certificate Alternative Names (SAN) Character Limit to 4096

### DIFF
--- a/backend/src/db/migrations/20250415010421_increase-certificate-altnames-character-limit.ts
+++ b/backend/src/db/migrations/20250415010421_increase-certificate-altnames-character-limit.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.Certificate, (t) => {
+    t.string("altNames", 4096).alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.Certificate, (t) => {
+    t.string("altNames").alter(); // Defaults to varchar(255)
+  });
+}

--- a/backend/src/db/migrations/20250415020304_increase-kmip-certificate-altnames-character-limit.ts
+++ b/backend/src/db/migrations/20250415020304_increase-kmip-certificate-altnames-character-limit.ts
@@ -1,0 +1,15 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.KmipOrgServerCertificates, (t) => {
+    t.string("altNames", 4096).alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.KmipOrgServerCertificates, (t) => {
+    t.string("altNames").alter(); // Defaults to varchar(255)
+  });
+}


### PR DESCRIPTION
# Description 📣

Simple PR which increases the character limit for the `altNames` column on the `certificates` and `kmip_org_server_certificates` tables to 4096. The previous character limit of 255 was too small for many SAN lists as seen in [this issue](https://github.com/Infisical/infisical/issues/3372). Using 4096 as a character limit is a good sweet spot which supports 99% of SAN lists while still enforcing a maximum string length.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Ran migrations, verified that columns changed from `varchar(255)` to `varchar(4096)` at the database level, and successfully generated a certificate with a SAN longer than 255 characters.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the character limit for the "altNames" field in certificates, allowing for longer alternative names.
  - Expanded the "altNames" field for KMIP server certificates to support more characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->