### PR TITLE
misc: allow org admins to bypass sso enforcement

### DIFF
--- a/backend/src/db/migrations/20250416145120_add-enable-bypass-org-auth-flag.ts
+++ b/backend/src/db/migrations/20250416145120_add-enable-bypass-org-auth-flag.ts
@@ -3,17 +3,17 @@ import { Knex } from "knex";
 import { TableName } from "../schemas";
 
 export async function up(knex: Knex): Promise<void> {
-  if (!(await knex.schema.hasColumn(TableName.Organization, "enableBypassOrgAuth"))) {
+  if (!(await knex.schema.hasColumn(TableName.Organization, "bypassOrgAuthEnabled"))) {
     await knex.schema.alterTable(TableName.Organization, (t) => {
-      t.boolean("enableBypassOrgAuth").defaultTo(false).notNullable();
+      t.boolean("bypassOrgAuthEnabled").defaultTo(false).notNullable();
     });
   }
 }
 
 export async function down(knex: Knex): Promise<void> {
-  if (await knex.schema.hasColumn(TableName.Organization, "enableBypassOrgAuth")) {
+  if (await knex.schema.hasColumn(TableName.Organization, "bypassOrgAuthEnabled")) {
     await knex.schema.alterTable(TableName.Organization, (t) => {
-      t.dropColumn("enableBypassOrgAuth");
+      t.dropColumn("bypassOrgAuthEnabled");
     });
   }
 }

--- a/backend/src/db/migrations/20250416145120_add-enable-bypass-org-auth-flag.ts
+++ b/backend/src/db/migrations/20250416145120_add-enable-bypass-org-auth-flag.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.Organization, "enableBypassOrgAuth"))) {
+    await knex.schema.alterTable(TableName.Organization, (t) => {
+      t.boolean("enableBypassOrgAuth").defaultTo(false).notNullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.Organization, "enableBypassOrgAuth")) {
+    await knex.schema.alterTable(TableName.Organization, (t) => {
+      t.dropColumn("enableBypassOrgAuth");
+    });
+  }
+}

--- a/backend/src/db/schemas/organizations.ts
+++ b/backend/src/db/schemas/organizations.ts
@@ -27,7 +27,7 @@ export const OrganizationsSchema = z.object({
   shouldUseNewPrivilegeSystem: z.boolean().default(true),
   privilegeUpgradeInitiatedByUsername: z.string().nullable().optional(),
   privilegeUpgradeInitiatedAt: z.date().nullable().optional(),
-  enableBypassOrgAuth: z.boolean().default(false)
+  bypassOrgAuthEnabled: z.boolean().default(false)
 });
 
 export type TOrganizations = z.infer<typeof OrganizationsSchema>;

--- a/backend/src/db/schemas/organizations.ts
+++ b/backend/src/db/schemas/organizations.ts
@@ -26,7 +26,8 @@ export const OrganizationsSchema = z.object({
   allowSecretSharingOutsideOrganization: z.boolean().default(true).nullable().optional(),
   shouldUseNewPrivilegeSystem: z.boolean().default(true),
   privilegeUpgradeInitiatedByUsername: z.string().nullable().optional(),
-  privilegeUpgradeInitiatedAt: z.date().nullable().optional()
+  privilegeUpgradeInitiatedAt: z.date().nullable().optional(),
+  enableBypassOrgAuth: z.boolean().default(false)
 });
 
 export type TOrganizations = z.infer<typeof OrganizationsSchema>;

--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -54,6 +54,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           db.ref("slug").withSchema(TableName.OrgRoles).withSchema(TableName.OrgRoles).as("customRoleSlug"),
           db.ref("permissions").withSchema(TableName.OrgRoles),
           db.ref("authEnforced").withSchema(TableName.Organization).as("orgAuthEnforced"),
+          db.ref("enableBypassOrgAuth").withSchema(TableName.Organization).as("enableBypassOrgAuth"),
           db.ref("groupId").withSchema("userGroups"),
           db.ref("groupOrgId").withSchema("userGroups"),
           db.ref("groupName").withSchema("userGroups"),
@@ -72,6 +73,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           OrgMembershipsSchema.extend({
             permissions: z.unknown(),
             orgAuthEnforced: z.boolean().optional().nullable(),
+            enableBypassOrgAuth: z.boolean(),
             customRoleSlug: z.string().optional().nullable(),
             shouldUseNewPrivilegeSystem: z.boolean()
           }).parse(el),
@@ -676,6 +678,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           db.ref("key").withSchema(TableName.IdentityMetadata).as("metadataKey"),
           db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue"),
           db.ref("authEnforced").withSchema(TableName.Organization).as("orgAuthEnforced"),
+          db.ref("enableBypassOrgAuth").withSchema(TableName.Organization).as("enableBypassOrgAuth"),
           db.ref("role").withSchema(TableName.OrgMembership).as("orgRole"),
           db.ref("orgId").withSchema(TableName.Project),
           db.ref("type").withSchema(TableName.Project).as("projectType"),
@@ -698,7 +701,8 @@ export const permissionDALFactory = (db: TDbClient) => {
           groupMembershipUpdatedAt,
           membershipUpdatedAt,
           projectType,
-          shouldUseNewPrivilegeSystem
+          shouldUseNewPrivilegeSystem,
+          enableBypassOrgAuth
         }) => ({
           orgId,
           orgAuthEnforced,
@@ -710,7 +714,8 @@ export const permissionDALFactory = (db: TDbClient) => {
           id: membershipId || groupMembershipId,
           createdAt: membershipCreatedAt || groupMembershipCreatedAt,
           updatedAt: membershipUpdatedAt || groupMembershipUpdatedAt,
-          shouldUseNewPrivilegeSystem
+          shouldUseNewPrivilegeSystem,
+          enableBypassOrgAuth
         }),
         childrenMapper: [
           {

--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -54,7 +54,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           db.ref("slug").withSchema(TableName.OrgRoles).withSchema(TableName.OrgRoles).as("customRoleSlug"),
           db.ref("permissions").withSchema(TableName.OrgRoles),
           db.ref("authEnforced").withSchema(TableName.Organization).as("orgAuthEnforced"),
-          db.ref("enableBypassOrgAuth").withSchema(TableName.Organization).as("enableBypassOrgAuth"),
+          db.ref("bypassOrgAuthEnabled").withSchema(TableName.Organization).as("bypassOrgAuthEnabled"),
           db.ref("groupId").withSchema("userGroups"),
           db.ref("groupOrgId").withSchema("userGroups"),
           db.ref("groupName").withSchema("userGroups"),
@@ -73,7 +73,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           OrgMembershipsSchema.extend({
             permissions: z.unknown(),
             orgAuthEnforced: z.boolean().optional().nullable(),
-            enableBypassOrgAuth: z.boolean(),
+            bypassOrgAuthEnabled: z.boolean(),
             customRoleSlug: z.string().optional().nullable(),
             shouldUseNewPrivilegeSystem: z.boolean()
           }).parse(el),
@@ -678,7 +678,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           db.ref("key").withSchema(TableName.IdentityMetadata).as("metadataKey"),
           db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue"),
           db.ref("authEnforced").withSchema(TableName.Organization).as("orgAuthEnforced"),
-          db.ref("enableBypassOrgAuth").withSchema(TableName.Organization).as("enableBypassOrgAuth"),
+          db.ref("bypassOrgAuthEnabled").withSchema(TableName.Organization).as("bypassOrgAuthEnabled"),
           db.ref("role").withSchema(TableName.OrgMembership).as("orgRole"),
           db.ref("orgId").withSchema(TableName.Project),
           db.ref("type").withSchema(TableName.Project).as("projectType"),
@@ -702,7 +702,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           membershipUpdatedAt,
           projectType,
           shouldUseNewPrivilegeSystem,
-          enableBypassOrgAuth
+          bypassOrgAuthEnabled
         }) => ({
           orgId,
           orgAuthEnforced,
@@ -715,7 +715,7 @@ export const permissionDALFactory = (db: TDbClient) => {
           createdAt: membershipCreatedAt || groupMembershipCreatedAt,
           updatedAt: membershipUpdatedAt || groupMembershipUpdatedAt,
           shouldUseNewPrivilegeSystem,
-          enableBypassOrgAuth
+          bypassOrgAuthEnabled
         }),
         childrenMapper: [
           {

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -121,7 +121,7 @@ function isAuthMethodSaml(actorAuthMethod: ActorAuthMethod) {
 function validateOrgSSO(
   actorAuthMethod: ActorAuthMethod,
   isOrgSsoEnforced: TOrganizations["authEnforced"],
-  isOrgSsoBypassEnabled: TOrganizations["enableBypassOrgAuth"],
+  isOrgSsoBypassEnabled: TOrganizations["bypassOrgAuthEnabled"],
   orgRole: OrgMembershipRole
 ) {
   if (actorAuthMethod === undefined) {

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -121,14 +121,18 @@ function isAuthMethodSaml(actorAuthMethod: ActorAuthMethod) {
 function validateOrgSSO(
   actorAuthMethod: ActorAuthMethod,
   isOrgSsoEnforced: TOrganizations["authEnforced"],
+  isOrgSsoBypassEnabled: TOrganizations["enableBypassOrgAuth"],
   orgRole: OrgMembershipRole
 ) {
   if (actorAuthMethod === undefined) {
     throw new UnauthorizedError({ name: "No auth method defined" });
   }
 
+  if (isOrgSsoEnforced && isOrgSsoBypassEnabled && orgRole === OrgMembershipRole.Admin) {
+    return;
+  }
+
   if (
-    orgRole !== OrgMembershipRole.Admin &&
     isOrgSsoEnforced &&
     actorAuthMethod !== null &&
     !isAuthMethodSaml(actorAuthMethod) &&

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -2,7 +2,7 @@
 import { ForbiddenError, MongoAbility, PureAbility, subject } from "@casl/ability";
 import { z } from "zod";
 
-import { TOrganizations } from "@app/db/schemas";
+import { OrgMembershipRole, TOrganizations } from "@app/db/schemas";
 import { validatePermissionBoundary } from "@app/lib/casl/boundary";
 import { BadRequestError, ForbiddenRequestError, UnauthorizedError } from "@app/lib/errors";
 import { ActorAuthMethod, AuthMethod } from "@app/services/auth/auth-type";
@@ -118,12 +118,17 @@ function isAuthMethodSaml(actorAuthMethod: ActorAuthMethod) {
   ].includes(actorAuthMethod);
 }
 
-function validateOrgSSO(actorAuthMethod: ActorAuthMethod, isOrgSsoEnforced: TOrganizations["authEnforced"]) {
+function validateOrgSSO(
+  actorAuthMethod: ActorAuthMethod,
+  isOrgSsoEnforced: TOrganizations["authEnforced"],
+  orgRole: OrgMembershipRole
+) {
   if (actorAuthMethod === undefined) {
     throw new UnauthorizedError({ name: "No auth method defined" });
   }
 
   if (
+    orgRole !== OrgMembershipRole.Admin &&
     isOrgSsoEnforced &&
     actorAuthMethod !== null &&
     !isAuthMethodSaml(actorAuthMethod) &&

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -139,7 +139,7 @@ export const permissionServiceFactory = ({
       throw new ForbiddenRequestError({ name: "You are not logged into this organization" });
     }
 
-    validateOrgSSO(authMethod, membership.orgAuthEnforced);
+    validateOrgSSO(authMethod, membership.orgAuthEnforced, membership.role as OrgMembershipRole);
 
     const finalPolicyRoles = [{ role: membership.role, permissions: membership.permissions }].concat(
       membership?.groups?.map(({ role, customRolePermission }) => ({
@@ -226,7 +226,7 @@ export const permissionServiceFactory = ({
       throw new ForbiddenRequestError({ name: "You are not logged into this organization" });
     }
 
-    validateOrgSSO(authMethod, userProjectPermission.orgAuthEnforced);
+    validateOrgSSO(authMethod, userProjectPermission.orgAuthEnforced, userProjectPermission.orgRole);
 
     if (actionProjectType !== ActionProjectType.Any && actionProjectType !== userProjectPermission.projectType) {
       throw new BadRequestError({

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -139,7 +139,12 @@ export const permissionServiceFactory = ({
       throw new ForbiddenRequestError({ name: "You are not logged into this organization" });
     }
 
-    validateOrgSSO(authMethod, membership.orgAuthEnforced, membership.role as OrgMembershipRole);
+    validateOrgSSO(
+      authMethod,
+      membership.orgAuthEnforced,
+      membership.enableBypassOrgAuth,
+      membership.role as OrgMembershipRole
+    );
 
     const finalPolicyRoles = [{ role: membership.role, permissions: membership.permissions }].concat(
       membership?.groups?.map(({ role, customRolePermission }) => ({
@@ -226,7 +231,12 @@ export const permissionServiceFactory = ({
       throw new ForbiddenRequestError({ name: "You are not logged into this organization" });
     }
 
-    validateOrgSSO(authMethod, userProjectPermission.orgAuthEnforced, userProjectPermission.orgRole);
+    validateOrgSSO(
+      authMethod,
+      userProjectPermission.orgAuthEnforced,
+      userProjectPermission.enableBypassOrgAuth,
+      userProjectPermission.orgRole
+    );
 
     if (actionProjectType !== ActionProjectType.Any && actionProjectType !== userProjectPermission.projectType) {
       throw new BadRequestError({

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -142,7 +142,7 @@ export const permissionServiceFactory = ({
     validateOrgSSO(
       authMethod,
       membership.orgAuthEnforced,
-      membership.enableBypassOrgAuth,
+      membership.bypassOrgAuthEnabled,
       membership.role as OrgMembershipRole
     );
 
@@ -234,7 +234,7 @@ export const permissionServiceFactory = ({
     validateOrgSSO(
       authMethod,
       userProjectPermission.orgAuthEnforced,
-      userProjectPermission.enableBypassOrgAuth,
+      userProjectPermission.bypassOrgAuthEnabled,
       userProjectPermission.orgRole
     );
 

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -31,7 +31,8 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         200: z.object({
           organizations: sanitizedOrganizationSchema
             .extend({
-              orgAuthMethod: z.string()
+              orgAuthMethod: z.string(),
+              userRole: z.string()
             })
             .array()
         })

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -260,7 +260,8 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         defaultMembershipRoleSlug: slugSchema({ max: 64, field: "Default Membership Role" }).optional(),
         enforceMfa: z.boolean().optional(),
         selectedMfaMethod: z.nativeEnum(MfaMethod).optional(),
-        allowSecretSharingOutsideOrganization: z.boolean().optional()
+        allowSecretSharingOutsideOrganization: z.boolean().optional(),
+        enableBypassOrgAuth: z.boolean().optional()
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -261,7 +261,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         enforceMfa: z.boolean().optional(),
         selectedMfaMethod: z.nativeEnum(MfaMethod).optional(),
         allowSecretSharingOutsideOrganization: z.boolean().optional(),
-        enableBypassOrgAuth: z.boolean().optional()
+        bypassOrgAuthEnabled: z.boolean().optional()
       }),
       response: {
         200: z.object({

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -96,7 +96,9 @@ export const orgDALFactory = (db: TDbClient) => {
   };
 
   // special query
-  const findAllOrgsByUserId = async (userId: string): Promise<(TOrganizations & { orgAuthMethod: string })[]> => {
+  const findAllOrgsByUserId = async (
+    userId: string
+  ): Promise<(TOrganizations & { orgAuthMethod: string; userRole: string })[]> => {
     try {
       const org = (await db
         .replicaNode()(TableName.OrgMembership)
@@ -117,6 +119,7 @@ export const orgDALFactory = (db: TDbClient) => {
           );
         })
         .select(selectAllTableCols(TableName.Organization))
+        .select(db.ref("role").withSchema(TableName.OrgMembership).as("userRole"))
         .select(
           db.raw(`
             CASE
@@ -125,7 +128,7 @@ export const orgDALFactory = (db: TDbClient) => {
               ELSE ''
             END as "orgAuthMethod"
         `)
-        )) as (TOrganizations & { orgAuthMethod: string })[];
+        )) as (TOrganizations & { orgAuthMethod: string; userRole: string })[];
 
       return org;
     } catch (error) {

--- a/backend/src/services/org/org-schema.ts
+++ b/backend/src/services/org/org-schema.ts
@@ -17,5 +17,5 @@ export const sanitizedOrganizationSchema = OrganizationsSchema.pick({
   shouldUseNewPrivilegeSystem: true,
   privilegeUpgradeInitiatedByUsername: true,
   privilegeUpgradeInitiatedAt: true,
-  enableBypassOrgAuth: true
+  bypassOrgAuthEnabled: true
 });

--- a/backend/src/services/org/org-schema.ts
+++ b/backend/src/services/org/org-schema.ts
@@ -16,5 +16,6 @@ export const sanitizedOrganizationSchema = OrganizationsSchema.pick({
   allowSecretSharingOutsideOrganization: true,
   shouldUseNewPrivilegeSystem: true,
   privilegeUpgradeInitiatedByUsername: true,
-  privilegeUpgradeInitiatedAt: true
+  privilegeUpgradeInitiatedAt: true,
+  enableBypassOrgAuth: true
 });

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -350,7 +350,7 @@ export const orgServiceFactory = ({
       enforceMfa,
       selectedMfaMethod,
       allowSecretSharingOutsideOrganization,
-      enableBypassOrgAuth
+      bypassOrgAuthEnabled
     }
   }: TUpdateOrgDTO) => {
     const appCfg = getConfig();
@@ -431,7 +431,7 @@ export const orgServiceFactory = ({
       enforceMfa,
       selectedMfaMethod,
       allowSecretSharingOutsideOrganization,
-      enableBypassOrgAuth
+      bypassOrgAuthEnabled
     });
     if (!org) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
     return org;

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -349,7 +349,8 @@ export const orgServiceFactory = ({
       defaultMembershipRoleSlug,
       enforceMfa,
       selectedMfaMethod,
-      allowSecretSharingOutsideOrganization
+      allowSecretSharingOutsideOrganization,
+      enableBypassOrgAuth
     }
   }: TUpdateOrgDTO) => {
     const appCfg = getConfig();
@@ -429,7 +430,8 @@ export const orgServiceFactory = ({
       defaultMembershipRole,
       enforceMfa,
       selectedMfaMethod,
-      allowSecretSharingOutsideOrganization
+      allowSecretSharingOutsideOrganization,
+      enableBypassOrgAuth
     });
     if (!org) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
     return org;

--- a/backend/src/services/org/org-types.ts
+++ b/backend/src/services/org/org-types.ts
@@ -73,6 +73,7 @@ export type TUpdateOrgDTO = {
     enforceMfa: boolean;
     selectedMfaMethod: MfaMethod;
     allowSecretSharingOutsideOrganization: boolean;
+    enableBypassOrgAuth: boolean;
   }>;
 } & TOrgPermission;
 

--- a/backend/src/services/org/org-types.ts
+++ b/backend/src/services/org/org-types.ts
@@ -73,7 +73,7 @@ export type TUpdateOrgDTO = {
     enforceMfa: boolean;
     selectedMfaMethod: MfaMethod;
     allowSecretSharingOutsideOrganization: boolean;
-    enableBypassOrgAuth: boolean;
+    bypassOrgAuthEnabled: boolean;
   }>;
 } & TOrgPermission;
 

--- a/docs/documentation/platform/sso/auth0-oidc.mdx
+++ b/docs/documentation/platform/sso/auth0-oidc.mdx
@@ -65,7 +65,9 @@ description: "Learn how to configure Auth0 OIDC for Infisical SSO."
          We recommend ensuring that your account is provisioned using the application in Auth0
          prior to enforcing OIDC SSO to prevent any unintended issues.
       </Warning>
-
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
    </Step>
 </Steps>
 

--- a/docs/documentation/platform/sso/auth0-saml.mdx
+++ b/docs/documentation/platform/sso/auth0-saml.mdx
@@ -72,6 +72,10 @@ description: "Learn how to configure Auth0 SAML for Infisical SSO."
 
         To enforce SAML SSO, you're required to test out the SAML connection by successfully authenticating at least one Auth0 user with Infisical;
         Once you've completed this requirement, you can toggle the **Enforce SAML SSO** button to enforce SAML SSO.
+
+        <Info>
+            In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+        </Info>
     </Step>
 
 </Steps>

--- a/docs/documentation/platform/sso/azure.mdx
+++ b/docs/documentation/platform/sso/azure.mdx
@@ -106,6 +106,9 @@ description: "Learn how to configure Microsoft Entra ID for Infisical SSO."
          We recommend ensuring that your account is provisioned the application in Azure
          prior to enforcing SAML SSO to prevent any unintended issues.
       </Warning>
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
    </Step>
 </Steps>
 

--- a/docs/documentation/platform/sso/general-oidc.mdx
+++ b/docs/documentation/platform/sso/general-oidc.mdx
@@ -66,6 +66,9 @@ Prerequisites:
       <Warning>
          We recommend ensuring that your account is provisioned using the identity provider prior to enforcing OIDC SSO to prevent any unintended issues.
       </Warning>
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
     </Step>
 
   </Steps>

--- a/docs/documentation/platform/sso/google-saml.mdx
+++ b/docs/documentation/platform/sso/google-saml.mdx
@@ -81,6 +81,9 @@ description: "Learn how to configure Google SAML for Infisical SSO."
             We recommend ensuring that your account is provisioned the application in Google
             prior to enforcing SAML SSO to prevent any unintended issues.
         </Warning>
+        <Info>
+            In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+        </Info>
     </Step>
 
 </Steps>

--- a/docs/documentation/platform/sso/jumpcloud.mdx
+++ b/docs/documentation/platform/sso/jumpcloud.mdx
@@ -86,6 +86,9 @@ description: "Learn how to configure JumpCloud SAML for Infisical SSO."
          We recommend ensuring that your account is provisioned the application in JumpCloud
          prior to enforcing SAML SSO to prevent any unintended issues.
       </Warning>
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
    </Step>
 </Steps>
 

--- a/docs/documentation/platform/sso/keycloak-oidc/overview.mdx
+++ b/docs/documentation/platform/sso/keycloak-oidc/overview.mdx
@@ -92,7 +92,9 @@ description: "Learn how to configure Keycloak OIDC for Infisical SSO."
             We recommend ensuring that your account is provisioned using the application in Keycloak
             prior to enforcing OIDC SSO to prevent any unintended issues.
         </Warning>
-
+        <Info>
+            In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+        </Info>
     </Step>
 </Steps>
 

--- a/docs/documentation/platform/sso/keycloak-saml.mdx
+++ b/docs/documentation/platform/sso/keycloak-saml.mdx
@@ -127,6 +127,9 @@ description: "Learn how to configure Keycloak SAML for Infisical SSO."
          We recommend ensuring that your account is provisioned the application in Keycloak
          prior to enforcing SAML SSO to prevent any unintended issues.
       </Warning>
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
    </Step>
 </Steps>
 

--- a/docs/documentation/platform/sso/okta.mdx
+++ b/docs/documentation/platform/sso/okta.mdx
@@ -94,6 +94,9 @@ description: "Learn how to configure Okta SAML 2.0 for Infisical SSO."
          We recommend ensuring that your account is provisioned the application in Okta
          prior to enforcing SAML SSO to prevent any unintended issues.
       </Warning>
+      <Info>
+         In case of a lockout, an organization admin can use the admin login portal in the `/login/admin` path e.g. https://app.infisical.com/login/admin.
+      </Info>
 
    </Step>
 </Steps>

--- a/frontend/src/helpers/roles.ts
+++ b/frontend/src/helpers/roles.ts
@@ -1,6 +1,6 @@
 import { ProjectMembershipRole, TOrgRole } from "@app/hooks/api/roles/types";
 
-enum OrgMembershipRole {
+export enum OrgMembershipRole {
   Admin = "admin",
   Member = "member",
   NoAccess = "no-access"

--- a/frontend/src/hooks/api/organization/queries.tsx
+++ b/frontend/src/hooks/api/organization/queries.tsx
@@ -110,7 +110,8 @@ export const useUpdateOrg = () => {
       defaultMembershipRoleSlug,
       enforceMfa,
       selectedMfaMethod,
-      allowSecretSharingOutsideOrganization
+      allowSecretSharingOutsideOrganization,
+      enableBypassOrgAuth
     }) => {
       return apiRequest.patch(`/api/v1/organization/${orgId}`, {
         name,
@@ -120,7 +121,8 @@ export const useUpdateOrg = () => {
         defaultMembershipRoleSlug,
         enforceMfa,
         selectedMfaMethod,
-        allowSecretSharingOutsideOrganization
+        allowSecretSharingOutsideOrganization,
+        enableBypassOrgAuth
       });
     },
     onSuccess: () => {

--- a/frontend/src/hooks/api/organization/queries.tsx
+++ b/frontend/src/hooks/api/organization/queries.tsx
@@ -111,7 +111,7 @@ export const useUpdateOrg = () => {
       enforceMfa,
       selectedMfaMethod,
       allowSecretSharingOutsideOrganization,
-      enableBypassOrgAuth
+      bypassOrgAuthEnabled
     }) => {
       return apiRequest.patch(`/api/v1/organization/${orgId}`, {
         name,
@@ -122,7 +122,7 @@ export const useUpdateOrg = () => {
         enforceMfa,
         selectedMfaMethod,
         allowSecretSharingOutsideOrganization,
-        enableBypassOrgAuth
+        bypassOrgAuthEnabled
       });
     },
     onSuccess: () => {

--- a/frontend/src/hooks/api/organization/types.ts
+++ b/frontend/src/hooks/api/organization/types.ts
@@ -9,6 +9,7 @@ export type Organization = {
   createAt: string;
   updatedAt: string;
   authEnforced: boolean;
+  enableBypassOrgAuth: boolean;
   orgAuthMethod: string;
   scimEnabled: boolean;
   slug: string;
@@ -30,6 +31,7 @@ export type UpdateOrgDTO = {
   enforceMfa?: boolean;
   selectedMfaMethod?: MfaMethod;
   allowSecretSharingOutsideOrganization?: boolean;
+  enableBypassOrgAuth?: boolean;
 };
 
 export type BillingDetails = {

--- a/frontend/src/hooks/api/organization/types.ts
+++ b/frontend/src/hooks/api/organization/types.ts
@@ -17,6 +17,7 @@ export type Organization = {
   selectedMfaMethod?: MfaMethod;
   shouldUseNewPrivilegeSystem: boolean;
   allowSecretSharingOutsideOrganization?: boolean;
+  userRole: string;
 };
 
 export type UpdateOrgDTO = {

--- a/frontend/src/hooks/api/organization/types.ts
+++ b/frontend/src/hooks/api/organization/types.ts
@@ -9,7 +9,7 @@ export type Organization = {
   createAt: string;
   updatedAt: string;
   authEnforced: boolean;
-  enableBypassOrgAuth: boolean;
+  bypassOrgAuthEnabled: boolean;
   orgAuthMethod: string;
   scimEnabled: boolean;
   slug: string;
@@ -31,7 +31,7 @@ export type UpdateOrgDTO = {
   enforceMfa?: boolean;
   selectedMfaMethod?: MfaMethod;
   allowSecretSharingOutsideOrganization?: boolean;
-  enableBypassOrgAuth?: boolean;
+  bypassOrgAuthEnabled?: boolean;
 };
 
 export type BillingDetails = {

--- a/frontend/src/pages/auth/AdminLoginPage/route.tsx
+++ b/frontend/src/pages/auth/AdminLoginPage/route.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { LoginPage } from "../LoginPage/LoginPage";
+
+export const Route = createFileRoute("/_restrict-login-signup/login/admin")({
+  component: () => <LoginPage isAdmin />
+});

--- a/frontend/src/pages/auth/LoginPage/Login.utils.tsx
+++ b/frontend/src/pages/auth/LoginPage/Login.utils.tsx
@@ -33,14 +33,21 @@ export const useNavigateToSelectOrganization = () => {
   const { config } = useServerConfig();
   const navigate = useNavigate();
 
-  const navigateToSelectOrganization = async (cliCallbackPort?: string) => {
+  const navigateToSelectOrganization = async (
+    cliCallbackPort?: string,
+    isFromAdminLogin?: boolean
+  ) => {
     if (!config.defaultAuthOrgId) {
       queryClient.invalidateQueries({ queryKey: userKeys.getUser });
     }
 
     navigate({
       to: "/login/select-organization",
-      search: { callback_port: cliCallbackPort, org_id: config.defaultAuthOrgId }
+      search: {
+        callback_port: cliCallbackPort,
+        org_id: config.defaultAuthOrgId,
+        is_admin_login: isFromAdminLogin
+      }
     });
   };
 

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -8,7 +8,7 @@ import { isLoggedIn } from "@app/hooks/api/reactQuery";
 import { InitialStep, SSOStep } from "./components";
 import { useNavigateToSelectOrganization } from "./Login.utils";
 
-export const LoginPage = () => {
+export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
   const { t } = useTranslation();
   const [step, setStep] = useState(0);
   const [email, setEmail] = useState("");
@@ -44,6 +44,7 @@ export const LoginPage = () => {
       case 0:
         return (
           <InitialStep
+            isAdmin={isAdmin}
             setStep={setStep}
             email={email}
             setEmail={setEmail}

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -130,7 +130,7 @@ export const InitialStep = ({
 
         if (isLoginSuccessful && isLoginSuccessful.success) {
           // case: login was successful
-          navigateToSelectOrganization();
+          navigateToSelectOrganization(undefined, isAdmin);
           createNotification({
             text: "Successfully logged in",
             type: "success"

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -34,6 +34,7 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [loginError, setLoginError] = useState(false);
+  const [isOtherLoginMethodsSelected, setIsOtherLoginMethodsSelected] = useState(false);
   const { config } = useServerConfig();
   const queryParams = new URLSearchParams(window.location.search);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -160,7 +161,11 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
     setIsLoading(false);
   };
 
-  if (config.defaultAuthOrgAuthEnforced && config.defaultAuthOrgAuthMethod) {
+  if (
+    config.defaultAuthOrgAuthEnforced &&
+    config.defaultAuthOrgAuthMethod &&
+    !isOtherLoginMethodsSelected
+  ) {
     return (
       <form
         onSubmit={handleLogin}
@@ -196,6 +201,14 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
             </Button>
           </div>
         )}
+        <Button
+          colorSchema="gray"
+          variant="link"
+          className="mt-6 font-normal text-mineshaft-400 transition-all duration-75 hover:text-mineshaft-300"
+          onClick={() => setIsOtherLoginMethodsSelected(true)}
+        >
+          Continue with other login methods
+        </Button>
       </form>
     );
   }

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -26,15 +26,22 @@ type Props = {
   setEmail: (email: string) => void;
   password: string;
   setPassword: (email: string) => void;
+  isAdmin?: boolean;
 };
 
-export const InitialStep = ({ setStep, email, setEmail, password, setPassword }: Props) => {
+export const InitialStep = ({
+  setStep,
+  email,
+  setEmail,
+  password,
+  setPassword,
+  isAdmin
+}: Props) => {
   const navigate = useNavigate();
 
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [loginError, setLoginError] = useState(false);
-  const [isOtherLoginMethodsSelected, setIsOtherLoginMethodsSelected] = useState(false);
   const { config } = useServerConfig();
   const queryParams = new URLSearchParams(window.location.search);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -63,7 +70,9 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
   };
 
   useEffect(() => {
-    if (serverDetails?.samlDefaultOrgSlug) redirectToSaml(serverDetails.samlDefaultOrgSlug);
+    if (serverDetails?.samlDefaultOrgSlug && !isAdmin) {
+      redirectToSaml(serverDetails.samlDefaultOrgSlug);
+    }
   }, [serverDetails?.samlDefaultOrgSlug]);
 
   const handleSaml = () => {
@@ -83,7 +92,7 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
   };
 
   const shouldDisplayLoginMethod = (method: LoginMethod) =>
-    !config.enabledLoginMethods || config.enabledLoginMethods.includes(method);
+    isAdmin || !config.enabledLoginMethods || config.enabledLoginMethods.includes(method);
 
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -161,11 +170,7 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
     setIsLoading(false);
   };
 
-  if (
-    config.defaultAuthOrgAuthEnforced &&
-    config.defaultAuthOrgAuthMethod &&
-    !isOtherLoginMethodsSelected
-  ) {
+  if (config.defaultAuthOrgAuthEnforced && config.defaultAuthOrgAuthMethod && !isAdmin) {
     return (
       <form
         onSubmit={handleLogin}
@@ -201,14 +206,6 @@ export const InitialStep = ({ setStep, email, setEmail, password, setPassword }:
             </Button>
           </div>
         )}
-        <Button
-          colorSchema="gray"
-          variant="link"
-          className="mt-6 font-normal text-mineshaft-400 transition-all duration-75 hover:text-mineshaft-300"
-          onClick={() => setIsOtherLoginMethodsSelected(true)}
-        >
-          Continue with other login methods
-        </Button>
       </form>
     );
   }

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -14,6 +14,7 @@ import { IsCliLoginSuccessful } from "@app/components/utilities/attemptCliLogin"
 import SecurityClient from "@app/components/utilities/SecurityClient";
 import { Button, Spinner } from "@app/components/v2";
 import { SessionStorageKeys } from "@app/const";
+import { OrgMembershipRole } from "@app/helpers/roles";
 import { useToggle } from "@app/hooks";
 import {
   useGetOrganizations,
@@ -68,7 +69,7 @@ export const SelectOrganizationPage = () => {
 
   const handleSelectOrganization = useCallback(
     async (organization: Organization) => {
-      if (organization.authEnforced) {
+      if (organization.authEnforced && organization.userRole !== OrgMembershipRole.Admin) {
         // org has an org-level auth method enabled (e.g. SAML)
         // -> logout + redirect to SAML SSO
         await logout.mutateAsync();

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -71,7 +71,7 @@ export const SelectOrganizationPage = () => {
   const handleSelectOrganization = useCallback(
     async (organization: Organization) => {
       const canBypassOrgAuth =
-        organization.enableBypassOrgAuth &&
+        organization.bypassOrgAuthEnabled &&
         organization.userRole === OrgMembershipRole.Admin &&
         isAdminLogin;
 

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -69,7 +69,10 @@ export const SelectOrganizationPage = () => {
 
   const handleSelectOrganization = useCallback(
     async (organization: Organization) => {
-      if (organization.authEnforced && organization.userRole !== OrgMembershipRole.Admin) {
+      const canBypassOrgAuth =
+        organization.enableBypassOrgAuth && organization.userRole === OrgMembershipRole.Admin;
+
+      if (organization.authEnforced && !canBypassOrgAuth) {
         // org has an org-level auth method enabled (e.g. SAML)
         // -> logout + redirect to SAML SSO
         await logout.mutateAsync();

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -54,6 +54,7 @@ export const SelectOrganizationPage = () => {
   const queryParams = new URLSearchParams(window.location.search);
   const orgId = queryParams.get("org_id");
   const callbackPort = queryParams.get("callback_port");
+  const isAdminLogin = queryParams.get("is_admin_login") === "true";
   const defaultSelectedOrg = organizations.data?.find((org) => org.id === orgId);
 
   const logout = useLogoutUser(true);
@@ -70,7 +71,9 @@ export const SelectOrganizationPage = () => {
   const handleSelectOrganization = useCallback(
     async (organization: Organization) => {
       const canBypassOrgAuth =
-        organization.enableBypassOrgAuth && organization.userRole === OrgMembershipRole.Admin;
+        organization.enableBypassOrgAuth &&
+        organization.userRole === OrgMembershipRole.Admin &&
+        isAdminLogin;
 
       if (organization.authEnforced && !canBypassOrgAuth) {
         // org has an org-level auth method enabled (e.g. SAML)

--- a/frontend/src/pages/auth/SelectOrgPage/route.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/route.tsx
@@ -6,13 +6,16 @@ import { SelectOrganizationPage } from "./SelectOrgPage";
 
 export const SelectOrganizationPageQueryParams = z.object({
   org_id: z.string().optional().catch(""),
-  callback_port: z.coerce.number().optional().catch(undefined)
+  callback_port: z.coerce.number().optional().catch(undefined),
+  is_admin_login: z.boolean().optional().catch(false)
 });
 
 export const Route = createFileRoute("/_restrict-login-signup/login/select-organization")({
   component: SelectOrganizationPage,
   validateSearch: zodValidator(SelectOrganizationPageQueryParams),
   search: {
-    middlewares: [stripSearchParams({ org_id: "", callback_port: undefined })]
+    middlewares: [
+      stripSearchParams({ org_id: "", callback_port: undefined, is_admin_login: false })
+    ]
   }
 });

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -58,7 +58,7 @@ export const OrgGeneralAuthSection = () => {
   const handleEnableBypassOrgAuthToggle = async (value: boolean) => {
     try {
       if (!currentOrg?.id) return;
-      if (!subscription?.oidcSSO) {
+      if (!subscription?.samlSSO) {
         handlePopUpOpen("upgradePlan");
         return;
       }
@@ -144,7 +144,7 @@ export const OrgGeneralAuthSection = () => {
           </div>
           <p className="text-sm text-mineshaft-300">
             <span>
-              Allow organization admins to bypass OIDC enforcement when SSO is unavailable,
+              Allow organization admins to bypass SAML enforcement when SSO is unavailable,
               misconfigured, or inaccessible.
             </span>
           </p>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -85,7 +85,7 @@ export const OrgGeneralAuthSection = () => {
           </OrgPermissionCan>
         </div>
         <p className="text-sm text-mineshaft-300">
-          Enforce members to authenticate via SAML to access this organization
+          Enforce non-admin users to authenticate via SAML to access this organization
         </p>
       </div>
       <UpgradePlanModal

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -122,7 +122,25 @@ export const OrgGeneralAuthSection = () => {
               <span className="text-md text-mineshaft-100">Enable Admin SSO Bypass</span>
               <Tooltip
                 className="max-w-lg"
-                content="When this is enabled, we strongly recommend enforcing MFA at the organization level."
+                content={
+                  <div>
+                    <span>
+                      When this is enabled, we strongly recommend enforcing MFA at the organization
+                      level.
+                    </span>
+                    <p className="mt-4">
+                      In case of a lockout, admins can use the admin login portal{" "}
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-2 hover:text-mineshaft-300"
+                        href={`${window.location.origin}/login/admin`}
+                      >
+                        here.
+                      </a>
+                    </p>
+                  </div>
+                }
               >
                 <FontAwesomeIcon
                   icon={faInfoCircle}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -129,14 +129,14 @@ export const OrgGeneralAuthSection = () => {
                       level.
                     </span>
                     <p className="mt-4">
-                      In case of a lockout, admins can use the admin login portal{" "}
+                      In case of a lockout, admins can use the admin login portal in{" "}
                       <a
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline underline-offset-2 hover:text-mineshaft-300"
                         href={`${window.location.origin}/login/admin`}
                       >
-                        here.
+                        {window.location.origin}/login/admin
                       </a>
                     </p>
                   </div>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -1,7 +1,10 @@
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Switch } from "@app/components/v2";
+import { Switch, Tooltip } from "@app/components/v2";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -72,7 +75,38 @@ export const OrgGeneralAuthSection = () => {
             </div> */}
       <div className="py-4">
         <div className="mb-2 flex justify-between">
-          <h3 className="text-md text-mineshaft-100">Enforce SAML SSO</h3>
+          <div className="flex items-center gap-1">
+            <span className="text-md text-mineshaft-100">Enforce SAML SSO</span>
+            <Tooltip
+              className="max-w-lg"
+              content={
+                <div>
+                  <span>
+                    Login enforcement is only applied to non-admin users in order to prevent total
+                    lockout from the organization when the SAML provider is unavailable.
+                  </span>
+
+                  <p className="mt-4">
+                    In case of a lockout, use the admin login portal{" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2 hover:text-mineshaft-300"
+                      href={`${window.location.origin}/admin/login`}
+                    >
+                      here.
+                    </a>
+                  </p>
+                </div>
+              }
+            >
+              <FontAwesomeIcon
+                icon={faInfoCircle}
+                size="sm"
+                className="mt-0.5 inline-block text-mineshaft-400"
+              />
+            </Tooltip>
+          </div>
           <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
             {(isAllowed) => (
               <Switch

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -55,6 +55,28 @@ export const OrgGeneralAuthSection = () => {
     }
   };
 
+  const handleEnableBypassOrgAuthToggle = async (value: boolean) => {
+    try {
+      if (!currentOrg?.id) return;
+      if (!subscription?.oidcSSO) {
+        handlePopUpOpen("upgradePlan");
+        return;
+      }
+
+      await mutateAsync({
+        orgId: currentOrg?.id,
+        enableBypassOrgAuth: value
+      });
+
+      createNotification({
+        text: `Successfully ${value ? "enabled" : "disabled"} admin bypassing of org-level auth`,
+        type: "success"
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <>
       {/* <div className="py-4">
@@ -77,35 +99,6 @@ export const OrgGeneralAuthSection = () => {
         <div className="mb-2 flex justify-between">
           <div className="flex items-center gap-1">
             <span className="text-md text-mineshaft-100">Enforce SAML SSO</span>
-            <Tooltip
-              className="max-w-lg"
-              content={
-                <div>
-                  <span>
-                    Login enforcement is only applied to non-admin users in order to prevent total
-                    lockout from the organization when the SAML provider is unavailable.
-                  </span>
-
-                  <p className="mt-4">
-                    In case of a lockout, use the admin login portal{" "}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline underline-offset-2 hover:text-mineshaft-300"
-                      href={`${window.location.origin}/admin/login`}
-                    >
-                      here.
-                    </a>
-                  </p>
-                </div>
-              }
-            >
-              <FontAwesomeIcon
-                icon={faInfoCircle}
-                size="sm"
-                className="mt-0.5 inline-block text-mineshaft-400"
-              />
-            </Tooltip>
           </div>
           <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
             {(isAllowed) => (
@@ -119,9 +112,44 @@ export const OrgGeneralAuthSection = () => {
           </OrgPermissionCan>
         </div>
         <p className="text-sm text-mineshaft-300">
-          Enforce non-admin users to authenticate via SAML to access this organization
+          Enforce users to authenticate via SAML to access this organization
         </p>
       </div>
+      {currentOrg?.authEnforced && (
+        <div className="py-4">
+          <div className="mb-2 flex justify-between">
+            <div className="flex items-center gap-1">
+              <span className="text-md text-mineshaft-100">Enable Admin SSO Bypass</span>
+              <Tooltip
+                className="max-w-lg"
+                content="When this is enabled, we strongly recommend enforcing MFA at the organization level."
+              >
+                <FontAwesomeIcon
+                  icon={faInfoCircle}
+                  size="sm"
+                  className="mt-0.5 inline-block text-mineshaft-400"
+                />
+              </Tooltip>
+            </div>
+            <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
+              {(isAllowed) => (
+                <Switch
+                  id="allow-admin-bypass"
+                  isChecked={currentOrg?.enableBypassOrgAuth ?? false}
+                  onCheckedChange={(value) => handleEnableBypassOrgAuthToggle(value)}
+                  isDisabled={!isAllowed}
+                />
+              )}
+            </OrgPermissionCan>
+          </div>
+          <p className="text-sm text-mineshaft-300">
+            <span>
+              Allow organization admins to bypass OIDC enforcement when SSO is unavailable,
+              misconfigured, or inaccessible.
+            </span>
+          </p>
+        </div>
+      )}
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgGeneralAuthSection.tsx
@@ -65,7 +65,7 @@ export const OrgGeneralAuthSection = () => {
 
       await mutateAsync({
         orgId: currentOrg?.id,
-        enableBypassOrgAuth: value
+        bypassOrgAuthEnabled: value
       });
 
       createNotification({
@@ -129,7 +129,7 @@ export const OrgGeneralAuthSection = () => {
                       level.
                     </span>
                     <p className="mt-4">
-                      In case of a lockout, admins can use the admin login portal in{" "}
+                      In case of a lockout, admins can use the admin login portal at{" "}
                       <a
                         target="_blank"
                         rel="noopener noreferrer"
@@ -153,7 +153,7 @@ export const OrgGeneralAuthSection = () => {
               {(isAllowed) => (
                 <Switch
                   id="allow-admin-bypass"
-                  isChecked={currentOrg?.enableBypassOrgAuth ?? false}
+                  isChecked={currentOrg?.bypassOrgAuthEnabled ?? false}
                   onCheckedChange={(value) => handleEnableBypassOrgAuthToggle(value)}
                   isDisabled={!isAllowed}
                 />

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -158,7 +158,38 @@ export const OrgOIDCSection = (): JSX.Element => {
       )}
       <div className="py-4">
         <div className="mb-2 flex justify-between">
-          <h3 className="text-md text-mineshaft-100">Enforce OIDC SSO</h3>
+          <div className="flex items-center gap-1">
+            <span className="text-md text-mineshaft-100">Enforce OIDC SSO</span>
+            <Tooltip
+              className="max-w-lg"
+              content={
+                <div>
+                  <span>
+                    Login enforcement is only applied to non-admin users in order to prevent total
+                    lockout from the organization when the OIDC provider is unavailable.
+                  </span>
+
+                  <p className="mt-4">
+                    In case of a lockout, use the admin login portal{" "}
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2 hover:text-mineshaft-300"
+                      href={`${window.location.origin}/admin/login`}
+                    >
+                      here.
+                    </a>
+                  </p>
+                </div>
+              }
+            >
+              <FontAwesomeIcon
+                icon={faInfoCircle}
+                size="sm"
+                className="mt-0.5 inline-block text-mineshaft-400"
+              />
+            </Tooltip>
+          </div>
           <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
             {(isAllowed) => (
               <Switch
@@ -171,7 +202,7 @@ export const OrgOIDCSection = (): JSX.Element => {
           </OrgPermissionCan>
         </div>
         <p className="text-sm text-mineshaft-300">
-          Enforce non-admin users to authenticate via OIDC to access this organization.
+          <span>Enforce non-admin users to authenticate via OIDC to access this organization.</span>
         </p>
       </div>
       <div className="py-4">

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -92,7 +92,7 @@ export const OrgOIDCSection = (): JSX.Element => {
 
       await updateOrg({
         orgId: currentOrg?.id,
-        enableBypassOrgAuth: value
+        bypassOrgAuthEnabled: value
       });
 
       createNotification({
@@ -212,7 +212,7 @@ export const OrgOIDCSection = (): JSX.Element => {
                       level.
                     </span>
                     <p className="mt-4">
-                      In case of a lockout, admins can use the admin login portal in{" "}
+                      In case of a lockout, admins can use the admin login portal at{" "}
                       <a
                         target="_blank"
                         rel="noopener noreferrer"
@@ -236,7 +236,7 @@ export const OrgOIDCSection = (): JSX.Element => {
               {(isAllowed) => (
                 <Switch
                   id="allow-admin-bypass"
-                  isChecked={currentOrg?.enableBypassOrgAuth ?? false}
+                  isChecked={currentOrg?.bypassOrgAuthEnabled ?? false}
                   onCheckedChange={(value) => handleEnableBypassOrgAuthToggle(value)}
                   isDisabled={!isAllowed}
                 />

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -205,7 +205,25 @@ export const OrgOIDCSection = (): JSX.Element => {
               <span className="text-md text-mineshaft-100">Enable Admin SSO Bypass</span>
               <Tooltip
                 className="max-w-lg"
-                content="When this is enabled, we strongly recommend enforcing MFA at the organization level."
+                content={
+                  <div>
+                    <span>
+                      When this is enabled, we strongly recommend enforcing MFA at the organization
+                      level.
+                    </span>
+                    <p className="mt-4">
+                      In case of a lockout, admins can use the admin login portal{" "}
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-2 hover:text-mineshaft-300"
+                        href={`${window.location.origin}/login/admin`}
+                      >
+                        here.
+                      </a>
+                    </p>
+                  </div>
+                }
               >
                 <FontAwesomeIcon
                   icon={faInfoCircle}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -171,7 +171,7 @@ export const OrgOIDCSection = (): JSX.Element => {
           </OrgPermissionCan>
         </div>
         <p className="text-sm text-mineshaft-300">
-          Enforce members to authenticate via OIDC to access this organization
+          Enforce non-admin users to authenticate via OIDC to access this organization.
         </p>
       </div>
       <div className="py-4">

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -82,6 +82,28 @@ export const OrgOIDCSection = (): JSX.Element => {
     }
   };
 
+  const handleEnableBypassOrgAuthToggle = async (value: boolean) => {
+    try {
+      if (!currentOrg?.id) return;
+      if (!subscription?.oidcSSO) {
+        handlePopUpOpen("upgradePlan");
+        return;
+      }
+
+      await updateOrg({
+        orgId: currentOrg?.id,
+        enableBypassOrgAuth: value
+      });
+
+      createNotification({
+        text: `Successfully ${value ? "enabled" : "disabled"} admin bypassing of org-level auth`,
+        type: "success"
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   const handleOIDCGroupManagement = async (value: boolean) => {
     try {
       if (!currentOrg?.id) return;
@@ -160,35 +182,6 @@ export const OrgOIDCSection = (): JSX.Element => {
         <div className="mb-2 flex justify-between">
           <div className="flex items-center gap-1">
             <span className="text-md text-mineshaft-100">Enforce OIDC SSO</span>
-            <Tooltip
-              className="max-w-lg"
-              content={
-                <div>
-                  <span>
-                    Login enforcement is only applied to non-admin users in order to prevent total
-                    lockout from the organization when the OIDC provider is unavailable.
-                  </span>
-
-                  <p className="mt-4">
-                    In case of a lockout, use the admin login portal{" "}
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline underline-offset-2 hover:text-mineshaft-300"
-                      href={`${window.location.origin}/admin/login`}
-                    >
-                      here.
-                    </a>
-                  </p>
-                </div>
-              }
-            >
-              <FontAwesomeIcon
-                icon={faInfoCircle}
-                size="sm"
-                className="mt-0.5 inline-block text-mineshaft-400"
-              />
-            </Tooltip>
           </div>
           <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
             {(isAllowed) => (
@@ -202,9 +195,44 @@ export const OrgOIDCSection = (): JSX.Element => {
           </OrgPermissionCan>
         </div>
         <p className="text-sm text-mineshaft-300">
-          <span>Enforce non-admin users to authenticate via OIDC to access this organization.</span>
+          <span>Enforce users to authenticate via OIDC to access this organization.</span>
         </p>
       </div>
+      {currentOrg?.authEnforced && (
+        <div className="py-4">
+          <div className="mb-2 flex justify-between">
+            <div className="flex items-center gap-1">
+              <span className="text-md text-mineshaft-100">Enable Admin SSO Bypass</span>
+              <Tooltip
+                className="max-w-lg"
+                content="When this is enabled, we strongly recommend enforcing MFA at the organization level."
+              >
+                <FontAwesomeIcon
+                  icon={faInfoCircle}
+                  size="sm"
+                  className="mt-0.5 inline-block text-mineshaft-400"
+                />
+              </Tooltip>
+            </div>
+            <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
+              {(isAllowed) => (
+                <Switch
+                  id="allow-admin-bypass"
+                  isChecked={currentOrg?.enableBypassOrgAuth ?? false}
+                  onCheckedChange={(value) => handleEnableBypassOrgAuthToggle(value)}
+                  isDisabled={!isAllowed}
+                />
+              )}
+            </OrgPermissionCan>
+          </div>
+          <p className="text-sm text-mineshaft-300">
+            <span>
+              Allow organization admins to bypass OIDC enforcement when SSO is unavailable,
+              misconfigured, or inaccessible.
+            </span>
+          </p>
+        </div>
+      )}
       <div className="py-4">
         <div className="mb-2 flex justify-between">
           <div className="text-md flex items-center text-mineshaft-100">

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgOIDCSection.tsx
@@ -212,14 +212,14 @@ export const OrgOIDCSection = (): JSX.Element => {
                       level.
                     </span>
                     <p className="mt-4">
-                      In case of a lockout, admins can use the admin login portal{" "}
+                      In case of a lockout, admins can use the admin login portal in{" "}
                       <a
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline underline-offset-2 hover:text-mineshaft-300"
                         href={`${window.location.origin}/login/admin`}
                       >
-                        here.
+                        {window.location.origin}/login/admin
                       </a>
                     </p>
                   </div>

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as authSignUpSsoPageRouteImport } from './pages/auth/SignUpSsoPag
 import { Route as authLoginSsoPageRouteImport } from './pages/auth/LoginSsoPage/route'
 import { Route as authSelectOrgPageRouteImport } from './pages/auth/SelectOrgPage/route'
 import { Route as authLoginLdapPageRouteImport } from './pages/auth/LoginLdapPage/route'
+import { Route as authAdminLoginPageRouteImport } from './pages/auth/AdminLoginPage/route'
 import { Route as adminSignUpPageRouteImport } from './pages/admin/SignUpPage/route'
 import { Route as organizationNoOrgPageRouteImport } from './pages/organization/NoOrgPage/route'
 import { Route as authSignUpPageRouteImport } from './pages/auth/SignUpPage/route'
@@ -390,6 +391,12 @@ const authSelectOrgPageRouteRoute = authSelectOrgPageRouteImport.update({
 const authLoginLdapPageRouteRoute = authLoginLdapPageRouteImport.update({
   id: '/ldap',
   path: '/ldap',
+  getParentRoute: () => RestrictLoginSignupLoginRoute,
+} as any)
+
+const authAdminLoginPageRouteRoute = authAdminLoginPageRouteImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => RestrictLoginSignupLoginRoute,
 } as any)
 
@@ -1774,6 +1781,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/signup'
       preLoaderRoute: typeof adminSignUpPageRouteImport
       parentRoute: typeof middlewaresRestrictLoginSignupImport
+    }
+    '/_restrict-login-signup/login/admin': {
+      id: '/_restrict-login-signup/login/admin'
+      path: '/admin'
+      fullPath: '/login/admin'
+      preLoaderRoute: typeof authAdminLoginPageRouteImport
+      parentRoute: typeof RestrictLoginSignupLoginImport
     }
     '/_restrict-login-signup/login/ldap': {
       id: '/_restrict-login-signup/login/ldap'
@@ -3655,6 +3669,7 @@ const middlewaresAuthenticateRouteWithChildren =
 
 interface RestrictLoginSignupLoginRouteChildren {
   authLoginPageRouteRoute: typeof authLoginPageRouteRoute
+  authAdminLoginPageRouteRoute: typeof authAdminLoginPageRouteRoute
   authLoginLdapPageRouteRoute: typeof authLoginLdapPageRouteRoute
   authSelectOrgPageRouteRoute: typeof authSelectOrgPageRouteRoute
   authLoginSsoPageRouteRoute: typeof authLoginSsoPageRouteRoute
@@ -3665,6 +3680,7 @@ interface RestrictLoginSignupLoginRouteChildren {
 const RestrictLoginSignupLoginRouteChildren: RestrictLoginSignupLoginRouteChildren =
   {
     authLoginPageRouteRoute: authLoginPageRouteRoute,
+    authAdminLoginPageRouteRoute: authAdminLoginPageRouteRoute,
     authLoginLdapPageRouteRoute: authLoginLdapPageRouteRoute,
     authSelectOrgPageRouteRoute: authSelectOrgPageRouteRoute,
     authLoginSsoPageRouteRoute: authLoginSsoPageRouteRoute,
@@ -3739,6 +3755,7 @@ export interface FileRoutesByFullPath {
   '/signup/': typeof authSignUpPageRouteRoute
   '/organization/none': typeof organizationNoOrgPageRouteRoute
   '/admin/signup': typeof adminSignUpPageRouteRoute
+  '/login/admin': typeof authAdminLoginPageRouteRoute
   '/login/ldap': typeof authLoginLdapPageRouteRoute
   '/login/select-organization': typeof authSelectOrgPageRouteRoute
   '/login/sso': typeof authLoginSsoPageRouteRoute
@@ -3918,6 +3935,7 @@ export interface FileRoutesByTo {
   '/signup': typeof authSignUpPageRouteRoute
   '/organization/none': typeof organizationNoOrgPageRouteRoute
   '/admin/signup': typeof adminSignUpPageRouteRoute
+  '/login/admin': typeof authAdminLoginPageRouteRoute
   '/login/ldap': typeof authLoginLdapPageRouteRoute
   '/login/select-organization': typeof authSelectOrgPageRouteRoute
   '/login/sso': typeof authLoginSsoPageRouteRoute
@@ -4096,6 +4114,7 @@ export interface FileRoutesById {
   '/_restrict-login-signup/signup/': typeof authSignUpPageRouteRoute
   '/_authenticate/organization/none': typeof organizationNoOrgPageRouteRoute
   '/_restrict-login-signup/admin/signup': typeof adminSignUpPageRouteRoute
+  '/_restrict-login-signup/login/admin': typeof authAdminLoginPageRouteRoute
   '/_restrict-login-signup/login/ldap': typeof authLoginLdapPageRouteRoute
   '/_restrict-login-signup/login/select-organization': typeof authSelectOrgPageRouteRoute
   '/_restrict-login-signup/login/sso': typeof authLoginSsoPageRouteRoute
@@ -4286,6 +4305,7 @@ export interface FileRouteTypes {
     | '/signup/'
     | '/organization/none'
     | '/admin/signup'
+    | '/login/admin'
     | '/login/ldap'
     | '/login/select-organization'
     | '/login/sso'
@@ -4464,6 +4484,7 @@ export interface FileRouteTypes {
     | '/signup'
     | '/organization/none'
     | '/admin/signup'
+    | '/login/admin'
     | '/login/ldap'
     | '/login/select-organization'
     | '/login/sso'
@@ -4640,6 +4661,7 @@ export interface FileRouteTypes {
     | '/_restrict-login-signup/signup/'
     | '/_authenticate/organization/none'
     | '/_restrict-login-signup/admin/signup'
+    | '/_restrict-login-signup/login/admin'
     | '/_restrict-login-signup/login/ldap'
     | '/_restrict-login-signup/login/select-organization'
     | '/_restrict-login-signup/login/sso'
@@ -4928,6 +4950,7 @@ export const routeTree = rootRoute
       "parent": "/_restrict-login-signup",
       "children": [
         "/_restrict-login-signup/login/",
+        "/_restrict-login-signup/login/admin",
         "/_restrict-login-signup/login/ldap",
         "/_restrict-login-signup/login/select-organization",
         "/_restrict-login-signup/login/sso",
@@ -4958,6 +4981,10 @@ export const routeTree = rootRoute
     "/_restrict-login-signup/admin/signup": {
       "filePath": "admin/SignUpPage/route.tsx",
       "parent": "/_restrict-login-signup"
+    },
+    "/_restrict-login-signup/login/admin": {
+      "filePath": "auth/AdminLoginPage/route.tsx",
+      "parent": "/_restrict-login-signup/login"
     },
     "/_restrict-login-signup/login/ldap": {
       "filePath": "auth/LoginLdapPage/route.tsx",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -328,6 +328,7 @@ export const routes = rootRoute("root.tsx", [
     route("/admin/signup", "admin/SignUpPage/route.tsx"),
     route("/login", [
       index("auth/LoginPage/route.tsx"),
+      route("/admin", "auth/AdminLoginPage/route.tsx"),
       route("/select-organization", "auth/SelectOrgPage/route.tsx"),
       route("/sso", "auth/LoginSsoPage/route.tsx"),
       route("/ldap", "auth/LoginLdapPage/route.tsx"),


### PR DESCRIPTION
# Description 📣
This PR will allow organization admins to bypass SSO enforcement. This will serve as the break-glass mechanism for when SSO provider is down

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization APIs and UI now include the user's role within each organization.
  - Added "Enable Admin SSO Bypass" toggle in organization settings for SAML and OIDC enforcement.
  - Users with admin roles can view all login methods during authentication, bypassing default method restrictions.
  - Introduced a dedicated admin login page with a specialized login flow and route.
  - Admin users bypass login method restrictions that apply to regular users.
  - Admin login flow supports bypassing organization-level enforced authentication when enabled.

- **Bug Fixes**
  - SSO enforcement now applies only to non-admin users; admins are exempt from enforced SAML/OIDC login flows.
  - Admin users no longer get redirected to SSO login on organization selection if enforcement is enabled.

- **Documentation**
  - Updated organization authentication settings to clarify that SSO enforcement targets non-admin users.
  - Added notes across SSO documentation highlighting the admin login portal as a recovery option in case of lockout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->