### PR TITLE
Add confused deputy problem to AWS assume role docs

### DIFF
--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -56,7 +56,15 @@ Infisical supports two methods for connecting to AWS.
 
                 2. Select **AWS Account** as the **Trusted Entity Type**.
                 3. Choose **Another AWS Account** and enter **381492033652** (Infisical AWS Account ID). This restricts the role to be assumed only by Infisical. If self-hosting, provide your AWS account number instead.
-                4. Optionally, enable **Require external ID** and enter your **Organization ID** to further enhance security.
+                4. (Recommended) <strong>Enable "Require external ID"</strong> and input your **Organization ID** to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).
+
+                <Warning type="warning" title="Security Best Practice: Use External ID to Prevent Confused Deputy Attacks">
+                    When configuring an IAM Role that Infisical will assume, it’s highly recommended to enable the **"Require external ID"** option and specify your **Organization ID**.
+
+                    This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where a third party could be tricked into performing actions on your behalf by an unauthorized actor.
+
+                    <strong>Always enable "Require external ID" and use a unique value such as your Organization ID when setting up the IAM Role.</strong>
+                </Warning>
             </Step>
 
             <Step title="Add Required Permissions to the IAM Role">

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -61,9 +61,9 @@ Infisical supports two methods for connecting to AWS.
                 <Warning type="warning" title="Security Best Practice: Use External ID to Prevent Confused Deputy Attacks">
                     When configuring an IAM Role that Infisical will assume, it’s highly recommended to enable the **"Require external ID"** option and specify your **Organization ID**.
 
-                    This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where a third party could be tricked into performing actions on your behalf by an unauthorized actor.
+                    This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
-                    <strong>Always enable "Require external ID" and use a unique value such as your Organization ID when setting up the IAM Role.</strong>
+                    <strong>Always enable "Require external ID" and use your Organization ID when setting up the IAM Role.</strong>
                 </Warning>
             </Step>
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

![CleanShot 2025-04-15 at 15 45 34@2x](https://github.com/user-attachments/assets/5da5ce1b-6ac6-4376-abb1-cd30f96f943c)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated AWS integration guide to strongly recommend enabling "Require external ID" and entering the Organization ID when configuring IAM Roles.
  - Added a detailed warning explaining the security importance of this setting and the risk of confused deputy attacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->