### PR TITLE
Block user on crossing the identity limit

### DIFF
--- a/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from "react-i18next";
 import { faMobile } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Link, Outlet, useRouterState } from "@tanstack/react-router";
+import { Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { motion } from "framer-motion";
 
+import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import {
   BreadcrumbContainer,
   Menu,
@@ -31,6 +32,19 @@ export const ProjectLayout = () => {
   const { t } = useTranslation();
   const workspaceId = currentWorkspace?.id || "";
   const projectSlug = currentWorkspace?.slug || "";
+  const { subscription } = useSubscription();
+  const navigate = useNavigate();
+  const hasIdentityLimitCrossed =
+    subscription?.identityLimit && subscription?.identitiesUsed > subscription?.identityLimit;
+  const hasUserLimitCrossed =
+    subscription?.memberLimit && subscription?.membersUsed > subscription?.memberLimit;
+  const shouldUpgrade = Boolean(hasUserLimitCrossed || hasIdentityLimitCrossed);
+  let upgradeText = "";
+  if (hasUserLimitCrossed) {
+    upgradeText = `You've reached the maximum number of organisation users(${subscription.membersUsed}/${subscription?.memberLimit}).`;
+  } else if (hasIdentityLimitCrossed) {
+    upgradeText = `You've reached the maximum number of organisation identities(${subscription.identitiesUsed}/${subscription?.identityLimit}).`;
+  }
 
   const isSecretManager = currentWorkspace?.type === ProjectType.SecretManager;
   const isCertManager = currentWorkspace?.type === ProjectType.CertificateManager;
@@ -47,7 +61,6 @@ export const ProjectLayout = () => {
   });
 
   // we only show the secret rotations v1 tab if they have existing rotations
-  const { subscription } = useSubscription();
   const { data: secretRotations } = useGetSecretRotations({
     workspaceId,
     options: {
@@ -267,6 +280,17 @@ export const ProjectLayout = () => {
           </div>
         </div>
       </div>
+      {shouldUpgrade && (
+        <UpgradePlanModal
+          isOpen={shouldUpgrade}
+          text={upgradeText}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) {
+              navigate({ to: "/organization/access-management" });
+            }
+          }}
+        />
+      )}
       <div className="z-[200] flex h-screen w-screen flex-col items-center justify-center bg-bunker-800 md:hidden">
         <FontAwesomeIcon icon={faMobile} className="mb-8 text-7xl text-gray-300" />
         <p className="max-w-sm px-6 text-center text-lg text-gray-200">

--- a/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
@@ -41,9 +41,9 @@ export const ProjectLayout = () => {
   const shouldUpgrade = Boolean(hasUserLimitCrossed || hasIdentityLimitCrossed);
   let upgradeText = "";
   if (hasUserLimitCrossed) {
-    upgradeText = `You've reached the maximum number of organisation users(${subscription.membersUsed}/${subscription?.memberLimit}).`;
+    upgradeText = `You've reached the maximum number of organisation users(${subscription?.memberLimit}).`;
   } else if (hasIdentityLimitCrossed) {
-    upgradeText = `You've reached the maximum number of organisation identities(${subscription.identitiesUsed}/${subscription?.identityLimit}).`;
+    upgradeText = `You've reached the maximum number of organisation identities(${subscription?.identityLimit}).`;
   }
 
   const isSecretManager = currentWorkspace?.type === ProjectType.SecretManager;

--- a/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
@@ -35,9 +35,9 @@ export const ProjectLayout = () => {
   const { subscription } = useSubscription();
   const navigate = useNavigate();
   const hasIdentityLimitCrossed =
-    subscription?.identityLimit && subscription?.identitiesUsed > subscription?.identityLimit;
+    subscription?.identityLimit && subscription?.identitiesUsed > subscription.identityLimit + 10;
   const hasUserLimitCrossed =
-    subscription?.memberLimit && subscription?.membersUsed > subscription?.memberLimit;
+    subscription?.memberLimit && subscription?.membersUsed > subscription.memberLimit + 10;
   const shouldUpgrade = Boolean(hasUserLimitCrossed || hasIdentityLimitCrossed);
   let upgradeText = "";
   if (hasUserLimitCrossed) {

--- a/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
+++ b/frontend/src/layouts/ProjectLayout/ProjectLayout.tsx
@@ -41,9 +41,9 @@ export const ProjectLayout = () => {
   const shouldUpgrade = Boolean(hasUserLimitCrossed || hasIdentityLimitCrossed);
   let upgradeText = "";
   if (hasUserLimitCrossed) {
-    upgradeText = `You've reached the maximum number of organisation users(${subscription?.memberLimit}).`;
+    upgradeText = `You've reached the maximum number of organisation users (${subscription?.memberLimit}).`;
   } else if (hasIdentityLimitCrossed) {
-    upgradeText = `You've reached the maximum number of organisation identities(${subscription?.identityLimit}).`;
+    upgradeText = `You've reached the maximum number of organisation identities (${subscription?.identityLimit}).`;
   }
 
   const isSecretManager = currentWorkspace?.type === ProjectType.SecretManager;


### PR DESCRIPTION
# Description 📣

This would block all org projects on crossing the identity or members limit, if it's set in the plan

![image](https://github.com/user-attachments/assets/fd952b63-29cb-4e37-9286-d219d0fa0e27)


## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic display of an upgrade modal when identity or member limits are exceeded, including a message explaining the exceeded limit.
  - Closing the modal now redirects users to the access management page.

- **Refactor**
  - Improved internal handling of subscription checks for a more streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->