### PR TITLE
Fixed `v1/folders` API backward compatibility with `directory` parameter

### DIFF
--- a/backend/src/server/routes/v1/secret-folder-router.ts
+++ b/backend/src/server/routes/v1/secret-folder-router.ts
@@ -39,17 +39,19 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if path is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.CREATE.path),
+          .describe(FOLDERS.CREATE.path)
+          .optional(),
         // backward compatiability with cli
         directory: z
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if directory is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.CREATE.directory),
+          .describe(FOLDERS.CREATE.directory)
+          .optional(),
         description: z.string().optional().nullable().describe(FOLDERS.CREATE.description)
       }),
       response: {
@@ -60,7 +62,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const path = req.body.path || req.body.directory;
+      const path = req.body.path || req.body.directory || "/";
       const folder = await server.services.folder.createFolder({
         actorId: req.permission.id,
         actor: req.permission.type,
@@ -120,17 +122,19 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if path is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.UPDATE.path),
+          .describe(FOLDERS.UPDATE.path)
+          .optional(),
         // backward compatiability with cli
         directory: z
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if directory is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.UPDATE.directory),
+          .describe(FOLDERS.UPDATE.directory)
+          .optional(),
         description: z.string().optional().nullable().describe(FOLDERS.UPDATE.description)
       }),
       response: {
@@ -141,7 +145,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const path = req.body.path || req.body.directory;
+      const path = req.body.path || req.body.directory || "/";
       const { folder, old } = await server.services.folder.updateFolder({
         actorId: req.permission.id,
         actor: req.permission.type,
@@ -271,17 +275,19 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if path is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.DELETE.path),
+          .describe(FOLDERS.DELETE.path)
+          .optional(),
         // keep this here as cli need directory
         directory: z
           .string()
           .trim()
           .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if directory is undefined
           .transform(removeTrailingSlash)
           .describe(FOLDERS.DELETE.directory)
+          .optional()
       }),
       response: {
         200: z.object({
@@ -291,7 +297,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const path = req.body.path || req.body.directory;
+      const path = req.body.path || req.body.directory || "/";
       const folder = await server.services.folder.deleteFolder({
         actorId: req.permission.id,
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/secret-folder-router.ts
+++ b/backend/src/server/routes/v1/secret-folder-router.ts
@@ -339,18 +339,18 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         path: z
           .string()
           .trim()
-          .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if path is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.LIST.path),
+          .describe(FOLDERS.LIST.path)
+          .optional(),
         // backward compatiability with cli
         directory: z
           .string()
           .trim()
-          .default("/")
-          .transform(prefixWithSlash)
+          .transform(prefixWithSlash) // Transformations get skipped if directory is undefined
           .transform(removeTrailingSlash)
-          .describe(FOLDERS.LIST.directory),
+          .describe(FOLDERS.LIST.directory)
+          .optional(),
         recursive: booleanSchema.default(false).describe(FOLDERS.LIST.recursive)
       }),
       response: {
@@ -363,7 +363,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const path = req.query.path || req.query.directory;
+      const path = req.query.path || req.query.directory || "/";
       const folders = await server.services.folder.getFolders({
         actorId: req.permission.id,
         actor: req.permission.type,


### PR DESCRIPTION
# Description 📣

As seen in [this issue](https://github.com/Infisical/infisical/issues/3297), the --path flag for the Infisical CLI folder commands does not work on the main branch. This issue is caused by a misconfiguration in the Zod schema for the `GET /api/v1/folders` endpoint. The CLI uses a `directory` query parameter while other portions of the app use the `path` query parameter. With the way that Zod was previously configured, `path` would always default to `/` and overwrite `directory` in the handler.

My fix was to simply make both `path` and `directory` optional and to remove their `/` defaults. This fixes any overwrite issues. In the case that both `directory` and `path` are undefined, I added a `/` fallback in the actual endpoint handler.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I tested every `v1/folders` endpoint with both `path` and `directory` query parameters. I also ran tests without either parameter. Lastly I tested in-app folder CRUD functionality as well as some CLI commands to verify that https://github.com/Infisical/infisical/issues/3297 was fixed.

Here's an image of the CLI `--path` command properly working again:
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/41c94e23-0530-4bed-815b-a101c5d431d4" />

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of folder operations to ensure a valid default path is used when no path or directory is provided, preventing errors when these fields are omitted.
- **Documentation**
	- Added comments clarifying behavior when path or directory fields are undefined in folder-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->