### PR TITLE
Revert "fix: removed legacy sdk's"

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -570,7 +570,9 @@
         "sdks/languages/node",
         "sdks/languages/python",
         "sdks/languages/java",
-        "sdks/languages/go"
+        "sdks/languages/go",
+        "sdks/languages/ruby",
+        "sdks/languages/csharp"
       ]
     },
     {

--- a/docs/sdks/languages/csharp.mdx
+++ b/docs/sdks/languages/csharp.mdx
@@ -9,6 +9,12 @@ If you're working with C#, the official [Infisical C# SDK](https://github.com/In
 - [Nuget Package](https://www.nuget.org/packages/Infisical.Sdk)
 - [Github Repository](https://github.com/Infisical/sdk/tree/main/languages/csharp)
 
+<Warning>
+  **Deprecation Notice**
+
+  All versions prior to **2.3.9** should be considered deprecated and are no longer supported by Infisical. Please update to version **2.3.9** or newer. All changes are fully backwards compatible with older versions.
+</Warning>
+
 ## Basic Usage
 
 ```cs

--- a/docs/sdks/languages/csharp.mdx
+++ b/docs/sdks/languages/csharp.mdx
@@ -1,4 +1,4 @@
-{/* ---
+---
 title: "Infisical .NET SDK"
 sidebarTitle: ".NET"
 icon: "bars"
@@ -584,4 +584,4 @@ var decryptedPlaintext = infisical.DecryptSymmetric(decryptOptions);
 
 #### Returns (string)
 `Plaintext` (string): The decrypted plaintext.
- */}
+

--- a/docs/sdks/languages/ruby.mdx
+++ b/docs/sdks/languages/ruby.mdx
@@ -6,10 +6,16 @@ icon: "diamond"
 
 
 
-If you're working with Ruby , the official [Infisical Ruby SDK](https://github.com/infisical/sdk) package is the easiest way to fetch and work with secrets for your application.
+If you're working with Ruby, the official [Infisical Ruby SDK](https://github.com/infisical/sdk) package is the easiest way to fetch and work with secrets for your application.
 
 - [Ruby Package](https://rubygems.org/gems/infisical-sdk)
 - [Github Repository](https://github.com/infisical/sdk)
+
+<Warning>
+  **Deprecation Notice**
+
+  All versions prior to **2.3.9** should be considered deprecated and are no longer supported by Infisical. Please update to version **2.3.9** or newer. All changes are fully backwards compatible with older versions.
+</Warning>
 
 ## Basic Usage
 

--- a/docs/sdks/languages/ruby.mdx
+++ b/docs/sdks/languages/ruby.mdx
@@ -1,4 +1,4 @@
-{/* ---
+---
 title: "Infisical Ruby SDK"
 sidebarTitle: "Ruby"
 icon: "diamond"
@@ -433,4 +433,4 @@ decrypted_data = infisical.cryptography.decrypt_symmetric(
 </ParamField>
 
 #### Returns (string)
-`Plaintext` (string): The decrypted plaintext. */}
+`Plaintext` (string): The decrypted plaintext.


### PR DESCRIPTION
Reverts Infisical/infisical#3439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Ruby and C# SDKs to the list of supported languages in the documentation.
  - Fixed formatting issues in the Ruby and C# SDK documentation pages by removing unnecessary comment delimiters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->