### PR TITLE
Updated doc to have europe infisical aws account id

### DIFF
--- a/docs/documentation/platform/kms-configuration/aws-kms.mdx
+++ b/docs/documentation/platform/kms-configuration/aws-kms.mdx
@@ -19,7 +19,7 @@ Before you begin, you'll first need to choose a method of authentication with AW
         ![IAM Role Creation](/images/integrations/aws/integration-aws-iam-assume-role.png)
 
       2. Select **AWS Account** as the **Trusted Entity Type**.
-      3. Choose **Another AWS Account** and enter **381492033652** (Infisical AWS Account ID). This restricts the role to be assumed only by Infisical. If you are self-hosting, provide the AWS account number where Infisical is hosted.
+      3. Select **Another AWS Account** and provide the appropriate Infisical AWS Account ID: use **381492033652** for the **US region**, and **345594589636** for the **EU region**. This restricts the role to be assumed only by Infisical. If you are self-hosting, provide the AWS account number where Infisical is hosted.
       4. Optionally, enable **Require external ID** and enter your Infisical **project ID** to further enhance security.
     </Step>
     <Step title="Add Required Permissions for the IAM Role">

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -55,7 +55,7 @@ Infisical supports two methods for connecting to AWS.
                 ![IAM Role Creation](/images/integrations/aws/integration-aws-iam-assume-role.png)
 
                 2. Select **AWS Account** as the **Trusted Entity Type**.
-                3. Choose **Another AWS Account** and enter **381492033652** (Infisical AWS Account ID). This restricts the role to be assumed only by Infisical. If self-hosting, provide your AWS account number instead.
+                3. Select **Another AWS Account** and provide the appropriate Infisical AWS Account ID: use **381492033652** for the **US region**, and **345594589636** for the **EU region**. This restricts the role to be assumed only by Infisical. If self-hosting, provide your AWS account number instead.
                 4. (Recommended) <strong>Enable "Require external ID"</strong> and input your **Organization ID** to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).
 
                 <Warning type="warning" title="Security Best Practice: Use External ID to Prevent Confused Deputy Attacks">
@@ -362,4 +362,5 @@ Infisical supports two methods for connecting to AWS.
         </Steps>
 
     </Tab>
+
 </Tabs>


### PR DESCRIPTION
# Description 📣

This PR improves to doc to have respective aws account id information on US and Europe

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated AWS integration and KMS configuration guides to specify different Infisical AWS Account IDs for US and EU regions, improving clarity for region-specific setup.
	- Clarified instructions for selecting the appropriate AWS Account ID when configuring IAM roles.
	- Minor formatting improvement with a trailing newline added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->