### PR TITLE
Improvement: Set Project Delete Protection to False by Default

### DIFF
--- a/backend/src/db/migrations/20250414234624_add-project-delete-protection.ts
+++ b/backend/src/db/migrations/20250414234624_add-project-delete-protection.ts
@@ -6,7 +6,7 @@ export async function up(knex: Knex): Promise<void> {
   const hasCol = await knex.schema.hasColumn(TableName.Project, "hasDeleteProtection");
   if (!hasCol) {
     await knex.schema.alterTable(TableName.Project, (t) => {
-      t.boolean("hasDeleteProtection").defaultTo(true);
+      t.boolean("hasDeleteProtection").defaultTo(false);
     });
   }
 }


### PR DESCRIPTION
# Description 📣

This PR modifies the exisiting project delete protection PR to default the value to `false`. Note this migration has not been released and will be manually rolled back for Gamma.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝