### PR TITLE
Fix: Vercel Connection Validation API Call

### DIFF
--- a/backend/src/services/app-connection/vercel/vercel-connection-fns.ts
+++ b/backend/src/services/app-connection/vercel/vercel-connection-fns.ts
@@ -28,7 +28,7 @@ export const validateVercelConnectionCredentials = async (config: TVercelConnect
   const { credentials: inputCredentials } = config;
 
   try {
-    await request.get<VercelApp[]>(`${IntegrationUrls.VERCEL_API_URL}/v2/user`, {
+    await request.get(`${IntegrationUrls.VERCEL_API_URL}/v2/user`, {
       headers: {
         Authorization: `Bearer ${inputCredentials.apiToken}`
       }

--- a/backend/src/services/app-connection/vercel/vercel-connection-fns.ts
+++ b/backend/src/services/app-connection/vercel/vercel-connection-fns.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
@@ -27,10 +27,8 @@ export const getVercelConnectionListItem = () => {
 export const validateVercelConnectionCredentials = async (config: TVercelConnectionConfig) => {
   const { credentials: inputCredentials } = config;
 
-  let response: AxiosResponse<VercelApp[]> | null = null;
-
   try {
-    response = await request.get<VercelApp[]>(`${IntegrationUrls.VERCEL_API_URL}/v9/projects`, {
+    await request.get<VercelApp[]>(`${IntegrationUrls.VERCEL_API_URL}/v2/user`, {
       headers: {
         Authorization: `Bearer ${inputCredentials.apiToken}`
       }
@@ -38,17 +36,14 @@ export const validateVercelConnectionCredentials = async (config: TVercelConnect
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       throw new BadRequestError({
-        message: `Failed to validate credentials: ${error.message || "Unknown error"}`
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        message: `Failed to validate credentials: ${
+          error.response?.data ? JSON.stringify(error.response?.data) : error.message || "Unknown error"
+        }`
       });
     }
     throw new BadRequestError({
-      message: "Unable to validate connection - verify credentials"
-    });
-  }
-
-  if (!response?.data) {
-    throw new InternalServerError({
-      message: "Failed to get organizations: Response was empty"
+      message: `Unable to validate connection: ${(error as Error).message || "Verify credentials"}`
     });
   }
 


### PR DESCRIPTION
# Description 📣

This PR corrects the Vercel Connection validation to use a non-team based API call to verify the access token.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages when validating Vercel connection credentials, providing more detailed information if validation fails.

- **Refactor**
	- Simplified the credential validation process for Vercel connections, resulting in clearer and more concise error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->