### PR TITLE
Improved saml error messages

### DIFF
--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -136,7 +136,7 @@ declare module "fastify" {
     rateLimits: RateLimitConfiguration;
     // passport data
     passportUser: {
-      isUserCompleted: string;
+      isUserCompleted: boolean;
       providerAuthToken: string;
     };
     kmipUser: {


### PR DESCRIPTION
# Description 📣

Right now SAML auth failing throws internal server error leaving users clueless. This would improve it with better error message

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during SAML authentication, providing clearer error messages if authentication fails.

- **Refactor**
  - Enhanced authentication logic for SAML login to streamline user verification. 

- **Chores**
  - Updated internal user completion status to use a boolean value for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->