### PR TITLE
Allow user to remove SAML config

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgAuthTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/OrgAuthTab.tsx
@@ -45,6 +45,7 @@ export const OrgAuthTab = withPermission(
     const { data: samlConfig, isPending: isLoadingSamlConfig } = useGetSSOConfig(
       currentOrg?.id ?? ""
     );
+
     const { data: ldapConfig, isPending: isLoadingLdapConfig } = useGetLDAPConfig(
       currentOrg?.id ?? ""
     );
@@ -54,7 +55,8 @@ export const OrgAuthTab = withPermission(
       !enabledLoginMethods || enabledLoginMethods.includes(method);
 
     const isOidcConfigured = oidcConfig && (oidcConfig.discoveryURL || oidcConfig.issuer);
-    const isSamlConfigured = samlConfig && samlConfig.entryPoint;
+    const isSamlConfigured =
+      samlConfig && (samlConfig.entryPoint || samlConfig.issuer || samlConfig.cert);
     const isLdapConfigured = ldapConfig && ldapConfig.url;
 
     const shouldShowCreateIdentityProviderView =

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
@@ -301,6 +301,7 @@ export const SSOModal = ({ popUp, handlePopUpClose, handlePopUpToggle, hideDelet
                       label={renderLabels(authProvider).entryPoint}
                       errorText={error?.message}
                       isError={Boolean(error)}
+                      isRequired
                     >
                       <Input
                         {...field}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
@@ -63,7 +63,7 @@ const ssoAuthProviders = [
 const schema = z
   .object({
     authProvider: z.string().min(1, "SSO Type is required"),
-    entryPoint: z.string().default(""),
+    entryPoint: z.string().min(1, "Entry Point is required").default(""),
     issuer: z.string().default(""),
     cert: z.string().default("")
   })


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
Make entryPoint mandatory on SSOModal and check all fields on isSamlConfigured check

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of SAML configuration by considering additional fields, ensuring more reliable recognition of configured identity providers.

- **Style**
  - The "Entry Point" field in the SSO modal is now visually marked as required in the user interface.

- **New Features**
  - The "Entry Point" field in the SSO modal form now requires a non-empty value, enhancing form validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->