### PR TITLE
Removed low entropy password regexes that threw false positives

### DIFF
--- a/frontend/src/components/utilities/checks/password/checkPassword.ts
+++ b/frontend/src/components/utilities/checks/password/checkPassword.ts
@@ -31,7 +31,7 @@ interface CheckPasswordParams {
  * - Contains at least 1 number (0-9) or special character (emojis included)
  * - Does not contain 3 repeat, consecutive characters
  * - Does not contain any escape characters/sequences
- * - Does not contain PII and/or low entropy data (eg. email address, URL, phone number, DoB, SSN, driver's license, passport)
+ * - Does not contain PII and/or low entropy data (eg. email address, URL, SSN)
  * - Is not in a database of breached passwords
  *
  * The function returns whether or not the password [password]

--- a/frontend/src/components/utilities/checks/password/passwordRegexes.ts
+++ b/frontend/src/components/utilities/checks/password/passwordRegexes.ts
@@ -20,18 +20,6 @@ export const lowEntropyRegexes = [
   // URL (incl. subdomains, paths, top-level domains & query params)
   /^(?:(?:https?|ftp):\/\/)?(?:\w+\.)?[a-zA-Z0-9.-]+\.(?:com|org|net|edu)(?:\/\S*)?(?:\?\S*)?$/,
 
-  // Date in various formats
-  /(\b\d{1,4}[-/.]?\d{1,2}[-/.]?\d{1,4}\b)|(\b\d{1,4}[-/.]?\w{3}[-/.]?\d{1,4}\b)/,
-
-  // Phone numbers (generalized)
-  /(?:\+(?:[1-9]\d{0,2})\s?)?(?:\(\d{1,4}\)\s?)?(?:\d[-.\s]?){5,}\d/,
-
-  // Passport numbers (generalized)
-  /\b(?:[A-Z0-9]{6,9}|[A-Z0-9]{8,9}|[A-Z0-9]{9}|[A-Z0-9]{10,11})\b/,
-
-  // Driver's license numbers (generalized)
-  /\b(?:[A-Z0-9]{7,10}|[A-Z0-9]{10,11}|[A-Z0-9]{7,10})\b/,
-
   // US social security number
   /\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b/
 ];


### PR DESCRIPTION
# Description 📣

A few low-entropy password regexes were throwing false positives for several character combinations that would be present in typical passwords. This PR makes the password requirements more lax. Removed regexes include:
- Date regex
- Phone number regex
- Passport number regex
- Driver's license number regex

Before:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/bb052901-79ab-4353-a6a1-47c2ff1ed205" />

After:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/331ff896-8b2c-4735-9f17-66a0c93242e1" />

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated password validation documentation to streamline examples of prohibited PII and low-entropy data.

- **Refactor**
  - Simplified password validation by removing certain checks for dates, phone numbers, passport numbers, and driver's license numbers. Only email addresses, URLs, and SSNs are now checked for low-entropy data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->