### PR TITLE
fix: stuck on saml sso creation page

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgAuthTab/SSOModal.tsx
@@ -63,7 +63,7 @@ const ssoAuthProviders = [
 const schema = z
   .object({
     authProvider: z.string().min(1, "SSO Type is required"),
-    entryPoint: z.string().min(1, "Entry Point is required").default(""),
+    entryPoint: z.string().default(""),
     issuer: z.string().default(""),
     cert: z.string().default("")
   })


### PR DESCRIPTION
# Description 📣

This PR fixes a bug causing folks to be stuck on the SAML SSO creation page indefinitely if they haven't previously configured SAML SSO. The bug was caused by input validation requiring a string with minimum 1 length. It was defaulting to an empty string (0 length). The `entryPoint` is first configured **after** the initial Add step, which means users couldn't continue in the setup flow at all.  

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated SSO modal form validation to allow the entry point field to be left empty without causing a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->