### PR TITLE
Fix: Correct Enterprise Plan Display

### DIFF
--- a/frontend/src/layouts/OrganizationLayout/components/MinimizedOrgSidebar/MinimizedOrgSidebar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/MinimizedOrgSidebar/MinimizedOrgSidebar.tsx
@@ -57,7 +57,7 @@ import { MenuIconButton } from "../MenuIconButton";
 import { ServerAdminsPanel } from "../ServerAdminsPanel/ServerAdminsPanel";
 
 const getPlan = (subscription: SubscriptionPlan) => {
-  if (subscription.dynamicSecret) return "Enterprise Plan";
+  if (subscription.groups) return "Enterprise Plan";
   if (subscription.pitRecovery) return "Pro Plan";
   return "Free Plan";
 };

--- a/frontend/src/layouts/OrganizationLayout/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/SidebarHeader/SidebarHeader.tsx
@@ -2,7 +2,7 @@ import { useOrganization, useSubscription } from "@app/context";
 import { SubscriptionPlan } from "@app/hooks/api/types";
 
 const getPlan = (subscription: SubscriptionPlan) => {
-  if (subscription.dynamicSecret) return "Enterprise Plan";
+  if (subscription.groups) return "Enterprise Plan";
   if (subscription.pitRecovery) return "Pro Plan";
   return "Free Plan";
 };


### PR DESCRIPTION
# Description 📣

This plan corrects the check of when to display enterprise plan in the Infisical app. We we're using `dynamicSecret` but this is currently in pro plan as well, switched to `group` which is enterprise only

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the logic for displaying the "Enterprise Plan" label to improve accuracy in the organization sidebar and header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->