### PR TITLE
misc: reordered kube auth not found check

### DIFF
--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -435,12 +435,16 @@ export const identityKubernetesAuthServiceFactory = ({
     const identityMembershipOrg = await identityOrgMembershipDAL.findOne({ identityId });
     if (!identityMembershipOrg) throw new NotFoundError({ message: `Failed to find identity with ID ${identityId}` });
 
+    const identityKubernetesAuth = await identityKubernetesAuthDAL.findOne({ identityId });
+    if (!identityKubernetesAuth) {
+      throw new NotFoundError({ message: `Failed to find Kubernetes Auth for identity with ID ${identityId}` });
+    }
+
     if (!identityMembershipOrg.identity.authMethods.includes(IdentityAuthMethod.KUBERNETES_AUTH)) {
       throw new BadRequestError({
         message: "The identity does not have Kubernetes Auth attached"
       });
     }
-    const identityKubernetesAuth = await identityKubernetesAuthDAL.findOne({ identityId });
 
     const { permission } = await permissionService.getOrgPermission(
       actor,


### PR DESCRIPTION
# Description 📣
- This PR adds a not found assertion for kubernetes auth which is a prerequisite for Crossplane

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when retrieving Kubernetes Auth records, providing clearer feedback if a record does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->