### PR TITLE
feat(api): implemented secret caching version 2

### DIFF
--- a/backend/src/ee/services/secret-replication/secret-replication-service.ts
+++ b/backend/src/ee/services/secret-replication/secret-replication-service.ts
@@ -267,7 +267,6 @@ export const secretReplicationServiceFactory = ({
       const sourceLocalSecrets = await secretV2BridgeDAL.find({ folderId: folder.id, type: SecretType.Shared });
       const sourceSecretImports = await secretImportDAL.find({ folderId: folder.id });
       const sourceImportedSecrets = await fnSecretsV2FromImports({
-        projectId,
         secretImports: sourceSecretImports,
         secretDAL: secretV2BridgeDAL,
         folderDAL,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1089,7 +1089,8 @@ export const registerRoutes = async (
     secretApprovalRequestSecretDAL,
     kmsService,
     snapshotService,
-    resourceMetadataDAL
+    resourceMetadataDAL,
+    keyStore
   });
 
   const secretApprovalRequestService = secretApprovalRequestServiceFactory({

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -68,17 +68,14 @@ const awsRegionFromHeader = (authorizationHeader: string): string | null => {
   return null;
 };
 
-
-
-function isValidAwsRegion(region: (string | null)): boolean {
-  const validRegionPattern = new RE2('^[a-z0-9-]+$');
-  if (typeof region !== 'string' || region.length === 0 || region.length > 20) {
+function isValidAwsRegion(region: string | null): boolean {
+  const validRegionPattern = new RE2("^[a-z0-9-]+$");
+  if (typeof region !== "string" || region.length === 0 || region.length > 20) {
     return false;
   }
-  
+
   return validRegionPattern.test(region);
 }
-
 
 export const identityAwsAuthServiceFactory = ({
   identityAccessTokenDAL,
@@ -100,7 +97,7 @@ export const identityAwsAuthServiceFactory = ({
     const region = headers.Authorization ? awsRegionFromHeader(headers.Authorization) : null;
 
     if (!isValidAwsRegion(region)) {
-      throw new BadRequestError({message: "Invalid AWS region"});
+      throw new BadRequestError({ message: "Invalid AWS region" });
     }
 
     const url = region ? `https://sts.${region}.amazonaws.com` : identityAwsAuth.stsEndpoint;

--- a/backend/src/services/integration-auth/integration-delete-secret.ts
+++ b/backend/src/services/integration-auth/integration-delete-secret.ts
@@ -50,7 +50,7 @@ const getIntegrationSecretsV2 = async (
   }
 
   // process secrets in current folder
-  const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId, projectId: dto.projectId });
+  const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId });
 
   secrets.forEach((secret) => {
     const secretKey = secret.key;
@@ -63,7 +63,6 @@ const getIntegrationSecretsV2 = async (
   // if no imports then return secrets in the current folder
   if (!secretImports.length) return content;
   const importedSecrets = await fnSecretsV2FromImports({
-    projectId: dto.projectId,
     decryptor: dto.decryptor,
     folderDAL,
     secretDAL: secretV2BridgeDAL,

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -159,8 +159,7 @@ export const fnSecretsV2FromImports = async ({
   decryptor,
   expandSecretReferences,
   hasSecretAccess,
-  viewSecretValue,
-  projectId
+  viewSecretValue
 }: {
   secretImports: (Omit<TSecretImports, "importEnv"> & {
     importEnv: { id: string; slug: string; name: string };
@@ -177,7 +176,6 @@ export const fnSecretsV2FromImports = async ({
     environment: string;
   }) => Promise<string | undefined>;
   hasSecretAccess: (environment: string, secretPath: string, secretName: string, secretTagSlugs: string[]) => boolean;
-  projectId: string;
 }) => {
   const cyclicDetector = new Set();
   const stack: {
@@ -218,8 +216,7 @@ export const fnSecretsV2FromImports = async ({
         type: SecretType.Shared
       },
       {
-        sort: [["id", "asc"]],
-        useCache: { projectId }
+        sort: [["id", "asc"]]
       }
     );
     const importedSecretsGroupByFolderId = groupBy(importedSecrets, (i) => i.folderId);

--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -698,7 +698,6 @@ export const secretImportServiceFactory = ({
         projectId
       });
       const importedSecrets = await fnSecretsV2FromImports({
-        projectId,
         secretImports,
         folderDAL,
         viewSecretValue: true,

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -214,7 +214,7 @@ export const secretSyncQueueFactory = ({
       canExpandValue: () => true
     });
 
-    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId, projectId });
+    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId });
 
     await Promise.allSettled(
       secrets.map(async (secret) => {
@@ -244,7 +244,6 @@ export const secretSyncQueueFactory = ({
 
     if (secretImports.length) {
       const importedSecrets = await fnSecretsV2FromImports({
-        projectId,
         decryptor: decryptSecretValue,
         folderDAL,
         secretDAL: secretV2BridgeDAL,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -509,7 +509,7 @@ export const expandSecretReferencesFactory = ({
 
     const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
     if (!folder) return { value: "", tags: [] };
-    const secrets = await secretDAL.findByFolderId({ folderId: folder.id, projectId, useCache: true });
+    const secrets = await secretDAL.findByFolderId({ folderId: folder.id });
 
     const decryptedSecret = secrets.reduce<Record<string, { value: string; tags: string[] }>>((prev, secret) => {
       // eslint-disable-next-line no-param-reassign

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -43,7 +43,12 @@ import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretImportDALFactory } from "../secret-import/secret-import-dal";
 import { fnSecretsV2FromImports } from "../secret-import/secret-import-fns";
 import { TSecretTagDALFactory } from "../secret-tag/secret-tag-dal";
-import { TSecretV2BridgeDALFactory } from "./secret-v2-bridge-dal";
+import {
+  MAX_SECRET_CACHE_BYTES,
+  SECRET_DAL_TTL,
+  SecretDalCacheKeys,
+  TSecretV2BridgeDALFactory
+} from "./secret-v2-bridge-dal";
 import {
   buildHierarchy,
   expandSecretReferencesFactory,
@@ -76,6 +81,7 @@ import {
 } from "./secret-v2-bridge-types";
 import { TSecretVersionV2DALFactory } from "./secret-version-dal";
 import { TSecretVersionV2TagDALFactory } from "./secret-version-tag-dal";
+import { TKeyStoreFactory } from "@app/keystore/keystore";
 
 type TSecretV2BridgeServiceFactoryDep = {
   secretDAL: TSecretV2BridgeDALFactory;
@@ -105,6 +111,7 @@ type TSecretV2BridgeServiceFactoryDep = {
   >;
   snapshotService: Pick<TSecretSnapshotServiceFactory, "performSnapshot">;
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete">;
+  keyStore: Pick<TKeyStoreFactory, "getItem" | "setExpiry" | "setItemWithExpiry">;
 };
 
 export type TSecretV2BridgeServiceFactory = ReturnType<typeof secretV2BridgeServiceFactory>;
@@ -127,7 +134,8 @@ export const secretV2BridgeServiceFactory = ({
   secretApprovalRequestDAL,
   secretApprovalRequestSecretDAL,
   kmsService,
-  resourceMetadataDAL
+  resourceMetadataDAL,
+  keyStore
 }: TSecretV2BridgeServiceFactoryDep) => {
   const $validateSecretReferences = async (
     projectId: string,
@@ -800,12 +808,10 @@ export const secretV2BridgeServiceFactory = ({
     const groupedFolderMappings = groupBy(folderMappings, (folderMapping) => folderMapping.folderId);
 
     const secrets = await secretDAL.findByFolderIds({
-      projectId,
       folderIds: folderMappings.map((folderMapping) => folderMapping.folderId),
       userId,
       tx: undefined,
-      filters,
-      useCache: true
+      filters
     });
 
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
@@ -909,21 +915,22 @@ export const secretV2BridgeServiceFactory = ({
     return decryptedSecrets;
   };
 
-  const getSecrets = async ({
-    actorId,
-    path,
-    environment,
-    projectId,
-    actor,
-    actorOrgId,
-    viewSecretValue,
-    actorAuthMethod,
-    includeImports,
-    recursive,
-    expandSecretReferences: shouldExpandSecretReferences,
-    throwOnMissingReadValuePermission = true,
-    ...params
-  }: TGetSecretsDTO) => {
+  const getSecrets = async (dto: TGetSecretsDTO) => {
+    const {
+      actorId,
+      path,
+      environment,
+      projectId,
+      actor,
+      actorOrgId,
+      viewSecretValue,
+      actorAuthMethod,
+      includeImports,
+      recursive,
+      expandSecretReferences: shouldExpandSecretReferences,
+      throwOnMissingReadValuePermission = true,
+      ...params
+    } = dto;
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -933,6 +940,32 @@ export const secretV2BridgeServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
     throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret);
+
+    const cachedSecretDalVersion = await keyStore.getItem(SecretDalCacheKeys.getSecretDalVersion(projectId));
+    const secretDalVersion = Number(cachedSecretDalVersion || 0);
+    const cacheKey = SecretDalCacheKeys.getSecretsOfServiceLayer(projectId, secretDalVersion, {
+      ...dto,
+      permissionRules: permission.rules
+    });
+
+    const { decryptor: secretManagerDecryptor, encryptor: secretManagerEncryptor } =
+      await kmsService.createCipherPairWithDataKey({
+        type: KmsDataKey.SecretManager,
+        projectId
+      });
+    const encryptedCachedSecrets = await keyStore.getItem(cacheKey);
+    if (encryptedCachedSecrets) {
+      await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL);
+      const cachedSecrets = secretManagerDecryptor({ cipherTextBlob: Buffer.from(encryptedCachedSecrets, "base64") });
+      const { secrets, imports = [] } = JSON.parse(cachedSecrets.toString("utf8")) as {
+        secrets: typeof decryptedSecrets;
+        imports: typeof importedSecrets;
+      };
+      return {
+        secrets: secrets.map((el) => ({ ...el, createdAt: new Date(el.createdAt), updatedAt: new Date(el.updatedAt) })),
+        imports
+      };
+    }
 
     let paths: { folderId: string; path: string }[] = [];
 
@@ -958,17 +991,10 @@ export const secretV2BridgeServiceFactory = ({
     const groupedPaths = groupBy(paths, (p) => p.folderId);
 
     const secrets = await secretDAL.findByFolderIds({
-      projectId,
       folderIds: paths.map((p) => p.folderId),
       userId: actorId,
       tx: undefined,
-      filters: params,
-      useCache: true
-    });
-
-    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId
+      filters: params
     });
 
     // scott: if any of this changes it also needs to be mirrored in secret rotation for getting dashboard secrets
@@ -1086,15 +1112,19 @@ export const secretV2BridgeServiceFactory = ({
     }
 
     if (!includeImports) {
-      return {
-        secrets: decryptedSecrets
-      };
+      const payload = { secrets: decryptedSecrets, imports: [] };
+      const encryptedUpdatedCachedSecrets = secretManagerEncryptor({
+        plainText: Buffer.from(JSON.stringify(payload))
+      }).cipherTextBlob;
+      if (encryptedUpdatedCachedSecrets.byteLength < MAX_SECRET_CACHE_BYTES) {
+        await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL, encryptedUpdatedCachedSecrets.toString("base64"));
+      }
+      return payload;
     }
 
     const secretImports = await secretImportDAL.findByFolderIds(paths.map((p) => p.folderId));
     const allowedImports = secretImports.filter(({ isReplication }) => !isReplication);
     const importedSecrets = await fnSecretsV2FromImports({
-      projectId,
       viewSecretValue,
       secretImports: allowedImports,
       secretDAL,
@@ -1129,10 +1159,14 @@ export const secretV2BridgeServiceFactory = ({
       }
     });
 
-    return {
-      secrets: decryptedSecrets,
-      imports: importedSecrets
-    };
+    const payload = { secrets: decryptedSecrets, imports: importedSecrets };
+    const encryptedUpdatedCachedSecrets = secretManagerEncryptor({
+      plainText: Buffer.from(JSON.stringify(payload))
+    }).cipherTextBlob;
+    if (encryptedUpdatedCachedSecrets.byteLength < MAX_SECRET_CACHE_BYTES) {
+      await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL, encryptedUpdatedCachedSecrets.toString("base64"));
+    }
+    return payload;
   };
 
   const getSecretById = async ({ actorId, actor, actorOrgId, actorAuthMethod, secretId }: TGetASecretByIdDTO) => {
@@ -1312,7 +1346,6 @@ export const secretV2BridgeServiceFactory = ({
     if (!secret && includeImports) {
       const secretImports = await secretImportDAL.find({ folderId, isReplication: false });
       const importedSecrets = await fnSecretsV2FromImports({
-        projectId,
         secretImports,
         viewSecretValue,
         secretDAL,
@@ -2729,7 +2762,7 @@ export const secretV2BridgeServiceFactory = ({
       generatePaths(folderMap).map(({ folderId, path }) => [folderId, path === "/" ? path : path.substring(1)])
     );
 
-    const secrets = await secretDAL.findByFolderIds({ folderIds: folders.map((f) => f.id), projectId, useCache: true });
+    const secrets = await secretDAL.findByFolderIds({ folderIds: folders.map((f) => f.id) });
 
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.SecretManager,

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -367,7 +367,7 @@ export const secretQueueFactory = ({
       canExpandValue: () => true
     });
     // process secrets in current folder
-    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId, projectId: dto.projectId });
+    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId: dto.folderId });
 
     await Promise.allSettled(
       secrets.map(async (secret) => {
@@ -397,7 +397,6 @@ export const secretQueueFactory = ({
     // if no imports then return secrets in the current folder
     if (!secretImports.length) return content;
     const importedSecrets = await fnSecretsV2FromImports({
-      projectId: dto.projectId,
       decryptor: dto.decryptor,
       folderDAL,
       secretDAL: secretV2BridgeDAL,


### PR DESCRIPTION
# Description 📣

This PR implements version 2 of secret caching as part of performance improvement. Instead of caching just the dal we cache the entire response of the secret api. Now to make it secure it saved as encrypted and importantly the hash key is generated from the permission and rest of secret operation parameter

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced encrypted secret caching to improve performance when fetching secrets, reducing database load and response times.

- **Refactor**
  - Simplified secret retrieval by removing unnecessary parameters and internal caching logic from several backend services.
  - Updated secret service method signatures and dependencies to better support the new caching approach.

- **Chores**
  - Cleaned up unused imports and redundant code related to previous caching mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->