### PR TITLE
Fix: Filter Out Deleted Imports with Replication

### DIFF
--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -207,7 +207,10 @@ export const fnSecretsV2FromImports = async ({
     );
     if (!importedFolders.length) continue;
 
-    const importedFolderIds = importedFolders.map((el) => el?.id) as string[];
+    const importedFolderIds = importedFolders.filter(Boolean).map((el) => el?.id) as string[];
+
+    if (!importedFolderIds.length) continue;
+
     const importedFolderGroupBySourceImport = groupBy(importedFolders, (i) => `${i?.envId}-${i?.path}`);
 
     const importedSecrets = await secretDAL.find(


### PR DESCRIPTION
# Description 📣

This PR fixes getting imported secrets from replications when the import has been deleted

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of imported folders to prevent processing when no valid folder IDs are present, reducing potential errors during secret import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->