### PR TITLE
fix(dynamic-secret): improve error propagation and add FAQ to docs

### DIFF
--- a/docs/documentation/platform/dynamic-secrets/overview.mdx
+++ b/docs/documentation/platform/dynamic-secrets/overview.mdx
@@ -41,3 +41,16 @@ Dynamic secrets are particularly useful in environments with stringent security 
 4. [Oracle](./oracle)
 6. [Redis](./redis)
 5. [AWS IAM](./aws-iam)
+
+**FAQ**
+
+<AccordionGroup>
+<Accordion title="Why is my SQL dynamic secret failing when I generate a lease?">
+  This usually happens when the SQL statements defined for creating or revoking the secret are not compatible with your database provider.
+
+  Different SQL engines have different expectations for quoting identifiers and values. For example, some use backticks (`` `username` ``), others use single quotes (`'username'`), and some expect double quotes (`"username"`). A statement that works on one provider might fail on another.
+
+  **Recommendation:**  
+  Make sure to adjust your SQL statements to follow the syntax required by your specific database provider. Always test them directly on your target database to ensure they execute without errors.
+</Accordion>
+</AccordionGroup>


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨
Improve error propagation for dynamic secret SQL errors and add the reminder to verify SQL statements syntax on FAQ docs

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for SQL-related issues during dynamic secret lease creation, providing clearer error messages for users.
- **Documentation**
  - Added an FAQ section to the dynamic secrets overview, explaining common causes and solutions for SQL dynamic secret lease generation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->