### PR TITLE
Infisical SSH: Add Alias Field to SSH Hosts

### DIFF
--- a/backend/src/db/migrations/20250426044605_ssh-host-alias.ts
+++ b/backend/src/db/migrations/20250426044605_ssh-host-alias.ts
@@ -1,0 +1,23 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasAliasColumn = await knex.schema.hasColumn(TableName.SshHost, "alias");
+  if (!hasAliasColumn) {
+    await knex.schema.alterTable(TableName.SshHost, (t) => {
+      t.string("alias").nullable();
+      t.unique(["projectId", "alias"]);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasAliasColumn = await knex.schema.hasColumn(TableName.SshHost, "alias");
+  if (hasAliasColumn) {
+    await knex.schema.alterTable(TableName.SshHost, (t) => {
+      t.dropUnique(["projectId", "alias"]);
+      t.dropColumn("alias");
+    });
+  }
+}

--- a/backend/src/db/schemas/ssh-hosts.ts
+++ b/backend/src/db/schemas/ssh-hosts.ts
@@ -16,7 +16,8 @@ export const SshHostsSchema = z.object({
   userCertTtl: z.string(),
   hostCertTtl: z.string(),
   userSshCaId: z.string().uuid(),
-  hostSshCaId: z.string().uuid()
+  hostSshCaId: z.string().uuid(),
+  alias: z.string().nullable().optional()
 });
 
 export type TSshHosts = z.infer<typeof SshHostsSchema>;

--- a/backend/src/ee/routes/v1/ssh-host-router.ts
+++ b/backend/src/ee/routes/v1/ssh-host-router.ts
@@ -193,7 +193,7 @@ export const registerSshHostRouter = async (server: FastifyZodProvider) => {
             message: "Alias must be a valid slug"
           })
           .optional()
-          .describe(SSH_HOSTS.CREATE.alias),
+          .describe(SSH_HOSTS.UPDATE.alias),
         userCertTtl: z
           .string()
           .refine((val) => ms(val) > 0, "TTL must be a positive number")

--- a/backend/src/ee/routes/v1/ssh-host-router.ts
+++ b/backend/src/ee/routes/v1/ssh-host-router.ts
@@ -1,4 +1,3 @@
-import slugify from "@sindresorhus/slugify";
 import { z } from "zod";
 
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
@@ -8,6 +7,7 @@ import { isValidHostname } from "@app/ee/services/ssh-host/ssh-host-validators";
 import { SSH_HOSTS } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
 import { publicSshCaLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -102,15 +102,7 @@ export const registerSshHostRouter = async (server: FastifyZodProvider) => {
             message: "Hostname must be a valid hostname"
           })
           .describe(SSH_HOSTS.CREATE.hostname),
-        alias: z
-          .string()
-          .trim()
-          .nullable()
-          .default(null)
-          .refine((v) => v == null || slugify(v) === v, {
-            message: "Alias must be a valid slug"
-          })
-          .describe(SSH_HOSTS.CREATE.alias),
+        alias: slugSchema({ min: 0, max: 64, field: "alias" }).describe(SSH_HOSTS.CREATE.alias).default(""),
         userCertTtl: z
           .string()
           .refine((val) => ms(val) > 0, "TTL must be a positive number")
@@ -185,15 +177,7 @@ export const registerSshHostRouter = async (server: FastifyZodProvider) => {
           })
           .optional()
           .describe(SSH_HOSTS.UPDATE.hostname),
-        alias: z
-          .string()
-          .trim()
-          .nullable()
-          .refine((v) => v == null || slugify(v) === v, {
-            message: "Alias must be a valid slug"
-          })
-          .optional()
-          .describe(SSH_HOSTS.UPDATE.alias),
+        alias: slugSchema({ min: 0, max: 64, field: "alias" }).describe(SSH_HOSTS.UPDATE.alias).optional(),
         userCertTtl: z
           .string()
           .refine((val) => ms(val) > 0, "TTL must be a positive number")

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -1494,6 +1494,7 @@ interface CreateSshHost {
   metadata: {
     sshHostId: string;
     hostname: string;
+    alias: string | null;
     userCertTtl: string;
     hostCertTtl: string;
     loginMappings: {
@@ -1512,6 +1513,7 @@ interface UpdateSshHost {
   metadata: {
     sshHostId: string;
     hostname?: string;
+    alias?: string | null;
     userCertTtl?: string;
     hostCertTtl?: string;
     loginMappings?: {

--- a/backend/src/ee/services/ssh-host/ssh-host-dal.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-dal.ts
@@ -33,6 +33,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.SshHost).as("sshHostId"),
           db.ref("projectId").withSchema(TableName.SshHost),
           db.ref("hostname").withSchema(TableName.SshHost),
+          db.ref("alias").withSchema(TableName.SshHost),
           db.ref("userCertTtl").withSchema(TableName.SshHost),
           db.ref("hostCertTtl").withSchema(TableName.SshHost),
           db.ref("loginUser").withSchema(TableName.SshHostLoginUser),
@@ -45,7 +46,8 @@ export const sshHostDALFactory = (db: TDbClient) => {
 
       const grouped = groupBy(rows, (r) => r.sshHostId);
       return Object.values(grouped).map((hostRows) => {
-        const { sshHostId, hostname, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId, projectId } = hostRows[0];
+        const { sshHostId, hostname, alias, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId, projectId } =
+          hostRows[0];
 
         const loginMappingGrouped = groupBy(hostRows, (r) => r.loginUser);
 
@@ -59,6 +61,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
         return {
           id: sshHostId,
           hostname,
+          alias,
           projectId,
           userCertTtl,
           hostCertTtl,
@@ -87,6 +90,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.SshHost).as("sshHostId"),
           db.ref("projectId").withSchema(TableName.SshHost),
           db.ref("hostname").withSchema(TableName.SshHost),
+          db.ref("alias").withSchema(TableName.SshHost),
           db.ref("userCertTtl").withSchema(TableName.SshHost),
           db.ref("hostCertTtl").withSchema(TableName.SshHost),
           db.ref("loginUser").withSchema(TableName.SshHostLoginUser),
@@ -99,7 +103,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
 
       const hostsGrouped = groupBy(rows, (r) => r.sshHostId);
       return Object.values(hostsGrouped).map((hostRows) => {
-        const { sshHostId, hostname, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId } = hostRows[0];
+        const { sshHostId, hostname, alias, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId } = hostRows[0];
 
         const loginMappingGrouped = groupBy(
           hostRows.filter((r) => r.loginUser),
@@ -116,6 +120,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
         return {
           id: sshHostId,
           hostname,
+          alias,
           projectId,
           userCertTtl,
           hostCertTtl,
@@ -144,6 +149,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.SshHost).as("sshHostId"),
           db.ref("projectId").withSchema(TableName.SshHost),
           db.ref("hostname").withSchema(TableName.SshHost),
+          db.ref("alias").withSchema(TableName.SshHost),
           db.ref("userCertTtl").withSchema(TableName.SshHost),
           db.ref("hostCertTtl").withSchema(TableName.SshHost),
           db.ref("loginUser").withSchema(TableName.SshHostLoginUser),
@@ -155,7 +161,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
 
       if (rows.length === 0) return null;
 
-      const { sshHostId: id, projectId, hostname, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId } = rows[0];
+      const { sshHostId: id, projectId, hostname, alias, userCertTtl, hostCertTtl, userSshCaId, hostSshCaId } = rows[0];
 
       const loginMappingGrouped = groupBy(
         rows.filter((r) => r.loginUser),
@@ -173,6 +179,7 @@ export const sshHostDALFactory = (db: TDbClient) => {
         id,
         projectId,
         hostname,
+        alias,
         userCertTtl,
         hostCertTtl,
         loginMappings,

--- a/backend/src/ee/services/ssh-host/ssh-host-schema.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-schema.ts
@@ -6,6 +6,7 @@ export const sanitizedSshHost = SshHostsSchema.pick({
   id: true,
   projectId: true,
   hostname: true,
+  alias: true,
   userCertTtl: true,
   hostCertTtl: true,
   userSshCaId: true,

--- a/backend/src/ee/services/ssh-host/ssh-host-service.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-service.ts
@@ -193,7 +193,7 @@ export const sshHostServiceFactory = ({
         {
           projectId,
           hostname,
-          alias,
+          alias: alias === "" ? null : alias,
           userCertTtl,
           hostCertTtl,
           userSshCaId,
@@ -300,7 +300,7 @@ export const sshHostServiceFactory = ({
         sshHostId,
         {
           hostname,
-          alias,
+          alias: alias === "" ? null : alias,
           userCertTtl,
           hostCertTtl
         },

--- a/backend/src/ee/services/ssh-host/ssh-host-service.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-service.ts
@@ -119,6 +119,7 @@ export const sshHostServiceFactory = ({
   const createSshHost = async ({
     projectId,
     hostname,
+    alias,
     userCertTtl,
     hostCertTtl,
     loginMappings,
@@ -192,6 +193,7 @@ export const sshHostServiceFactory = ({
         {
           projectId,
           hostname,
+          alias,
           userCertTtl,
           hostCertTtl,
           userSshCaId,
@@ -265,6 +267,7 @@ export const sshHostServiceFactory = ({
   const updateSshHost = async ({
     sshHostId,
     hostname,
+    alias,
     userCertTtl,
     hostCertTtl,
     loginMappings,
@@ -297,6 +300,7 @@ export const sshHostServiceFactory = ({
         sshHostId,
         {
           hostname,
+          alias,
           userCertTtl,
           hostCertTtl
         },

--- a/backend/src/ee/services/ssh-host/ssh-host-types.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-types.ts
@@ -4,6 +4,7 @@ export type TListSshHostsDTO = Omit<TProjectPermission, "projectId">;
 
 export type TCreateSshHostDTO = {
   hostname: string;
+  alias: string | null;
   userCertTtl: string;
   hostCertTtl: string;
   loginMappings: {
@@ -19,6 +20,7 @@ export type TCreateSshHostDTO = {
 export type TUpdateSshHostDTO = {
   sshHostId: string;
   hostname?: string;
+  alias?: string | null;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings?: {

--- a/backend/src/ee/services/ssh-host/ssh-host-types.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-types.ts
@@ -4,7 +4,7 @@ export type TListSshHostsDTO = Omit<TProjectPermission, "projectId">;
 
 export type TCreateSshHostDTO = {
   hostname: string;
-  alias: string | null;
+  alias?: string;
   userCertTtl: string;
   hostCertTtl: string;
   loginMappings: {
@@ -20,7 +20,7 @@ export type TCreateSshHostDTO = {
 export type TUpdateSshHostDTO = {
   sshHostId: string;
   hostname?: string;
-  alias?: string | null;
+  alias?: string;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings?: {

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1387,6 +1387,7 @@ export const SSH_HOSTS = {
   CREATE: {
     projectId: "The ID of the project to create the SSH host in.",
     hostname: "The hostname of the SSH host.",
+    alias: "The alias for the SSH host.",
     userCertTtl: "The time to live for user certificates issued under this host.",
     hostCertTtl: "The time to live for host certificates issued under this host.",
     loginUser: "A login user on the remote machine (e.g. 'ec2-user', 'deploy', 'admin')",
@@ -1401,6 +1402,7 @@ export const SSH_HOSTS = {
   UPDATE: {
     sshHostId: "The ID of the SSH host to update.",
     hostname: "The hostname of the SSH host to update to.",
+    alias: "The alias for the SSH host to update to.",
     userCertTtl: "The time to live for user certificates issued under this host to update to.",
     hostCertTtl: "The time to live for host certificates issued under this host to update to.",
     loginUser: "A login user on the remote machine (e.g. 'ec2-user', 'deploy', 'admin')",

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/semgroup v1.2.0
 	github.com/gitleaks/go-gitdiff v0.8.0
 	github.com/h2non/filetype v1.1.3
-	github.com/infisical/go-sdk v0.5.8
+	github.com/infisical/go-sdk v0.5.92
 	github.com/infisical/infisical-kmip v0.3.5
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/ansi v0.0.0-20221106050444-61f0cd9a192a

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -277,8 +277,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infisical/go-sdk v0.5.8 h1:bCetYLp7HWt8DnU9KPh1n8n3z5pjmunkGDB4bA3lEFs=
-github.com/infisical/go-sdk v0.5.8/go.mod h1:ExjqFLRz7LSpZpGluqDLvFl6dFBLq5LKyLW7GBaMAIs=
+github.com/infisical/go-sdk v0.5.92 h1:PoCnVndrd6Dbkipuxl9fFiwlD5vCKsabtQo09mo8lUE=
+github.com/infisical/go-sdk v0.5.92/go.mod h1:ExjqFLRz7LSpZpGluqDLvFl6dFBLq5LKyLW7GBaMAIs=
 github.com/infisical/infisical-kmip v0.3.5 h1:QM3s0e18B+mYv3a9HQNjNAlbwZJBzXq5BAJM2scIeiE=
 github.com/infisical/infisical-kmip v0.3.5/go.mod h1:bO1M4YtKyutNg1bREPmlyZspC5duSR7hyQ3lPmLzrIs=
 github.com/jedib0t/go-pretty v4.3.0+incompatible h1:CGs8AVhEKg/n9YbUenWmNStRW2PHJzaeDodcfvRAbIo=

--- a/docs/cli/commands/ssh.mdx
+++ b/docs/cli/commands/ssh.mdx
@@ -22,15 +22,15 @@ This command enables you to obtain SSH credentials used to access a remote host.
     <Accordion title="--hostname">
         The hostname of the SSH host to connect to. If not provided, you will be prompted to select from available hosts.
     </Accordion>
-    <Accordion title="--loginUser">
+    <Accordion title="--login-user">
         The login user for the SSH connection. If not provided, you will be prompted to select from available login users.
     </Accordion>
-    <Accordion title="--writeHostCaToFile">
+    <Accordion title="--write-host-ca-to-file">
         Whether to write the Host CA public key to `~/.ssh/known_hosts` if it doesn't already exist.
 
         Default value: `true`
     </Accordion>
-    <Accordion title="--outFilePath">
+    <Accordion title="--out-file-path">
         The path to write the SSH credentials to such as `~/.ssh`, `./some_folder`, `./some_folder/id_rsa-cert.pub`. If not provided, the credentials will be added to the SSH agent and used to establish an interactive SSH connection.
     </Accordion>
     <Accordion title="--token">
@@ -39,108 +39,52 @@ This command enables you to obtain SSH credentials used to access a remote host.
 
 </Accordion>
 
-<Accordion title="infisical ssh issue-credentials">
-    This command is used to issue SSH credentials (SSH certificate, public key, and private key) against a certificate template.
+<Accordion title="infisical ssh add-host">
+    This command is used to register a new SSH host with Infisical.
     
-    We recommend using the `--addToAgent` flag to automatically load issued SSH credentials to the SSH agent.
-    
+    This command can be used with the `--write-user-ca-to-file`, `--write-host-cert-to-file`, and `--configure-sshd` flags
+    to also configure the host's SSH daemon with the necessary certificate authority and host certificate settings.
+
     ```bash
-    $ infisical ssh issue-credentials --certificateTemplateId=<certificate-template-id> --principals=<principals> --addToAgent
+    $ infisical ssh add-host --projectId=<project-id> --hostname=<hostname>
     ```
 
     ### Flags
-    <Accordion title="--certificateTemplateId">
-        The ID of the SSH certificate template to issue SSH credentials for.
+    <Accordion title="--projectId">
+        Project ID the host belongs to (required)
     </Accordion>
-    <Accordion title="--principals">
-        A comma-separated list of principals (i.e. usernames like `ec2-user` or hostnames) to issue SSH credentials for.
+    <Accordion title="--hostname">
+        Hostname of the SSH host (required)
     </Accordion>
-    <Accordion title="--addToAgent">
-        Whether to add issued SSH credentials to the SSH agent.
+    <Accordion title="--write-user-ca-to-file">
+        Write User CA public key to `/etc/ssh/infisical_user_ca.pub`
+
+        Default value: `false`
+    </Accordion>
+    <Accordion title="--user-ca-out-file-path">
+        Custom file path to write the User CA public key
+
+        Default value: `/etc/ssh/infisical_user_ca.pub`
+    </Accordion>
+    <Accordion title="--write-host-cert-to-file">
+        Write SSH host certificate to `/etc/ssh/ssh_host_<type>_key-cert.pub`
+
+        Default value: `false`
+    </Accordion>
+    <Accordion title="--configure-sshd">
+        Update `TrustedUserCAKeys`, `HostKey`, and `HostCertificate` in the `/etc/ssh/sshd_config` file
 
         Default value: `false`
 
-        Note that either the `--outFilePath` or `--addToAgent` flag must be set for the sub-command to execute successfully.
+        Note: This flag requires both --write-user-ca-to-file and --write-host-cert-to-file to be set
     </Accordion>
-    <Accordion title="--outFilePath">
-        The path to write the SSH credentials to such as `~/.ssh`, `./some_folder`, `./some_folder/id_rsa-cert.pub`. If not provided, the credentials will be saved to the current working directory where the command is run.
+    <Accordion title="--force">
+        Force overwrite of existing certificate files as part of `--write-user-ca-to-file` and `--write-host-cert-to-file`
 
-        Note that either the `--outFilePath` or `--addToAgent` flag must be set for the sub-command to execute successfully.
-    </Accordion>
-    <Accordion title="--keyAlgorithm">
-        The key algorithm to issue SSH credentials for.
-
-        Default value: `RSA_2048`
-
-        Available options: `RSA_2048`, `RSA_4096`, `EC_prime256v1`, `EC_secp384r1`.
-    </Accordion>
-    <Accordion title="--certType">
-        The certificate type to issue SSH credentials for.
-
-        Default value: `user`
-
-        Available options: `user` or `host`
-    </Accordion>
-    <Accordion title="--ttl">
-        The time-to-live (TTL) for the issued SSH certificate (e.g. `2 days`, `1d`, `2h`, `1y`).
-
-        Defaults to the Default TTL value set in the certificate template.
-    </Accordion>
-    <Accordion title="--keyId">
-        A custom Key ID to issue SSH credentials for.
-
-        Defaults to the autogenerated Key ID by Infisical.
+        Default value: `false`
     </Accordion>
     <Accordion title="--token">
-        An authenticated token to use to issue SSH credentials.
-    </Accordion>
-
-</Accordion>
-
-<Accordion title="infisical ssh sign-key">
-    This command is used to sign an existing SSH public key against a certificate template; the command outputs the corresponding signed SSH certificate.
-    
-    ```bash
-    $ infisical ssh sign-key --certificateTemplateId=<certificate-template-id> --publicKey=<public-key> --principals=<principals> --outFilePath=<out-file-path>
-    ```
-    <Accordion title="--certificateTemplateId">
-        The ID of the SSH certificate template to issue the SSH certificate for.
-    </Accordion>
-    <Accordion title="--publicKey">
-        The public key to sign.
-
-        Note that either the `--publicKey` or `--publicKeyFilePath` flag must be set for the sub-command to execute successfully.
-    </Accordion>
-    <Accordion title="--publicKeyFilePath">
-        The path to the public key file to sign.
-
-        Note that either the `--publicKey` or `--publicKeyFilePath` flag must be set for the sub-command to execute successfully.
-    </Accordion>
-    <Accordion title="--principals">
-        A comma-separated list of principals (i.e. usernames like `ec2-user` or hostnames) to issue SSH credentials for.
-    </Accordion>
-    <Accordion title="--outFilePath">
-        The path to write the SSH certificate to such as `~/.ssh/id_rsa-cert.pub`; the specified file must have the `.pub` extension. If not provided, the credentials will be saved to the directory of the specified `--publicKeyFilePath` or the current working directory where the command is run.
-    </Accordion>
-    <Accordion title="--certType">
-        The certificate type to issue SSH credentials for.
-
-        Default value: `user`
-
-        Available options: `user` or `host`
-    </Accordion>
-    <Accordion title="--ttl">
-        The time-to-live (TTL) for the issued SSH certificate (e.g. `2 days`, `1d`, `2h`, `1y`).
-
-        Defaults to the Default TTL value set in the certificate template.
-    </Accordion>
-    <Accordion title="--keyId">
-        A custom Key ID to issue SSH credentials for.
-
-        Defaults to the autogenerated Key ID by Infisical.
-    </Accordion>
-    <Accordion title="--token">
-        An authenticated token to use to issue SSH credentials.
+        Use a machine identity access token
     </Accordion>
 
 </Accordion>

--- a/docs/cli/commands/ssh.mdx
+++ b/docs/cli/commands/ssh.mdx
@@ -34,7 +34,7 @@ This command enables you to obtain SSH credentials used to access a remote host.
         The path to write the SSH credentials to such as `~/.ssh`, `./some_folder`, `./some_folder/id_rsa-cert.pub`. If not provided, the credentials will be added to the SSH agent and used to establish an interactive SSH connection.
     </Accordion>
     <Accordion title="--token">
-        An authenticated token to use to authenticate with Infisical.
+        Use a machine identity access token
     </Accordion>
 
 </Accordion>
@@ -55,6 +55,9 @@ This command enables you to obtain SSH credentials used to access a remote host.
     </Accordion>
     <Accordion title="--hostname">
         Hostname of the SSH host (required)
+    </Accordion>
+    <Accordion title="--alias">
+        Alias for the SSH host (optional)
     </Accordion>
     <Accordion title="--write-user-ca-to-file">
         Write User CA public key to `/etc/ssh/infisical_user_ca.pub`

--- a/frontend/src/hooks/api/sshHost/types.ts
+++ b/frontend/src/hooks/api/sshHost/types.ts
@@ -16,7 +16,7 @@ export type TSshHost = {
 export type TCreateSshHostDTO = {
   projectId: string;
   hostname: string;
-  alias: string | null;
+  alias?: string;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings: {
@@ -30,7 +30,7 @@ export type TCreateSshHostDTO = {
 export type TUpdateSshHostDTO = {
   sshHostId: string;
   hostname?: string;
-  alias?: string | null;
+  alias?: string;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings?: {

--- a/frontend/src/hooks/api/sshHost/types.ts
+++ b/frontend/src/hooks/api/sshHost/types.ts
@@ -2,6 +2,7 @@ export type TSshHost = {
   id: string;
   projectId: string;
   hostname: string;
+  alias: string | null;
   userCertTtl: string;
   hostCertTtl: string;
   loginMappings: {
@@ -15,6 +16,7 @@ export type TSshHost = {
 export type TCreateSshHostDTO = {
   projectId: string;
   hostname: string;
+  alias: string | null;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings: {
@@ -28,6 +30,7 @@ export type TCreateSshHostDTO = {
 export type TUpdateSshHostDTO = {
   sshHostId: string;
   hostname?: string;
+  alias?: string | null;
   userCertTtl?: string;
   hostCertTtl?: string;
   loginMappings?: {

--- a/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
+++ b/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
@@ -35,8 +35,8 @@ type Props = {
 
 const schema = z
   .object({
-    hostname: z.string(),
-    alias: z.string(),
+    hostname: z.string().trim(),
+    alias: z.string().trim(),
     userCertTtl: z
       .string()
       .trim()

--- a/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
+++ b/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
@@ -36,6 +36,7 @@ type Props = {
 const schema = z
   .object({
     hostname: z.string(),
+    alias: z.string(),
     userCertTtl: z
       .string()
       .trim()
@@ -81,6 +82,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
     resolver: zodResolver(schema),
     defaultValues: {
       hostname: "",
+      alias: "",
       userCertTtl: "8h",
       loginMappings: []
     }
@@ -95,6 +97,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
     if (sshHost) {
       reset({
         hostname: sshHost.hostname,
+        alias: sshHost.alias ?? "",
         userCertTtl: sshHost.userCertTtl,
         loginMappings: sshHost.loginMappings.map(({ loginUser, allowedPrincipals }) => ({
           loginUser,
@@ -108,13 +111,14 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
     } else {
       reset({
         hostname: "",
+        alias: "",
         userCertTtl: "8h",
         loginMappings: []
       });
     }
   }, [sshHost]);
 
-  const onFormSubmit = async ({ hostname, userCertTtl, loginMappings }: FormData) => {
+  const onFormSubmit = async ({ hostname, alias, userCertTtl, loginMappings }: FormData) => {
     try {
       if (!projectId) return;
 
@@ -122,7 +126,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
       const existingHostnames =
         sshHosts?.filter((h) => h.id !== sshHost?.id).map((h) => h.hostname) || [];
 
-      if (existingHostnames.includes(hostname)) {
+      if (existingHostnames.includes(hostname.trim())) {
         createNotification({
           text: "A host with this hostname already exists.",
           type: "error"
@@ -130,10 +134,28 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
         return;
       }
 
+      const processedAlias = alias.trim() || null;
+
+      // check if there is already a different host with the same non-null alias
+      if (processedAlias) {
+        const existingAliases =
+          sshHosts?.filter((h) => h.id !== sshHost?.id && h.alias !== null).map((h) => h.alias) ||
+          [];
+
+        if (existingAliases.includes(processedAlias)) {
+          createNotification({
+            text: "A host with this alias already exists.",
+            type: "error"
+          });
+          return;
+        }
+      }
+
       if (sshHost) {
         await updateMutateAsync({
           sshHostId: sshHost.id,
           hostname,
+          alias: processedAlias,
           userCertTtl,
           loginMappings: loginMappings.map(({ loginUser, allowedPrincipals }) => ({
             loginUser,
@@ -146,6 +168,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
         await createMutateAsync({
           projectId,
           hostname,
+          alias: processedAlias,
           userCertTtl,
           loginMappings: loginMappings.map(({ loginUser, allowedPrincipals }) => ({
             loginUser,
@@ -206,6 +229,16 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
                 isRequired
               >
                 <Input {...field} placeholder="host.example.com" />
+              </FormControl>
+            )}
+          />
+          <Controller
+            control={control}
+            defaultValue=""
+            name="alias"
+            render={({ field, fieldState: { error } }) => (
+              <FormControl label="Alias" isError={Boolean(error)} errorText={error?.message}>
+                <Input {...field} placeholder="host" />
               </FormControl>
             )}
           />

--- a/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
+++ b/frontend/src/pages/ssh/SshHostsPage/components/SshHostModal.tsx
@@ -134,15 +134,15 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
         return;
       }
 
-      const processedAlias = alias.trim() || null;
+      const trimmedAlias = alias.trim();
 
       // check if there is already a different host with the same non-null alias
-      if (processedAlias) {
+      if (trimmedAlias) {
         const existingAliases =
           sshHosts?.filter((h) => h.id !== sshHost?.id && h.alias !== null).map((h) => h.alias) ||
           [];
 
-        if (existingAliases.includes(processedAlias)) {
+        if (existingAliases.includes(trimmedAlias)) {
           createNotification({
             text: "A host with this alias already exists.",
             type: "error"
@@ -155,7 +155,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
         await updateMutateAsync({
           sshHostId: sshHost.id,
           hostname,
-          alias: processedAlias,
+          alias: trimmedAlias,
           userCertTtl,
           loginMappings: loginMappings.map(({ loginUser, allowedPrincipals }) => ({
             loginUser,
@@ -168,7 +168,7 @@ export const SshHostModal = ({ popUp, handlePopUpToggle }: Props) => {
         await createMutateAsync({
           projectId,
           hostname,
-          alias: processedAlias,
+          alias: trimmedAlias,
           userCertTtl,
           loginMappings: loginMappings.map(({ loginUser, allowedPrincipals }) => ({
             loginUser,

--- a/frontend/src/pages/ssh/SshHostsPage/components/SshHostsTable.tsx
+++ b/frontend/src/pages/ssh/SshHostsPage/components/SshHostsTable.tsx
@@ -66,6 +66,7 @@ export const SshHostsTable = ({ handlePopUpOpen }: Props) => {
         <Table>
           <THead>
             <Tr>
+              <Th>Alias</Th>
               <Th>Hostname</Th>
               <Th>Login User - Authorized Principals Mapping</Th>
               <Th />
@@ -83,6 +84,7 @@ export const SshHostsTable = ({ handlePopUpOpen }: Props) => {
                     className="h-10"
                     key={`ssh-host-${host.id}`}
                   >
+                    <Td>{host.alias ?? "-"}</Td>
                     <Td>{host.hostname}</Td>
                     <Td>
                       {host.loginMappings.length === 0 ? (


### PR DESCRIPTION
# Description 📣

This PR allows users/admins to specify aliases for registered hosts in Infisical SSH. Previously, users/admins only specified the `hostname` but from a UX standpoint this isn't that useful because you wouldn't know what you're SSH-ing into from just looking at a list of IPs.

Instead, you can now define `hostname` like `host.example.com` and specify an alias like `host` for it; this is possible in the UI and via the `infisical ssh add-host` command using the `--alias` flag. Conversely, when users use `infisical ssh connect`, they will now see the `alias` of a host as part of the dropdown if alias is defined; otherwise, `hostname` will be shown.

<img width="1617" alt="Screenshot 2025-04-26 at 8 06 20 PM" src="https://github.com/user-attachments/assets/65f2b106-5a49-4bb2-b994-d88449772fb8" />

## Type ✨

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional, unique alias for SSH hosts throughout the platform.
  - Users can now specify an alias when creating or updating SSH hosts via the web interface and CLI.
  - The SSH hosts table and forms in the UI now display and accept aliases.
  - CLI commands for managing SSH hosts have improved flag naming and support for the new alias field.

- **Documentation**
  - Updated CLI documentation to reflect new commands, flags, and usage for SSH host registration and alias support.

- **Style**
  - CLI flags for SSH host commands now use kebab-case for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->