### PR TITLE
Fix KMS memory leak

### DIFF
--- a/backend/src/ee/services/external-kms/providers/aws-kms.ts
+++ b/backend/src/ee/services/external-kms/providers/aws-kms.ts
@@ -2,8 +2,6 @@ import { CreateKeyCommand, DecryptCommand, DescribeKeyCommand, EncryptCommand, K
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { randomUUID } from "crypto";
 
-import { logger } from "@app/lib/logger";
-
 import { ExternalKmsAwsSchema, KmsAwsCredentialType, TExternalKmsAwsSchema, TExternalKmsProviderFns } from "./model";
 
 const getAwsKmsClient = async (providerInputs: TExternalKmsAwsSchema) => {

--- a/backend/src/ee/services/external-kms/providers/aws-kms.ts
+++ b/backend/src/ee/services/external-kms/providers/aws-kms.ts
@@ -107,10 +107,8 @@ export const AwsKmsProviderFactory = async ({ inputs }: AwsKmsProviderArgs): Pro
   const cleanup = async () => {
     try {
       awsClient.destroy();
-      return true;
     } catch (error) {
-      logger.error(error, "cleanup: failed to destroy AWS KMS client");
-      return false;
+      throw new Error("Failed to cleanup AWS KMS client", { cause: error });
     }
   };
 

--- a/backend/src/ee/services/external-kms/providers/gcp-kms.ts
+++ b/backend/src/ee/services/external-kms/providers/gcp-kms.ts
@@ -45,6 +45,16 @@ export const GcpKmsProviderFactory = async ({ inputs }: GcpKmsProviderArgs): Pro
     }
   };
 
+  const cleanup = async () => {
+    try {
+      await gcpKmsClient.close();
+      return true;
+    } catch (error) {
+      logger.error(error, "cleanup: failed to close GCP KMS client");
+      return false;
+    }
+  };
+
   // Used when adding the KMS to fetch the list of keys in specified region
   const getKeysList = async () => {
     try {
@@ -108,6 +118,7 @@ export const GcpKmsProviderFactory = async ({ inputs }: GcpKmsProviderArgs): Pro
     validateConnection,
     getKeysList,
     encrypt,
-    decrypt
+    decrypt,
+    cleanup
   };
 };

--- a/backend/src/ee/services/external-kms/providers/gcp-kms.ts
+++ b/backend/src/ee/services/external-kms/providers/gcp-kms.ts
@@ -48,10 +48,8 @@ export const GcpKmsProviderFactory = async ({ inputs }: GcpKmsProviderArgs): Pro
   const cleanup = async () => {
     try {
       await gcpKmsClient.close();
-      return true;
     } catch (error) {
-      logger.error(error, "cleanup: failed to close GCP KMS client");
-      return false;
+      throw new Error("Failed to cleanup GCP KMS client", { cause: error });
     }
   };
 

--- a/backend/src/ee/services/external-kms/providers/model.ts
+++ b/backend/src/ee/services/external-kms/providers/model.ts
@@ -98,5 +98,5 @@ export type TExternalKmsProviderFns = {
   validateConnection: () => Promise<boolean>;
   encrypt: (data: Buffer) => Promise<{ encryptedBlob: Buffer }>;
   decrypt: (encryptedBlob: Buffer) => Promise<{ data: Buffer }>;
-  cleanup: () => Promise<boolean>;
+  cleanup: () => Promise<void>;
 };

--- a/backend/src/ee/services/external-kms/providers/model.ts
+++ b/backend/src/ee/services/external-kms/providers/model.ts
@@ -98,4 +98,5 @@ export type TExternalKmsProviderFns = {
   validateConnection: () => Promise<boolean>;
   encrypt: (data: Buffer) => Promise<{ encryptedBlob: Buffer }>;
   decrypt: (encryptedBlob: Buffer) => Promise<{ data: Buffer }>;
+  cleanup: () => Promise<boolean>;
 };

--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -12,6 +12,7 @@ import { generateSrpServerKey, srpCheckClientProof } from "@app/lib/crypto";
 import { infisicalSymmetricEncypt } from "@app/lib/crypto/encryption";
 import { getUserPrivateKey } from "@app/lib/crypto/srp";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, UnauthorizedError } from "@app/lib/errors";
+import { removeTrailingSlash } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { getUserAgentType } from "@app/server/plugins/audit-log";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
@@ -39,7 +40,6 @@ import {
   AuthTokenType,
   MfaMethod
 } from "./auth-type";
-import { removeTrailingSlash } from "@app/lib/fn";
 
 type TAuthLoginServiceFactoryDep = {
   userDAL: TUserDALFactory;

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -342,9 +342,12 @@ export const kmsServiceFactory = ({
       }
 
       return async ({ cipherTextBlob }: Pick<TDecryptWithKmsDTO, "cipherTextBlob">) => {
-        const { data } = await externalKms.decrypt(cipherTextBlob);
-
-        return data;
+        try {
+          const { data } = await externalKms.decrypt(cipherTextBlob);
+          return data;
+        } finally {
+          await externalKms.cleanup();
+        }
       };
     }
 
@@ -557,9 +560,12 @@ export const kmsServiceFactory = ({
       }
 
       return async ({ plainText }: Pick<TEncryptWithKmsDTO, "plainText">) => {
-        const { encryptedBlob } = await externalKms.encrypt(plainText);
-
-        return { cipherTextBlob: encryptedBlob };
+        try {
+          const { encryptedBlob } = await externalKms.encrypt(plainText);
+          return { cipherTextBlob: encryptedBlob };
+        } finally {
+          await externalKms.cleanup();
+        }
       };
     }
 


### PR DESCRIPTION
Adds a clean up method because KMS clients like GCP use a persistent connection snd if not closed, will continue to eat up the memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability by ensuring external Key Management Service (KMS) resources are always properly cleaned up after use.
- **Chores**
	- Removed a duplicate import to streamline internal code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->