### PR TITLE
feat: increased secret caching to 10mins with jitter of 2min

### DIFF
--- a/backend/src/lib/dates/index.ts
+++ b/backend/src/lib/dates/index.ts
@@ -2,7 +2,7 @@ export const daysToMillisecond = (days: number) => days * 24 * 60 * 60 * 1000;
 
 export const secondsToMillis = (seconds: number) => seconds * 1000;
 
-export const applyJitter = (delayMs: number, jitterMs: number) => {
-  const jitter = Math.floor(Math.random() * (2 * jitterMs)) - jitterMs;
-  return delayMs + jitter;
+export const applyJitter = (delay: number, jitter: number) => {
+  const jitterTime = Math.floor(Math.random() * (2 * jitter)) - jitter;
+  return delay + jitterTime;
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -22,6 +22,7 @@ import type {
   TFindSecretsByFolderIdsFilter,
   TGetSecretsDTO
 } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
+import { applyJitter } from "@app/lib/dates";
 
 export const SecretServiceCacheKeys = {
   get productKey() {
@@ -48,7 +49,7 @@ interface TSecretV2DalArg {
   keyStore: TKeyStoreFactory;
 }
 
-export const SECRET_DAL_TTL = 5 * 60;
+export const SECRET_DAL_TTL = () => applyJitter(10 * 60, 2 * 60);
 export const SECRET_DAL_VERSION_TTL = 15 * 60;
 export const MAX_SECRET_CACHE_BYTES = 25 * 1024 * 1024;
 export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -962,7 +962,7 @@ export const secretV2BridgeServiceFactory = ({
     const encryptedCachedSecrets = await keyStore.getItem(cacheKey);
     if (encryptedCachedSecrets) {
       try {
-        await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL);
+        await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL());
         const cachedSecrets = secretManagerDecryptor({ cipherTextBlob: Buffer.from(encryptedCachedSecrets, "base64") });
         const { secrets, imports = [] } = JSON.parse(cachedSecrets.toString("utf8")) as {
           secrets: typeof decryptedSecrets;
@@ -1132,7 +1132,7 @@ export const secretV2BridgeServiceFactory = ({
         plainText: Buffer.from(JSON.stringify(payload))
       }).cipherTextBlob;
       if (encryptedUpdatedCachedSecrets.byteLength < MAX_SECRET_CACHE_BYTES) {
-        await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL, encryptedUpdatedCachedSecrets.toString("base64"));
+        await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
       }
       return payload;
     }
@@ -1179,7 +1179,7 @@ export const secretV2BridgeServiceFactory = ({
       plainText: Buffer.from(JSON.stringify(payload))
     }).cipherTextBlob;
     if (encryptedUpdatedCachedSecrets.byteLength < MAX_SECRET_CACHE_BYTES) {
-      await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL, encryptedUpdatedCachedSecrets.toString("base64"));
+      await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
     }
     return payload;
   };


### PR DESCRIPTION
# Description 📣

This PR increases caching for secret to 10mins with jittter of 2mins

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated time-to-live (TTL) handling for secret caching to use a dynamic duration with slight variability, instead of a fixed duration.
- **Chores**
	- Renamed some internal parameters for improved clarity. 

No user-facing features or bug fixes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->