### PR TITLE
feat: strict find filter

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -144,14 +144,9 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
   const find = async (filter: TFindFilter<TSecretsV2>, opts: TFindOpt<TSecretsV2> = {}) => {
     const { offset, limit, sort, tx } = opts;
     try {
-      const qualifiedFilter = { ...filter };
-      if ("userId" in qualifiedFilter) {
-        delete qualifiedFilter.userId;
-      }
-
       const query = (tx || db)(TableName.SecretV2)
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        .where(buildFindFilter(qualifiedFilter))
+        .where(buildFindFilter(filter))
         .leftJoin(
           TableName.SecretV2JnTag,
           `${TableName.SecretV2}.id`,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -10,7 +10,6 @@ import { generateCacheKeyFromData } from "@app/lib/crypto/cache";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import {
   buildFindFilter,
-  buildStrictFindFilter,
   ormify,
   selectAllTableCols,
   sqlNestRelationships,
@@ -65,7 +64,7 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
     try {
       const docs = await (tx || db)(TableName.SecretV2)
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        .where(buildStrictFindFilter(filter, TableName.SecretV2))
+        .where(buildFindFilter(filter, TableName.SecretV2))
         .leftJoin(
           TableName.SecretV2JnTag,
           `${TableName.SecretV2}.id`,


### PR DESCRIPTION
# Description 📣

This PR adds a new and improved find filter function, which will always prefix the table name to avoid ambiguous field postgres errors. This also fixes the bug with not being able to update personal secret overrides.
## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced data query filters for stricter and more precise results by adding table name prefixes and key exclusions.
	- Improved query construction for multi-table contexts and joins.

- **Chores**
	- Updated internal logic to prevent specific fields from unintentionally affecting search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->