### PR TITLE
fix(external-connections): Use Hostname for Blocking Internal IPs DNS Resolve

### DIFF
--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -15,13 +15,13 @@ export const blockLocalAndPrivateIpAddresses = async (url: string) => {
 
   const validUrl = new URL(url);
   const inputHostIps: string[] = [];
-  if (isIPv4(validUrl.host)) {
-    inputHostIps.push(validUrl.host);
+  if (isIPv4(validUrl.hostname)) {
+    inputHostIps.push(validUrl.hostname);
   } else {
-    if (validUrl.host === "localhost" || validUrl.host === "host.docker.internal") {
+    if (validUrl.hostname === "localhost" || validUrl.hostname === "host.docker.internal") {
       throw new BadRequestError({ message: "Local IPs not allowed as URL" });
     }
-    const resolvedIps = await dns.resolve4(validUrl.host);
+    const resolvedIps = await dns.resolve4(validUrl.hostname);
     inputHostIps.push(...resolvedIps);
   }
   const isInternalIp = inputHostIps.some((el) => isPrivateIp(el));


### PR DESCRIPTION
# Description 📣

This PR corrects our DNS resolve in blocking internal IPs to use `hostname` instead of `host` which contains the port if present

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝