### PR TITLE
fix(api): project deletion failing

### DIFF
--- a/backend/src/lib/knex/index.ts
+++ b/backend/src/lib/knex/index.ts
@@ -47,21 +47,21 @@ export const buildFindFilter =
     if ($in) {
       Object.entries($in).forEach(([key, val]) => {
         if (val) {
-          void bd.whereIn([`${tableName ? `${tableName}.` : ""}${key}`] as never, val as never);
+          void bd.whereIn(`${tableName ? `${tableName}.` : ""}${key}`, val as never);
         }
       });
     }
 
     if ($notNull?.length) {
       $notNull.forEach((key) => {
-        void bd.whereNotNull([`${tableName ? `${tableName}.` : ""}${key as string}`] as never);
+        void bd.whereNotNull(`${tableName ? `${tableName}.` : ""}${key as string}`);
       });
     }
 
     if ($search) {
       Object.entries($search).forEach(([key, val]) => {
         if (val) {
-          void bd.whereILike([`${tableName ? `${tableName}.` : ""}${key}`] as never, val as never);
+          void bd.whereILike(`${tableName ? `${tableName}.` : ""}${key}`, val as never);
         }
       });
     }


### PR DESCRIPTION
# Description 📣

Fixed a recently introduced bug causing project deletion to fail. The bug was happening because we were wrapping keys with brackets `[]` when doing special filtering like `$notNull`. This would result in an `syntax error at or near "as"` error, because it was taking the first item in the array, resulting in `as "0"` SQL. This wasn't caught by typescript due to the `as never` casting. The repercussions of this appear minimal as all tests are passing and there's no big uptick in logs related to the `syntax error at or near "as"` SQL error.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way database query filters are constructed, ensuring more consistent handling of filter conditions. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->