### PR TITLE
feat(vite.config): Allowed Hosts Defined Through Env Variable

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig, PluginOption } from "vite";
+import { defineConfig, loadEnv, PluginOption } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
@@ -20,32 +20,38 @@ const virtualRouteFileChangeReloadPlugin: PluginOption = {
 };
 
 // https://vite.dev/config/
-export default defineConfig({
-  server: {
-    host: true,
-    port: 3000
-    // proxy: {
-    //   "/api": {
-    //     target: "http://localhost:8080",
-    //     changeOrigin: true,
-    //     secure: false,
-    //     ws: true
-    //   }
-    // }
-  },
-  plugins: [
-    tsconfigPaths(),
-    nodePolyfills({
-      globals: {
-        Buffer: true
-      }
-    }),
-    wasm(),
-    topLevelAwait(),
-    TanStackRouterVite({
-      virtualRouteConfig: "./src/routes.ts"
-    }),
-    react(),
-    virtualRouteFileChangeReloadPlugin
-  ]
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  const allowedHosts = env.VITE_ALLOWED_HOSTS?.split(",") ?? [];
+
+  return {
+    server: {
+      allowedHosts,
+      host: true,
+      port: 3000
+      // proxy: {
+      //   "/api": {
+      //     target: "http://localhost:8080",
+      //     changeOrigin: true,
+      //     secure: false,
+      //     ws: true
+      //   }
+      // }
+    },
+    plugins: [
+      tsconfigPaths(),
+      nodePolyfills({
+        globals: {
+          Buffer: true
+        }
+      }),
+      wasm(),
+      topLevelAwait(),
+      TanStackRouterVite({
+        virtualRouteConfig: "./src/routes.ts"
+      }),
+      react(),
+      virtualRouteFileChangeReloadPlugin
+    ]
+  };
 });


### PR DESCRIPTION
# Description 📣

Allowed Hosts Defined Through Env Variable

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment-specific configuration is now supported, allowing the app to adjust settings based on the current mode.
  - The list of allowed hosts for the development server can now be customized via an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->