### PR TITLE
doc: added daemonset and statefulset auto-redeploy example

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
@@ -1230,13 +1230,13 @@ To address this, we added functionality to automatically redeploy your deploymen
 
 #### Enabling Automatic Redeployment
 
-To enable auto redeployment you simply have to add the following annotation to the deployment, statefulset, or daemonset that consumes a managed secret.
+To enable auto redeployment you simply have to add the following annotation to the Deployment, StatefulSet, or DaemonSet that consumes a managed secret.
 
 ```yaml
 secrets.infisical.com/auto-reload: "true"
 ```
 
-<Accordion title="Deployment example with auto redeploy enabled">
+<Accordion title="Deployment example">
   ```yaml
   apiVersion: apps/v1
   kind: Deployment
@@ -1266,10 +1266,82 @@ secrets.infisical.com/auto-reload: "true"
           - containerPort: 80
   ```
 </Accordion>
+
+<Accordion title="DaemonSet example">
+  ```yaml
+  apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    name: log-agent
+    labels:
+      app: log-agent
+    annotations:
+      secrets.infisical.com/auto-reload: "true" # <- redeployment annotation
+  spec:
+    selector:
+      matchLabels:
+        app: log-agent
+    template:
+      metadata:
+        labels:
+          app: log-agent
+      spec:
+        containers:
+          - name: log-agent
+            image: mycompany/log-agent:latest
+            envFrom:
+              - secretRef:
+                  name: managed-secret # <- name of the managed secret
+            volumeMounts:
+              - name: config-volume
+                mountPath: /etc/config
+                readOnly: true
+        volumes:
+          - name: config-volume
+            secret:
+              secretName: managed-secret
+  ```
+</Accordion>
+
+<Accordion title="StatefulSet example">
+  ```yaml
+  apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    name: db-worker
+    labels:
+      app: db-worker
+    annotations:
+      secrets.infisical.com/auto-reload: "true" # <- redeployment annotation
+  spec:
+    selector:
+      matchLabels:
+        app: db-worker
+    serviceName: "db-worker"
+    replicas: 2
+    template:
+      metadata:
+        labels:
+          app: db-worker
+      spec:
+        containers:
+          - name: db-worker
+            image: mycompany/db-worker:stable
+            env:
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: managed-secret
+                    key: DB_PASSWORD
+            ports:
+              - containerPort: 5432
+  ```
+</Accordion>
+
 <Info>
   #### How it works 
-  When a secret change occurs, the operator will check to see which deployments are using the operator-managed Kubernetes secret that received the update. 
-  Then, for each deployment that has this annotation present, a rolling update will be triggered.
+  When a managed secret is updated, the operator checks for any Deployments, DaemonSets, or StatefulSets that consume the updated secret and have the annotation
+  `secrets.infisical.com/auto-reload: "true"`. For each matching workload, the operator triggers a rolling restart to ensure it picks up the latest secret values.
 </Info>
 
 ## Using Managed ConfigMap In Your Deployment


### PR DESCRIPTION
# Description 📣
This PR adds auto-redeploy examples for statefulsets and daemonsets
<img width="698" alt="image" src="https://github.com/user-attachments/assets/e011454b-b516-4b79-96ce-0073762989a1" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded and clarified instructions for enabling automatic redeployment of Kubernetes workloads using managed secrets.
	- Added separate example manifests for Deployment, DaemonSet, and StatefulSet, each showing required annotations and secret consumption.
	- Improved explanation of how automatic redeployment works for annotated workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->