### PR TITLE
misc: made user and machine identity labels clearer

### DIFF
--- a/backend/src/ee/services/license/licence-enums.ts
+++ b/backend/src/ee/services/license/licence-enums.ts
@@ -1,6 +1,6 @@
 export const BillingPlanRows = {
-  MemberLimit: { name: "Organization member limit", field: "memberLimit" },
-  IdentityLimit: { name: "Organization identity limit", field: "identityLimit" },
+  MemberLimit: { name: "Organization user identity limit", field: "memberLimit" },
+  IdentityLimit: { name: "Organization machine identity limit", field: "identityLimit" },
   WorkspaceLimit: { name: "Project limit", field: "workspaceLimit" },
   EnvironmentLimit: { name: "Environment limit", field: "environmentLimit" },
   SecretVersioning: { name: "Secret versioning", field: "secretVersioning" },

--- a/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
@@ -45,7 +45,7 @@ export const AccessManagementPage = () => {
   const tabSections = [
     {
       key: OrgAccessControlTabSections.Member,
-      label: "Users",
+      label: "User Identities",
       isHidden: permission.cannot(OrgPermissionActions.Read, OrgPermissionSubjects.Member),
       component: OrgMembersTab
     },
@@ -57,7 +57,7 @@ export const AccessManagementPage = () => {
     },
     {
       key: OrgAccessControlTabSections.Identities,
-      label: "Identities",
+      label: "Machine Identities",
       isHidden: permission.cannot(
         OrgPermissionIdentityActions.Read,
         OrgPermissionSubjects.Identity
@@ -80,7 +80,7 @@ export const AccessManagementPage = () => {
       <div className="mx-auto mb-6 w-full max-w-7xl">
         <PageHeader
           title="Organization Access Control"
-          description="Manage fine-grained access for users, groups, roles, and identities within your organization resources."
+          description="Manage fine-grained access for user identities, groups, roles, and machine identities within your organization resources."
         />
         {!currentOrg.shouldUseNewPrivilegeSystem && (
           <div className="mb-4 mt-4 flex flex-col rounded-r border-l-2 border-l-primary bg-mineshaft-300/5 px-4 py-2.5">

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentitySection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentitySection.tsx
@@ -71,9 +71,9 @@ export const IdentitySection = withPermission(
 
     return (
       <div className="rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-        <div className="mb-4 flex justify-between">
-          <p className="text-xl font-semibold text-mineshaft-100">Identities</p>
-          <div className="flex w-full justify-end pr-4">
+        <div className="mb-4 flex items-center">
+          <p className="text-xl font-semibold text-mineshaft-100">Machine Identities</p>
+          <div className="ml-auto flex items-center gap-2">
             <a
               target="_blank"
               rel="noopener noreferrer"
@@ -86,31 +86,32 @@ export const IdentitySection = withPermission(
                 className="mb-[0.06rem] ml-1 text-xs"
               />
             </a>
+            <OrgPermissionCan
+              I={OrgPermissionIdentityActions.Create}
+              a={OrgPermissionSubjects.Identity}
+            >
+              {(isAllowed) => (
+                <Button
+                  colorSchema="primary"
+                  type="submit"
+                  leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                  onClick={() => {
+                    if (!isMoreIdentitiesAllowed && !isEnterprise) {
+                      handlePopUpOpen("upgradePlan", {
+                        description:
+                          "You can add more identities if you upgrade your Infisical plan."
+                      });
+                      return;
+                    }
+                    handlePopUpOpen("identity");
+                  }}
+                  isDisabled={!isAllowed}
+                >
+                  Create Identity
+                </Button>
+              )}
+            </OrgPermissionCan>
           </div>
-          <OrgPermissionCan
-            I={OrgPermissionIdentityActions.Create}
-            a={OrgPermissionSubjects.Identity}
-          >
-            {(isAllowed) => (
-              <Button
-                colorSchema="primary"
-                type="submit"
-                leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                onClick={() => {
-                  if (!isMoreIdentitiesAllowed && !isEnterprise) {
-                    handlePopUpOpen("upgradePlan", {
-                      description: "You can add more identities if you upgrade your Infisical plan."
-                    });
-                    return;
-                  }
-                  handlePopUpOpen("identity");
-                }}
-                isDisabled={!isAllowed}
-              >
-                Create Identity
-              </Button>
-            )}
-          </OrgPermissionCan>
         </div>
         <IdentityTable handlePopUpOpen={handlePopUpOpen} />
         <IdentityModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -116,7 +116,7 @@ export const OrgMembersSection = () => {
   return (
     <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
       <div className="mb-4 flex justify-between">
-        <p className="text-xl font-semibold text-mineshaft-100">Users</p>
+        <p className="text-xl font-semibold text-mineshaft-100">User Identities</p>
         <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
           {(isAllowed) => (
             <Button

--- a/frontend/src/pages/project/AccessControlPage/AccessControlPage.tsx
+++ b/frontend/src/pages/project/AccessControlPage/AccessControlPage.tsx
@@ -38,11 +38,11 @@ const Page = () => {
       <div className="mx-auto mb-6 w-full max-w-7xl">
         <PageHeader
           title="Access Control"
-          description="Manage fine-grained access for users, groups, roles, and identities within your project resources."
+          description="Manage fine-grained access for user identities, groups, roles, and machine identities within your project resources."
         />
         <Tabs value={selectedTab} onValueChange={updateSelectedTab}>
           <TabList>
-            <Tab value={ProjectAccessControlTabs.Member}>Users</Tab>
+            <Tab value={ProjectAccessControlTabs.Member}>User Identities</Tab>
             <Tab value={ProjectAccessControlTabs.Groups}>Groups</Tab>
             <Tab value={ProjectAccessControlTabs.Identities}>
               <div className="flex items-center">

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -156,9 +156,9 @@ export const IdentityTab = withProjectPermission(
         exit={{ opacity: 0, translateX: 30 }}
       >
         <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-          <div className="mb-4 flex items-center justify-between">
-            <p className="text-xl font-semibold text-mineshaft-100">Identities</p>
-            <div className="flex w-full justify-end pr-4">
+          <div className="mb-4 flex items-center">
+            <p className="text-xl font-semibold text-mineshaft-100">Machine Identities</p>
+            <div className="ml-auto flex items-center gap-2">
               <a
                 target="_blank"
                 rel="noopener noreferrer"
@@ -172,23 +172,23 @@ export const IdentityTab = withProjectPermission(
                   />
                 </span>
               </a>
+              <ProjectPermissionCan
+                I={ProjectPermissionActions.Create}
+                a={ProjectPermissionSub.Identity}
+              >
+                {(isAllowed) => (
+                  <Button
+                    colorSchema="primary"
+                    type="submit"
+                    leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                    onClick={() => handlePopUpOpen("identity")}
+                    isDisabled={!isAllowed}
+                  >
+                    Add Identity
+                  </Button>
+                )}
+              </ProjectPermissionCan>
             </div>
-            <ProjectPermissionCan
-              I={ProjectPermissionActions.Create}
-              a={ProjectPermissionSub.Identity}
-            >
-              {(isAllowed) => (
-                <Button
-                  colorSchema="primary"
-                  type="submit"
-                  leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                  onClick={() => handlePopUpOpen("identity")}
-                  isDisabled={!isAllowed}
-                >
-                  Add Identity
-                </Button>
-              )}
-            </ProjectPermissionCan>
           </div>
           <Input
             containerClassName="mb-4"

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
@@ -57,7 +57,7 @@ export const MembersSection = () => {
   return (
     <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
       <div className="mb-4 flex justify-between">
-        <p className="text-xl font-semibold text-mineshaft-100">Users</p>
+        <p className="text-xl font-semibold text-mineshaft-100">User Identities</p>
         <ProjectPermissionCan I={ProjectPermissionActions.Create} a={ProjectPermissionSub.Member}>
           {(isAllowed) => (
             <Button


### PR DESCRIPTION
# Description 📣
<img width="966" alt="image" src="https://github.com/user-attachments/assets/18b71cc3-8e16-42ac-9ed9-28b6f87865bd" />
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/20c464be-f70f-4874-916b-9d1871610b44" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated labels and headings throughout access management and control pages to use "User Identities" instead of "Users" and "Machine Identities" instead of "Identities" for improved clarity.
  - Revised descriptive text to align with new terminology.
  - Adjusted layout for identity management sections for a more consistent appearance.
- **Bug Fixes**
  - Removed duplicate "Create/Add Identity" button blocks, consolidating UI elements and permission logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->