### PR TITLE
fix(external-connections): Use DNS Lookup as Fallback for DNS Resolve

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
@@ -24,8 +24,13 @@ export const verifyHostInputValidity = async (host: string, isGateway = false) =
       if (net.isIPv4(el)) {
         exclusiveIps.push(el);
       } else {
-        const resolvedIps = await dns.resolve4(el);
-        exclusiveIps.push(...resolvedIps);
+        try {
+          const resolvedIps = await dns.resolve4(el);
+          exclusiveIps.push(...resolvedIps);
+        } catch {
+          const resolvedIps = (await dns.lookup(el, { all: true })).map(({ address }) => address);
+          exclusiveIps.push(...resolvedIps);
+        }
       }
     }
   }
@@ -38,8 +43,13 @@ export const verifyHostInputValidity = async (host: string, isGateway = false) =
     if (normalizedHost === "localhost" || normalizedHost === "host.docker.internal") {
       throw new BadRequestError({ message: "Invalid db host" });
     }
-    const resolvedIps = await dns.resolve4(host);
-    inputHostIps.push(...resolvedIps);
+    try {
+      const resolvedIps = await dns.resolve4(host);
+      inputHostIps.push(...resolvedIps);
+    } catch {
+      const resolvedIps = (await dns.lookup(host, { all: true })).map(({ address }) => address);
+      inputHostIps.push(...resolvedIps);
+    }
   }
 
   if (!isGateway && !(appCfg.DYNAMIC_SECRET_ALLOW_INTERNAL_IP || appCfg.ALLOW_INTERNAL_IP_CONNECTIONS)) {

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-fns.ts
@@ -9,7 +9,7 @@ import { getDbConnectionHost } from "@app/lib/knex";
 export const verifyHostInputValidity = async (host: string, isGateway = false) => {
   const appCfg = getConfig();
 
-  // if (appCfg.isDevelopmentMode) return [host];
+  if (appCfg.isDevelopmentMode) return [host];
 
   const reservedHosts = [appCfg.DB_HOST || getDbConnectionHost(appCfg.DB_CONNECTION_URI)].concat(
     (appCfg.DB_READ_REPLICAS || []).map((el) => getDbConnectionHost(el.DB_CONNECTION_URI)),


### PR DESCRIPTION
# Description 📣

This PR adds a fallback for failed dns.resolve4 calls to handle improper kubernetes domain name resolution.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of DNS resolution when validating host inputs by adding a fallback method, ensuring IP addresses are obtained even if the primary DNS lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->