### PR TITLE
fix(workflow-integrations): microsoft teams scaling issues

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1784,6 +1784,10 @@ export const registerRoutes = async (
     if (licenseSyncJob) {
       cronJobs.push(licenseSyncJob);
     }
+    const microsoftTeamsSyncJob = await microsoftTeamsService.initializeBackgroundSync();
+    if (microsoftTeamsSyncJob) {
+      cronJobs.push(microsoftTeamsSyncJob);
+    }
   }
 
   server.decorate<FastifyZodProvider["store"]>("store", {

--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -246,7 +246,8 @@ export const superAdminServiceFactory = ({
 
       await microsoftTeamsService.initializeTeamsBot({
         botAppId: decryptedAppId.toString(),
-        botAppPassword: decryptedAppPassword.toString()
+        botAppPassword: decryptedAppPassword.toString(),
+        lastUpdatedAt: updatedServerCfg.updatedAt
       });
     }
 

--- a/frontend/src/pages/admin/OverviewPage/components/MicrosoftTeamsIntegrationForm.tsx
+++ b/frontend/src/pages/admin/OverviewPage/components/MicrosoftTeamsIntegrationForm.tsx
@@ -52,7 +52,7 @@ export const MicrosoftTeamsIntegrationForm = ({ adminIntegrationsConfig }: Props
     });
 
     createNotification({
-      text: "Updated admin Microsoft Teams configuration",
+      text: "Updated admin Microsoft Teams configuration. It can take up to 5 minutes to take effect.",
       type: "success"
     });
   };


### PR DESCRIPTION
# Description 📣

This PR fixes issues with the Microsoft Teams workflow integration on deployments using horizontal scaling. The issue was that the `teamsBot` and `adapter` variables defined in the microsoft-teams-service.ts` service handler were stateful. This means that if I trigger an update for instance-level settings, it wouldn't propagate to all the API instances. We are now using cron to forcefully resync every 5 minutes if a change has happened in the server config.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x]  I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->