### PR TITLE
fix: move cli install to aws

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -133,7 +133,7 @@ RUN apt-get update && apt-get install -y \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 # Install Infisical CLI
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash \
+RUN curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
     && apt-get update && apt-get install -y infisical=0.41.2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -127,7 +127,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Infisical CLI
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash \
+RUN curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
     && apt-get update && apt-get install -y infisical=0.41.2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=build /app .
 
 # Install Infisical CLI
 RUN apt-get install -y curl bash && \
-    curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash && \
+    curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash && \
     apt-get update && apt-get install -y infisical=0.41.2 git
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s \  

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -55,7 +55,7 @@ RUN mkdir -p /etc/softhsm2/tokens && \
 # ? App setup
 
 # Install Infisical CLI
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash && \
+RUN curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash && \
     apt-get update && \
     apt-get install -y infisical=0.41.2
 

--- a/backend/Dockerfile.dev.fips
+++ b/backend/Dockerfile.dev.fips
@@ -64,7 +64,7 @@ RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
 # ? App setup
 
 # Install Infisical CLI
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | bash && \
+RUN curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash && \
     apt-get update && \
     apt-get install -y infisical=0.41.2
 


### PR DESCRIPTION
# Description 📣

This PR fixes a recent bug introduced when we bumped the CLI version to 0.41.2. We recently stopped releasing ubuntu/debian to cloudsmith and moved it to AWS. I've updated the install URL to our new AWS code artifacts.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->