### PR TITLE
docs: fix typos in doc CLI

### DIFF
--- a/docs/cli/commands/login.mdx
+++ b/docs/cli/commands/login.mdx
@@ -343,9 +343,9 @@ In this example we'll be using the `universal-auth` method to login to obtain an
         ```
     </Step>
 
-      <Step title="Fetch all secrets from an evironment">
+      <Step title="Fetch all secrets from an environment">
         ```bash
-          infisical secrets --projectId=<your-project-id --env=dev --recursive
+          infisical secrets --projectId=<your-project-id> --env=dev --recursive
         ```
 
         This command will fetch all secrets from the `dev` environment in your project, including all secrets in subfolders.


### PR DESCRIPTION
# Description 📣

I've fixed some typos in doc CLI.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# To reproduce:

- Go to https://infisical.com/docs/cli/commands/login
- See the typo error :
<img width="765" alt="image" src="https://github.com/user-attachments/assets/097a97a7-916d-434f-b11c-0d420d56ded7" />


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->