### PR TITLE
fix(auth): cli auth bug

### DIFF
--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -10,7 +10,7 @@ import { useNavigateToSelectOrganization } from "./Login.utils";
 
 export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
   const { t } = useTranslation();
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState<number | null>(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const { navigateToSelectOrganization } = useNavigateToSelectOrganization();
@@ -36,6 +36,8 @@ export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
 
     if (isLoggedIn()) {
       handleRedirects();
+    } else {
+      setStep(1);
     }
   }, []);
 

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -37,7 +37,7 @@ export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
     if (isLoggedIn()) {
       handleRedirects();
     } else {
-      setStep(1);
+      setStep(0);
     }
   }, []);
 


### PR DESCRIPTION
# Description 📣

At last, we fixed the CLI login bug with callback port not being used correctly.

The issue was that on the login page we had a useEffect that would redirect to select org, and within select org we'd do SAML auth flow or redirect to the organization page. But at the same time, it would also load the `InitialStep` component because the step would always default to 1 on page load. Inside the InitialStep component we also handle SAML auth. This created a race condition leading to strange behavior for SAML auth handling.

The solution is to first wait for the useEffect to finish before rendering the rest of the login page.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->