### PR TITLE
fix(identities-auth): fixed kubernetes auth login

### DIFF
--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -79,7 +79,7 @@ export const identityKubernetesAuthServiceFactory = ({
 
     const callbackResult = await withGatewayProxy(
       async (port) => {
-        const res = await gatewayCallback("localhost", port);
+        const res = await gatewayCallback("https://localhost", port);
         return res;
       },
       {
@@ -138,11 +138,7 @@ export const identityKubernetesAuthServiceFactory = ({
     }
 
     const tokenReviewCallback = async (host: string = identityKubernetesAuth.kubernetesHost, port?: number) => {
-      let baseUrl = `https://${host}`;
-
-      if (port) {
-        baseUrl += `:${port}`;
-      }
+      const baseUrl = port ? `${host}:${port}` : host;
 
       const res = await axios
         .post<TCreateTokenReviewResponse>(

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -79,6 +79,7 @@ export const identityKubernetesAuthServiceFactory = ({
 
     const callbackResult = await withGatewayProxy(
       async (port) => {
+        // Needs to be https protocol or the kubernetes API server will fail with "Client sent an HTTP request to an HTTPS server"
         const res = await gatewayCallback("https://localhost", port);
         return res;
       },


### PR DESCRIPTION
# Description 📣

This PR addresses an issue with Kubernetes auth, which assumes that users using Kubernetes auth doesn't have a protocol specified for their kubernetes host URL. This was recently introduced when rolling out gateway support for k8s auth, #3590 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->