### PR TITLE
fix(agent): exit code 1 on fetch secrets error

### DIFF
--- a/cli/packages/cmd/agent.go
+++ b/cli/packages/cmd/agent.go
@@ -884,6 +884,12 @@ func (tm *AgentManager) MonitorSecretChanges(secretTemplate Template, templateId
 
 					if err != nil {
 						log.Error().Msgf("unable to process template because %v", err)
+
+						// case: if exit-after-auth is true, it should exit the agent once an error on secret fetching occurs with the appropriate exit code (1)
+						// previous behavior would exit after 25 sec with status code 0, even if this step errors
+						if tm.exitAfterAuth {
+							os.Exit(1)
+						}
 					} else {
 						if (existingEtag != currentEtag) || firstRun {
 


### PR DESCRIPTION
# Description 📣

This PR fixes the exit code on secrets error if `exit-on-auth` is set to true.

We are using the agent in our K8s agent injector, and it depends on the exit codes being correct.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->