### PR TITLE
fix(password-resets): allow password resets when users don't have a password set

### DIFF
--- a/backend/src/services/auth/auth-password-service.ts
+++ b/backend/src/services/auth/auth-password-service.ts
@@ -189,16 +189,15 @@ export const authPaswordServiceFactory = ({
       throw new BadRequestError({ message: `User encryption key not found for user with ID '${userId}'` });
     }
 
-    if (!user.hashedPassword) {
-      throw new BadRequestError({ message: "Unable to reset password, no password is set" });
-    }
-
     if (!user.authMethods?.includes(AuthMethod.EMAIL)) {
       throw new BadRequestError({ message: "Unable to reset password, no email authentication method is configured" });
     }
 
     // we check the old password if the user is resetting their password while logged in
     if (type === ResetPasswordV2Type.LoggedInReset) {
+      if (!user.hashedPassword) {
+        throw new BadRequestError({ message: "Unable to change password, no password is set" });
+      }
       if (!oldPassword) {
         throw new BadRequestError({ message: "Current password is required." });
       }


### PR DESCRIPTION
# Description 📣

This PR updates the password reset logic to allow for password resets even if a user doesn't have a pre-existing password set.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->