### PR TITLE
fix(k8s): disable clustergenerator watching in namespace scoped installations

### DIFF
--- a/k8-operator/controllers/infisicalpushsecret/infisicalpushsecret_controller.go
+++ b/k8-operator/controllers/infisicalpushsecret/infisicalpushsecret_controller.go
@@ -30,9 +30,9 @@ import (
 // InfisicalSecretReconciler reconciles a InfisicalSecret object
 type InfisicalPushSecretReconciler struct {
 	client.Client
-
-	BaseLogger logr.Logger
-	Scheme     *runtime.Scheme
+	IsNamespaceScoped bool
+	BaseLogger        logr.Logger
+	Scheme            *runtime.Scheme
 }
 
 var infisicalPushSecretResourceVariablesMap map[string]util.ResourceVariables = make(map[string]util.ResourceVariables)
@@ -51,7 +51,7 @@ func (r *InfisicalPushSecretReconciler) GetLogger(req ctrl.Request) logr.Logger 
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 //+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create
 //+kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
-// +kubebuilder:rbac:groups=secrets.infisical.com,resources=clustergenerators,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=secrets.infisical.com,resources=clustergenerators,verbs=get;list;watch;create;update;patch;delete
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // For more details, check Reconcile and its Result here:
@@ -249,19 +249,26 @@ func (r *InfisicalPushSecretReconciler) SetupWithManager(mgr ctrl.Manager) error
 		},
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	controllerManager := ctrl.NewControllerManagedBy(mgr).
 		For(&secretsv1alpha1.InfisicalPushSecret{}, builder.WithPredicates(
 			specChangeOrDelete,
 		)).
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.findPushSecretsForSecret),
-		).
-		Watches(
+		)
+
+	if !r.IsNamespaceScoped {
+		r.BaseLogger.Info("Watching ClusterGenerators for namespace scoped operator")
+		controllerManager.Watches(
 			&source.Kind{Type: &secretsv1alpha1.ClusterGenerator{}},
 			handler.EnqueueRequestsFromMapFunc(r.findPushSecretsForClusterGenerator),
-		).
-		Complete(r)
+		)
+	} else {
+		r.BaseLogger.Info("Not watching ClusterGenerators for namespace scoped operator")
+	}
+
+	return controllerManager.Complete(r)
 }
 
 func (r *InfisicalPushSecretReconciler) findPushSecretsForClusterGenerator(o client.Object) []reconcile.Request {
@@ -277,6 +284,7 @@ func (r *InfisicalPushSecretReconciler) findPushSecretsForClusterGenerator(o cli
 	}
 
 	requests := []reconcile.Request{}
+
 	for _, pushSecret := range pushSecrets.Items {
 		if pushSecret.Spec.Push.Generators != nil {
 			for _, generator := range pushSecret.Spec.Push.Generators {

--- a/k8-operator/controllers/infisicalpushsecret/infisicalpushsecret_controller.go
+++ b/k8-operator/controllers/infisicalpushsecret/infisicalpushsecret_controller.go
@@ -259,7 +259,7 @@ func (r *InfisicalPushSecretReconciler) SetupWithManager(mgr ctrl.Manager) error
 		)
 
 	if !r.IsNamespaceScoped {
-		r.BaseLogger.Info("Watching ClusterGenerators for namespace scoped operator")
+		r.BaseLogger.Info("Watching ClusterGenerators for non-namespace scoped operator")
 		controllerManager.Watches(
 			&source.Kind{Type: &secretsv1alpha1.ClusterGenerator{}},
 			handler.EnqueueRequestsFromMapFunc(r.findPushSecretsForClusterGenerator),

--- a/k8-operator/main.go
+++ b/k8-operator/main.go
@@ -99,9 +99,10 @@ func main() {
 	}
 
 	if err = (&infisicalPushSecretController.InfisicalPushSecretReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		BaseLogger: ctrl.Log,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		BaseLogger:        ctrl.Log,
+		IsNamespaceScoped: namespace != "",
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InfisicalPushSecret")
 		os.Exit(1)


### PR DESCRIPTION
# Description 📣

This PR serves as a fix for the error below. Essentially when users would try to create namespace-scoped installations, it would fail because the PushSecret controller manager would try to watch for clustergenerator crd changes. This doesn't work in namespace-scoped installations because they don't have access to cluster resources by default when rbac is scoped as well.

```
E0520 17:51:12.363296       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.1/tools/cache/reflector.go:169: Failed to watch *v1alpha1.ClusterGenerator: failed to list *v1alpha1.ClusterGenerator: clustergenerators.secrets.infisical.com is forbidden: User "system:serviceaccount:custom-namespace:infisical-opera-controller-manager" cannot list resource "clustergenerators" in API group "secrets.infisical.com" at the cluster scope
```

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->