### PR TITLE
Allow machine identity to read billing

### DIFF
--- a/backend/src/ee/routes/v1/license-router.ts
+++ b/backend/src/ee/routes/v1/license-router.ts
@@ -47,7 +47,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.object({ plan: z.any() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const plan = await server.services.license.getOrgPlan({
         actorId: req.permission.id,


### PR DESCRIPTION
Added this so we can add datadog tests. This will help us catch any issues with license server 