### PR TITLE
Fix(org-admin-project-access): Check for recipients prior to sending project access email

### DIFF
--- a/backend/src/services/org-admin/org-admin-service.ts
+++ b/backend/src/services/org-admin/org-admin-service.ts
@@ -196,7 +196,8 @@ export const orgAdminServiceFactory = ({
       .filter(
         (member) => member.roles.some((role) => role.role === ProjectMembershipRole.Admin) && member.userId !== actorId
       )
-      .map((el) => el.user.email!);
+      .map((el) => el.user.email!)
+      .filter(Boolean);
 
     if (filteredProjectMembers.length) {
       await smtpService.sendMail({


### PR DESCRIPTION
# Description 📣

This PR adds a check to send the project access email when an org admin directly access a project

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝