### PR TITLE
fix: allow https on gateway k8s hosts

### DIFF
--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -104,7 +104,6 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z
             .string()
-            .url()
             .trim()
             .min(1)
             .describe(KUBERNETES_AUTH.ATTACH.kubernetesHost)
@@ -224,7 +223,6 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z
             .string()
-            .url()
             .trim()
             .min(1)
             .optional()

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -104,6 +104,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z
             .string()
+            .url()
             .trim()
             .min(1)
             .describe(KUBERNETES_AUTH.ATTACH.kubernetesHost)
@@ -223,6 +224,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
         .object({
           kubernetesHost: z
             .string()
+            .url()
             .trim()
             .min(1)
             .optional()

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -189,10 +189,10 @@ export const identityKubernetesAuthServiceFactory = ({
     let { kubernetesHost } = identityKubernetesAuth;
 
     if (kubernetesHost.startsWith("https://") || kubernetesHost.startsWith("http://")) {
-      kubernetesHost = kubernetesHost.replace(new RE2("^https?:\\/\\/"), "");
+      kubernetesHost = new RE2("^https?:\\/\\/").replace(kubernetesHost, "");
     }
 
-    const [k8sHost, k8sPort] = kubernetesHost.split(":") ?? [];
+    const [k8sHost, k8sPort] = kubernetesHost.split(":");
 
     const data = identityKubernetesAuth.gatewayId
       ? await $gatewayProxyWrapper(

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -2,6 +2,7 @@ import { ForbiddenError } from "@casl/ability";
 import axios, { AxiosError } from "axios";
 import https from "https";
 import jwt from "jsonwebtoken";
+import RE2 from "re2";
 
 import { IdentityAuthMethod, TIdentityKubernetesAuthsUpdate } from "@app/db/schemas";
 import { TGatewayDALFactory } from "@app/ee/services/gateway/gateway-dal";
@@ -185,7 +186,13 @@ export const identityKubernetesAuthServiceFactory = ({
       return res.data;
     };
 
-    const [k8sHost, k8sPort] = identityKubernetesAuth.kubernetesHost.split(":");
+    let { kubernetesHost } = identityKubernetesAuth;
+
+    if (kubernetesHost.startsWith("https://") || kubernetesHost.startsWith("http://")) {
+      kubernetesHost = kubernetesHost.replace(new RE2("^https?:\\/\\/"), "");
+    }
+
+    const [k8sHost, k8sPort] = kubernetesHost.split(":") ?? [];
 
     const data = identityKubernetesAuth.gatewayId
       ? await $gatewayProxyWrapper(


### PR DESCRIPTION
# Description 📣

Currently users can't use https/http on gateway kubernetes hosts. This PR handles the split operation for both with/without protocol.

Example:
Previously `https://kubernetes.default.svc.cluster.local:443` would fail if a gateway is selected.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->