### PR TITLE
feat(access-request): fix deleted policy interfering with the newest and valid policy and fix for default values on the creation form

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -57,7 +57,7 @@ type TSecretApprovalRequestServiceFactoryDep = {
     | "findOne"
     | "getCount"
   >;
-  accessApprovalPolicyDAL: Pick<TAccessApprovalPolicyDALFactory, "findOne" | "find">;
+  accessApprovalPolicyDAL: Pick<TAccessApprovalPolicyDALFactory, "findOne" | "find" | "findLastValidPolicy">;
   accessApprovalRequestReviewerDAL: Pick<
     TAccessApprovalRequestReviewerDALFactory,
     "create" | "find" | "findOne" | "transaction"
@@ -132,7 +132,7 @@ export const accessApprovalRequestServiceFactory = ({
 
     if (!environment) throw new NotFoundError({ message: `Environment with slug '${envSlug}' not found` });
 
-    const policy = await accessApprovalPolicyDAL.findOne({
+    const policy = await accessApprovalPolicyDAL.findLastValidPolicy({
       envId: environment.id,
       secretPath
     });

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -45,7 +45,7 @@ const formSchema = z
     environment: z.object({ slug: z.string(), name: z.string() }),
     name: z.string().optional(),
     secretPath: z.string().optional(),
-    approvals: z.number().min(1),
+    approvals: z.number().min(1).default(1),
     userApprovers: z
       .object({ type: z.literal(ApproverType.User), id: z.string() })
       .array()
@@ -55,7 +55,7 @@ const formSchema = z
       .array()
       .default([]),
     policyType: z.nativeEnum(PolicyType),
-    enforcementLevel: z.nativeEnum(EnforcementLevel),
+    enforcementLevel: z.nativeEnum(EnforcementLevel).default(EnforcementLevel.Hard),
     allowedSelfApprovals: z.boolean().default(true)
   })
   .superRefine((data, ctx) => {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Fix for an edge case where we were retrieving a deleted policy when there was one valid in place (blocking users from requesting access), and minor fix on default values on policy form where by default some prefilled values were not set on the form leading to errors on the validation although there were values on the inputs.

![CleanShot 2025-05-29 at 17 45 51](https://github.com/user-attachments/assets/18039cad-05dd-48d5-81e2-032c97a0ee51)


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->