### PR TITLE
Add support for offline lottie 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@lexical/react": "^0.29.0",
         "@lottiefiles/dotlottie-react": "^0.12.0",
-        "@lottiefiles/dotlottie-web": "^0.44.0",
+        "@lottiefiles/dotlottie-web": "^0.38.2",
         "@octokit/rest": "^21.0.2",
         "@peculiar/x509": "^1.12.3",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -1839,16 +1839,10 @@
         "react": "^17 || ^18 || ^19"
       }
     },
-    "node_modules/@lottiefiles/dotlottie-react/node_modules/@lottiefiles/dotlottie-web": {
+    "node_modules/@lottiefiles/dotlottie-web": {
       "version": "0.38.2",
       "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.38.2.tgz",
       "integrity": "sha512-01d+UjJ8NG7ZStYQxtb8FPzknzGmauG7gEkcH+wHfSdiSQJY9PoBNVSTB9V6F5hAnmFqOxaocTtd7TIEEnzMnA==",
-      "license": "MIT"
-    },
-    "node_modules/@lottiefiles/dotlottie-web": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.44.0.tgz",
-      "integrity": "sha512-IUWKVciDJI/BMWDWnh7j0Ngd0N8q9ySRAwm84aDqIE07qpmdZ7x1rkIpBaU1yHSNqNYHeh1Rxsl+LC3CY4f0KA==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@lexical/react": "^0.29.0",
         "@lottiefiles/dotlottie-react": "^0.12.0",
+        "@lottiefiles/dotlottie-web": "^0.44.0",
         "@octokit/rest": "^21.0.2",
         "@peculiar/x509": "^1.12.3",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -1838,10 +1839,16 @@
         "react": "^17 || ^18 || ^19"
       }
     },
-    "node_modules/@lottiefiles/dotlottie-web": {
+    "node_modules/@lottiefiles/dotlottie-react/node_modules/@lottiefiles/dotlottie-web": {
       "version": "0.38.2",
       "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.38.2.tgz",
       "integrity": "sha512-01d+UjJ8NG7ZStYQxtb8FPzknzGmauG7gEkcH+wHfSdiSQJY9PoBNVSTB9V6F5hAnmFqOxaocTtd7TIEEnzMnA==",
+      "license": "MIT"
+    },
+    "node_modules/@lottiefiles/dotlottie-web": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.44.0.tgz",
+      "integrity": "sha512-IUWKVciDJI/BMWDWnh7j0Ngd0N8q9ySRAwm84aDqIE07qpmdZ7x1rkIpBaU1yHSNqNYHeh1Rxsl+LC3CY4f0KA==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@lexical/react": "^0.29.0",
     "@lottiefiles/dotlottie-react": "^0.12.0",
+    "@lottiefiles/dotlottie-web": "^0.44.0",
     "@octokit/rest": "^21.0.2",
     "@peculiar/x509": "^1.12.3",
     "@radix-ui/react-accordion": "^1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@lexical/react": "^0.29.0",
     "@lottiefiles/dotlottie-react": "^0.12.0",
-    "@lottiefiles/dotlottie-web": "^0.44.0",
+    "@lottiefiles/dotlottie-web": "^0.38.2",
     "@octokit/rest": "^21.0.2",
     "@peculiar/x509": "^1.12.3",
     "@radix-ui/react-accordion": "^1.2.2",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,8 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import NProgress from "nprogress";
+import { setWasmUrl } from '@lottiefiles/dotlottie-react';
+import lottieWasmUrl from '@lottiefiles/dotlottie-web/dist/dotlottie-player.wasm?url';
 
 import { ContentLoader } from "./components/v2";
 import { queryClient } from "./hooks/api/reactQuery";
@@ -21,6 +23,9 @@ import "./translation";
 // don't want to use this?
 // have a look at the Quick start guide
 // for passing in lng and translations on init/
+
+// Configure Lottie player to use local WASM file
+setWasmUrl(lottieWasmUrl);
 
 // Create a new router instance
 NProgress.configure({ showSpinner: false });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
+import { setWasmUrl } from "@lottiefiles/dotlottie-react";
+import lottieWasmUrl from "@lottiefiles/dotlottie-web/dist/dotlottie-player.wasm?url";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import NProgress from "nprogress";
-import { setWasmUrl } from '@lottiefiles/dotlottie-react';
-import lottieWasmUrl from '@lottiefiles/dotlottie-web/dist/dotlottie-player.wasm?url';
 
 import { ContentLoader } from "./components/v2";
 import { queryClient } from "./hooks/api/reactQuery";


### PR DESCRIPTION
In air gapped, lotties won't load because the WASM player is fetched from CDN. This PR bundles the player so we can fetch it directly from file system

Note: When using @lottiefiles/dotlottie-web directly, we need to make sure its version matches the one required by @lottiefiles/dotlottie-react. You can double check this with:

`npm list @lottiefiles/dotlottie-web`

The version should match in both places:

@lottiefiles/dotlottie-web@0.38.2  <-- This version
@lottiefiles/dotlottie-web@0.38.2    <-- Should match this version

If they don't match, the Lottie animations will fail to load because the WASM binary version needs to be compatible with the React components.