### PR TITLE
misc: workspace file now only needed when project id is omitted (CLI)

### DIFF
--- a/cli/packages/cmd/dynamic_secrets.go
+++ b/cli/packages/cmd/dynamic_secrets.go
@@ -72,7 +72,6 @@ func getDynamicSecretList(cmd *cobra.Command, args []string) {
 		infisicalToken = token.Token
 	} else {
 		util.RequireLogin()
-		util.RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {
@@ -190,7 +189,6 @@ func createDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		infisicalToken = token.Token
 	} else {
 		util.RequireLogin()
-		util.RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {
@@ -321,7 +319,6 @@ func renewDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		infisicalToken = token.Token
 	} else {
 		util.RequireLogin()
-		util.RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {
@@ -429,7 +426,6 @@ func revokeDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		infisicalToken = token.Token
 	} else {
 		util.RequireLogin()
-		util.RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {
@@ -536,7 +532,6 @@ func listDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 		infisicalToken = token.Token
 	} else {
 		util.RequireLogin()
-		util.RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 		if err != nil {

--- a/cli/packages/cmd/dynamic_secrets.go
+++ b/cli/packages/cmd/dynamic_secrets.go
@@ -63,7 +63,7 @@ func getDynamicSecretList(cmd *cobra.Command, args []string) {
 	if projectId == "" {
 		workspaceFile, err := util.GetWorkSpaceFromFile()
 		if err != nil {
-			util.HandleError(err, "Unable to get local project details")
+			util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 		}
 		projectId = workspaceFile.WorkspaceId
 	}
@@ -180,7 +180,7 @@ func createDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 	if projectId == "" {
 		workspaceFile, err := util.GetWorkSpaceFromFile()
 		if err != nil {
-			util.HandleError(err, "Unable to get local project details")
+			util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 		}
 		projectId = workspaceFile.WorkspaceId
 	}
@@ -310,7 +310,7 @@ func renewDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 	if projectId == "" {
 		workspaceFile, err := util.GetWorkSpaceFromFile()
 		if err != nil {
-			util.HandleError(err, "Unable to get local project details")
+			util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 		}
 		projectId = workspaceFile.WorkspaceId
 	}
@@ -417,7 +417,7 @@ func revokeDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 	if projectId == "" {
 		workspaceFile, err := util.GetWorkSpaceFromFile()
 		if err != nil {
-			util.HandleError(err, "Unable to get local project details")
+			util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 		}
 		projectId = workspaceFile.WorkspaceId
 	}
@@ -523,7 +523,7 @@ func listDynamicSecretLeaseByName(cmd *cobra.Command, args []string) {
 	if projectId == "" {
 		workspaceFile, err := util.GetWorkSpaceFromFile()
 		if err != nil {
-			util.HandleError(err, "Unable to get local project details")
+			util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 		}
 		projectId = workspaceFile.WorkspaceId
 	}

--- a/cli/packages/cmd/folder.go
+++ b/cli/packages/cmd/folder.go
@@ -112,7 +112,7 @@ var createCmd = &cobra.Command{
 		if projectId == "" {
 			workspaceFile, err := util.GetWorkSpaceFromFile()
 			if err != nil {
-				util.HandleError(err, "Unable to get workspace file")
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 			}
 
 			projectId = workspaceFile.WorkspaceId
@@ -180,7 +180,7 @@ var deleteCmd = &cobra.Command{
 		if projectId == "" {
 			workspaceFile, err := util.GetWorkSpaceFromFile()
 			if err != nil {
-				util.HandleError(err, "Unable to get workspace file")
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 			}
 
 			projectId = workspaceFile.WorkspaceId

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -172,7 +172,10 @@ var secretsSetCmd = &cobra.Command{
 		}
 
 		if token == nil && projectId == "" {
-			util.RequireLocalWorkspaceFile()
+			_, err := util.GetWorkSpaceFromFile()
+			if err != nil {
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
+			}
 		}
 
 		secretsPath, err := cmd.Flags().GetString("path")
@@ -225,7 +228,7 @@ var secretsSetCmd = &cobra.Command{
 			if projectId == "" {
 				workspaceFile, err := util.GetWorkSpaceFromFile()
 				if err != nil {
-					util.HandleError(err, "unable to get your local config details [err=%v]")
+					util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 				}
 
 				projectId = workspaceFile.WorkspaceId
@@ -308,7 +311,7 @@ var secretsDeleteCmd = &cobra.Command{
 		if projectId == "" {
 			workspaceFile, err := util.GetWorkSpaceFromFile()
 			if err != nil {
-				util.HandleError(err, "Unable to get local project details")
+				util.PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 			}
 			projectId = workspaceFile.WorkspaceId
 		}

--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -158,10 +158,6 @@ var secretsSetCmd = &cobra.Command{
 			util.HandleError(err, "Unable to parse flag")
 		}
 
-		if token == nil {
-			util.RequireLocalWorkspaceFile()
-		}
-
 		environmentName, _ := cmd.Flags().GetString("env")
 		if !cmd.Flags().Changed("env") {
 			environmentFromWorkspace := util.GetEnvFromWorkspaceFile()
@@ -173,6 +169,10 @@ var secretsSetCmd = &cobra.Command{
 		projectId, err := cmd.Flags().GetString("projectId")
 		if err != nil {
 			util.HandleError(err, "Unable to parse flag")
+		}
+
+		if token == nil && projectId == "" {
+			util.RequireLocalWorkspaceFile()
 		}
 
 		secretsPath, err := cmd.Flags().GetString("path")
@@ -317,7 +317,6 @@ var secretsDeleteCmd = &cobra.Command{
 			httpClient.SetAuthToken(token.Token)
 		} else {
 			util.RequireLogin()
-			util.RequireLocalWorkspaceFile()
 
 			loggedInUserDetails, err := util.GetCurrentLoggedInUserDetails(true)
 			if err != nil {

--- a/cli/packages/util/folders.go
+++ b/cli/packages/util/folders.go
@@ -15,7 +15,6 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 	var folderErr error
 	if params.InfisicalToken == "" && params.UniversalAuthAccessToken == "" {
 		RequireLogin()
-		RequireLocalWorkspaceFile()
 
 		log.Debug().Msg("GetAllFolders: Trying to fetch folders using logged in details")
 
@@ -28,16 +27,15 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 			loggedInUserDetails = EstablishUserLoginSession()
 		}
 
-		workspaceFile, err := GetWorkSpaceFromFile()
-		if err != nil {
-			return nil, err
+		if params.WorkspaceId == "" {
+			workspaceFile, err := GetWorkSpaceFromFile()
+			if err != nil {
+				return nil, err
+			}
+			params.WorkspaceId = workspaceFile.WorkspaceId
 		}
 
-		if params.WorkspaceId != "" {
-			workspaceFile.WorkspaceId = params.WorkspaceId
-		}
-
-		folders, err := GetFoldersViaJTW(loggedInUserDetails.UserCredentials.JTWToken, workspaceFile.WorkspaceId, params.Environment, params.FoldersPath)
+		folders, err := GetFoldersViaJTW(loggedInUserDetails.UserCredentials.JTWToken, params.WorkspaceId, params.Environment, params.FoldersPath)
 		folderErr = err
 		foldersToReturn = folders
 	} else if params.InfisicalToken != "" {
@@ -186,7 +184,6 @@ func CreateFolder(params models.CreateFolderParameters) (models.SingleFolder, er
 	// If no token is provided, we will try to get the token from the current logged in user
 	if params.InfisicalToken == "" {
 		RequireLogin()
-		RequireLocalWorkspaceFile()
 		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 
 		if err != nil {
@@ -235,7 +232,6 @@ func DeleteFolder(params models.DeleteFolderParameters) ([]models.SingleFolder, 
 	// If no token is provided, we will try to get the token from the current logged in user
 	if params.InfisicalToken == "" {
 		RequireLogin()
-		RequireLocalWorkspaceFile()
 
 		loggedInUserDetails, err := GetCurrentLoggedInUserDetails(true)
 

--- a/cli/packages/util/folders.go
+++ b/cli/packages/util/folders.go
@@ -30,7 +30,7 @@ func GetAllFolders(params models.GetAllFoldersParameters) ([]models.SingleFolder
 		if params.WorkspaceId == "" {
 			workspaceFile, err := GetWorkSpaceFromFile()
 			if err != nil {
-				return nil, err
+				PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 			}
 			params.WorkspaceId = workspaceFile.WorkspaceId
 		}

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -251,10 +251,12 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 	var errorToReturn error
 
 	if params.InfisicalToken == "" && params.UniversalAuthAccessToken == "" {
-		if projectConfigFilePath == "" {
-			RequireLocalWorkspaceFile()
-		} else {
-			ValidateWorkspaceFile(projectConfigFilePath)
+		if params.WorkspaceId == "" {
+			if projectConfigFilePath == "" {
+				RequireLocalWorkspaceFile()
+			} else {
+				ValidateWorkspaceFile(projectConfigFilePath)
+			}
 		}
 
 		RequireLogin()
@@ -276,29 +278,28 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 			loggedInUserDetails = EstablishUserLoginSession()
 		}
 
-		var infisicalDotJson models.WorkspaceConfigFile
+		if params.WorkspaceId == "" {
+			var infisicalDotJson models.WorkspaceConfigFile
 
-		if projectConfigFilePath == "" {
-			projectConfig, err := GetWorkSpaceFromFile()
-			if err != nil {
-				return nil, err
+			if projectConfigFilePath == "" {
+				projectConfig, err := GetWorkSpaceFromFile()
+				if err != nil {
+					return nil, err
+				}
+
+				infisicalDotJson = projectConfig
+			} else {
+				projectConfig, err := GetWorkSpaceFromFilePath(projectConfigFilePath)
+				if err != nil {
+					return nil, err
+				}
+
+				infisicalDotJson = projectConfig
 			}
-
-			infisicalDotJson = projectConfig
-		} else {
-			projectConfig, err := GetWorkSpaceFromFilePath(projectConfigFilePath)
-			if err != nil {
-				return nil, err
-			}
-
-			infisicalDotJson = projectConfig
+			params.WorkspaceId = infisicalDotJson.WorkspaceId
 		}
 
-		if params.WorkspaceId != "" {
-			infisicalDotJson.WorkspaceId = params.WorkspaceId
-		}
-
-		res, err := GetPlainTextSecretsV3(loggedInUserDetails.UserCredentials.JTWToken, infisicalDotJson.WorkspaceId,
+		res, err := GetPlainTextSecretsV3(loggedInUserDetails.UserCredentials.JTWToken, params.WorkspaceId,
 			params.Environment, params.SecretsPath, params.IncludeImport, params.Recursive, params.TagSlugs, true)
 		log.Debug().Msgf("GetAllEnvironmentVariables: Trying to fetch secrets JTW token [err=%s]", err)
 
@@ -307,7 +308,7 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 			if err != nil {
 				return nil, err
 			}
-			WriteBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey, res.Secrets)
+			WriteBackupSecrets(params.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey, res.Secrets)
 		}
 
 		secretsToReturn = res.Secrets
@@ -316,7 +317,7 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 		if !isConnected {
 			backupEncryptionKey, _ := GetBackupEncryptionKey()
 			if backupEncryptionKey != nil {
-				backedUpSecrets, err := ReadBackupSecrets(infisicalDotJson.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey)
+				backedUpSecrets, err := ReadBackupSecrets(params.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey)
 				if len(backedUpSecrets) > 0 {
 					PrintWarning("Unable to fetch the latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug")
 					secretsToReturn = backedUpSecrets

--- a/cli/packages/util/secrets.go
+++ b/cli/packages/util/secrets.go
@@ -253,7 +253,10 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 	if params.InfisicalToken == "" && params.UniversalAuthAccessToken == "" {
 		if params.WorkspaceId == "" {
 			if projectConfigFilePath == "" {
-				RequireLocalWorkspaceFile()
+				_, err := GetWorkSpaceFromFile()
+				if err != nil {
+					PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
+				}
 			} else {
 				ValidateWorkspaceFile(projectConfigFilePath)
 			}
@@ -284,7 +287,7 @@ func GetAllEnvironmentVariables(params models.GetAllSecretsParameters, projectCo
 			if projectConfigFilePath == "" {
 				projectConfig, err := GetWorkSpaceFromFile()
 				if err != nil {
-					return nil, err
+					PrintErrorMessageAndExit("Please either run infisical init to connect to a project or pass in project id with --projectId flag")
 				}
 
 				infisicalDotJson = projectConfig


### PR DESCRIPTION
# Description 📣
- This PR ensures that the `infisical init` error only shows up when project ID flag is not defined for the command. 

<img width="793" alt="image" src="https://github.com/user-attachments/assets/6d200ec5-8f3e-4fe8-81ca-302b78d3172e" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->