### PR TITLE
feat(admin): add password visibility toggle to signup form

### DIFF
--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -1,10 +1,14 @@
 import { Helmet } from "react-helmet";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { z } from "zod";
+
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { createNotification } from "@app/components/notifications";
 // TODO(akhilmhdh): rewrite this into module functions in lib
@@ -33,6 +37,9 @@ type TFormSchema = z.infer<typeof formSchema>;
 export const SignUpPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  
   const {
     control,
     handleSubmit,
@@ -156,7 +163,21 @@ export const SignUpPage = () => {
                       errorText={error?.message}
                       isError={Boolean(error)}
                     >
-                      <Input isFullWidth size="md" type="password" {...field} />
+                      <div className="relative">
+                        <Input 
+                          isFullWidth 
+                          size="md" 
+                          type={showPassword ? "text" : "password"} 
+                          {...field} 
+                        />
+                        <button
+                          type="button"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-bunker-300 hover:text-bunker-200"
+                          onClick={() => setShowPassword(!showPassword)}
+                        >
+                          <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />
+                        </button>
+                      </div>
                     </FormControl>
                   )}
                 />
@@ -169,7 +190,21 @@ export const SignUpPage = () => {
                       errorText={error?.message}
                       isError={Boolean(error)}
                     >
-                      <Input isFullWidth size="md" type="password" {...field} />
+                      <div className="relative">
+                        <Input 
+                          isFullWidth 
+                          size="md" 
+                          type={showConfirmPassword ? "text" : "password"} 
+                          {...field} 
+                        />
+                        <button
+                          type="button"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-bunker-300 hover:text-bunker-200"
+                          onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                        >
+                          <FontAwesomeIcon icon={showConfirmPassword ? faEyeSlash : faEye} />
+                        </button>
+                      </div>
                     </FormControl>
                   )}
                 />


### PR DESCRIPTION
# Description 📣

This PR adds password visibility toggle functionality to the admin signup page, allowing users to show/hide their password and confirm password fields using eye/eye-slash icons. This improves user experience during password entry by reducing input errors and following modern UX patterns.

![Screenshot 2025-06-03 at 15 13 23](https://github.com/user-attachments/assets/fa587e0a-2e32-4d2a-acb0-a0e8ee0d3f8c)

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

To verify the changes work correctly:

1. Navigate to the admin signup page
2. Enter text in the password field
3. Click the eye icon to toggle visibility
4. Verify the icon changes from eye to eye-slash and password becomes visible
5. Repeat for the confirm password field
6. Ensure form validation still works properly
7. Test hover states on the toggle buttons

**Features added:**
- Eye/eye-slash icons for both password fields
- Independent visibility state management for each field
- Proper positioning and hover effects
- Maintains existing design system styling

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝