### PR TITLE
improvement(email-templates): Add y-padding to email body

### DIFF
--- a/backend/src/services/smtp/emails/BaseEmailWrapper.tsx
+++ b/backend/src/services/smtp/emails/BaseEmailWrapper.tsx
@@ -13,7 +13,7 @@ export const BaseEmailWrapper = ({ title, preview, children, siteUrl }: BaseEmai
     <Html>
       <Head title={title} />
       <Tailwind>
-        <Body className="bg-gray-300 my-auto mx-auto font-sans px-[8px]">
+        <Body className="bg-gray-300 my-auto mx-auto font-sans px-[8px] py-[4px]">
           <Preview>{preview}</Preview>
           <Container className="bg-white rounded-xl my-[40px] mx-auto pb-[0px] max-w-[500px]">
             <Section className="border-0 border-b border-[#d1e309] border-solid bg-[#EBF852] mb-[44px] h-[10px] rounded-t-xl" />


### PR DESCRIPTION
# Description 📣

This PR adds a small amount of y padding so emails aren't flush with top of container if they don't auto center

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝