### PR TITLE
improvement(org-access-control): Add org access control no access display

### DIFF
--- a/frontend/src/hooks/api/roles/mutation.tsx
+++ b/frontend/src/hooks/api/roles/mutation.tsx
@@ -96,7 +96,7 @@ export const useUpdateOrgRole = () => {
         data: { role }
       } = await apiRequest.patch(`/api/v1/organization/${orgId}/roles/${id}`, {
         ...dto,
-        permissions: permissions?.length ? packRules(permissions) : undefined
+        permissions: permissions ? packRules(permissions) : undefined
       });
 
       return role;

--- a/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
@@ -5,6 +5,7 @@ import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
+import { OrgPermissionGuardBanner } from "@app/components/permissions/OrgPermissionCan";
 import { Button, PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
@@ -72,6 +73,8 @@ export const AccessManagementPage = () => {
     }
   ];
 
+  const hasNoAccess = tabSections.every((tab) => tab.isHidden);
+
   return (
     <div className="container mx-auto flex flex-col justify-between bg-bunker-800 text-white">
       <Helmet>
@@ -126,6 +129,7 @@ export const AccessManagementPage = () => {
             ))}
         </Tabs>
       </div>
+      {hasNoAccess && <OrgPermissionGuardBanner />}
     </div>
   );
 };


### PR DESCRIPTION
# Description 📣

This PR adds a permission display when no elements on the org access control page are visible. 

Also includes fix for role permissions update mutation

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝