### PR TITLE
helm(infisical-gateway): bump CLI image version to latest

### DIFF
--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.2 (June 6, 2025)
+
+* Bumped default CLI image version from 0.41.1 -> 0.41.8.
+   * This new image version supports using the gateway as a token reviewer for the Identity Kubernetes Auth method. 
+
 ## 0.0.1 (May 1, 2025)
 
 * Initial helm release

--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.0.2"

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: IfNotPresent
-  tag: "0.41.1"
+  tag: "0.41.8"
 
 secret:
   # The secret that contains the environment variables to be used by the gateway, such as INFISICAL_API_URL and TOKEN


### PR DESCRIPTION
# Description 📣

Bumps the CLI image version to the latest version to support using the gateway as reviewer for K8's identity auth.
Related PR: https://github.com/Infisical/infisical/pull/3731

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->