### PR TITLE
disable caching for frontend assets 

### DIFF
--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -58,9 +58,10 @@ export const registerServeUI = async (
           return;
         }
 
-        // This should help avoid caching any chunks (temp)
-        reply.header("Cache-Control", "no-cache, no-store, must-revalidate");
-        reply.header("Pragma", "no-cache");
+        // This should help avoid caching any chunks (temp fix)
+        void reply.header("Cache-Control", "no-cache, no-store, must-revalidate, private, max-age=0");
+        void reply.header("Pragma", "no-cache");
+        void reply.header("Expires", "0");
         return reply.sendFile("index.html");
       }
     });

--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -57,9 +57,12 @@ export const registerServeUI = async (
           reply.callNotFound();
           return;
         }
-        // reference: https://github.com/fastify/fastify-static?tab=readme-ov-file#managing-cache-control-headers
-        // to avoid ui bundle skew on new deployment
-        return reply.sendFile("index.html", { maxAge: 0, immutable: false });
+        
+        // This should help avoid caching any chunks (temp)
+        reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+        reply.header('Pragma', 'no-cache');
+        return reply.sendFile("index.html");
+        
       }
     });
   }

--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -57,12 +57,11 @@ export const registerServeUI = async (
           reply.callNotFound();
           return;
         }
-        
+
         // This should help avoid caching any chunks (temp)
-        reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
-        reply.header('Pragma', 'no-cache');
+        reply.header("Cache-Control", "no-cache, no-store, must-revalidate");
+        reply.header("Pragma", "no-cache");
         return reply.sendFile("index.html");
-        
       }
     });
   }


### PR DESCRIPTION
This aims to fix the issue where it says 

```
TypeError
Cannot read properties of undefined (reading 'component')
```

by telling the browser to not cache any chunks. It seems that the existing no cache header from fastify isn't doing the trick. this may be worth a shot