### PR TITLE
feat(gateway): use gateway for full k8s request life-cycle

### DIFF
--- a/backend/src/db/migrations/20250610173646_identity-kubernetes-auth-optional-host-url.ts
+++ b/backend/src/db/migrations/20250610173646_identity-kubernetes-auth-optional-host-url.ts
@@ -1,0 +1,45 @@
+import { Knex } from "knex";
+
+import { selectAllTableCols } from "@app/lib/knex";
+
+import { TableName } from "../schemas";
+
+const BATCH_SIZE = 1000;
+
+export async function up(knex: Knex): Promise<void> {
+  const hasKubernetesHostColumn = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "kubernetesHost");
+
+  if (hasKubernetesHostColumn) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (table) => {
+      table.string("kubernetesHost").nullable().alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasKubernetesHostColumn = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "kubernetesHost");
+
+  // find all rows where kubernetesHost is null
+  const rows = await knex(TableName.IdentityKubernetesAuth)
+    .whereNull("kubernetesHost")
+    .select(selectAllTableCols(TableName.IdentityKubernetesAuth));
+
+  if (rows.length > 0) {
+    for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      const batch = rows.slice(i, i + BATCH_SIZE);
+      // eslint-disable-next-line no-await-in-loop
+      await knex(TableName.IdentityKubernetesAuth)
+        .whereIn(
+          "id",
+          batch.map((row) => row.id)
+        )
+        .update({ kubernetesHost: "" });
+    }
+  }
+
+  if (hasKubernetesHostColumn) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (table) => {
+      table.string("kubernetesHost").notNullable().alter();
+    });
+  }
+}

--- a/backend/src/db/schemas/identity-kubernetes-auths.ts
+++ b/backend/src/db/schemas/identity-kubernetes-auths.ts
@@ -18,7 +18,7 @@ export const IdentityKubernetesAuthsSchema = z.object({
   createdAt: z.date(),
   updatedAt: z.date(),
   identityId: z.string().uuid(),
-  kubernetesHost: z.string(),
+  kubernetesHost: z.string().nullable().optional(),
   encryptedCaCert: z.string().nullable().optional(),
   caCertIV: z.string().nullable().optional(),
   caCertTag: z.string().nullable().optional(),

--- a/backend/src/lib/gateway/types.ts
+++ b/backend/src/lib/gateway/types.ts
@@ -10,7 +10,8 @@ export enum GatewayProxyProtocol {
 }
 
 export enum GatewayHttpProxyActions {
-  InjectGatewayK8sServiceAccountToken = "inject-k8s-sa-auth-token"
+  InjectGatewayK8sServiceAccountToken = "inject-k8s-sa-auth-token",
+  UseGatewayK8sServiceAccount = "use-k8s-sa"
 }
 
 export interface IGatewayProxyOptions {

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
@@ -12,7 +12,7 @@ export enum IdentityKubernetesAuthTokenReviewMode {
 
 export type TAttachKubernetesAuthDTO = {
   identityId: string;
-  kubernetesHost: string;
+  kubernetesHost: string | null;
   caCert: string;
   tokenReviewerJwt?: string;
   tokenReviewMode: IdentityKubernetesAuthTokenReviewMode;
@@ -29,7 +29,7 @@ export type TAttachKubernetesAuthDTO = {
 
 export type TUpdateKubernetesAuthDTO = {
   identityId: string;
-  kubernetesHost?: string;
+  kubernetesHost?: string | null;
   caCert?: string;
   tokenReviewerJwt?: string | null;
   tokenReviewMode?: IdentityKubernetesAuthTokenReviewMode;

--- a/cli/packages/gateway/constants.go
+++ b/cli/packages/gateway/constants.go
@@ -1,0 +1,17 @@
+package gateway
+
+const (
+	KUBERNETES_SERVICE_HOST_ENV_NAME        = "KUBERNETES_SERVICE_HOST"
+	KUBERNETES_SERVICE_PORT_HTTPS_ENV_NAME  = "KUBERNETES_SERVICE_PORT_HTTPS"
+	KUBERNETES_SERVICE_ACCOUNT_CA_CERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH   = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	INFISICAL_HTTP_PROXY_ACTION_HEADER = "x-infisical-action"
+)
+
+type HttpProxyAction string
+
+const (
+	HttpProxyActionInjectGatewayK8sServiceAccountToken HttpProxyAction = "inject-k8s-sa-auth-token"
+	HttpProxyActionUseGatewayK8sServiceAccount         HttpProxyAction = "use-k8s-sa"
+)

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -403,7 +403,7 @@ export type IdentityKubernetesAuth = {
 export type AddIdentityKubernetesAuthDTO = {
   organizationId: string;
   identityId: string;
-  kubernetesHost: string;
+  kubernetesHost: string | null;
   tokenReviewerJwt?: string;
   tokenReviewMode: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces: string;
@@ -422,7 +422,7 @@ export type AddIdentityKubernetesAuthDTO = {
 export type UpdateIdentityKubernetesAuthDTO = {
   organizationId: string;
   identityId: string;
-  kubernetesHost?: string;
+  kubernetesHost?: string | null;
   tokenReviewerJwt?: string | null;
   tokenReviewMode?: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces?: string;

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -301,30 +301,6 @@ export const IdentityKubernetesAuthForm = ({
           <Tab value={IdentityFormTab.Advanced}>Advanced</Tab>
         </TabList>
         <TabPanel value={IdentityFormTab.Configuration}>
-          {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
-            <Controller
-              control={control}
-              defaultValue="2592000"
-              name="kubernetesHost"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Kubernetes Host / Base Kubernetes API URL "
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  tooltipText="The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running 'kubectl cluster-info'"
-                  isRequired
-                >
-                  <Input
-                    {...field}
-                    placeholder="https://my-example-k8s-api-host.com"
-                    type="text"
-                    value={field.value || ""}
-                  />
-                </FormControl>
-              )}
-            />
-          )}
-
           <div className="flex w-full items-center gap-2">
             <div className="w-full flex-1">
               <OrgPermissionCan
@@ -413,6 +389,29 @@ export const IdentityKubernetesAuthForm = ({
               )}
             />
           </div>
+          {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
+            <Controller
+              control={control}
+              defaultValue="2592000"
+              name="kubernetesHost"
+              render={({ field, fieldState: { error } }) => (
+                <FormControl
+                  label="Kubernetes Host / Base Kubernetes API URL "
+                  isError={Boolean(error)}
+                  errorText={error?.message}
+                  tooltipText="The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running 'kubectl cluster-info'"
+                  isRequired
+                >
+                  <Input
+                    {...field}
+                    placeholder="https://my-example-k8s-api-host.com"
+                    type="text"
+                    value={field.value || ""}
+                  />
+                </FormControl>
+              )}
+            />
+          )}
 
           {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
             <Controller

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -46,13 +46,13 @@ const schema = z
     tokenReviewMode: z
       .nativeEnum(IdentityKubernetesAuthTokenReviewMode)
       .default(IdentityKubernetesAuthTokenReviewMode.Api),
-    kubernetesHost: z.string().min(1),
+    kubernetesHost: z.string().min(1).optional().nullable(),
     tokenReviewerJwt: z.string().optional(),
     gatewayId: z.string().optional().nullable(),
     allowedNames: z.string(),
     allowedNamespaces: z.string(),
     allowedAudience: z.string(),
-    caCert: z.string(),
+    caCert: z.string().optional(),
     accessTokenTTL: z.string().refine((val) => Number(val) <= 315360000, {
       message: "Access Token TTL cannot be greater than 315360000"
     }),
@@ -69,6 +69,17 @@ const schema = z
       .min(1)
   })
   .superRefine((data, ctx) => {
+    if (
+      data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+      !data.kubernetesHost
+    ) {
+      ctx.addIssue({
+        path: ["kubernetesHost"],
+        code: z.ZodIssueCode.custom,
+        message: "When token review mode is set to API, a Kubernetes host must be provided"
+      });
+    }
+
     if (data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Gateway && !data.gatewayId) {
       ctx.addIssue({
         path: ["gatewayId"],
@@ -201,7 +212,13 @@ export const IdentityKubernetesAuthForm = ({
       if (data) {
         await updateMutateAsync({
           organizationId: orgId,
-          kubernetesHost,
+          ...(tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api
+            ? {
+                kubernetesHost: kubernetesHost || ""
+              }
+            : {
+                kubernetesHost: null
+              }),
           tokenReviewerJwt: tokenReviewerJwt || null,
           allowedNames,
           allowedNamespaces,
@@ -219,7 +236,13 @@ export const IdentityKubernetesAuthForm = ({
         await addMutateAsync({
           organizationId: orgId,
           identityId,
-          kubernetesHost: kubernetesHost || "",
+          ...(tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api
+            ? {
+                kubernetesHost: kubernetesHost || ""
+              }
+            : {
+                kubernetesHost: null
+              }),
           tokenReviewerJwt: tokenReviewerJwt || undefined,
           allowedNames: allowedNames || "",
           allowedNamespaces: allowedNamespaces || "",
@@ -278,22 +301,29 @@ export const IdentityKubernetesAuthForm = ({
           <Tab value={IdentityFormTab.Advanced}>Advanced</Tab>
         </TabList>
         <TabPanel value={IdentityFormTab.Configuration}>
-          <Controller
-            control={control}
-            defaultValue="2592000"
-            name="kubernetesHost"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                label="Kubernetes Host / Base Kubernetes API URL "
-                isError={Boolean(error)}
-                errorText={error?.message}
-                tooltipText="The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running 'kubectl cluster-info'"
-                isRequired
-              >
-                <Input {...field} placeholder="https://my-example-k8s-api-host.com" type="text" />
-              </FormControl>
-            )}
-          />
+          {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
+            <Controller
+              control={control}
+              defaultValue="2592000"
+              name="kubernetesHost"
+              render={({ field, fieldState: { error } }) => (
+                <FormControl
+                  label="Kubernetes Host / Base Kubernetes API URL "
+                  isError={Boolean(error)}
+                  errorText={error?.message}
+                  tooltipText="The host string, host:port pair, or URL to the base of the Kubernetes API server. This can usually be obtained by running 'kubectl cluster-info'"
+                  isRequired
+                >
+                  <Input
+                    {...field}
+                    placeholder="https://my-example-k8s-api-host.com"
+                    type="text"
+                    value={field.value || ""}
+                  />
+                </FormControl>
+              )}
+            />
+          )}
 
           <div className="flex w-full items-center gap-2">
             <div className="w-full flex-1">
@@ -384,7 +414,7 @@ export const IdentityKubernetesAuthForm = ({
             />
           </div>
 
-          {tokenReviewMode === "api" && (
+          {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
             <Controller
               control={control}
               name="tokenReviewerJwt"
@@ -493,20 +523,22 @@ export const IdentityKubernetesAuthForm = ({
               </FormControl>
             )}
           />
-          <Controller
-            control={control}
-            name="caCert"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                label="CA Certificate"
-                errorText={error?.message}
-                isError={Boolean(error)}
-                tooltipText="An optional PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server."
-              >
-                <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
-              </FormControl>
-            )}
-          />
+          {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
+            <Controller
+              control={control}
+              name="caCert"
+              render={({ field, fieldState: { error } }) => (
+                <FormControl
+                  label="CA Certificate"
+                  errorText={error?.message}
+                  isError={Boolean(error)}
+                  tooltipText="An optional PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server."
+                >
+                  <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
+                </FormControl>
+              )}
+            />
+          )}
           {accessTokenTrustedIpsFields.map(({ id }, index) => (
             <div className="mb-3 flex items-end space-x-2" key={id}>
               <Controller

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -128,7 +128,7 @@ export const IdentityKubernetesAuthForm = ({
     watch,
     setValue,
 
-    formState: { isSubmitting, errors }
+    formState: { isSubmitting }
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -46,7 +46,7 @@ const schema = z
     tokenReviewMode: z
       .nativeEnum(IdentityKubernetesAuthTokenReviewMode)
       .default(IdentityKubernetesAuthTokenReviewMode.Api),
-    kubernetesHost: z.string().min(1).optional().nullable(),
+    kubernetesHost: z.string().optional().nullable(),
     tokenReviewerJwt: z.string().optional(),
     gatewayId: z.string().optional().nullable(),
     allowedNames: z.string(),
@@ -71,7 +71,7 @@ const schema = z
   .superRefine((data, ctx) => {
     if (
       data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
-      !data.kubernetesHost
+      !data.kubernetesHost?.length
     ) {
       ctx.addIssue({
         path: ["kubernetesHost"],
@@ -128,7 +128,7 @@ export const IdentityKubernetesAuthForm = ({
     watch,
     setValue,
 
-    formState: { isSubmitting }
+    formState: { isSubmitting, errors }
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {

--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 0.0.41 (June 10, 2025)
+* Added new gateway action for fully off-loading CA certificate, cluster URL, and token management to the gateway.
+* Structural improvements
+
+## 0.0.4 (June 7th, 2025)
+* Improvements to HTTP proxy error handling.
+
 ## 0.0.3 (June 6, 2025)
 
-* Minor fix for handling malformed URLs for HTTP forwarding
+* Minor fix for handling malformed URLs for HTTP forwarding.
 
 ## 0.0.2 (June 6, 2025)
 
@@ -9,4 +16,4 @@
 
 ## 0.0.1 (May 1, 2025)
 
-* Initial helm release
+* Initial helm release.

--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.41
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.41"
+appVersion: "0.0.5"

--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.41
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.4"
+appVersion: "0.0.41"

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: IfNotPresent
-  tag: "0.41.83"
+  tag: "0.41.84"
 
 secret:
   # The secret that contains the environment variables to be used by the gateway, such as INFISICAL_API_URL and TOKEN


### PR DESCRIPTION
# Description 📣

This PR expands on the gateway HTTP proxy initiative, and the gateway can now be used as an end-to-end proxy for Kubernetes API. The new action will off-load the cluster URL, CA Certificate, and token management directly to the gateway. This means the user won't need to specify certificates, tokens, or cluster URL's anymore.

Currently we're rolling this out for K8's auth, But we are planning on adding it to the Kubernetes dynamic secrets as well.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->