### PR TITLE
fix: allow for empty target URLs

### DIFF
--- a/backend/src/lib/gateway/types.ts
+++ b/backend/src/lib/gateway/types.ts
@@ -15,8 +15,8 @@ export enum GatewayHttpProxyActions {
 }
 
 export interface IGatewayProxyOptions {
-  targetHost: string;
-  targetPort: number;
+  targetHost?: string;
+  targetPort?: number;
   relayHost: string;
   relayPort: number;
   tlsOptions: TGatewayTlsOptions;

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -72,8 +72,8 @@ export const identityKubernetesAuthServiceFactory = ({
   const $gatewayProxyWrapper = async <T>(
     inputs: {
       gatewayId: string;
-      targetHost: string;
-      targetPort: number;
+      targetHost?: string;
+      targetPort?: number;
       caCert?: string;
       reviewTokenThroughGateway: boolean;
     },
@@ -286,8 +286,6 @@ export const identityKubernetesAuthServiceFactory = ({
       data = await $gatewayProxyWrapper(
         {
           gatewayId: identityKubernetesAuth.gatewayId,
-          targetHost: `/`, // note(daniel): the targetURL will be constructed as `/:0`, which the gateway will handle as a special case, by replacing the /:0, with the internal kubernetes base URL (only when the action header is set to `GatewayHttpProxyActions.UseGatewayK8sServiceAccount`)
-          targetPort: 0,
           reviewTokenThroughGateway: true
         },
         tokenReviewCallbackThroughGateway


### PR DESCRIPTION
# Description 📣

Minor change to allow for actual empty target URLs. Previously we'd specifically handle `/:0`, but now it just works as an empty string, meaning we can now pass undefined target hosts when using gateway's on the backend.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->