### PR TITLE
feat(invite-users): fix issue where invitations were not sent when the actor was an identity

### DIFF
--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1211,8 +1211,8 @@ export const orgServiceFactory = ({
           subjectLine: "Infisical organization invitation",
           recipients: [el.email],
           substitutions: {
-            inviterFirstName: invitingUser.firstName,
-            inviterUsername: invitingUser.email,
+            inviterFirstName: invitingUser?.firstName,
+            inviterUsername: invitingUser?.email,
             organizationName: org?.name,
             email: el.email,
             organizationId: org?.id.toString(),

--- a/backend/src/services/smtp/emails/OrganizationInvitationTemplate.tsx
+++ b/backend/src/services/smtp/emails/OrganizationInvitationTemplate.tsx
@@ -5,8 +5,8 @@ import { BaseEmailWrapper, BaseEmailWrapperProps } from "./BaseEmailWrapper";
 
 interface OrganizationInvitationTemplateProps extends Omit<BaseEmailWrapperProps, "preview" | "title"> {
   metadata?: string;
-  inviterFirstName: string;
-  inviterUsername: string;
+  inviterFirstName?: string;
+  inviterUsername?: string;
   organizationName: string;
   email: string;
   organizationId: string;
@@ -38,11 +38,19 @@ export const OrganizationInvitationTemplate = ({
       </Heading>
       <Section className="px-[24px] mt-[36px] pt-[12px] pb-[8px] border text-center border-solid border-gray-200 rounded-md bg-gray-50">
         <Text className="text-black text-[14px] leading-[24px]">
-          <strong>{inviterFirstName}</strong> (
-          <Link href={`mailto:${inviterUsername}`} className="text-slate-700 no-underline">
-            {inviterUsername}
-          </Link>
-          ) has invited you to collaborate on <strong>{organizationName}</strong>.
+          {inviterFirstName && inviterUsername ? (
+            <>
+              <strong>{inviterFirstName}</strong> (
+              <Link href={`mailto:${inviterUsername}`} className="text-slate-700 no-underline">
+                {inviterUsername}
+              </Link>
+              ) has invited you to collaborate on <strong>{organizationName}</strong>.
+            </>
+          ) : (
+            <>
+              You have been invited to collaborate on <strong>{organizationName}</strong>.
+            </>
+          )}
         </Text>
       </Section>
       <Section className="text-center mt-[28px]">


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

The issue with the `firstName` and `email` usage in the `inviteUserToOrganization` function was that, for Terraform and machine identity flows, the email was not being sent. As a result, users were not receiving the invitation email.
This has been fixed to handle these cases properly, and the template message has been updated accordingly.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->