### PR TITLE
fix: hidden secret value in secret approvals

### DIFF
--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -285,6 +285,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
               commits: secretRawSchema
                 .omit({ _id: true, environment: true, workspace: true, type: true, version: true, secretValue: true })
                 .extend({
+                  secretValueHidden: z.boolean(),
                   secretValue: z.string().optional(),
                   isRotatedSecret: z.boolean().optional(),
                   op: z.string(),
@@ -296,6 +297,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
                       version: z.number(),
                       secretKey: z.string(),
                       secretValue: z.string().optional(),
+                      secretValueHidden: z.boolean(),
                       secretComment: z.string().optional()
                     })
                     .optional()
@@ -306,6 +308,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
                       version: z.number(),
                       secretKey: z.string(),
                       secretValue: z.string().optional(),
+                      secretValueHidden: z.boolean(),
                       secretComment: z.string().optional(),
                       tags: SanitizedTagSchema.array().optional(),
                       secretMetadata: ResourceMetadataSchema.nullish()

--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -48,6 +48,7 @@ const syntaxHighlight = (content?: string | null, isVisible?: boolean, isImport?
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   value?: string | null;
   isVisible?: boolean;
+  valueAlwaysHidden?: boolean;
   isImport?: boolean;
   isReadOnly?: boolean;
   isDisabled?: boolean;
@@ -63,6 +64,7 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
       value,
       isVisible,
       isImport,
+      valueAlwaysHidden,
       containerClassName,
       onBlur,
       isDisabled,
@@ -84,7 +86,11 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
           <pre aria-hidden className="m-0">
             <code className={`inline-block w-full ${commonClassName}`}>
               <span style={{ whiteSpace: "break-spaces" }}>
-                {syntaxHighlight(value, isVisible || isSecretFocused, isImport)}
+                {syntaxHighlight(
+                  value,
+                  isVisible || (isSecretFocused && !valueAlwaysHidden),
+                  isImport
+                )}
               </span>
             </code>
           </pre>

--- a/frontend/src/hooks/api/secretApprovalRequest/types.ts
+++ b/frontend/src/hooks/api/secretApprovalRequest/types.ts
@@ -32,6 +32,7 @@ export type TSecretApprovalSecChange = {
   version: number;
   secretKey: string;
   secretValue?: string;
+  secretValueHidden?: boolean;
   secretComment?: string;
   isRotatedSecret?: boolean;
   tags?: string[];

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
@@ -11,10 +11,10 @@ import {
   faKey
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { twMerge } from "tailwind-merge";
 
 import { SecretInput, Tag, Tooltip } from "@app/components/v2";
 import { CommitType, SecretV3Raw, TSecretApprovalSecChange, WsTag } from "@app/hooks/api/types";
-import { twMerge } from "tailwind-merge";
 
 export type Props = {
   op: CommitType;
@@ -107,8 +107,11 @@ export const SecretApprovalRequestChangeItem = ({
                   ) : (
                     <div className="relative">
                       {secretVersion?.secretValueHidden && (
-                        <div className="absolute left-1 top-1/2 -translate-y-1/2">
-                          <Tooltip content="You do not have access to view the old secret value.">
+                        <div className="absolute left-1 top-1/2 z-50 -translate-y-1/2">
+                          <Tooltip
+                            position="right"
+                            content="You do not have access to view the old secret value."
+                          >
                             <FontAwesomeIcon
                               className="pl-2 text-mineshaft-300"
                               size="sm"
@@ -230,8 +233,11 @@ export const SecretApprovalRequestChangeItem = ({
                   ) : (
                     <div className="relative">
                       {newVersion?.secretValueHidden && (
-                        <div className="absolute left-1 top-1/2 -translate-y-1/2">
-                          <Tooltip content="You do not have access to view the new secret value.">
+                        <div className="absolute left-1 top-1/2 z-50 -translate-y-1/2">
+                          <Tooltip
+                            position="right"
+                            content="You do not have access to view the new secret value."
+                          >
                             <FontAwesomeIcon
                               className="pl-2 text-mineshaft-300"
                               size="sm"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
@@ -14,6 +14,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { SecretInput, Tag, Tooltip } from "@app/components/v2";
 import { CommitType, SecretV3Raw, TSecretApprovalSecChange, WsTag } from "@app/hooks/api/types";
+import { twMerge } from "tailwind-merge";
 
 export type Props = {
   op: CommitType;
@@ -105,21 +106,38 @@ export const SecretApprovalRequestChangeItem = ({
                     </span>
                   ) : (
                     <div className="relative">
+                      {secretVersion?.secretValueHidden && (
+                        <div className="absolute left-1 top-1/2 -translate-y-1/2">
+                          <Tooltip content="You do not have access to view the old secret value.">
+                            <FontAwesomeIcon
+                              className="pl-2 text-mineshaft-300"
+                              size="sm"
+                              icon={faEyeSlash}
+                            />
+                          </Tooltip>
+                        </div>
+                      )}
                       <SecretInput
                         isReadOnly
                         isVisible={isOldSecretValueVisible}
+                        valueAlwaysHidden={secretVersion?.secretValueHidden}
                         value={secretVersion?.secretValue}
-                        containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-700 px-2 py-1.5"
+                        containerClassName={twMerge(
+                          "border border-mineshaft-600 bg-bunker-700 py-1.5 text-bunker-300 hover:border-primary-400/50",
+                          secretVersion?.secretValueHidden ? "pl-8 pr-2" : "px-2"
+                        )}
                       />
-                      <div
-                        className="absolute right-1 top-1"
-                        onClick={() => setIsOldSecretValueVisible(!isOldSecretValueVisible)}
-                      >
-                        <FontAwesomeIcon
-                          icon={isOldSecretValueVisible ? faEyeSlash : faEye}
-                          className="cursor-pointer rounded-md border border-mineshaft-500 bg-mineshaft-800 p-1.5 text-mineshaft-300 hover:bg-mineshaft-700"
-                        />
-                      </div>
+                      {!secretVersion?.secretValueHidden && (
+                        <div
+                          className="absolute right-1 top-1"
+                          onClick={() => setIsOldSecretValueVisible(!isOldSecretValueVisible)}
+                        >
+                          <FontAwesomeIcon
+                            icon={isOldSecretValueVisible ? faEyeSlash : faEye}
+                            className="cursor-pointer rounded-md border border-mineshaft-500 bg-mineshaft-800 p-1.5 text-mineshaft-300 hover:bg-mineshaft-700"
+                          />
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
@@ -211,21 +229,38 @@ export const SecretApprovalRequestChangeItem = ({
                     </span>
                   ) : (
                     <div className="relative">
+                      {newVersion?.secretValueHidden && (
+                        <div className="absolute left-1 top-1/2 -translate-y-1/2">
+                          <Tooltip content="You do not have access to view the new secret value.">
+                            <FontAwesomeIcon
+                              className="pl-2 text-mineshaft-300"
+                              size="sm"
+                              icon={faEyeSlash}
+                            />
+                          </Tooltip>
+                        </div>
+                      )}
                       <SecretInput
                         isReadOnly
+                        valueAlwaysHidden={newVersion?.secretValueHidden}
                         isVisible={isNewSecretValueVisible}
                         value={newVersion?.secretValue}
-                        containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-700 px-2 py-1.5"
+                        containerClassName={twMerge(
+                          "border border-mineshaft-600 bg-bunker-700 py-1.5 text-bunker-300 hover:border-primary-400/50",
+                          newVersion?.secretValueHidden ? "pl-8 pr-2" : "px-2"
+                        )}
                       />
-                      <div
-                        className="absolute right-1 top-1"
-                        onClick={() => setIsNewSecretValueVisible(!isNewSecretValueVisible)}
-                      >
-                        <FontAwesomeIcon
-                          icon={isNewSecretValueVisible ? faEyeSlash : faEye}
-                          className="cursor-pointer rounded-md border border-mineshaft-500 bg-mineshaft-800 p-1.5 text-mineshaft-300 hover:bg-mineshaft-700"
-                        />
-                      </div>
+                      {!newVersion?.secretValueHidden && (
+                        <div
+                          className="absolute right-1 top-1"
+                          onClick={() => setIsNewSecretValueVisible(!isNewSecretValueVisible)}
+                        >
+                          <FontAwesomeIcon
+                            icon={isNewSecretValueVisible ? faEyeSlash : faEye}
+                            className="cursor-pointer rounded-md border border-mineshaft-500 bg-mineshaft-800 p-1.5 text-mineshaft-300 hover:bg-mineshaft-700"
+                          />
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
# Description 📣

This PR fixes a smaller UI bug related to how hidden secret values are displayed in the secret change approval page. Previously it would allow you to click the "Hide/Unhide" icons. Now it mirrors the logic we have on the main secrets page.

I've also removed the `*****` value being returned directly on the API level. I've made it more inline with our secrets router which returns `<hidden-by-infisical>`, and a boolean flag to indicate if the secret value is hidden or not.

![CleanShot 2025-06-13 at 18 48 03](https://github.com/user-attachments/assets/80a0dcf4-f608-4a6d-b1c1-b8d9c756e2ec)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->