### PR TITLE
fix: editing secrets with value hidden

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -96,6 +96,10 @@ import { SecretOverviewSecretRotationRow } from "@app/pages/secret-manager/Overv
 
 import { CreateDynamicSecretForm } from "../SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm";
 import { FolderForm } from "../SecretDashboardPage/components/ActionBar/FolderForm";
+import {
+  HIDDEN_SECRET_VALUE,
+  HIDDEN_SECRET_VALUE_API_MASK
+} from "../SecretDashboardPage/components/SecretListView/SecretItem";
 import { CreateSecretForm } from "./components/CreateSecretForm";
 import { FolderBreadCrumbs } from "./components/FolderBreadCrumbs";
 import { SecretOverviewDynamicSecretRow } from "./components/SecretOverviewDynamicSecretRow";
@@ -509,15 +513,25 @@ export const OverviewPage = () => {
     env: string,
     key: string,
     value: string,
+    secretValueHidden: boolean,
     type = SecretType.Shared
   ) => {
+    let secretValue: string | undefined = value;
+
+    if (
+      secretValueHidden &&
+      (value === HIDDEN_SECRET_VALUE_API_MASK || value === HIDDEN_SECRET_VALUE)
+    ) {
+      secretValue = undefined;
+    }
+
     try {
       const result = await updateSecretV3({
         environment: env,
         workspaceId,
         secretPath,
         secretKey: key,
-        secretValue: value,
+        secretValue,
         type
       });
 

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -50,6 +50,7 @@ type Props = {
     env: string,
     key: string,
     value: string,
+    secretValueHidden: boolean,
     type?: SecretType,
     secretId?: string
   ) => Promise<void>;
@@ -147,6 +148,7 @@ export const SecretEditRow = ({
           environment,
           secretName,
           value,
+          secretValueHidden,
           isOverride ? SecretType.Personal : SecretType.Shared,
           secretId
         );
@@ -166,6 +168,7 @@ export const SecretEditRow = ({
       environment,
       secretName,
       secretValue,
+      secretValueHidden,
       isOverride ? SecretType.Personal : SecretType.Shared,
       secretId
     );
@@ -257,7 +260,7 @@ export const SecretEditRow = ({
             >
               {(isAllowed) => (
                 <div>
-                  <Tooltip content="save">
+                  <Tooltip content="Save">
                     <IconButton
                       variant="plain"
                       ariaLabel="submit-value"

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -24,6 +24,7 @@ import { useToggle } from "@app/hooks";
 import { SecretType, SecretV3RawSanitized } from "@app/hooks/api/secrets/types";
 import { WorkspaceEnv } from "@app/hooks/api/types";
 import { getExpandedRowStyle } from "@app/pages/secret-manager/OverviewPage/components/utils";
+import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem";
 
 import { SecretEditRow } from "./SecretEditRow";
 import SecretRenameRow from "./SecretRenameRow";
@@ -40,6 +41,7 @@ type Props = {
     env: string,
     key: string,
     value: string,
+    secretValueHidden: boolean,
     type?: SecretType,
     secretId?: string
   ) => Promise<void>;
@@ -96,7 +98,7 @@ export const SecretOverviewTableRow = ({
     );
 
     if (secret?.secretValueHidden && !secret?.valueOverride) {
-      return canEditSecretValue ? "******" : "";
+      return canEditSecretValue ? HIDDEN_SECRET_VALUE : "";
     }
     return secret?.valueOverride || secret?.value || importedSecret?.secret?.value || "";
   };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -62,6 +62,7 @@ import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
 import { camelCaseToSpaces } from "@app/lib/fn/string";
 
 import { CreateReminderForm } from "./CreateReminderForm";
+import { HIDDEN_SECRET_VALUE } from "./SecretItem";
 import { formSchema, SecretActionType, TFormSchema } from "./SecretListView.utils";
 
 type Props = {
@@ -897,7 +898,9 @@ export const SecretDetailSidebar = ({
                                     </button>
                                   </div>
                                   <span className="group-[.show-value]:hidden">
-                                    {secretValueHidden ? "******" : secretValue?.replace(/./g, "*")}
+                                    {secretValueHidden
+                                      ? HIDDEN_SECRET_VALUE
+                                      : secretValue?.replace(/./g, "*")}
                                     <button
                                       type="button"
                                       className="ml-1 cursor-pointer"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -59,6 +59,7 @@ import {
 import { CollapsibleSecretImports } from "./CollapsibleSecretImports";
 
 export const HIDDEN_SECRET_VALUE = "******";
+export const HIDDEN_SECRET_VALUE_API_MASK = "<hidden-by-infisical>";
 
 type Props = {
   secret: SecretV3RawSanitized;

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -20,7 +20,7 @@ import { AddShareSecretModal } from "@app/pages/organization/SecretSharingPage/c
 import { useSelectedSecretActions, useSelectedSecrets } from "../../SecretMainPage.store";
 import { CollapsibleSecretImports } from "./CollapsibleSecretImports";
 import { SecretDetailSidebar } from "./SecretDetailSidebar";
-import { SecretItem } from "./SecretItem";
+import { HIDDEN_SECRET_VALUE, HIDDEN_SECRET_VALUE_API_MASK, SecretItem } from "./SecretItem";
 import { FontAwesomeSpriteSymbols } from "./SecretListView.utils";
 
 type Props = {
@@ -168,7 +168,7 @@ export const SecretListView = ({
       },
       cb?: () => void
     ) => {
-      const { key: oldKey } = orgSecret;
+      const { key: oldKey, secretValueHidden } = orgSecret;
       const {
         key,
         value,
@@ -235,8 +235,17 @@ export const SecretListView = ({
 
         // shared secret change
         if (!isSharedSecUnchanged && !personalAction) {
+          let secretValue = value;
+
+          if (
+            secretValueHidden &&
+            (value === HIDDEN_SECRET_VALUE_API_MASK || value === HIDDEN_SECRET_VALUE)
+          ) {
+            secretValue = undefined;
+          }
+
           await handleSecretOperation("update", SecretType.Shared, oldKey, {
-            value,
+            value: secretValue,
             tags: tagIds,
             comment,
             reminderRepeatDays,


### PR DESCRIPTION
# Description 📣

This PR is a fix for updating secrets without the read value permission. Currently if you update the comment on a secret with the value hidden, it will actually send the `<hidden-by-infisical>` or `*****` placeholder to the API, and the user will accidentally update the value unknowingly. This PR serves as a fix for this issue by removing the secret value from the update request if: (a) the user doesn't have the read value permission, and (b) the user is trying to set the value to a placeholder value.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->