### PR TITLE
feat(dynamic-secret): Add custom tags to AWS IAM dynamic secret

### DIFF
--- a/backend/src/db/migrations/20250617181915_add-dynamic-secret-tags.ts
+++ b/backend/src/db/migrations/20250617181915_add-dynamic-secret-tags.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.DynamicSecret, "tags");
+  if (!hasCol) {
+    await knex.schema.alterTable(TableName.DynamicSecret, (t) => {
+      t.jsonb("tags").nullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.DynamicSecret, "tags");
+  if (hasCol) {
+    await knex.schema.alterTable(TableName.DynamicSecret, (t) => {
+      t.dropColumn("tags");
+    });
+  }
+}

--- a/backend/src/db/schemas/dynamic-secrets.ts
+++ b/backend/src/db/schemas/dynamic-secrets.ts
@@ -29,7 +29,8 @@ export const DynamicSecretsSchema = z.object({
   encryptedInput: zodBuffer,
   projectGatewayId: z.string().uuid().nullable().optional(),
   gatewayId: z.string().uuid().nullable().optional(),
-  usernameTemplate: z.string().nullable().optional()
+  usernameTemplate: z.string().nullable().optional(),
+  tags: z.unknown().nullable().optional()
 });
 
 export type TDynamicSecrets = z.infer<typeof DynamicSecretsSchema>;

--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -80,6 +80,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         environmentSlug: z.string().describe(DYNAMIC_SECRETS.CREATE.environmentSlug).min(1),
         name: slugSchema({ min: 1, max: 64, field: "Name" }).describe(DYNAMIC_SECRETS.CREATE.name),
         metadata: ResourceMetadataSchema.optional(),
+        tags: ResourceMetadataSchema.optional(),
         usernameTemplate: userTemplateSchema.optional()
       }),
       response: {
@@ -146,6 +147,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
             .nullable(),
           newName: z.string().describe(DYNAMIC_SECRETS.UPDATE.newName).optional(),
           metadata: ResourceMetadataSchema.optional(),
+          tags: ResourceMetadataSchema.optional(),
           usernameTemplate: userTemplateSchema.nullable().optional()
         })
       }),

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
@@ -166,6 +166,7 @@ export const dynamicSecretLeaseServiceFactory = ({
         usernameTemplate: dynamicSecretCfg.usernameTemplate,
         identity,
         metadata: { projectId },
+        tags: dynamicSecretCfg.tags as Record<string, string>[] | undefined,
         config
       });
     } catch (error: unknown) {

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -79,6 +79,7 @@ export const dynamicSecretServiceFactory = ({
     defaultTTL,
     actorAuthMethod,
     metadata,
+    tags,
     usernameTemplate
   }: TCreateDynamicSecretDTO) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
@@ -165,7 +166,8 @@ export const dynamicSecretServiceFactory = ({
           folderId: folder.id,
           name,
           gatewayId: selectedGatewayId,
-          usernameTemplate
+          usernameTemplate,
+          tags: JSON.stringify(tags)
         },
         tx
       );
@@ -202,6 +204,7 @@ export const dynamicSecretServiceFactory = ({
     actorOrgId,
     actorAuthMethod,
     metadata,
+    tags,
     usernameTemplate
   }: TUpdateDynamicSecretDTO) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
@@ -315,7 +318,8 @@ export const dynamicSecretServiceFactory = ({
           name: newName ?? name,
           status: null,
           gatewayId: selectedGatewayId,
-          usernameTemplate
+          usernameTemplate,
+          tags: JSON.stringify(tags)
         },
         tx
       );

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -23,6 +23,7 @@ export type TCreateDynamicSecretDTO = {
   projectSlug: string;
   metadata?: ResourceMetadataDTO;
   usernameTemplate?: string | null;
+  tags?: ResourceMetadataDTO;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TUpdateDynamicSecretDTO = {
@@ -35,6 +36,7 @@ export type TUpdateDynamicSecretDTO = {
   inputs?: TProvider["inputs"];
   projectSlug: string;
   metadata?: ResourceMetadataDTO;
+  tags?: ResourceMetadataDTO;
   usernameTemplate?: string | null;
 } & Omit<TProjectPermission, "projectId">;
 

--- a/backend/src/ee/services/dynamic-secret/providers/models.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/models.ts
@@ -525,6 +525,7 @@ export type TDynamicProviderFns = {
       name: string;
     };
     metadata: { projectId: string };
+    tags?: Record<string, string>[];
     config?: TDynamicSecretLeaseConfig;
   }) => Promise<{ entityId: string; data: unknown }>;
   validateConnection: (inputs: unknown, metadata: { projectId: string }) => Promise<boolean>;

--- a/frontend/src/hooks/api/dynamicSecret/types.ts
+++ b/frontend/src/hooks/api/dynamicSecret/types.ts
@@ -15,6 +15,7 @@ export type TDynamicSecret = {
   maxTTL: string;
   usernameTemplate?: string | null;
   metadata?: { key: string; value: string }[];
+  tags?: { key: string; value: string }[];
 };
 
 export enum DynamicSecretProviders {
@@ -89,6 +90,7 @@ export type TDynamicSecretProvider =
     }
   | {
       type: DynamicSecretProviders.AwsIam;
+      tags?: { key: string; value: string }[];
       inputs:
         | {
             method: DynamicSecretAwsIamAuth.AccessKey;
@@ -345,6 +347,7 @@ export type TCreateDynamicSecretDTO = {
   name: string;
   metadata?: { key: string; value: string }[];
   usernameTemplate?: string;
+  tags?: { key: string; value: string }[];
 };
 
 export type TUpdateDynamicSecretDTO = {
@@ -359,6 +362,7 @@ export type TUpdateDynamicSecretDTO = {
     maxTTL?: string | null;
     inputs?: unknown;
     usernameTemplate?: string | null;
+    tags?: { key: string; value: string }[];
   };
 };
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsIamInputForm.tsx
@@ -21,6 +21,8 @@ import {
 } from "@app/hooks/api/dynamicSecret/types";
 import { WorkspaceEnv } from "@app/hooks/api/types";
 
+import { MetadataForm } from "../../DynamicSecretListView/MetadataForm";
+
 const formSchema = z.object({
   provider: z.discriminatedUnion("method", [
     z.object({
@@ -67,7 +69,10 @@ const formSchema = z.object({
     }),
   name: z.string().refine((val) => val.toLowerCase() === val, "Must be lowercase"),
   environment: z.object({ name: z.string(), slug: z.string() }),
-  usernameTemplate: z.string().nullable().optional()
+  usernameTemplate: z.string().nullable().optional(),
+  tags: z
+    .array(z.object({ key: z.string().trim().min(1), value: z.string().trim().min(1) }))
+    .optional()
 });
 type TForm = z.infer<typeof formSchema>;
 
@@ -100,7 +105,8 @@ export const AwsIamInputForm = ({
       usernameTemplate: "{{randomUsername}}",
       provider: {
         method: DynamicSecretAwsIamAuth.AssumeRole
-      }
+      },
+      tags: []
     }
   });
 
@@ -113,7 +119,8 @@ export const AwsIamInputForm = ({
     provider,
     defaultTTL,
     environment,
-    usernameTemplate
+    usernameTemplate,
+    tags
   }: TForm) => {
     // wait till previous request is finished
     if (createDynamicSecret.isPending) return;
@@ -129,7 +136,8 @@ export const AwsIamInputForm = ({
         projectSlug,
         environmentSlug: environment.slug,
         usernameTemplate:
-          !usernameTemplate || isDefaultUsernameTemplate ? undefined : usernameTemplate
+          !usernameTemplate || isDefaultUsernameTemplate ? undefined : usernameTemplate,
+        tags
       });
       onCompleted();
     } catch {
@@ -398,6 +406,7 @@ export const AwsIamInputForm = ({
                   </FormControl>
                 )}
               />
+              <MetadataForm control={control} name="tags" isValueRequired />
               {!isSingleEnvironmentMode && (
                 <Controller
                   control={control}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAwsIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAwsIamForm.tsx
@@ -10,6 +10,8 @@ import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretAwsIamAuth, TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 import { slugSchema } from "@app/lib/schemas";
 
+import { MetadataForm } from "../MetadataForm";
+
 const formSchema = z.object({
   inputs: z.discriminatedUnion("method", [
     z.object({
@@ -56,6 +58,9 @@ const formSchema = z.object({
     })
     .nullable(),
   newName: slugSchema().optional(),
+  tags: z
+    .array(z.object({ key: z.string().trim().min(1), value: z.string().trim().min(1) }))
+    .optional(),
   usernameTemplate: z.string().trim().nullable().optional()
 });
 type TForm = z.infer<typeof formSchema>;
@@ -89,7 +94,8 @@ export const EditDynamicSecretAwsIamForm = ({
       usernameTemplate: dynamicSecret?.usernameTemplate || "{{randomUsername}}",
       inputs: {
         ...(dynamicSecret.inputs as TForm["inputs"])
-      }
+      },
+      tags: dynamicSecret.tags
     }
   });
   const isAccessKeyMethod = watch("inputs.method") === DynamicSecretAwsIamAuth.AccessKey;
@@ -101,7 +107,8 @@ export const EditDynamicSecretAwsIamForm = ({
     maxTTL,
     defaultTTL,
     newName,
-    usernameTemplate
+    usernameTemplate,
+    tags
   }: TForm) => {
     // wait till previous request is finished
     if (updateDynamicSecret.isPending) return;
@@ -117,7 +124,9 @@ export const EditDynamicSecretAwsIamForm = ({
           defaultTTL,
           inputs,
           newName: newName === dynamicSecret.name ? undefined : newName,
-          usernameTemplate: !usernameTemplate || isDefaultUsernameTemplate ? null : usernameTemplate
+          usernameTemplate:
+            !usernameTemplate || isDefaultUsernameTemplate ? null : usernameTemplate,
+          tags
         }
       });
       onClose();
@@ -380,6 +389,7 @@ export const EditDynamicSecretAwsIamForm = ({
                 </FormControl>
               )}
             />
+            <MetadataForm control={control} name="tags" isValueRequired />
           </div>
         </div>
         <div className="mt-4 flex items-center space-x-4">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/MetadataForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/MetadataForm.tsx
@@ -4,14 +4,22 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { FormControl, FormLabel, IconButton, Input } from "@app/components/v2";
 
-export const MetadataForm = ({ control }: { control: Control<any> }) => {
+export const MetadataForm = ({
+  control,
+  name = "metadata",
+  isValueRequired = false
+}: {
+  control: Control<any>;
+  name?: string;
+  isValueRequired?: boolean;
+}) => {
   const metadataFormFields = useFieldArray({
     control,
-    name: "metadata"
+    name
   });
 
   return (
-    <FormControl label="Metadata">
+    <FormControl label={name.charAt(0).toUpperCase() + name.slice(1)}>
       <div className="flex flex-col space-y-2">
         {metadataFormFields.fields.map(({ id: metadataFieldId }, i) => (
           <div key={metadataFieldId} className="flex items-end space-x-2">
@@ -19,7 +27,7 @@ export const MetadataForm = ({ control }: { control: Control<any> }) => {
               {i === 0 && <span className="text-xs text-mineshaft-400">Key</span>}
               <Controller
                 control={control}
-                name={`metadata.${i}.key`}
+                name={`${name}.${i}.key`}
                 render={({ field, fieldState: { error } }) => (
                   <FormControl
                     isError={Boolean(error?.message)}
@@ -33,11 +41,15 @@ export const MetadataForm = ({ control }: { control: Control<any> }) => {
             </div>
             <div className="flex-grow">
               {i === 0 && (
-                <FormLabel label="Value" className="text-xs text-mineshaft-400" isOptional />
+                <FormLabel
+                  label="Value"
+                  className="text-xs text-mineshaft-400"
+                  isOptional={!isValueRequired}
+                />
               )}
               <Controller
                 control={control}
-                name={`metadata.${i}.value`}
+                name={`${name}.${i}.value`}
                 render={({ field, fieldState: { error } }) => (
                   <FormControl
                     isError={Boolean(error?.message)}


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This PR adds a new option on the AWS IAM dynamic secrets settings, now it's possible to add custom tags to the users generated (keeping the existing Tag `createdBy: infisical-dynamic-secret` used to mark the users created by our platform)
![CleanShot 2025-06-17 at 15 59 48](https://github.com/user-attachments/assets/589de39f-6911-4406-bc21-c840569ab405)
![CleanShot 2025-06-17 at 15 59 14@2x](https://github.com/user-attachments/assets/ba65f5f4-33b1-4ee1-879d-0e0e26ed4430)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->