### PR TITLE
fix: updated aws principal arn field size to 2048

### DIFF
--- a/backend/src/db/migrations/20250618172150_increase-aws-arn-field-size.ts
+++ b/backend/src/db/migrations/20250618172150_increase-aws-arn-field-size.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.IdentityAwsAuth, "allowedPrincipalArns");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.IdentityAwsAuth, (t) => {
+      t.string("allowedPrincipalArns", 2048).notNullable().alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.IdentityAwsAuth, "allowedPrincipalArns");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.IdentityAwsAuth, (t) => {
+      t.string("allowedPrincipalArns", 255).notNullable().alter();
+    });
+  }
+}

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
@@ -9,6 +9,7 @@ const arnRegex = new RE2(/^arn:aws:iam::\d{12}:(user\/[a-zA-Z0-9_.@+*/-]+|role\/
 export const validateAccountIds = z
   .string()
   .trim()
+  .max(2048)
   .default("")
   // Custom validation to ensure each part is a 12-digit number
   .refine(
@@ -36,6 +37,7 @@ export const validateAccountIds = z
 export const validatePrincipalArns = z
   .string()
   .trim()
+  .max(2048)
   .default("")
   // Custom validation for ARN format
   .refine(


### PR DESCRIPTION
# Description 📣

Previously, we had a varchar(255) character limit for aws arn in identity aws auth. A single arn average around 150 characters and AWS size limit is 20-2048 characters for an ARN. We save multiple arn in a single db field as comma separated. This was causing max length validation error from database.

To avoid this
1. I have increased the field size to 2048 characters. Allowing multiple aws arn of average size
2. I have also added backend validation in place.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->