### PR TITLE
fix: resolved failing duplication of predefined roles

### DIFF
--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/DuplicateProjectRoleModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/DuplicateProjectRoleModal.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { Button, FormControl, Input, Modal, ModalContent, Spinner } from "@app/components/v2";
-import { ProjectPermissionActions, ProjectPermissionSub, useWorkspace } from "@app/context";
+import { ProjectPermissionSub, useWorkspace } from "@app/context";
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useCreateProjectRole, useGetProjectRoleBySlug } from "@app/hooks/api";
 import { TProjectRole } from "@app/hooks/api/roles/types";
@@ -61,7 +61,7 @@ const Content = ({ role, onClose }: ContentProps) => {
         return {
           ...permission,
           action: (permission.action as string[])?.filter(
-            (action) => action !== ProjectPermissionActions.Read
+            (action) => action !== ProjectPermissionSecretActions.DescribeAndReadValue
           )
         };
       }

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/DuplicateProjectRoleModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/DuplicateProjectRoleModal.tsx
@@ -5,7 +5,8 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { Button, FormControl, Input, Modal, ModalContent, Spinner } from "@app/components/v2";
-import { useWorkspace } from "@app/context";
+import { ProjectPermissionActions, ProjectPermissionSub, useWorkspace } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useCreateProjectRole, useGetProjectRoleBySlug } from "@app/hooks/api";
 import { TProjectRole } from "@app/hooks/api/roles/types";
 import { slugSchema } from "@app/lib/schemas";
@@ -49,9 +50,27 @@ const Content = ({ role, onClose }: ContentProps) => {
   const navigate = useNavigate();
 
   const handleDuplicateRole = async (form: FormData) => {
+    const sanitizedPermission = role.permissions.map((permission) => {
+      if (
+        // if contains new secret action the legacy one can be stripped off
+        // mainly done for duplicating predefined roles
+        permission.subject === ProjectPermissionSub.Secrets &&
+        (permission.action.includes(ProjectPermissionSecretActions.DescribeSecret) ||
+          permission.action.includes(ProjectPermissionSecretActions.ReadValue))
+      ) {
+        return {
+          ...permission,
+          action: (permission.action as string[])?.filter(
+            (action) => action !== ProjectPermissionActions.Read
+          )
+        };
+      }
+      return permission;
+    });
+
     const newRole = await createRole.mutateAsync({
       projectId: currentWorkspace.id,
-      permissions: role.permissions,
+      permissions: sanitizedPermission,
       ...form
     });
 


### PR DESCRIPTION
# Description 📣

Duplicating predefined roles in project would fail due to those roles having `read`, `readValue` and `describeSecret` permission to keep backward compatibility.

This PR fixes that by removing `read` action if the permission contains the newer permission set.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->