### PR TITLE
feat: resolved okta oidc failing

### DIFF
--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -698,7 +698,7 @@ export const oidcConfigServiceFactory = ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (_req: any, tokenSet: TokenSet, cb: any) => {
         const claims = tokenSet.claims();
-        if (!claims.email || !claims.given_name) {
+        if (!claims.email) {
           throw new BadRequestError({
             message: "Invalid request. Missing email or first name"
           });
@@ -718,7 +718,7 @@ export const oidcConfigServiceFactory = ({
         oidcLogin({
           email: claims.email.toLowerCase(),
           externalId: claims.sub,
-          firstName: claims.given_name ?? "",
+          firstName: claims?.given_name || claims?.name || "",
           lastName: claims.family_name ?? "",
           orgId: org.id,
           groups,

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -700,7 +700,7 @@ export const oidcConfigServiceFactory = ({
         const claims = tokenSet.claims();
         if (!claims.email) {
           throw new BadRequestError({
-            message: "Invalid request. Missing email or first name"
+            message: "Invalid request. Missing email claim."
           });
         }
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -713,12 +713,19 @@ export const oidcConfigServiceFactory = ({
           }
         }
 
+        const name = claims?.given_name || claims?.name;
+        if (!name) {
+          throw new BadRequestError({
+            message: "Invalid request. Missing name claim."
+          });
+        }
+
         const groups = typeof claims.groups === "string" ? [claims.groups] : (claims.groups as string[] | undefined);
 
         oidcLogin({
           email: claims.email.toLowerCase(),
           externalId: claims.sub,
-          firstName: claims?.given_name || claims?.name || "",
+          firstName: name,
           lastName: claims.family_name ?? "",
           orgId: org.id,
           groups,


### PR DESCRIPTION
# Description 📣

Okta OIDC was failing due to missing `given_name`. From the response it seems Okta only returns name and nothing else. 

As email is required one for our authentication. I have put given_name first priority and default to name if that doesn't exist. It will only throw error if none of them exist.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->