### PR TITLE
feat: migrated dynamic secret to pg queue and corrected service layer

### DIFF
--- a/backend/e2e-test/mocks/queue.ts
+++ b/backend/e2e-test/mocks/queue.ts
@@ -26,6 +26,7 @@ export const mockQueue = (): TQueueServiceFactory => {
     getRepeatableJobs: async () => [],
     clearQueue: async () => {},
     stopJobById: async () => {},
+    stopJobByIdPg: async () => {},
     stopRepeatableJobByJobId: async () => true,
     stopRepeatableJobByKey: async () => true
   };

--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -10,8 +10,8 @@ import { TAuditLogServiceFactory, TCreateAuditLogDTO } from "@app/ee/services/au
 import { TAuditLogStreamServiceFactory } from "@app/ee/services/audit-log-stream/audit-log-stream-types";
 import { TCertificateAuthorityCrlServiceFactory } from "@app/ee/services/certificate-authority-crl/certificate-authority-crl-types";
 import { TCertificateEstServiceFactory } from "@app/ee/services/certificate-est/certificate-est-service";
-import { TDynamicSecretServiceFactory } from "@app/ee/services/dynamic-secret/dynamic-secret-service";
-import { TDynamicSecretLeaseServiceFactory } from "@app/ee/services/dynamic-secret-lease/dynamic-secret-lease-service";
+import { TDynamicSecretServiceFactory } from "@app/ee/services/dynamic-secret/dynamic-secret-types";
+import { TDynamicSecretLeaseServiceFactory } from "@app/ee/services/dynamic-secret-lease/dynamic-secret-lease-types";
 import { TExternalKmsServiceFactory } from "@app/ee/services/external-kms/external-kms-service";
 import { TGatewayServiceFactory } from "@app/ee/services/gateway/gateway-service";
 import { TGithubOrgSyncServiceFactory } from "@app/ee/services/github-org-sync/github-org-sync-service";

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-dal.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-dal.ts
@@ -3,9 +3,43 @@ import { Knex } from "knex";
 import { TDbClient } from "@app/db";
 import { DynamicSecretLeasesSchema, TableName } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
-import { ormify, selectAllTableCols } from "@app/lib/knex";
+import { ormify, selectAllTableCols, TOrmify } from "@app/lib/knex";
 
-export type TDynamicSecretLeaseDALFactory = ReturnType<typeof dynamicSecretLeaseDALFactory>;
+export interface TDynamicSecretLeaseDALFactory extends Omit<TOrmify<TableName.DynamicSecretLease>, "findById"> {
+  countLeasesForDynamicSecret: (dynamicSecretId: string, tx?: Knex) => Promise<number>;
+  findById: (
+    id: string,
+    tx?: Knex
+  ) => Promise<
+    | {
+        dynamicSecret: {
+          id: string;
+          name: string;
+          version: number;
+          type: string;
+          defaultTTL: string;
+          maxTTL: string | null | undefined;
+          encryptedInput: Buffer;
+          folderId: string;
+          status: string | null | undefined;
+          statusDetails: string | null | undefined;
+          createdAt: Date;
+          updatedAt: Date;
+        };
+        version: number;
+        id: string;
+        createdAt: Date;
+        updatedAt: Date;
+        externalEntityId: string;
+        expireAt: Date;
+        dynamicSecretId: string;
+        status?: string | null | undefined;
+        config?: unknown;
+        statusDetails?: string | null | undefined;
+      }
+    | undefined
+  >;
+}
 
 export const dynamicSecretLeaseDALFactory = (db: TDbClient) => {
   const orm = ormify(db, TableName.DynamicSecretLease);

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-queue.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-queue.ts
@@ -21,7 +21,12 @@ type TDynamicSecretLeaseQueueServiceFactoryDep = {
   folderDAL: Pick<TSecretFolderDALFactory, "findById">;
 };
 
-export type TDynamicSecretLeaseQueueServiceFactory = ReturnType<typeof dynamicSecretLeaseQueueServiceFactory>;
+export type TDynamicSecretLeaseQueueServiceFactory = {
+  pruneDynamicSecret: (dynamicSecretCfgId: string) => Promise<void>;
+  setLeaseRevocation: (leaseId: string, expiryAt: Date) => Promise<void>;
+  unsetLeaseRevocation: (leaseId: string) => Promise<void>;
+  init: () => Promise<void>;
+};
 
 export const dynamicSecretLeaseQueueServiceFactory = ({
   queueService,
@@ -30,55 +35,47 @@ export const dynamicSecretLeaseQueueServiceFactory = ({
   dynamicSecretLeaseDAL,
   kmsService,
   folderDAL
-}: TDynamicSecretLeaseQueueServiceFactoryDep) => {
+}: TDynamicSecretLeaseQueueServiceFactoryDep): TDynamicSecretLeaseQueueServiceFactory => {
   const pruneDynamicSecret = async (dynamicSecretCfgId: string) => {
-    await queueService.queue(
-      QueueName.DynamicSecretRevocation,
+    await queueService.queuePg<QueueName.DynamicSecretRevocation>(
       QueueJobs.DynamicSecretPruning,
       { dynamicSecretCfgId },
       {
-        jobId: dynamicSecretCfgId,
-        backoff: {
-          type: "exponential",
-          delay: 3000
-        },
-        removeOnFail: {
-          count: 3
-        },
-        removeOnComplete: true
+        singletonKey: dynamicSecretCfgId,
+        retryLimit: 3,
+        retryBackoff: true
       }
     );
   };
 
-  const setLeaseRevocation = async (leaseId: string, expiry: number) => {
-    await queueService.queue(
-      QueueName.DynamicSecretRevocation,
+  const setLeaseRevocation = async (leaseId: string, expiryAt: Date) => {
+    await queueService.queuePg<QueueName.DynamicSecretRevocation>(
       QueueJobs.DynamicSecretRevocation,
       { leaseId },
       {
-        jobId: leaseId,
-        backoff: {
-          type: "exponential",
-          delay: 3000
-        },
-        delay: expiry,
-        removeOnFail: {
-          count: 3
-        },
-        removeOnComplete: true
+        id: leaseId,
+        singletonKey: leaseId,
+        startAfter: expiryAt,
+        retryLimit: 3,
+        retryBackoff: true,
+        retentionDays: 2
       }
     );
   };
 
   const unsetLeaseRevocation = async (leaseId: string) => {
-    await queueService.stopJobById(QueueName.DynamicSecretRevocation, leaseId);
+    await queueService.stopJobByIdPg(QueueName.DynamicSecretRevocation, leaseId);
   };
 
-  queueService.start(QueueName.DynamicSecretRevocation, async (job) => {
+  const $dynamicSecretQueueJob = async (
+    jobName: string,
+    jobId: string,
+    data: { leaseId: string } | { dynamicSecretCfgId: string }
+  ): Promise<void> => {
     try {
-      if (job.name === QueueJobs.DynamicSecretRevocation) {
-        const { leaseId } = job.data as { leaseId: string };
-        logger.info("Dynamic secret lease revocation started: ", leaseId, job.id);
+      if (jobName === QueueJobs.DynamicSecretRevocation) {
+        const { leaseId } = data as { leaseId: string };
+        logger.info("Dynamic secret lease revocation started: ", leaseId, jobId);
 
         const dynamicSecretLease = await dynamicSecretLeaseDAL.findById(leaseId);
         if (!dynamicSecretLease) throw new DisableRotationErrors({ message: "Dynamic secret lease not found" });
@@ -107,9 +104,9 @@ export const dynamicSecretLeaseQueueServiceFactory = ({
         return;
       }
 
-      if (job.name === QueueJobs.DynamicSecretPruning) {
-        const { dynamicSecretCfgId } = job.data as { dynamicSecretCfgId: string };
-        logger.info("Dynamic secret pruning started: ", dynamicSecretCfgId, job.id);
+      if (jobName === QueueJobs.DynamicSecretPruning) {
+        const { dynamicSecretCfgId } = data as { dynamicSecretCfgId: string };
+        logger.info("Dynamic secret pruning started: ", dynamicSecretCfgId, jobId);
         const dynamicSecretCfg = await dynamicSecretDAL.findById(dynamicSecretCfgId);
         if (!dynamicSecretCfg) throw new DisableRotationErrors({ message: "Dynamic secret not found" });
         if ((dynamicSecretCfg.status as DynamicSecretStatus) !== DynamicSecretStatus.Deleting)
@@ -150,38 +147,67 @@ export const dynamicSecretLeaseQueueServiceFactory = ({
 
         await dynamicSecretDAL.deleteById(dynamicSecretCfgId);
       }
-      logger.info("Finished dynamic secret job", job.id);
+      logger.info("Finished dynamic secret job", jobId);
     } catch (error) {
       logger.error(error);
 
-      if (job?.name === QueueJobs.DynamicSecretPruning) {
-        const { dynamicSecretCfgId } = job.data as { dynamicSecretCfgId: string };
+      if (jobName === QueueJobs.DynamicSecretPruning) {
+        const { dynamicSecretCfgId } = data as { dynamicSecretCfgId: string };
         await dynamicSecretDAL.updateById(dynamicSecretCfgId, {
           status: DynamicSecretStatus.FailedDeletion,
           statusDetails: (error as Error)?.message?.slice(0, 255)
         });
       }
 
-      if (job?.name === QueueJobs.DynamicSecretRevocation) {
-        const { leaseId } = job.data as { leaseId: string };
+      if (jobName === QueueJobs.DynamicSecretRevocation) {
+        const { leaseId } = data as { leaseId: string };
         await dynamicSecretLeaseDAL.updateById(leaseId, {
           status: DynamicSecretStatus.FailedDeletion,
           statusDetails: (error as Error)?.message?.slice(0, 255)
         });
       }
       if (error instanceof DisableRotationErrors) {
-        if (job.id) {
-          await queueService.stopRepeatableJobByJobId(QueueName.DynamicSecretRevocation, job.id);
+        if (jobId) {
+          await queueService.stopRepeatableJobByJobId(QueueName.DynamicSecretRevocation, jobId);
         }
       }
       // propogate to next part
       throw error;
     }
+  };
+
+  queueService.start(QueueName.DynamicSecretRevocation, async (job) => {
+    await $dynamicSecretQueueJob(job.name, job.id as string, job.data);
   });
+
+  const init = async () => {
+    await queueService.startPg<QueueName.DynamicSecretRevocation>(
+      QueueJobs.DynamicSecretRevocation,
+      async ([job]) => {
+        await $dynamicSecretQueueJob(job.name, job.id, job.data);
+      },
+      {
+        workerCount: 2,
+        pollingIntervalSeconds: 30
+      }
+    );
+
+    await queueService.startPg<QueueName.DynamicSecretRevocation>(
+      QueueJobs.DynamicSecretPruning,
+      async ([job]) => {
+        await $dynamicSecretQueueJob(job.name, job.id, job.data);
+      },
+      {
+        workerCount: 2,
+        pollingIntervalSeconds: 5
+      }
+    );
+  };
 
   return {
     pruneDynamicSecret,
     setLeaseRevocation,
-    unsetLeaseRevocation
+    unsetLeaseRevocation,
+    init
   };
 };

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
@@ -26,12 +26,8 @@ import { TDynamicSecretLeaseDALFactory } from "./dynamic-secret-lease-dal";
 import { TDynamicSecretLeaseQueueServiceFactory } from "./dynamic-secret-lease-queue";
 import {
   DynamicSecretLeaseStatus,
-  TCreateDynamicSecretLeaseDTO,
-  TDeleteDynamicSecretLeaseDTO,
-  TDetailsDynamicSecretLeaseDTO,
   TDynamicSecretLeaseConfig,
-  TListDynamicSecretLeasesDTO,
-  TRenewDynamicSecretLeaseDTO
+  TDynamicSecretLeaseServiceFactory
 } from "./dynamic-secret-lease-types";
 
 type TDynamicSecretLeaseServiceFactoryDep = {
@@ -48,8 +44,6 @@ type TDynamicSecretLeaseServiceFactoryDep = {
   identityDAL: TIdentityDALFactory;
 };
 
-export type TDynamicSecretLeaseServiceFactory = ReturnType<typeof dynamicSecretLeaseServiceFactory>;
-
 export const dynamicSecretLeaseServiceFactory = ({
   dynamicSecretLeaseDAL,
   dynamicSecretProviders,
@@ -62,14 +56,14 @@ export const dynamicSecretLeaseServiceFactory = ({
   kmsService,
   userDAL,
   identityDAL
-}: TDynamicSecretLeaseServiceFactoryDep) => {
+}: TDynamicSecretLeaseServiceFactoryDep): TDynamicSecretLeaseServiceFactory => {
   const extractEmailUsername = (email: string) => {
     const regex = new RE2(/^([^@]+)/);
     const match = email.match(regex);
     return match ? match[1] : email;
   };
 
-  const create = async ({
+  const create: TDynamicSecretLeaseServiceFactory["create"] = async ({
     environmentSlug,
     path,
     name,
@@ -80,7 +74,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     actorAuthMethod,
     ttl,
     config
-  }: TCreateDynamicSecretLeaseDTO) => {
+  }) => {
     const appCfg = getConfig();
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
@@ -184,11 +178,11 @@ export const dynamicSecretLeaseServiceFactory = ({
       config
     });
 
-    await dynamicSecretQueueService.setLeaseRevocation(dynamicSecretLease.id, Number(expireAt) - Number(new Date()));
+    await dynamicSecretQueueService.setLeaseRevocation(dynamicSecretLease.id, expireAt);
     return { lease: dynamicSecretLease, dynamicSecret: dynamicSecretCfg, data };
   };
 
-  const renewLease = async ({
+  const renewLease: TDynamicSecretLeaseServiceFactory["renewLease"] = async ({
     ttl,
     actorAuthMethod,
     actorOrgId,
@@ -198,7 +192,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     path,
     environmentSlug,
     leaseId
-  }: TRenewDynamicSecretLeaseDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -278,7 +272,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     );
 
     await dynamicSecretQueueService.unsetLeaseRevocation(dynamicSecretLease.id);
-    await dynamicSecretQueueService.setLeaseRevocation(dynamicSecretLease.id, Number(expireAt) - Number(new Date()));
+    await dynamicSecretQueueService.setLeaseRevocation(dynamicSecretLease.id, expireAt);
     const updatedDynamicSecretLease = await dynamicSecretLeaseDAL.updateById(dynamicSecretLease.id, {
       expireAt,
       externalEntityId: entityId
@@ -286,7 +280,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     return updatedDynamicSecretLease;
   };
 
-  const revokeLease = async ({
+  const revokeLease: TDynamicSecretLeaseServiceFactory["revokeLease"] = async ({
     leaseId,
     environmentSlug,
     path,
@@ -296,7 +290,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     actorOrgId,
     actorAuthMethod,
     isForced
-  }: TDeleteDynamicSecretLeaseDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -376,7 +370,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     return deletedDynamicSecretLease;
   };
 
-  const listLeases = async ({
+  const listLeases: TDynamicSecretLeaseServiceFactory["listLeases"] = async ({
     path,
     name,
     actor,
@@ -385,7 +379,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     actorOrgId,
     environmentSlug,
     actorAuthMethod
-  }: TListDynamicSecretLeasesDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -424,7 +418,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     return dynamicSecretLeases;
   };
 
-  const getLeaseDetails = async ({
+  const getLeaseDetails: TDynamicSecretLeaseServiceFactory["getLeaseDetails"] = async ({
     projectSlug,
     actorOrgId,
     path,
@@ -433,7 +427,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     actorId,
     leaseId,
     actorAuthMethod
-  }: TDetailsDynamicSecretLeaseDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-types.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-types.ts
@@ -1,4 +1,5 @@
-import { TProjectPermission } from "@app/lib/types";
+import { TDynamicSecretLeases } from "@app/db/schemas";
+import { TDynamicSecretWithMetadata, TProjectPermission } from "@app/lib/types";
 
 export enum DynamicSecretLeaseStatus {
   FailedDeletion = "Failed to delete"
@@ -48,3 +49,40 @@ export type TDynamicSecretKubernetesLeaseConfig = {
 };
 
 export type TDynamicSecretLeaseConfig = TDynamicSecretKubernetesLeaseConfig;
+
+export type TDynamicSecretLeaseServiceFactory = {
+  create: (arg: TCreateDynamicSecretLeaseDTO) => Promise<{
+    lease: TDynamicSecretLeases;
+    dynamicSecret: TDynamicSecretWithMetadata;
+    data: unknown;
+  }>;
+  listLeases: (arg: TListDynamicSecretLeasesDTO) => Promise<TDynamicSecretLeases[]>;
+  revokeLease: (arg: TDeleteDynamicSecretLeaseDTO) => Promise<TDynamicSecretLeases>;
+  renewLease: (arg: TRenewDynamicSecretLeaseDTO) => Promise<TDynamicSecretLeases>;
+  getLeaseDetails: (arg: TDetailsDynamicSecretLeaseDTO) => Promise<{
+    dynamicSecret: {
+      id: string;
+      name: string;
+      version: number;
+      type: string;
+      defaultTTL: string;
+      maxTTL: string | null | undefined;
+      encryptedInput: Buffer;
+      folderId: string;
+      status: string | null | undefined;
+      statusDetails: string | null | undefined;
+      createdAt: Date;
+      updatedAt: Date;
+    };
+    version: number;
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    externalEntityId: string;
+    expireAt: Date;
+    dynamicSecretId: string;
+    status?: string | null | undefined;
+    config?: unknown;
+    statusDetails?: string | null | undefined;
+  }>;
+};

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -8,7 +8,7 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
-import { OrderByDirection, OrgServiceActor } from "@app/lib/types";
+import { OrderByDirection } from "@app/lib/types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -20,17 +20,7 @@ import { TDynamicSecretLeaseQueueServiceFactory } from "../dynamic-secret-lease/
 import { TGatewayDALFactory } from "../gateway/gateway-dal";
 import { OrgPermissionGatewayActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TDynamicSecretDALFactory } from "./dynamic-secret-dal";
-import {
-  DynamicSecretStatus,
-  TCreateDynamicSecretDTO,
-  TDeleteDynamicSecretDTO,
-  TDetailsDynamicSecretDTO,
-  TGetDynamicSecretsCountDTO,
-  TListDynamicSecretsByFolderMappingsDTO,
-  TListDynamicSecretsDTO,
-  TListDynamicSecretsMultiEnvDTO,
-  TUpdateDynamicSecretDTO
-} from "./dynamic-secret-types";
+import { DynamicSecretStatus, TDynamicSecretServiceFactory } from "./dynamic-secret-types";
 import { AzureEntraIDProvider } from "./providers/azure-entra-id";
 import { DynamicSecretProviders, TDynamicProviderFns } from "./providers/models";
 
@@ -51,8 +41,6 @@ type TDynamicSecretServiceFactoryDep = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete">;
 };
 
-export type TDynamicSecretServiceFactory = ReturnType<typeof dynamicSecretServiceFactory>;
-
 export const dynamicSecretServiceFactory = ({
   dynamicSecretDAL,
   dynamicSecretLeaseDAL,
@@ -65,8 +53,8 @@ export const dynamicSecretServiceFactory = ({
   kmsService,
   gatewayDAL,
   resourceMetadataDAL
-}: TDynamicSecretServiceFactoryDep) => {
-  const create = async ({
+}: TDynamicSecretServiceFactoryDep): TDynamicSecretServiceFactory => {
+  const create: TDynamicSecretServiceFactory["create"] = async ({
     path,
     actor,
     name,
@@ -80,7 +68,7 @@ export const dynamicSecretServiceFactory = ({
     actorAuthMethod,
     metadata,
     usernameTemplate
-  }: TCreateDynamicSecretDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -188,7 +176,7 @@ export const dynamicSecretServiceFactory = ({
     return dynamicSecretCfg;
   };
 
-  const updateByName = async ({
+  const updateByName: TDynamicSecretServiceFactory["updateByName"] = async ({
     name,
     maxTTL,
     defaultTTL,
@@ -203,7 +191,7 @@ export const dynamicSecretServiceFactory = ({
     actorAuthMethod,
     metadata,
     usernameTemplate
-  }: TUpdateDynamicSecretDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -345,7 +333,7 @@ export const dynamicSecretServiceFactory = ({
     return updatedDynamicCfg;
   };
 
-  const deleteByName = async ({
+  const deleteByName: TDynamicSecretServiceFactory["deleteByName"] = async ({
     actorAuthMethod,
     actorOrgId,
     actorId,
@@ -355,7 +343,7 @@ export const dynamicSecretServiceFactory = ({
     path,
     environmentSlug,
     isForced
-  }: TDeleteDynamicSecretDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -413,7 +401,7 @@ export const dynamicSecretServiceFactory = ({
     return deletedDynamicSecretCfg;
   };
 
-  const getDetails = async ({
+  const getDetails: TDynamicSecretServiceFactory["getDetails"] = async ({
     name,
     projectSlug,
     path,
@@ -422,7 +410,7 @@ export const dynamicSecretServiceFactory = ({
     actorOrgId,
     actorId,
     actor
-  }: TDetailsDynamicSecretDTO) => {
+  }) => {
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
@@ -480,7 +468,7 @@ export const dynamicSecretServiceFactory = ({
   };
 
   // get unique dynamic secret count across multiple envs
-  const getCountMultiEnv = async ({
+  const getCountMultiEnv: TDynamicSecretServiceFactory["getCountMultiEnv"] = async ({
     actorAuthMethod,
     actorOrgId,
     actorId,
@@ -490,7 +478,7 @@ export const dynamicSecretServiceFactory = ({
     environmentSlugs,
     search,
     isInternal
-  }: TListDynamicSecretsMultiEnvDTO) => {
+  }) => {
     if (!isInternal) {
       const { permission } = await permissionService.getProjectPermission({
         actor,
@@ -526,7 +514,7 @@ export const dynamicSecretServiceFactory = ({
   };
 
   // get dynamic secret count for a single env
-  const getDynamicSecretCount = async ({
+  const getDynamicSecretCount: TDynamicSecretServiceFactory["getDynamicSecretCount"] = async ({
     actorAuthMethod,
     actorOrgId,
     actorId,
@@ -535,7 +523,7 @@ export const dynamicSecretServiceFactory = ({
     environmentSlug,
     search,
     projectId
-  }: TGetDynamicSecretsCountDTO) => {
+  }) => {
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -561,7 +549,7 @@ export const dynamicSecretServiceFactory = ({
     return Number(dynamicSecretCfg[0]?.count ?? 0);
   };
 
-  const listDynamicSecretsByEnv = async ({
+  const listDynamicSecretsByEnv: TDynamicSecretServiceFactory["listDynamicSecretsByEnv"] = async ({
     actorAuthMethod,
     actorOrgId,
     actorId,
@@ -575,7 +563,7 @@ export const dynamicSecretServiceFactory = ({
     orderDirection = OrderByDirection.ASC,
     search,
     ...params
-  }: TListDynamicSecretsDTO) => {
+  }) => {
     let { projectId } = params;
 
     if (!projectId) {
@@ -619,9 +607,9 @@ export const dynamicSecretServiceFactory = ({
     });
   };
 
-  const listDynamicSecretsByFolderIds = async (
-    { folderMappings, filters, projectId }: TListDynamicSecretsByFolderMappingsDTO,
-    actor: OrgServiceActor
+  const listDynamicSecretsByFolderIds: TDynamicSecretServiceFactory["listDynamicSecretsByFolderIds"] = async (
+    { folderMappings, filters, projectId },
+    actor
   ) => {
     const { permission } = await permissionService.getProjectPermission({
       actor: actor.type,
@@ -657,7 +645,7 @@ export const dynamicSecretServiceFactory = ({
   };
 
   // get dynamic secrets for multiple envs
-  const listDynamicSecretsByEnvs = async ({
+  const listDynamicSecretsByEnvs: TDynamicSecretServiceFactory["listDynamicSecretsByEnvs"] = async ({
     actorAuthMethod,
     actorOrgId,
     actorId,
@@ -667,7 +655,7 @@ export const dynamicSecretServiceFactory = ({
     projectId,
     isInternal,
     ...params
-  }: TListDynamicSecretsMultiEnvDTO) => {
+  }) => {
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -700,14 +688,10 @@ export const dynamicSecretServiceFactory = ({
     });
   };
 
-  const fetchAzureEntraIdUsers = async ({
+  const fetchAzureEntraIdUsers: TDynamicSecretServiceFactory["fetchAzureEntraIdUsers"] = async ({
     tenantId,
     applicationId,
     clientSecret
-  }: {
-    tenantId: string;
-    applicationId: string;
-    clientSecret: string;
   }) => {
     const azureEntraIdUsers = await AzureEntraIDProvider().fetchAzureEntraIdUsers(
       tenantId,

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { OrderByDirection, TProjectPermission } from "@app/lib/types";
+import { TDynamicSecrets } from "@app/db/schemas";
+import { OrderByDirection, OrgServiceActor, TDynamicSecretWithMetadata, TProjectPermission } from "@app/lib/types";
 import { ResourceMetadataDTO } from "@app/services/resource-metadata/resource-metadata-schema";
 import { SecretsOrderBy } from "@app/services/secret/secret-types";
 
@@ -82,4 +83,28 @@ export type TListDynamicSecretsMultiEnvDTO = Omit<
 
 export type TGetDynamicSecretsCountDTO = Omit<TListDynamicSecretsDTO, "projectSlug" | "projectId"> & {
   projectId: string;
+};
+
+export type TDynamicSecretServiceFactory = {
+  create: (arg: TCreateDynamicSecretDTO) => Promise<TDynamicSecrets>;
+  updateByName: (arg: TUpdateDynamicSecretDTO) => Promise<TDynamicSecrets>;
+  deleteByName: (arg: TDeleteDynamicSecretDTO) => Promise<TDynamicSecrets>;
+  getDetails: (arg: TDetailsDynamicSecretDTO) => Promise<TDynamicSecretWithMetadata>;
+  listDynamicSecretsByEnv: (arg: TListDynamicSecretsDTO) => Promise<TDynamicSecretWithMetadata[]>;
+  listDynamicSecretsByEnvs: (
+    arg: TListDynamicSecretsMultiEnvDTO
+  ) => Promise<Array<TDynamicSecretWithMetadata & { environment: string }>>;
+  getDynamicSecretCount: (arg: TGetDynamicSecretsCountDTO) => Promise<number>;
+  getCountMultiEnv: (arg: TListDynamicSecretsMultiEnvDTO) => Promise<number>;
+  fetchAzureEntraIdUsers: (arg: { tenantId: string; applicationId: string; clientSecret: string }) => Promise<
+    {
+      name: string;
+      id: string;
+      email: string;
+    }[]
+  >;
+  listDynamicSecretsByFolderIds: (
+    arg: TListDynamicSecretsByFolderMappingsDTO,
+    actor: OrgServiceActor
+  ) => Promise<Array<TDynamicSecretWithMetadata & { environment: string; path: string }>>;
 };

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -18,7 +18,7 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   environmentsUsed: 0,
   identityLimit: null,
   identitiesUsed: 0,
-  dynamicSecret: false,
+  dynamicSecret: true,
   secretVersioning: true,
   pitRecovery: false,
   ipAllowlisting: false,

--- a/backend/src/lib/fn/time.ts
+++ b/backend/src/lib/fn/time.ts
@@ -19,3 +19,5 @@ export const getMinExpiresIn = (exp1: string | number, exp2: string | number): s
 
   return ms1 <= ms2 ? exp1 : exp2;
 };
+
+export const convertMsToSecond = (time: number) => time / 1000;

--- a/backend/src/lib/types/index.ts
+++ b/backend/src/lib/types/index.ts
@@ -1,3 +1,4 @@
+import { TDynamicSecrets } from "@app/db/schemas";
 import { ActorAuthMethod, ActorType } from "@app/services/auth/auth-type";
 
 export type TGenericPermission = {
@@ -83,4 +84,8 @@ export enum QueueWorkerProfile {
   All = "all",
   Standard = "standard",
   SecretScanning = "secret-scanning"
+}
+
+export interface TDynamicSecretWithMetadata extends TDynamicSecrets {
+  metadata: { id: string; key: string; value: string }[];
 }

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -377,6 +377,7 @@ export type TQueueServiceFactory = {
   stopRepeatableJobByKey: <T extends QueueName>(name: T, repeatJobKey: string) => Promise<boolean>;
   clearQueue: (name: QueueName) => Promise<void>;
   stopJobById: <T extends QueueName>(name: T, jobId: string) => Promise<void | undefined>;
+  stopJobByIdPg: <T extends QueueName>(name: T, jobId: string) => Promise<void | undefined>;
   getRepeatableJobs: (
     name: QueueName,
     startOffset?: number,
@@ -542,6 +543,10 @@ export const queueServiceFactory = (
     return q.removeRepeatableByKey(repeatJobKey);
   };
 
+  const stopJobByIdPg: TQueueServiceFactory["stopJobByIdPg"] = async (name, jobId) => {
+    await pgBoss.deleteJob(name, jobId);
+  };
+
   const stopJobById: TQueueServiceFactory["stopJobById"] = async (name, jobId) => {
     const q = queueContainer[name];
     const job = await q.getJob(jobId);
@@ -568,6 +573,7 @@ export const queueServiceFactory = (
     stopRepeatableJobByKey,
     clearQueue,
     stopJobById,
+    stopJobByIdPg,
     getRepeatableJobs,
     startPg,
     queuePg,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1903,6 +1903,7 @@ export const registerRoutes = async (
   await pkiSubscriberQueue.startDailyAutoRenewalJob();
   await kmsService.startService();
   await microsoftTeamsService.start();
+  await dynamicSecretQueueService.init();
 
   // inject all services
   server.decorate<FastifyZodProvider["services"]>("services", {


### PR DESCRIPTION
# Description 📣

Previously our dynamic secret was queue using bullmq. We are moving away from persistent model in redis and keeping persistence in postgres.

This is first one of the PRs for this migration. Moving dynamic secret to pg queue. I have also fixed types for dynamic secret, lease and queue types to speed up ts infer

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->