### PR TITLE
fix(folders): multiple folders being created

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -44,7 +44,11 @@ export const KeyStorePrefixes = {
   IdentityAccessTokenStatusUpdate: (identityAccessTokenId: string) =>
     `identity-access-token-status:${identityAccessTokenId}`,
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
-  GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`
+  GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`,
+
+  CreateFolderLock: (envId: string, projectId: string) => `folder-creation-${envId}-${projectId}` as const,
+  WaitUntilReadyCreateFolder: (envId: string, projectId: string) =>
+    `wait-until-ready-folder-creation-${envId}-${projectId}` as const
 };
 
 export const KeyStoreTtls = {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1187,7 +1187,8 @@ export const registerRoutes = async (
     projectEnvDAL,
     snapshotService,
     projectDAL,
-    folderCommitService
+    folderCommitService,
+    keyStore
   });
 
   const secretImportService = secretImportServiceFactory({


### PR DESCRIPTION
# Description 📣

This PR is a fix for multiple folders being created when many requests are being sent at once. Before when multiple requests are being sent, it may end up creating multiple folders because the API processes all the requests at once. I've added a keystore lock to the service, so only one folder can be created at the same time per environment.

There was another issue with the path segments folder creation causing duplicate folders to be created. The issue was that we weren't checking if those missing segments already existed as folders.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->