### PR TITLE
fix(helm): resolve existing secrets for in-cluster postgresql and redis

### DIFF
--- a/helm-charts/infisical-standalone-postgres/Chart.lock
+++ b/helm-charts/infisical-standalone-postgres/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-  - name: ingress-nginx
-    repository: https://kubernetes.github.io/ingress-nginx
-    version: 4.0.13
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 14.1.3
-  - name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 18.14.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.0.13
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.1.3
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.14.0
 digest: sha256:296e0ef65914eea70af7e7904188b2efa37089c785305109abc70b7bed42306b
-generated: "2024-02-20T01:25:47.224526-05:00"
+generated: "2025-06-24T16:52:59.829711+01:00"

--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -112,13 +112,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.redis.fullnameOverride -}}
 {{- printf "%s-master" .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-master" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-redis-master" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
-
 
 {{- define "infisical.redisConnectionString" -}}
 {{- $password := .Values.redis.auth.password -}}
 {{- $serviceName := include "infisical.redisServiceName" . -}}
-{{- printf "redis://default:%s@%s:6379" $password "redis-master" -}}
+{{- printf "redis://default:%s@%s:6379" $password $serviceName -}}
 {{- end -}}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -63,6 +63,27 @@ spec:
           periodSeconds: 5
         ports: 
         - containerPort: 8080
+        {{- $usePostgresSecret := and .Values.postgresql.enabled .Values.postgresql.auth.existingSecret (ne .Values.postgresql.auth.existingSecret "") }}
+        {{- $useRedisSecret := and .Values.redis.enabled .Values.redis.auth.existingSecret (ne .Values.redis.auth.existingSecret "") }}
+        {{- if or $usePostgresSecret $useRedisSecret }}
+        # Use shell to build connection string when using existing secrets
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - |
+            {{- if $usePostgresSecret }}
+            export DB_CONNECTION_URI="postgresql://{{ .Values.postgresql.auth.username }}:${DB_PASSWORD}@{{ include "infisical.postgresService" . }}:5432/{{ .Values.postgresql.auth.database }}"
+            {{- end }}
+            {{- if and .Values.redis.enabled $useRedisSecret }}
+            export REDIS_URL="redis://default:${REDIS_PASSWORD}@{{ include "infisical.redisServiceName" . }}:6379"
+            {{- end }}
+            # Execute the original container entrypoint/command
+            {{- if $infisicalValues.startupCommand }}
+            exec {{ $infisicalValues.startupCommand }}
+            {{- else }}
+            exec npm start
+            {{- end }}
+        {{- end }}
         env:
         {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
         - name: DB_CONNECTION_URI
@@ -70,12 +91,28 @@ spec:
             secretKeyRef:
               name: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name }}
               key: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key }}
-        {{- end }}
-        {{- if .Values.postgresql.enabled }}
+        {{- else if not $usePostgresSecret }}
+        # Only set static connection string when NOT using existing secret
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
         {{- end }}
-        {{- if .Values.redis.enabled }}
+        {{- if $usePostgresSecret }}
+        # Set DB_PASSWORD from existing secret
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.postgresql.auth.existingSecret }}
+              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+        {{- end }}
+        {{- if $useRedisSecret }}
+        # Set REDIS_PASSWORD from existing secret
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
+        {{- end }}
+        {{- if and .Values.redis.enabled (not $useRedisSecret) }}
         - name: REDIS_URL
           value: {{ include "infisical.redisConnectionString" . }}
         {{- end }}

--- a/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/schema-migration-job.yaml
@@ -25,7 +25,16 @@ spec:
       containers:
         - name: infisical-schema-migration
           image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
+          {{- if .Values.postgresql.auth.existingSecret }}
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - |
+              export DB_CONNECTION_URI="postgresql://{{ .Values.postgresql.auth.username }}:${DB_PASSWORD}@{{ include "infisical.postgresService" . }}:5432/{{ .Values.postgresql.auth.database }}"
+              npm run migration:latest
+          {{- else }}
           command: ["npm", "run", "migration:latest"]
+          {{- end }}
           env:
           {{- if .Values.postgresql.useExistingPostgresSecret.enabled }}
           - name: DB_CONNECTION_URI
@@ -33,12 +42,19 @@ spec:
               secretKeyRef:
                 name: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name }}
                 key: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key }}
-          {{- end }}
-          {{- if .Values.postgresql.enabled }}
+          {{- else if not .Values.postgresql.auth.existingSecret }}
           - name: DB_CONNECTION_URI
-            value: {{ include "infisical.postgresDBConnectionString" . }}
+            value: {{ include "infisical.postgresDBConnectionString" . }}  
+          {{- end }}
+          {{- if .Values.postgresql.auth.existingSecret }}
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.postgresql.auth.existingSecret }}
+                key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
           {{- end }}
           envFrom:
           - secretRef:
               name: {{ $infisicalValues.kubeSecretRef }}
+
 {{- end }}

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -56,7 +56,7 @@ infisical:
     name: null
 
   # -- Override for the full name of Infisical resources in this deployment
-  fullnameOverride: ""
+  fullnameOverride: "infisical"
   # -- Custom annotations for Infisical pods
   podAnnotations: {}
   # -- Custom annotations for Infisical deployment
@@ -68,7 +68,7 @@ infisical:
     # -- Image repository for the Infisical service
     repository: infisical/infisical
     # -- Specific version tag of the Infisical image. View the latest version here https://hub.docker.com/r/infisical/infisical
-    tag: "v0.93.1-postgres"
+    tag: "v0.133.0-postgres"
     # -- Pulls image only if not already present on the node
     pullPolicy: IfNotPresent
     # -- Secret references for pulling the image, if needed
@@ -128,7 +128,7 @@ postgresql:
   # -- PostgreSQL resource name
   name: "postgresql"
   # -- Full name override for PostgreSQL resources
-  fullnameOverride: "postgresql"
+  fullnameOverride: "infisical-postgresql"
 
   auth:
     # -- Database username for PostgreSQL
@@ -137,6 +137,14 @@ postgresql:
     password: root
     # -- Database name for Infisical
     database: infisicalDB
+
+    # -- Overrides password if not null or not empty
+    existingSecret: ""
+
+    # -- Keys for the passwords in the existingsecret
+    secretKeys:
+      adminPasswordKey: ""
+      userPasswordKey: ""
 
   useExistingPostgresSecret:
     # -- Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string
@@ -153,7 +161,7 @@ redis:
   # -- Redis resource name
   name: "redis"
   # -- Full name override for Redis resources
-  fullnameOverride: "redis"
+  fullnameOverride: "infisical-redis"
 
   cluster:
     # -- Clustered Redis deployment
@@ -165,6 +173,10 @@ redis:
   auth:
     # -- Redis password
     password: "mysecretpassword"
+    # -- Overrides password if not null or not empty
+    existingSecret: ""
+    # -- Key for the password in the existingsecret
+    existingSecretPasswordKey: ""
 
   # -- Redis deployment type (e.g., standalone or cluster)
   architecture: standalone


### PR DESCRIPTION
# Description 📣

This PR adds support for using existing secrets for PostgreSQL and Redis databases in the Helm chart, providing users with more flexibility in secret management.

## Changes Made:
- Added `existingSecret` configuration options for PostgreSQL and Redis in `values.yml`
- Updated Helm templates to conditionally use existing secrets when specified
- Maintained backward compatibility with current secret generation approach

## Motivation:
Many users prefer to manage database credentials through external secret management systems (like Vault, External Secrets Operator, etc.) rather than having Helm generate them. This change allows users to reference pre-existing secrets while maintaining the current behavior as default.

## Type ✨
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

## Testing with Existing Secrets:

1. **Create test secrets:**
```sh
# Create PostgreSQL secret
kubectl create secret generic my-postgres-secret \
  --from-literal=postgres-password=mypostgresadminpassword \
  --from-literal=user-password=mypostgresuserpassword

# Create Redis secret  
kubectl create secret generic my-redis-secret \
  --from-literal=redis-password=myredispassword
```

2. **Deploy with existing secrets:**
```sh
helm install infisical ./helm-chart \
  --set postgresql.auth.existingSecret=my-postgres-secret \
  --set postgresql.auth.secretKeys.adminPasswordKey=postgres-password \
  --set postgresql.auth.secretKeys.userPasswordKey=user-password \
  --set redis.auth.existingSecret=my-redis-secret \
  --set redis.auth.existingSecretPasswordKey=redis-password
```

3. **Verify the deployment uses existing secrets:**
```sh
# Check that pods reference the correct secrets
kubectl describe deployment infisical
kubectl get pods -o yaml | grep -A5 -B5 "secretKeyRef"
```

## Testing Backward Compatibility:
```sh
# Deploy without specifying existing secrets (should work as before)
helm install infisical-default ./helm-chart

# Verify auto-generated secrets are created and used
kubectl get secrets | grep infisical
```

## Configuration Examples:
```yaml
# values.yml - Using existing secrets
postgresql:
  auth:
    existingSecret: "my-postgres-secret"
    secretKeys:
      adminPasswordKey: "postgres-password"
      userPasswordKey: "user-password"

redis:
  auth:
    existingSecret: "my-redis-secret"
    existingSecretPasswordKey: "redis-password"
```

---
- [x] I have read the [[contributing guide](https://infisical.com/docs/contributing/getting-started/overview)](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [[code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct)](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝