### PR TITLE
fix(docs): sdk and changelog tab not loading

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2018,7 +2018,7 @@
         "tab": "SDKs",
         "groups": [
           {
-            "group": "",
+            "group": "Overview",
             "pages": ["sdks/overview"]
           },
           {
@@ -2038,7 +2038,7 @@
         "tab": "Changelog",
         "groups": [
           {
-            "group": "",
+            "group": "Overview",
             "pages": ["changelog/overview"]
           }
         ]


### PR DESCRIPTION
# Description 📣

This PR is a fix for the SDK and changelog tabs in the documentation navigation. There was a missing group name causing the page to not render.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->