### PR TITLE
✅ PR: fix infisical-schema-migration CrashLoopBackOff when upgrading to 0.133.0 #3849

### DIFF
--- a/backend/src/db/migrations/20250602155451_fix-secret-versions.ts
+++ b/backend/src/db/migrations/20250602155451_fix-secret-versions.ts
@@ -3,9 +3,11 @@ import { Knex } from "knex";
 
 import { chunkArray } from "@app/lib/fn";
 import { selectAllTableCols } from "@app/lib/knex";
-import { logger } from "@app/lib/logger";
+import { logger, initLogger } from "@app/lib/logger";
 
 import { SecretType, TableName } from "../schemas";
+
+initLogger();
 
 export async function up(knex: Knex): Promise<void> {
   logger.info("Starting secret version fix migration");


### PR DESCRIPTION
Fixes a runtime error in the migration 20250602155451_fix-secret-versions.ts that causes infisical-schema-migration to crash with a CrashLoopBackOff when upgrading to version 0.133.0.

The root cause is that the logger is not initialized before being used in the migration. While the logger is typically initialized during application startup, this does not happen during standalone migrations.

This PR resolves the issue by explicitly calling initLogger() at the beginning of the up() function in the migration script.

Related issue: [#3849](https://github.com/Infisical/infisical/issues/3849)

Type ✨
	•	Bug fix

Tests 🛠️

Tested locally by running the migration using:

`npm run migration:latest`

Confirmed:
	•	The migration runs without throwing TypeError: Cannot read properties of undefined (reading 'info')
	•	Log output from the migration is correctly printed to stdout
	•	No changes to actual secret/version logic

Also validated in a Helm deployment using infisical:0.133.0, where the infisical-schema-migration job previously failed and now completes successfully.

⸻

	•	I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝