### PR TITLE
misc: add plain support for user get token in CLI

### DIFF
--- a/cli/packages/cmd/user.go
+++ b/cli/packages/cmd/user.go
@@ -114,6 +114,11 @@ var userGetTokenCmd = &cobra.Command{
 			loggedInUserDetails = util.EstablishUserLoginSession()
 		}
 
+		plain, err := cmd.Flags().GetBool("plain")
+		if err != nil {
+			util.HandleError(err, "[infisical user get token]: Unable to get plain flag")
+		}
+
 		if err != nil {
 			util.HandleError(err, "[infisical user get token]: Unable to get logged in user token")
 		}
@@ -135,8 +140,12 @@ var userGetTokenCmd = &cobra.Command{
 			util.HandleError(err, "[infisical user get token]: Unable to parse token payload")
 		}
 
-		fmt.Println("Session ID:", tokenPayload.TokenVersionId)
-		fmt.Println("Token:", loggedInUserDetails.UserCredentials.JTWToken)
+		if plain {
+			fmt.Println(loggedInUserDetails.UserCredentials.JTWToken)
+		} else {
+			fmt.Println("Session ID:", tokenPayload.TokenVersionId)
+			fmt.Println("Token:", loggedInUserDetails.UserCredentials.JTWToken)
+		}
 	},
 }
 
@@ -240,7 +249,10 @@ var domainCmd = &cobra.Command{
 func init() {
 	updateCmd.AddCommand(domainCmd)
 	userCmd.AddCommand(updateCmd)
+
+	userGetTokenCmd.Flags().Bool("plain", false, "print token without formatting")
 	userGetCmd.AddCommand(userGetTokenCmd)
+
 	userCmd.AddCommand(userGetCmd)
 	userCmd.AddCommand(switchCmd)
 	rootCmd.AddCommand(userCmd)

--- a/docs/cli/commands/user.mdx
+++ b/docs/cli/commands/user.mdx
@@ -35,19 +35,40 @@ infisical user update domain
 <Accordion title="infisical user get token">
   Use this command to get your current Infisical access token and session information. This command requires you to be logged in.
 
-  The command will display:
+The command will display:
 
-  - Your session ID
-  - Your full JWT access token
+- Your session ID
+- Your full JWT access token
 
-  ```bash
-  infisical user get token
-  ```
+```bash
+infisical user get token
+```
 
-  Example output:
+Example output:
 
-  ```bash
-  Session ID: abc123-xyz-456
-  Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-  ```
+```bash
+Session ID: abc123-xyz-456
+Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+### Flags
+
+  <Accordion title="--plain">
+    Output only the JWT token without formatting (no session ID)
+
+    Default value: `false`
+
+    ```bash
+    # Example
+    infisical user get token --plain
+    ```
+
+    Example output:
+
+    ```bash
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+    ```
+
+  </Accordion>
+
 </Accordion>


### PR DESCRIPTION
# Description 📣
This PR will allow users to fetch just the JWT for `infisical user get token` command using the `--plain` flag

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->