### PR TITLE
fix(secret-folders): delete folder by ID

### DIFF
--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -487,7 +487,7 @@ export const secretFolderServiceFactory = ({
       })
       .catch(() => null);
 
-    if (!targetFolder) {
+    if (!targetFolder && uuidValidate(idOrName)) {
       targetFolder = await folderDAL
         .findOne({
           envId: env.id,
@@ -611,7 +611,7 @@ export const secretFolderServiceFactory = ({
         })
         .catch(() => null);
 
-      if (!folderToDelete) {
+      if (!folderToDelete && uuidValidate(idOrName)) {
         folderToDelete = await folderDAL
           .findOne({
             envId: env.id,

--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -519,7 +519,7 @@ export const secretFolderServiceFactory = ({
     }
 
     // Find the target folder in the folderPaths to get its full details
-    const targetFolderWithPath = folderPaths.find((f) => f.id === targetFolder.id);
+    const targetFolderWithPath = folderPaths.find((f) => f.id === targetFolder!.id);
     if (!targetFolderWithPath) {
       throw new NotFoundError({ message: `Target folder path not found` });
     }


### PR DESCRIPTION
# Description 📣

This PR resolves an issue with deleting folders with UUID as names. Our delete folder endpoint supports both ID's and folder names as input. 

Previously, if the folder had a UUID as name, it would be impossible to delete because it would try to delete by ID. The fix is to first check for name, and if nothing is found then find by ID instead.


To reproduce the issue, use the Go SDK as seen below:
```go
func TestInfisical(t *testing.T) {
	if err := godotenv.Load("../../.env"); err != nil {
		t.Fatalf("Failed to load environment variables: %v", err)
	}

	environment := os.Getenv("ENVIRONMENT")
	clientID := os.Getenv("INFISICAL_CLIENT_ID")
	clientSecret := os.Getenv("INFISICAL_CLIENT_SECRET")
	projectID := os.Getenv("INFISICAL_PROJECT_ID")
	siteURL := os.Getenv("INFISICAL_SITE_URL")

	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{SiteUrl: siteURL})
	_, err := client.Auth().UniversalAuthLogin(clientID, clientSecret)
	if err != nil {
		t.Fatalf("Failed to login to infisical: %v", err)
	}

	folderName := uuid.NewString()

	folder, err := client.Folders().Create(infisical.CreateFolderOptions{
		ProjectID:   projectID,
		Environment: environment,
		Name:        folderName,
		Path:        "/",
	})
	assert.NoError(t, err)
	assert.NotNil(t, folder)

	_, err = client.Folders().Delete(infisical.DeleteFolderOptions{
		ProjectID:   projectID,
		Environment: environment,
		FolderName:  folderName,
		Path:        "/",
	})
	assert.NoError(t, err)
}
```

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->