### PR TITLE
feat(helm-charts/infiscal-core): topologySpreadConstraints support

### DIFF
--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.5.1 (July 3, 2025)
+
+Changes:
+* Added support for `topologySpreadConstraints` configuration in Helm chart
+
+Features:
+* `topologySpreadConstraints`: Configure pod distribution across availability zones and nodes for high availability
+
 ## 1.5.0 (March 26, 2025)
 
 Changes:

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -25,6 +25,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- with $infisicalValues.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with $infisicalValues.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -80,6 +80,10 @@ infisical:
   tolerations: []
   # -- Node selector for pod placement
   nodeSelector: {}
+  # -- Topology spread constraints for multi-zone deployments
+  # -- Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+
   # -- Kubernetes Secret reference containing Infisical root credentials
   kubeSecretRef: "infisical-secrets"
 


### PR DESCRIPTION
# Description 📣

This PR adds support for `topologySpreadConstraints` in the Infisical core helm chart. This makes it possible for users to deploy Infisical across multiple availability zones and nodes (useful for HA)
## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->