### PR TITLE
fix(secret-syncs): pass audit log info from import/delete secrets for sync endpoint

### DIFF
--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -382,7 +382,8 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         {
           syncId,
           destination,
-          importBehavior
+          importBehavior,
+          auditLogInfo: req.auditLogInfo
         },
         req.permission
       )) as T;
@@ -415,7 +416,8 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
       const secretSync = (await server.services.secretSync.triggerSecretSyncRemoveSecretsById(
         {
           syncId,
-          destination
+          destination,
+          auditLogInfo: req.auditLogInfo
         },
         req.permission
       )) as T;


### PR DESCRIPTION
# Description 📣

This PR fixes audit log details not being passed from remove/import secrets endpoints for secret syncs

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝