### PR TITLE
fix(approval-policies): improve policies handling

### DIFF
--- a/backend/src/db/migrations/20250710115149_required-path-on-approval-policies.ts
+++ b/backend/src/db/migrations/20250710115149_required-path-on-approval-policies.ts
@@ -1,0 +1,55 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const existingSecretApprovalPolicies = await knex(TableName.SecretApprovalPolicy)
+    .whereNull("secretPath")
+    .orWhere("secretPath", "");
+
+  const existingAccessApprovalPolicies = await knex(TableName.AccessApprovalPolicy)
+    .whereNull("secretPath")
+    .orWhere("secretPath", "");
+
+  // update all the secret approval policies secretPath to be "/**"
+  if (existingSecretApprovalPolicies.length) {
+    await knex(TableName.SecretApprovalPolicy)
+      .whereIn(
+        "id",
+        existingSecretApprovalPolicies.map((el) => el.id)
+      )
+      .update({
+        secretPath: "/**"
+      });
+  }
+
+  // update all the access approval policies secretPath to be "/**"
+  if (existingAccessApprovalPolicies.length) {
+    await knex(TableName.AccessApprovalPolicy)
+      .whereIn(
+        "id",
+        existingAccessApprovalPolicies.map((el) => el.id)
+      )
+      .update({
+        secretPath: "/**"
+      });
+  }
+
+  await knex.schema.alterTable(TableName.SecretApprovalPolicy, (table) => {
+    table.string("secretPath").notNullable().alter();
+  });
+
+  await knex.schema.alterTable(TableName.AccessApprovalPolicy, (table) => {
+    table.string("secretPath").notNullable().alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.SecretApprovalPolicy, (table) => {
+    table.string("secretPath").nullable().alter();
+  });
+
+  await knex.schema.alterTable(TableName.AccessApprovalPolicy, (table) => {
+    table.string("secretPath").nullable().alter();
+  });
+}

--- a/backend/src/db/schemas/access-approval-policies.ts
+++ b/backend/src/db/schemas/access-approval-policies.ts
@@ -11,7 +11,7 @@ export const AccessApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   approvals: z.number().default(1),
-  secretPath: z.string().nullable().optional(),
+  secretPath: z.string(),
   envId: z.string().uuid(),
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/backend/src/db/schemas/secret-approval-policies.ts
+++ b/backend/src/db/schemas/secret-approval-policies.ts
@@ -10,7 +10,7 @@ import { TImmutableDBKeys } from "./models";
 export const SecretApprovalPoliciesSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  secretPath: z.string().nullable().optional(),
+  secretPath: z.string(),
   approvals: z.number().default(1),
   envId: z.string().uuid(),
   createdAt: z.date(),

--- a/backend/src/ee/routes/v1/access-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-policy-router.ts
@@ -19,7 +19,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       body: z.object({
         projectSlug: z.string().trim(),
         name: z.string().optional(),
-        secretPath: z.string().trim().default("/"),
+        secretPath: z.string().trim().min(1, { message: "Secret path cannot be empty" }),
         environment: z.string(),
         approvers: z
           .discriminatedUnion("type", [
@@ -171,11 +171,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       }),
       body: z.object({
         name: z.string().optional(),
-        secretPath: z
-          .string()
-          .trim()
-          .optional()
-          .transform((val) => (val === "" ? "/" : val)),
+        secretPath: z.string().trim().optional(),
         approvers: z
           .discriminatedUnion("type", [
             z.object({

--- a/backend/src/ee/routes/v1/access-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-policy-router.ts
@@ -171,7 +171,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       }),
       body: z.object({
         name: z.string().optional(),
-        secretPath: z.string().trim().optional(),
+        secretPath: z.string().trim().min(1, { message: "Secret path cannot be empty" }).optional(),
         approvers: z
           .discriminatedUnion("type", [
             z.object({

--- a/backend/src/ee/routes/v1/access-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-policy-router.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { ApproverType, BypasserType } from "@app/ee/services/access-approval-policy/access-approval-policy-types";
+import { removeTrailingSlash } from "@app/lib/fn";
 import { EnforcementLevel } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -19,7 +20,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       body: z.object({
         projectSlug: z.string().trim(),
         name: z.string().optional(),
-        secretPath: z.string().trim().min(1, { message: "Secret path cannot be empty" }),
+        secretPath: z.string().trim().min(1, { message: "Secret path cannot be empty" }).transform(removeTrailingSlash),
         environment: z.string(),
         approvers: z
           .discriminatedUnion("type", [
@@ -171,7 +172,12 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       }),
       body: z.object({
         name: z.string().optional(),
-        secretPath: z.string().trim().min(1, { message: "Secret path cannot be empty" }).optional(),
+        secretPath: z
+          .string()
+          .trim()
+          .min(1, { message: "Secret path cannot be empty" })
+          .optional()
+          .transform((val) => (val ? removeTrailingSlash(val) : val)),
         approvers: z
           .discriminatedUnion("type", [
             z.object({

--- a/backend/src/ee/routes/v1/secret-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-policy-router.ts
@@ -102,8 +102,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
           .string()
           .optional()
           .nullable()
-          .transform((val) => (val ? removeTrailingSlash(val) : val))
-          .transform((val) => (val === "" ? "/" : val)),
+          .transform((val) => (val ? removeTrailingSlash(val) : val)),
         enforcementLevel: z.nativeEnum(EnforcementLevel).optional(),
         allowedSelfApprovals: z.boolean().default(true)
       }),

--- a/backend/src/ee/routes/v1/secret-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-policy-router.ts
@@ -23,10 +23,8 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         environment: z.string(),
         secretPath: z
           .string()
-          .optional()
-          .nullable()
-          .default("/")
-          .transform((val) => (val ? removeTrailingSlash(val) : val)),
+          .min(1, { message: "Secret path cannot be empty" })
+          .transform((val) => removeTrailingSlash(val)),
         approvers: z
           .discriminatedUnion("type", [
             z.object({ type: z.literal(ApproverType.Group), id: z.string() }),
@@ -100,9 +98,10 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         approvals: z.number().min(1).default(1),
         secretPath: z
           .string()
+          .trim()
+          .min(1, { message: "Secret path cannot be empty" })
           .optional()
-          .nullable()
-          .transform((val) => (val ? removeTrailingSlash(val) : val)),
+          .transform((val) => (val ? removeTrailingSlash(val) : undefined)),
         enforcementLevel: z.nativeEnum(EnforcementLevel).optional(),
         allowedSelfApprovals: z.boolean().default(true)
       }),

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
@@ -53,7 +53,7 @@ export interface TAccessApprovalPolicyDALFactory
       envId: string;
       enforcementLevel: string;
       allowedSelfApprovals: boolean;
-      secretPath?: string | null | undefined;
+      secretPath: string;
       deletedAt?: Date | null | undefined;
       environment: {
         id: string;
@@ -93,7 +93,7 @@ export interface TAccessApprovalPolicyDALFactory
         envId: string;
         enforcementLevel: string;
         allowedSelfApprovals: boolean;
-        secretPath?: string | null | undefined;
+        secretPath: string;
         deletedAt?: Date | null | undefined;
         environment: {
           id: string;
@@ -116,7 +116,7 @@ export interface TAccessApprovalPolicyDALFactory
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
   }>;
   findLastValidPolicy: (
@@ -138,7 +138,7 @@ export interface TAccessApprovalPolicyDALFactory
         envId: string;
         enforcementLevel: string;
         allowedSelfApprovals: boolean;
-        secretPath?: string | null | undefined;
+        secretPath: string;
         deletedAt?: Date | null | undefined;
       }
     | undefined
@@ -190,7 +190,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
   }>;
   deleteAccessApprovalPolicy: ({
@@ -214,7 +214,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
     environment: {
       id: string;
@@ -252,7 +252,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
   }>;
   getAccessApprovalPolicyByProjectSlug: ({
@@ -286,7 +286,7 @@ export interface TAccessApprovalPolicyServiceFactory {
       envId: string;
       enforcementLevel: string;
       allowedSelfApprovals: boolean;
-      secretPath?: string | null | undefined;
+      secretPath: string;
       deletedAt?: Date | null | undefined;
       environment: {
         id: string;
@@ -337,7 +337,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
     environment: {
       id: string;

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -305,7 +305,11 @@ export const accessApprovalPolicyServiceFactory = ({
     ) as { username: string; sequence?: number }[];
 
     const accessApprovalPolicy = await accessApprovalPolicyDAL.findById(policyId);
-    if (!accessApprovalPolicy) throw new BadRequestError({ message: "Approval policy not found" });
+    if (!accessApprovalPolicy) {
+      throw new NotFoundError({
+        message: `Access approval policy with ID '${policyId}' not found`
+      });
+    }
 
     const currentApprovals = approvals || accessApprovalPolicy.approvals;
     if (
@@ -334,9 +338,6 @@ export const accessApprovalPolicyServiceFactory = ({
       });
     }
 
-    if (!accessApprovalPolicy) {
-      throw new NotFoundError({ message: `Secret approval policy with ID '${policyId}' not found` });
-    }
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -320,16 +320,10 @@ export const accessApprovalPolicyServiceFactory = ({
       throw new BadRequestError({ message: "Approvals cannot be greater than approvers" });
     }
 
-    // Case: Previously we allowed secret path to be null, but now we don't.
-    // This check ensures that we have a secret path to match with for finding conflicting policies.
-    if (!secretPath && !accessApprovalPolicy.secretPath) {
-      throw new BadRequestError({ message: "Secret path is required to update the policy" });
-    }
-
     if (
       await $policyExists({
         envId: accessApprovalPolicy.envId,
-        secretPath: secretPath || accessApprovalPolicy.secretPath || "",
+        secretPath: secretPath || accessApprovalPolicy.secretPath,
         policyId: accessApprovalPolicy.id
       })
     ) {

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-types.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-types.ts
@@ -122,7 +122,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
   }>;
   deleteAccessApprovalPolicy: ({
@@ -146,7 +146,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
     environment: {
       id: string;
@@ -218,7 +218,7 @@ export interface TAccessApprovalPolicyServiceFactory {
       envId: string;
       enforcementLevel: string;
       allowedSelfApprovals: boolean;
-      secretPath?: string | null | undefined;
+      secretPath: string;
       deletedAt?: Date | null | undefined;
       environment: {
         id: string;
@@ -269,7 +269,7 @@ export interface TAccessApprovalPolicyServiceFactory {
     envId: string;
     enforcementLevel: string;
     allowedSelfApprovals: boolean;
-    secretPath?: string | null | undefined;
+    secretPath: string;
     deletedAt?: Date | null | undefined;
     environment: {
       id: string;

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
@@ -61,14 +61,13 @@ export const secretApprovalPolicyServiceFactory = ({
     policyId
   }: {
     envId: string;
-    secretPath?: string | null;
+    secretPath: string;
     policyId?: string;
   }) => {
     const policy = await secretApprovalPolicyDAL
       .findOne({
         envId,
-        // For environment-wide policies, we store the path as an empty string, even though the column is nullable; for that reason we check for an empty string.
-        ...(secretPath ? { secretPath } : { secretPath: "" }),
+        secretPath,
         deletedAt: null
       })
       .catch(() => null);
@@ -288,7 +287,13 @@ export const secretApprovalPolicyServiceFactory = ({
       });
     }
 
-    if (await $policyExists({ envId: secretApprovalPolicy.envId, secretPath, policyId: secretApprovalPolicy.id })) {
+    if (
+      await $policyExists({
+        envId: secretApprovalPolicy.envId,
+        secretPath: secretPath || secretApprovalPolicy.secretPath,
+        policyId: secretApprovalPolicy.id
+      })
+    ) {
       throw new BadRequestError({
         message: `A policy for secret path '${secretPath}' already exists in environment '${secretApprovalPolicy.environment.slug}'`
       });

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
@@ -5,7 +5,6 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
-import { logger } from "@app/lib/logger";
 import { containsGlobPatterns } from "@app/lib/picomatch";
 import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-types.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-types.ts
@@ -4,7 +4,7 @@ import { ApproverType, BypasserType } from "../access-approval-policy/access-app
 
 export type TCreateSapDTO = {
   approvals: number;
-  secretPath?: string | null;
+  secretPath: string;
   environment: string;
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; username?: string })[];
   bypassers?: (
@@ -20,7 +20,7 @@ export type TCreateSapDTO = {
 export type TUpdateSapDTO = {
   secretPolicyId: string;
   approvals?: number;
-  secretPath?: string | null;
+  secretPath?: string;
   approvers: ({ type: ApproverType.Group; id: string } | { type: ApproverType.User; id?: string; username?: string })[];
   bypassers?: (
     | { type: BypasserType.Group; id: string }

--- a/frontend/src/hooks/api/accessApproval/types.ts
+++ b/frontend/src/hooks/api/accessApproval/types.ts
@@ -170,7 +170,7 @@ export type TCreateAccessPolicyDTO = {
   approvers?: Approver[];
   bypassers?: Bypasser[];
   approvals?: number;
-  secretPath?: string;
+  secretPath: string;
   enforcementLevel?: EnforcementLevel;
   allowedSelfApprovals: boolean;
   approvalsRequired?: { numberOfApprovals: number; stepNumber: number }[];

--- a/frontend/src/hooks/api/secretApproval/types.ts
+++ b/frontend/src/hooks/api/secretApproval/types.ts
@@ -49,7 +49,7 @@ export type TCreateSecretPolicyDTO = {
   workspaceId: string;
   name?: string;
   environment: string;
-  secretPath?: string | null;
+  secretPath: string;
   approvers?: Approver[];
   bypassers?: Bypasser[];
   approvals?: number;
@@ -62,7 +62,7 @@ export type TUpdateSecretPolicyDTO = {
   name?: string;
   approvers?: Approver[];
   bypassers?: Bypasser[];
-  secretPath?: string | null;
+  secretPath?: string;
   approvals?: number;
   allowedSelfApprovals?: boolean;
   enforcementLevel?: EnforcementLevel;

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -55,7 +55,7 @@ const formSchema = z
   .object({
     environment: z.object({ slug: z.string(), name: z.string() }),
     name: z.string().optional(),
-    secretPath: z.string().trim().optional(),
+    secretPath: z.string().trim().min(1),
     approvals: z.number().min(1).default(1),
     userApprovers: z
       .object({ type: z.literal(ApproverType.User), id: z.string() })
@@ -104,14 +104,6 @@ const formSchema = z
           path: ["groupApprovers"],
           code: z.ZodIssueCode.custom,
           message: "At least one approver should be provided"
-        });
-      }
-    } else if (data.policyType === PolicyType.AccessPolicy) {
-      if (!data.secretPath) {
-        ctx.addIssue({
-          path: ["secretPath"],
-          code: z.ZodIssueCode.custom,
-          message: "Secret path cannot be empty"
         });
       }
     }
@@ -477,6 +469,7 @@ const Form = ({
               <FormControl
                 tooltipText="Secret paths support glob patterns. For example, '/**' will match all paths."
                 label="Secret Path"
+                isRequired
                 isError={Boolean(error)}
                 errorText={error?.message}
                 className="flex-1"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -55,7 +55,7 @@ const formSchema = z
   .object({
     environment: z.object({ slug: z.string(), name: z.string() }),
     name: z.string().optional(),
-    secretPath: z.string().optional(),
+    secretPath: z.string().trim().optional(),
     approvals: z.number().min(1).default(1),
     userApprovers: z
       .object({ type: z.literal(ApproverType.User), id: z.string() })
@@ -93,20 +93,27 @@ const formSchema = z
       .optional()
   })
   .superRefine((data, ctx) => {
-    if (
-      data.policyType === PolicyType.ChangePolicy &&
-      !(data.groupApprovers.length || data.userApprovers.length)
-    ) {
-      ctx.addIssue({
-        path: ["userApprovers"],
-        code: z.ZodIssueCode.custom,
-        message: "At least one approver should be provided"
-      });
-      ctx.addIssue({
-        path: ["groupApprovers"],
-        code: z.ZodIssueCode.custom,
-        message: "At least one approver should be provided"
-      });
+    if (data.policyType === PolicyType.ChangePolicy) {
+      if (!(data.groupApprovers.length || data.userApprovers.length)) {
+        ctx.addIssue({
+          path: ["userApprovers"],
+          code: z.ZodIssueCode.custom,
+          message: "At least one approver should be provided"
+        });
+        ctx.addIssue({
+          path: ["groupApprovers"],
+          code: z.ZodIssueCode.custom,
+          message: "At least one approver should be provided"
+        });
+      }
+    } else if (data.policyType === PolicyType.AccessPolicy) {
+      if (!data.secretPath) {
+        ctx.addIssue({
+          path: ["secretPath"],
+          code: z.ZodIssueCode.custom,
+          message: "Secret path cannot be empty"
+        });
+      }
     }
   });
 
@@ -127,6 +134,7 @@ const Form = ({
     control,
     handleSubmit,
     watch,
+    resetField,
     formState: { isSubmitting }
   } = useForm<TFormSchema>({
     resolver: zodResolver(formSchema),
@@ -177,6 +185,7 @@ const Form = ({
       : undefined,
     defaultValues: !editValues
       ? {
+          secretPath: "/",
           sequenceApprovers: [{ approvals: 1 }]
         }
       : undefined
@@ -405,7 +414,10 @@ const Form = ({
                 <Select
                   isDisabled={isEditMode}
                   value={value}
-                  onValueChange={(val) => onChange(val as PolicyType)}
+                  onValueChange={(val) => {
+                    onChange(val as PolicyType);
+                    resetField("secretPath");
+                  }}
                   className="w-full border border-mineshaft-500"
                 >
                   {Object.values(PolicyType).map((policyType) => {


### PR DESCRIPTION
# Description 📣

This PR improves how we handle approval policies. We have some discrepancies in how paths are handled in change/access policies.

**Change policy:** Allows for an empty path, and it will result in a environment-wide policy
**Access policy**: Doesn't allow for an empty path, it'll break if an empty path is used.


For access policies I've added extra validation to ensure policies are never created/updated with an empty path. 

For _both_ access and change policies, I've added extra checks to ensure there can never be duplicate policies, because this would mess up the UI when creating access requests; and there's really no logical reason to have duplicate policies for a path by our current approach for approval policies
## Type ✨

- [x] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->