### PR TITLE
fix: remove duplicate toasts on app connections oauth callback page

### DIFF
--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -114,7 +114,7 @@ export const GitHubConnectionForm = ({ appConnection }: Props) => {
                   ? `Credentials have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
-                        : `See Docs to configure Github ${methodDetails.name} Connections.`
+                        : `See Docs to configure ${methodDetails.name} Connections.`
                     }`
                   : error?.message
               }

--- a/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
+++ b/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
@@ -179,11 +179,6 @@ export const OAuthCallbackPage = () => {
         appConnectionName: formData.app
       };
     } catch (err: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} GitLab Connection`,
-        text: err?.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
@@ -222,14 +217,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (err: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} Azure Key Vault Connection`,
-        text: err?.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -270,14 +261,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (err: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} Azure App Configuration Connection`,
-        text: err?.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -318,14 +305,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (err: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} Azure Client Secrets Connection`,
-        text: err?.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -372,14 +355,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (err: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} Azure DevOps Connection`,
-        text: err?.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -438,14 +417,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (e: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} GitHub Connection`,
-        text: e.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -486,14 +461,10 @@ export const OAuthCallbackPage = () => {
         });
       }
     } catch (e: any) {
-      createNotification({
-        title: `Failed to ${connectionId ? "update" : "add"} GitHub Radar Connection`,
-        text: e.message,
-        type: "error"
-      });
       navigate({
         to: returnUrl ?? "/organization/app-connections"
       });
+      return null;
     }
 
     return {
@@ -537,11 +508,6 @@ export const OAuthCallbackPage = () => {
         createNotification({
           text: `Successfully ${data.connectionId ? "updated" : "added"} ${data.appConnectionName ? APP_CONNECTION_MAP[data.appConnectionName as AppConnection].name : ""} Connection`,
           type: "success"
-        });
-      } else {
-        createNotification({
-          text: "Failed to add connection",
-          type: "error"
         });
       }
 


### PR DESCRIPTION
# Description 📣

While I was adding a GitHub app connection with the same name as another connection I already created, the following notifications popped up:

<img width="457" alt="Screenshot 2025-07-06 at 11 57 36 PM" src="https://github.com/user-attachments/assets/939ef7e9-6a00-4669-993c-da598742c805" />

As there was an error, the success notification shouldn't have popped up, so I disabled the success notification for the case where there is an error. I also removed the redundant "Failed to add GitHub Connection" toast with the status code (as all the information the user needs to retry adding the app connection is in the first toast) and fixed a small typo in the add connection modal for GitHub app connections.

The main "error + success notifications" issue was caused by `OAuthCallbackPage.tsx`- when OAuth callbacks in that file failed, the error handlers would return data instead of returning `null`. This data triggered the success notification in `OauthCallbackPage.tsx`'s second (from the top) useEffect handler, causing both the success and error notifications to be displayed. I believe this could have been confusing to a user.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Manually tested

Before:

https://github.com/user-attachments/assets/55d1b049-cedf-4a91-82fb-bc7396083f69

After:

https://github.com/user-attachments/assets/1d05ed5c-87d2-4c58-801d-19d48f2d9267

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->