### PR TITLE
fix(secret-imports-dashboard): support filtering imported secrets in single env view

### DIFF
--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -732,8 +732,8 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
           actorOrgId: req.permission.orgId,
           projectId,
           environment,
-          path: secretPath,
-          search
+          path: secretPath
+          // search scott: removing for now because this prevents searching imported secrets which are fetched separately client side
         });
 
         if (remainingLimit > 0 && totalImportCount > adjustedOffset) {
@@ -745,7 +745,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
             projectId,
             environment,
             path: secretPath,
-            search,
+            // search scott: removing for now because this prevents searching imported secrets which are fetched separately client side
             limit: remainingLimit,
             offset: adjustedOffset
           });

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretImportListView/SecretImportItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretImportListView/SecretImportItem.tsx
@@ -9,6 +9,7 @@ import {
   faInfoCircle,
   faKey,
   faRotate,
+  faSearch,
   faUpDown,
   faWarning,
   faXmark
@@ -139,6 +140,10 @@ export const SecretImportItem = ({
       setIsExpanded.toggle();
     }
   };
+
+  const filteredImportedSecrets = importedSecrets.filter((secret) =>
+    secret.key.toUpperCase().includes(searchTerm.toUpperCase())
+  );
 
   return (
     <>
@@ -305,21 +310,26 @@ export const SecretImportItem = ({
                       </td>
                     </tr>
                   )}
-                  {importedSecrets
-                    .filter((secret) => secret.key.toUpperCase().includes(searchTerm.toUpperCase()))
-                    .map(({ key, value }, index) => (
-                      <tr key={`${id}-${key}-${index + 1}`}>
-                        <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
-                          {key}
-                        </td>
-                        <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
-                          <SecretInput value={value} isReadOnly />
-                        </td>
-                        {/* <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
+                  {filteredImportedSecrets.length === 0 && importedSecrets?.length !== 0 && (
+                    <tr>
+                      <td colSpan={3}>
+                        <EmptyState title="No secrets match search" icon={faSearch} />
+                      </td>
+                    </tr>
+                  )}
+                  {filteredImportedSecrets.map(({ key, value }, index) => (
+                    <tr key={`${id}-${key}-${index + 1}`}>
+                      <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
+                        {key}
+                      </td>
+                      <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
+                        <SecretInput value={value} isReadOnly />
+                      </td>
+                      {/* <td className="h-10" style={{ padding: "0.25rem 1rem" }}>
                           <EnvFolderIcon env={overriden?.env} secretPath={overriden?.secretPath} />
                         </td> */}
-                      </tr>
-                    ))}
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </TableContainer>


### PR DESCRIPTION
# Description 📣

This PR removes applying the search filter on single environment view to import names to support filtering imported secrets on the client side (they are fetched separately from the client)

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝