### PR TITLE
fix: support email link template pre-fill

### DIFF
--- a/frontend/src/layouts/PersonalSettingsLayout/PersonalSettingsLayout.tsx
+++ b/frontend/src/layouts/PersonalSettingsLayout/PersonalSettingsLayout.tsx
@@ -44,21 +44,24 @@ export const PersonalSettingsLayout = () => {
                     </div>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start" className="p-1">
-                    {INFISICAL_SUPPORT_OPTIONS.map(([icon, text, url]) => (
-                      <DropdownMenuItem key={url as string}>
-                        <a
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href={String(url)}
-                          className="flex w-full items-center rounded-md font-normal text-mineshaft-300 duration-200"
-                        >
-                          <div className="relative flex w-full cursor-pointer select-none items-center justify-start rounded-md">
-                            {icon}
-                            <div className="text-sm">{text}</div>
-                          </div>
-                        </a>
-                      </DropdownMenuItem>
-                    ))}
+                    {INFISICAL_SUPPORT_OPTIONS.map(([icon, text, getUrl]) => {
+                      const url = text === "Email Support" ? getUrl("personal", null) : getUrl();
+                      return (
+                        <DropdownMenuItem key={url as string}>
+                          <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href={String(url)}
+                            className="flex w-full items-center rounded-md font-normal text-mineshaft-300 duration-200"
+                          >
+                            <div className="relative flex w-full cursor-pointer select-none items-center justify-start rounded-md">
+                              {icon}
+                              <div className="text-sm">{text}</div>
+                            </div>
+                          </a>
+                        </DropdownMenuItem>
+                      );
+                    })}
                     {envConfig.PLATFORM_VERSION && (
                       <div className="mb-2 mt-2 w-full cursor-default pl-5 text-sm duration-200 hover:text-mineshaft-200">
                         <FontAwesomeIcon icon={faInfo} className="mr-4 px-[0.1rem]" />


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
This PR improves the existing support email link on organisation and personal account settings by adding an email template with things like organisation name, id, etc. already pre-filled.


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->