### PR TITLE
fix(typo): add missing space on integrations audit log upgrade prompt

### DIFF
--- a/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
@@ -70,7 +70,7 @@ export const IntegrationAuditLogsSection = ({ integration }: Props) => {
                     upgrade your subscription
                   </a>
                 </a>
-              )}
+              )}{" "}
               to view integration logs
             </p>
           </div>


### PR DESCRIPTION
# Description 📣

This PR adds a missing space to the upgrade prompt for audit logs on the integration details page

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝