### PR TITLE
fix(migration): move logger init for standalone migration to entry knexfile

### DIFF
--- a/backend/src/db/knexfile.ts
+++ b/backend/src/db/knexfile.ts
@@ -4,6 +4,7 @@ import "ts-node/register";
 import dotenv from "dotenv";
 import type { Knex } from "knex";
 import path from "path";
+import { initLogger } from "@app/lib/logger";
 
 // Update with your config settings. .
 dotenv.config({
@@ -12,6 +13,8 @@ dotenv.config({
 dotenv.config({
   path: path.join(__dirname, "../../../.env")
 });
+
+initLogger();
 
 export default {
   development: {

--- a/backend/src/db/migrations/20250602155451_fix-secret-versions.ts
+++ b/backend/src/db/migrations/20250602155451_fix-secret-versions.ts
@@ -3,12 +3,11 @@ import { Knex } from "knex";
 
 import { chunkArray } from "@app/lib/fn";
 import { selectAllTableCols } from "@app/lib/knex";
-import { logger, initLogger } from "@app/lib/logger";
+import { logger } from "@app/lib/logger";
 
 import { SecretType, TableName } from "../schemas";
 
 export async function up(knex: Knex): Promise<void> {
-  initLogger();
   logger.info("Starting secret version fix migration");
 
   // Get all shared secret IDs first to optimize versions query


### PR DESCRIPTION
# Description 📣

This PR moves the logger init function for standalone migrations to the entry knexfile

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝