### PR TITLE
add index for referencing columns in identity access token

### DIFF
--- a/backend/src/db/migrations/20250710022434_add-index-for-access-token.ts
+++ b/backend/src/db/migrations/20250710022434_add-index-for-access-token.ts
@@ -1,0 +1,47 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+const MIGRATION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
+
+export async function up(knex: Knex): Promise<void> {
+  const result = await knex.raw('SHOW statement_timeout');
+  const originalTimeout = result.rows[0].statement_timeout;
+  
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+
+    await knex.raw(`
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS ${TableName.IdentityAccessToken}_identityid_index 
+          ON ${TableName.IdentityAccessToken} ("identityId")
+        `);
+
+    await knex.raw(`
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS ${TableName.IdentityAccessToken}_identityuaclientsecretid_index 
+          ON ${TableName.IdentityAccessToken} ("identityUAClientSecretId")
+        `);
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalTimeout}'`);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const result = await knex.raw('SHOW statement_timeout');
+  const originalTimeout = result.rows[0].statement_timeout;
+  
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+
+    await knex.raw(`
+          DROP INDEX IF EXISTS ${TableName.IdentityAccessToken}_identityid_index
+        `);
+
+    await knex.raw(`
+          DROP INDEX IF EXISTS ${TableName.IdentityAccessToken}_identityuaclientsecretid_index
+        `);
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalTimeout}'`);
+  }
+}
+
+export const config = { transaction: false };

--- a/backend/src/db/migrations/20250710022434_add-index-for-access-token.ts
+++ b/backend/src/db/migrations/20250710022434_add-index-for-access-token.ts
@@ -5,19 +5,20 @@ import { TableName } from "../schemas";
 const MIGRATION_TIMEOUT = 30 * 60 * 1000; // 30 minutes
 
 export async function up(knex: Knex): Promise<void> {
-  const result = await knex.raw('SHOW statement_timeout');
+  const result = await knex.raw("SHOW statement_timeout");
   const originalTimeout = result.rows[0].statement_timeout;
-  
+
   try {
     await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
 
+    // iat means IdentityAccessToken
     await knex.raw(`
-          CREATE INDEX CONCURRENTLY IF NOT EXISTS ${TableName.IdentityAccessToken}_identityid_index 
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_iat_identity_id 
           ON ${TableName.IdentityAccessToken} ("identityId")
         `);
 
     await knex.raw(`
-          CREATE INDEX CONCURRENTLY IF NOT EXISTS ${TableName.IdentityAccessToken}_identityuaclientsecretid_index 
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_iat_ua_client_secret_id 
           ON ${TableName.IdentityAccessToken} ("identityUAClientSecretId")
         `);
   } finally {
@@ -26,18 +27,18 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  const result = await knex.raw('SHOW statement_timeout');
+  const result = await knex.raw("SHOW statement_timeout");
   const originalTimeout = result.rows[0].statement_timeout;
-  
+
   try {
     await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
 
     await knex.raw(`
-          DROP INDEX IF EXISTS ${TableName.IdentityAccessToken}_identityid_index
+          DROP INDEX IF EXISTS idx_iat_identity_id
         `);
 
     await knex.raw(`
-          DROP INDEX IF EXISTS ${TableName.IdentityAccessToken}_identityuaclientsecretid_index
+          DROP INDEX IF EXISTS idx_iat_ua_client_secret_id
         `);
   } finally {
     await knex.raw(`SET statement_timeout = '${originalTimeout}'`);


### PR DESCRIPTION
This PR will address issue with very long identity deletions due to a sequential scan over ALL identity access rows during CASCADE