### PR TITLE
improvement(frontend): make empty value circle display on overview page yellow

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretOverviewTableRow.tsx
@@ -174,7 +174,7 @@ export const SecretOverviewTableRow = ({
                   )}
                   {isSecretEmpty && (
                     <Tooltip content="Empty value">
-                      <FontAwesomeIcon size="sm" icon={faCircle} />
+                      <FontAwesomeIcon size="sm" icon={faCircle} className="text-yellow" />
                     </Tooltip>
                   )}
                 </div>


### PR DESCRIPTION
# Description 📣

This PR makes the empty value circle on the secret overview table yellow instead of gray like the good ol' days

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝