### PR TITLE
Fix authEnforced returning a token when org has authEnforced enabled

### DIFF
--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1274,6 +1274,8 @@ export const orgServiceFactory = ({
         message: "No pending invitation found"
       });
 
+    const organization = await orgDAL.findById(orgId);
+
     await tokenService.validateTokenForUser({
       type: TokenType.TOKEN_EMAIL_ORG_INVITATION,
       userId: user.id,
@@ -1293,6 +1295,13 @@ export const orgServiceFactory = ({
         status: OrgMembershipStatus.Accepted
       });
       await licenseService.updateSubscriptionOrgMemberCount(orgId);
+      return { user };
+    }
+
+    if (
+      organization.authEnforced &&
+      !(organization.bypassOrgAuthEnabled && orgMembership.role === OrgMembershipRole.Admin)
+    ) {
       return { user };
     }
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Fix for the case where, before enabling SSO auth enforcement, any previously sent invitations remained valid. These invites will now redirect users to the login page (with the membership already accepted), but without including a token, as it's no longer allowed by the organization’s settings. This also prevents incorrect emails from being sent that claimed the login was bypassed (a flow only allowed for admins).

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->