### PR TITLE
fix cli secrets dropped error

### DIFF
--- a/cli/packages/cmd/secrets.go
+++ b/cli/packages/cmd/secrets.go
@@ -247,10 +247,9 @@ var secretsSetCmd = &cobra.Command{
 				Type:  "",
 				Token: loggedInUserDetails.UserCredentials.JTWToken,
 			}, file)
-		}
-
-		if err != nil {
-			util.HandleError(err, "Unable to set secrets")
+			if err != nil {
+				util.HandleError(err, "Unable to set secrets")
+			}
 		}
 
 		// Print secret operations


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This fixes an issue in the cli where an `err` variable was being declared inside a block with `:=`, but was then being tested as `!= nil` outside that block, where it was no longer in scope.

This moves the error check inside the block where the error can be checked.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->