### PR TITLE
improvement(frontend): prevent organization name wrap in header

### DIFF
--- a/frontend/src/components/v2/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/components/v2/Breadcrumb/Breadcrumb.tsx
@@ -121,7 +121,7 @@ export type TBreadcrumbFormat =
     };
 
 const BreadcrumbContainer = ({ breadcrumbs }: { breadcrumbs: TBreadcrumbFormat[] }) => (
-  <div className="mx-auto max-w-7xl py-4 text-white">
+  <div className="mx-auto max-w-7xl text-white">
     <Breadcrumb>
       <BreadcrumbList>
         {(breadcrumbs as TBreadcrumbFormat[]).map((el, index) => {

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -180,7 +180,7 @@ export const Navbar = () => {
   }
 
   return (
-    <div className="z-10 flex h-12 items-center border-b border-mineshaft-600 bg-mineshaft-800 px-4 py-2">
+    <div className="z-10 flex min-h-12 items-center border-b border-mineshaft-600 bg-mineshaft-800 px-4">
       <div>
         <Link to="/organization/projects">
           <img alt="infisical logo" src="/images/logotransparent.png" className="h-4" />
@@ -194,7 +194,7 @@ export const Navbar = () => {
               <div>
                 <FontAwesomeIcon icon={faBuilding} className="text-xs text-bunker-300" />
               </div>
-              <div className="max-w-32 overflow-hidden text-ellipsis">{currentOrg?.name}</div>
+              <div className="whitespace-nowrap">{currentOrg?.name}</div>
               <div className="mr-1 rounded border border-mineshaft-500 px-1 text-xs text-bunker-300 !no-underline">
                 {getPlan(subscription)}
               </div>

--- a/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
@@ -114,7 +114,7 @@ export const ProjectSelect = () => {
               <FontAwesomeIcon icon={faTable} className="text-xs text-bunker-300" />
             </div>
             <Tooltip content={currentWorkspace.name} className="max-w-96">
-              <div className="max-w-32 overflow-hidden text-ellipsis whitespace-nowrap">
+              <div className="max-w-44 overflow-hidden text-ellipsis whitespace-nowrap">
                 {currentWorkspace?.name}
               </div>
             </Tooltip>


### PR DESCRIPTION
# Description 📣

This PR prevents the organization name from wrapping in the nav bar header, and expands header height if breadcrumbs wraps

<img width="1872" height="88" alt="CleanShot 2025-07-15 at 08 55 54@2x" src="https://github.com/user-attachments/assets/d62d177f-b0df-444d-8ed3-31d525fe3815" />


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝