### PR TITLE
fix: oci auth for go sdk

### DIFF
--- a/backend/src/server/routes/v1/identity-oci-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-oci-auth-router.ts
@@ -28,7 +28,17 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
           .object({
             authorization: z.string(),
             host: z.string(),
-            "x-date": z.string()
+            "x-date": z.string().optional(),
+            date: z.string().optional()
+          })
+          .superRefine((val, ctx) => {
+            if (!val.date && !val["x-date"]) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "Either date or x-date must be provided",
+                path: ["headers", "date"]
+              });
+            }
           })
           .describe(OCI_AUTH.LOGIN.headers)
       }),

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-types.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-types.ts
@@ -6,7 +6,8 @@ export type TLoginOciAuthDTO = {
   headers: {
     authorization: string;
     host: string;
-    "x-date": string;
+    "x-date"?: string;
+    date?: string;
   };
 };
 


### PR DESCRIPTION
# Description 📣

This PR adds support for OCI auth on the Go SDK, which works differently than the Node SDK. The Go SDK sends a Date header, not a x-date header. The signature generated doesn't include the date, and instead expects a separate `date` header to be present.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->