### PR TITLE
Improvement(UI): align docs link with heading on secret sharing

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
@@ -1,6 +1,6 @@
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
-import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { faBookOpen, faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { PageHeader } from "@app/components/v2";
@@ -22,22 +22,28 @@ export const SecretSharingPage = () => {
       <div className="h-full">
         <div className="container mx-auto h-full w-full max-w-7xl bg-bunker-800 text-white">
           <PageHeader
-            title="Secret Sharing"
+            title={
+              <div className="flex w-full items-center">
+                <span>Secret Sharing</span>
+                <a
+                  className="-mt-1.5"
+                  href="https://infisical.com/docs/documentation/platform/secret-sharing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <div className="ml-2 inline-block rounded-md bg-yellow/20 px-1.5 text-sm font-normal text-yellow opacity-80 hover:opacity-100">
+                    <FontAwesomeIcon icon={faBookOpen} className="mr-1.5" />
+                    <span>Docs</span>
+                    <FontAwesomeIcon
+                      icon={faArrowUpRightFromSquare}
+                      className="mb-[0.07rem] ml-1.5 text-[10px]"
+                    />
+                  </div>
+                </a>
+              </div>
+            }
             description="Share secrets securely using a shareable link"
           >
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://infisical.com/docs/documentation/platform/secret-sharing"
-            >
-              <div className="flex w-max cursor-pointer items-center rounded-md border border-mineshaft-500 bg-mineshaft-600 px-4 py-2 text-mineshaft-200 duration-200 hover:border-primary/40 hover:bg-primary/10 hover:text-white">
-                Documentation{" "}
-                <FontAwesomeIcon
-                  icon={faArrowUpRightFromSquare}
-                  className="mb-[0.06rem] ml-1 text-xs"
-                />
-              </div>
-            </a>
           </PageHeader>
           <ShareSecretSection />
         </div>


### PR DESCRIPTION
# Description 📣

Closes https://github.com/Infisical/infisical/issues/4150

Moved the secret sharing docs link to sit beside the page title to match the layout pattern used across the app. Improves UI consistency and maintains design standards.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

Before: 
<img width="1918" height="296" alt="before " src="https://github.com/user-attachments/assets/fd8e0d3f-508f-4d86-a2ce-22da8f0c83bf" />


After: 
<img width="1918" height="295" alt="after" src="https://github.com/user-attachments/assets/f2ceba26-5a1c-425f-a1fc-3ef617f52c63" />




---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->