### PR TITLE
fixed goarch for cli

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -219,7 +219,7 @@ dockers:
       - "--platform=linux/amd64"
   - dockerfile: docker/alpine
     goos: linux
-    goarch: amd64
+    goarch: arm64
     use: buildx
     ids:
       - all-other-builds


### PR DESCRIPTION
# Description 📣

CLI is not building arm arch in gorelease. After investigating we seem to be doing 2 docker image builds for CLI with amd where it is obvious it should be only 1 and the other is arm.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o infisical .
```

```
root@ankra-io:~# ./infisical-arm64
Infisical is a simple, end-to-end encrypted service that enables teams to sync and manage their environment variables across their development life cycle.

Usage:
  infisical [command]

Available Commands:
  agent           Used to launch a client daemon that streamlines authentication and secret retrieval processes in various environments
  bootstrap       Used to bootstrap your Infisical instance
  dynamic-secrets Used to list dynamic secrets
  export          Used to export environment variables to a file
  gateway         Run the Infisical gateway or manage its systemd service
  help            Help about any command
  init            Used to connect your local project with Infisical project
  kmip            Used to manage KMIP servers
  login           Login into your Infisical account
  reset           Used to delete all Infisical related data on your machine
  run             Used to inject environments variables into your application process
  scan            Scan for leaked secrets in git history, directories, and files
  secrets         Used to create, read update and delete secrets
  service-token   Manage service tokens
  ssh             Used to issue SSH credentials
  token           Manage your access tokens
  user            Used to manage local user credentials
  vault           Used to manage where your Infisical login token is saved on your machine

Flags:
      --domain string      Point the CLI to your own backend [can also set via environment variable name: INFISICAL_API_URL] (default "https://app.infisical.com/api")
  -h, --help               help for infisical
  -l, --log-level string   log level (trace, debug, info, warn, error, fatal) (default "info")
      --silent             Disable output of tip/info messages. Useful when running in scripts or CI/CD pipelines.
      --telemetry          Infisical collects non-sensitive telemetry data to enhance features and improve user experience. Participation is voluntary (default true)
  -v, --version            version for infisical

Use "infisical [command] --help" for more information about a command.
```
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->