### PR TITLE
Make certificate collection required

### DIFF
--- a/frontend/src/pages/cert-manager/AlertingPage/components/PkiAlertModal.tsx
+++ b/frontend/src/pages/cert-manager/AlertingPage/components/PkiAlertModal.tsx
@@ -31,7 +31,7 @@ enum TimeUnit {
 
 const schema = z.object({
   name: z.string().trim().min(1),
-  pkiCollectionId: z.string(),
+  pkiCollectionId: z.string().min(1),
   alertBefore: z.string(),
   alertUnit: z.nativeEnum(TimeUnit),
   emails: z.string().trim()


### PR DESCRIPTION
# Description 📣

When going to `/projects/<project-id>/cert-manager/alerting` and creating an alert without selecting a Certificate Collection, it throws a server error without any details.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation