### PR TITLE
fix: propogate Github app connection errors to the client properly

### DIFF
--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -199,7 +199,7 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
         client_id: clientId,
         client_secret: clientSecret,
         code: credentials.code,
-        redirect_uri: `${SITE_URL}-test/organization/app-connections/github/oauth/callback`
+        redirect_uri: `${SITE_URL}/organization/app-connections/github/oauth/callback`
       },
       headers: {
         Accept: "application/json",

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -145,11 +145,19 @@ export const getGitHubEnvironments = async (appConnection: TGitHubConnection, ow
 };
 
 type TokenRespData = {
-  access_token: string;
+  access_token?: string;
   scope: string;
   token_type: string;
   error?: string;
 };
+
+function isErrorResponse(data: TokenRespData): data is TokenRespData & {
+  error: string;
+  error_description: string;
+  error_uri: string;
+} {
+  return "error" in data;
+}
 
 export const validateGitHubConnectionCredentials = async (config: TGitHubConnectionConfig) => {
   const { credentials, method } = config;
@@ -198,7 +206,17 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
         "Accept-Encoding": "application/json"
       }
     });
+
+    if (isErrorResponse(tokenResp?.data)) {
+      throw new BadRequestError({
+        message: `Unable to validate credentials: GitHub responded with an error: ${tokenResp.data.error} - ${tokenResp.data.error_description}.`
+      });
+    }
   } catch (e: unknown) {
+    if (e instanceof BadRequestError) {
+      throw e;
+    }
+
     throw new BadRequestError({
       message: `Unable to validate connection: verify credentials`
     });
@@ -211,6 +229,10 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
   }
 
   if (method === GitHubConnectionMethod.App) {
+    if (!tokenResp.data.access_token) {
+      throw new InternalServerError({ message: `Missing access token: ${tokenResp.data.error}` });
+    }
+
     const installationsResp = await request.get<{
       installations: {
         id: number;
@@ -237,10 +259,6 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
         message: "User does not have access to the provided installation"
       });
     }
-  }
-
-  if (!tokenResp.data.access_token) {
-    throw new InternalServerError({ message: `Missing access token: ${tokenResp.data.error}` });
   }
 
   switch (method) {

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -199,7 +199,7 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
         client_id: clientId,
         client_secret: clientSecret,
         code: credentials.code,
-        redirect_uri: `${SITE_URL}/organization/app-connections/github/oauth/callback`
+        redirect_uri: `${SITE_URL}-test/organization/app-connections/github/oauth/callback`
       },
       headers: {
         Accept: "application/json",
@@ -209,7 +209,7 @@ export const validateGitHubConnectionCredentials = async (config: TGitHubConnect
 
     if (isErrorResponse(tokenResp?.data)) {
       throw new BadRequestError({
-        message: `Unable to validate credentials: GitHub responded with an error: ${tokenResp.data.error} - ${tokenResp.data.error_description}.`
+        message: `Unable to validate credentials: GitHub responded with an error: ${tokenResp.data.error} - ${tokenResp.data.error_description}`
       });
     }
   } catch (e: unknown) {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

This PR improves error handling during GitHub credential validation by explicitly propagating relevant error messages from GitHub to the client. Previously, generic error messages were returned, which made debugging and user feedback more difficult.

This should in-turn help with debugging connection issues like #3820

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->