### PR TITLE
docs: document use of port 8433 for TLS certificate auth

### DIFF
--- a/docs/api-reference/endpoints/tls-cert-auth/login.mdx
+++ b/docs/api-reference/endpoints/tls-cert-auth/login.mdx
@@ -5,5 +5,5 @@ openapi: "POST /api/v1/auth/tls-cert-auth/login"
 
 <Warning>
   Infisical US/EU and dedicated instances are deployed with AWS ALB. TLS Certificate Auth must flow through our ALB mTLS pass-through in order to authenticate.
-  When you are authenticating with TLS Certificate Auth, you must use the port `8433` instead of the default `443`. Example: `https://app.infisical.com:8433/api/v1/auth/tls-cert-auth/login`
+  When you are authenticating with TLS Certificate Auth, you must use the port `8443` instead of the default `443`. Example: `https://app.infisical.com:8443/api/v1/auth/tls-cert-auth/login`
 </Warning>

--- a/docs/documentation/platform/identities/tls-cert-auth.mdx
+++ b/docs/documentation/platform/identities/tls-cert-auth.mdx
@@ -47,7 +47,7 @@ To be more specific:
 
 <Note>
   Infisical US/EU and dedicated instances are deployed with AWS ALB. TLS Certificate Auth must flow through our ALB mTLS pass-through in order to authenticate.
-  When you are authenticating with TLS Certificate Auth, you must use the port `8433` instead of the default `443`. Example: `https://app.infisical.com:8433/api/v1/auth/tls-cert-auth/login`
+  When you are authenticating with TLS Certificate Auth, you must use the port `8443` instead of the default `443`. Example: `https://app.infisical.com:8443/api/v1/auth/tls-cert-auth/login`
 </Note>
 
 ## Guide
@@ -127,7 +127,7 @@ try {
   const clientCertificate = fs.readFileSync("client-cert.pem", "utf8");
   const clientKeyCertificate = fs.readFileSync("client-key.pem", "utf8");
 
-  const infisicalUrl = "https://app.infisical.com:8433"; // or your self-hosted Infisical URL
+  const infisicalUrl = "https://app.infisical.com:8443"; // or your self-hosted Infisical URL
   const identityId = "<your-identity-id>";
 
   // Create HTTPS agent with client certificate and key


### PR DESCRIPTION
# Description 📣

We rolled out a change disabling TLS certificate auth on port 443, instead forcing users to use port 8433. This doc change documents these changes so users will have a better experience authenticating with TLS certificate auth.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->