### PR TITLE
fix: verify response type

### DIFF
--- a/backend/src/services/app-connection/1password/1password-connection-fns.ts
+++ b/backend/src/services/app-connection/1password/1password-connection-fns.ts
@@ -31,12 +31,16 @@ export const validateOnePassConnectionCredentials = async (config: TOnePassConne
   const { apiToken } = config.credentials;
 
   try {
-    await request.get(`${instanceUrl}/v1/vaults`, {
+    const res = await request.get(`${instanceUrl}/v1/vaults`, {
       headers: {
         Authorization: `Bearer ${apiToken}`,
         Accept: "application/json"
       }
     });
+
+    if (!Array.isArray(res.data)) {
+      throw new AxiosError("Invalid response from 1Password API");
+    }
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       throw new BadRequestError({


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->
This PR adds a response content type check in the case of OnePassword app connection - which should in-turn help with debugging connection issues like #4177

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->