### PR TITLE
feat(ENG-3247): add auth origin domain cookie on token creation

### DIFF
--- a/backend/src/server/lib/cookie.ts
+++ b/backend/src/server/lib/cookie.ts
@@ -11,8 +11,15 @@ export function addAuthOriginDomainCookie(res: FastifyReply) {
     let domain: string | undefined;
 
     if (!siteUrl.includes("localhost")) {
-      const url = new URL(siteUrl);
-      domain = `.${url.host}`;
+      const { hostname } = new URL(siteUrl);
+      const parts = hostname.split(".");
+      if (parts.length >= 2) {
+        // For `app.infisical.com` => `.infisical.com`
+        domain = `.${parts.slice(-2).join(".")}`;
+      } else {
+        // If somehow only "example", fallback to itself
+        domain = `.${hostname}`;
+      }
     }
 
     void res.setCookie("aod", siteUrl, {

--- a/backend/src/server/lib/cookie.ts
+++ b/backend/src/server/lib/cookie.ts
@@ -7,6 +7,9 @@ export function addAuthOriginDomainCookie(res: FastifyReply) {
   try {
     const appCfg = getConfig();
 
+    // Only set the cookie if the app is running in cloud mode
+    if (!appCfg.isCloud) return;
+
     const siteUrl = appCfg.SITE_URL!;
     let domain: string | undefined;
 

--- a/backend/src/server/lib/cookie.ts
+++ b/backend/src/server/lib/cookie.ts
@@ -11,18 +11,18 @@ export function addAuthOriginDomainCookie(res: FastifyReply) {
     if (!appCfg.isCloud) return;
 
     const siteUrl = appCfg.SITE_URL!;
-    let domain: string | undefined;
+    let domain: string;
 
-    if (!siteUrl.includes("localhost")) {
-      const { hostname } = new URL(siteUrl);
-      const parts = hostname.split(".");
-      if (parts.length >= 2) {
-        // For `app.infisical.com` => `.infisical.com`
-        domain = `.${parts.slice(-2).join(".")}`;
-      } else {
-        // If somehow only "example", fallback to itself
-        domain = `.${hostname}`;
-      }
+    const { hostname } = new URL(siteUrl);
+
+    const parts = hostname.split(".");
+
+    if (parts.length >= 2) {
+      // For `app.infisical.com` => `.infisical.com`
+      domain = `.${parts.slice(-2).join(".")}`;
+    } else {
+      // If somehow only "example", fallback to itself
+      domain = `.${hostname}`;
     }
 
     void res.setCookie("aod", siteUrl, {

--- a/backend/src/server/lib/cookie.ts
+++ b/backend/src/server/lib/cookie.ts
@@ -1,0 +1,22 @@
+import { FastifyReply } from "fastify";
+
+import { getConfig } from "@app/lib/config/env";
+
+export function addAuthOriginDomainCookie(res: FastifyReply) {
+  const appCfg = getConfig();
+
+  const siteUrl = appCfg.SITE_URL!;
+  let domain: string | undefined;
+
+  if (!siteUrl.includes("localhost")) {
+    domain = `.${siteUrl.split("//")[1].split("/")[0]}`;
+  }
+
+  void res.setCookie("aod", siteUrl, {
+    domain,
+    path: "/",
+    sameSite: "strict",
+    httpOnly: false,
+    secure: appCfg.HTTPS_ENABLED
+  });
+}

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -12,6 +12,7 @@ import { getConfig, overridableKeys } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { invalidateCacheLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifySuperAdmin } from "@app/server/plugins/auth/superAdmin";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -592,6 +593,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
         sameSite: "strict",
         secure: appCfg.HTTPS_ENABLED
       });
+
+      addAuthOriginDomainCookie(res);
 
       return {
         message: "Successfully set up admin account",

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -22,6 +22,7 @@ import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
 import { fetchGithubEmails, fetchGithubUser } from "@app/lib/requests/github";
 import { authRateLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { AuthMethod } from "@app/services/auth/auth-type";
 import { OrgAuthMethod } from "@app/services/org/org-types";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
@@ -474,6 +475,8 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
         sameSite: "strict",
         secure: appCfg.HTTPS_ENABLED
       });
+
+      addAuthOriginDomainCookie(res);
 
       return {
         encryptionVersion: data.user.encryptionVersion,

--- a/backend/src/server/routes/v2/mfa-router.ts
+++ b/backend/src/server/routes/v2/mfa-router.ts
@@ -4,6 +4,7 @@ import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { mfaRateLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { AuthModeMfaJwtTokenPayload, AuthTokenType, MfaMethod } from "@app/services/auth/auth-type";
 
 export const registerMfaRouter = async (server: FastifyZodProvider) => {
@@ -130,6 +131,8 @@ export const registerMfaRouter = async (server: FastifyZodProvider) => {
         sameSite: "strict",
         secure: appCfg.HTTPS_ENABLED
       });
+
+      addAuthOriginDomainCookie(res);
 
       return {
         ...user,

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -10,6 +10,7 @@ import {
 import { ApiDocsTags, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { GenericResourceNameSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -395,6 +396,8 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         sameSite: "strict",
         secure: cfg.HTTPS_ENABLED
       });
+
+      addAuthOriginDomainCookie(res);
 
       return { organization, accessToken: tokens.accessToken };
     }

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { INFISICAL_PROVIDER_GITHUB_ACCESS_TOKEN } from "@app/lib/config/const";
 import { getConfig } from "@app/lib/config/env";
 import { authRateLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 
 export const registerLoginRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -93,6 +94,8 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
         secure: cfg.HTTPS_ENABLED
       });
 
+      addAuthOriginDomainCookie(res);
+
       void res.cookie("infisical-project-assume-privileges", "", {
         httpOnly: true,
         path: "/",
@@ -154,6 +157,8 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
         sameSite: "strict",
         secure: appCfg.HTTPS_ENABLED
       });
+
+      addAuthOriginDomainCookie(res);
 
       void res.cookie("infisical-project-assume-privileges", "", {
         httpOnly: true,

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -4,6 +4,7 @@ import { UsersSchema } from "@app/db/schemas";
 import { getConfig } from "@app/lib/config/env";
 import { ForbiddenRequestError } from "@app/lib/errors";
 import { authRateLimit, smtpRateLimit } from "@app/server/config/rateLimiter";
+import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { GenericResourceNameSchema } from "@app/server/lib/schemas";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
@@ -170,6 +171,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
         secure: appCfg.HTTPS_ENABLED
       });
 
+      addAuthOriginDomainCookie(res);
+
       return { message: "Successfully set up account", user, token: accessToken, organizationId };
     }
   });
@@ -238,6 +241,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
         secure: appCfg.HTTPS_ENABLED
       });
       // TODO(akhilmhdh-pg): add telemetry service
+
+      addAuthOriginDomainCookie(res);
 
       return { message: "Successfully set up account", user, token: accessToken };
     }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -12,7 +12,7 @@ server {
         proxy_redirect off;
 
         # proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
-        proxy_cookie_path / "/; SameSite=strict";
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
     location /api/v3/migrate {

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -12,7 +12,7 @@ server {
         proxy_redirect off;
 
         # proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
-        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+        proxy_cookie_path / "/; SameSite=strict";
     }
 
     location /api/v3/migrate {

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -14,7 +14,7 @@ server {
         proxy_pass http://backend:4000;
         proxy_redirect off;
 
-        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+        proxy_cookie_path / "/; SameSite=strict";
     }
 
 		location /runtime-ui-env.js {


### PR DESCRIPTION
# Description 📣

This PR adds a `aod` (Authentication origin domain) cookie that is shared between domains (`.infisical.com`) this is required for the dynamic dashboard button on the marketing website if people are already signed in.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->