### PR TITLE
fix: bump aws arn field size

### DIFF
--- a/backend/src/db/migrations/20250721101756_bump-aws-arn-field-size.ts
+++ b/backend/src/db/migrations/20250721101756_bump-aws-arn-field-size.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.IdentityAwsAuth, "allowedPrincipalArns");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.IdentityAwsAuth, (t) => {
+      t.string("allowedPrincipalArns", 4096).notNullable().alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.IdentityAwsAuth, "allowedPrincipalArns");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.IdentityAwsAuth, (t) => {
+      t.string("allowedPrincipalArns", 2048).notNullable().alter();
+    });
+  }
+}

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
@@ -37,7 +37,7 @@ export const validateAccountIds = z
 export const validatePrincipalArns = z
   .string()
   .trim()
-  .max(2048)
+  .max(4096)
   .default("")
   // Custom validation for ARN format
   .refine(


### PR DESCRIPTION
# Description 📣

Increase `infisical.public.identity_aws_auths.allowedPrincipalArns` 's field size in both database and validation schema.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->