### PR TITLE
Prevent users from deleting the last payment method attached to the org

### DIFF
--- a/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/PmtMethodsTable.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/PmtMethodsTable.tsx
@@ -32,6 +32,13 @@ export const PmtMethodsTable = () => {
 
   const handleDeletePmtMethodBtnClick = async () => {
     if (!currentOrg?.id || !pmtMethodToRemove) return;
+    if (data?.length === 1) {
+      createNotification({
+        type: "error",
+        text: "You must have at least one payment method"
+      });
+      return;
+    }
     try {
       await deleteOrgPmtMethod.mutateAsync({
         organizationId: currentOrg.id,


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Disable ability to remove a payment method if a customer only has one payment method on file

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->