### PR TITLE
fix: resolved project deletion not working for secret scanning on missing plan

### DIFF
--- a/frontend/src/pages/secret-scanning/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/secret-scanning/SettingsPage/SettingsPage.tsx
@@ -1,54 +1,16 @@
-import { useEffect } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
-import { faLock } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
-import { ProjectPermissionSub, useSubscription } from "@app/context";
+import { ProjectPermissionSub } from "@app/context";
 import { ProjectPermissionSecretScanningConfigActions } from "@app/context/ProjectPermissionContext/types";
-import { usePopUp } from "@app/hooks";
 import { ProjectGeneralTab } from "@app/pages/project/SettingsPage/components/ProjectGeneralTab";
 
 import { ProjectScanningConfigTab } from "./components/ProjectScanningConfigTab";
 
 export const SettingsPage = () => {
   const { t } = useTranslation();
-
-  const { subscription } = useSubscription();
-
-  const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
-
-  useEffect(() => {
-    if (!subscription.secretScanning) {
-      handlePopUpOpen("upgradePlan");
-    }
-  }, [subscription.secretScanning]);
-
-  if (!subscription.secretScanning) {
-    return (
-      <>
-        <div className="container mx-auto flex h-full items-center justify-center">
-          <div className="flex items-end space-x-12 rounded-md bg-mineshaft-800 p-16 text-bunker-300">
-            <div>
-              <FontAwesomeIcon icon={faLock} size="6x" />
-            </div>
-            <div>
-              <div className="mb-2 text-4xl font-medium">Access Restricted</div>
-              <div className="text-sm">Upgrade your plan to access Secret Scanning</div>
-            </div>
-          </div>
-        </div>
-        <UpgradePlanModal
-          isOpen={popUp.upgradePlan.isOpen}
-          onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-          text="Secret Scanning is not available on your current plan."
-        />
-      </>
-    );
-  }
 
   return (
     <div className="flex h-full w-full justify-center bg-bunker-800 text-white">

--- a/frontend/src/pages/secret-scanning/SettingsPage/components/ProjectScanningConfigTab/ProjectScanningConfigTab.tsx
+++ b/frontend/src/pages/secret-scanning/SettingsPage/components/ProjectScanningConfigTab/ProjectScanningConfigTab.tsx
@@ -1,16 +1,36 @@
 import { faBan } from "@fortawesome/free-solid-svg-icons";
 
 import { ContentLoader, EmptyState } from "@app/components/v2";
-import { useWorkspace } from "@app/context";
+import { useSubscription, useWorkspace } from "@app/context";
 import { useGetSecretScanningConfig } from "@app/hooks/api/secretScanningV2";
 
 import { SecretScanningConfigForm } from "./SecretScanningConfigForm";
 
 export const ProjectScanningConfigTab = () => {
   const { currentWorkspace } = useWorkspace();
+  const { subscription } = useSubscription();
   const { data: config, isPending: isConfigPending } = useGetSecretScanningConfig(
-    currentWorkspace.id
+    currentWorkspace.id,
+    { enabled: subscription.secretScanning }
   );
+
+  if (!subscription.secretScanning) {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-20">
+        <EmptyState
+          className="rounded-md text-center"
+          icon={faBan}
+          title={
+            <span>
+              Your current plan doesn&apos;t support Secret Scanning.
+              <br /> Please contact Infisical Support or reach out through our Slack channel for
+              assistance.
+            </span>
+          }
+        />
+      </div>
+    );
+  }
 
   if (isConfigPending) {
     return (


### PR DESCRIPTION
# Description 📣

Users were not able to delete project for secret scanning when there plan doesn't include it. This has been fixed in this PR

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->