### PR TITLE
improvement(frontend): Adjust select dropdown styling in add project modal

### DIFF
--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -271,6 +271,8 @@ const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
                     value={value}
                     onValueChange={onChange}
                     className="w-full"
+                    position="popper"
+                    dropdownContainerClassName="max-w-none"
                   >
                     {projectTemplates.length
                       ? projectTemplates.map((template) => (
@@ -306,6 +308,9 @@ const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
                         onChange(e);
                       }}
                       className="mb-12 w-full bg-mineshaft-600"
+                      position="popper"
+                      dropdownContainerClassName="max-w-none -top-1"
+                      side="top"
                     >
                       <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
                         Default Infisical KMS

--- a/frontend/src/components/v2/Select/Select.tsx
+++ b/frontend/src/components/v2/Select/Select.tsx
@@ -20,7 +20,7 @@ type Props = {
   isMulti?: boolean;
   iconClassName?: string;
   dropdownContainerStyle?: React.CSSProperties;
-  side: SelectPrimitive.SelectContentProps["side"];
+  side?: SelectPrimitive.SelectContentProps["side"];
 };
 
 export type SelectProps = Omit<SelectPrimitive.SelectProps, "disabled"> & Props;

--- a/frontend/src/components/v2/Select/Select.tsx
+++ b/frontend/src/components/v2/Select/Select.tsx
@@ -20,6 +20,7 @@ type Props = {
   isMulti?: boolean;
   iconClassName?: string;
   dropdownContainerStyle?: React.CSSProperties;
+  side: SelectPrimitive.SelectContentProps["side"];
 };
 
 export type SelectProps = Omit<SelectPrimitive.SelectProps, "disabled"> & Props;
@@ -37,6 +38,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
       containerClassName,
       iconClassName,
       dropdownContainerStyle,
+      side,
       ...props
     },
     ref
@@ -78,6 +80,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
           </SelectPrimitive.Trigger>
           <SelectPrimitive.Portal>
             <SelectPrimitive.Content
+              side={side}
               className={twMerge(
                 "relative top-1 z-[100] max-w-sm overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md",
                 position === "popper" && "max-h-72",


### PR DESCRIPTION
# Description 📣

This PR adjusts the styling of the project template and kms select dropdowns in the create project modal to use popper styling and inverts the kms modal

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝