### PR TITLE
feat(secret-sync/render): auto redeploy on sync

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2373,6 +2373,10 @@ export const SecretSyncs = {
       keyId: "The AWS KMS key ID or alias to use when encrypting parameters synced by Infisical.",
       tags: "Optional tags to add to secrets synced by Infisical.",
       syncSecretMetadataAsTags: `Whether Infisical secret metadata should be added as tags to secrets synced by Infisical.`
+    },
+    RENDER: {
+      autoRedeployServices:
+        "Whether Infisical should automatically redeploy the configured Render service upon secret changes."
     }
   },
   DESTINATION_CONFIG: {

--- a/backend/src/services/secret-sync/render/render-sync-fns.ts
+++ b/backend/src/services/secret-sync/render/render-sync-fns.ts
@@ -112,7 +112,7 @@ const redeployService = async (secretSync: TRenderSyncWithCredentials) => {
       {
         headers: {
           Authorization: `Bearer ${apiKey}`,
-          "Accept-Encoding": "application/json"
+          Accept: "application/json"
         }
       }
     )

--- a/backend/src/services/secret-sync/render/render-sync-schemas.ts
+++ b/backend/src/services/secret-sync/render/render-sync-schemas.ts
@@ -20,23 +20,33 @@ const RenderSyncDestinationConfigSchema = z.discriminatedUnion("scope", [
   })
 ]);
 
+const RenderSyncOptionsSchema = z.object({
+  autoRedeployServices: z.boolean().optional().describe(SecretSyncs.ADDITIONAL_SYNC_OPTIONS.RENDER.autoRedeployServices)
+});
+
 const RenderSyncOptionsConfig: TSyncOptionsConfig = { canImportSecrets: true };
 
-export const RenderSyncSchema = BaseSecretSyncSchema(SecretSync.Render, RenderSyncOptionsConfig).extend({
+export const RenderSyncSchema = BaseSecretSyncSchema(
+  SecretSync.Render,
+  RenderSyncOptionsConfig,
+  RenderSyncOptionsSchema
+).extend({
   destination: z.literal(SecretSync.Render),
   destinationConfig: RenderSyncDestinationConfigSchema
 });
 
 export const CreateRenderSyncSchema = GenericCreateSecretSyncFieldsSchema(
   SecretSync.Render,
-  RenderSyncOptionsConfig
+  RenderSyncOptionsConfig,
+  RenderSyncOptionsSchema
 ).extend({
   destinationConfig: RenderSyncDestinationConfigSchema
 });
 
 export const UpdateRenderSyncSchema = GenericUpdateSecretSyncFieldsSchema(
   SecretSync.Render,
-  RenderSyncOptionsConfig
+  RenderSyncOptionsConfig,
+  RenderSyncOptionsSchema
 ).extend({
   destinationConfig: RenderSyncDestinationConfigSchema.optional()
 });

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/RenderSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/RenderSyncFields.tsx
@@ -9,7 +9,7 @@ import {
   useRenderConnectionListServices
 } from "@app/hooks/api/appConnections/render";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
-import { RenderSyncScope, RenderSyncType } from "@app/hooks/api/secretSyncs/render-sync";
+import { RenderSyncScope, RenderSyncType } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 import { TSecretSyncForm } from "../schemas";
 

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/RenderSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/RenderSyncOptionsFields.tsx
@@ -1,0 +1,40 @@
+import { Controller, useFormContext } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { FormControl, Switch, Tooltip } from "@app/components/v2";
+import { SecretSync } from "@app/hooks/api/secretSyncs";
+
+import { TSecretSyncForm } from "../schemas";
+
+export const RenderSyncOptionsFields = () => {
+  const { control } = useFormContext<TSecretSyncForm & { destination: SecretSync.Render }>();
+
+  return (
+    <Controller
+      name="syncOptions.autoRedeployServices"
+      control={control}
+      render={({ field: { value, onChange }, fieldState: { error } }) => (
+        <FormControl className="mt-4" isError={Boolean(error?.message)} errorText={error?.message}>
+          <Switch
+            className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+            id="auto-redeploy-services"
+            thumbClassName="bg-mineshaft-800"
+            isChecked={value}
+            onCheckedChange={onChange}
+          >
+            Auto Redeploy Services On Sync
+            <Tooltip
+              className="max-w-md"
+              content={
+                <p>If enabled, services will be automatically redeployed upon secret changes.</p>
+              }
+            >
+              <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+            </Tooltip>
+          </Switch>
+        </FormControl>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
@@ -14,6 +14,7 @@ import { SecretSync, useSecretSyncOption } from "@app/hooks/api/secretSyncs";
 import { TSecretSyncForm } from "../schemas";
 import { AwsParameterStoreSyncOptionsFields } from "./AwsParameterStoreSyncOptionsFields";
 import { AwsSecretsManagerSyncOptionsFields } from "./AwsSecretsManagerSyncOptionsFields";
+import { RenderSyncOptionsFields } from "./RenderSyncOptionsFields";
 
 type Props = {
   hideInitialSync?: boolean;
@@ -38,6 +39,9 @@ export const SecretSyncOptionsFields = ({ hideInitialSync }: Props) => {
     case SecretSync.AWSSecretsManager:
       AdditionalSyncOptionsFieldsComponent = <AwsSecretsManagerSyncOptionsFields />;
       break;
+    case SecretSync.Render:
+      AdditionalSyncOptionsFieldsComponent = <RenderSyncOptionsFields />;
+      break;
     case SecretSync.GitHub:
     case SecretSync.GCPSecretManager:
     case SecretSync.AzureKeyVault:
@@ -54,7 +58,6 @@ export const SecretSyncOptionsFields = ({ hideInitialSync }: Props) => {
     case SecretSync.OnePass:
     case SecretSync.OCIVault:
     case SecretSync.Heroku:
-    case SecretSync.Render:
     case SecretSync.Flyio:
     case SecretSync.GitLab:
     case SecretSync.CloudflarePages:

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/RenderSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/RenderSyncReviewFields.tsx
@@ -2,7 +2,28 @@ import { useFormContext } from "react-hook-form";
 
 import { GenericFieldLabel } from "@app/components/secret-syncs";
 import { TSecretSyncForm } from "@app/components/secret-syncs/forms/schemas";
+import { Badge } from "@app/components/v2";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
+
+export const RenderSyncOptionsReviewFields = () => {
+  const { watch } = useFormContext<TSecretSyncForm & { destination: SecretSync.Render }>();
+
+  const [{ autoRedeployServices }] = watch(["syncOptions"]);
+
+  return (
+    <div>
+      {autoRedeployServices ? (
+        <GenericFieldLabel label="Auto Redeploy Services">
+          <Badge variant="success">Enabled</Badge>
+        </GenericFieldLabel>
+      ) : (
+        <GenericFieldLabel label="Auto Redeploy Services">
+          <Badge variant="danger">Disabled</Badge>
+        </GenericFieldLabel>
+      )}
+    </div>
+  );
+};
 
 export const RenderSyncReviewFields = () => {
   const { watch } = useFormContext<TSecretSyncForm & { destination: SecretSync.Render }>();

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -35,7 +35,7 @@ import { HumanitecSyncReviewFields } from "./HumanitecSyncReviewFields";
 import { OCIVaultSyncReviewFields } from "./OCIVaultSyncReviewFields";
 import { OnePassSyncReviewFields } from "./OnePassSyncReviewFields";
 import { RailwaySyncReviewFields } from "./RailwaySyncReviewFields";
-import { RenderSyncReviewFields } from "./RenderSyncReviewFields";
+import { RenderSyncOptionsReviewFields, RenderSyncReviewFields } from "./RenderSyncReviewFields";
 import { SupabaseSyncReviewFields } from "./SupabaseSyncReviewFields";
 import { TeamCitySyncReviewFields } from "./TeamCitySyncReviewFields";
 import { TerraformCloudSyncReviewFields } from "./TerraformCloudSyncReviewFields";
@@ -121,6 +121,7 @@ export const SecretSyncReviewFields = () => {
       break;
     case SecretSync.Render:
       DestinationFieldsComponent = <RenderSyncReviewFields />;
+      AdditionalSyncOptionsFieldsComponent = <RenderSyncOptionsReviewFields />;
       break;
     case SecretSync.Flyio:
       DestinationFieldsComponent = <FlyioSyncReviewFields />;

--- a/frontend/src/components/secret-syncs/forms/schemas/render-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/render-sync-destination-schema.ts
@@ -4,7 +4,11 @@ import { BaseSecretSyncSchema } from "@app/components/secret-syncs/forms/schemas
 import { SecretSync } from "@app/hooks/api/secretSyncs";
 import { RenderSyncScope, RenderSyncType } from "@app/hooks/api/secretSyncs/render-sync";
 
-export const RenderSyncDestinationSchema = BaseSecretSyncSchema().merge(
+export const RenderSyncDestinationSchema = BaseSecretSyncSchema(
+  z.object({
+    autoRedeployServices: z.boolean().optional()
+  })
+).merge(
   z.object({
     destination: z.literal(SecretSync.Render),
     destinationConfig: z.discriminatedUnion("scope", [

--- a/frontend/src/components/secret-syncs/forms/schemas/render-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/render-sync-destination-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { BaseSecretSyncSchema } from "@app/components/secret-syncs/forms/schemas/base-secret-sync-schema";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
-import { RenderSyncScope, RenderSyncType } from "@app/hooks/api/secretSyncs/render-sync";
+import { RenderSyncScope, RenderSyncType } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 export const RenderSyncDestinationSchema = BaseSecretSyncSchema(
   z.object({

--- a/frontend/src/helpers/secretSyncs.ts
+++ b/frontend/src/helpers/secretSyncs.ts
@@ -4,9 +4,9 @@ import {
   SecretSyncImportBehavior,
   SecretSyncInitialSyncBehavior
 } from "@app/hooks/api/secretSyncs";
-import { RenderSyncScope } from "@app/hooks/api/secretSyncs/render-sync";
 import { GcpSyncScope } from "@app/hooks/api/secretSyncs/types/gcp-sync";
 import { HumanitecSyncScope } from "@app/hooks/api/secretSyncs/types/humanitec-sync";
+import { RenderSyncScope } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 export const SECRET_SYNC_MAP: Record<SecretSync, { name: string; image: string }> = {
   [SecretSync.AWSParameterStore]: { name: "AWS Parameter Store", image: "Amazon Web Services.png" },

--- a/frontend/src/hooks/api/secretSyncs/render-sync.ts
+++ b/frontend/src/hooks/api/secretSyncs/render-sync.ts
@@ -16,6 +16,10 @@ export type TRenderSync = TRootSecretSync & {
     name: string;
     id: string;
   };
+
+  syncOptions: {
+    autoRedeployServices?: boolean;
+  };
 };
 
 export enum RenderSyncScope {

--- a/frontend/src/hooks/api/secretSyncs/types/index.ts
+++ b/frontend/src/hooks/api/secretSyncs/types/index.ts
@@ -1,7 +1,6 @@
 import { SecretSync, SecretSyncImportBehavior } from "@app/hooks/api/secretSyncs";
 import { DiscriminativePick } from "@app/types";
 
-import { TRenderSync } from "../render-sync";
 import { TOnePassSync } from "./1password-sync";
 import { TAwsParameterStoreSync } from "./aws-parameter-store-sync";
 import { TAwsSecretsManagerSync } from "./aws-secrets-manager-sync";
@@ -24,6 +23,7 @@ import { THerokuSync } from "./heroku-sync";
 import { THumanitecSync } from "./humanitec-sync";
 import { TOCIVaultSync } from "./oci-vault-sync";
 import { TRailwaySync } from "./railway-sync";
+import { TRenderSync } from "./render-sync";
 import { TSupabaseSync } from "./supabase";
 import { TTeamCitySync } from "./teamcity-sync";
 import { TTerraformCloudSync } from "./terraform-cloud-sync";

--- a/frontend/src/hooks/api/secretSyncs/types/render-sync.ts
+++ b/frontend/src/hooks/api/secretSyncs/types/render-sync.ts
@@ -1,6 +1,6 @@
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
-import { TRootSecretSync } from "@app/hooks/api/secretSyncs/types/root-sync";
+import { RootSyncOptions, TRootSecretSync } from "@app/hooks/api/secretSyncs/types/root-sync";
 
 export type TRenderSync = TRootSecretSync & {
   destination: SecretSync.Render;
@@ -17,7 +17,7 @@ export type TRenderSync = TRootSecretSync & {
     id: string;
   };
 
-  syncOptions: {
+  syncOptions: RootSyncOptions & {
     autoRedeployServices?: boolean;
   };
 };

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/SecretSyncDestinationCol/RenderSyncDestinationCol.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/SecretSyncDestinationCol/RenderSyncDestinationCol.tsx
@@ -1,5 +1,5 @@
 import { useRenderConnectionListServices } from "@app/hooks/api/appConnections/render";
-import { TRenderSync } from "@app/hooks/api/secretSyncs/render-sync";
+import { TRenderSync } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 import { getSecretSyncDestinationColValues } from "../helpers";
 import { SecretSyncTableCell } from "../SecretSyncTableCell";

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncDestinationSection/RenderSyncDestinationSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncDestinationSection/RenderSyncDestinationSection.tsx
@@ -1,6 +1,6 @@
 import { GenericFieldLabel } from "@app/components/secret-syncs";
 import { useRenderConnectionListServices } from "@app/hooks/api/appConnections/render";
-import { TRenderSync } from "@app/hooks/api/secretSyncs/render-sync";
+import { TRenderSync } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 type Props = {
   secretSync: TRenderSync;

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/RenderSyncOptionsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/RenderSyncOptionsSection.tsx
@@ -1,6 +1,6 @@
 import { GenericFieldLabel } from "@app/components/secret-syncs";
 import { Badge } from "@app/components/v2";
-import { TRenderSync } from "@app/hooks/api/secretSyncs/render-sync";
+import { TRenderSync } from "@app/hooks/api/secretSyncs/types/render-sync";
 
 type Props = {
   secretSync: TRenderSync;
@@ -12,16 +12,10 @@ export const RenderSyncOptionsSection = ({ secretSync }: Props) => {
   } = secretSync;
 
   return (
-    <div>
-      {autoRedeployServices ? (
-        <GenericFieldLabel label="Auto Redeploy Services">
-          <Badge variant="success">Enabled</Badge>
-        </GenericFieldLabel>
-      ) : (
-        <GenericFieldLabel label="Auto Redeploy Services">
-          <Badge variant="danger">Disabled</Badge>
-        </GenericFieldLabel>
-      )}
-    </div>
+    <GenericFieldLabel label="Auto Redeploy Services">
+      <Badge variant={autoRedeployServices ? "success" : "danger"}>
+        {autoRedeployServices ? "Enabled" : "Disabled"}
+      </Badge>
+    </GenericFieldLabel>
   );
 };

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/RenderSyncOptionsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/RenderSyncOptionsSection.tsx
@@ -1,0 +1,27 @@
+import { GenericFieldLabel } from "@app/components/secret-syncs";
+import { Badge } from "@app/components/v2";
+import { TRenderSync } from "@app/hooks/api/secretSyncs/render-sync";
+
+type Props = {
+  secretSync: TRenderSync;
+};
+
+export const RenderSyncOptionsSection = ({ secretSync }: Props) => {
+  const {
+    syncOptions: { autoRedeployServices }
+  } = secretSync;
+
+  return (
+    <div>
+      {autoRedeployServices ? (
+        <GenericFieldLabel label="Auto Redeploy Services">
+          <Badge variant="success">Enabled</Badge>
+        </GenericFieldLabel>
+      ) : (
+        <GenericFieldLabel label="Auto Redeploy Services">
+          <Badge variant="danger">Disabled</Badge>
+        </GenericFieldLabel>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/SecretSyncOptionsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/SecretSyncOptionsSection.tsx
@@ -13,6 +13,7 @@ import { SecretSync, TSecretSync } from "@app/hooks/api/secretSyncs";
 
 import { AwsParameterStoreSyncOptionsSection } from "./AwsParameterStoreSyncOptionsSection";
 import { AwsSecretsManagerSyncOptionsSection } from "./AwsSecretsManagerSyncOptionsSection";
+import { RenderSyncOptionsSection } from "./RenderSyncOptionsSection";
 
 type Props = {
   secretSync: TSecretSync;
@@ -40,6 +41,9 @@ export const SecretSyncOptionsSection = ({ secretSync, onEditOptions }: Props) =
         <AwsSecretsManagerSyncOptionsSection secretSync={secretSync} />
       );
       break;
+    case SecretSync.Render:
+      AdditionalSyncOptionsComponent = <RenderSyncOptionsSection secretSync={secretSync} />;
+      break;
     case SecretSync.GitHub:
     case SecretSync.GCPSecretManager:
     case SecretSync.AzureKeyVault:
@@ -56,7 +60,6 @@ export const SecretSyncOptionsSection = ({ secretSync, onEditOptions }: Props) =
     case SecretSync.OCIVault:
     case SecretSync.OnePass:
     case SecretSync.Heroku:
-    case SecretSync.Render:
     case SecretSync.Flyio:
     case SecretSync.GitLab:
     case SecretSync.CloudflarePages:


### PR DESCRIPTION
# Description 📣

Added support for automatically redeploying services on sync. We supported this for native integrations, but we haven't added it to secret syncs which is a blocker for some users.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->