### PR TITLE
fix(fips): increased image size and migrations

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -145,7 +145,11 @@ RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && cd openssl-3.1.2 \
     && ./Configure enable-fips \
     && make \
-    && make install_fips
+    && make install_fips \
+    && cd / \
+    && rm -rf /openssl-build \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Infisical CLI
 RUN curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
@@ -186,7 +190,7 @@ ENV NODE_ENV production
 ENV STANDALONE_BUILD true
 ENV STANDALONE_MODE true
 ENV ChrystokiConfigurationPath=/usr/safenet/lunaclient/
-ENV NODE_OPTIONS="--max-old-space-size=1024"
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 # FIPS mode of operation:
 ENV OPENSSL_CONF=/backend/nodejs.fips.cnf

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -190,12 +190,11 @@ ENV NODE_ENV production
 ENV STANDALONE_BUILD true
 ENV STANDALONE_MODE true
 ENV ChrystokiConfigurationPath=/usr/safenet/lunaclient/
-ENV NODE_OPTIONS="--max-old-space-size=8192"
+ENV NODE_OPTIONS="--max-old-space-size=8192 --force-fips"
 
 # FIPS mode of operation:
 ENV OPENSSL_CONF=/backend/nodejs.fips.cnf
 ENV OPENSSL_MODULES=/usr/local/lib/ossl-modules
-ENV NODE_OPTIONS=--force-fips
 ENV FIPS_ENABLED=true
   
 

--- a/backend/Dockerfile.dev.fips
+++ b/backend/Dockerfile.dev.fips
@@ -59,7 +59,11 @@ RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && cd openssl-3.1.2 \
     && ./Configure enable-fips \
     && make \
-    && make install_fips
+    && make install_fips \
+    && cd / \
+    && rm -rf /openssl-build \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # ? App setup
 

--- a/backend/src/db/migrations/utils/env-config.ts
+++ b/backend/src/db/migrations/utils/env-config.ts
@@ -53,7 +53,7 @@ export const getMigrationEnvConfig = async (superAdminDAL: TSuperAdminDALFactory
 
   let envCfg = Object.freeze(parsedEnv.data);
 
-  const fipsEnabled = await crypto.initialize(superAdminDAL);
+  const fipsEnabled = await crypto.initialize(superAdminDAL, envCfg);
 
   // Fix for 128-bit entropy encryption key expansion issue:
   // In FIPS it is not ideal to expand a 128-bit key into 256-bit. We solved this issue in the past by creating the ROOT_ENCRYPTION_KEY.


### PR DESCRIPTION
# Description 📣

This PR fixes the increased storage consumption by the FIPS image due to the OpenSSL build step.

Additionally I found an issue with running migrations on a fresh installation in FIPS mode. This PR addresses it by taking an optional preconfigured env parameter. The issue was that inside the crypto.initialize function, we call `getConfig()` which doesn't get the migration env config, which means the `ENCRYPTION_KEY` will be uninitialized.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->