### PR TITLE
improvement(frontend): remove click outside moda tol close disabling on various modals

### DIFF
--- a/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
+++ b/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
@@ -76,7 +76,6 @@ export const CreateSecretRotationV2Modal = ({ onOpenChange, isOpen, ...props }: 
             </div>
           )
         }
-        onPointerDownOutside={(e) => e.preventDefault()}
         className={selectedRotation ? "max-w-2xl" : "max-w-3xl"}
         subTitle={
           selectedRotation ? undefined : "Select a provider to create a secret rotation for."

--- a/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
+++ b/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
@@ -75,7 +75,6 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
             </div>
           )
         }
-        onPointerDownOutside={(e) => e.preventDefault()}
         className={selectedDataSource ? "max-w-2xl" : "max-w-3xl"}
         subTitle={
           selectedDataSource ? undefined : "Select a data source to configure secret scanning for."

--- a/frontend/src/components/secret-syncs/CreateSecretSyncModal.tsx
+++ b/frontend/src/components/secret-syncs/CreateSecretSyncModal.tsx
@@ -56,7 +56,6 @@ export const CreateSecretSyncModal = ({ onOpenChange, selectSync = null, ...prop
             "Add Sync"
           )
         }
-        onPointerDownOutside={(e) => e.preventDefault()}
         className="max-w-2xl"
         bodyClassName="overflow-visible"
         subTitle={selectedSync ? undefined : "Select a third-party service to sync secrets to."}


### PR DESCRIPTION
# Description 📣

This PR removes the disabling of clicking outside modal to close on several modals to address preventing interacting with toast notifications

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝