### PR TITLE
fix(fips): x86 support

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -79,7 +79,12 @@ jobs:
               working-directory: backend
             - name: version output
               run: |
-                  echo "Version: ${{ steps.version.outputs.major }}"
+                  echo "Output Value: ${{ steps.version.outputs.major }}"
+                  echo "Output Value: ${{ steps.version.outputs.minor }}"
+                  echo "Output Value: ${{ steps.version.outputs.patch }}"
+                  echo "Output Value: ${{ steps.version.outputs.version }}"
+                  echo "Output Value: ${{ steps.version.outputs.version_type }}"
+                  echo "Output Value: ${{ steps.version.outputs.increment }}"
             - name: Save commit hashes for tag
               id: commit
               uses: pr-mpt/actions-commit-hash@v2


### PR DESCRIPTION
# Description 📣

This PR fixes the FIPS standalone image to properly support x86_x64 architectures. The dependency library installation paths are different depending on if it's being installed on arm64/amd64. We create a symlink between the two installation paths so they both work universally.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->