### PR TITLE
fix(app-connections): github app connection creation

### DIFF
--- a/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
+++ b/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
@@ -408,7 +408,7 @@ export const OAuthCallbackPage = () => {
                 credentials: {
                   code: code as string,
                   installationId: installationId as string,
-                  host: credentials.host
+                  ...(credentials?.host && { host: credentials.host })
                 },
                 gatewayId
               }
@@ -416,7 +416,7 @@ export const OAuthCallbackPage = () => {
                 connectionId,
                 credentials: {
                   code: code as string,
-                  host: credentials.host
+                  ...(credentials?.host && { host: credentials.host })
                 },
                 gatewayId
               })
@@ -432,7 +432,7 @@ export const OAuthCallbackPage = () => {
                 credentials: {
                   code: code as string,
                   installationId: installationId as string,
-                  host: credentials.host
+                  ...(credentials?.host && { host: credentials.host })
                 },
                 gatewayId
               }
@@ -440,7 +440,7 @@ export const OAuthCallbackPage = () => {
                 method: GitHubConnectionMethod.OAuth,
                 credentials: {
                   code: code as string,
-                  host: credentials.host
+                  ...(credentials?.host && { host: credentials.host })
                 },
                 gatewayId
               })


### PR DESCRIPTION
# Description 📣

This PR is a fix for creating/updating github app connections. It fails due to `host` being undefined, which is always the case when creating app connections without a custom github instance.

<img width="436" height="107" alt="image" src="https://github.com/user-attachments/assets/8c17f851-ab18-45e3-8f81-cb0c1a49cd71" />


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->