### PR TITLE
Fix(helm chart): correct redis service name in connection string

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
+++ b/helm-charts/infisical-standalone-postgres/templates/_helpers.tpl
@@ -120,5 +120,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "infisical.redisConnectionString" -}}
 {{- $password := .Values.redis.auth.password -}}
 {{- $serviceName := include "infisical.redisServiceName" . -}}
-{{- printf "redis://default:%s@%s:6379" $password "redis-master" -}}
+{{- printf "redis://default:%s@%s:6379" $password $serviceName -}}
 {{- end -}}


### PR DESCRIPTION
# Description 📣
__Bug:__  
With value `redis.enabled` is `true`, the helm chart, infisical-standalone-postgres, defines redis connection string to direct service named "redis-master" even when the actual name is not.  
You can see this situation when you try to change the helm chart value `redis.fullnameOverride`.  
  
__Solution:__  
Correct service name was already defined, so I modified `_helpers.tpl` to use it.  
  

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->
__Before:__ A dry run shows that the actual service name and the one from the connection URL do not match, so the Infisical pod cannot find Redis
<img width="1410" height="296" alt="before" src="https://github.com/user-attachments/assets/1c0d34d7-4dff-4c36-a175-3f3bf1bbd361" />
  
__After:__  Match
<img width="1416" height="296" alt="after" src="https://github.com/user-attachments/assets/5304a8d1-2863-4759-b1b8-5358ce8a390b" />
  
Works well without specifying `redis.fullnameOverride` too.  
<img width="2832" height="592" alt="image" src="https://github.com/user-attachments/assets/e71c59c9-dcda-40aa-86e7-a574768ad064" />
  
Additionally, deploying with the change worked without error.
---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->