### PR TITLE
improvement(azure-client-secret-rotation): reduce token expiry to two rotation intervals

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/azure-client-secret/azure-client-secret-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/azure-client-secret/azure-client-secret-rotation-fns.ts
@@ -21,6 +21,8 @@ const GRAPH_API_BASE = "https://graph.microsoft.com/v1.0";
 
 type AzureErrorResponse = { error: { message: string } };
 
+const EXPIRY_PADDING_IN_DAYS = 3;
+
 const sleep = async () =>
   new Promise((resolve) => {
     setTimeout(resolve, 1000);
@@ -33,7 +35,8 @@ export const azureClientSecretRotationFactory: TRotationFactory<
   const {
     connection,
     parameters: { objectId, clientId: clientIdParam },
-    secretsMapping
+    secretsMapping,
+    rotationInterval
   } = secretRotation;
 
   /**
@@ -50,7 +53,7 @@ export const azureClientSecretRotationFactory: TRotationFactory<
     )}-${now.getFullYear()}`;
 
     const endDateTime = new Date();
-    endDateTime.setFullYear(now.getFullYear() + 5);
+    endDateTime.setDate(now.getDate() + rotationInterval * 2 + EXPIRY_PADDING_IN_DAYS); // give 72 hour buffer
 
     try {
       const { data } = await request.post<AzureAddPasswordResponse>(
@@ -195,6 +198,11 @@ export const azureClientSecretRotationFactory: TRotationFactory<
     callback
   ) => {
     const credentials = await $rotateClientSecret();
+
+    if (rotationInterval > 365 * 5 - EXPIRY_PADDING_IN_DAYS) {
+      throw new BadRequestError({ message: "Azure does not support token duration over 5 years" });
+    }
+
     return callback(credentials);
   };
 

--- a/backend/src/ee/services/secret-rotation-v2/azure-client-secret/azure-client-secret-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/azure-client-secret/azure-client-secret-rotation-fns.ts
@@ -199,7 +199,8 @@ export const azureClientSecretRotationFactory: TRotationFactory<
   ) => {
     const credentials = await $rotateClientSecret();
 
-    if (rotationInterval > 365 * 5 - EXPIRY_PADDING_IN_DAYS) {
+    // 2.5 years as expiry is set to x2 interval for the inactive period of credential
+    if (rotationInterval > Math.floor(365 * 2.5) - EXPIRY_PADDING_IN_DAYS) {
       throw new BadRequestError({ message: "Azure does not support token duration over 5 years" });
     }
 


### PR DESCRIPTION
# Description 📣

This PR reduces the client secret expiry duration to two rotation intervals (padded 3 extra days) instead of 

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝