### PR TITLE
feat(helm): add support for imagePullSecrets

### DIFF
--- a/helm-charts/secrets-operator/templates/deployment.yaml
+++ b/helm-charts/secrets-operator/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "secrets-operator.fullname" . }}-controller-manager
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       tolerations: {{ toYaml .Values.controllerManager.tolerations | nindent 8 }}

--- a/helm-charts/secrets-operator/values.yaml
+++ b/helm-charts/secrets-operator/values.yaml
@@ -56,3 +56,4 @@ kubernetesClusterDomain: cluster.local
 scopedNamespace: ""
 scopedRBAC: false
 installCRDs: true
+imagePullSecrets: []


### PR DESCRIPTION
# Description 📣

While container images are publicly available, there are use cases where they might not be. For example for customers whitelisting only their private registry, registering authentication, to pull images and use pull through cache rules. This MR would add the support to define an `imagePullSecrets` if required.

## Type ✨

- [ x] Improvement

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
helm template secrets-operator helm-charts/secrets-operator --set 'imagePullSecrets[0].name=registry-secret' | grep imagePullSecrets -A 1

      imagePullSecrets:
        - name: registry-secret
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝