### PR TITLE
fix(external-migration/vault): fix vault parsing

### DIFF
--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -22,6 +22,7 @@ import { crypto } from "@app/lib/crypto";
 import { logger } from "@app/lib/logger";
 import { QueueWorkerProfile } from "@app/lib/types";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
+import { ExternalPlatforms } from "@app/services/external-migration/external-migration-types";
 import {
   TFailedIntegrationSyncEmailsPayload,
   TIntegrationSyncPayload,
@@ -228,6 +229,7 @@ export type TQueueJobTypes = {
     name: QueueJobs.ImportSecretsFromExternalSource;
     payload: {
       actorEmail: string;
+      importType: ExternalPlatforms;
       data: {
         iv: string;
         tag: string;

--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -17,25 +17,16 @@ type VaultData = {
 const vaultFactory = () => {
   const getMounts = async (request: AxiosInstance) => {
     const response = await request
-      .get<
-        Record<
-          string,
-          {
-            accessor: string;
-            options: {
-              version?: string;
-            } | null;
-            type: string;
-          }
-        >
-      >("/v1/sys/mounts")
+      .get<{
+        data: Record<string, { accessor: string; options: { version?: string } | null; type: string }>;
+      }>("/v1/sys/mounts")
       .catch((err) => {
         if (axios.isAxiosError(err)) {
           logger.error(err.response?.data, "External migration: Failed to get Vault mounts");
         }
         throw err;
       });
-    return response.data;
+    return response.data.data;
   };
 
   const getPaths = async (

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -6,7 +6,7 @@ import { BadRequestError, ForbiddenRequestError } from "@app/lib/errors";
 import { TUserDALFactory } from "../user/user-dal";
 import { decryptEnvKeyDataFn, importVaultDataFn, parseEnvKeyDataFn } from "./external-migration-fns";
 import { TExternalMigrationQueueFactory } from "./external-migration-queue";
-import { ImportType, TImportEnvKeyDataDTO, TImportVaultDataDTO } from "./external-migration-types";
+import { ExternalPlatforms, TImportEnvKeyDataDTO, TImportVaultDataDTO } from "./external-migration-types";
 
 type TExternalMigrationServiceFactoryDep = {
   permissionService: TPermissionServiceFactory;
@@ -60,8 +60,8 @@ export const externalMigrationServiceFactory = ({
 
     await externalMigrationQueue.startImport({
       actorEmail: user.email!,
+      importType: ExternalPlatforms.EnvKey,
       data: {
-        importType: ImportType.EnvKey,
         ...encrypted
       }
     });
@@ -110,8 +110,8 @@ export const externalMigrationServiceFactory = ({
 
     await externalMigrationQueue.startImport({
       actorEmail: user.email!,
+      importType: ExternalPlatforms.Vault,
       data: {
-        importType: ImportType.Vault,
         ...encrypted
       }
     });

--- a/backend/src/services/external-migration/external-migration-types.ts
+++ b/backend/src/services/external-migration/external-migration-types.ts
@@ -2,11 +2,6 @@ import { TOrgPermission } from "@app/lib/types";
 
 import { ActorAuthMethod, ActorType } from "../auth/auth-type";
 
-export enum ImportType {
-  EnvKey = "envkey",
-  Vault = "vault"
-}
-
 export enum VaultMappingType {
   Namespace = "namespace",
   KeyVault = "key-vault"
@@ -112,5 +107,6 @@ export type TEnvKeyExportJSON = {
 };
 
 export enum ExternalPlatforms {
-  EnvKey = "EnvKey"
+  EnvKey = "EnvKey",
+  Vault = "Vault"
 }


### PR DESCRIPTION
# Description 📣

This PR fixes the vault parsing. The mounts are returned in a `data` object, which the migration didn't factor in. This is tested for both Vault self-hosted and Vault dedicated. 

Additionally, I've also fixed the mailing inconsistency where users would receive migration email updates mentioning "EnvKey", even though they were doing a Vault migration. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->