### PR TITLE
improvements: adjust secret search padding when no clear icon and fix access approval reviewer tooltips display

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/SecretSearchInput.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/SecretSearchInput.tsx
@@ -52,8 +52,15 @@ export const SecretSearchInput = ({
                     if (activeIndex === 0 && e.key === "Enter") setIsOpen(true);
                   }}
                   autoComplete="off"
-                  className="input text-md h-[2.3rem] w-full rounded-md rounded-l-none bg-mineshaft-800 py-[0.375rem] pl-2.5 pr-8 text-gray-400 placeholder-mineshaft-50 placeholder-opacity-50 outline-none duration-200 placeholder:text-sm hover:ring-bunker-400/60 focus:bg-mineshaft-700/80 focus:ring-1 focus:ring-primary-400/50"
-                  placeholder="Search by secret, folder, tag or metadata..."
+                  className={twMerge(
+                    "input text-md h-[2.3rem] w-full rounded-md rounded-l-none bg-mineshaft-800 py-[0.375rem] pl-2.5 text-gray-400 placeholder-mineshaft-50 placeholder-opacity-50 outline-none duration-200 placeholder:text-sm hover:ring-bunker-400/60 focus:bg-mineshaft-700/80 focus:ring-1 focus:ring-primary-400/50",
+                    hasSearch ? "pr-8" : "pr-2.5"
+                  )}
+                  placeholder={
+                    isSingleEnv
+                      ? "Search by secret, folder, tag or metadata..."
+                      : "Search by secret or folder name..."
+                  }
                   value={value}
                   onChange={(e) => onChange(e.target.value)}
                 />

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -538,16 +538,20 @@ export const SecretApprovalRequestChanges = ({
                   className="flex flex-nowrap items-center justify-between space-x-2 rounded border border-mineshaft-600 bg-mineshaft-800 px-2 py-1"
                   key={`required-approver-${requiredApprover.userId}`}
                 >
-                  <div className="flex text-sm">
-                    <Tooltip
-                      content={`${requiredApprover.firstName || ""} ${
-                        requiredApprover.lastName || ""
-                      }`}
-                    >
-                      <span>{requiredApprover?.email}</span>
-                    </Tooltip>
-                    <span className="text-red">*</span>
-                  </div>
+                  <Tooltip
+                    content={
+                      requiredApprover.firstName
+                        ? `${requiredApprover.firstName || ""} ${requiredApprover.lastName || ""}`
+                        : undefined
+                    }
+                    position="left"
+                    sideOffset={10}
+                  >
+                    <div className="flex text-sm">
+                      <div>{requiredApprover?.email}</div>
+                      <span className="text-red">*</span>
+                    </div>
+                  </Tooltip>
                   <div>
                     {reviewer?.comment && (
                       <Tooltip className="max-w-lg break-words" content={reviewer.comment}>


### PR DESCRIPTION
# Description 📣

This PR adjusts the secret dashboard search bar padding when no clear icon is present and fixes access approval reviewer tooltips display

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝