### PR TITLE
improvement(frontend): make secret overview table header sticky, add underlines to env header links and limit table height for scroll

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -1207,13 +1207,16 @@ export const OverviewPage = () => {
           secretsToDeleteKeys={secretsToDeleteKeys}
           usedBySecretSyncs={usedBySecretSyncs}
         />
-        <div ref={tableRef} className="thin-scrollbar mt-4">
+        <div ref={tableRef} className="mt-4">
           <TableContainer
             onScroll={(e) => setScrollOffset(e.currentTarget.scrollLeft)}
-            className="thin-scrollbar rounded-b-none"
+            className="thin-scrollbar max-h-[66vh] overflow-y-auto rounded-b-none"
           >
             <Table>
-              <THead style={{ height: collapseEnvironments ? headerHeight : undefined }}>
+              <THead
+                className="sticky top-0 z-20"
+                style={{ height: collapseEnvironments ? headerHeight : undefined }}
+              >
                 <Tr
                   className="sticky top-0 z-20 border-0"
                   style={{ height: collapseEnvironments ? headerHeight : undefined }}
@@ -1370,7 +1373,7 @@ export const OverviewPage = () => {
                               })}
                               onClick={() => handleExploreEnvClick(slug)}
                             >
-                              <p className="truncate font-medium">{name}</p>
+                              <p className="truncate font-medium underline">{name}</p>
                             </button>
                             {!collapseEnvironments && missingKeyCount > 0 && (
                               <Tooltip


### PR DESCRIPTION
# Description 📣

This PR updates the secret overview table to have a sticky header, adds underlines to env col headers to make more clear they are links, and limits table height and adds scroll to ensure explore/headers are always visible

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝