### PR TITLE
fix: add react import to email button component

### DIFF
--- a/backend/src/services/smtp/emails/BaseButton.tsx
+++ b/backend/src/services/smtp/emails/BaseButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@react-email/components";
+import React from "react";
 
 type Props = {
   href: string;


### PR DESCRIPTION
# Description 📣

This PR fixes the email template base button not importing react

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝