### PR TITLE
Allow users to type the same original value on bulk commits and remove them if no changes are left

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -222,7 +222,7 @@ export const SecretItem = memo(
       }
 
       if (isDirty && !isSubmitting && !isAutoSavingRef.current) {
-        const debounceTime = 600;
+        const debounceTime = 200;
 
         autoSaveTimeoutRef.current = setTimeout(() => {
           autoSaveChanges(formValues);

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -343,31 +343,18 @@ export const SecretListView = ({
                 id: orgSecret.id,
                 type: PendingAction.Update,
                 secretKey: trueOriginalSecret.key,
-                ...(key !== trueOriginalSecret.key && { newSecretName: key }),
-                ...(value !== trueOriginalSecret.value && {
-                  originalValue: trueOriginalSecret.value,
-                  secretValue: value
-                }),
-                ...(comment !== trueOriginalSecret.comment && {
-                  originalComment: trueOriginalSecret.comment,
-                  secretComment: comment
-                }),
-                ...(modSecret.skipMultilineEncoding !==
-                  trueOriginalSecret.skipMultilineEncoding && {
-                  originalSkipMultilineEncoding: trueOriginalSecret.skipMultilineEncoding,
-                  skipMultilineEncoding: modSecret.skipMultilineEncoding
-                }),
-                ...(!isSameTags && {
-                  originalTags:
-                    trueOriginalSecret.tags?.map((tag) => ({ id: tag.id, slug: tag.slug })) || [],
-                  tags: tags?.map((tag) => ({ id: tag.id, slug: tag.name || tag.slug || "" })) || []
-                }),
-                ...(JSON.stringify(secretMetadata) !==
-                  JSON.stringify(trueOriginalSecret.secretMetadata) && {
-                  originalSecretMetadata: trueOriginalSecret.secretMetadata || [],
-                  secretMetadata: secretMetadata || []
-                }),
-
+                newSecretName: key,
+                originalValue: trueOriginalSecret.value,
+                secretValue: value,
+                originalComment: trueOriginalSecret.comment,
+                secretComment: comment,
+                originalSkipMultilineEncoding: trueOriginalSecret.skipMultilineEncoding,
+                skipMultilineEncoding: modSecret.skipMultilineEncoding,
+                originalTags:
+                  trueOriginalSecret.tags?.map((tag) => ({ id: tag.id, slug: tag.slug })) || [],
+                tags: tags?.map((tag) => ({ id: tag.id, slug: tag.name || tag.slug || "" })) || [],
+                originalSecretMetadata: trueOriginalSecret.secretMetadata || [],
+                secretMetadata: secretMetadata || [],
                 timestamp: Date.now(),
                 resourceType: "secret",
                 existingSecret: orgSecret


### PR DESCRIPTION
# Description 📣

Fix weird behavior when typing the original value on a pending change caused the change to not be valid and go back to the last edited value. Also reduced the row debounce time to 200ms

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->