### PR TITLE
FIX: SAN extension field in certificate issuance

### DIFF
--- a/backend/src/services/certificate-authority/certificate-authority-validators.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-validators.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { isValidIp } from "@app/lib/ip";
 import { isFQDN } from "@app/lib/validator/validate-url";
+import { TAltNameMapping, TAltNameType } from "@app/services/certificate/certificate-types";
 
 const isValidDate = (dateString: string) => {
   const date = new Date(dateString);
@@ -56,3 +57,19 @@ export const validateAltNamesField = z
       message: "Each alt name must be a valid hostname, email address, IP address or URL"
     }
   );
+
+export const validateAndMapAltNameType = (name: string): TAltNameMapping | null => {
+  if (isFQDN(name, { allow_wildcard: true, require_tld: false })) {
+    return { type: TAltNameType.DNS, value: name };
+  }
+  if (z.string().url().safeParse(name).success) {
+    return { type: TAltNameType.URL, value: name };
+  }
+  if (z.string().email().safeParse(name).success) {
+    return { type: TAltNameType.EMAIL, value: name };
+  }
+  if (isValidIp(name)) {
+    return { type: TAltNameType.IP, value: name };
+  }
+  return null;
+};

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-fns.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-bitwise */
 import * as x509 from "@peculiar/x509";
 import RE2 from "re2";
-import { z } from "zod";
 
 import { TCertificateTemplates, TPkiSubscribers } from "@app/db/schemas";
 import { TCertificateAuthorityCrlDALFactory } from "@app/ee/services/certificate-authority-crl/certificate-authority-crl-dal";
@@ -9,7 +8,6 @@ import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
-import { isFQDN } from "@app/lib/validator/validate-url";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
 import { TCertificateSecretDALFactory } from "@app/services/certificate/certificate-secret-dal";
@@ -17,7 +15,8 @@ import {
   CertExtendedKeyUsage,
   CertKeyAlgorithm,
   CertKeyUsage,
-  CertStatus
+  CertStatus,
+  TAltNameMapping
 } from "@app/services/certificate/certificate-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -34,6 +33,7 @@ import {
 } from "../certificate-authority-fns";
 import { TCertificateAuthoritySecretDALFactory } from "../certificate-authority-secret-dal";
 import { TIssueCertWithTemplateDTO } from "./internal-certificate-authority-types";
+import { validateAndMapAltNameType } from "../certificate-authority-validators";
 
 type TInternalCertificateAuthorityFnsDeps = {
   certificateAuthorityDAL: Pick<TCertificateAuthorityDALFactory, "findByIdWithAssociatedCa" | "findById">;
@@ -152,27 +152,15 @@ export const InternalCertificateAuthorityFns = ({
       extensions.push(extendedKeyUsagesExtension);
     }
 
-    let altNamesArray: { type: "email" | "dns" | "ip" | "url"; value: string }[] = [];
+    let altNamesArray: TAltNameMapping[] = [];
 
     if (subscriber.subjectAlternativeNames?.length) {
       altNamesArray = subscriber.subjectAlternativeNames.map((altName) => {
-        if (z.string().email().safeParse(altName).success) {
-          return { type: "email", value: altName };
+        const altNameType = validateAndMapAltNameType(altName);
+        if (!altNameType) {
+          throw new BadRequestError({ message: `Invalid SAN entry: ${altName}` });
         }
-
-        if (isFQDN(altName, { allow_wildcard: true, require_tld: false })) {
-          return { type: "dns", value: altName };
-        }
-
-        if (z.string().url().safeParse(altName).success) {
-          return { type: "url", value: altName };
-        }
-
-        if (z.string().ip().safeParse(altName).success) {
-          return { type: "ip", value: altName };
-        }
-
-        throw new BadRequestError({ message: `Invalid SAN entry: ${altName}` });
+        return altNameType;
       });
 
       const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
@@ -426,27 +414,15 @@ export const InternalCertificateAuthorityFns = ({
       );
     }
 
-    let altNamesArray: { type: "email" | "dns" | "ip" | "url"; value: string }[] = [];
+    let altNamesArray: TAltNameMapping[] = [];
 
     if (altNames) {
       altNamesArray = altNames.split(",").map((altName) => {
-        if (z.string().email().safeParse(altName).success) {
-          return { type: "email", value: altName };
+        const altNameType = validateAndMapAltNameType(altName);
+        if (!altNameType) {
+          throw new BadRequestError({ message: `Invalid SAN entry: ${altName}` });
         }
-
-        if (isFQDN(altName, { allow_wildcard: true, require_tld: false })) {
-          return { type: "dns", value: altName };
-        }
-
-        if (z.string().url().safeParse(altName).success) {
-          return { type: "url", value: altName };
-        }
-
-        if (z.string().ip().safeParse(altName).success) {
-          return { type: "ip", value: altName };
-        }
-
-        throw new BadRequestError({ message: `Invalid SAN entry: ${altName}` });
+        return altNameType;
       });
 
       const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -1365,7 +1365,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     }
 
     let altNamesArray: {
-      type: "email" | "dns";
+      type: "email" | "dns" | "url" | "ip";
       value: string;
     }[] = [];
 
@@ -1388,6 +1388,14 @@ export const internalCertificateAuthorityServiceFactory = ({
               type: "dns",
               value: altName
             };
+          }
+
+          if (z.string().url().safeParse(altName).success) {
+            return { type: "url", value: altName };
+          }
+
+          if (z.string().ip().safeParse(altName).success) {
+            return { type: "ip", value: altName };
           }
 
           // If altName is neither a valid email nor a valid hostname, throw an error or handle it accordingly
@@ -1767,7 +1775,7 @@ export const internalCertificateAuthorityServiceFactory = ({
 
     let altNamesFromCsr: string = "";
     let altNamesArray: {
-      type: "email" | "dns";
+      type: "email" | "dns" | "url" | "ip";
       value: string;
     }[] = [];
     if (altNames) {
@@ -1789,6 +1797,14 @@ export const internalCertificateAuthorityServiceFactory = ({
               type: "dns",
               value: altName
             };
+          }
+
+          if (z.string().url().safeParse(altName).success) {
+            return { type: "url", value: altName };
+          }
+
+          if (z.string().ip().safeParse(altName).success) {
+            return { type: "ip", value: altName };
           }
 
           // If altName is neither a valid email nor a valid hostname, throw an error or handle it accordingly

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -2,7 +2,6 @@
 import { ForbiddenError, subject } from "@casl/ability";
 import * as x509 from "@peculiar/x509";
 import slugify from "@sindresorhus/slugify";
-import { z } from "zod";
 
 import { ActionProjectType, TableName, TCertificateAuthorities, TCertificateTemplates } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -18,7 +17,6 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
-import { isFQDN } from "@app/lib/validator/validate-url";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -34,7 +32,8 @@ import {
   CertExtendedKeyUsageOIDToName,
   CertKeyAlgorithm,
   CertKeyUsage,
-  CertStatus
+  CertStatus,
+  TAltNameMapping
 } from "../../certificate/certificate-types";
 import { TCertificateTemplateDALFactory } from "../../certificate-template/certificate-template-dal";
 import { validateCertificateDetailsAgainstTemplate } from "../../certificate-template/certificate-template-fns";
@@ -69,6 +68,7 @@ import {
   TSignIntermediateDTO,
   TUpdateCaDTO
 } from "./internal-certificate-authority-types";
+import { validateAndMapAltNameType } from "../certificate-authority-validators";
 
 type TInternalCertificateAuthorityServiceFactoryDep = {
   certificateAuthorityDAL: Pick<
@@ -1364,42 +1364,18 @@ export const internalCertificateAuthorityServiceFactory = ({
       );
     }
 
-    let altNamesArray: {
-      type: "email" | "dns" | "url" | "ip";
-      value: string;
-    }[] = [];
+    let altNamesArray: TAltNameMapping[] = [];
 
     if (altNames) {
       altNamesArray = altNames
         .split(",")
         .map((name) => name.trim())
-        .map((altName) => {
-          // check if the altName is a valid email
-          if (z.string().email().safeParse(altName).success) {
-            return {
-              type: "email",
-              value: altName
-            };
+        .map((altName): TAltNameMapping => {
+          const altNameType = validateAndMapAltNameType(altName);
+          if (!altNameType) {
+            throw new Error(`Invalid altName: ${altName}`);
           }
-
-          // check if the altName is a valid hostname
-          if (isFQDN(altName, { allow_wildcard: true })) {
-            return {
-              type: "dns",
-              value: altName
-            };
-          }
-
-          if (z.string().url().safeParse(altName).success) {
-            return { type: "url", value: altName };
-          }
-
-          if (z.string().ip().safeParse(altName).success) {
-            return { type: "ip", value: altName };
-          }
-
-          // If altName is neither a valid email nor a valid hostname, throw an error or handle it accordingly
-          throw new Error(`Invalid altName: ${altName}`);
+          return altNameType;
         });
 
       const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
@@ -1774,42 +1750,22 @@ export const internalCertificateAuthorityServiceFactory = ({
     }
 
     let altNamesFromCsr: string = "";
-    let altNamesArray: {
-      type: "email" | "dns" | "url" | "ip";
-      value: string;
-    }[] = [];
+    let altNamesArray: TAltNameMapping[] = [];
+
     if (altNames) {
       altNamesArray = altNames
         .split(",")
         .map((name) => name.trim())
-        .map((altName) => {
-          // check if the altName is a valid email
-          if (z.string().email().safeParse(altName).success) {
-            return {
-              type: "email",
-              value: altName
-            };
+        .map((altName): TAltNameMapping => {
+          const altNameType = validateAndMapAltNameType(altName);
+          if (!altNameType) {
+            throw new Error(`Invalid altName: ${altName}`);
           }
-
-          // check if the altName is a valid hostname
-          if (isFQDN(altName, { allow_wildcard: true })) {
-            return {
-              type: "dns",
-              value: altName
-            };
-          }
-
-          if (z.string().url().safeParse(altName).success) {
-            return { type: "url", value: altName };
-          }
-
-          if (z.string().ip().safeParse(altName).success) {
-            return { type: "ip", value: altName };
-          }
-
-          // If altName is neither a valid email nor a valid hostname, throw an error or handle it accordingly
-          throw new Error(`Invalid altName: ${altName}`);
+          return altNameType;
         });
+
+      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
+      extensions.push(altNamesExtension);
     } else {
       // attempt to read from CSR if altNames is not explicitly provided
       const sanExtension = csrObj.extensions.find((ext) => ext.type === "2.5.29.17");
@@ -1817,11 +1773,16 @@ export const internalCertificateAuthorityServiceFactory = ({
         const sanNames = new x509.GeneralNames(sanExtension.value);
 
         altNamesArray = sanNames.items
-          .filter((value) => value.type === "email" || value.type === "dns")
-          .map((name) => ({
-            type: name.type as "email" | "dns",
-            value: name.value
-          }));
+          .filter(
+            (value) => value.type === "email" || value.type === "dns" || value.type === "url" || value.type === "ip"
+          )
+          .map((name): TAltNameMapping => {
+            const altNameType = validateAndMapAltNameType(name.value);
+            if (!altNameType) {
+              throw new Error(`Invalid altName from CSR: ${name.value}`);
+            }
+            return altNameType;
+          });
 
         altNamesFromCsr = sanNames.items.map((item) => item.value).join(",");
       }

--- a/backend/src/services/certificate/certificate-types.ts
+++ b/backend/src/services/certificate/certificate-types.ts
@@ -104,3 +104,14 @@ export type TGetCertificateCredentialsDTO = {
   projectDAL: Pick<TProjectDALFactory, "findOne" | "updateById" | "transaction">;
   kmsService: Pick<TKmsServiceFactory, "decryptWithKmsKey" | "generateKmsKey">;
 };
+
+export enum TAltNameType {
+  EMAIL = "email",
+  DNS = "dns",
+  IP = "ip",
+  URL = "url"
+}
+export type TAltNameMapping = {
+  type: TAltNameType;
+  value: string;
+};


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Fixed the SAN extension field value validation when creating a new certificate.
The SAN field now allows both IP addresses and non-TLD domains, as allowed by x509 specifications.
The exact issue is mentioned here: [https://github.com/Infisical/infisical/pull/4282#issuecomment-3154680591](https://github.com/Infisical/infisical/pull/4282#issuecomment-3154680591)

## Type ✨

- [X] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

[Screencast From 2025-08-05 20-11-55.webm](https://github.com/user-attachments/assets/0116b86d-e191-43a2-91d4-d2e4b08ffc1d)

---

- [X] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->