### PR TITLE
Fix version display padding in NavBar

### DIFF
--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -320,7 +320,7 @@ export const Navbar = () => {
             );
           })}
           {envConfig.PLATFORM_VERSION && (
-            <div className="mb-2 mt-2 w-full cursor-default pl-5 text-sm duration-200 hover:text-mineshaft-200">
+            <div className="mb-2 mt-2 w-full cursor-default px-5 text-sm duration-200 hover:text-mineshaft-200">
               <FontAwesomeIcon icon={faInfo} className="mr-4 px-[0.1rem]" />
               Version: {envConfig.PLATFORM_VERSION}
             </div>


### PR DESCRIPTION
# Description 📣

This PR increases the horizontal padding for the version display in Navbar.tsx. The change prevents long version strings from getting too close to the border, improving readability and UI consistency. No other logic or styling was modified.

Previous:
<img width="258" height="269" alt="Screenshot From 2025-08-08 12-20-25" src="https://github.com/user-attachments/assets/d633cec4-20e4-49df-8e05-5ea9fd2c2096" />

After:
<img width="321" height="263" alt="Screenshot From 2025-08-08 12-24-04" src="https://github.com/user-attachments/assets/ec3e0378-5b91-4ce5-8233-fd223b01f7cf" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->