### PR TITLE
feat: enable Lottie autoplay on hover in new project modal

### DIFF
--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -84,6 +84,7 @@ const PROJECT_TYPE_MENU_ITEMS = [
 ];
 
 const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
+  const [hovered, setHovered] = useState<string | null>(null);
   const navigate = useNavigate();
   const { currentOrg } = useOrganization();
   const { permission } = useOrgPermission();
@@ -209,8 +210,15 @@ const NewProjectForm = ({ onOpenChange }: NewProjectFormProps) => {
                         field.onChange(el.value);
                       }
                     }}
+                    onMouseEnter={() => setHovered(el.value)}
+                    onMouseLeave={() => setHovered(null)}
                   >
-                    <Lottie icon={getProjectLottieIcon(el.value)} className="h-8 w-8" />
+                    <Lottie
+                      key={`${hovered === el.value ? "playing" : "paused"}-${el.value}`}
+                      icon={getProjectLottieIcon(el.value)}
+                      className="h-8 w-8"
+                      isAutoPlay={hovered === el.value}
+                    />
                     <div className="text-center text-xs">{el.label}</div>
                   </div>
                 ))}

--- a/frontend/src/components/v2/Lottie/Lottie.tsx
+++ b/frontend/src/components/v2/Lottie/Lottie.tsx
@@ -14,19 +14,14 @@ export const Lottie = forwardRef<HTMLDivElement, LottieProps>(
   ({ children, icon, iconMode, isAutoPlay, ...props }, ref): JSX.Element => {
     const iconRef = useRef<DotLottie | null>(null);
     return (
-      <div
-        onMouseEnter={() => iconRef.current?.play()}
-        onMouseLeave={() => iconRef.current?.stop()}
-        {...props}
-        ref={ref}
-      >
+      <div {...props} ref={ref}>
         <DotLottieReact
           dotLottieRefCallback={(el) => {
             iconRef.current = el;
           }}
           mode={iconMode}
           src={`/lotties/${icon}.json`}
-          loop
+          loop={false}
           autoplay={isAutoPlay}
           className="h-full w-full"
         />


### PR DESCRIPTION
# Description 📣

Previously, hovering directly on the Lottie icon triggered its animation. With this update, hovering anywhere on the project type card now animates the Lottie icon, providing a more intuitive and interactive experience.

Before:

https://github.com/user-attachments/assets/106054cd-f324-4647-829f-22e9399688c6

After:

https://github.com/user-attachments/assets/b73b95f9-9f22-4760-b17b-c19844790a8a



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->