### PR TITLE
feat: oauth error resolved due to srp removal

### DIFF
--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -557,14 +557,13 @@ export const ldapConfigServiceFactory = ({
     });
 
     const isUserCompleted = Boolean(user.isAccepted);
-    const userEnc = await userDAL.findUserEncKeyByUserId(user.id);
 
     const providerAuthToken = crypto.jwt().sign(
       {
         authTokenType: AuthTokenType.PROVIDER_TOKEN,
         userId: user.id,
         username: user.username,
-        hasExchangedPrivateKey: Boolean(userEnc?.serverEncryptedPrivateKey),
+        hasExchangedPrivateKey: true,
         ...(user.email && { email: user.email, isEmailVerified: user.isEmailVerified }),
         firstName,
         lastName,

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -404,7 +404,6 @@ export const oidcConfigServiceFactory = ({
 
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
-    const userEnc = await userDAL.findUserEncKeyByUserId(user.id);
     const isUserCompleted = Boolean(user.isAccepted);
     const providerAuthToken = crypto.jwt().sign(
       {
@@ -417,7 +416,7 @@ export const oidcConfigServiceFactory = ({
         organizationName: organization.name,
         organizationId: organization.id,
         organizationSlug: organization.slug,
-        hasExchangedPrivateKey: Boolean(userEnc?.serverEncryptedPrivateKey),
+        hasExchangedPrivateKey: true,
         authMethod: AuthMethod.OIDC,
         authType: UserAliasType.OIDC,
         isUserCompleted,

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -411,7 +411,6 @@ export const samlConfigServiceFactory = ({
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
     const isUserCompleted = Boolean(user.isAccepted && user.isEmailVerified);
-    const userEnc = await userDAL.findUserEncKeyByUserId(user.id);
     const providerAuthToken = crypto.jwt().sign(
       {
         authTokenType: AuthTokenType.PROVIDER_TOKEN,
@@ -424,7 +423,7 @@ export const samlConfigServiceFactory = ({
         organizationId: organization.id,
         organizationSlug: organization.slug,
         authMethod: authProvider,
-        hasExchangedPrivateKey: Boolean(userEnc?.serverEncryptedPrivateKey),
+        hasExchangedPrivateKey: true,
         authType: UserAliasType.SAML,
         isUserCompleted,
         ...(relayState

--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -824,7 +824,6 @@ export const authLoginServiceFactory = ({
       }
     }
 
-    const userEnc = await userDAL.findUserEncKeyByUserId(user.id);
     const isUserCompleted = user.isAccepted;
     const providerAuthToken = crypto.jwt().sign(
       {
@@ -835,7 +834,7 @@ export const authLoginServiceFactory = ({
         isEmailVerified: user.isEmailVerified,
         firstName: user.firstName,
         lastName: user.lastName,
-        hasExchangedPrivateKey: Boolean(userEnc?.serverEncryptedPrivateKey),
+        hasExchangedPrivateKey: true,
         authMethod,
         isUserCompleted,
         ...(callbackPort
@@ -880,8 +879,7 @@ export const authLoginServiceFactory = ({
     const userEnc =
       usersByUsername?.length > 1 ? usersByUsername.find((el) => el.username === email) : usersByUsername?.[0];
 
-    if (!userEnc?.serverEncryptedPrivateKey)
-      throw new BadRequestError({ message: "Key handoff incomplete. Please try logging in again." });
+    if (!userEnc) throw new BadRequestError({ message: "User encryption not found" });
 
     const token = await generateUserTokens({
       user: { ...userEnc, id: userEnc.userId },


### PR DESCRIPTION
# Description 📣

This PR resolves a bug that is blocking new oauth users finishing login asking for master password.

The problem was server encrypted key is not saved any more as we are not using it, due to SRP removal. This made our old strategy of hand of key needed in oauth as true. Meaning master password requested

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->