### PR TITLE
feat: resolved audit log date issue in integration page

### DIFF
--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
@@ -40,12 +40,20 @@ export const LogsSection = withPermission(
     });
     const [timezone, setTimezone] = useState<Timezone>(Timezone.Local);
 
-    const [dateFilter, setDateFilter] = useState<TAuditLogDateFilterFormData>({
-      startDate: new Date(Number(new Date()) - ms("1h")),
-      endDate: new Date(),
-      type: AuditLogDateFilterType.Relative,
-      relativeModeValue: "1h"
-    });
+    const [dateFilter, setDateFilter] = useState<TAuditLogDateFilterFormData>(
+      presets?.endDate || presets?.startDate
+        ? {
+            type: AuditLogDateFilterType.Absolute,
+            startDate: presets?.startDate || new Date(Number(new Date()) - ms("1h")),
+            endDate: presets?.endDate || new Date()
+          }
+        : {
+            startDate: new Date(Number(new Date()) - ms("1h")),
+            endDate: new Date(),
+            type: AuditLogDateFilterType.Relative,
+            relativeModeValue: "1h"
+          }
+    );
 
     useEffect(() => {
       if (subscription && !subscription.auditLogs) {


### PR DESCRIPTION
# Description 📣

This PR fixes audit log in integration page date issue where it only shows audit log for 1 hour. This was because of missing preset of date in it


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->