### PR TITLE
fix(k8s-operator): duplicate helm labels

### DIFF
--- a/helm-charts/secrets-operator/templates/deployment.yaml
+++ b/helm-charts/secrets-operator/templates/deployment.yaml
@@ -9,13 +9,11 @@ spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: k8-operator
       control-plane: controller-manager
     {{- include "secrets-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: k8-operator
         control-plane: controller-manager
       {{- include "secrets-operator.selectorLabels" . | nindent 8 }}
       annotations:

--- a/helm-charts/secrets-operator/templates/metrics-service.yaml
+++ b/helm-charts/secrets-operator/templates/metrics-service.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   type: {{ .Values.metricsService.type }}
   selector:
-    app.kubernetes.io/name: k8-operator
     control-plane: controller-manager
   {{- include "secrets-operator.selectorLabels" . | nindent 4 }}
   ports:

--- a/k8-operator/config/default/metrics_service.yaml
+++ b/k8-operator/config/default/metrics_service.yaml
@@ -15,4 +15,3 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
-    app.kubernetes.io/name: k8-operator

--- a/k8-operator/config/manager/manager.yaml
+++ b/k8-operator/config/manager/manager.yaml
@@ -20,7 +20,6 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: k8-operator
   replicas: 1
   template:
     metadata:
@@ -28,7 +27,6 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        app.kubernetes.io/name: k8-operator
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.


### PR DESCRIPTION
# Description 📣

This PR fixes a recently introduced bug caused by the v4 kubebuilder upgrade, resulting in duplicate helm labels. This was not caught by testing because a regular helm installation / upgrade doesn't warn or error out about this, but other flows such as using kustomize will throw an error in such cases.

This patch will resolve https://github.com/Infisical/infisical/issues/4347

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->