### PR TITLE
Fix UI folder row issue with multiple onClick events triggered before the redirect occurs

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewFolderRow/SecretOverviewFolderRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewFolderRow/SecretOverviewFolderRow.tsx
@@ -29,11 +29,8 @@ export const SecretOverviewFolderRow = ({
     if (isClicking) return;
 
     setIsClicking(true);
-    try {
-      onClick(folderName);
-    } finally {
-      setTimeout(() => setIsClicking(false), 1000);
-    }
+    onClick(folderName);
+    setTimeout(() => setIsClicking(false), 1000);
   };
   return (
     <Tr isHoverable isSelectable className="group" onClick={handleClick}>


### PR DESCRIPTION
# Description 📣

Add a little await time when any user clicks on a folder row so we skip this weird behavior. Also not blocked it with just a state since if there is a network issue or any other problem we won't be blocking users from clicking it again

<img width="2098" height="1054" alt="image" src="https://github.com/user-attachments/assets/8d388364-5183-4709-833b-3ba06785c493" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->