### PR TITLE
Disable environments edit when a project has more environment than the allowed by the org plan

### DIFF
--- a/backend/src/services/project-env/project-env-service.ts
+++ b/backend/src/services/project-env/project-env-service.ts
@@ -177,6 +177,18 @@ export const projectEnvServiceFactory = ({
         }
       }
 
+      const envs = await projectEnvDAL.find({ projectId });
+      const project = await projectDAL.findById(projectId);
+      const plan = await licenseService.getPlan(project.orgId);
+      if (plan.environmentLimit !== null && envs.length > plan.environmentLimit) {
+        // case: limit imposed on number of environments allowed
+        // case: number of environments used exceeds the number of environments allowed
+        throw new BadRequestError({
+          message:
+            "Failed to update environment due to environment limit exceeded. To update an environment, please upgrade your plan or remove unused environments."
+        });
+      }
+
       const env = await projectEnvDAL.transaction(async (tx) => {
         if (position) {
           const existingEnvWithPosition = await projectEnvDAL.findOne({ projectId, position }, tx);

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/EnvironmentTable.tsx
@@ -75,7 +75,7 @@ export const EnvironmentTable = ({ handlePopUpOpen }: Props) => {
 
   const environmentsOverPlanLimit =
     subscription?.environmentLimit && currentWorkspace?.environments
-      ? currentWorkspace.environments.length - subscription.environmentLimit
+      ? Math.max(0, currentWorkspace.environments.length - subscription.environmentLimit)
       : 0;
 
   return (


### PR DESCRIPTION
# Description 📣

Block users from editing their project environments if they exceed the limit of their plan. Won't block or delete them but to in order to edit any of them, the max number of environments of the plan should be greater or equal to the number of envs on the project

<img width="2544" height="810" alt="CleanShot 2025-08-13 at 13 45 30@2x" src="https://github.com/user-attachments/assets/659a91ab-6005-4655-aeef-6207d44fdb45" />

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->