### PR TITLE
fix(aws-parameter-store-sync): handle keyschema with path segments for aws parameter store

### DIFF
--- a/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
@@ -38,6 +38,10 @@ const sleep = async () =>
 const getFullPath = ({ path, keySchema, environment }: { path: string; keySchema?: string; environment: string }) => {
   if (!keySchema || !keySchema.includes("/")) return path;
 
+  if (keySchema.startsWith("/")) {
+    throw new SecretSyncError({ message: `Key schema cannot contain leading '/'`, shouldRetry: false });
+  }
+
   const keySchemaSegments = handlebars
     .compile(keySchema)({
       environment,


### PR DESCRIPTION
# Description 📣

This PR updates the AWS parameter store sync to account for path segments present in the keySchema

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝