### PR TITLE
Bring Back Missing Secrets Documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -416,6 +416,9 @@
                 "pages": [
                   "documentation/platform/secrets-mgmt/project",
                   "documentation/platform/folder",
+                  "documentation/platform/secret-versioning",
+                  "documentation/platform/pit-recovery",
+                  "documentation/platform/secret-reference",
                   {
                     "group": "Secret Rotation",
                     "pages": [
@@ -459,7 +462,8 @@
                       "documentation/platform/dynamic-secrets/kubernetes",
                       "documentation/platform/dynamic-secrets/vertica"
                     ]
-                  }
+                  },
+                  "documentation/platform/webhooks"
                 ]
               },
               {

--- a/docs/documentation/platform/secrets-mgmt/concepts/secrets-delivery.mdx
+++ b/docs/documentation/platform/secrets-mgmt/concepts/secrets-delivery.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Delivering Secrets"
-description: "Learn how to get secrets out of Infisical and into the systems, applications, and environments that need them."
+title: "Fetching Secrets"
+description: "Learn how to deliver secrets from Infisical into the systems, applications, and environments that need them."
 ---
 
 Once secrets are stored and scoped in Infisical, the next step is delivering them securely to the systems and applications that need them.


### PR DESCRIPTION
# Description 📣

The multi-product documentation PR accidentally removed the documentation for secret versioning, PIT, webhooks, etc.

This PR brings these docs pages back into the sidebar for the Secrets Management product line.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->