### PR TITLE
fix(cli): failing tests

### DIFF
--- a/backend/src/server/routes/v1/auth-router.ts
+++ b/backend/src/server/routes/v1/auth-router.ts
@@ -67,7 +67,7 @@ export const registerAuthRoutes = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT], { requireOrg: false }),
     handler: () => ({ message: "Authenticated" as const })
   });
 


### PR DESCRIPTION
# Description 📣

The CLI tests are failing on `init`. This happens because when we call the `init` function, we are checking if the user is already logged in. If the user isn't logged in, we'll trigger the login flow. This is a new addition, and in the past it would just throw an error if you tried to do init without being logged in.

The core issue is that when you do interactive login, it doesn't ask you to select an organization. But when we check if the user is logged in during the `init` command, we call the `/checkAuth` endpoint. The `/checkAuth` endpoint will throw an error if no organization is set on the user's access token.

The fix is to allow the `/checkAuth` api call without having an organization selected.

**Why this worked in the past:**
In the past we used to force the user to select an organization during login (see screenshot attached), but in the latest versions we don't ask users to select an organization during interactive login. This means when you log in with interactive mode and then try to use `init`, the authentication check will fail because no organization is selected.

<img width="1210" height="372" alt="CleanShot 2025-08-18 at 10 19 29@2x" src="https://github.com/user-attachments/assets/102a7cd8-bfda-4033-8e5d-5d80791b4f2a" />


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->