### PR TITLE
Fix folder path UI issue breaking the page on many nested folders

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -1124,7 +1124,7 @@ export const OverviewPage = () => {
                       <FontAwesomeIcon icon={faAngleDown} />
                     </IconButton>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
+                  <DropdownMenuContent align="end" sideOffset={4}>
                     <div className="flex flex-col space-y-1 p-1.5">
                       <ProjectPermissionCan
                         I={ProjectPermissionActions.Create}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
@@ -31,7 +31,7 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
     path: string,
     index: number,
     arr: string[],
-    isIntermiditate: boolean
+    isIntermediate: boolean
   ) => {
     return (
       <div

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
@@ -31,7 +31,7 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
     path: string,
     index: number,
     arr: string[],
-    isIntermiditate: boolean
+    isIntermediate: boolean
   ) => {
     return (
       <div
@@ -48,11 +48,11 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
           position="top"
           className="max-w-sm p-2"
           content={path}
-          isDisabled={!(path.length > 40) || isIntermiditate}
+          isDisabled={!(path.length > 40) || isIntermediate}
         >
           <div>
-            {isIntermiditate ? path : path.substring(0, 40)}
-            {path.length > 40 && !isIntermiditate ? "..." : ""}
+            {isIntermediate ? path : path.substring(0, 40)}
+            {path.length > 40 && !isIntermediate ? "..." : ""}
           </div>
         </Tooltip>
       </div>
@@ -70,12 +70,12 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
   const lastFolders = folderPaths
     .slice(-2)
     .map((item) => getFolderPathArrowComponent(item.path, item.index, item.arr, false));
-  const intermidiateFolders = folderPaths.length > 2 ? folderPaths.slice(0, -2) : [];
-  const intermidiateFoldersComponent = (
+  const intermediateFolders = folderPaths.length > 2 ? folderPaths.slice(0, -2) : [];
+  const intermediateFoldersComponent = (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <div
-          key="secret-path-intermidiate"
+          key="secret-path-intermediate"
           className="breadcrumb relative z-20 cursor-pointer border-solid border-mineshaft-600 py-1 pl-5 pr-2 text-sm text-mineshaft-200"
           role="button"
           tabIndex={0}
@@ -92,7 +92,7 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
       >
         <div className="data-[highlighted]:bg-bunker-800">
           <div className="flex w-max flex-row gap-2 pr-3">
-            {intermidiateFolders.map((item) =>
+            {intermediateFolders.map((item) =>
               getFolderPathArrowComponent(item.path, item.index, item.arr, true)
             )}
           </div>
@@ -102,7 +102,7 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
   );
 
   const filteredFolders =
-    folderPaths.length > 2 ? [intermidiateFoldersComponent].concat(lastFolders) : lastFolders;
+    folderPaths.length > 2 ? [intermediateFoldersComponent].concat(lastFolders) : lastFolders;
 
   return (
     <div className="flex items-center space-x-2">

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadCrumbs/FolderBreadCrumbs.tsx
@@ -2,6 +2,13 @@ import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate } from "@tanstack/react-router";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  Tooltip
+} from "@app/components/v2";
+
 type Props = {
   secretPath: string;
   onResetSearch: (path: string) => void;
@@ -20,6 +27,83 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
     }).then(() => onResetSearch(newSecPath));
   };
 
+  const getFolderPathArrowComponent = (
+    path: string,
+    index: number,
+    arr: string[],
+    isIntermiditate: boolean
+  ) => {
+    return (
+      <div
+        key={`secret-path-${index + 1}`}
+        className={`breadcrumb relative z-20 ${
+          index + 1 === arr.length ? "cursor-default" : "cursor-pointer"
+        } border-solid border-mineshaft-600 py-1 pl-5 pr-2 text-sm text-mineshaft-200`}
+        onClick={() => onFolderCrumbClick(index + 1)}
+        onKeyDown={() => null}
+        role="button"
+        tabIndex={0}
+      >
+        <Tooltip
+          position="top"
+          className="max-w-sm p-2"
+          content={path}
+          isDisabled={!(path.length > 40) || isIntermiditate}
+        >
+          <div>
+            {isIntermiditate ? path : path.substring(0, 40)}
+            {path.length > 40 && !isIntermiditate ? "..." : ""}
+          </div>
+        </Tooltip>
+      </div>
+    );
+  };
+
+  const folderPaths = (secretPath || "")
+    .split("/")
+    .filter(Boolean)
+    .map((path, index, arr) => ({
+      path,
+      index,
+      arr
+    }));
+  const lastFolders = folderPaths
+    .slice(-2)
+    .map((item) => getFolderPathArrowComponent(item.path, item.index, item.arr, false));
+  const intermidiateFolders = folderPaths.length > 2 ? folderPaths.slice(0, -2) : [];
+  const intermidiateFoldersComponent = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div
+          key="secret-path-intermidiate"
+          className="breadcrumb relative z-20 cursor-pointer border-solid border-mineshaft-600 py-1 pl-5 pr-2 text-sm text-mineshaft-200"
+          role="button"
+          tabIndex={0}
+        >
+          ...
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="-ml-2 max-w-[100vh] overflow-x-auto p-2 pr-2 no-scrollbar"
+        side="bottom"
+        sideOffset={12}
+        align="start"
+        style={{ zIndex: 999 }}
+      >
+        <div className="data-[highlighted]:bg-bunker-800">
+          <div className="flex w-max flex-row gap-2 pr-3">
+            {intermidiateFolders.map((item) =>
+              getFolderPathArrowComponent(item.path, item.index, item.arr, true)
+            )}
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const filteredFolders =
+    folderPaths.length > 2 ? [intermidiateFoldersComponent].concat(lastFolders) : lastFolders;
+
   return (
     <div className="flex items-center space-x-2">
       <div
@@ -31,23 +115,7 @@ export const FolderBreadCrumbs = ({ secretPath = "/", onResetSearch }: Props) =>
       >
         <FontAwesomeIcon icon={faFolderOpen} className="text-primary-700" />
       </div>
-      {(secretPath || "")
-        .split("/")
-        .filter(Boolean)
-        .map((path, index, arr) => (
-          <div
-            key={`secret-path-${index + 1}`}
-            className={`breadcrumb relative z-20 ${
-              index + 1 === arr.length ? "cursor-default" : "cursor-pointer"
-            } border-solid border-mineshaft-600 py-1 pl-5 pr-2 text-sm text-mineshaft-200`}
-            onClick={() => onFolderCrumbClick(index + 1)}
-            onKeyDown={() => null}
-            role="button"
-            tabIndex={0}
-          >
-            {path}
-          </div>
-        ))}
+      {filteredFolders}
     </div>
   );
 };


### PR DESCRIPTION
# Description 📣

Fix on the secrets table UI, where many nested folders or really long folder names could break the UI entirely, now it will be displayed a bit more effectively showing up to 2 folders and using a dropdown to display the previous N folders

Before:
<img width="2544" height="1592" alt="CleanShot 2025-08-18 at 13 54 34@2x" src="https://github.com/user-attachments/assets/e073d324-0a95-4999-926c-b00667ad53a8" />

After:
<img width="2540" height="1044" alt="CleanShot 2025-08-18 at 13 54 31@2x" src="https://github.com/user-attachments/assets/86052e17-8d5e-4ffd-96a8-06c548537135" />



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->