### PR TITLE
fix(audit-logs): clear deleted audit logs on error to prevent infinite looping of audit log prune

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -179,6 +179,7 @@ export const auditLogDALFactory = (db: TDbClient) => {
           numberOfRetryOnFailure = 0; // reset
         } catch (error) {
           numberOfRetryOnFailure += 1;
+          deletedAuditLogIds = [];
           logger.error(error, "Failed to delete audit log on pruning");
         } finally {
           // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
# Description 📣

This PR fixes the audit log prune while loop exit logic to prevent infinite looping

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝