### PR TITLE
fix(secrets-service): throw on invalid env / path

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -22,26 +22,6 @@ const INTERPOLATION_TEST_REGEX = new RE2(INTERPOLATION_PATTERN_STRING);
 
 export const shouldUseSecretV2Bridge = (version: number) => version === 3;
 
-export const validateSecretPath = async (
-  data: {
-    projectId: string;
-    environment: string;
-    secretPath: string;
-  },
-  folderDAL: Pick<TSecretFolderDALFactory, "findBySecretPath">
-) => {
-  const { projectId, environment, secretPath } = data;
-
-  const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
-
-  if (!folder) {
-    throw new NotFoundError({
-      message: `Folder with path '${secretPath}' in environment '${environment}' was not found. Please ensure the environment slug and secret path is correct.`,
-      name: "SecretPathNotFound"
-    });
-  }
-};
-
 /**
  * Grabs and processes nested secret references from a string
  *


### PR DESCRIPTION
# Description 📣

This PR adds proper input validation on environment / secret path. Previously we would return an empty secrets / imports response if the environment or secret path was invalid. This is incorrect behavior, and it should throw an error when invalid input is detected. 

Below is a screenshot of `kubectl describe InfisicalSecret <crd-name>`, which now properly shows an error when an invalid environment or path is passed.


<img width="1664" height="524" alt="CleanShot 2025-08-26 at 19 54 46@2x" src="https://github.com/user-attachments/assets/33431fdd-3ee3-4ce5-ab05-6406dcab6be4" />

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->