### PR TITLE
improvement(fips): remove fips installation check

### DIFF
--- a/backend/src/lib/crypto/cryptography/crypto.ts
+++ b/backend/src/lib/crypto/cryptography/crypto.ts
@@ -150,28 +150,28 @@ const cryptographyFactory = () => {
 
     const serverCfg = await superAdminDAL.findById(ADMIN_CONFIG_DB_UUID).catch(() => null);
 
-    if (serverCfg?.fipsEnabled && !fipsEnabled) {
+    if (fipsEnabled) {
+      if (serverCfg?.fipsEnabled === false) {
+        throw new CryptographyError({
+          message:
+            "Your instance is configured for non-FIPS mode of operation, but you are attempting to run Infisical in FIPS mode."
+        });
+      }
+
+      logger.info("Cryptography module initialized in FIPS mode of operation.");
+      $setFipsModeEnabled(true, envCfg);
+      return true;
+    }
+
+    if (serverCfg?.fipsEnabled === true) {
       throw new CryptographyError({
         message:
           "Your instance is configured for FIPS mode of operation, but you are attempting to run Infisical in non-FIPS mode."
       });
     }
-    if (serverCfg?.fipsEnabled === false && fipsEnabled) {
-      throw new CryptographyError({
-        message:
-          "Your instance is configured for non-FIPS mode of operation, but you are attempting to run Infisical in FIPS mode."
-      });
-    }
-
-    if (!fipsEnabled) {
-      logger.info("Cryptography module initialized in normal operation mode.");
-      $setFipsModeEnabled(false, envCfg);
-      return false;
-    }
-
-    logger.info("Cryptography module initialized in FIPS mode of operation.");
-    $setFipsModeEnabled(true, envCfg);
-    return true;
+    logger.info("Cryptography module initialized in normal operation mode.");
+    $setFipsModeEnabled(false, envCfg);
+    return false;
   };
 
   const encryption = () => {


### PR DESCRIPTION
# Description 📣

This PR removes the FIPS installation check. Previously we were checking if instances were created on the `infisical-fips` image _before_ Fips Inside was added. This check is now removed, and we assume that all users using the `infisical-fips` image are using FIPS Inside mode.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->