### PR TITLE
Fix broken SDK link in docs

### DIFF
--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -10,7 +10,7 @@ should approach the development and contribution process.
 Infisical has two major code-bases. One for the platform code, and one for SDKs. The contribution process has some key differences between the two, so we've split the documentation into two sections:
 
 - The [Infisical Platform](https://github.com/Infisical/infisical), the Infisical platform itself.
-- The [Infisical SDK](https://github.com/Infisical/sdk), the official Infisical client SDKs.
+- The [Infisical SDK](https://infisical.com/docs/sdks/overview), the official Infisical client SDKs.
 
 
 <CardGroup cols={2}>


### PR DESCRIPTION
# Description 📣
The previous link for the SDK was broken.
I’ve updated it to point to the SDK Overview page, which is stable and gives a clear entry point for developers.

If we prefer, I can instead make the link redirect directly to the relevant GitHub repositories — let me know your preference and I’ll adjust.

## Type ✨

- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

