### PR TITLE
Fix :  incorrect toast message when removing last org user

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -136,8 +136,8 @@ export const OrgMembersSection = () => {
       });
 
       createNotification({
-        text: "Successfully removed users from organization",
-        type: "success"
+        text: selectedMembers.length === 1 && members.length === 1 ? "At least one member must remain in the organization" : "Successfully removed users from organization",
+        type: selectedMembers.length === 1 && members.length === 1 ? "error" : "success"
       });
 
       setSelectedMemberIds([]);


### PR DESCRIPTION
# Description 📣
Fix the incorrect toast message shown when attempting to remove the only member from an organization.
Previously, even though removal was blocked (as expected), the toast displayed: `Successfully removed users from organization.`
This PR updates the notification logic to display a clear error message instead: `At least one member must remain in the organization.`

## Type ✨
- [x] Improvement


**Before**
Trying to remove the last member shows:
`Successfully removed users from organization` (incorrect).

**After**
Trying to remove the last member shows:
`At least one member must remain in the organization` (correct).

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->