### PR TITLE
improvement(secret-syncs): update secret sync lock to use connection ID to enforce sequential processing to avoid concurrent syncs

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -37,7 +37,7 @@ export const KeyStorePrefixes = {
     `sync-integration-mutex-${projectId}-${environmentSlug}-${secretPath}` as const,
   SyncSecretIntegrationLastRunTimestamp: (projectId: string, environmentSlug: string, secretPath: string) =>
     `sync-integration-last-run-${projectId}-${environmentSlug}-${secretPath}` as const,
-  SecretSyncLock: (syncId: string) => `secret-sync-mutex-${syncId}` as const,
+  SecretSyncLock: (connectionId: string) => `secret-sync-mutex-${connectionId}` as const,
   SecretRotationLock: (rotationId: string) => `secret-rotation-v2-mutex-${rotationId}` as const,
   SecretScanningLock: (dataSourceId: string, resourceExternalId: string) =>
     `secret-scanning-v2-mutex-${dataSourceId}-${resourceExternalId}` as const,

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -465,10 +465,14 @@ export const secretSyncServiceFactory = ({
           message: `Invalid source configuration: folder no longer exists. Please configure a valid source and try again.`
         });
 
-      const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(syncId)));
+      const isSyncJobRunning = Boolean(
+        await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(secretSync.connectionId))
+      );
 
       if (isSyncJobRunning)
-        throw new BadRequestError({ message: `A job for this sync is already in progress. Please try again shortly.` });
+        throw new BadRequestError({
+          message: `A job using this app connection is already in progress. Please try again shortly.`
+        });
 
       await secretSyncQueue.queueSecretSyncRemoveSecretsById({ syncId, deleteSyncOnComplete: true });
 
@@ -536,10 +540,12 @@ export const secretSyncServiceFactory = ({
         message: `Invalid source configuration: folder no longer exists. Please configure a valid source and try again.`
       });
 
-    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(syncId)));
+    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(secretSync.connectionId)));
 
     if (isSyncJobRunning)
-      throw new BadRequestError({ message: `A job for this sync is already in progress. Please try again shortly.` });
+      throw new BadRequestError({
+        message: `A job using this app connection is already in progress. Please try again shortly.`
+      });
 
     await secretSyncQueue.queueSecretSyncSyncSecretsById({ syncId, ...params });
 
@@ -608,10 +614,12 @@ export const secretSyncServiceFactory = ({
         message: `Invalid source configuration: folder no longer exists. Please configure a valid source and try again.`
       });
 
-    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(syncId)));
+    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(secretSync.connectionId)));
 
     if (isSyncJobRunning)
-      throw new BadRequestError({ message: `A job for this sync is already in progress. Please try again shortly.` });
+      throw new BadRequestError({
+        message: `A job using this app connection is already in progress. Please try again shortly.`
+      });
 
     await secretSyncQueue.queueSecretSyncImportSecretsById({ syncId, ...params });
 
@@ -674,10 +682,12 @@ export const secretSyncServiceFactory = ({
         message: `Invalid source configuration: folder no longer exists. Please configure a valid source and try again.`
       });
 
-    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(syncId)));
+    const isSyncJobRunning = Boolean(await keyStore.getItem(KeyStorePrefixes.SecretSyncLock(secretSync.connectionId)));
 
     if (isSyncJobRunning)
-      throw new BadRequestError({ message: `A job for this sync is already in progress. Please try again shortly.` });
+      throw new BadRequestError({
+        message: `A job using this app connection is already in progress. Please try again shortly.`
+      });
 
     await secretSyncQueue.queueSecretSyncRemoveSecretsById({ syncId, ...params });
 

--- a/frontend/src/components/secret-syncs/SecretSyncStatusBadge.tsx
+++ b/frontend/src/components/secret-syncs/SecretSyncStatusBadge.tsx
@@ -1,6 +1,7 @@
 import {
   faCheck,
   faExclamationTriangle,
+  faHourglass,
   faRotate,
   IconDefinition
 } from "@fortawesome/free-solid-svg-icons";
@@ -29,7 +30,11 @@ export const SecretSyncStatusBadge = ({ status }: Props) => {
       text = "Synced";
       icon = faCheck;
       break;
-    case SecretSyncStatus.Pending: // no need to differentiate from user perspective
+    case SecretSyncStatus.Pending:
+      variant = "primary";
+      text = "Queued";
+      icon = faHourglass;
+      break;
     case SecretSyncStatus.Running:
     default:
       variant = "primary";
@@ -42,11 +47,7 @@ export const SecretSyncStatusBadge = ({ status }: Props) => {
     <Badge className="flex h-5 w-min items-center gap-1.5 whitespace-nowrap" variant={variant}>
       <FontAwesomeIcon
         icon={icon}
-        className={
-          [SecretSyncStatus.Pending, SecretSyncStatus.Running].includes(status)
-            ? "animate-spin"
-            : ""
-        }
+        className={[SecretSyncStatus.Running].includes(status) ? "animate-spin" : ""}
       />
       <span>{text}</span>
     </Badge>


### PR DESCRIPTION
# Description 📣

This PR updates the secret sync job lock to use the connection ID instead to prevent concurrent syncs using the same connection to prevent compounding rate limiting. Refactors queue/service code accordingly and updates badge to display pending status in UI

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝