### PR TITLE
Fix Google SSO issue with SAML configs when SSO is enforced and not SAML

### DIFF
--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
@@ -88,28 +88,23 @@ export const SelectOrganizationSection = () => {
         // org has an org-level auth method enabled (e.g. SAML)
         // -> logout + redirect to SAML SSO
         let url = "";
-        if (organization.orgAuthMethod === AuthMethod.OIDC) {
+        if (organization.googleSsoAuthEnforced) {
+          if (authToken.authMethod !== AuthMethod.GOOGLE) {
+            url = `/api/v1/sso/redirect/google?org_slug=${organization.slug}`;
+
+            if (callbackPort) {
+              url += `&callback_port=${callbackPort}`;
+            }
+          }
+        } else if (organization.orgAuthMethod === AuthMethod.OIDC) {
           url = `/api/v1/sso/oidc/login?orgSlug=${organization.slug}${
             callbackPort ? `&callbackPort=${callbackPort}` : ""
           }`;
-        } else if (
-          organization.orgAuthMethod === AuthMethod.SAML &&
-          // if google sso is enforced, we don't want to redirect to saml
-          !organization.googleSsoAuthEnforced
-        ) {
+        } else if (organization.orgAuthMethod === AuthMethod.SAML) {
           url = `/api/v1/sso/redirect/saml2/organizations/${organization.slug}`;
 
           if (callbackPort) {
             url += `?callback_port=${callbackPort}`;
-          }
-        } else if (
-          organization.googleSsoAuthEnforced &&
-          authToken.authMethod !== AuthMethod.GOOGLE
-        ) {
-          url = `/api/v1/sso/redirect/google?org_slug=${organization.slug}`;
-
-          if (callbackPort) {
-            url += `&callback_port=${callbackPort}`;
           }
         }
 

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
@@ -92,7 +92,11 @@ export const SelectOrganizationSection = () => {
           url = `/api/v1/sso/oidc/login?orgSlug=${organization.slug}${
             callbackPort ? `&callbackPort=${callbackPort}` : ""
           }`;
-        } else if (organization.orgAuthMethod === AuthMethod.SAML) {
+        } else if (
+          organization.orgAuthMethod === AuthMethod.SAML &&
+          // if google sso is enforced, we don't want to redirect to saml
+          !organization.googleSsoAuthEnforced
+        ) {
           url = `/api/v1/sso/redirect/saml2/organizations/${organization.slug}`;
 
           if (callbackPort) {

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
@@ -204,9 +204,10 @@ export const OrgGeneralAuthSection = ({
             </OrgPermissionCan>
           </div>
           <p className="text-sm text-mineshaft-300">
-            Enforce users to authenticate via Google to access this organization.
+            Enforce users to authenticate via Google OAuth SSO to access this organization.
             <br />
-            When this is enabled your organization members will only be able to login with Google.
+            When this is enabled your organization members will only be able to login with Google
+            OAuth (not Google SAML).
           </p>
         </div>
       </div>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
@@ -207,7 +207,7 @@ export const OrgGeneralAuthSection = ({
             Enforce users to authenticate via Google OAuth SSO to access this organization.
             <br />
             When this is enabled your organization members will only be able to login with Google
-            OAuth (not Google SAML).
+            SSO (not Google SAML).
           </p>
         </div>
       </div>


### PR DESCRIPTION
# Description 📣

Fix for endless loop of login when Google SSO enforcement is active but there is a Google SAML config in place 

The user goes to Infinity like this: 
1. Sets up Google SAML.
2. Enables Google SSO enforcement
3. Logs in via Google SSO
4. Selects the organization, redirects for SAML SSO
5. Now comes back to the main page - trigger google SSO enforcement
6. Kicks back - repeat

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->