### PR TITLE
improvement(pro-trial): sync org identity seat count prior to starting trial as fallback for correct count

### DIFF
--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -323,6 +323,8 @@ export const licenseServiceFactory = ({
       });
     }
 
+    await updateSubscriptionOrgMemberCount(orgId);
+
     const {
       data: { url }
     } = await licenseServerCloudApi.request.post(


### PR DESCRIPTION
# Description 📣

This PR adds an update license org identity seat count prior to starting the pro trial as a fallback

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝