### PR TITLE
Optimize re-render issue on secrets page

### DIFF
--- a/frontend/src/hooks/api/migration/queries.tsx
+++ b/frontend/src/hooks/api/migration/queries.tsx
@@ -1,5 +1,7 @@
-import { apiRequest } from "@app/config/request";
 import { useQuery } from "@tanstack/react-query";
+
+import { apiRequest } from "@app/config/request";
+
 import { ExternalMigrationProviders } from "./types";
 
 const externalMigrationQueryKeys = {

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
@@ -15,8 +15,8 @@ import {
   OrgPermissionSubjects
 } from "@app/context/OrgPermissionContext/types";
 import { gatewaysQueryKeys } from "@app/hooks/api";
-import { useImportVault } from "@app/hooks/api/migration/mutations";
 import { useHasCustomMigrationAvailable } from "@app/hooks/api/migration";
+import { useImportVault } from "@app/hooks/api/migration/mutations";
 import { ExternalMigrationProviders } from "@app/hooks/api/migration/types";
 
 type Props = {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -75,7 +75,7 @@ type Props = {
   onCreateTag: () => void;
   environment: string;
   secretPath: string;
-  handleSecretShare: () => void;
+  onShareSecret: (sec: SecretV3RawSanitized) => void;
   importedBy?: {
     environment: { name: string; slug: string };
     folders: {
@@ -102,7 +102,7 @@ export const SecretItem = memo(
     onToggleSecretSelect,
     environment,
     secretPath,
-    handleSecretShare,
+    onShareSecret,
     importedBy,
     isPending,
     pendingAction,
@@ -682,7 +682,7 @@ export const SecretItem = memo(
                       variant="plain"
                       size="md"
                       ariaLabel="share-secret"
-                      onClick={handleSecretShare}
+                      onClick={() => onShareSecret(secret)}
                     >
                       <Tooltip content="Share Secret">
                         <FontAwesomeSymbol


### PR DESCRIPTION
Optimize re-render issue on secrets page.

Updating a single secret value causes them all to be re-rendered, which adds lag to the UI.

This change reduced total re-render time from 800ms+ to ~40ms