### PR TITLE
fix(sso): SSO login plan seat limit check correction

### DIFF
--- a/backend/src/ee/routes/v2/index.ts
+++ b/backend/src/ee/routes/v2/index.ts
@@ -7,9 +7,9 @@ import {
   SECRET_SCANNING_REGISTER_ROUTER_MAP
 } from "@app/ee/routes/v2/secret-scanning-v2-routers";
 
+import { registerGatewayV2Router } from "./gateway-router";
 import { registerIdentityProjectAdditionalPrivilegeRouter } from "./identity-project-additional-privilege-router";
 import { registerProjectRoleRouter } from "./project-role-router";
-import { registerGatewayV2Router } from "./gateway-router";
 
 export const registerV2EERoutes = async (server: FastifyZodProvider) => {
   // org role starts with organization

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -1,6 +1,6 @@
 import handlebars from "handlebars";
-import RE2 from "re2";
 import knex from "knex";
+import RE2 from "re2";
 import { z } from "zod";
 
 import { crypto } from "@app/lib/crypto/cryptography";

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -1,8 +1,11 @@
 import axios, { AxiosError } from "axios";
 
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
+import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TFeatureSet } from "./license-types";
 
@@ -132,4 +135,19 @@ export const setupLicenseRequestWithStore = (
   );
 
   return { request: licenseReq, refreshLicense };
+};
+
+export const throwOnPlanSeatLimitReached = async (
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">,
+  orgId: string,
+  type?: UserAliasType
+) => {
+  const plan = await licenseService.getPlan(orgId);
+
+  if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
+    // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
+    throw new BadRequestError({
+      message: `Failed to create new member${type ? ` via ${type.toUpperCase()}` : ""} due to member limit reached. Upgrade plan to add more members.`
+    });
+  }
 };

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -8,6 +8,7 @@ import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/a
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import { addUsersToGroupByUserIds, removeUsersFromGroupByUserIds } from "@app/ee/services/group/group-fns";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
+import { throwOnPlanSeatLimitReached } from "@app/ee/services/license/license-fns";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -294,14 +295,7 @@ export const oidcConfigServiceFactory = ({
         );
 
         if (!orgMembership) {
-          const plan = await licenseService.getPlan(orgId);
-          if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
-            // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
-            throw new BadRequestError({
-              message:
-                "Failed to create new member via OIDC due to member limit reached. Upgrade plan to add more members."
-            });
-          }
+          await throwOnPlanSeatLimitReached(licenseService, orgId, UserAliasType.OIDC);
 
           const { role, roleId } = await getDefaultOrgMembershipRole(organization.defaultMembershipRole);
 


### PR DESCRIPTION
# Description 📣

This PR corrects where plan identity limits are checked during sso login to prevent throwing limit error on users that already have a membership for email login and adds the check to OIDC

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝