### PR TITLE
Enable email login on change of emails flows to avoid blocked users

### DIFF
--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -294,11 +294,18 @@ export const userServiceFactory = ({
       // Delete all user aliases since the email is changing
       await userAliasDAL.delete({ userId }, tx);
 
+      // Ensure EMAIL auth method is included if not already present
+      const currentAuthMethods = user.authMethods || [];
+      const updatedAuthMethods = currentAuthMethods.includes(AuthMethod.EMAIL)
+        ? currentAuthMethods
+        : [...currentAuthMethods, AuthMethod.EMAIL];
+
       const updatedUser = await userDAL.updateById(
         userId,
         {
           email: newEmail.toLowerCase(),
-          username: newEmail.toLowerCase()
+          username: newEmail.toLowerCase(),
+          authMethods: updatedAuthMethods
         },
         tx
       );

--- a/docs/documentation/platform/auth-methods/email-password.mdx
+++ b/docs/documentation/platform/auth-methods/email-password.mdx
@@ -30,7 +30,7 @@ You can update your account email address:
 2. Navigate to the `Authentication` tab.
 3. In the `Change Email` section, enter your new email address.
 <Info>
-If you don't currently have Email authentication enabled, it will be automatically activated when you change your email. You can change this back in your authentication settings after logging in with your new email if desired.
+If you don't currently have Email authentication enabled, it will be automatically activated when you change your email. You may disable it in the authentication settings after logging in with your new email if needed.
 </Info>
 ![change email section](../../../images/auth-methods/personal-settings-authentication-change-email-password.png)
 4. Click `Send Verification Code` to receive an 6-digit verification code at your new email address.

--- a/docs/documentation/platform/auth-methods/email-password.mdx
+++ b/docs/documentation/platform/auth-methods/email-password.mdx
@@ -29,6 +29,9 @@ You can update your account email address:
 1. Open the `Personal Settings` menu.
 2. Navigate to the `Authentication` tab.
 3. In the `Change Email` section, enter your new email address.
+<Info>
+If you don't currently have Email authentication enabled, it will be automatically activated when you change your email. You can change this back in your authentication settings after logging in with your new email if desired.
+</Info>
 ![change email section](../../../images/auth-methods/personal-settings-authentication-change-email-password.png)
 4. Click `Send Verification Code` to receive an 6-digit verification code at your new email address.
 5. Check your new email inbox and enter the verification code.

--- a/frontend/src/pages/user/PersonalSettingsPage/components/ChangeEmailSection/ChangeEmailSection.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/ChangeEmailSection/ChangeEmailSection.tsx
@@ -10,6 +10,7 @@ import { Button, FormControl, Input, Modal, ModalContent } from "@app/components
 import { useUser } from "@app/context";
 import { useRequestEmailChangeOTP, useUpdateUserEmail } from "@app/hooks/api/users";
 import { clearSession } from "@app/hooks/api/users/queries";
+import { AuthMethod } from "@app/hooks/api/users/types";
 
 const emailSchema = z
   .object({
@@ -43,6 +44,7 @@ const otpInputProps = {
 export const ChangeEmailSection = () => {
   const navigate = useNavigate();
   const { user } = useUser();
+  const hasEmailAuth = user?.authMethods?.includes(AuthMethod.EMAIL) ?? false;
   const [isOTPModalOpen, setIsOTPModalOpen] = useState(false);
   const [pendingEmail, setPendingEmail] = useState("");
 
@@ -177,6 +179,11 @@ export const ChangeEmailSection = () => {
                   label="New email address"
                   isError={Boolean(error)}
                   errorText={error?.message}
+                  tooltipText={
+                    hasEmailAuth
+                      ? "Your email authentication method is currently enabled and will remain active after changing your email."
+                      : "Email authentication method will be automatically enabled after changing your email. You can change this back after logging in with your new email if desired."
+                  }
                 >
                   <Input
                     {...field}

--- a/frontend/src/pages/user/PersonalSettingsPage/components/ChangeEmailSection/ChangeEmailSection.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/ChangeEmailSection/ChangeEmailSection.tsx
@@ -182,7 +182,7 @@ export const ChangeEmailSection = () => {
                   tooltipText={
                     hasEmailAuth
                       ? "Your email authentication method is currently enabled and will remain active after changing your email."
-                      : "Email authentication method will be automatically enabled after changing your email. You can change this back after logging in with your new email if desired."
+                      : "Email authentication method will be automatically enabled after changing your email. You may disable email authentication after logging in with your new email if needed."
                   }
                 >
                   <Input


### PR DESCRIPTION
# Description 📣

This update ensures users aren’t blocked when changing their email addresses. By default, the EMAIL login flow will now be enabled, so if SSO/SAML is misconfigured or unavailable, users can still access their accounts via email. Admins can later revert to SSO/SAML if needed.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->