### PR TITLE
fix(secret-dashboard): add project slug param for moving secrets on dashboard overview and environment view

### DIFF
--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -337,7 +337,7 @@ export const useMoveSecrets = ({
       destinationSecretPath,
       secretIds,
       shouldOverwrite,
-      projectId
+      projectSlug
     }) => {
       const { data } = await apiRequest.post<{
         isSourceUpdated: boolean;
@@ -349,7 +349,7 @@ export const useMoveSecrets = ({
         destinationSecretPath,
         secretIds,
         shouldOverwrite,
-        projectId
+        projectSlug
       });
 
       return data;

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -228,6 +228,7 @@ export type TDeleteSecretBatchDTO = {
 
 export type TMoveSecretsDTO = {
   projectId: string;
+  projectSlug: string;
   sourceEnvironment: string;
   sourceSecretPath: string;
   destinationEnvironment: string;

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/MoveSecretsDialog/MoveSecretsDialog.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/MoveSecretsDialog/MoveSecretsDialog.tsx
@@ -66,6 +66,7 @@ const Content = ({
   secrets,
   environments,
   projectId,
+  projectSlug,
   sourceSecretPath
 }: ContentProps) => {
   const [search, setSearch] = useState(sourceSecretPath);
@@ -194,6 +195,7 @@ const Content = ({
           destinationEnvironment: environment.slug,
           destinationSecretPath: value.secretPath,
           projectId,
+          projectSlug,
           secretIds: secretsToMove.map((sec) => sec.id)
         });
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -72,10 +72,7 @@ import {
   useMoveSecrets,
   useUpdateSecretBatch
 } from "@app/hooks/api";
-import {
-  dashboardKeys,
-  fetchDashboardProjectSecretsByKeys
-} from "@app/hooks/api/dashboard/queries";
+import { dashboardKeys, fetchDashboardProjectSecretsByKeys } from "@app/hooks/api/dashboard/queries";
 import { UsedBySecretSyncs } from "@app/hooks/api/dashboard/types";
 import { secretApprovalRequestKeys } from "@app/hooks/api/secretApprovalRequest/queries";
 import { PendingAction } from "@app/hooks/api/secretFolders/types";
@@ -349,6 +346,7 @@ export const ActionBar = ({
         destinationEnvironment,
         destinationSecretPath,
         projectId,
+        projectSlug: currentProject.slug,
         secretIds: secretsToMove.map((sec) => sec.id)
       });
 


### PR DESCRIPTION
# Description 📣

This PR fixes the move secret mutation to use projectSlug instead of project ID for the secret overview and environment view dashboards

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝