### PR TITLE
feat: resolved secret move failing

### DIFF
--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -762,7 +762,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
       hide: false,
       tags: [ApiDocsTags.Secrets],
       body: z.object({
-        projectSlug: z.string().trim(),
+        projectId: z.string().trim(),
         sourceEnvironment: z.string().trim(),
         sourceSecretPath: z.string().trim().default("/").transform(removeTrailingSlash),
         destinationEnvironment: z.string().trim(),


### PR DESCRIPTION
# Description 📣

This PR fixes secret move failing due to recent workspace id removal revamp happened. The service would accept both slug and id, but the. router expected slug only which should have been project id. The frontend was passing id only

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->