### PR TITLE
docs(k8s-operator): `secretName` field for fetching a single secret

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
@@ -146,6 +146,7 @@ spec:
               projectSlug: <project-slug> # <-- project slug
               projectId: <project-id> # <-- project id
 
+              secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
               envSlug: <env-slug> # "dev", "staging", "prod", etc..
               secretsPath: "<secrets-path>" # Root is "/"
           credentialsRef:
@@ -331,6 +332,7 @@ spec:
                   projectSlug: your-project-slug
                   envSlug: prod
                   secretsPath: "/path"
+                  secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
                   recursive: true
       ...
     ```
@@ -526,6 +528,7 @@ spec:
                   projectSlug: your-project-slug
                   envSlug: prod
                   secretsPath: "/path"
+                  secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
                   recursive: true
       ...
     ```
@@ -574,6 +577,7 @@ spec:
               projectSlug: your-project-slug
               envSlug: prod
               secretsPath: "/path"
+              secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
               recursive: true
   ...
 ```
@@ -619,6 +623,7 @@ spec:
               projectSlug: your-project-slug
               envSlug: prod
               secretsPath: "/path"
+              secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
               recursive: true
   ...
 ```
@@ -664,6 +669,7 @@ spec:
               projectSlug: your-project-slug
               envSlug: prod
               secretsPath: "/path"
+              secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
               recursive: true
   ...
 ```
@@ -711,6 +717,7 @@ spec:
               projectSlug: your-project-slug
               envSlug: prod
               secretsPath: "/path"
+              secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
               recursive: true
   ...
 ```
@@ -764,6 +771,7 @@ spec:
         projectSlug: <project-slug> # <-- project slug
         envSlug: <env-slug> # "dev", "staging", "prod", etc..
         secretsPath: "<secrets-path>" # Root is "/"
+        secretName: <secret-name> # OPTIONAL: If you want to fetch a single Infisical secret, you can specify the secret name here. If not specified, all secrets in the specified scope will be fetched.
       identityId: <machine-identity-id>
       credentialsRef:
         secretName: ldap-auth-credentials # <-- name of the Kubernetes secret that stores our machine identity credentials


### PR DESCRIPTION
# Description 📣

Documentation for the new `secretName` field for fetching a single secret using the InfisicalSecret CRD without using templates.

PR: https://github.com/Infisical/kubernetes-operator/pull/10

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->