### PR TITLE
fix: increased service name size to 1000

### DIFF
--- a/backend/src/db/migrations/20250921120821_k8-auth-name-increase.ts
+++ b/backend/src/db/migrations/20250921120821_k8-auth-name-increase.ts
@@ -1,4 +1,5 @@
 import { Knex } from "knex";
+
 import { TableName } from "../schemas";
 
 export async function up(knex: Knex): Promise<void> {
@@ -8,9 +9,9 @@ export async function up(knex: Knex): Promise<void> {
 
   if (hasAllowedNamespaces || hasAllowedNames || hasAllowedAudience) {
     await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
-      if (hasAllowedNames) t.string("allowedNames", 1000).alter();
-      if (hasAllowedNamespaces) t.string("allowedNamespaces", 1000).alter();
-      if (hasAllowedAudience) t.string("allowedAudience", 1000).alter();
+      if (hasAllowedNames) t.string("allowedNames", 1000).notNullable().alter();
+      if (hasAllowedNamespaces) t.string("allowedNamespaces", 1000).notNullable().alter();
+      if (hasAllowedAudience) t.string("allowedAudience", 1000).notNullable().alter();
     });
   }
 }
@@ -22,9 +23,9 @@ export async function down(knex: Knex): Promise<void> {
 
   if (hasAllowedNamespaces || hasAllowedNames || hasAllowedAudience) {
     await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
-      if (hasAllowedNames) t.string("allowedNames", 255).alter();
-      if (hasAllowedNamespaces) t.string("allowedNamespaces", 255).alter();
-      if (hasAllowedAudience) t.string("allowedAudience", 255).alter();
+      if (hasAllowedNames) t.string("allowedNames", 255).notNullable().alter();
+      if (hasAllowedNamespaces) t.string("allowedNamespaces", 255).notNullable().alter();
+      if (hasAllowedAudience) t.string("allowedAudience", 255).notNullable().alter();
     });
   }
 }

--- a/backend/src/db/migrations/20250921120821_k8-auth-name-increase.ts
+++ b/backend/src/db/migrations/20250921120821_k8-auth-name-increase.ts
@@ -1,0 +1,30 @@
+import { Knex } from "knex";
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasAllowedNamespaces = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedNamespaces");
+  const hasAllowedNames = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedNames");
+  const hasAllowedAudience = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedAudience");
+
+  if (hasAllowedNamespaces || hasAllowedNames || hasAllowedAudience) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
+      if (hasAllowedNames) t.string("allowedNames", 1000).alter();
+      if (hasAllowedNamespaces) t.string("allowedNamespaces", 1000).alter();
+      if (hasAllowedAudience) t.string("allowedAudience", 1000).alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasAllowedNamespaces = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedNamespaces");
+  const hasAllowedNames = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedNames");
+  const hasAllowedAudience = await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "allowedAudience");
+
+  if (hasAllowedNamespaces || hasAllowedNames || hasAllowedAudience) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
+      if (hasAllowedNames) t.string("allowedNames", 255).alter();
+      if (hasAllowedNamespaces) t.string("allowedNamespaces", 255).alter();
+      if (hasAllowedAudience) t.string("allowedAudience", 255).alter();
+    });
+  }
+}


### PR DESCRIPTION
# Description 📣

This PR addresses k8s auth failing when allowed service name increases to more than 255 characters

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->