### PR TITLE
Improve user expired token behavior

### DIFF
--- a/frontend/src/config/request.ts
+++ b/frontend/src/config/request.ts
@@ -1,7 +1,15 @@
 import axios from "axios";
+import { addSeconds, formatISO } from "date-fns";
 
+import { createNotification } from "@app/components/notifications";
 import SecurityClient from "@app/components/utilities/SecurityClient";
-import { getAuthToken, getMfaTempToken, getSignupTempToken } from "@app/hooks/api/reactQuery";
+import { SessionStorageKeys } from "@app/const";
+import {
+  getAuthToken,
+  getMfaTempToken,
+  getSignupTempToken,
+  setAuthToken
+} from "@app/hooks/api/reactQuery";
 
 export const apiRequest = axios.create({
   baseURL: "/",
@@ -34,3 +42,57 @@ apiRequest.interceptors.request.use((config) => {
 
   return config;
 });
+
+let isRedirecting = false;
+
+apiRequest.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { response } = error;
+
+    if (response && (response.status === 401 || response.status === 403)) {
+      const currentToken = getAuthToken();
+      const isAuthenticatedRequest = Boolean(currentToken);
+
+      if (isAuthenticatedRequest && !isRedirecting) {
+        // Check if the error indicates token expiration
+        const errorMessage = response.data?.message || "";
+        const isTokenExpired =
+          response.status === 401 ||
+          (errorMessage.toLowerCase().includes("token") &&
+            (errorMessage.toLowerCase().includes("expired") ||
+              errorMessage.toLowerCase().includes("invalid") ||
+              errorMessage.toLowerCase().includes("unauthorized")));
+
+        if (isTokenExpired) {
+          isRedirecting = true;
+
+          setAuthToken("");
+          SecurityClient.setToken("");
+
+          createNotification({
+            type: "error",
+            title: "Session Expired",
+            text: "Your session has expired. Redirecting to login page..."
+          });
+
+          sessionStorage.setItem(
+            SessionStorageKeys.ORG_LOGIN_SUCCESS_REDIRECT_URL,
+            JSON.stringify({
+              expiry: formatISO(addSeconds(new Date(), 300)), // 5 minutes
+              data: window.location.href
+            })
+          );
+
+          setTimeout(() => {
+            window.location.href = "/login";
+          }, 5000); // 5 seconds to read the notification
+
+          return Promise.reject(new Error("Session expired - redirecting to login"));
+        }
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);


### PR DESCRIPTION
# Description 📣

Improve the UI behavior for expired tokens, this will show a toast message when that expiration happens and correctly redirects the user back to the login page.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->