### PR TITLE
Update image registry and repository for Helm charts

### DIFF
--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -134,6 +134,12 @@ postgresql:
   # -- Full name override for PostgreSQL resources
   fullnameOverride: "postgresql"
 
+  image:
+    # -- Image registry for PostgreSQL
+    registry: mirror.gcr.io
+    # -- Image repository for PostgreSQL
+    repository: bitnamilegacy/postgresql
+
   auth:
     # -- Database username for PostgreSQL
     username: infisical
@@ -158,6 +164,12 @@ redis:
   name: "redis"
   # -- Full name override for Redis resources
   fullnameOverride: "redis"
+
+  image:
+    # -- Image registry for Redis
+    registry: mirror.gcr.io
+    # -- Image repository for Redis
+    repository: bitnamilegacy/redis
 
   cluster:
     # -- Clustered Redis deployment


### PR DESCRIPTION
# Description 📣

This PR updates the image registry and repository references for the Helm charts.
It addresses [[bitnami/charts#35164](https://github.com/bitnami/charts/issues/35164)](https://github.com/bitnami/charts/issues/35164) by switching PostgreSQL and Redis images to the **Bitnami Legacy** repository, as Bitnami announced the deprecation of Debian-based images and their migration to a legacy registry.

This change ensures continued compatibility and stability for deployments using the `infisical-standalone-postgres` Helm chart.

## Type ✨

* [ ] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Breaking change
* [ ] Documentation

# Tests 🛠️

The following steps were performed to verify the changes:

```sh
# Helm lint check
helm lint helm-charts/infisical-standalone-postgres

# Dry-run upgrade with updated values
helm upgrade --install infisical helm-charts/infisical-standalone-postgres
```

Everything works good.
<img width="2264" height="216" alt="CleanShot 2025-09-30 at 11 56 32@2x" src="https://github.com/user-attachments/assets/517422f5-490e-4bab-b30e-2ebf8b9763c0" />


---

* [x] I have read the [[contributing guide](https://infisical.com/docs/contributing/getting-started/overview)](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [[code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct)](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝
