### PR TITLE
docs: add default and minimum for agent polling-interval and execute.timeout

### DIFF
--- a/docs/integrations/platforms/infisical-agent.mdx
+++ b/docs/integrations/platforms/infisical-agent.mdx
@@ -60,9 +60,9 @@ While specifying an authentication method is mandatory to start the agent, confi
 | `templates[].source-path`                  | The path to the template file that should be used to render secrets.                                                                                                                              |
 | `templates[].template-content`             | The inline secret template to be used for rendering the secrets.                                                                                                                                                      |
 | `templates[].destination-path`             | The path where the rendered secrets from the source template will be saved to.                                                                                                                    |
-| `templates[].config.polling-interval`      | How frequently to check for secret changes. Default: `5 minutes` (optional)                                                                                                                       |
-| `templates[].config.execute.command`       | The command to execute when secret change is detected (optional)                                                                                                                                  |
-| `templates[].config.execute.timeout`       | How long in seconds to wait for command to execute before timing out (optional)                                                                                                                   |
+| `templates[].config.polling-interval`      | How frequently to check for secret changes (optional).<br/><br/>Minimum of `60s`. Default: `5m`                                                                                                                        |
+| `templates[].config.execute.command`       | The command to execute when secret change is detected (optional).                                                                                                                                  |
+| `templates[].config.execute.timeout`       | How long in seconds to wait for command to execute before timing out (optional).<br/><br/>Default: no timeout                                                                                                                   |
 
 ## Authentication
 
@@ -333,11 +333,11 @@ infisical agent --config example-agent-config-file.yaml
 {{- end }}
   ```
 
-  
+
 
 **Function name**: listSecrets
 
-**Description**: This function can be used to render the full list of secrets within a given project, environment and secret path. 
+**Description**: This function can be used to render the full list of secrets within a given project, environment and secret path.
 
 An optional JSON argument is also available. It includes the properties `recursive`, which defaults to false, and `expandSecretReferences`, which defaults to true and expands the returned secrets.
 


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Closes #4493

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

No test, but here are links to the relevant `agent.go`:

1. `templates[].config.execute.timeout`
   - [cli/packages/cmd/agent.go](https://github.com/Infisical/cli/blob/main/packages/cmd/agent.go#L233-L237)

1. `templates[].config.polling-interval`
   - [packages/util/agent.go](https://github.com/Infisical/cli/blob/main/packages/util/agent.go#L26-L28)

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->