### PR TITLE
docs: fix broken Role Assignment link in Machine Identities page

### DIFF
--- a/docs/documentation/platform/identities/machine-identities.mdx
+++ b/docs/documentation/platform/identities/machine-identities.mdx
@@ -13,7 +13,7 @@ Each identity must authenticate with the Infisical API using a supported authent
 
 Key Features:
 
-- Role Assignment: Identities must be assigned [roles](/documentation/platform/role-based-access-controls). These roles determine the scope of access to resources, either at the organization level or project level.
+- Role Assignment: Identities must be assigned [roles](/documentation/platform/access-controls/role-based-access-controls). These roles determine the scope of access to resources, either at the organization level or project level.
 - Auth/Token Configuration: Identities must be configured with corresponding authentication methods and access token properties to securely interact with the Infisical API.
 
 ## Workflow


### PR DESCRIPTION
# Fixes a broken link in the **Machine Identities** documentation.

- The "Role Assignment" link in `docs/documentation/platform/identities/machine-identities.mdx`
  was pointing to `/documentation/platform/role-based-access-controls` which returned a **404**.
- Updated it to `/documentation/platform/access-controls/role-based-access-controls`, which is the correct path already used elsewhere in the same file.
- This ensures that the documentation is consistent and that the link resolves properly.

Fixes #4597

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

## Tests

I tested this change locally using **Mintlify**:

```sh
cd docs
mintlify dev
```

### Steps performed
1. Opened the local docs at: `http://localhost:3001/documentation/platform/identities/machine-identities`
2. Navigated to Key Features → Role Assignment.
3. Verified that the link now points to: `http://localhost:3001//documentation/platform/access-controls/role-based-access-controls` and opens without a 404.

### Screenshot

<img width="1920" height="1080" alt="Screenshot 2025-10-02 at 10 12 36" src="https://github.com/user-attachments/assets/f0c19647-acc4-45b0-890e-8a69817b63db" />

### Additional checks
- Confirmed the updated link resolves correctly without errors.
- Verified that the docs build successfully with no regressions.

---

* [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct).
