### PR TITLE
docs(aws): note for dedicated instances for AWS account ID's

### DIFF
--- a/docs/documentation/platform/dynamic-secrets/aws-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/aws-iam.mdx
@@ -101,6 +101,9 @@ Replace **\<account id\>** with your AWS account id and **\<aws-scope-path\>** w
 
                 2. Select **AWS Account** as the **Trusted Entity Type**.
                 3. Select **Another AWS Account** and provide the appropriate Infisical AWS Account ID: use **381492033652** for the **US region**, and **345594589636** for the **EU region**. This restricts the role to be assumed only by Infisical. If self-hosting, provide your AWS account number instead.
+                <Note>
+                  **For Dedicated Instances**: Your AWS account ID differs from the one provided above. Please reach out to Infisical support to obtain your AWS account ID.
+                </Note>
                 4. (Recommended) <strong>Enable "Require external ID"</strong> and input your **Project ID** to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).
                 5. Assign permission as shared in prerequisite.
 

--- a/docs/documentation/platform/kms-configuration/aws-kms.mdx
+++ b/docs/documentation/platform/kms-configuration/aws-kms.mdx
@@ -23,6 +23,9 @@ Before you begin, you'll first need to choose a method of authentication with AW
 
       2. Select **AWS Account** as the **Trusted Entity Type**.
       3. Select **Another AWS Account** and provide the appropriate Infisical AWS Account ID: use **381492033652** for the **US region**, and **345594589636** for the **EU region**. This restricts the role to be assumed only by Infisical. If you are self-hosting, provide the AWS account number where Infisical is hosted.
+      <Note>
+        **For Dedicated Instances**: Your AWS account ID differs from the one provided above. Please reach out to Infisical support to obtain your AWS account ID.
+      </Note>
       4. Optionally, enable **Require external ID** and enter your Infisical **project ID** to further enhance security.
     </Step>
     <Step title="Add Required Permissions for the IAM Role">

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -56,6 +56,9 @@ Infisical supports two methods for connecting to AWS.
 
                 2. Select **AWS Account** as the **Trusted Entity Type**.
                 3. Select **Another AWS Account** and provide the appropriate Infisical AWS Account ID: use **381492033652** for the **US region**, and **345594589636** for the **EU region**. This restricts the role to be assumed only by Infisical. If self-hosting, provide your AWS account number instead.
+                <Note>
+                  **For Dedicated Instances**: Your AWS account ID differs from the one provided above. Please reach out to Infisical support to obtain your AWS account ID.
+                </Note>
                 4. (Recommended) <strong>Enable "Require external ID"</strong> and input your **Organization ID** to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).
 
                 <Warning type="warning" title="Security Best Practice: Use External ID to Prevent Confused Deputy Attacks">


### PR DESCRIPTION
# Description 📣

Added notes about AWS account ID's for dedicated instances, because the AWS account ID's differ for each individual dedicated instance.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->