### PR TITLE
Fix broken Components link in internals overview

### DIFF
--- a/docs/internals/overview.mdx
+++ b/docs/internals/overview.mdx
@@ -15,7 +15,7 @@ This section covers the internals of Infisical including its technical underpinn
 
 <CardGroup cols={2}>
   <Card
-    href="./components"
+    href="./architecture/components"
     title="Components"
     icon="boxes-stacked"
     color="#000000"


### PR DESCRIPTION
# Description 📣

Fixed a broken link on the /internals/overview page. The "Components" card now correctly points to /internals/architecture/components, resolving issue #4608.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->