### PR TITLE
docs(binary): move to s3

### DIFF
--- a/docs/self-hosting/deployment-options/native/linux-package/installation.mdx
+++ b/docs/self-hosting/deployment-options/native/linux-package/installation.mdx
@@ -28,7 +28,7 @@ Please ensure you have the following before beginning installation of Infisical:
     <Tab title="Debian/Ubuntu">
 
     <Warning>
-      As of 10/10/2025, all future releases for Debian/Ubuntu will be distributed via the official Infisical repository at https://artifacts-infisical-core.infisical.com.
+      As of October 10, 2025, all future releases for Debian/Ubuntu will be distributed via the official Infisical repository at https://artifacts-infisical-core.infisical.com.
       No new releases will be published for Debian/Ubuntu on Cloudsmith going forward.
     </Warning>
 
@@ -42,13 +42,13 @@ Please ensure you have the following before beginning installation of Infisical:
       sudo apt-get update && sudo apt-get install -y infisical-core
       ```
 
-      > **Note**: For production use, we recommend locking to a specific version to ensure consistency. [View available versions](https://cloudsmith.io/~infisical/repos/infisical-core/packages/).
+      > **Note**: For production use, we recommend locking to a specific version to ensure consistency. [View available versions](https://github.com/Infisical/infisical/releases). All versions from `infisical-core-0.150.0~nightly~20251005` and above are supported.
 
   </Tab>
     <Tab title="RedHat/CentOS/Amazon Linux">
 
     <Warning>
-      As of 10/10/2025, all future releases for Red Hat/CentOS/Amazon Linux will be distributed via the official Infisical repository at https://artifacts-infisical-core.infisical.com.
+      As of October 10, 2025, all future releases for Red Hat/CentOS/Amazon Linux will be distributed via the official Infisical repository at https://artifacts-infisical-core.infisical.com.
       No new releases will be published for Red Hat/CentOS/Amazon Linux on Cloudsmith going forward.
     </Warning>
 
@@ -62,7 +62,7 @@ Please ensure you have the following before beginning installation of Infisical:
       sudo yum install infisical-core
       ```
 
-      > **Note**: For production use, we recommend locking to a specific version to ensure consistency. [View available versions](https://cloudsmith.io/~infisical/repos/infisical-core/packages/).
+      > **Note**: For production use, we recommend locking to a specific version to ensure consistency. [View available versions](https://github.com/Infisical/infisical/releases). All versions from `infisical-core-0.150.0~nightly~20251005` and above are supported.
       
     </Tab>
   </Tabs>


### PR DESCRIPTION
# Description 📣

I've moved the binary installation links to our S3 artifacts repositories & added a warning letting users know that future releases won't be released to CloudSmith.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->