### PR TITLE
fix: remove offset limit for certificate and CA listing endpoints

### DIFF
--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1195,7 +1195,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       querystring: z.object({
         friendlyName: z.string().optional().describe(PROJECTS.LIST_CERTIFICATES.friendlyName),
         commonName: z.string().optional().describe(PROJECTS.LIST_CERTIFICATES.commonName),
-        offset: z.coerce.number().min(0).max(100).default(0).describe(PROJECTS.LIST_CERTIFICATES.offset),
+        offset: z.coerce.number().min(0).default(0).describe(PROJECTS.LIST_CERTIFICATES.offset),
         limit: z.coerce.number().min(1).max(100).default(25).describe(PROJECTS.LIST_CERTIFICATES.limit)
       }),
       response: {

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -370,7 +370,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       querystring: z.object({
         friendlyName: z.string().optional().describe(PROJECTS.LIST_CERTIFICATES.friendlyName),
         commonName: z.string().optional().describe(PROJECTS.LIST_CERTIFICATES.commonName),
-        offset: z.coerce.number().min(0).max(100).default(0).describe(PROJECTS.LIST_CERTIFICATES.offset),
+        offset: z.coerce.number().min(0).default(0).describe(PROJECTS.LIST_CERTIFICATES.offset),
         limit: z.coerce.number().min(1).max(100).default(25).describe(PROJECTS.LIST_CERTIFICATES.limit)
       }),
       response: {


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

issue: #4640
- Remove max(100) constraint from offset parameter in certificate listing endpoints
- Fixes pagination issue where users couldn't list more than 200 certificates
- Affects both v1 and v2 API endpoints for certificates and certificate authorities
- Allows unlimited pagination through large certificate collections


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
npm run test:unit
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝


