### PR TITLE
fix: broken path to components page

### DIFF
--- a/docs/internals/overview.mdx
+++ b/docs/internals/overview.mdx
@@ -15,7 +15,7 @@ This section covers the internals of Infisical including its technical underpinn
 
 <CardGroup cols={2}>
   <Card
-    href="./components"
+    href="./architecture/components"
     title="Components"
     icon="boxes-stacked"
     color="#000000"


### PR DESCRIPTION
# Description 📣

The path to `Components` section was broken in the Overview page under `Internals`

Fixes #4608 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

[Screencast from 2025-10-10 21-38-38.webm](https://github.com/user-attachments/assets/06dc79ab-225d-4fef-8300-897704da5686)

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->