### PR TITLE
fix: name field allows empty strings

### DIFF
--- a/frontend/src/pages/user/PersonalSettingsPage/components/UserNameSection/UserNameSection.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/UserNameSection/UserNameSection.tsx
@@ -31,7 +31,7 @@ export const UserNameSection = (): JSX.Element => {
       if (!user?.id) return;
       if (name.trim() === "") return;
 
-      await mutateAsync({ newName: name });
+      await mutateAsync({ newName: name.trim() });
       createNotification({
         text: "Successfully renamed user",
         type: "success"


### PR DESCRIPTION
# Description 📣

This PR aims to prevent users from setting empty strings as their name by implementing trim() logic

Fixes #4650 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

[Screencast from 2025-10-10 22-49-52.webm](https://github.com/user-attachments/assets/408136d4-74ad-461a-81da-5c9e4587b4d9)

```sh
  const onFormSubmit = async ({ name }: FormData) => {
    try {
      if (!user?.id) return;
      if (name === "") return;

      await mutateAsync({ newName: name });
      createNotification({
        text: "Successfully renamed user",
        type: "success"
      });
    } catch (error) {
      console.error(error);
      createNotification({
        text: "Failed to rename user",
        type: "error"
      });
    }
  };

```

In the above code the trim logic was missing !! 

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->