### PR TITLE
Add missing projectId to useMoveSecrets mutation

### DIFF
--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -337,7 +337,8 @@ export const useMoveSecrets = ({
       destinationSecretPath,
       secretIds,
       shouldOverwrite,
-      projectSlug
+      projectSlug,
+      projectId
     }) => {
       const { data } = await apiRequest.post<{
         isSourceUpdated: boolean;
@@ -349,7 +350,8 @@ export const useMoveSecrets = ({
         destinationSecretPath,
         secretIds,
         shouldOverwrite,
-        projectSlug
+        projectSlug,
+        projectId
       });
 
       return data;


### PR DESCRIPTION
# Description 📣

Add missing projectId on move secrets mutation (if missing the query will fail every time)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->