### PR TITLE
fix: hsm init check failing

### DIFF
--- a/backend/src/ee/services/hsm/hsm-fns.ts
+++ b/backend/src/ee/services/hsm/hsm-fns.ts
@@ -25,7 +25,7 @@ export const initializeHsmModule = (envConfig: Pick<TEnvConfig, "isHsmConfigured
 
       logger.info("PKCS#11 module initialized");
     } catch (error) {
-      if (error instanceof pkcs11js.Pkcs11Error && error.code === pkcs11js.CKR_CRYPTOKI_ALREADY_INITIALIZED) {
+      if ((error as { code?: number })?.code === pkcs11js.CKR_CRYPTOKI_ALREADY_INITIALIZED) {
         logger.info("Skipping HSM initialization because it's already initialized.");
       } else {
         logger.error(error, "Failed to initialize PKCS#11 module");


### PR DESCRIPTION
# Description 📣

Fix for hsm init check failing when the client is already initialized.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->