### PR TITLE
Remove unnecessary status check on identity count query

### DIFF
--- a/backend/src/ee/services/license/license-dal.ts
+++ b/backend/src/ee/services/license/license-dal.ts
@@ -44,7 +44,7 @@ export const licenseDALFactory = (db: TDbClient) => {
 
       // count org identities
       const identityDoc = await (tx || db.replicaNode())(TableName.Membership)
-        .where({ status: OrgMembershipStatus.Accepted, scope: AccessScope.Organization })
+        .where({ scope: AccessScope.Organization })
         .whereNotNull(`${TableName.Membership}.actorIdentityId`)
         .where((bd) => {
           if (orgId) {


### PR DESCRIPTION
# Description 📣

Removed the status filter on the query that returned the count of identity memberships of the organizations as machine identities never accept the membership, those are created by an organization user with a membership already set.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->