### PR TITLE
Add condition to exclude invited members from total identity count in billing query

### DIFF
--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -5,6 +5,7 @@ import {
   AccessScope,
   OrganizationsSchema,
   OrgMembershipRole,
+  OrgMembershipStatus,
   TableName,
   TMemberships,
   TMembershipsInsert,
@@ -346,6 +347,7 @@ export const orgDALFactory = (db: TDbClient) => {
         .replicaNode()(TableName.Membership)
         .where(`${TableName.Membership}.scopeOrgId`, orgId)
         .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Membership}.status`, OrgMembershipStatus.Accepted)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
         .count("*")
         .join(TableName.Users, `${TableName.Membership}.actorUserId`, `${TableName.Users}.id`)


### PR DESCRIPTION
# Description 📣

On the billing page metrics, the `Organization identity limit` row was counting all user memberships instead of only the accepted ones. Updated the query to include a filter so that only memberships with `status = accepted` are considered, as pending or invited users are not actual members yet.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->