### PR TITLE
fix: auto binary release strict check

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -135,7 +135,9 @@ jobs:
             TAG_NAME="${{ github.ref_name }}"
             echo "Checking for tag: $TAG_NAME"
 
-            if gh api repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME --silent 2>/dev/null; then
+            EXACT_MATCH=$(gh api repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME | jq -r 'if type == "array" then .[].ref else .ref end' | grep -x "refs/tags/$TAG_NAME")
+
+            if [ "$EXACT_MATCH" == "refs/tags/$TAG_NAME" ]; then
             echo "Tag $TAG_NAME already exists, skipping..."
             else
               echo "Creating tag in Infisical/infisical-omnibus: $TAG_NAME"


### PR DESCRIPTION
# Description 📣

The binary release would skip stable releases when a nightly release was already triggered in the past.

Example: 
1. `v0.150.0-nightly-20251006`
2. `v0.150.0-nightly-20251007`
3. `v0.150.0-nightly-20251008`

These 3 nightly releases would be released, and then when `v0150.0` was triggered as a stable release, the binary release step would skip the stable release because the `gh api repos/Infisical/infisical-omnibus/git/refs/tags/v0.150.0` api call would. return the existing nightly releases, because `v0.150.0` matches the `-nightly` suffix.

This PR enforces a strict check for the tag ref to ensure that no releases are skipped. For now we'll trigger a manual release for the `v0.150.0` binary release.

<img width="932" height="262" alt="image" src="https://github.com/user-attachments/assets/c1e9bbf6-fa43-4ab2-bd8a-4fd9cd5f8118" />


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->