### PR TITLE
docs(cli): show how to install a specific CLI version (fixes #4434)Docs/cli pin version 4434

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -137,28 +137,28 @@ You can use it across various environments, whether it's local development, CI/C
 
 ---
 
-## 🔢 Install a Specific Version (New Section)
+## Install a Specific Version
 
 In production or CI environments, it’s best to **pin the Infisical CLI to a specific version** to avoid unexpected updates.  
 Below are the common methods to do so:
 
-### **1. npm (cross-platform)**
+### npm (cross-platform)
 ```bash
 # Replace <version> with the desired release
 npm install -g @infisical/cli@<version>
 infisical --version
 ```
 
-### **2. Homebrew (macOS/Linux)**
+### Homebrew (macOS/Linux)
 > Homebrew keeps only the latest formula. To install a specific version, extract and install from a local tap:
 ```bash
 brew tap-new $USER/local
-brew extract --version=<version> infisical $USER/local
+brew extract --version <version> infisical $USER/local
 brew install $USER/local/infisical@<version>
 infisical --version
 ```
 
-### **3. Direct Binary (GitHub Releases)**
+### Direct Binary (GitHub Releases)
 > Download the tarball for your OS/architecture from [Infisical CLI Releases](https://github.com/Infisical/cli/releases)
 ```bash
 # Example (macOS arm64)
@@ -168,7 +168,7 @@ sudo mv infisical /usr/local/bin/
 infisical --version
 ```
 
-> 💡 **Tip:** For CI/CD pipelines, always pin a fixed version and update it manually through PRs or release workflows.
+> 💡 For CI/CD pipelines, always pin a fixed version and update it manually through PRs or release workflows.
 
 ---
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -77,9 +77,7 @@ You can use it across various environments, whether it's local development, CI/C
 
     	Add Infisical repository
     	```bash
-    	curl -1sLf \
-    		'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.alpine.sh' \
-    		| bash
+    	curl -1sLf     		'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.alpine.sh'     		| bash
     	```
 
     	Then install CLI
@@ -94,9 +92,7 @@ You can use it across various environments, whether it's local development, CI/C
 	 <Tab title="RedHat/CentOs/Amazon">
 	 Add Infisical repository
 		```bash
-		curl -1sLf \
-		'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.rpm.sh' \
-		| sudo -E bash
+		curl -1sLf 		'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.rpm.sh' 		| sudo -E bash
 		```
 
     	Then install CLI
@@ -113,9 +109,7 @@ You can use it across various environments, whether it's local development, CI/C
 	 	Add Infisical repository 
 			
 		```bash
-		curl -1sLf \
-		'https://artifacts-cli.infisical.com/setup.deb.sh' \
-		| sudo -E bash
+		curl -1sLf 		'https://artifacts-cli.infisical.com/setup.deb.sh' 		| sudo -E bash
 		```
 
     	Then install CLI
@@ -141,7 +135,45 @@ You can use it across various environments, whether it's local development, CI/C
    </Tab>
 </Tabs>
 
+---
+
+## 🔢 Install a Specific Version (New Section)
+
+In production or CI environments, it’s best to **pin the Infisical CLI to a specific version** to avoid unexpected updates.  
+Below are the common methods to do so:
+
+### **1. npm (cross-platform)**
+```bash
+# Replace <version> with the desired release
+npm install -g @infisical/cli@<version>
+infisical --version
+```
+
+### **2. Homebrew (macOS/Linux)**
+> Homebrew keeps only the latest formula. To install a specific version, extract and install from a local tap:
+```bash
+brew tap-new $USER/local
+brew extract --version=<version> infisical $USER/local
+brew install $USER/local/infisical@<version>
+infisical --version
+```
+
+### **3. Direct Binary (GitHub Releases)**
+> Download the tarball for your OS/architecture from [Infisical CLI Releases](https://github.com/Infisical/cli/releases)
+```bash
+# Example (macOS arm64)
+curl -L -o infisical.tar.gz   https://github.com/Infisical/cli/releases/download/v<version>/infisical_<version>_Darwin_arm64.tar.gz
+tar -xzf infisical.tar.gz
+sudo mv infisical /usr/local/bin/
+infisical --version
+```
+
+> 💡 **Tip:** For CI/CD pipelines, always pin a fixed version and update it manually through PRs or release workflows.
+
+---
+
 ## Quick Usage Guide
 <Card color="#00A300" href="./usage">
   Now that you have the CLI installed on your system, follow this guide to make the best use of it
 </Card>
+

--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -10,7 +10,7 @@ should approach the development and contribution process.
 Infisical has two major code-bases. One for the platform code, and one for SDKs. The contribution process has some key differences between the two, so we've split the documentation into two sections:
 
 - The [Infisical Platform](https://github.com/Infisical/infisical), the Infisical platform itself.
-- The [Infisical SDK](https://infisical.com/docs/sdks/overview), the official Infisical client SDKs.
+- The [Infisical SDKs (local development guide)](/contributing/sdks/developing), for contributing to the official client SDKs.
 
 <CardGroup cols={2}>
   <Card
@@ -22,12 +22,12 @@ Infisical has two major code-bases. One for the platform code, and one for SDKs.
     The Infisical platform is the core of the Infisical ecosystem.
   </Card>
   <Card
-    href="/sdks/overview"
+    href="/contributing/sdks/developing"
     title="Infisical SDK"
     icon="code"
     color="#A1B659"
   >
-    The SDKs are the official Infisical client libraries, used by developers to easily interact with the Infisical platform.
+    The SDKs are the official Infisical client libraries, used by developers to easily interact with and contribute to the Infisical platform.
   </Card>
 </CardGroup>
 
@@ -57,10 +57,11 @@ If you're ever in doubt about whether or not a proposed feature aligns with Infi
 Anyone can contribute code to Infisical. To get started, check out the local development guides for each language.
 
 - Local development guide for Platform is [here](/contributing/platform/developing).
-- Local development guide for SDK is [here](/sdks/overview).
+- Local development guide for SDKs is [here](/contributing/sdks/developing).
 
 ## Licensing
 
 Most of Infisical's code is under the MIT license, though some paid feature restrictions are covered by a proprietary license.
 
 Any third party components incorporated into our code are licensed under the original license provided by the applicable component owner.
+

--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -12,14 +12,23 @@ Infisical has two major code-bases. One for the platform code, and one for SDKs.
 - The [Infisical Platform](https://github.com/Infisical/infisical), the Infisical platform itself.
 - The [Infisical SDK](https://infisical.com/docs/sdks/overview), the official Infisical client SDKs.
 
-
 <CardGroup cols={2}>
-    <Card title="Infisical Platform" href="/contributing/platform/developing" icon="layer-group" color="#A1B659">
-        The Infisical platform is the core of the Infisical ecosystem.
-    </Card>
-    <Card href="/contributing/sdk/developing" title="Infisical SDK" icon="code" color="#A1B659">
+  <Card
+    title="Infisical Platform"
+    href="/contributing/platform/developing"
+    icon="layer-group"
+    color="#A1B659"
+  >
+    The Infisical platform is the core of the Infisical ecosystem.
+  </Card>
+  <Card
+    href="/sdks/overview"
+    title="Infisical SDK"
+    icon="code"
+    color="#A1B659"
+  >
     The SDKs are the official Infisical client libraries, used by developers to easily interact with the Infisical platform.
-    </Card>
+  </Card>
 </CardGroup>
 
 ## Community
@@ -47,13 +56,11 @@ If you're ever in doubt about whether or not a proposed feature aligns with Infi
 
 Anyone can contribute code to Infisical. To get started, check out the local development guides for each language.
 
-- Local development guide for Platform is [here](/contributing/platform/developing). 
-- Local development guide for SDK is [here](/contributing/sdk/developing).
-
+- Local development guide for Platform is [here](/contributing/platform/developing).
+- Local development guide for SDK is [here](/sdks/overview).
 
 ## Licensing
 
 Most of Infisical's code is under the MIT license, though some paid feature restrictions are covered by a proprietary license.
 
 Any third party components incorporated into our code are licensed under the original license provided by the applicable component owner.
-

--- a/docs/contributing/sdks/developing.mdx
+++ b/docs/contributing/sdks/developing.mdx
@@ -1,0 +1,74 @@
+Developing Infisical SDKs Locally
+
+This guide explains how to **clone, run, test, and contribute** to Infisical SDKs across supported languages.
+
+> This page is for **contributors** who want to work on the SDKs themselves.  
+> To **use** SDKs in your app, see the [SDKs overview](/docs/sdks/overview).
+
+## Repositories
+
+Pick your target SDK and follow its repository’s CONTRIBUTING guide:
+
+- **Node.js / TypeScript** — https://github.com/Infisical/infisical-node#contributing
+- **Python** — https://github.com/Infisical/python-sdk-official#contributing
+- **Go** — https://github.com/Infisical/infisical-go#contributing
+- **Java / Kotlin** — https://github.com/Infisical/infisical-java#contributing
+- **.NET (C#)** — https://github.com/Infisical/infisical-dotnet#contributing
+- **C++** — https://github.com/Infisical/infisical-cpp#contributing
+- **PHP** — https://github.com/Infisical/infisical-php#contributing
+- **Ruby** — https://github.com/Infisical/infisical-ruby#contributing
+
+> Each SDK repository documents language-specific local setup, testing, and release steps.
+
+## Prerequisites
+- Git + a GitHub account.
+- The language toolchain for your SDK (Node.js LTS, Python 3.x, Go toolchain, JDK, .NET SDK, etc.).
+- Any SDK-specific tools listed in that repository’s README/CONTRIBUTING.
+
+## Recommended workflow
+
+1. **Fork** the SDK repository and **clone** it locally.  
+2. Create a feature branch:
+   ```bash
+   git checkout -b feat/<short-desc>
+   ```
+3. **Install dependencies** (language-specific).  
+4. **Run tests** locally to validate your setup.  
+5. Implement changes; add/adjust tests as needed.  
+6. **Lint/format** per repo guidelines (ESLint/Prettier, Black/Flake8, gofmt, rustfmt, etc.).  
+7. **Commit & push**, then open a PR to the SDK repository with a clear summary and rationale.
+
+## Common commands (examples)
+
+### Node / TypeScript
+```
+pnpm install
+pnpm build
+pnpm test
+```
+
+### Python
+```
+pip install -r requirements-dev.txt
+pytest
+```
+
+### Go
+```
+go test ./...
+```
+
+### Java (Gradle)
+```
+./gradlew build test
+```
+
+> See the specific SDK repo’s CONTRIBUTING for authoritative commands.
+
+## Code style & CI
+Follow each SDK repo’s style and CI rules. Keep PRs focused and include test results or screenshots where helpful.
+
+## Need help?
+- Ask in the SDK repo’s issues/discussions.
+- Or open a docs issue on the main Infisical repo to improve this guide.
+

--- a/docs/contributing/sdks/developing.mdx
+++ b/docs/contributing/sdks/developing.mdx
@@ -3,7 +3,7 @@ Developing Infisical SDKs Locally
 This guide explains how to **clone, run, test, and contribute** to Infisical SDKs across supported languages.
 
 > This page is for **contributors** who want to work on the SDKs themselves.  
-> To **use** SDKs in your app, see the [SDKs overview](/docs/sdks/overview).
+> To **use** SDKs in your app, see the [SDKs overview](../../sdks/overview.mdx).
 
 ## Repositories
 

--- a/docs/contributing/sdks/developing.mdx
+++ b/docs/contributing/sdks/developing.mdx
@@ -3,7 +3,8 @@ Developing Infisical SDKs Locally
 This guide explains how to **clone, run, test, and contribute** to Infisical SDKs across supported languages.
 
 > This page is for **contributors** who want to work on the SDKs themselves.  
-> To **use** SDKs in your app, see the [SDKs overview](../../sdks/overview.mdx).
+> To **use** SDKs in your app, check out the official [Infisical SDK documentation](https://infisical.com/docs/sdks/overview).
+
 
 ## Repositories
 

--- a/docs/contributing/sdks/developing.mdx
+++ b/docs/contributing/sdks/developing.mdx
@@ -9,18 +9,19 @@ This guide explains how to **clone, run, test, and contribute** to Infisical SDK
 
 Pick your target SDK and follow its repository’s CONTRIBUTING guide:
 
-- **Node.js / TypeScript** — https://github.com/Infisical/infisical-node#contributing
-- **Python** — https://github.com/Infisical/python-sdk-official#contributing
-- **Go** — https://github.com/Infisical/infisical-go#contributing
-- **Java / Kotlin** — https://github.com/Infisical/infisical-java#contributing
-- **.NET (C#)** — https://github.com/Infisical/infisical-dotnet#contributing
-- **C++** — https://github.com/Infisical/infisical-cpp#contributing
-- **PHP** — https://github.com/Infisical/infisical-php#contributing
-- **Ruby** — https://github.com/Infisical/infisical-ruby#contributing
+- **Node.js** — https://github.com/Infisical/node-sdk-v2
+- **Python** —  https://github.com/Infisical/python-sdk-official
+- **Go** —  https://github.com/Infisical/go-sdk
+- **Java** — https://github.com/Infisical/java-sdk
+- **rust** — https://github.com/Infisical/rust-sdk 
+- **C++** — https://github.com/Infisical/infisical-cpp-sdk
+- **PHP** — https://github.com/Infisical/php-sdk
+
 
 > Each SDK repository documents language-specific local setup, testing, and release steps.
 
 ## Prerequisites
+
 - Git + a GitHub account.
 - The language toolchain for your SDK (Node.js LTS, Python 3.x, Go toolchain, JDK, .NET SDK, etc.).
 - Any SDK-specific tools listed in that repository’s README/CONTRIBUTING.


### PR DESCRIPTION
## Context
The CLI overview mentioned setting a specific version for production, but didn't show how.

## Changes
- Added a new **"Install a Specific Version"** section below installation tabs.
- Included examples for:
  - npm (`@infisical/cli@<version>`)
  - Homebrew (`brew extract`)
  - Direct binary download (GitHub Releases)

## Why
Improves clarity for CI/CD users who need reproducible CLI installs.

✅ Tested locally with `mintlify dev` — renders correctly.

🔗 Related Issue
Closes https://github.com/Infisical/infisical/issues/4434