### PR TITLE
fix(docs): repair Internals → Components link (404 → valid path)

### DIFF
--- a/docs/internals/overview.mdx
+++ b/docs/internals/overview.mdx
@@ -15,7 +15,7 @@ This section covers the internals of Infisical including its technical underpinn
 
 <CardGroup cols={2}>
   <Card
-    href="./components"
+    href="./architecture/components"
     title="Components"
     icon="boxes-stacked"
     color="#000000"


### PR DESCRIPTION
🧩 Summary
Fixes the broken "Components" link on the Internals → Overview page.

Old: ./components → 404
New: ./architecture/components → valid
Keeps consistency with other relative links (./security, ./service-tokens).

🔍 Rationale
The Components page actually resides under internals/architecture/components.
This update corrects the Overview link to match the current documentation structure.

🧪 Verification
Checked old URL → 404 ❌
Checked new URL → loads Components page ✅
Relative path syntax verified for Mintlify docs.

🧱 Type of Change
 📝 Docs fix (non-breaking)
 
🔗 Related Issue
Closes https://github.com/Infisical/infisical/issues/4660