### PR TITLE
fix(docs): align security contact email with Security Policy

### DIFF
--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -34,7 +34,7 @@ Before raising a new issue, please search existing ones to make sure you're not 
 
 <Info>
   If the issue is related to security, please email us directly at
-  security@infisical.com
+  security@infisical.com.
   
   See our [GitHub Security Policy](https://github.com/Infisical/infisical/security/policy) for details.
 

--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -34,7 +34,10 @@ Before raising a new issue, please search existing ones to make sure you're not 
 
 <Info>
   If the issue is related to security, please email us directly at
-  team@infisical.com.
+  security@infisical.com
+  
+  See our [GitHub Security Policy](https://github.com/Infisical/infisical/security/policy) for details.
+
 </Info>
 
 ## Deciding what to work on


### PR DESCRIPTION
### Summary
Fixes an inconsistency in the security contact email across documentation.

- **Contributing docs:** previously listed `team@infisical.com`
- **Security Policy:** lists `security@infisical.com`

This PR updates the Contributing docs to use `security@infisical.com` for consistency and clarity.

### Rationale
- Keeps a single, canonical security contact across all public references  
- Reduces confusion for security reporters  
- Aligns with GitHub’s Security Policy page

### Scope
- Documentation only (no runtime or code changes)
- File updated: `docs/contributing/getting-started/overview.mdx`

### References
- [Contributing Docs](https://infisical.com/docs/contributing/getting-started/overview)
- [Security Policy](https://github.com/Infisical/infisical/security/policy)

### Checklist
- [x] Updated to `security@infisical.com`
- [x] Verified no other mismatched instances remain

### Issue: #4704 

Closes https://github.com/Infisical/infisical/issues/4704


