### PR TITLE
fix(sub-organizations): migration edge-case

### DIFF
--- a/backend/src/db/migrations/20251018061215_sub-org.ts
+++ b/backend/src/db/migrations/20251018061215_sub-org.ts
@@ -41,6 +41,8 @@ export async function up(knex: Knex): Promise<void> {
       [TableName.Identity, TableName.Membership, AccessScope.Organization]
     );
 
+    await knex.raw(`DELETE FROM ?? WHERE "orgId" IS NULL`, [TableName.Identity]);
+
     await knex.schema.alterTable(TableName.Identity, (t) => {
       t.uuid("orgId").notNullable().alter();
     });


### PR DESCRIPTION
# Description 📣

Fixed migration to delete orphaned identities. We wren't cleaning up identities on org deletions in the past, so some identities exist without org memberships. This is no longer an issue after membership simplification because we cascade identities on delete. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->