### PR TITLE
Fix: getImportReplicatedFolder function now retrieve only the id of the replicated folder

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretImportListView/SecretImportListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretImportListView/SecretImportListView.tsx
@@ -130,7 +130,7 @@ export const SecretImportListView = ({
   const [items, setItems] = useState(secretImports ?? []);
 
   const getImportReplicatedFolder = (importPath: string) => {
-    if (!importPath.includes("/__reserve_replication_")) return importPath;
+    if (!importPath.includes("/__reserve_replication_")) return undefined;
     const cleanImportPath = importPath.split("/__reserve_replication_")[1];
     const replicatedFolder = items?.find(({ id }) => id === cleanImportPath);
     return replicatedFolder;


### PR DESCRIPTION
# Description 📣

Small fix on the getImportReplicatedFolder function, changing replace to split on the `cleanImportPath` so we avoid computing anything that is sent before the fixed values (and that way we only get the clean import path id)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->