### PR TITLE
fix: backwards compatibility for assumed roles as role formatting

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
@@ -8,7 +8,7 @@ interface PrincipalArnEntity {
   SessionInfo: string; // Only populated for assumed-role
 }
 
-export const extractPrincipalArnEntity = (arn: string): PrincipalArnEntity => {
+export const extractPrincipalArnEntity = (arn: string, formatAsIamRole: boolean = false): PrincipalArnEntity => {
   // split the ARN into parts using ":" as the delimiter
   const fullParts = arn.split(":");
   if (fullParts.length !== 6) {
@@ -49,7 +49,7 @@ export const extractPrincipalArnEntity = (arn: string): PrincipalArnEntity => {
       }
       // assumed roles use a special format where the friendly name is the role name
       const [roleName, sessionId] = rest;
-      finalType = "assumed-role";
+      finalType = formatAsIamRole ? "role" : "assumed-role";
       friendlyName = roleName;
       sessionInfo = sessionId;
       break;
@@ -84,8 +84,8 @@ export const extractPrincipalArnEntity = (arn: string): PrincipalArnEntity => {
  * - arn:aws:iam::123456789012:user/MyUserName
  * - arn:aws:iam::123456789012:role/MyRoleName
  */
-export const extractPrincipalArn = (arn: string) => {
-  const entity = extractPrincipalArnEntity(arn);
+export const extractPrincipalArn = (arn: string, formatAsIamRole: boolean = false) => {
+  const entity = extractPrincipalArnEntity(arn, formatAsIamRole);
 
-  return `arn:aws:${entity.Service}::${entity.AccountNumber}:${entity.Type}/${entity.FriendlyName}`;
+  return `arn:aws:${formatAsIamRole ? "iam" : entity.Service}::${entity.AccountNumber}:${entity.Type}/${entity.FriendlyName}`;
 };

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -158,7 +158,7 @@ export const identityAwsAuthServiceFactory = ({
           // considers exact matches + wildcard matches
           // heavily validated in router
           const regex = new RE2(`^${principalArn.replaceAll("*", ".*")}$`);
-          return regex.test(formattedArn);
+          return regex.test(formattedArn) || regex.test(extractPrincipalArn(Arn, true));
         });
 
       if (!isArnAllowed) {


### PR DESCRIPTION
# Description 📣

Added backwards compatibility for incorrectly formatted aws auth arn's.

Before the fix for AWS principle arns (https://github.com/Infisical/infisical/pull/4725), we were allowing assumed roles to be validated against regular iam roles. In the PR above we are correctly validating the assumed roles, but this has caused a downstream issue for people already using the wrong role formatting.

This PR adds support for **both** assumed-role and role _(with IAM arn format)_.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->