### PR TITLE
fix: support GovCloud (US) ARNs

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
@@ -83,9 +83,11 @@ export const extractPrincipalArnEntity = (arn: string, formatAsIamRole: boolean 
  * Extracts the identity ARN from the GetCallerIdentity response to one of the following formats:
  * - arn:aws:iam::123456789012:user/MyUserName
  * - arn:aws:iam::123456789012:role/MyRoleName
+ * - arn:aws-us-gov:iam::123456789012:user/MyUserName (GovCloud)
+ * - arn:aws-us-gov:iam::123456789012:role/MyRoleName (GovCloud)
  */
 export const extractPrincipalArn = (arn: string, formatAsIamRole: boolean = false) => {
   const entity = extractPrincipalArnEntity(arn, formatAsIamRole);
 
-  return `arn:aws:${formatAsIamRole ? "iam" : entity.Service}::${entity.AccountNumber}:${entity.Type}/${entity.FriendlyName}`;
+  return `arn:${entity.Partition}:${formatAsIamRole ? "iam" : entity.Service}::${entity.AccountNumber}:${entity.Type}/${entity.FriendlyName}`;
 };

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
@@ -6,7 +6,7 @@ const twelveDigitRegex = new RE2(/^\d{12}$/);
 // akhilmhdh: change this to a normal function later. Checked no redosable at the moment
 
 const arnRegex = new RE2(
-  /^arn:aws:(iam|sts)::\d{12}:(user\/[a-zA-Z0-9_.@+*/-]+|role\/[a-zA-Z0-9_.@+*/-]+|assumed-role\/[a-zA-Z0-9_.@+*/-]+|\*)$/
+  /^arn:aws(?:-us-gov)?:(iam|sts)::\d{12}:(user\/[a-zA-Z0-9_.@+*/-]+|role\/[a-zA-Z0-9_.@+*/-]+|assumed-role\/[a-zA-Z0-9_.@+*/-]+|\*)$/
 );
 
 export const validateAccountIds = z
@@ -55,7 +55,7 @@ export const validatePrincipalArns = z
     },
     {
       message:
-        "Each ARN must be in the format of 'arn:aws:iam::123456789012:user/UserName', 'arn:aws:iam::123456789012:role/RoleName', or 'arn:aws:iam::123456789012:*', 'arn:aws:sts::123456789012:assumed-role/RoleName'."
+        "Each ARN must be in the format of 'arn:aws:iam::123456789012:user/UserName', 'arn:aws:iam::123456789012:role/RoleName', or 'arn:aws:iam::123456789012:*', 'arn:aws:sts::123456789012:assumed-role/RoleName'. GovCloud ARNs (arn:aws-us-gov:...) are also supported."
     }
   )
   // Transform to normalize the spaces around commas


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

- Added support for GovCloud (US) arns (`arn:aws-us-gov:iam::`)

https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-arns.html

https://github.com/user-attachments/assets/5476b6e9-b829-4845-9349-ff3de3cd4ffd

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

- Try to add a Gov Cloud (US) ARN in a machine identity AWS Auth
- Check if the AWS auth still works for non-Gov Cloud (US) ARNs

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->