### PR TITLE
fix(front-end): add optional chain operator to fix enterprise check from throwing error

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -1281,7 +1281,7 @@ export const ActionBar = ({
             subscription.slug === null
               ? "You can perform this action under an Enterprise license"
               : `You can perform this action if you switch to Infisical's ${
-                  popUp.upgradePlan.data.isEnterpriseFeature ? "Enterprise" : "Pro"
+                  popUp.upgradePlan.data?.isEnterpriseFeature ? "Enterprise" : "Pro"
                 } plan`
           }
         />


### PR DESCRIPTION
# Description 📣

This PR adds an optional chain operator to prevent the upgrade modal enterprise check from throwing an error

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝