### PR TITLE
fix: omnibus automatic releases failing

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -135,10 +135,10 @@ jobs:
             TAG_NAME="${{ github.ref_name }}"
             echo "Checking for tag: $TAG_NAME"
 
-            EXACT_MATCH=$(gh api repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME | jq -r 'if type == "array" then .[].ref else .ref end' | grep -x "refs/tags/$TAG_NAME")
+            EXACT_MATCH=$(gh api repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME 2>/dev/null | jq -r 'if type == "array" then .[].ref else .ref end' | grep -x "refs/tags/$TAG_NAME" || true)
 
             if [ "$EXACT_MATCH" == "refs/tags/$TAG_NAME" ]; then
-            echo "Tag $TAG_NAME already exists, skipping..."
+              echo "Tag $TAG_NAME already exists, skipping..."
             else
               echo "Creating tag in Infisical/infisical-omnibus: $TAG_NAME"
               LATEST_SHA=$(gh api repos/Infisical/infisical-omnibus/git/refs/heads/main --jq '.object.sha')


### PR DESCRIPTION
# Description 📣

Omnibus releases were failing due to the github CLI throwing non-zero status code, which causes the CI pipeline to fail. This wasn't caught during local testing as the rest of the script passed through. The non-zero status code would always happen if no tag is found (which is intentional).

The reason this wasn't caught locally but only became clear in the CI, is because Github passes `-e` to the script shell by default. When the `-e` flag is set, the whole script will error out if a non-zero return code is detected. This is however not the case when running the script locally.

The fix is ignoring the return code by doing an OR true statement at the end of the command where the fetch the existing tags.

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->