### PR TITLE
fix(commit): allow null for skip multiline encoding on commit endpoint

### DIFF
--- a/backend/src/ee/routes/v1/pit-router.ts
+++ b/backend/src/ee/routes/v1/pit-router.ts
@@ -468,7 +468,10 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
                     .transform((val) => (val.at(-1) === "\n" ? `${val.trim()}\n` : val.trim()))
                     .optional(),
                   secretComment: z.string().trim().optional().default(""),
-                  skipMultilineEncoding: z.boolean().optional(),
+                  skipMultilineEncoding: z
+                    .boolean()
+                    .nullish()
+                    .transform((val) => (val === null ? false : val)),
                   metadata: z.record(z.string()).optional(),
                   secretMetadata: ResourceMetadataSchema.optional(),
                   tagIds: z.string().array().optional()

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChangeItem.tsx
@@ -221,9 +221,7 @@ export const SecretApprovalRequestChangeItem = ({
               <div className="mb-2">
                 <div className="text-sm font-medium text-mineshaft-300">Multi-line Encoding</div>
                 <div className="text-sm">
-                  {secretVersion?.skipMultilineEncoding?.toString() || (
-                    <span className="text-sm text-mineshaft-300">-</span>
-                  )}{" "}
+                  {secretVersion?.skipMultilineEncoding?.toString() || "false"}
                 </div>
               </div>
             </div>
@@ -366,9 +364,8 @@ export const SecretApprovalRequestChangeItem = ({
                 <div className="text-sm font-medium text-mineshaft-300">Multi-line Encoding</div>
                 <div className="text-sm">
                   {newVersion?.skipMultilineEncoding?.toString() ??
-                    secretVersion?.skipMultilineEncoding?.toString() ?? (
-                      <span className="text-sm text-mineshaft-300">-</span>
-                    )}{" "}
+                    secretVersion?.skipMultilineEncoding?.toString() ??
+                    "false"}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description 📣

This PR updates the validation for the batch commit endpoint to handle `null` for `skipMultilineEncoding`

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝