### PR TITLE
feat: resolved metadata interpolation failing in project due to group membership

### DIFF
--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -201,11 +201,11 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         .leftJoin(TableName.IdentityMetadata, (queryBuilder) => {
           if (actorType === ActorType.USER) {
             void queryBuilder
-              .on(`${TableName.Membership}.actorUserId`, `${TableName.IdentityMetadata}.userId`)
+              .on(`${TableName.IdentityMetadata}.userId`, db.raw("?", [actorId]))
               .andOn(`${TableName.Membership}.scopeOrgId`, `${TableName.IdentityMetadata}.orgId`);
           } else if (actorType === ActorType.IDENTITY) {
             void queryBuilder
-              .on(`${TableName.Membership}.actorIdentityId`, `${TableName.IdentityMetadata}.identityId`)
+              .on(`${TableName.IdentityMetadata}.identityId`, db.raw("?", [actorId]))
               .andOn(`${TableName.Membership}.scopeOrgId`, `${TableName.IdentityMetadata}.orgId`);
           }
         })
@@ -488,7 +488,7 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         })
         .leftJoin(TableName.IdentityMetadata, (queryBuilder) => {
           void queryBuilder
-            .on(`${TableName.Membership}.actorUserId`, `${TableName.IdentityMetadata}.userId`)
+            .on(`${TableName.Users}.id`, `${TableName.IdentityMetadata}.userId`)
             .andOn(`${TableName.Membership}.scopeOrgId`, `${TableName.IdentityMetadata}.orgId`);
         })
         .where(`${TableName.Membership}.scopeOrgId`, orgId)


### PR DESCRIPTION


# Description 📣

This PR fixes metadata interpolation for permission failure due to when they don't have direct membership rather only group membership. The issue was joining with metadata table would fail as it contain on group id, Fix was joining using actorId

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->