### PR TITLE
Delete PKI templates on project removal

### DIFF
--- a/backend/src/db/migrations/20251106172316_delete-pki-templates-on-project-removal.ts
+++ b/backend/src/db/migrations/20251106172316_delete-pki-templates-on-project-removal.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.PkiCertificateTemplateV2)) {
+    await knex.schema.alterTable(TableName.PkiCertificateTemplateV2, (t) => {
+      t.dropForeign(["projectId"]);
+      t.foreign("projectId").references("id").inTable(TableName.Project).onDelete("CASCADE");
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasTable(TableName.PkiCertificateTemplateV2)) {
+    await knex.schema.alterTable(TableName.PkiCertificateTemplateV2, (t) => {
+      t.dropForeign(["projectId"]);
+      t.foreign("projectId").references("id").inTable(TableName.Project);
+    });
+  }
+}


### PR DESCRIPTION
# Description 📣

Add a small migration to delete PKI templates in cascade when the project is removed. Otherwise the removal is blocked until all templates are manually removed.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->