### PR TITLE
Do not expose redis by default in the prod docker-compose.

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,8 +26,6 @@ services:
     restart: always
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-    ports:
-      - 6379:6379
     networks:
       - infisical
     volumes:


### PR DESCRIPTION
# Description 📣

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. Here's how we expect a pull request to be : https://infisical.com/docs/contributing/getting-started/pull-requests -->

Redis is needlessly exposed on the prod docker compose. Since it has no password, this is a security risk.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

I setup Infisical from the provided docker-compose and it ran as expected without the redis port exposed.

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝

<!-- If you have any questions regarding contribution, here's the FAQ : https://infisical.com/docs/contributing/getting-started/faq -->