### PR TITLE
pam: fix ssl issue

### DIFF
--- a/backend/src/ee/services/pam-resource/shared/sql/sql-resource-factory.ts
+++ b/backend/src/ee/services/pam-resource/shared/sql/sql-resource-factory.ts
@@ -104,8 +104,7 @@ const makeSqlConnection = (
               //          (like being able to do an auth handshake regardless pass or not)
               if (
                 connectOnly &&
-                (error.message === `password authentication failed for user "${TEST_CONNECTION_USERNAME}"` ||
-                  error.message.includes("no pg_hba.conf entry for host"))
+                error.message === `password authentication failed for user "${TEST_CONNECTION_USERNAME}"`
               ) {
                 return;
               }


### PR DESCRIPTION
Fixes issue where you can add a resource that has require SSL without SSL, and then the error gets shown when adding acocunts