### PR TITLE
feat(cli): allow using project name to resolve project ID (#2594)

### DIFF
--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -1976,9 +1976,48 @@ export const projectServiceFactory = ({
     });
   };
 
+  const getProjectByName = async ({
+  name,
+  actor,
+  actorId,
+  actorOrgId,
+  actorAuthMethod
+}: {
+  name: string;
+  actor: ActorType;
+  actorId: string;
+  actorOrgId: string;
+  actorAuthMethod: ActorAuthMethod;
+}) => {
+  const project = await projectDAL.findOne({ name, orgId: actorOrgId });
+  if (!project) {
+    throw new NotFoundError({
+      message: `Project with name '${name}' not found`
+    });
+  }
+
+  const { permission } = await permissionService.getProjectPermission({
+    actor,
+    actorId,
+    projectId: project.id,
+    actorAuthMethod,
+    actorOrgId,
+    actionProjectType: ActionProjectType.Any
+  });
+
+  ForbiddenError.from(permission).throwUnlessCan(
+    ProjectPermissionActions.Read,
+    ProjectPermissionSub.Project
+  );
+
+  return project;
+};
+
+
   return {
     createProject,
     deleteProject,
+    getProjectByName,
     getProjects,
     updateProject,
     getProjectUpgradeStatus,


### PR DESCRIPTION
### Summary
Introduced a new `getProjectByName` service method in `projectServiceFactory` to retrieve a project by its name.

### Motivation
Currently, projects can only be retrieved using their ID or slug. This change adds the ability to fetch projects by their name while maintaining consistent permission checks and error handling.

### Implementation Details
- Added `getProjectByName` method in `project-service.ts`
- Integrated `permissionService.getProjectPermission` to enforce access control
- Throws `NotFoundError` when the project name does not exist
- Throws `ForbiddenError` when the user lacks project read permissions

### Impact
This improvement enhances developer experience when integrating APIs that rely on project names instead of IDs, making the API more flexible.

---

✅ Tested locally  
✅ Follows existing service structure and permission model
✅ Non-breaking enhancement
