### PR TITLE
Fix dropdown menu overlapping trigger in KMS Overview page

### DIFF
--- a/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
@@ -344,7 +344,7 @@ export const CmekTable = () => {
                                 <FontAwesomeIcon size="lg" icon={faEllipsis} />
                               </IconButton>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent className="min-w-[160px] mt-2">
+                            <DropdownMenuContent className="min-w-[160px]" sideOffset={2}>
                               {keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT && (
                                 <>
                                   <Tooltip


### PR DESCRIPTION
This updates the dropdown menu in the KMS Overview page by adding a small top offset. The menu was opening too close to the trigger, which caused the initial click to fall onto the first menu item and select it immediately. Adding mt-2 ensures the menu opens slightly lower and prevents accidental selections.
Fixes #4878.