### PR TITLE
[Resolve for #4882] feat: add regex validation for secret key

### DIFF
--- a/frontend/src/components/utilities/parseSecrets.ts
+++ b/frontend/src/components/utilities/parseSecrets.ts
@@ -1,7 +1,7 @@
 const LINE =
   /(?:^|^)\s*(?:export\s+)?([\w.:-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
 
-const VALID_KEY_REGEX = /^[A-Za-z0-9._-]+$/;
+export const VALID_KEY_REGEX = /^[A-Za-z0-9._-]+$/;
 
 /**
  * Return text that is the buffer parsed
@@ -124,6 +124,12 @@ export function parseYaml(src: ArrayBuffer | string) {
       const keyMatch = lines[i].match(/^([\w.-]+)\s*:\s*(.*)$/);
       if (keyMatch) {
         const [, key, rawValue] = keyMatch;
+
+        if (!VALID_KEY_REGEX.test(key)) {
+          i += 1;
+          continue;
+        }
+
         let value = rawValue.trim();
 
         // Multiline string handling

--- a/frontend/src/components/utilities/parseSecrets.ts
+++ b/frontend/src/components/utilities/parseSecrets.ts
@@ -1,6 +1,8 @@
 const LINE =
   /(?:^|^)\s*(?:export\s+)?([\w.:-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
 
+const VALID_KEY_REGEX = /^[A-Za-z0-9._-]+$/;
+
 /**
  * Return text that is the buffer parsed
  * @param {ArrayBuffer} src - source buffer
@@ -32,6 +34,10 @@ export function parseDotEnv(src: ArrayBuffer | string) {
         // eslint-disable-next-line no-cond-assign
         while ((match = LINE.exec(line)) !== null) {
           const key = match[1];
+
+          if (!VALID_KEY_REGEX.test(key)) {
+            continue;
+          }
 
           // Default undefined or null to empty string
           let value = match[2] || "";
@@ -66,11 +72,25 @@ export function parseDotEnv(src: ArrayBuffer | string) {
   return object;
 }
 
-export const parseJson = (src: ArrayBuffer | string) => {
+/**
+ * Parse a JSON secret object into a normalized key/value structure.
+ *
+ * - Only accepts keys that match ASCII-safe regex: /^[A-Za-z0-9._-]+$/
+ * - Keys containing Unicode or invalid characters will be ignored
+ * - Only string values are included in the output
+ *
+ * @param {ArrayBuffer | string} src - Raw JSON content as a string or ArrayBuffer
+ * @returns {Record<string, { value: string; comments: string[] }>} 
+ *          A normalized map of secret keys and their string values
+ */
+export const parseJson = (src: ArrayBuffer | string): Record<string, { value: string; comments: string[] }> => {
   const file = src.toString();
   const formatedData: Record<string, string> = JSON.parse(file);
   const env: Record<string, { value: string; comments: string[] }> = {};
   Object.keys(formatedData).forEach((key) => {
+    if (!VALID_KEY_REGEX.test(key)) {
+      return;
+    }
     if (typeof formatedData[key] === "string") {
       env[key] = { value: formatedData[key], comments: [] };
     }

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -1,4 +1,4 @@
-import { ClipboardEvent, useRef } from "react";
+import { ClipboardEvent, JSX, useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { faTriangleExclamation, faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -21,6 +21,7 @@ import {
   useBatchModeActions,
   usePopUpAction
 } from "../../SecretMainPage.store";
+import { VALID_KEY_REGEX } from "@app/components/utilities/parseSecrets";
 
 const typeSchema = z.object({
   key: z.string().trim().min(1, { message: "Secret key is required" }),
@@ -148,6 +149,57 @@ export const CreateSecretForm = ({
     }
   };
 
+  const getWarningTooltip = (secretKey: string): JSX.Element | undefined => {
+    if (secretKey && !VALID_KEY_REGEX.test(secretKey)) {
+      return (
+        <Tooltip
+          className="w-full max-w-72"
+          content={
+            <div>
+              Secret key contains invalid characters.
+              <br />
+              <br />
+              Allowed characters:
+              <code className="rounded-md bg-mineshaft-500 px-1 py-0.5 ml-1">
+                A–Z a–z 0–9 . _ -
+              </code>
+              <br />
+            </div>
+          }>
+          <FontAwesomeIcon
+            icon={faWarning}
+            className="absolute right-0 mr-3 text-yellow-600"
+          />
+        </Tooltip>
+      )
+    }
+
+    if (secretKey?.includes(" ")) {
+      return (
+        <Tooltip
+          className="w-full max-w-72"
+          content={
+            <div>
+              Secret key contains whitespaces.
+              <br />
+              <br /> If this is the desired format, you need to provide it as{" "}
+              <code className="rounded-md bg-mineshaft-500 px-1 py-0.5">
+                {encodeURIComponent(secretKey.trim())}
+              </code>{" "}
+              when making API requests.
+            </div>
+          }
+        >
+          <FontAwesomeIcon
+            icon={faWarning}
+            className="absolute right-0 mr-3 text-yellow-600"
+          />
+        </Tooltip>
+      )
+    }
+    return undefined;
+  }
+
   return (
     <form onSubmit={handleSubmit(handleFormSubmit)} noValidate>
       <FormControl
@@ -163,29 +215,7 @@ export const CreateSecretForm = ({
             // @ts-expect-error this is for multiple ref single component
             secretKeyInputRef.current = e;
           }}
-          warning={
-            secretKey?.includes(" ") ? (
-              <Tooltip
-                className="w-full max-w-72"
-                content={
-                  <div>
-                    Secret key contains whitespaces.
-                    <br />
-                    <br /> If this is the desired format, you need to provide it as{" "}
-                    <code className="rounded-md bg-mineshaft-500 px-1 py-0.5">
-                      {encodeURIComponent(secretKey.trim())}
-                    </code>{" "}
-                    when making API requests.
-                  </div>
-                }
-              >
-                <FontAwesomeIcon
-                  icon={faWarning}
-                  className="absolute right-0 mr-3 text-yellow-600"
-                />
-              </Tooltip>
-            ) : undefined
-          }
+          warning={getWarningTooltip(secretKey)}
           placeholder="Type your secret name"
           onPaste={handlePaste}
           autoCapitalization={autoCapitalize}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -150,6 +150,30 @@ export const CreateSecretForm = ({
   };
 
   const getWarningTooltip = (secretKey: string): JSX.Element | undefined => {
+    if (secretKey?.includes(" ")) {
+      return (
+        <Tooltip
+          className="w-full max-w-72"
+          content={
+            <div>
+              Secret key contains whitespaces.
+              <br />
+              <br /> If this is the desired format, you need to provide it as{" "}
+              <code className="rounded-md bg-mineshaft-500 px-1 py-0.5">
+                {encodeURIComponent(secretKey.trim())}
+              </code>{" "}
+              when making API requests.
+            </div>
+          }
+        >
+          <FontAwesomeIcon
+            icon={faWarning}
+            className="absolute right-0 mr-3 text-yellow-600"
+          />
+        </Tooltip>
+      )
+    }
+
     if (secretKey && !VALID_KEY_REGEX.test(secretKey)) {
       return (
         <Tooltip
@@ -174,29 +198,6 @@ export const CreateSecretForm = ({
       )
     }
 
-    if (secretKey?.includes(" ")) {
-      return (
-        <Tooltip
-          className="w-full max-w-72"
-          content={
-            <div>
-              Secret key contains whitespaces.
-              <br />
-              <br /> If this is the desired format, you need to provide it as{" "}
-              <code className="rounded-md bg-mineshaft-500 px-1 py-0.5">
-                {encodeURIComponent(secretKey.trim())}
-              </code>{" "}
-              when making API requests.
-            </div>
-          }
-        >
-          <FontAwesomeIcon
-            icon={faWarning}
-            className="absolute right-0 mr-3 text-yellow-600"
-          />
-        </Tooltip>
-      )
-    }
     return undefined;
   }
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
@@ -13,7 +13,8 @@ import {
   parseCsvToMatrix,
   parseDotEnv,
   parseJson,
-  parseYaml
+  parseYaml,
+  VALID_KEY_REGEX
 } from "@app/components/utilities/parseSecrets";
 import {
   Button,
@@ -372,7 +373,7 @@ export const SecretDropzone = ({
     const env: TParsedEnv = {};
     matrix.forEach((row) => {
       const key = row[importSecretMatrixMap.key];
-      if (key) {
+      if (key && VALID_KEY_REGEX.test(key)) {
         env[key] = {
           value: importSecretMatrixMap.value ? row[importSecretMatrixMap.value] : "",
           comments: importSecretMatrixMap.comment ? [row[importSecretMatrixMap.comment]] : []
@@ -561,9 +562,9 @@ export const SecretDropzone = ({
                 popUp.importMatrixMap.data?.matrix
                   ? finishMappedMatrixImport(popUp.importMatrixMap.data?.matrix)
                   : createNotification({
-                      text: "Invalid secret matrix.",
-                      type: "error"
-                    })
+                    text: "Invalid secret matrix.",
+                    type: "error"
+                  })
               }
               isFullWidth
               variant="outline_bg"


### PR DESCRIPTION
# Description 📣
Resolves #4882 
Improves secret key validation for .env, .json, .yml, and manual entry.
Blocks Unicode and special-character keys and shows warning tooltips.
Ensures secret keys remain compatible with AWS, Docker, Kubernetes, and other platforms.

Only allow ASCII-safe keys:
A–Z a–z 0–9 . _ -

Invalid keys should be rejected or highlighted with a tooltip warning.


## Type ✨

- [x] Bug fix
- [x] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️
- Should prevent users from including JSON or .env files that contain invalid keys in the "Paste Secret Values" modal.
Image
<img width="1320" height="1384" alt="image" src="https://github.com/user-attachments/assets/8667bd3b-7522-412a-b2d3-d92a0cd678e9" />

- When users enter an invalid key in the "Add secret key" modal, a warning should be displayed to let the user correct it.
Image
<img width="2090" height="970" alt="image" src="https://github.com/user-attachments/assets/a75421fb-628d-41a3-8db6-9f90f28f2fdd" />


---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝