### PR TITLE
docs: add documentation for project identities

### DIFF
--- a/docs/documentation/platform/identities/machine-identities.mdx
+++ b/docs/documentation/platform/identities/machine-identities.mdx
@@ -29,7 +29,7 @@ perform organization-level operations. Organization-level identities are useful 
 ## Workflow
 
 <Tabs>
-    <Tab title="Project Identity">
+    <Tab title="Project Identities">
         A typical workflow for using project identities consists of three steps:
 
         1. Creating the identity with a name and [role](/documentation/platform/access-controls/role-based-access-controls) in Project > Access Control > Machine Identities.
@@ -37,7 +37,7 @@ perform organization-level operations. Organization-level identities are useful 
         2. Authenticating the identity with the Infisical API based on the configured authentication method on it and receiving a short-lived access token back.
         3. Authenticating subsequent requests with the Infisical API using the short-lived access token.
     </Tab>
-    <Tab title="Organization Identity">
+    <Tab title="Organization Identities">
         A typical workflow for using organization identities consists of four steps:
 
         1. Creating the identity with a name and [role](/documentation/platform/access-controls/role-based-access-controls) in Organization > Access Control > Machine Identities.


### PR DESCRIPTION
# Description 📣

This PR adds documentation for project identities on the machine identities page

<img width="3398" height="1910" alt="CleanShot 2025-11-17 at 14 09 06@2x" src="https://github.com/user-attachments/assets/8f844aa3-0ba5-4f00-8265-d7fff8f64468" />


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [x] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝