### PR TITLE
fix: resolved duplicate membership in identity

### DIFF
--- a/backend/src/services/membership-group/membership-group-service.ts
+++ b/backend/src/services/membership-group/membership-group-service.ts
@@ -93,15 +93,6 @@ export const membershipGroupServiceFactory = ({
     }
 
     const scopeDatabaseFields = factory.getScopeDatabaseFields(dto.scopeData);
-    const existingMembership = await membershipGroupDAL.findOne({
-      scope: scopeData.scope,
-      ...scopeDatabaseFields,
-      actorGroupId: dto.data.groupId
-    });
-    if (existingMembership)
-      throw new BadRequestError({
-        message: "Group is already a member"
-      });
 
     await factory.onCreateMembershipGroupGuard(dto);
 
@@ -122,6 +113,19 @@ export const membershipGroupServiceFactory = ({
     const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
 
     const membership = await membershipGroupDAL.transaction(async (tx) => {
+      const existingMembership = await membershipGroupDAL.findOne(
+        {
+          scope: scopeData.scope,
+          ...scopeDatabaseFields,
+          actorGroupId: dto.data.groupId
+        },
+        tx
+      );
+      if (existingMembership)
+        throw new BadRequestError({
+          message: "Group is already a member"
+        });
+
       const doc = await membershipGroupDAL.create(
         {
           scope: scopeData.scope,

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -102,19 +102,22 @@ export const membershipIdentityServiceFactory = ({
       throw new NotFoundError({ message: "One or more custom roles not found" });
     }
 
-    const existingMembership = await membershipIdentityDAL.findOne({
-      scope: scopeData.scope,
-      ...scopeDatabaseFields,
-      actorIdentityId: dto.data.identityId
-    });
-    if (existingMembership)
-      throw new BadRequestError({
-        message: "Identity is already a member"
-      });
-
     const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
 
     const membership = await membershipIdentityDAL.transaction(async (tx) => {
+      const existingMembership = await membershipIdentityDAL.findOne(
+        {
+          scope: scopeData.scope,
+          ...scopeDatabaseFields,
+          actorIdentityId: dto.data.identityId
+        },
+        tx
+      );
+      if (existingMembership)
+        throw new BadRequestError({
+          message: "Identity is already a member"
+        });
+
       const doc = await membershipIdentityDAL.create(
         {
           scope: scopeData.scope,


### PR DESCRIPTION
# Description 📣

This PR fixes a bug in identity membership and group membership where duplicate membership can be created. This will no throw an error

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝