### PR TITLE
style: info color and documentation link badge adjustments

### DIFF
--- a/frontend/src/components/v3/platform/DocumentationLinkBadge/DocumentationLinkBadge.tsx
+++ b/frontend/src/components/v3/platform/DocumentationLinkBadge/DocumentationLinkBadge.tsx
@@ -1,4 +1,4 @@
-import { BookOpenIcon } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 
 import { Badge } from "@app/components/v3";
 
@@ -8,10 +8,10 @@ type TDocumentationLinkBadgeProps = {
 
 export function DocumentationLinkBadge({ href }: TDocumentationLinkBadgeProps) {
   return (
-    <Badge variant="neutral" asChild>
+    <Badge variant="info" asChild>
       <a href={href} target="_blank" rel="noopener noreferrer">
-        <BookOpenIcon />
         Documentation
+        <ExternalLinkIcon />
       </a>
     </Badge>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,11 +29,11 @@
 }
 
 :root {
-    font-family: var(--font-inter);
-    --foreground: oklch(0.985 0 0);
-    --background: oklch(0.145 0 0);
+  font-family: var(--font-inter);
+  --foreground: oklch(0.985 0 0);
+  --background: oklch(0.145 0 0);
 
-    --toastify-color-dark: var(--color-mineshaft-700);
+  --toastify-color-dark: var(--color-mineshaft-700);
 }
 
 @theme {
@@ -45,16 +45,16 @@
   --color-background: #19191c;
   --color-foreground: white;
   --color-success: #2ecc71;
-  --color-info: #34c2db;
+  --color-info: #63b0bd;
   --color-warning: #f1c40f;
   --color-danger: #e74c3c;
-  --color-org: #30B3FF;
+  --color-org: #30b3ff;
   --color-sub-org: #96ff59;
   --color-project: #e0ed34;
   --color-neutral: #adaeb0;
 
   /*legacy color schema */
-  --color-org-v1: #30B3FF;
+  --color-org-v1: #30b3ff;
   --color-namespace-v1: #96ff59;
 
   /* Primary */
@@ -418,15 +418,15 @@
 }
 
 .Toastify__toast {
-    @apply rounded-md;
+  @apply rounded-md;
 }
 
 .Toastify__toast-body {
-    @apply items-start;
+  @apply items-start;
 }
 
 .Toastify__toast-icon {
-    @apply w-4 pt-1;
+  @apply w-4 pt-1;
 }
 
 .tags-conic-bg {


### PR DESCRIPTION
# Description 📣

This PR updates the info color in our theme to be more subtle and updates the documentation link badge to use info variant and replaces book icon with external link icon

<img width="3456" height="1916" alt="CleanShot 2025-11-21 at 12 34 16@2x" src="https://github.com/user-attachments/assets/eb38ac66-b235-4a17-8964-678cb61cc7ec" />


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝