### PR TITLE
fix: project navigation

### DIFF
--- a/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
@@ -242,6 +242,7 @@ const ProjectSelectInner = () => {
 export const ProjectSelect = () => {
   const params = useParams({ strict: false });
 
+  // Return null during navigation when projectId is not available
   if (!params.projectId) {
     return null;
   }


### PR DESCRIPTION
# Description 📣
fixes project navigation

We added a ProjectSelect component to the navbar and during the navigation from the project list to the project overview page, a race condition occurs when the project id doesn't exist in the params. This causes the ProjectSelect component to break. To fix this, we’ve added conditional rendering for project navigation only when a project id is available.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [x] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝