### PR TITLE
feat: added a graceful handling when version skew happens

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -29,6 +29,7 @@ export const PgSqlLock = {
 
 // all the key prefixes used must be set here to avoid conflict
 export const KeyStorePrefixes = {
+  InfisicalVersion: "infisical-version",
   SecretReplication: "secret-replication-import-lock",
   KmsProjectDataKeyCreation: "kms-project-data-key-creation-lock",
   KmsProjectKeyCreation: "kms-project-key-creation-lock",

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -16,7 +16,7 @@ import { Cluster, Redis } from "ioredis";
 import { Knex } from "knex";
 
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
-import { TKeyStoreFactory } from "@app/keystore/keystore";
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED, TEnvConfig } from "@app/lib/config/env";
 import { CustomLogger } from "@app/lib/logger/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
@@ -161,10 +161,12 @@ export const main = async ({
 
     await server.register(registerServeUI, {
       standaloneMode: appCfg.STANDALONE_MODE || IS_PACKAGED,
-      dir: path.join(__dirname, IS_PACKAGED ? "../../../" : "../../")
+      dir: path.join(__dirname, IS_PACKAGED ? "../../../" : "../../"),
+      keyStore
     });
 
     await server.ready();
+    await keyStore.setItem(KeyStorePrefixes.InfisicalVersion, appCfg.INFISICAL_PLATFORM_VERSION || "v0.0.1");
     server.swagger();
     return server;
   } catch (err) {

--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -2,17 +2,22 @@ import path from "node:path";
 
 import staticServe from "@fastify/static";
 
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED } from "@app/lib/config/env";
+import { applyJitter } from "@app/lib/dates";
+import { delay } from "@app/lib/delay";
 
 // to enabled this u need to set standalone mode to true
 export const registerServeUI = async (
   server: FastifyZodProvider,
   {
     standaloneMode,
-    dir
+    dir,
+    keyStore
   }: {
     standaloneMode?: boolean;
     dir: string;
+    keyStore: Pick<TKeyStoreFactory, "getItem">;
   }
 ) => {
   // use this only for frontend runtime static non-sensitive configuration in standalone mode
@@ -54,13 +59,31 @@ export const registerServeUI = async (
       schema: {
         hide: true
       },
-      handler: (request, reply) => {
+      handler: async (request, reply) => {
         if (request.url.startsWith("/api")) {
           reply.callNotFound();
           return;
         }
 
-        if (request.url.startsWith("/assets") && request.url.endsWith(".js")) {
+        // all the assets available will be served from the top static serve middleware
+        // if a request is reaching here this only happens due to version skew that happens on deployment
+        if (request.url.startsWith("/assets") && (request.url.endsWith(".js") || request.url.endsWith(".css"))) {
+          const infisicalVersion = await keyStore.getItem(KeyStorePrefixes.InfisicalVersion);
+          const appCfg = getConfig();
+          if (
+            infisicalVersion &&
+            appCfg.INFISICAL_PLATFORM_VERSION &&
+            appCfg.SITE_URL &&
+            infisicalVersion !== appCfg.INFISICAL_PLATFORM_VERSION
+          ) {
+            // this means version skew is happening and container version is old
+            // we wait for 5 second with jitter and then redirect to load balancer again to serve the correct one
+            await delay(applyJitter(5000, 2000));
+            const redirectUrl = new URL(appCfg.SITE_URL);
+            redirectUrl.pathname = request.raw.url || "/";
+            return reply.redirect(redirectUrl.toString());
+          }
+
           reply.callNotFound();
           return;
         }

--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -60,6 +60,11 @@ export const registerServeUI = async (
           return;
         }
 
+        if (request.url.startsWith("/assets") && request.url.endsWith(".js")) {
+          reply.callNotFound();
+          return;
+        }
+
         return reply.sendFile("index.html", {
           immutable: false,
           maxAge: 0,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,34 +32,6 @@ setWasmUrl(lottieWasmUrl);
 // Create a new router instance
 NProgress.configure({ showSpinner: false });
 
-window.addEventListener("vite:preloadError", async (event) => {
-  event.preventDefault();
-  // Get current count from session storage or initialize to 0
-  const reloadCount = parseInt(sessionStorage.getItem("vitePreloadErrorCount") || "0", 10);
-
-  // Check if we've already tried 3 times
-  if (reloadCount >= 2) {
-    console.warn("Vite preload has failed multiple times. Stopping automatic reload.");
-    // Optionally show a user-facing message here
-    return;
-  }
-
-  try {
-    if ("caches" in window) {
-      const keys = await caches.keys();
-      await Promise.all(keys.map((key) => caches.delete(key)));
-    }
-  } catch (cleanupError) {
-    console.error(cleanupError);
-  }
-  //
-  // Increment and save the counter
-  sessionStorage.setItem("vitePreloadErrorCount", (reloadCount + 1).toString());
-
-  console.log(`Reloading page (attempt ${reloadCount + 1} of 2)...`);
-  window.location.reload(); // for example, refresh the page
-});
-
 const router = createRouter({
   routeTree,
   context: { serverConfig: null, queryClient },

--- a/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
@@ -1,19 +1,44 @@
+import { useEffect } from "react";
 import { faBugs, faHome } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ErrorComponentProps, Link } from "@tanstack/react-router";
 import { AxiosError } from "axios";
 
-import { Button } from "@app/components/v2";
+import { Button, Lottie } from "@app/components/v2";
 
 import { ProjectAccessError } from "./components";
 
 export const ErrorPage = ({ error }: ErrorComponentProps) => {
+  const isDeploymentSkew =
+    error instanceof TypeError &&
+    error.message.includes("error loading dynamically imported module");
+
+  const reloadCount = parseInt(sessionStorage.getItem("vitePreloadErrorCount") || "0", 10);
+
+  useEffect(() => {
+    if (isDeploymentSkew && reloadCount <= 3) {
+      const timeout = setTimeout(() => {
+        clearTimeout(timeout);
+        sessionStorage.setItem("vitePreloadErrorCount", (reloadCount + 1).toString());
+        window.location.reload();
+      }, 10000);
+    }
+  }, [isDeploymentSkew]);
+
   if (
     error instanceof AxiosError &&
     error.status === 403 &&
     error.response?.data?.error === "User not a part of the specified project"
   ) {
     return <ProjectAccessError />;
+  }
+
+  if (isDeploymentSkew && reloadCount <= 3) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-bunker-800">
+        <Lottie isAutoPlay icon="infisical_loading" className="h-32 w-32" />
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
@@ -16,13 +16,17 @@ export const ErrorPage = ({ error }: ErrorComponentProps) => {
   const reloadCount = parseInt(sessionStorage.getItem("vitePreloadErrorCount") || "0", 10);
 
   useEffect(() => {
+    let timeout: NodeJS.Timeout | null = null;
     if (isDeploymentSkew && reloadCount <= 3) {
-      const timeout = setTimeout(() => {
-        clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        if (timeout) clearTimeout(timeout);
         sessionStorage.setItem("vitePreloadErrorCount", (reloadCount + 1).toString());
         window.location.reload();
       }, 10000);
     }
+    return () => {
+      if (timeout) clearTimeout(timeout);
+    };
   }, [isDeploymentSkew]);
 
   if (

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,11 +23,6 @@ const virtualRouteFileChangeReloadPlugin: PluginOption = {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
   const allowedHosts = env.VITE_ALLOWED_HOSTS?.split(",") ?? [];
-  const version = (
-    env.INFISICAL_PLATFORM_VERSION ||
-    env.VITE_INFISICAL_PLATFORM_VERSION ||
-    "0.0.1"
-  ).replaceAll(".", "-");
 
   return {
     server: {
@@ -42,15 +37,6 @@ export default defineConfig(({ mode }) => {
       //     ws: true
       //   }
       // }
-    },
-    build: {
-      rollupOptions: {
-        output: {
-          entryFileNames: `assets/[name]-${version}-[hash].js`,
-          chunkFileNames: `assets/[name]-${version}-[hash].js`,
-          assetFileNames: `assets/[name]-${version}-[hash].[ext]`
-        }
-      }
     },
     plugins: [
       tsconfigPaths(),


### PR DESCRIPTION
# Description 📣

This PR addresses couple of counter measures for version skew that happens on deployment
1. UI handles it more gracefully now when there is a version skew. The UI will show a loading state and then do a hard reload
2. Server when it gets a request it does a version check and if there is a version mismatch meaning the container is old, it will hold the request for few seconds and redirect it again back to LB to pick by new containers

## Type ✨

- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```

---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct). 📝