### PR TITLE
fix: correct ENCRYPTION_KEY example and improve .env.example developer guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # Keys
 # Required key for platform encryption/decryption ops
 # THIS IS A SAMPLE ENCRYPTION KEY AND SHOULD NEVER BE USED FOR PRODUCTION
-ENCRYPTION_KEY=VVHnGZ0w98WLgISK4XSJcagezuG6EWRFTk48KE4Y5Mw=
+# Must be a random 16 byte hex string. Can be generated with openssl rand -hex 16
+ENCRYPTION_KEY=d7223bec7fe90b45a6538c03cf64a384
 
 # JWT
 # Required secrets to sign JWT tokens
 # THIS IS A SAMPLE AUTH_SECRET KEY AND SHOULD NEVER BE USED FOR PRODUCTION
+# Must be a random 32 byte base64 string. Can be generated with openssl rand -base64 32
 AUTH_SECRET=5lrMXKKWCVocS/uerPsl7V+TX/aaUaI7iDkgl3tSmLE=
 
 # Postgres creds
@@ -19,7 +21,7 @@ DB_CONNECTION_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POS
 # Redis
 REDIS_URL=redis://redis:6379
 
-# Website URL
+# Website URL - Must be an absolute URL including the protocol 
 # Required
 SITE_URL=http://localhost:8080
 


### PR DESCRIPTION
This PR improves the developer onboarding experience by fixing and clarifying the `.env.example` file used for local development.

###  What was wrong

The previous `ENCRYPTION_KEY` example caused the backend to fail during migrations with:

```
Error: Invalid key length
```

This happens because the example key provided did not match the expected size required by Infisical’s cryptography module.

###  What this PR changes

* Replaces the sample `ENCRYPTION_KEY` with a valid-length base64 key to avoid runtime crypto errors.
* Adds a comment explaining the key length requirement.
* Improves comments around key usage to guide new developers.
* Enhances onboarding clarity without introducing any breaking changes.

###  Why this helps

New contributors following the development docs were hitting boot-up migration failures due to the invalid sample key.
Fixing this removes a common point of confusion and creates a smoother, more reliable local setup experience — especially for first-time contributors.

## Type 

* [x] Improvement
* [x] Documentation

# Tests 

### Steps taken:

1. Rebuilt and recreated all dev containers using:

   ```sh
   docker compose -f docker-compose.dev.yml up --build --force-recreate
   ```
2. Verified backend starts without crypto initialization errors.
3. Confirmed migrations run successfully using the corrected key.

No additional dependencies required.

---

* [x] I have read the contributing guide and agree to the code of conduct. 📝

---
