### PR TITLE
fix(api): resolved identity name missing in audit log

### DIFF
--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -195,7 +195,7 @@ export const injectIdentity = fp(
             rootOrgId: identity.rootOrgId,
             parentOrgId: identity.parentOrgId,
             identityId: identity.identityId,
-            identityName: identity.name,
+            identityName: identity.identityName,
             authMethod: null,
             isInstanceAdmin: serverCfg?.adminIdentityIds?.includes(identity.identityId),
             token

--- a/backend/src/services/identity-access-token/identity-access-token-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-dal.ts
@@ -19,6 +19,7 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.IdentityAccessToken}.identityId`)
         .select(selectAllTableCols(TableName.IdentityAccessToken))
         .select(db.ref("orgId").withSchema(TableName.Identity).as("identityScopeOrgId"))
+        .select(db.ref("name").withSchema(TableName.Identity).as("identityName"))
         .first();
 
       return doc;


### PR DESCRIPTION
## Context

This is the fix for audit log identity name missing in metadata due to the removal happened in this [PR](https://github.com/Infisical/infisical/commit/a76e323b6cf4528aea3b5769624e2ddbe36620ba) 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Execute an operation that has audit log with identity access token
2. Checkl the identity name is present in audit log table

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)