### PR TITLE
fix(ui): resolves range error that happaned when providing a large ttl for scim token

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -57,7 +57,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         organizationId: z.string().trim(),
         description: z.string().trim().default(""),
-        ttlDays: z.number().min(0).default(0)
+        ttlDays: z.number().min(0).max(730).default(0)
       }),
       response: {
         200: z.object({

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/ScimTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/ScimTokenModal.tsx
@@ -245,15 +245,22 @@ export const ScimTokenModal = ({ popUp, handlePopUpOpen, handlePopUpToggle }: Pr
                 data &&
                 data.length > 0 &&
                 data.map(({ id, description, ttlDays, createdAt }) => {
+                  const isInvalidTTLDays = ttlDays > 9999; // added validation later so some users would still be using this
                   let expiresAt;
                   if (ttlDays > 0) {
-                    expiresAt = new Date(new Date(createdAt).getTime() + ttlDays * 86400 * 1000);
+                    expiresAt = isInvalidTTLDays
+                      ? new Date()
+                      : new Date(new Date(createdAt).getTime() + ttlDays * 86400 * 1000);
                   }
 
                   return (
                     <Tr className="h-10 items-center" key={`mi-client-secret-${id}`}>
                       <Td>{description === "" ? "-" : description}</Td>
-                      <Td>{expiresAt ? format(expiresAt, "yyyy-MM-dd HH:mm:ss") : "-"}</Td>
+                      <Td>
+                        {expiresAt && !isInvalidTTLDays
+                          ? format(expiresAt, "yyyy-MM-dd HH:mm:ss")
+                          : "-"}
+                      </Td>
                       <Td>{format(new Date(createdAt), "yyyy-MM-dd HH:mm:ss")}</Td>
                       <Td>
                         <IconButton


### PR DESCRIPTION
## Context

This PR aims to resolve ui range error that happened when a large value like `999999` provided as TTL for SCIM token modal. This PR conditionally renders that in the UI and also added a max validation in router

## Screenshots

1. Add a big value for TTL
2. Gracefully handles it

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)