### PR TITLE
fix(frontend): correct query removal call sequence in when changing organization

### DIFF
--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -183,9 +183,6 @@ export const Navbar = () => {
   }, [subscription, isBillingPage, isModalIntrusive]);
 
   const handleOrgChange = async (orgId: string) => {
-    queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
-    queryClient.removeQueries({ queryKey: projectKeys.getAllUserProjects() });
-
     const { token, isMfaEnabled, mfaMethod } = await selectOrganization({
       organizationId: orgId
     });
@@ -202,6 +199,8 @@ export const Navbar = () => {
     await router.invalidate();
     await navigateUserToOrg(navigate, orgId);
     queryClient.removeQueries({ queryKey: subOrgQuery.queryKey });
+    queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
+    queryClient.removeQueries({ queryKey: projectKeys.getAllUserProjects() });
   };
 
   const { mutateAsync } = useGetOrgTrialUrl();


### PR DESCRIPTION
## Context

This PR fixes when query removal occurs when changing organizations to ensure the the projects list correctly refreshes on the overview page.

## Screenshots


https://github.com/user-attachments/assets/a75bfd69-a983-434f-9995-d8f6c054e493

## Steps to verify the change

Change organizations and ensure the project list is updated to the respective orgs projects.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)