### PR TITLE
improvement(frontend): only display 1p autofill on email, username and password fields

### DIFF
--- a/frontend/src/components/v2/Input/Input.tsx
+++ b/frontend/src/components/v2/Input/Input.tsx
@@ -65,6 +65,12 @@ const inputParentContainerVariants = cva("inline-flex font-inter items-center bo
   }
 });
 
+const data1pIgnore = (autoComplete?: string) => {
+  if (!autoComplete) return true;
+
+  return !autoComplete.match(/(email|password|username)/i);
+};
+
 export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "size"> &
   VariantProps<typeof inputVariants> &
   Props;
@@ -86,6 +92,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       isReadOnly,
       autoCapitalization,
       warning,
+      autoComplete,
       ...props
     },
     ref
@@ -116,6 +123,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           readOnly={isReadOnly}
           disabled={isDisabled}
           onInput={handleInput}
+          autoComplete={autoComplete}
+          data-1p-ignore={data1pIgnore(autoComplete)}
           className={twMerge(
             leftIcon ? "pl-10" : "pl-2.5",
             rightIcon || warning ? "pr-10" : "pr-2.5",


### PR DESCRIPTION
## Context

This PR updates our input to set the 1password ignore data attribute to false unless auto-complete is specified for email, username or password fields 

## Screenshots

https://github.com/user-attachments/assets/c1aeb612-adf3-4c4c-b5ee-42cb7dc0465d


## Steps to verify the change

- Should still see 1password auto-complete for login/sign-up
- Should not see 1password auto-complete for non-credential fields

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)