### PR TITLE
fix(project-templates): fix error when editing or creating roles on project templates

### DIFF
--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
@@ -220,7 +220,11 @@ export const IdentityProjectAdditionalPrivilegeModifySection = ({
               >
                 Save
               </Button>
-              <AddPoliciesButton isDisabled={isDisabled} projectType={currentProject.type} />
+              <AddPoliciesButton
+                isDisabled={isDisabled}
+                projectType={currentProject.type}
+                projectId={projectId}
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
@@ -216,7 +216,11 @@ export const MembershipProjectAdditionalPrivilegeModifySection = ({
               >
                 Save
               </Button>
-              <AddPoliciesButton isDisabled={isDisabled} projectType={currentProject.type} />
+              <AddPoliciesButton
+                isDisabled={isDisabled}
+                projectType={currentProject.type}
+                projectId={projectId}
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton.tsx
@@ -21,9 +21,10 @@ import { VaultPolicyImportModal } from "@app/pages/project/RoleDetailsBySlugPage
 type Props = {
   isDisabled?: boolean;
   projectType: ProjectType;
+  projectId?: string;
 };
 
-export const AddPoliciesButton = ({ isDisabled, projectType }: Props) => {
+export const AddPoliciesButton = ({ isDisabled, projectType, projectId }: Props) => {
   const { popUp, handlePopUpToggle, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "addPolicy",
     "addPolicyOptions",
@@ -109,6 +110,7 @@ export const AddPoliciesButton = ({ isDisabled, projectType }: Props) => {
         </DropdownMenuContent>
       </DropdownMenu>
       <PolicySelectionModal
+        projectId={projectId}
         type={projectType}
         isOpen={popUp.addPolicy.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("addPolicy", isOpen)}

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
@@ -18,7 +18,7 @@ import {
   Tooltip,
   Tr
 } from "@app/components/v2";
-import { ProjectPermissionSub, useProject } from "@app/context";
+import { ProjectPermissionSub } from "@app/context";
 import { useGetWorkspaceIntegrations } from "@app/hooks/api";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -34,23 +34,25 @@ type Props = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   type: ProjectType;
+  projectId?: string;
 };
 
 type ContentProps = {
   onClose: () => void;
 
+  // note(daniel): we allow projectId to be undefined because we use this component for project templates, in which case no project ID will be present.
+  projectId?: string;
   type: ProjectType;
 };
 
 type TForm = { permissions: Record<ProjectPermissionSub, boolean> };
 
-const Content = ({ onClose, type: projectType }: ContentProps) => {
+const Content = ({ onClose, projectId, type: projectType }: ContentProps) => {
   const rootForm = useFormContext<TFormSchema>();
   const [search, setSearch] = useState("");
-  const { currentProject, projectId } = useProject();
-  const isSecretManagerProject = currentProject.type === ProjectType.SecretManager;
-  const { data: integrations = [] } = useGetWorkspaceIntegrations(projectId, {
-    enabled: isSecretManagerProject,
+  const isSecretManagerProject = projectType === ProjectType.SecretManager;
+  const { data: integrations = [] } = useGetWorkspaceIntegrations(projectId ?? "", {
+    enabled: Boolean(isSecretManagerProject && projectId),
     refetchInterval: false
   });
 
@@ -216,7 +218,7 @@ const Content = ({ onClose, type: projectType }: ContentProps) => {
   );
 };
 
-export const PolicySelectionModal = ({ isOpen, onOpenChange, type }: Props) => {
+export const PolicySelectionModal = ({ isOpen, onOpenChange, type, projectId }: Props) => {
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
       <ModalContent
@@ -224,7 +226,7 @@ export const PolicySelectionModal = ({ isOpen, onOpenChange, type }: Props) => {
         subTitle="Select one or more policies to add to this role."
         className="max-w-3xl"
       >
-        <Content onClose={() => onOpenChange(false)} type={type} />
+        <Content onClose={() => onOpenChange(false)} type={type} projectId={projectId} />
       </ModalContent>
     </Modal>
   );

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
@@ -209,7 +209,11 @@ export const RolePermissionsSection = ({ roleSlug, isDisabled }: Props) => {
                   Save
                 </Button>
                 <div className="ml-2 border-l border-mineshaft-500 pl-4">
-                  <AddPoliciesButton isDisabled={isDisabled} projectType={currentProject.type} />
+                  <AddPoliciesButton
+                    isDisabled={isDisabled}
+                    projectType={currentProject.type}
+                    projectId={projectId}
+                  />
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Context

Users currently see the following error when editing or creating roles on project templates because it attempts to use the project context, which is only available within projects. The fix is passing the project ID down into the component directly, avoiding the useProject hook entirely.

## Screenshots

<img width="810" height="373" alt="CleanShot 2025-12-09 at 19 57 07" src="https://github.com/user-attachments/assets/d51d4986-40b8-42d5-aa99-cfb89ea02de5" />


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)