### PR TITLE
improvement(frontend): update docs footer to make it similar to rest of the website

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3002,7 +3002,7 @@
           },
           {
             "label": "Company Handbook",
-            "href": "https://infisical.com/wiki/handbook/"
+            "href": "https://infisical.com/wiki/handbook"
           },
           {
             "label": "Careers",


### PR DESCRIPTION
## Context

footer section in docs has a different layout compared to rest of the website.

This PR adds a [community slack](https://infisical.com/slack) endpoint to the Developers section.
OTHERS section is renamed as RESOURCES & LEGAL.  
some minor adjustments to positions of links for better organization.

since mintify allows only 4 columns, both RESOURCES and LEGALS were included in the same column.

## Screenshots
● main website footer
<img width="1897" height="802" alt="image" src="https://github.com/user-attachments/assets/c7853dee-96e9-4b59-8d03-114b3f551509" />

● docs footer - before
<img width="1897" height="802" alt="image" src="https://github.com/user-attachments/assets/892647db-524d-4f5a-8191-db7771f66914" />

● docs footer - after
<img width="1897" height="802" alt="image" src="https://github.com/user-attachments/assets/71ad9795-877f-45c1-bd25-47d6ca26b1dc" />


## Steps to verify the change
```
npm i -g mint
```

```
cd docs; mint dev;
```

go to [localhost:3000](http://localhost:3000) and navigate at bottom to view the updated footer

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)