### PR TITLE
feature(docs): add redirect for deleted Native Integrations docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3248,7 +3248,7 @@
     },
     {
       "source": "/integrations/cloud/teamcity",
-      "destination": "/integrations/cicd/teamcity"
+      "destination": "/integrations/secret-syncs/teamcity"
     }
   ]
 }

--- a/docs/integrations/cicd/teamcity.mdx
+++ b/docs/integrations/cicd/teamcity.mdx
@@ -1,8 +1,0 @@
----
-title: "TeamCity"
-description: "How to sync secrets from Infisical to TeamCity"
----
-
-<Note>
-    The TeamCity Native Integration will be deprecated in 2026. Please migrate to our new [TeamCity Sync](../secret-syncs/teamcity).
-</Note>


### PR DESCRIPTION
## Context

We started the Native Integrations phase-out in this PR https://github.com/Infisical/infisical/pull/4947 and deleted several documentation files.

We need to add redirects to the URLs of those files to avoid affecting our SEO with 404 pages.

## Steps to verify the change

Try to access any deleted file route, you should land in this page:

<img width="1904" height="868" alt="image" src="https://github.com/user-attachments/assets/6cc11a22-bc8c-4f29-83e1-dd2daa2778bc" />

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)