### PR TITLE
fix(style): fix blank screen after admin account signup

### DIFF
--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -62,7 +62,13 @@ export const SignUpPage = () => {
     navigate({ to: "/admin" });
   };
 
-  if (config?.initialized) return <ContentLoader text="Redirecting to admin page..." />;
+  if (config?.initialized) {
+    return (
+      <div className="flex min-h-screen flex-col justify-center bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
+        <ContentLoader text="Redirecting to admin page..." />
+      </div>
+    );
+  }
 
   return (
     <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">


### PR DESCRIPTION
## Context

Fix this blank screen that shows up after signing up with the admin account when you load the application for the very first time.

https://linear.app/infisical/issue/PLATFRM-121/first-time-startup-of-self-hosted-app-fails-due-to-assets-still

## Steps to verify the change

- Check out the PR
- Build the image: `docker build -f Dockerfile.standalone-infisical -t infisical/infisical:local-test .`
- Update the prod docker compose yml to use the new image you created:` image: infisical/infisical:local-test`
- Run it: `docker compose -f docker-compose.prod.yml up`

After signing up with the admin account, you should see the loader on the same black screen.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)