### PR TITLE
improvement: auto focus first input on create identity forms

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityLinkForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityLinkForm.tsx
@@ -84,6 +84,7 @@ export const OrgIdentityLinkForm = ({ onClose }: Props) => {
               onChange={onChange}
               placeholder="Select machine identity..."
               // onInputChange={setSearchValue}
+              autoFocus
               options={rootOrgIdentities}
               getOptionValue={(option) => option.id}
               getOptionLabel={(option) => option.name}

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
@@ -185,7 +185,7 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
               isError={Boolean(error)}
               errorText={error?.message}
             >
-              <Input {...field} placeholder="Machine 1" />
+              <Input {...field} autoFocus placeholder="Machine 1" />
             </FormControl>
           )}
         />

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
@@ -170,7 +170,7 @@ export const ProjectIdentityModal = ({ onClose, identity }: ContentProps) => {
             isError={Boolean(error)}
             errorText={error?.message}
           >
-            <Input {...field} placeholder="Machine 1" />
+            <Input {...field} autoFocus placeholder="Machine 1" />
           </FormControl>
         )}
       />

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectLinkIdentityModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectLinkIdentityModal.tsx
@@ -113,6 +113,7 @@ export const ProjectLinkIdentityModal = ({ handlePopUpToggle }: Props) => {
               onChange={onChange}
               isLoading={isMembershipsLoading}
               placeholder="Select machine identity..."
+              autoFocus
               // onInputChange={setSearchValue}
               options={filteredIdentityMembershipOrgs.map((membership) => ({
                 name: membership.name,


### PR DESCRIPTION
## Context

This PR adds autofocus to the first form input on both the org and project identity creation forms for both linking/creating a machine identity forms.

## Screenshots


https://github.com/user-attachments/assets/66a9619f-d29f-4416-9387-9b82677b229f

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)