### PR TITLE
fix(frontend): remove requester email on access grant from url

### DIFF
--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
@@ -151,6 +151,11 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
       type: "success"
     });
     handlePopUpToggle("addMember", false);
+    if (requesterEmail) {
+      navigate({
+        search: (prev) => ({ ...prev, requesterEmail: "" })
+      });
+    }
     reset();
   };
 
@@ -203,7 +208,7 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
     <Modal
       isOpen={popUp?.addMember?.isOpen}
       onOpenChange={(isOpen) => {
-        if (!isOpen)
+        if (!isOpen && requesterEmail)
           navigate({
             search: (prev) => ({ ...prev, requesterEmail: "" })
           });


### PR DESCRIPTION
## Context

This PR removes the requesting user email from the project access request URL after granting access so refresh / back does not re-open the modal for the user with access already

## Screenshots

https://github.com/user-attachments/assets/19f718a9-b02a-4606-998a-ecf76d2a642d

## Steps to verify the change

create project access request, grant role, and verify requester email is removed from search params

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)