### PR TITLE
chore: corrected prod yaml and automated provisioning docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ up-dev-metrics:
 	docker compose -f docker-compose.dev.yml --profile metrics up --build
 
 up-prod:
-	docker-compose -f docker-compose.prod.yml up --build
+	docker compose -f docker-compose.prod.yml up --build
 
 down:
 	docker compose -f docker-compose.dev.yml down

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    image: infisical/infisical:latest-postgres
+    image: infisical/infisical:latest # PIN THIS TO A SPECIFIC TAG
     pull_policy: always
     env_file: .env
     ports:

--- a/docs/self-hosting/guides/automated-bootstrapping.mdx
+++ b/docs/self-hosting/guides/automated-bootstrapping.mdx
@@ -247,9 +247,9 @@ curl -X POST \
     "projectDescription": "A project created via API",
     "slug": "new-project-slug",
     "template": "default",
-    "type": "SECRET_MANAGER"
+    "type": "secret-manager"
   }' \
-  https://your-infisical-instance.com/api/v2/projects
+  https://your-infisical-instance.com/api/v1/projects
 ```
 
 ## Important Notes


### PR DESCRIPTION
## Context
This PR updates the tag in prod docker compose file to use `latest` instead of the outdated `latest-postgres`. This also corrects API example in automated provisioning docs


<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)