### PR TITLE
fix(cdn): add index option to serve-ui configuration to fix index.html caching

### DIFF
--- a/backend/src/server/plugins/serve-ui.ts
+++ b/backend/src/server/plugins/serve-ui.ts
@@ -79,7 +79,8 @@ export const registerServeUI = async (
       root: frontendPath,
       wildcard: false,
       maxAge: "30d",
-      immutable: true
+      immutable: true,
+      index: false
     });
 
     server.route({


### PR DESCRIPTION
## Context

The fastify/static plugin was intercepting the index.html here when it was called on the root path of the application

<img width="314" height="133" alt="image" src="https://github.com/user-attachments/assets/3c667290-9c2f-4601-a808-e9da21a41b2a" />

Then it never reached the custom rule in this case

<img width="588" height="369" alt="image" src="https://github.com/user-attachments/assets/241a11f0-f1d7-47e5-a9ae-5484b595d281" />

The custom rule above is where we set the cache control header for the index file, because it should never be cached.

We can see the difference when we call the gamma base path and any other path:

<img width="860" height="154" alt="image" src="https://github.com/user-attachments/assets/25bd3bec-7bdf-4dc3-b659-9a365fed0aa7" />

The login route (and any other route) works because the wildcard path is false in fastify/static.

To fix the root path, too, we added the `index: false` property https://www.npmjs.com/package/@fastify/send#index, allowing our custom rule to handle it.

This is what I got from an image built after this change:

<img width="876" height="138" alt="image" src="https://github.com/user-attachments/assets/2a4d007f-ff3a-4384-832c-c89c8f5bf865" />

In the end, we have:
- All routes loading without cache 
- If CDN_HOST is not set, fastify/static serves all frontend files with 30d cache
- If CDN_HOST is not set, fastify/static serves all frontend files with 30d cache, except for the assets that are coming from the CDN_HOST URL.

## Steps to verify the change

- Build an image and do the same curl test above

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)