### PR TITLE
docs: add icons to overview page cards

### DIFF
--- a/docs/documentation/getting-started/overview.mdx
+++ b/docs/documentation/getting-started/overview.mdx
@@ -18,6 +18,7 @@ description: "The open source platform for managing secrets, certificates, and s
   <Card
     title="Secrets Management"
     href="/documentation/platform/secrets-mgmt/overview"
+    icon="vault"
   >
   Securely store, manage, and control access to sensitive application secrets across your environments.
 
@@ -25,30 +26,35 @@ description: "The open source platform for managing secrets, certificates, and s
   <Card
     title="Secrets Scanning"
     href="/documentation/platform/secret-scanning/overview"
+    icon="radar"
   >
   Automatically detect and alert on hardcoded secrets in source code, CI pipelines, and infrastructure.
   </Card>
   <Card
     title="Certificate Management"
     href="/documentation/platform/pki/overview"
+    icon="file-certificate"
   >
   Automate CA and X.509 certificate lifecycle management across your infrastructure.
   </Card>
   <Card
     title="Infisical SSH"
     href="/documentation/platform/ssh/overview"
+    icon="rectangle-terminal"
   >
   Replace static SSH keys with short-lived SSH certificates to simplify access and improve security.
   </Card>
   <Card
     title="Infisical PAM"
     href="/documentation/platform/pam/overview"
+    icon="user-shield"
   >
     Manage access to resources like databases, servers, and accounts with policy-based controls and approvals.
   </Card>
   <Card
     title="Infisical KMS"
     href="/documentation/platform/kms/overview"
+    icon="key"
   >
     Encrypt and decrypt sensitive data using a centralized key management system.
   </Card>
@@ -57,17 +63,17 @@ description: "The open source platform for managing secrets, certificates, and s
 ## Resources
 
 <Columns cols="2">
-  <Card title="CLI Reference" href="/cli/overview">
+  <Card title="CLI Reference" icon="terminal" href="/cli/overview">
     Explore Infisical’s command-line interface for managing secrets,
     certificates, and system operations via terminal.
   </Card>
-  <Card title="API Reference" href="/api-reference/overview/introduction">
+  <Card title="API Reference" icon="book-open-lines" href="/api-reference/overview/introduction">
     Browse Infisical’s API documentation to programmatically interact with
     secrets, access controls, and certificate workflows.
   </Card>
 </Columns>
 <Columns cols="1">
-  <Card title="Self-Hosting" href="/self-hosting/overview">
+  <Card title="Self-Hosting" icon="server" href="/self-hosting/overview">
     Learn how to deploy and operate Infisical on your own infrastructure with
     full control and data ownership.
   </Card>


### PR DESCRIPTION
## Context

This PR adds icons to the overview doc page cards

## Screenshots
<img width="3456" height="1916" alt="CleanShot 2025-12-18 at 19 56 10@2x" src="https://github.com/user-attachments/assets/ef09e6be-3ad1-4e58-a965-6fdedbc326eb" />
<img width="3456" height="1916" alt="CleanShot 2025-12-18 at 19 56 06@2x" src="https://github.com/user-attachments/assets/44e3ce8a-68d4-4300-8cc8-3bb4fc780aaa" />

## Steps to verify the change

look at docs

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)