### PR TITLE
fix: show duplicate accounts with no org attached and fix duplicate invited accounts

### DIFF
--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -185,14 +185,14 @@ export const authSignupServiceFactory = ({
         },
         { tx }
       );
-      const duplicateUserIds = duplicateUsers
+      const nonAcceptedDuplicateUserIds = duplicateUsers
         .filter((duplicateUser) => duplicateUser.id !== user.id)
         .map((duplicateUser) => duplicateUser.id);
-      if (duplicateUserIds.length > 0) {
+      if (nonAcceptedDuplicateUserIds.length > 0) {
         await userDAL.delete(
           {
             $in: {
-              id: duplicateUserIds
+              id: nonAcceptedDuplicateUserIds
             }
           },
           tx
@@ -370,14 +370,14 @@ export const authSignupServiceFactory = ({
         },
         { tx }
       );
-      const duplicateUserIds = duplicateUsers
+      const nonAcceptedDuplicateUserIds = duplicateUsers
         .filter((duplicateUser) => duplicateUser.id !== user.id)
         .map((duplicateUser) => duplicateUser.id);
-      if (duplicateUserIds.length > 0) {
+      if (nonAcceptedDuplicateUserIds.length > 0) {
         await userDAL.delete(
           {
             $in: {
-              id: duplicateUserIds
+              id: nonAcceptedDuplicateUserIds
             }
           },
           tx

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -198,7 +198,11 @@ export const userDALFactory = (db: TDbClient) => {
     try {
       const doc = await db(TableName.Users)
         .where({ email })
-        .leftJoin(TableName.Membership, `${TableName.Membership}.actorUserId`, `${TableName.Users}.id`)
+        .leftJoin(TableName.Membership, (qb) => {
+          void qb
+            .on(`${TableName.Membership}.actorUserId`, `${TableName.Users}.id`)
+            .andOn(`${TableName.Membership}.scope`, db.raw("?", [AccessScope.Organization]));
+        })
         .leftJoin(TableName.Organization, `${TableName.Organization}.id`, `${TableName.Membership}.scopeOrgId`)
         .select(selectAllTableCols(TableName.Users))
         .select(


### PR DESCRIPTION
## Context

Remove duplicate non-completed accounts with the same email during account signup completion to prevent orphaned user records. Also fixed an issue where duplicate accounts with no organization attached were not being properly cleaned up.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)