### PR TITLE
fix: fix project MI pagination, search and org identity name search regex

### DIFF
--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -20,7 +20,10 @@ const searchResourceZodValidate = zodValidateCharacters([
   CharacterType.AlphaNumeric,
   CharacterType.Spaces,
   CharacterType.Underscore,
-  CharacterType.Hyphen
+  CharacterType.Hyphen,
+  CharacterType.ForwardSlash
+  // TODO: scott - adding forwardslash for quick fix but we don't constrain identity name creation - not sure why we added this but we should evaluate if needed and if so make consistent with
+  // the actual name limitations
 ]);
 
 export const registerIdentityRouter = async (server: FastifyZodProvider) => {

--- a/frontend/src/hooks/api/projectIdentityMembership/queries.ts
+++ b/frontend/src/hooks/api/projectIdentityMembership/queries.ts
@@ -71,7 +71,7 @@ export const useListProjectIdentityMemberships = (
         limit: String(limit),
         orderBy: String(orderBy),
         orderDirection: String(orderDirection),
-        search: String(search)
+        identityName: String(search)
       });
 
       const { data } = await apiRequest.get<TProjectIdentityMembershipsListV2>(


### PR DESCRIPTION
## Context

This PR fixes several issues related to MI membership list functionality:
- corrects project MI membership search parameter on frontend
- fixes project MI membership pagination calculation and resolution
- fixes project MI membership query filtering
- fixes forward slash regex inclusion for searching on org MI (which is a valid name character)

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)