### PR TITLE
improvement(oidc): update params to include prompt for login

### DIFF
--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -717,7 +717,7 @@ export const oidcConfigServiceFactory = ({
         client,
         passReqToCallback: true,
         usePKCE: supportsPKCE,
-        params: supportsPKCE ? { code_challenge_method: "S256" } : undefined
+        params: { prompt: "login", ...(supportsPKCE ? { code_challenge_method: "S256" } : {}) }
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (_req: any, tokenSet: TokenSet, cb: any) => {


### PR DESCRIPTION
## Context

This PR adds the `{ prompt: "login" }` to OIDC strategy parameters. This should require the user to reauthenticate on every login.

More information on the official specs https://openid.net/specs/openid-connect-core-1_0.html.

It's important to notice that not all IdPs follow the same convention. For example, Google will take you to the account selection screen, but not ask for your password again.

## Steps to verify the change

- Log out and log in again with OIDC configured in your instance.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)