### PR TITLE
chore: removed HTTPS port mapping for nginx service in development compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,6 @@ services:
     restart: "always"
     ports:
       - 8080:80
-      - 8443:443
     volumes:
       - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:


### PR DESCRIPTION
Removed the HTTPS port mapping from the nginx service because it isn't used and conflicts with Relay development locally since relay port is hard coded.

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)