### PR TITLE
feat(pam): implement browser-accessible PAM session for postgres

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -662,7 +662,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.637.0.tgz",
       "integrity": "sha512-xUi7x4qDubtA8QREtlblPuAcn91GS/09YVEY/RwU7xCY0aqGuFwgszAANlha4OUIqva8oVj2WO4gJuG+iaSnhw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2109,7 +2108,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.682.0.tgz",
       "integrity": "sha512-ZPZ7Y/r/w3nx/xpPzGSqSQsB090Xk5aZZOH+WBhTDn/pBEuim09BYXCLzvvxb7R7NnuoQdrTJiwimdJAhHl7ZQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2163,7 +2161,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.682.0.tgz",
       "integrity": "sha512-xKuo4HksZ+F8m9DOfx/ZuWNhaPuqZFPwwy0xqcBT6sWH7OAuBjv/fnpOTzyQhpVTWddlf+ECtMAMrxjxuOExGQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2663,7 +2660,6 @@
       "version": "3.632.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.632.0.tgz",
       "integrity": "sha512-Oh1fIWaoZluihOCb/zDEpRTi+6an82fgJz7fyRBugyLhEtDjmvpCQ3oKjzaOhoN+4EvXAm1ZS/ZgpvXBlIRTgw==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2740,7 +2736,6 @@
       "version": "3.632.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.632.0.tgz",
       "integrity": "sha512-Ss5cBH09icpTvT+jtGGuQlRdwtO7RyE9BF4ZV/CEPATdd9whtJt4Qxdya8BUnkWR7h5HHTrQHqai3YVYjku41A==",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -5178,7 +5173,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -7210,7 +7204,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7232,7 +7225,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9213,9 +9205,6 @@
         "win32"
       ]
     },
-    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
-      "optional": true
-    },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
@@ -10665,7 +10654,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
       "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -11109,7 +11097,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -11750,7 +11737,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.0.tgz",
       "integrity": "sha512-9GCWmVmKUAoRfloboCd+RKm6X17xn7eGL7HnpAZUnjBXBilWCxsKnLMTC/ixSHDKS/A/057M1Tx6ZUXd89sVBw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.0 || ^19.0 || ^19.0.0-rc"
       }
@@ -11760,7 +11746,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.0.tgz",
       "integrity": "sha512-8i+v6cMxr2emz4ihCrRiYJPp2/sdYsNNsBzXStlcA+/B9Umpm5Jj3WJKYpgTPM+aeyiqlG/MMI1AucnBm4f1oQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11773,7 +11758,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.0.tgz",
       "integrity": "sha512-eIrPW9PIFgDopQU0e/OPpwCW2QWQDtNZDSsiN4sJO8KdMnWWnXJicnRfzrit5rHwFo+Y98i+w/Y5ScnBAFr1dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -11789,7 +11773,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.5.tgz",
       "integrity": "sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11865,7 +11848,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.15.tgz",
       "integrity": "sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11899,7 +11881,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.15.tgz",
       "integrity": "sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11912,7 +11893,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.11.tgz",
       "integrity": "sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11937,7 +11917,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.11.tgz",
       "integrity": "sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11950,7 +11929,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.12.tgz",
       "integrity": "sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11978,7 +11956,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.13.tgz",
       "integrity": "sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12083,7 +12060,6 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.5.tgz",
       "integrity": "sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14072,7 +14048,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
       "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -14551,7 +14526,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.20.0.tgz",
       "integrity": "sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.20.0",
         "@typescript-eslint/types": "6.20.0",
@@ -15216,7 +15190,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -15339,22 +15312,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ajv/node_modules/fast-uri": {
       "version": "3.1.0",
@@ -15721,7 +15678,6 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
       "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -15946,7 +15902,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -16548,7 +16503,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -18103,7 +18057,6 @@
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
       "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18489,7 +18442,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -18572,7 +18524,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -18671,7 +18622,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -18760,7 +18710,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -19242,6 +19191,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
       "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "0.7.2",
         "cookie-signature": "1.0.7",
@@ -19259,12 +19209,14 @@
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "peer": true
     },
     "node_modules/express-session/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -19272,7 +19224,8 @@
     "node_modules/express-session/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.1",
@@ -25929,6 +25882,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -26628,7 +26582,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
       "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -26971,7 +26924,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -27087,7 +27039,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -27551,6 +27502,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
       "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -27646,7 +27598,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27656,7 +27607,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -29481,7 +29431,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
       "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -30980,7 +30929,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -31158,7 +31106,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
       "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -31199,6 +31146,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "peer": true,
       "dependencies": {
         "random-bytes": "~1.0.0"
       },
@@ -31786,7 +31734,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -32468,7 +32415,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
       "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -30,6 +30,7 @@ import { TLdapConfigServiceFactory } from "@app/ee/services/ldap-config/ldap-con
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TOidcConfigServiceFactory } from "@app/ee/services/oidc/oidc-config-service";
 import { TPamAccountServiceFactory } from "@app/ee/services/pam-account/pam-account-service";
+import { TPamAccountSessionManagerFactory } from "@app/ee/services/pam-account/pam-account-session-manager";
 import { TPamFolderServiceFactory } from "@app/ee/services/pam-folder/pam-folder-service";
 import { TPamResourceServiceFactory } from "@app/ee/services/pam-resource/pam-resource-service";
 import { TPamSessionServiceFactory } from "@app/ee/services/pam-session/pam-session-service";
@@ -354,6 +355,7 @@ declare module "fastify" {
       pamFolder: TPamFolderServiceFactory;
       pamResource: TPamResourceServiceFactory;
       pamAccount: TPamAccountServiceFactory;
+      pamAccountSessionManager: TPamAccountSessionManagerFactory;
       pamSession: TPamSessionServiceFactory;
       upgradePath: TUpgradePathService;
 

--- a/backend/src/ee/routes/v1/index.ts
+++ b/backend/src/ee/routes/v1/index.ts
@@ -29,6 +29,7 @@ import { registerOidcRouter } from "./oidc-router";
 import { registerOrgRoleRouter } from "./org-role-router";
 import { PAM_ACCOUNT_REGISTER_ROUTER_MAP } from "./pam-account-routers";
 import { registerPamAccountRouter } from "./pam-account-routers/pam-account-router";
+import { registerPamAccountSessionRouter } from "./pam-account-routers/pam-account-session-router";
 import { registerPamFolderRouter } from "./pam-folder-router";
 import { PAM_RESOURCE_REGISTER_ROUTER_MAP } from "./pam-resource-routers";
 import { registerPamResourceRouter } from "./pam-resource-routers/pam-resource-router";
@@ -199,6 +200,7 @@ export const registerV1EERoutes = async (server: FastifyZodProvider) => {
       await pamRouter.register(
         async (pamAccountRouter) => {
           await pamAccountRouter.register(registerPamAccountRouter);
+          await pamAccountRouter.register(registerPamAccountSessionRouter);
 
           // Provider-specific endpoints
           await Promise.all(

--- a/backend/src/ee/routes/v1/pam-account-routers/pam-account-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-account-routers/pam-account-session-router.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
+import { BadRequestError } from "@app/lib/errors";
+import { ms } from "@app/lib/ms";
+import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
+import { AuthMode } from "@app/services/auth/auth-type";
+
+export const registerPamAccountSessionRouter = async (server: FastifyZodProvider) => {
+  // 1. Create Session
+  server.route({
+    method: "POST",
+    url: "/session",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      description: "Create PAM browser session",
+      body: z.object({
+        accountPath: z.string().trim(),
+        projectId: z.string().uuid(),
+        duration: z
+          .string()
+          .min(1)
+          .optional()
+          .default("4h")
+          .transform((val, ctx) => {
+            const parsedMs = ms(val);
+
+            if (parsedMs <= 0) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "Invalid duration format. Must be a positive duration (e.g., '1h', '30m', '2d')."
+              });
+              return z.NEVER;
+            }
+            return val;
+          })
+      }),
+      response: {
+        200: z.object({
+          sessionId: z.string(),
+          expiresAt: z.date(),
+          metadata: z.object({
+            username: z.string(),
+            database: z.string(),
+            host: z.string(),
+            port: z.number()
+          }),
+          account: z.object({
+            id: z.string(),
+            name: z.string()
+          })
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      if (req.auth.authMode !== AuthMode.JWT) {
+        throw new BadRequestError({ message: "You can only create PAM sessions using JWT auth tokens." });
+      }
+
+      const { accountPath, projectId, duration } = req.body;
+
+      const session = await server.services.pamAccountSessionManager.createSession(
+        {
+          accountPath,
+          projectId,
+          duration
+        },
+        req.permission
+      );
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        projectId,
+        event: {
+          type: EventType.PAM_ACCOUNT_ACCESS,
+          metadata: {
+            accountId: session.account.id,
+            accountPath,
+            accountName: session.account.name,
+            duration
+          }
+        }
+      });
+
+      return session;
+    }
+  });
+
+  // 2. Health Check
+  server.route({
+    method: "GET",
+    url: "/session/:sessionId/health",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      description: "Check PAM session health",
+      params: z.object({
+        sessionId: z.string().uuid()
+      }),
+      response: {
+        200: z.object({
+          isAlive: z.boolean(),
+          expiresAt: z.date().optional(),
+          error: z.string().optional()
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { sessionId } = req.params;
+
+      const health = await server.services.pamAccountSessionManager.checkHealth(sessionId);
+
+      return health;
+    }
+  });
+
+  // 3. Execute Query
+  server.route({
+    method: "POST",
+    url: "/session/:sessionId/query",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      description: "Execute query on PAM session",
+      params: z.object({
+        sessionId: z.string().uuid()
+      }),
+      body: z.object({
+        query: z.string().min(1).max(100000) // Max 100KB query
+      }),
+      response: {
+        200: z.object({
+          // TODO: Replace z.any() with proper PostgreSQL field type union (z.union([z.string(), z.number(), z.boolean(), z.null(), z.instanceof(Buffer)]))
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          rows: z.array(z.array(z.any())),
+          fields: z.array(z.string()).optional(),
+          rowCount: z.number(),
+          executionTimeMs: z.number()
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { sessionId } = req.params;
+      const { query } = req.body;
+
+      const sessionInfo = server.services.pamAccountSessionManager.getSessionInfo(sessionId);
+      if (!sessionInfo) {
+        throw new BadRequestError({ message: "Session not found" });
+      }
+
+      const result = await server.services.pamAccountSessionManager.executeQuery(sessionId, query);
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.PAM_SESSION_LOGS_UPDATE,
+          metadata: {
+            sessionId,
+            accountName: sessionInfo.accountName
+          }
+        }
+      });
+
+      return result;
+    }
+  });
+
+  // 4. Terminate Session
+  server.route({
+    method: "POST",
+    url: "/session/:sessionId/terminate",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      description: "Terminate PAM session",
+      params: z.object({
+        sessionId: z.string().uuid()
+      }),
+      response: {
+        200: z.object({
+          success: z.boolean()
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { sessionId } = req.params;
+
+      const sessionInfo = server.services.pamAccountSessionManager.getSessionInfo(sessionId);
+      if (!sessionInfo) {
+        throw new BadRequestError({ message: "Session not found" });
+      }
+
+      await server.services.pamAccountSessionManager.terminateSession(sessionId);
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.PAM_SESSION_END,
+          metadata: {
+            sessionId,
+            accountName: sessionInfo.accountName
+          }
+        }
+      });
+
+      return { success: true };
+    }
+  });
+};

--- a/backend/src/ee/services/pam-account/pam-account-session-manager.ts
+++ b/backend/src/ee/services/pam-account/pam-account-session-manager.ts
@@ -1,0 +1,601 @@
+import tls, { TLSSocket } from "tls";
+
+import { TPamAccounts, TPamSessions } from "@app/db/schemas";
+import { BadRequestError, GoneError, NotFoundError } from "@app/lib/errors";
+import { logger } from "@app/lib/logger";
+import { ms } from "@app/lib/ms";
+import { OrgServiceActor } from "@app/lib/types";
+
+import { TPamAccountServiceFactory } from "./pam-account-service";
+
+type TActiveSession = {
+  sessionId: string;
+  pamSessionId: string;
+  relayConnection: TLSSocket;
+  gatewayConnection: TLSSocket;
+  relayHost: string;
+  relayCerts: {
+    clientCertificate: string;
+    clientPrivateKey: string;
+    serverCertificateChain: string;
+  };
+  gatewayCerts: {
+    clientCertificate: string;
+    clientPrivateKey: string;
+    serverCertificateChain: string;
+  };
+  metadata: {
+    username: string;
+    database: string;
+    host: string;
+    port: number;
+  };
+  createdAt: Date;
+  expiresAt: Date;
+  account: TPamAccounts;
+  pamSession: TPamSessions;
+};
+
+type TCreateSessionDTO = {
+  accountPath: string;
+  projectId: string;
+  duration?: string;
+};
+
+type TQueryResult = {
+  // TODO: Replace any with proper PostgreSQL field type union (string | number | boolean | null | Buffer)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rows: Array<Array<any>>;
+  fields?: Array<string>;
+  rowCount: number;
+  executionTimeMs: number;
+};
+
+type THealthCheckResult = {
+  isAlive: boolean;
+  expiresAt?: Date;
+  error?: string;
+};
+
+type TPamAccountSessionManagerFactoryDep = {
+  pamAccountService: Pick<TPamAccountServiceFactory, "access">;
+};
+
+export type TPamAccountSessionManagerFactory = ReturnType<typeof pamAccountSessionManagerFactory>;
+
+export const pamAccountSessionManagerFactory = ({ pamAccountService }: TPamAccountSessionManagerFactoryDep) => {
+  // In-memory storage for active sessions
+  const activeSessions = new Map<string, TActiveSession>();
+
+  // PostgreSQL wire protocol helpers
+  const buildStartupMessage = (user: string, database: string): Buffer => {
+    const params = ["user", user, "database", database, "client_encoding", "UTF8"];
+    let paramsLength = 0;
+    for (const param of params) {
+      paramsLength += Buffer.from(param, "utf8").length + 1;
+    }
+    paramsLength += 1; // Null terminator
+
+    const messageLength = 4 + 4 + paramsLength;
+    const message = Buffer.alloc(messageLength);
+    let offset = 0;
+
+    message.writeInt32BE(messageLength, offset);
+    offset += 4;
+    message.writeInt32BE(196608, offset); // Protocol version 3.0
+    offset += 4;
+
+    for (const param of params) {
+      const paramBuf = Buffer.from(`${param}\0`, "utf8");
+      paramBuf.copy(message, offset);
+      offset += paramBuf.length;
+    }
+    message.writeInt8(0, offset);
+
+    return message;
+  };
+
+  const buildQueryMessage = (query: string): Buffer => {
+    const queryStr = `${query}\0`;
+    const queryBytes = Buffer.from(queryStr, "utf8");
+    const length = Buffer.alloc(4);
+    length.writeInt32BE(4 + queryBytes.length);
+
+    return Buffer.concat([Buffer.from("Q"), length, queryBytes]);
+  };
+
+  // Connect to relay server with TLS
+  const connectToRelay = async (
+    relayHost: string,
+    certs: {
+      clientCertificate: string;
+      clientPrivateKey: string;
+      serverCertificateChain: string;
+    }
+  ): Promise<TLSSocket> => {
+    const [host, portStr] = relayHost.includes(":") ? relayHost.split(":") : [relayHost, "8443"];
+    const port = parseInt(portStr, 10);
+
+    return new Promise((resolve, reject) => {
+      const options = {
+        host,
+        port,
+        cert: Buffer.from(certs.clientCertificate),
+        key: Buffer.from(certs.clientPrivateKey),
+        ca: Buffer.from(certs.serverCertificateChain),
+        minVersion: "TLSv1.2" as const,
+        rejectUnauthorized: true
+      };
+
+      const conn = tls.connect(options);
+      const timeout = setTimeout(() => {
+        conn.destroy();
+        reject(new Error("Relay connection timeout"));
+      }, 30000);
+
+      conn.on("secureConnect", () => {
+        clearTimeout(timeout);
+        resolve(conn);
+      });
+
+      conn.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  };
+
+  // Connect to gateway through relay
+  const connectToGateway = async (
+    relayConn: TLSSocket,
+    certs: {
+      clientCertificate: string;
+      clientPrivateKey: string;
+      serverCertificateChain: string;
+    },
+    alpn = "infisical-pam-proxy"
+  ): Promise<TLSSocket> => {
+    return new Promise((resolve, reject) => {
+      const options = {
+        socket: relayConn,
+        cert: Buffer.from(certs.clientCertificate),
+        key: Buffer.from(certs.clientPrivateKey),
+        ca: Buffer.from(certs.serverCertificateChain),
+        ALPNProtocols: [alpn],
+        servername: "localhost",
+        minVersion: "TLSv1.2" as const,
+        maxVersion: "TLSv1.3" as const,
+        rejectUnauthorized: true
+      };
+
+      const gatewayConn = tls.connect(options);
+      const timeout = setTimeout(() => {
+        gatewayConn.destroy();
+        reject(new Error("Gateway connection timeout"));
+      }, 30000);
+
+      gatewayConn.on("secureConnect", () => {
+        clearTimeout(timeout);
+        resolve(gatewayConn);
+      });
+
+      gatewayConn.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  };
+
+  // Send PostgreSQL startup message and wait for ready
+  const initializePostgresConnection = async (
+    gatewayConn: TLSSocket,
+    username: string,
+    database: string
+  ): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      let responseData = Buffer.alloc(0);
+      let timeout: NodeJS.Timeout;
+
+      const dataHandler = (chunk: Buffer) => {
+        responseData = Buffer.concat([responseData, chunk]);
+
+        let offset = 0;
+        while (offset < responseData.length) {
+          if (offset + 5 > responseData.length) break;
+
+          const messageType = String.fromCharCode(responseData[offset]);
+          const messageLength = responseData.readInt32BE(offset + 1);
+
+          if (offset + 1 + messageLength > responseData.length) break;
+
+          if (messageType === "Z") {
+            // ReadyForQuery
+            clearTimeout(timeout);
+            gatewayConn.removeListener("data", dataHandler);
+            resolve();
+            return;
+          }
+          if (messageType === "E") {
+            // Error
+            clearTimeout(timeout);
+            gatewayConn.removeListener("data", dataHandler);
+            reject(new Error("PostgreSQL startup error"));
+            return;
+          }
+
+          offset += 1 + messageLength;
+        }
+
+        responseData = responseData.slice(offset);
+      };
+
+      timeout = setTimeout(() => {
+        gatewayConn.removeListener("data", dataHandler);
+        reject(new Error("PostgreSQL startup timeout"));
+      }, 15000);
+
+      gatewayConn.on("data", dataHandler);
+      gatewayConn.on("error", (err) => {
+        clearTimeout(timeout);
+        gatewayConn.removeListener("data", dataHandler);
+        reject(err);
+      });
+
+      // Send startup message
+      const startupMessage = buildStartupMessage(username, database);
+      gatewayConn.write(startupMessage);
+    });
+  };
+
+  // Execute PostgreSQL query
+  const executePostgresQuery = async (
+    gatewayConn: TLSSocket,
+    query: string
+    // TODO: Replace any with proper PostgreSQL field type union (string | number | boolean | null | Buffer)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<{ rows: Array<Array<any>>; rowCount: number }> => {
+    return new Promise((resolve, reject) => {
+      let responseData = Buffer.alloc(0);
+      // TODO: Replace any with proper PostgreSQL field type union
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const results: Array<Array<any>> = [];
+      let timeout: NodeJS.Timeout;
+
+      const dataHandler = (chunk: Buffer) => {
+        responseData = Buffer.concat([responseData, chunk]);
+
+        let offset = 0;
+        while (offset < responseData.length) {
+          if (offset + 5 > responseData.length) break;
+
+          const messageType = String.fromCharCode(responseData[offset]);
+          const messageLength = responseData.readInt32BE(offset + 1);
+
+          if (offset + 1 + messageLength > responseData.length) break;
+
+          const messageData = responseData.slice(offset + 5, offset + 1 + messageLength);
+
+          if (messageType === "D") {
+            // DataRow
+            const fieldCount = messageData.readInt16BE(0);
+            // TODO: Replace any with proper PostgreSQL field type union
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const fields: Array<any> = [];
+            let fieldOffset = 2;
+
+            for (let i = 0; i < fieldCount; i += 1) {
+              const fieldLength = messageData.readInt32BE(fieldOffset);
+              fieldOffset += 4;
+              if (fieldLength > 0) {
+                const fieldValue = messageData.slice(fieldOffset, fieldOffset + fieldLength).toString("utf8");
+                fields.push(fieldValue);
+                fieldOffset += fieldLength;
+              } else {
+                fields.push(null);
+              }
+            }
+            results.push(fields);
+          } else if (messageType === "Z") {
+            // ReadyForQuery
+            clearTimeout(timeout);
+            gatewayConn.removeListener("data", dataHandler);
+            resolve({ rows: results, rowCount: results.length });
+            return;
+          } else if (messageType === "E") {
+            // Error
+            clearTimeout(timeout);
+            gatewayConn.removeListener("data", dataHandler);
+            reject(new Error("PostgreSQL query error"));
+            return;
+          }
+
+          offset += 1 + messageLength;
+        }
+
+        responseData = responseData.slice(offset);
+      };
+
+      timeout = setTimeout(() => {
+        gatewayConn.removeListener("data", dataHandler);
+        reject(new Error("Query timeout"));
+      }, 60000); // 60 second query timeout
+
+      gatewayConn.on("data", dataHandler);
+      gatewayConn.on("error", (err) => {
+        clearTimeout(timeout);
+        gatewayConn.removeListener("data", dataHandler);
+        reject(err);
+      });
+
+      // Send query
+      const queryMessage = buildQueryMessage(query);
+      gatewayConn.write(queryMessage);
+    });
+  };
+
+  // Terminate session
+  const terminateSession = async (sessionId: string): Promise<void> => {
+    const session = activeSessions.get(sessionId);
+
+    if (!session) {
+      throw new NotFoundError({ message: "Session not found" });
+    }
+
+    try {
+      // Connect with session cancellation ALPN
+      const cancelRelay = await connectToRelay(session.relayHost, session.relayCerts).catch(() => null); // Ignore errors on cancellation connect
+
+      if (cancelRelay) {
+        const cancelConn = await connectToGateway(
+          cancelRelay,
+          session.gatewayCerts,
+          "infisical-pam-session-cancellation"
+        ).catch(() => null);
+
+        if (cancelConn) {
+          cancelConn.end();
+        }
+        cancelRelay.end();
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(`Error during session cancellation for ${sessionId}`, errorMessage);
+    }
+
+    // Close connections
+    try {
+      session.gatewayConnection.destroy();
+    } catch (e) {
+      // Ignore
+    }
+    try {
+      session.relayConnection.destroy();
+    } catch (e) {
+      // Ignore
+    }
+
+    // Remove from map
+    activeSessions.delete(sessionId);
+
+    logger.info(`Terminated browser PAM session: ${sessionId}`);
+  };
+
+  // Create a new session
+  const createSession = async (
+    { accountPath, projectId, duration = "4h" }: TCreateSessionDTO,
+    actor: OrgServiceActor
+  ) => {
+    // Parse duration
+    const durationMs = ms(duration);
+    if (durationMs <= 0) {
+      throw new BadRequestError({
+        message: "Invalid duration format. Must be a positive duration (e.g., '1h', '30m', '2d')."
+      });
+    }
+
+    // Get PAM access details
+    const accessResponse = await pamAccountService.access(
+      {
+        accountPath,
+        projectId,
+        actorEmail: "",
+        actorIp: "",
+        actorName: "",
+        actorUserAgent: "",
+        duration: durationMs
+      },
+      actor
+    );
+
+    // Only support gateway-based Postgres resources for now
+    if (accessResponse.resourceType !== "postgres") {
+      throw new BadRequestError({
+        message: "Only PostgreSQL resources are supported for browser-based sessions"
+      });
+    }
+
+    if (!accessResponse.metadata || !accessResponse.metadata.username || !accessResponse.metadata.database) {
+      throw new BadRequestError({
+        message: "Missing required connection metadata"
+      });
+    }
+
+    try {
+      // Connect to relay
+      const relayConnection = await connectToRelay(accessResponse.relayHost, {
+        clientCertificate: accessResponse.relayClientCertificate,
+        clientPrivateKey: accessResponse.relayClientPrivateKey,
+        serverCertificateChain: accessResponse.relayServerCertificateChain
+      });
+
+      // Connect to gateway through relay
+      const gatewayConnection = await connectToGateway(relayConnection, {
+        clientCertificate: accessResponse.gatewayClientCertificate,
+        clientPrivateKey: accessResponse.gatewayClientPrivateKey,
+        serverCertificateChain: accessResponse.gatewayServerCertificateChain
+      });
+
+      // Initialize PostgreSQL connection
+      await initializePostgresConnection(
+        gatewayConnection,
+        accessResponse.metadata.username,
+        accessResponse.metadata.database
+      );
+
+      const relayCerts = {
+        clientCertificate: accessResponse.relayClientCertificate,
+        clientPrivateKey: accessResponse.relayClientPrivateKey,
+        serverCertificateChain: accessResponse.relayServerCertificateChain
+      };
+
+      const gatewayCerts = {
+        clientCertificate: accessResponse.gatewayClientCertificate,
+        clientPrivateKey: accessResponse.gatewayClientPrivateKey,
+        serverCertificateChain: accessResponse.gatewayServerCertificateChain
+      };
+
+      const session: TActiveSession = {
+        sessionId: accessResponse.sessionId,
+        pamSessionId: accessResponse.sessionId,
+        relayConnection,
+        gatewayConnection,
+        relayHost: accessResponse.relayHost,
+        relayCerts,
+        gatewayCerts,
+        metadata: {
+          username: accessResponse.metadata.username,
+          database: accessResponse.metadata.database,
+          host: "",
+          port: 0
+        },
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + durationMs),
+        account: accessResponse.account,
+        pamSession: {} as TPamSessions
+      };
+
+      // Store session
+      activeSessions.set(session.sessionId, session);
+
+      logger.info(`Created browser PAM session: ${session.sessionId}`);
+
+      return {
+        sessionId: session.sessionId,
+        expiresAt: session.expiresAt,
+        metadata: session.metadata,
+        account: {
+          id: session.account.id,
+          name: session.account.name
+        }
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logger.error("Failed to create PAM session", errorMessage);
+      throw new BadRequestError({
+        message: `Failed to establish connection: ${errorMessage}`
+      });
+    }
+  };
+
+  // Get session info
+  const getSessionInfo = (sessionId: string): { accountId: string; accountName: string } | null => {
+    const session = activeSessions.get(sessionId);
+    if (!session) {
+      return null;
+    }
+    return {
+      accountId: session.account.id,
+      accountName: session.account.name
+    };
+  };
+
+  // Check if session is alive
+  const checkHealth = async (sessionId: string): Promise<THealthCheckResult> => {
+    const session = activeSessions.get(sessionId);
+
+    if (!session) {
+      return { isAlive: false, error: "Session not found" };
+    }
+
+    if (new Date() > session.expiresAt) {
+      // Clean up expired session
+      await terminateSession(sessionId);
+      return { isAlive: false, error: "Session expired" };
+    }
+
+    // Check if connections are still alive
+    if (session.relayConnection.destroyed || session.gatewayConnection.destroyed) {
+      await terminateSession(sessionId);
+      return { isAlive: false, error: "Connection closed" };
+    }
+
+    return {
+      isAlive: true,
+      expiresAt: session.expiresAt
+    };
+  };
+
+  // Execute query on existing session
+  const executeQuery = async (sessionId: string, query: string): Promise<TQueryResult> => {
+    const session = activeSessions.get(sessionId);
+
+    if (!session) {
+      throw new NotFoundError({ message: "Session not found" });
+    }
+
+    if (new Date() > session.expiresAt) {
+      await terminateSession(sessionId);
+      throw new GoneError({ message: "Session expired" });
+    }
+
+    // Check if connection is alive before executing
+    if (session.gatewayConnection.destroyed) {
+      await terminateSession(sessionId);
+      throw new BadRequestError({ message: "Connection closed" });
+    }
+
+    try {
+      const startTime = Date.now();
+      const { rows, rowCount } = await executePostgresQuery(session.gatewayConnection, query);
+      const executionTimeMs = Date.now() - startTime;
+
+      return {
+        rows,
+        rowCount,
+        executionTimeMs
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      logger.error(`Query execution failed for session ${sessionId}`, errorMessage);
+      throw new BadRequestError({
+        message: `Query execution failed: ${errorMessage}`
+      });
+    }
+  };
+
+  // Background cleanup job for expired sessions
+  const startCleanupInterval = () => {
+    setInterval(() => {
+      const now = new Date();
+      for (const [sessionId, session] of activeSessions.entries()) {
+        if (now > session.expiresAt) {
+          terminateSession(sessionId).catch((err) => {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            logger.error(`Failed to cleanup expired session ${sessionId}`, errorMessage);
+          });
+        }
+      }
+    }, 60000); // Run every 60 seconds
+  };
+
+  // Start cleanup on service initialization
+  startCleanupInterval();
+
+  return {
+    createSession,
+    getSessionInfo,
+    checkHealth,
+    executeQuery,
+    terminateSession
+  };
+};

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -116,6 +116,18 @@ export class NotFoundError extends Error {
   }
 }
 
+export class GoneError extends Error {
+  name: string;
+
+  error: unknown;
+
+  constructor({ name, error, message }: { message?: string; name?: string; error?: unknown }) {
+    super(message ?? "The requested resource is no longer available");
+    this.name = name || "Gone";
+    this.error = error;
+  }
+}
+
 export class DisableRotationErrors extends Error {
   name: string;
 

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -13,6 +13,7 @@ import {
   DatabaseError,
   ForbiddenRequestError,
   GatewayTimeoutError,
+  GoneError,
   InternalServerError,
   NotFoundError,
   OidcAuthError,
@@ -31,14 +32,15 @@ enum JWTErrors {
 
 enum HttpStatusCodes {
   BadRequest = 400,
-  NotFound = 404,
   Unauthorized = 401,
   Forbidden = 403,
+  NotFound = 404,
+  Gone = 410,
   UnprocessableContent = 422,
+  TooManyRequests = 429,
   // eslint-disable-next-line @typescript-eslint/no-shadow
   InternalServerError = 500,
-  GatewayTimeout = 504,
-  TooManyRequests = 429
+  GatewayTimeout = 504
 }
 
 export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider) => {
@@ -141,6 +143,10 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
       void res
         .status(HttpStatusCodes.NotFound)
         .send({ reqId: req.id, statusCode: HttpStatusCodes.NotFound, message: error.message, error: error.name });
+    } else if (error instanceof GoneError) {
+      void res
+        .status(HttpStatusCodes.Gone)
+        .send({ reqId: req.id, statusCode: HttpStatusCodes.Gone, message: error.message, error: error.name });
     } else if (error instanceof UnauthorizedError) {
       void res.status(HttpStatusCodes.Unauthorized).send({
         reqId: req.id,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -81,6 +81,7 @@ import { oidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { oidcConfigServiceFactory } from "@app/ee/services/oidc/oidc-config-service";
 import { pamAccountDALFactory } from "@app/ee/services/pam-account/pam-account-dal";
 import { pamAccountServiceFactory } from "@app/ee/services/pam-account/pam-account-service";
+import { pamAccountSessionManagerFactory } from "@app/ee/services/pam-account/pam-account-session-manager";
 import { pamFolderDALFactory } from "@app/ee/services/pam-folder/pam-folder-dal";
 import { pamFolderServiceFactory } from "@app/ee/services/pam-folder/pam-folder-service";
 import { pamResourceDALFactory } from "@app/ee/services/pam-resource/pam-resource-dal";
@@ -2476,6 +2477,10 @@ export const registerRoutes = async (
     pamSessionExpirationService
   });
 
+  const pamAccountSessionManager = pamAccountSessionManagerFactory({
+    pamAccountService
+  });
+
   const pamAccountRotation = pamAccountRotationServiceFactory({
     queueService,
     pamAccountService
@@ -2724,6 +2729,7 @@ export const registerRoutes = async (
     pamFolder: pamFolderService,
     pamResource: pamResourceService,
     pamAccount: pamAccountService,
+    pamAccountSessionManager,
     pamSession: pamSessionService,
     upgradePath: upgradePathService,
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -152,7 +152,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -197,7 +198,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -490,7 +490,6 @@
       "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.2.tgz",
       "integrity": "sha512-KjKXlcjKbUz8dKw7PY56F7qlfOFgxTU6tnlJ8YrbDyWkJMIlHa6VRWzCD8RU20zbJUC1hExhOFggZjm6tf1mUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -549,7 +548,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1327,7 +1325,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.1.tgz",
       "integrity": "sha512-8dBIHbfsKlCk2jHQ9PoRBg2Z+4TwyE3vZICSnoDlnsHA6SiMlTwfmW6yX0lHsRmWJugkeb92sA0hZdkXJhuz+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.1"
       },
@@ -2018,7 +2015,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -4493,7 +4489,6 @@
       "integrity": "sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.13.0",
         "eslint-visitor-keys": "^4.2.0",
@@ -5119,7 +5114,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.95.1.tgz",
       "integrity": "sha512-P5x4yNhcdkYsCEoYeGZP8Q9Jlxf0WXJa4G/xvbmM905seZc9FqJqvCSRvX3dWTPOXRABhl4g+8DHqfft0c/AvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.95.0",
         "@tanstack/react-store": "^0.7.0",
@@ -5331,6 +5325,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5351,6 +5346,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5361,6 +5357,7 @@
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -5380,7 +5377,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
@@ -5388,6 +5386,7 @@
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -5408,7 +5407,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5461,6 +5461,7 @@
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -5534,7 +5535,8 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
@@ -5670,7 +5672,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
       "integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5682,7 +5683,6 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5730,7 +5730,6 @@
       "integrity": "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.34.0",
@@ -5771,7 +5770,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -6043,6 +6041,7 @@
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.4",
@@ -6060,6 +6059,7 @@
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
@@ -6087,6 +6087,7 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -6097,6 +6098,7 @@
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -6110,6 +6112,7 @@
       "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -6123,6 +6126,7 @@
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
@@ -6196,7 +6200,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6313,6 +6316,7 @@
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6361,6 +6365,7 @@
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6441,6 +6446,7 @@
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6528,6 +6534,7 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6538,6 +6545,7 @@
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6550,7 +6558,8 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -6600,6 +6609,7 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6701,6 +6711,7 @@
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -6937,7 +6948,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7119,6 +7129,7 @@
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -7189,6 +7200,7 @@
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -7574,7 +7586,8 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -7593,8 +7606,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cva": {
       "name": "class-variance-authority",
@@ -7666,7 +7678,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7720,7 +7731,8 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -7830,6 +7842,7 @@
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7864,6 +7877,7 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7985,7 +7999,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8195,6 +8210,7 @@
       "integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8278,7 +8294,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8320,6 +8335,7 @@
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8356,7 +8372,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8413,7 +8428,6 @@
       "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -8436,7 +8450,6 @@
       "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -8467,7 +8480,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8567,7 +8579,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -8697,6 +8708,7 @@
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8730,7 +8742,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8754,6 +8765,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -8767,6 +8779,7 @@
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -8785,6 +8798,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8946,6 +8960,7 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -9976,7 +9991,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       },
@@ -10070,6 +10084,7 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10346,6 +10361,7 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -10667,6 +10683,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -10702,6 +10719,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -10713,6 +10731,7 @@
       "integrity": "sha512-x4WH0BWmrMmg4oHHl+duwubhrvczGlyuGAZu3nvrf0UXOfPu8IhZObFEr7DE/iv01YgVZrsOiRcqw2srkKEDIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-object-atoms": "^1.0.0",
@@ -10862,6 +10881,7 @@
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -10896,7 +10916,8 @@
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
@@ -10904,6 +10925,7 @@
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "language-subtag-registry": "^0.3.20"
       },
@@ -10936,6 +10958,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.102.tgz",
       "integrity": "sha512-g70kydI0I1sZU0ChO8mBbhw0oUW/8U0GHzygpvEIx8k+jgOpqnTSb/E+70toYVqHxBhrERD21TwD5QcZJQ40ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11260,7 +11283,8 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -11287,6 +11311,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11978,6 +12003,7 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -12326,6 +12352,7 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -12595,6 +12622,7 @@
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -12746,7 +12774,6 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12863,6 +12890,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12878,6 +12906,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12890,7 +12919,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -13091,7 +13121,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13119,7 +13148,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -13211,7 +13239,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13262,7 +13289,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.3.tgz",
       "integrity": "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -13513,6 +13539,7 @@
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -13530,6 +13557,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13546,6 +13574,7 @@
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -13560,6 +13589,7 @@
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -13774,7 +13804,6 @@
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14285,6 +14314,7 @@
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14300,6 +14330,7 @@
       "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14327,6 +14358,7 @@
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -14547,8 +14579,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -14652,6 +14683,7 @@
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14662,6 +14694,7 @@
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14956,7 +14989,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15342,7 +15374,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -15760,6 +15791,7 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15804,7 +15836,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
       "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -15955,7 +15986,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
       "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/hooks/api/pam/types/index.ts
+++ b/frontend/src/hooks/api/pam/types/index.ts
@@ -173,3 +173,48 @@ export type TUpdatePamFolderDTO = Partial<Pick<TPamFolder, "name" | "description
 export type TDeletePamFolderDTO = {
   folderId: string;
 };
+
+// Browser session types
+export type TPamBrowserSession = {
+  sessionId: string;
+  expiresAt: string;
+  metadata: {
+    username: string;
+    database: string;
+    host: string;
+    port: number;
+  };
+  account: {
+    id: string;
+    name: string;
+  };
+};
+
+export type TPamSessionHealth = {
+  isAlive: boolean;
+  expiresAt?: string;
+  error?: string;
+};
+
+export type TPamQueryResult = {
+  rows: Array<Array<any>>;
+  fields?: Array<string>;
+  rowCount: number;
+  executionTimeMs: number;
+};
+
+// Browser session DTOs
+export type TCreateBrowserSessionDTO = {
+  accountPath: string;
+  projectId: string;
+  duration?: string;
+};
+
+export type TExecuteQueryDTO = {
+  sessionId: string;
+  query: string;
+};
+
+export type TTerminateSessionDTO = {
+  sessionId: string;
+};

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamAccessAccountModal.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamAccessAccountModal.tsx
@@ -1,12 +1,20 @@
 import { useMemo, useState } from "react";
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { faGlobe, faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ms from "ms";
 
 import { createNotification } from "@app/components/notifications";
-import { FormLabel, IconButton, Input, Modal, ModalContent } from "@app/components/v2";
-import { PamResourceType, TPamAccount } from "@app/hooks/api/pam";
+import { Button, FormLabel, IconButton, Input, Modal, ModalContent } from "@app/components/v2";
+import {
+  PamResourceType,
+  TPamAccount,
+  TPamBrowserSession,
+  useCreateBrowserSession,
+  useTerminateBrowserSession
+} from "@app/hooks/api/pam";
+
+import { PamBrowserSessionModal } from "./PamBrowserSessionModal";
 
 type Props = {
   account?: TPamAccount;
@@ -24,6 +32,12 @@ export const PamAccessAccountModal = ({
   accountPath
 }: Props) => {
   const [duration, setDuration] = useState("4h");
+  const [isBrowserSessionModalOpen, setIsBrowserSessionModalOpen] = useState(false);
+  const [browserSession, setBrowserSession] = useState<TPamBrowserSession | null>(null);
+
+  const { mutateAsync: createBrowserSession, isPending: isCreatingSession } =
+    useCreateBrowserSession();
+  const { mutateAsync: terminateSession } = useTerminateBrowserSession();
 
   const { protocol, hostname, port } = window.location;
   const portSuffix = port && port !== "80" && port !== "443" ? `:${port}` : "";
@@ -92,57 +106,155 @@ export const PamAccessAccountModal = ({
     }
   }, [account, fullAccountPath, projectId, cliDuration, siteURL]);
 
+  // Handler for browser access
+  const handleBrowserAccess = async () => {
+    if (!isDurationValid) {
+      createNotification({
+        type: "error",
+        text: "Please enter a valid duration"
+      });
+      return;
+    }
+
+    try {
+      // Terminate existing session if any
+      if (browserSession?.sessionId) {
+        try {
+          await terminateSession({ sessionId: browserSession.sessionId });
+        } catch {
+          // Ignore errors from terminating old session
+        }
+      }
+
+      // Clear previous state
+      setBrowserSession(null);
+      setIsBrowserSessionModalOpen(false);
+
+      // Create new session
+      const session = await createBrowserSession({
+        accountPath: fullAccountPath,
+        projectId,
+        duration
+      });
+
+      // Set session data and open browser session modal
+      setBrowserSession(session);
+      setIsBrowserSessionModalOpen(true);
+    } catch (error: any) {
+      createNotification({
+        type: "error",
+        text: error?.message || "Failed to create browser session"
+      });
+    }
+  };
+
+  // Check if browser access is available (PostgreSQL only for now)
+  const isBrowserAccessAvailable = account?.resource.resourceType === PamResourceType.Postgres;
+
   if (!account) return null;
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        className="max-w-2xl pb-2"
-        title="Access Account"
-        subTitle={`Access ${account.name} using a CLI command.`}
-      >
-        <FormLabel
-          label="Duration"
-          tooltipText="The maximum duration of your session. Ex: 1h, 3w, 30d"
-        />
-        <Input
-          value={duration}
-          onChange={(e) => setDuration(e.target.value)}
-          placeholder="permanent"
-          isError={!isDurationValid}
-        />
-        <FormLabel label="CLI Command" className="mt-4" />
-        <div className="flex gap-2">
-          <Input value={command} isDisabled />
-          <IconButton
-            ariaLabel="copy"
-            variant="outline_bg"
-            colorSchema="secondary"
-            onClick={() => {
-              navigator.clipboard.writeText(command);
-
-              createNotification({
-                text: "Command copied to clipboard",
-                type: "info"
-              });
-
-              onOpenChange(false);
-            }}
-            className="w-10"
-          >
-            <FontAwesomeIcon icon={faCopy} />
-          </IconButton>
-        </div>
-        <a
-          href="https://infisical.com/docs/cli/overview"
-          target="_blank"
-          className="mt-2 flex h-4 w-fit items-center gap-2 border-b border-mineshaft-400 text-sm text-mineshaft-400 transition-colors duration-100 hover:border-yellow-400 hover:text-yellow-400"
-          rel="noreferrer"
+    <>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent
+          className="max-w-2xl pb-2"
+          title="Access Account"
+          subTitle={`Access ${account.name} using a CLI command.`}
         >
-          <span>Install the Infisical CLI</span>
-          <FontAwesomeIcon icon={faUpRightFromSquare} className="size-3" />
-        </a>
-      </ModalContent>
-    </Modal>
+          <FormLabel
+            label="Duration"
+            tooltipText="The maximum duration of your session. Ex: 1h, 3w, 30d"
+          />
+          <Input
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            placeholder="permanent"
+            isError={!isDurationValid}
+          />
+          <FormLabel label="CLI Command" className="mt-4" />
+          <div className="flex gap-2">
+            <Input value={command} isDisabled />
+            <IconButton
+              ariaLabel="copy"
+              variant="outline_bg"
+              colorSchema="secondary"
+              onClick={() => {
+                navigator.clipboard.writeText(command);
+
+                createNotification({
+                  text: "Command copied to clipboard",
+                  type: "info"
+                });
+
+                onOpenChange(false);
+              }}
+              className="w-10"
+            >
+              <FontAwesomeIcon icon={faCopy} />
+            </IconButton>
+          </div>
+          <a
+            href="https://infisical.com/docs/cli/overview"
+            target="_blank"
+            className="mt-2 flex h-4 w-fit items-center gap-2 border-b border-mineshaft-400 text-sm text-mineshaft-400 transition-colors duration-100 hover:border-yellow-400 hover:text-yellow-400"
+            rel="noreferrer"
+          >
+            <span>Install the Infisical CLI</span>
+            <FontAwesomeIcon icon={faUpRightFromSquare} className="size-3" />
+          </a>
+
+          {/* Browser Access Section */}
+          {isBrowserAccessAvailable && (
+            <>
+              <div className="relative my-6">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-mineshaft-600" />
+                </div>
+                <div className="relative flex justify-center text-xs">
+                  <span className="bg-mineshaft-900 px-2 text-mineshaft-400">OR</span>
+                </div>
+              </div>
+
+              <div className="mb-2">
+                <FormLabel label="Browser Access" />
+                <p className="mb-3 text-xs text-bunker-400">
+                  Connect directly from your browser and execute SQL queries
+                </p>
+                <Button
+                  onClick={handleBrowserAccess}
+                  isLoading={isCreatingSession}
+                  isDisabled={isCreatingSession || !isDurationValid}
+                  className="w-full"
+                  size="sm"
+                  colorSchema="secondary"
+                  leftIcon={<FontAwesomeIcon icon={faGlobe} />}
+                >
+                  Connect in Browser
+                </Button>
+              </div>
+            </>
+          )}
+
+          {!isBrowserAccessAvailable && (
+            <div className="mt-4 rounded-md bg-mineshaft-800 p-3 text-xs text-bunker-400">
+              Browser access is currently available for PostgreSQL databases only.
+            </div>
+          )}
+        </ModalContent>
+      </Modal>
+
+      <PamBrowserSessionModal
+        key={browserSession?.sessionId || "no-session"}
+        isOpen={isBrowserSessionModalOpen}
+        onOpenChange={(open) => {
+          setIsBrowserSessionModalOpen(open);
+          // Close the access modal when browser session modal opens
+          if (open) {
+            onOpenChange(false);
+          }
+        }}
+        session={browserSession}
+      />
+    </>
   );
 };

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamBrowserSessionModal.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamBrowserSessionModal.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+
+import { Button, Modal, ModalContent, TextArea } from "@app/components/v2";
+import {
+  TPamBrowserSession,
+  useCheckSessionHealth,
+  useExecuteSessionQuery,
+  useTerminateBrowserSession
+} from "@app/hooks/api/pam";
+
+import { PamQueryResultsTable } from "../../PamSessionsByIDPage/components/PamQueryResultsTable";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  session: TPamBrowserSession | null;
+};
+
+export const PamBrowserSessionModal = ({ isOpen, onOpenChange, session }: Props) => {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<any>(null);
+
+  // Health check
+  const { data: health } = useCheckSessionHealth(session?.sessionId || "", {
+    refetchInterval: 30000,
+    enabled: !!session?.sessionId && isOpen
+  });
+
+  // Mutations
+  const { mutateAsync: executeQuery, isPending: isExecuting } = useExecuteSessionQuery();
+  const { mutateAsync: terminateSession } = useTerminateBrowserSession();
+
+  // Execute query handler
+  const handleExecute = async () => {
+    if (!session || !query.trim()) {
+      return;
+    }
+
+    try {
+      const queryResult = await executeQuery({ sessionId: session.sessionId, query: query.trim() });
+      setResult(queryResult);
+    } catch {
+      // Silently fail - errors will be shown in the UI if needed
+    }
+  };
+
+  // Auto-close modal when session expires
+  useEffect(() => {
+    if (health && !health.isAlive) {
+      onOpenChange(false);
+    }
+  }, [health, onOpenChange]);
+
+  // Terminate session when modal closes
+  const handleClose = async () => {
+    if (session?.sessionId) {
+      try {
+        await terminateSession({ sessionId: session.sessionId });
+      } catch {
+        // Ignore errors, session might already be terminated
+      }
+    }
+    onOpenChange(false);
+  };
+
+  if (!session) return null;
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={handleClose}>
+      <ModalContent
+        className="max-h-[85vh] max-w-5xl"
+        title={`${session.account.name} - Browser Session`}
+        subTitle={`Database: ${session.metadata.database}`}
+      >
+        {/* Query Editor */}
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="text-sm font-medium text-mineshaft-300">SQL Query</div>
+            <TextArea
+              value={query}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setQuery(e.target.value)}
+              placeholder="SELECT * FROM users LIMIT 10;"
+              className="min-h-[150px] border-mineshaft-600 bg-mineshaft-900 font-mono text-bunker-100"
+              isDisabled={isExecuting}
+            />
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={handleExecute}
+              isLoading={isExecuting}
+              isDisabled={!query.trim() || isExecuting}
+              size="sm"
+              colorSchema="secondary"
+              leftIcon={<span>▶</span>}
+            >
+              Execute Query
+            </Button>
+          </div>
+
+          {/* Results */}
+          {result && (
+            <div className="mt-4 flex flex-col gap-3">
+              <div className="flex items-center justify-between border-t border-mineshaft-600 pt-3 text-sm text-bunker-400">
+                <span className="font-medium">
+                  {result.rowCount} {result.rowCount === 1 ? "row" : "rows"} returned
+                </span>
+                <span>Executed in {result.executionTimeMs}ms</span>
+              </div>
+              <div className="max-h-[400px] overflow-auto">
+                <PamQueryResultsTable rows={result.rows} rowCount={result.rowCount} />
+              </div>
+            </div>
+          )}
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/frontend/src/pages/pam/PamSessionsByIDPage/components/PamQueryResultsTable.tsx
+++ b/frontend/src/pages/pam/PamSessionsByIDPage/components/PamQueryResultsTable.tsx
@@ -1,0 +1,51 @@
+import { Table, TBody, Td, Th, THead, Tr } from "@app/components/v2";
+
+type Props = {
+  rows: Array<Array<any>>;
+  rowCount: number;
+};
+
+export const PamQueryResultsTable = ({ rows, rowCount }: Props) => {
+  if (rowCount === 0) {
+    return (
+      <div className="flex items-center justify-center rounded-md border border-mineshaft-700 bg-mineshaft-800 p-8 text-bunker-300">
+        No rows returned
+      </div>
+    );
+  }
+
+  const columnCount = rows[0]?.length || 0;
+
+  return (
+    <div className="max-h-[500px] overflow-auto rounded-md border border-mineshaft-700">
+      {/* eslint-disable react/no-array-index-key */}
+      <Table>
+        <THead className="sticky top-0 z-10 bg-mineshaft-900">
+          <Tr>
+            {Array.from({ length: columnCount }).map((_, i) => (
+              <Th key={`col-${i}`} className="text-xs">
+                Column {i + 1}
+              </Th>
+            ))}
+          </Tr>
+        </THead>
+        <TBody>
+          {rows.map((row, rowIndex) => (
+            <Tr key={`row-${rowIndex}`} className="hover:bg-mineshaft-700">
+              {row.map((cell, cellIndex) => (
+                <Td key={`cell-${rowIndex}-${cellIndex}`} className="font-mono text-xs">
+                  {cell === null ? (
+                    <span className="text-bunker-400 italic">NULL</span>
+                  ) : (
+                    <span className="text-bunker-100">{String(cell)}</span>
+                  )}
+                </Td>
+              ))}
+            </Tr>
+          ))}
+        </TBody>
+      </Table>
+      {/* eslint-enable react/no-array-index-key */}
+    </div>
+  );
+};


### PR DESCRIPTION
## Context

This PR implements browser-accessible PAM sessions for PostgreSQL databases. Users can now create persistent database sessions through the browser and execute multiple SQL queries without reconnecting.

**What changed:**
- Added 4 REST API endpoints for session management (create, health check, query, terminate)
- Implemented PostgreSQL wire protocol for database communication (TODO: Replace with a pg client)
- Built frontend modal UI with query editor and results table
- Added automatic session cleanup and expiration handling

**Documentation:** (TODO: need to add documentation)

## Screenshots

<img width="1722" height="991" alt="image" src="https://github.com/user-attachments/assets/5c5aca39-4a16-48c5-9ccd-9ff042b241f2" />
<img width="1727" height="993" alt="image" src="https://github.com/user-attachments/assets/b9300d5a-ca78-4a3a-9bfe-677d1186adbf" />

## Steps to verify the change

1. Navigate to PAM Accounts page in the UI
2. Request access to a PostgreSQL account
3. Open browser session and execute SQL queries
4. Verify results display correctly

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
