### PR TITLE
Added liveness and readiness probes to infisical gateway

### DIFF
--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -53,6 +53,22 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http 
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: infisical-gateway-cached-relay-data
               mountPath: /var/lib/infisical

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -93,3 +93,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+# Trigger Greptile review for new commit

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.gateway.healthEndpoint }}
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -63,7 +63,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.gateway.healthEndpoint }}
               port: http 
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -12,6 +12,9 @@ gateway:
   # Defaults to /var/lib/infisical/session_recordings.
   pamSessionRecordingsDirectory: /var/lib/infisical/session_recordings
 
+  # http endpoint used for Kubernetes liveness/readiness probes
+  healthEndpoint: /health 
+
 resources:
   limits:
     cpu: 500m


### PR DESCRIPTION
This PR adds liveness and readiness HTTP probes to the infisical-gateway , Helm deployment to improve kubernetes pod health detection and restarts.

 related to the issue: #445
 
 please let me know if i made any mistake