### PR TITLE
docs: template metadata for infisical secret k8 resource

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
@@ -1628,7 +1628,8 @@ The operator provides flexible options for managing labels and annotations on ma
   - This allows you to keep InfisicalSecret-specific metadata separate from the managed secret metadata
 
   <Tip>
-    To prevent propagation while using `template.metadata`, pass empty objects for labels and/or annotations:
+    To prevent any propagation while using `template.metadata`, pass empty objects for labels and/or annotations. 
+    This will ensure no labels or annotations are propagated to the managed secret, even from the InfisicalSecret CRD's own labels/annotations:
     
     ```yaml
     template:


### PR DESCRIPTION
## Context
This PR adds documentation for the template.metadata field that allows users to define custom labels and annotations for managed Kubernetes secrets and ConfigMaps.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)