### PR TITLE
chore: add small tip on GCP app connection documentation for impersonation

### DIFF
--- a/docs/integrations/app-connections/gcp.mdx
+++ b/docs/integrations/app-connections/gcp.mdx
@@ -11,7 +11,19 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
 
     <Steps>
         <Step title="Enable the IAM Service Account Credentials API">
+            Enable the IAM Service Account Credentials API for the project containing the service account that will be impersonated. You can do this from the Google Cloud Console or via the command line.
+            
             ![Service Account API](/images/app-connections/gcp/service-account-credentials-api.png)
+            
+            To enable via command line, run the following command, replacing `projectId` with your GCP project ID:
+            ```bash
+            gcloud services enable iamcredentials.googleapis.com --project=projectId
+            ```
+            
+            Verify the API is enabled by running:
+            ```bash
+            gcloud services list --enabled --project=projectId | grep iamcredentials
+            ```
         </Step>
         <Step title="Navigate to IAM & Admin > Service Accounts in Google Cloud Console">
             ![Service Account IAM Page](/images/app-connections/gcp/service-account-overview.png)
@@ -33,13 +45,6 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
             4. You can now use GCP integration with service account impersonation.
         </Step>
     </Steps>
-
-    <Tip>
-        Before using service account impersonation, ensure that the IAM Service Account Credentials API is enabled for the project containing the service account that will be impersonated. Run the following command, replacing `projectId` with your GCP project ID:
-        ```bash
-        gcloud services enable iamcredentials.googleapis.com --project=projectId
-        ```
-    </Tip>
 
 </Accordion>
 


### PR DESCRIPTION
## Context

Add tip about enabling IAM Service Account Credentials API for service account impersonation in self-hosted GCP connection setup

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)