### PR TITLE
fix: nextUpdate on CRLs default to seven days

### DIFF
--- a/backend/src/services/certificate-authority/certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.ts
@@ -5,6 +5,7 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { NotFoundError } from "@app/lib/errors";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
 
+import { DEFAULT_CRL_VALIDITY_DAYS } from "../certificate-common/certificate-constants";
 import { CertKeyAlgorithm, CertStatus } from "../certificate/certificate-types";
 import { TCertificateAuthorityDALFactory } from "./certificate-authority-dal";
 import {
@@ -371,10 +372,14 @@ export const rebuildCaCrl = async ({
     status: CertStatus.REVOKED
   });
 
+  const thisUpdate = new Date();
+  const nextUpdate = new Date(thisUpdate);
+  nextUpdate.setDate(nextUpdate.getDate() + DEFAULT_CRL_VALIDITY_DAYS);
+
   const crl = await x509.X509CrlGenerator.create({
     issuer: ca.internalCa.dn,
-    thisUpdate: new Date(),
-    nextUpdate: new Date("2025/12/12"),
+    thisUpdate,
+    nextUpdate,
     entries: revokedCerts.map((revokedCert) => {
       const revocationDate = new Date(revokedCert.revokedAt as Date);
       return {

--- a/backend/src/services/certificate-authority/certificate-authority-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-queue.ts
@@ -7,6 +7,7 @@ import { daysToMillisecond, secondsToMillis } from "@app/lib/dates";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { QueueJobs, QueueName, TQueueServiceFactory } from "@app/queue";
+import { DEFAULT_CRL_VALIDITY_DAYS } from "@app/services/certificate-common/certificate-constants";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
 import { CertKeyAlgorithm, CertStatus } from "@app/services/certificate/certificate-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -243,10 +244,14 @@ export const certificateAuthorityQueueFactory = ({
       status: CertStatus.REVOKED
     });
 
+    const thisUpdate = new Date();
+    const nextUpdate = new Date(thisUpdate);
+    nextUpdate.setDate(nextUpdate.getDate() + DEFAULT_CRL_VALIDITY_DAYS);
+
     const crl = await x509.X509CrlGenerator.create({
       issuer: ca.internalCa.dn,
-      thisUpdate: new Date(),
-      nextUpdate: new Date("2025/12/12"), // TODO: depends on configured rebuild interval
+      thisUpdate,
+      nextUpdate,
       entries: revokedCerts.map((revokedCert) => {
         return {
           serialNumber: revokedCert.serialNumber,

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -37,6 +37,7 @@ import {
   CertStatus,
   TAltNameMapping
 } from "../../certificate/certificate-types";
+import { DEFAULT_CRL_VALIDITY_DAYS } from "../../certificate-common/certificate-constants";
 import { TCertificateTemplateDALFactory } from "../../certificate-template/certificate-template-dal";
 import { validateCertificateDetailsAgainstTemplate } from "../../certificate-template/certificate-template-fns";
 import { TCertificateAuthorityCertDALFactory } from "../certificate-authority-cert-dal";
@@ -313,10 +314,14 @@ export const internalCertificateAuthorityServiceFactory = ({
       }
 
       // create empty CRL
+      const thisUpdate = new Date();
+      const nextUpdate = new Date(thisUpdate);
+      nextUpdate.setDate(nextUpdate.getDate() + DEFAULT_CRL_VALIDITY_DAYS);
+
       const crl = await x509.X509CrlGenerator.create({
         issuer: internalCa.dn,
-        thisUpdate: new Date(),
-        nextUpdate: new Date("2025/12/12"), // TODO: change
+        thisUpdate,
+        nextUpdate,
         entries: [],
         signingAlgorithm: alg,
         signingKey: keys.privateKey

--- a/backend/src/services/certificate-common/certificate-constants.ts
+++ b/backend/src/services/certificate-common/certificate-constants.ts
@@ -195,6 +195,8 @@ export const CERTIFICATE_RENEWAL_CONFIG = {
   QUEUE_START_DELAY_MS: 5000
 } as const;
 
+export const DEFAULT_CRL_VALIDITY_DAYS = 7;
+
 export const SAN_TYPE_OPTIONS = Object.values(CertSubjectAlternativeNameType);
 export const KEY_USAGE_OPTIONS = Object.values(CertKeyUsageType);
 export const EXTENDED_KEY_USAGE_OPTIONS = Object.values(CertExtendedKeyUsageType);


### PR DESCRIPTION
## Context

 This PR fixes a bug where CRLs were generated with nextUpdate hardcoded to "2025/12/12", causing them to be immediately expired. Replaced the hardcoded date with a configurable DEFAULT_CRL_VALIDITY_DAYS constant (set to 7 days) used across all CRL generation points (rebuildCaCrl, CRL rotation queue handler, and initial CA creation), ensuring nextUpdate is always set to a future date relative to thisUpdate.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)