### PR TITLE
fix: resolved scim service failing when there is already non joined email user

### DIFF
--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -467,10 +467,11 @@ export const ldapConfigServiceFactory = ({
         );
 
         const verifiedEmail = usersWithSameEmail.find((el) => el.isEmailVerified);
+        const userWithSameUsername = usersWithSameEmail.find((el) => el.username === email.toLowerCase());
         if (verifiedEmail) {
           newUser = verifiedEmail;
-        } else if (usersWithSameEmail?.length === 1 && usersWithSameEmail?.[0]?.username === email.toLowerCase()) {
-          newUser = usersWithSameEmail?.[0];
+        } else if (userWithSameUsername) {
+          newUser = userWithSameUsername;
         }
 
         if (!newUser) {

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -253,10 +253,11 @@ export const oidcConfigServiceFactory = ({
         );
 
         const verifiedEmail = usersWithSameEmail.find((el) => el.isEmailVerified);
+        const userWithSameUsername = usersWithSameEmail.find((el) => el.username === email.toLowerCase());
         if (verifiedEmail) {
           newUser = verifiedEmail;
-        } else if (usersWithSameEmail?.length === 1 && usersWithSameEmail?.[0]?.username === email.toLowerCase()) {
-          newUser = usersWithSameEmail?.[0];
+        } else if (userWithSameUsername) {
+          newUser = userWithSameUsername;
         }
 
         if (!newUser) {

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -621,10 +621,11 @@ export const samlConfigServiceFactory = ({
         );
 
         const verifiedEmail = usersWithSameEmail.find((el) => el.isEmailVerified);
+        const userWithSameUsername = usersWithSameEmail.find((el) => el.username === email.toLowerCase());
         if (verifiedEmail) {
           newUser = verifiedEmail;
-        } else if (usersWithSameEmail?.length === 1 && usersWithSameEmail?.[0]?.username === email.toLowerCase()) {
-          newUser = usersWithSameEmail?.[0];
+        } else if (userWithSameUsername) {
+          newUser = userWithSameUsername;
         }
 
         if (!newUser) {

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -461,11 +461,12 @@ export const scimServiceFactory = ({
 
         // if there is a verified email user pick that
         const verifiedEmail = usersWithSameEmail.find((el) => el.isEmailVerified);
+        const userWithSameUsername = usersWithSameEmail.find((el) => el.username === email.toLowerCase());
         if (verifiedEmail) {
           user = verifiedEmail;
           // a user who is invited via email not logged in yet
-        } else if (usersWithSameEmail?.length === 1 && usersWithSameEmail?.[0]?.username === email.toLowerCase()) {
-          user = usersWithSameEmail?.[0];
+        } else if (userWithSameUsername) {
+          user = userWithSameUsername;
         }
 
         if (!user) {


### PR DESCRIPTION
## Context

This PR fixes a issue in scim/saml/ldap/oidc. The issue is - let's say you have enable trust email and there is already a email invited user who has not verified. This will fail the operation because the unique username constraint fails. 

This PR would fix it by selecting that user.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)