### PR TITLE
fix(backend): update key schema match handling to account for nested pathing

### DIFF
--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -179,13 +179,27 @@ export const matchesSchema = (key: string, environment: string, schema?: string)
 
   if (prefix === "" && suffix === "") return true;
 
-  // If prefix is empty, key must end with suffix
-  if (prefix === "") return key.endsWith(suffix);
+  // Check prefix match
+  if (prefix !== "" && !key.startsWith(prefix)) return false;
 
-  // If suffix is empty, key must start with prefix
-  if (suffix === "") return key.startsWith(prefix);
+  // Check suffix match
+  if (suffix !== "" && !key.endsWith(suffix)) return false;
 
-  return key.startsWith(prefix) && key.endsWith(suffix) && key.length >= prefix.length + suffix.length;
+  // Ensure key is long enough
+  if (key.length < prefix.length + suffix.length) return false;
+
+  // Extract the secretKey portion
+  const secretKeyPortion = key.slice(prefix.length, suffix.length > 0 ? key.length - suffix.length : undefined);
+
+  // If the schema uses path separators, the secretKey portion must NOT contain them.
+  // This prevents /path/segment/SECRET from matching /path/{{secretKey}}
+  if (prefix.includes("/") || suffix.includes("/")) {
+    if (secretKeyPortion.includes("/")) {
+      return false;
+    }
+  }
+
+  return true;
 };
 
 // Filter only for secrets with keys that match the schema


### PR DESCRIPTION
## Context

This PR updates `matchesSchema` to extract the `{{secretKey}}` portion from matched keys and validate that it doesn't contain path separators when the schema uses path-based prefixes or suffixes.

This fixes a conflict when two syncs have overlapping key schemas with different path depths; a more general schema can incorrectly match and delete secrets created by a more specific schema.

## Screenshots

## Steps to verify the change

- Ensure previous key schema functionality/behavior is preserved
- Create two secret syncs (AWS secrets manager) with the following key schemas:

1. `/path/nested/{{secretKey}}`
2. `/path/{{secretKey}}`

Prior to the PR if you trigger a sync for 2, it will remove secrets from 1. With this path only exact path matches should be removed. 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)