### PR TITLE
improvement(api): increase frequency of deleting expired identity tokens to hourly instead

### DIFF
--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -50,6 +50,7 @@ export enum QueueName {
   // TODO(akhilmhdh): This will get removed later. For now this is kept to stop the repeatable queue
   AuditLogPrune = "audit-log-prune",
   DailyResourceCleanUp = "daily-resource-cleanup",
+  FrequentResourceCleanUp = "frequent-resource-cleanup",
   DailyExpiringPkiItemAlert = "daily-expiring-pki-item-alert",
   DailyPkiAlertV2Processing = "daily-pki-alert-v2-processing",
   PkiSyncCleanup = "pki-sync-cleanup",
@@ -94,6 +95,7 @@ export enum QueueJobs {
   // TODO(akhilmhdh): This will get removed later. For now this is kept to stop the repeatable queue
   AuditLogPrune = "audit-log-prune-job",
   DailyResourceCleanUp = "daily-resource-cleanup-job",
+  FrequentResourceCleanUp = "frequent-resource-cleanup-job",
   DailyExpiringPkiItemAlert = "daily-expiring-pki-item-alert",
   DailyPkiAlertV2Processing = "daily-pki-alert-v2-processing",
   PkiSyncCleanup = "pki-sync-cleanup-job",
@@ -413,6 +415,10 @@ export type TQueueJobTypes = {
   [QueueName.PkiAcmeChallengeValidation]: {
     name: QueueJobs.PkiAcmeChallengeValidation;
     payload: { challengeId: string };
+  };
+  [QueueName.FrequentResourceCleanUp]: {
+    name: QueueJobs.FrequentResourceCleanUp;
+    payload: undefined;
   };
 };
 

--- a/backend/src/services/identity-access-token/identity-access-token-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-dal.ts
@@ -30,7 +30,7 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
   };
 
   const removeExpiredTokens = async (tx?: Knex) => {
-    logger.info(`${QueueName.DailyResourceCleanUp}: remove expired access token started`);
+    logger.info(`${QueueName.FrequentResourceCleanUp}: remove expired access token started`);
 
     const BATCH_SIZE = 5000;
     const MAX_RETRY_ON_FAILURE = 3;
@@ -139,7 +139,7 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
     }
 
     logger.info(
-      `${QueueName.DailyResourceCleanUp}: remove expired access token completed. Deleted ${totalDeletedCount} tokens.`
+      `${QueueName.FrequentResourceCleanUp}: remove expired access token completed. Deleted ${totalDeletedCount} tokens.`
     );
   };
 


### PR DESCRIPTION
## Context

ref: https://linear.app/infisical/issue/PLATFRM-94/reduce-time-to-delete-access-tokens

## Steps to verify the change

Change the schedule of the hourly expired identity token deleting to something like per minute to see if it's working as expected

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore
