### PR TITLE
fix(secret): record personal secret changes in environment snapshots …

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -389,8 +389,8 @@ export const secretV2BridgeServiceFactory = ({
       });
     }
 
+    await snapshotService.performSnapshot(folderId);
     if (inputSecret.type === SecretType.Shared) {
-      await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         secretPath,
         orgId: actorOrgId,
@@ -639,8 +639,8 @@ export const secretV2BridgeServiceFactory = ({
       });
     }
 
+    await snapshotService.performSnapshot(folderId);
     if (inputSecret.type === SecretType.Shared) {
-      await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         secretPath,
         actorId,
@@ -761,9 +761,9 @@ export const secretV2BridgeServiceFactory = ({
         await secretDAL.invalidateSecretCacheByProjectId(projectId, tx);
         return modifiedSecretsInDB;
       });
-
+      
+      await snapshotService.performSnapshot(folderId);
       if (inputSecret.type === SecretType.Shared) {
-        await snapshotService.performSnapshot(folderId);
         await secretQueueService.syncSecrets({
           secretPath,
           actorId,

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -304,9 +304,9 @@ export const secretServiceFactory = ({
         tx
       })
     );
-
+    
+    await snapshotService.performSnapshot(folderId);
     if (inputSecret.type === SecretType.Shared) {
-      await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         secretPath: path,
         actorId,
@@ -450,8 +450,8 @@ export const secretServiceFactory = ({
       })
     );
 
+    await snapshotService.performSnapshot(folderId);
     if (inputSecret.type === SecretType.Shared) {
-      await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         secretPath: path,
         orgId: actorOrgId,
@@ -565,8 +565,9 @@ export const secretServiceFactory = ({
       return secrets;
     });
 
+    // Take snapshot for all secret types to track deletion in environment history
+    await snapshotService.performSnapshot(folderId);
     if (inputSecret.type === SecretType.Shared) {
-      await snapshotService.performSnapshot(folderId);
       await secretQueueService.syncSecrets({
         secretPath: path,
         actorId,


### PR DESCRIPTION
## Description

Fixes a bug where **personal secret operations** (create, update, delete) were not being recorded in environment snapshots, making it impossible to track these changes in the environment's history.

### Problem
- ✅ Personal secret changes appeared in audit logs  
- ❌ Personal secret changes missing from environment snapshots

### Root Cause
`performSnapshot()` was only called for `SecretType.Shared`, excluding personal secrets from environment history.

### Solution
Moved `performSnapshot()` outside the conditional check to execute for all secret types while maintaining sync behavior only for shared secrets.

**Files Changed:**
- `secret-service.ts` - Fixed `createSecret`, `updateSecret`, `deleteSecret`
- `secret-v2-bridge-service.ts` - Fixed `createSecret`, `updateSecret`, `deleteSecret`

### Impact
- ✅ Complete environment history for all secret types
- ✅ Better audit trails for compliance
- ✅ No breaking changes - additive fix only
- ✅ Consistent behavior across secret operations

Fixes #2752