### PR TITLE
fix(agent-sentinel): oauth double-click issue

### DIFF
--- a/frontend/src/pages/ai/MCPPage/components/MCPServersTab/AddMCPServerModal/AuthenticationStep.tsx
+++ b/frontend/src/pages/ai/MCPPage/components/MCPServersTab/AddMCPServerModal/AuthenticationStep.tsx
@@ -37,7 +37,6 @@ export const AuthenticationStep = ({ onOAuthSuccess }: Props) => {
   const [oauthSessionId, setOauthSessionId] = useState<string | null>(null);
   const [isOAuthPending, setIsOAuthPending] = useState(false);
   const popupRef = useRef<Window | null>(null);
-  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Check if OAuth is already authorized (has access token)
   const oauthCredentials = authMethod === MCPServerAuthMethod.OAUTH ? watch("credentials") : null;
@@ -75,12 +74,6 @@ export const AuthenticationStep = ({ onOAuthSuccess }: Props) => {
       setIsOAuthPending(false);
       setOauthSessionId(null);
 
-      // Clear polling interval
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-        pollIntervalRef.current = null;
-      }
-
       createNotification({
         text: "OAuth authorization successful",
         type: "success"
@@ -99,9 +92,6 @@ export const AuthenticationStep = ({ onOAuthSuccess }: Props) => {
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (pollIntervalRef.current) {
-        clearInterval(pollIntervalRef.current);
-      }
       if (popupRef.current && !popupRef.current.closed) {
         popupRef.current.close();
       }
@@ -218,11 +208,6 @@ export const AuthenticationStep = ({ onOAuthSuccess }: Props) => {
 
     if (popupRef.current && !popupRef.current.closed) {
       popupRef.current.close();
-    }
-
-    if (pollIntervalRef.current) {
-      clearInterval(pollIntervalRef.current);
-      pollIntervalRef.current = null;
     }
   };
 


### PR DESCRIPTION
## Context

Fix OAuth double-click issue in Agent Sentinel. Replace popup close detection with timeout-based polling. The popupRef.closed check fails in production due to COOP headers.

## Screenshots

https://github.com/user-attachments/assets/c76f7dec-3537-46eb-9282-f8728c692b11


## Steps to verify the change

Try the OAuth method while adding an MCP server to Agent Sentinel project type.

Scenario 1: Let the popup be open for more than 5 minutes and the OAuth will timeout with a visual indicator.
Scenario 2: Complete the OAuth flow successfully and you will find that there is no need to click the button again.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)