### PR TITLE
chore: add Mintlify GTM integration to docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3074,6 +3074,9 @@
   "integrations": {
     "koala": {
       "publicApiKey": "pk_b50d7184e0e39ddd5cdb43cf6abeadd9b97d"
+    },
+    "gtm": {
+      "tagId": "GTM-WL5C7MWT"
     }
   },
   "redirects": [


### PR DESCRIPTION
## Context

Added GTM tag for docs tracking using Mintlify integration: https://www.mintlify.com/docs/integrations/analytics/google-tag-manager

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)