### PR TITLE
fix: list project identities

### DIFF
--- a/backend/src/services/identity-v2/identity-dal.ts
+++ b/backend/src/services/identity-v2/identity-dal.ts
@@ -145,7 +145,6 @@ export const identityV2DALFactory = (db: TDbClient) => {
     const countQuery = baseQuery.clone().count(`${TableName.Identity}.id as count`).first<{ count: string }>();
 
     const dataQuery = baseQuery
-      .clone()
       .leftJoin(TableName.IdentityMetadata, (queryBuilder) => {
         void queryBuilder.on(`${TableName.Identity}.id`, `${TableName.IdentityMetadata}.identityId`);
       })


### PR DESCRIPTION
## Context

Fixed a database error when listing project identities. The query used `COUNT(DISTINCT id) OVER()` to get the total count, but DISTINCT inside window function aggregates is not supported in SQL (including PostgreSQL). Refactored to use a separate count query that runs in parallel with the data query.

Endpoint for testing purposes: `/projects/:projectId/identities`


Error:
```
  |     err: {
infisical-dev-api              |       "type": "DatabaseError",
infisical-dev-api              |       "message": "select \"identities\".*, \"identity_metadata\".\"id\" as \"metadataId\", \"identity_metadata\".\"key\" as \"metadataKey\", \"identity_metadata\".\"value\" as \"metadataValue\", count(distinct \"identities\".\"id\") over () as \"count\" from \"identities\" left join \"identity_metadata\" on \"identities\".\"id\" = \"identity_metadata\".\"identityId\" where \"identities\".\"orgId\" = $1 and (\"identities\".\"projectId\" = $2) - DISTINCT is not implemented for window functions",
infisical-dev-api              |       "stack":
infisical-dev-api              |           error: select "identities".*, "identity_metadata"."id" as "metadataId", "identity_metadata"."key" as "metadataKey", "identity_metadata"."value" as "metadataValue", count(distinct "identities"."id") over () as "count" from "identities" left join "identity_metadata" on "identities"."id" = "identity_metadata"."identityId" where "identities"."orgId" = $1 and ("identities"."projectId" = $2) - DISTINCT is not implemented for window functions
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)