### PR TITLE
fix(pam): coerce SSH port input to number in validation schema

### DIFF
--- a/frontend/src/pages/pam/PamResourcesPage/components/PamResourceForm/SSHResourceForm.tsx
+++ b/frontend/src/pages/pam/PamResourcesPage/components/PamResourceForm/SSHResourceForm.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const BaseSshConnectionDetailsSchema = z.object({
   host: z.string().trim().min(1, "Host is required"),
-  port: z.number().int().min(1).max(65535)
+  port: z.coerce.number().int().min(1).max(65535)
 });
 
 const formSchema = genericResourceFieldsSchema.extend({


### PR DESCRIPTION
HTML number inputs return strings, but the Zod schema expected a number. Changed z.number() to z.coerce.number() to handle the type conversion.
Closes #5165 

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<img width="671" height="385" alt="Screenshot 2026-01-14 at 2 19 07 PM" src="https://github.com/user-attachments/assets/7a63853b-6545-45b2-9f8c-598d1234f729" />
<img width="671" height="308" alt="Screenshot 2026-01-14 at 2 15 43 PM" src="https://github.com/user-attachments/assets/1c73f1c5-81f2-4338-bf74-58f9e10126b3" />



<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
1) Go to PAM project:
2) Try to add SSH resource 
3) Enter your desired port number, it accepts properly now.(previously it was rejecting others)

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)