### PR TITLE
improvement(pam): add leading / in more places on the UI

### DIFF
--- a/frontend/src/pages/pam/PamAccountsPage/components/PamAccessAccountModal.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamAccessAccountModal.tsx
@@ -29,10 +29,10 @@ export const PamAccessAccountModal = ({
   const portSuffix = port && port !== "80" && port !== "443" ? `:${port}` : "";
   const siteURL = `${protocol}//${hostname}${portSuffix}`;
 
-  let fullAccountPath = account?.name ?? "";
+  let fullAccountPath = `/${account?.name ?? ""}`;
   if (accountPath) {
     const path = accountPath.replace(/^\/+|\/+$/g, "");
-    fullAccountPath = `${path}/${account?.name ?? ""}`;
+    fullAccountPath = `/${path}/${account?.name ?? ""}`;
   }
 
   const isDurationValid = useMemo(() => duration && ms(duration || "1s") > 0, [duration]);

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamAccountsTable.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamAccountsTable.tsx
@@ -235,7 +235,7 @@ export const PamAccountsTable = ({ projectId }: Props) => {
   const resources = resourcesData?.resources || [];
 
   const accessAccount = async (account: TPamAccount) => {
-    let fullAccountPath = account.name;
+    let fullAccountPath = `/${account.name}`;
     const folderPath = account.folderId ? folderPaths[account.folderId] : undefined;
     if (folderPath) {
       fullAccountPath = `${folderPath}/${account.name}`;


### PR DESCRIPTION
Added leading / when pre-populating request access modal with just account name, and show leading slashes in access account modals

## Screenshots

<img width="1246" height="586" alt="CleanShot 2026-01-14 at 12 34 14@2x" src="https://github.com/user-attachments/assets/06b594fb-c664-40dd-988c-deb00ec4e3f7" />
<img width="1248" height="580" alt="CleanShot 2026-01-14 at 12 35 06@2x" src="https://github.com/user-attachments/assets/559dca28-4b76-4cb3-bf65-913c2027cb7a" />
<img width="1244" height="1028" alt="CleanShot 2026-01-14 at 12 39 01@2x" src="https://github.com/user-attachments/assets/3a7de680-e71c-4dab-b21e-b1637900b8f9" />

## Steps to verify the change

- Click "connect" on an account without a policy, account path should have leading slash
- Click "connect" on an account with a policy but no nesting, and the request modal should be pre-filled with leading slash

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)