### PR TITLE
fix(mcp): support OAuth for servers without RFC 9728 protected resource metadata

### DIFF
--- a/backend/src/ee/services/ai-mcp-server/ai-mcp-server-service.ts
+++ b/backend/src/ee/services/ai-mcp-server/ai-mcp-server-service.ts
@@ -280,8 +280,11 @@ export const aiMcpServerServiceFactory = ({
             authServer
           };
         }
-      } catch {
-        // Fall through to error
+      } catch (err) {
+        // Log non-404 errors for debugging, but still fall through
+        if (!axios.isAxiosError(err) || err.response?.status !== 404) {
+          logger.warn(err, "Failed to fetch OAuth authorization server metadata");
+        }
       }
 
       throw new BadRequestError({


### PR DESCRIPTION
## Context

 MCP servers like Linear don't implement RFC 9728 Protected Resource Metadata (added in [2025-06-18 spec update](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location )). They only expose `.well-known/oauth-authorization-server`, causing OAuth discovery to fail.

Now we fallback to fetching auth server metadata directly when protected resource metadata isn't found.

## Screenshots

<img width="1727" height="991" alt="image" src="https://github.com/user-attachments/assets/3874c47f-070f-404c-abec-4b9218d97ea0" />

<img width="771" height="583" alt="image" src="https://github.com/user-attachments/assets/5fc1d597-0773-4a8b-9b3f-0a5b82de2330" />

## Steps to verify the change

1. Add linear HTTP MCP server
2. Create an MCP endpoint with that server and enable some tools
3. Use an MCP client like claude.ai to call some of the tools

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)