### PR TITLE
fix: secrets with metadata failing on move operations

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -110,7 +110,7 @@ export const fnSecretBulkInsert = async ({
   const actorType = actor?.type || ActorType.PLATFORM;
 
   const newSecrets = await secretDAL.insertMany(
-    sanitizedInputSecrets.map((el) => ({ ...el, folderId })),
+    sanitizedInputSecrets.map(({ metadata, ...el }) => ({ ...el, folderId })),
     tx
   );
 


### PR DESCRIPTION
## Context

This PR fixes an issue happening while moving secrets with metadata, the issue happened due to an old non-used column "metadata" being filled with data on the batch insert secrets flow

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)