### PR TITLE
fix(frontend): render no change commit comparison display instead of null when no changes on update

### DIFF
--- a/frontend/src/pages/secret-manager/CommitDetailsPage/components/SecretVersionDiffView/SecretVersionDiffView.tsx
+++ b/frontend/src/pages/secret-manager/CommitDetailsPage/components/SecretVersionDiffView/SecretVersionDiffView.tsx
@@ -516,10 +516,7 @@ export const SecretVersionDiffView = ({
     const cleanOldVersion = cleanVersionForComparison(oldVersion);
     const cleanNewVersion = cleanVersionForComparison(newVersion);
     diffPaths = getDiffPaths(cleanOldVersion, cleanNewVersion);
-
-    if (diffPaths.size === 0) {
-      return null;
-    }
+    const hasNoChanges = diffPaths.size === 0;
 
     oldVersionContent = (
       <div className="w-fit min-w-full font-mono text-sm">
@@ -538,7 +535,17 @@ export const SecretVersionDiffView = ({
       </div>
     );
     newVersionContent = (
-      <div className="w-fit min-w-full font-mono text-sm">
+      <div
+        className={twMerge(
+          "relative w-fit min-w-full font-mono text-sm",
+          hasNoChanges && "[&>*+*]:opacity-0" // still want to render json to make container equivalent size to old version
+        )}
+      >
+        {hasNoChanges && (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-mineshaft-400">
+            <span>No changes</span>
+          </div>
+        )}
         {renderJsonWithDiffs(
           cleanNewVersion,
           diffPaths,


### PR DESCRIPTION
## Context

This PR updates the commit changes view to display a "no changes" comparison view when there is no difference on an update instead of rendering nothing.

## Screenshots

<img width="3456" height="1916" alt="CleanShot 2026-01-19 at 10 09 53@2x" src="https://github.com/user-attachments/assets/7f1a6715-e074-48cf-9b22-ad77251c7b1e" />

## Steps to verify the change

- Test no change view works when "updating" a resource with no changes
- ensure other change comparison views are not effected

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)