### PR TITLE
improvement(frontend): add button to approve and merge change request in one action if tenable

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -392,13 +392,18 @@ export const SecretApprovalRequestChanges = ({ approvalRequestId, onGoBack }: Pr
                           {isMergableUponApprove && (
                             <Button
                               onClick={async () => {
-                                setWillMerge(true);
-                                await handleSubmit(handleSubmitReview)();
-                                await performSecretApprovalMerge({
-                                  projectId,
-                                  id: secretApprovalRequestDetails.id
-                                });
-                                setWillMerge(false);
+                                try {
+                                  setWillMerge(true);
+                                  await handleSubmit(handleSubmitReview)();
+                                  await performSecretApprovalMerge({
+                                    projectId,
+                                    id: secretApprovalRequestDetails.id
+                                  });
+                                } catch {
+                                  // Approval or merge failed, error already shown via mutation
+                                } finally {
+                                  setWillMerge(false);
+                                }
                               }}
                               variant="solid"
                               className="mt-auto ml-2 h-min"


### PR DESCRIPTION
## Context

This PR adds a button to both approve and merge a change request if upon approval the user would be able to merge the change request

## Screenshots

<img width="3456" height="1916" alt="CleanShot 2026-01-19 at 14 47 38@2x" src="https://github.com/user-attachments/assets/3c350482-629a-4d1c-8434-b540a932fab8" />

## Steps to verify the change

- Verify button only displays if user would be able to merge after approving

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)