### PR TITLE
fix(pam): k8s create account not working due to rotation

### DIFF
--- a/frontend/src/pages/pam/PamAccountsPage/components/PamAccountForm/KubernetesAccountForm.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamAccountForm/KubernetesAccountForm.tsx
@@ -7,7 +7,6 @@ import { KubernetesAuthMethod, PamResourceType, TKubernetesAccount } from "@app/
 import { UNCHANGED_PASSWORD_SENTINEL } from "@app/hooks/api/pam/constants";
 
 import { GenericAccountFields, genericAccountFieldsSchema } from "./GenericAccountFields";
-import { rotateAccountFieldsSchema } from "./RotateAccountFields";
 
 type Props = {
   account?: TKubernetesAccount;
@@ -21,8 +20,11 @@ const KubernetesServiceAccountTokenCredentialsSchema = z.object({
   serviceAccountToken: z.string().trim().min(1, "Service account token is required")
 });
 
-const formSchema = genericAccountFieldsSchema.extend(rotateAccountFieldsSchema.shape).extend({
-  credentials: KubernetesServiceAccountTokenCredentialsSchema
+const formSchema = genericAccountFieldsSchema.extend({
+  credentials: KubernetesServiceAccountTokenCredentialsSchema,
+  // We don't support rotation for now, just feed a false value to
+  // make the schema happy
+  rotationEnabled: z.boolean().default(false)
 });
 
 type FormData = z.infer<typeof formSchema>;


### PR DESCRIPTION
## Context

Fixes PAM k8s create account not working due to rotation schema

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

Creating a k8s account prior to this change was not possible, but after the change it is.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)