### PR TITLE
improvement(gitlab-integration): moved from 'name' to 'fullName' when using GitLab groups

### DIFF
--- a/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
@@ -72,7 +72,7 @@ export const registerGitLabConnectionRouter = async (server: FastifyZodProvider)
         200: z
           .object({
             id: z.string(),
-            name: z.string()
+            fullName: z.string()
           })
           .array()
       }

--- a/backend/src/services/app-connection/gitlab/gitlab-connection-fns.ts
+++ b/backend/src/services/app-connection/gitlab/gitlab-connection-fns.ts
@@ -367,7 +367,7 @@ export const listGitLabGroups = async ({
 
     return groups.map((group) => ({
       id: group.id.toString(),
-      name: group.name
+      fullName: group.fullName
     }));
   } catch (error: unknown) {
     if (error instanceof GitbeakerRequestError) {

--- a/backend/src/services/app-connection/gitlab/gitlab-connection-types.ts
+++ b/backend/src/services/app-connection/gitlab/gitlab-connection-types.ts
@@ -52,5 +52,5 @@ export type TGitLabRefreshTokenCredentials = {
 
 export interface TGitLabGroup {
   id: string;
-  name: string;
+  fullName: string;
 }

--- a/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/GitLabDataSourceConfigFields.tsx
+++ b/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/GitLabDataSourceConfigFields.tsx
@@ -190,13 +190,13 @@ export const GitLabDataSourceConfigFields = () => {
                     const group = newValue as SingleValue<TGitLabGroup>;
 
                     onChange(group ? Number.parseInt(group.id, 10) : null);
-                    setValue("config.groupName", group?.name ?? "");
+                    setValue("config.groupName", group?.fullName ?? "");
                     setValue("config.includeProjects", ["*"]);
                   }}
                   options={groups}
                   placeholder="Select group..."
-                  getOptionLabel={(option) => option.name}
-                  getOptionValue={(option) => option.name}
+                  getOptionLabel={(option) => option.fullName}
+                  getOptionValue={(option) => option.id}
                 />
               </FormControl>
             )}

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabSyncFields.tsx
@@ -153,12 +153,12 @@ export const GitLabSyncFields = () => {
                   onChange((option as SingleValue<TGitLabGroup>)?.id ?? "");
                   setValue(
                     "destinationConfig.groupName",
-                    (option as SingleValue<TGitLabGroup>)?.name ?? ""
+                    (option as SingleValue<TGitLabGroup>)?.fullName ?? ""
                   );
                 }}
                 options={groups}
                 placeholder="Select a group..."
-                getOptionLabel={(option) => option.name}
+                getOptionLabel={(option) => option.fullName}
                 getOptionValue={(option) => option.id}
               />
             </FormControl>

--- a/frontend/src/hooks/api/appConnections/gitlab/types.ts
+++ b/frontend/src/hooks/api/appConnections/gitlab/types.ts
@@ -5,7 +5,7 @@ export type TGitLabProject = {
 
 export type TGitLabGroup = {
   id: string;
-  name: string;
+  fullName: string;
 };
 
 export enum GitLabAccessTokenType {


### PR DESCRIPTION
## Context

We are now using the fullName instead of the name property for GitLab groups to show the full path for subgroups.

## Screenshots

<img width="1320" height="879" alt="image" src="https://github.com/user-attachments/assets/29135f9a-024f-41ba-9216-c1ab7868b2d9" />

<img width="1476" height="500" alt="image" src="https://github.com/user-attachments/assets/72a6e961-a098-4d82-9846-5ae4deb97437" />

## Steps to verify the change

Add subgroups to your GitLab account and test the integration in the secret sync and secret scanning features.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)