### PR TITLE
docs: add rate limits section to API reference

### DIFF
--- a/docs/api-reference/overview/introduction.mdx
+++ b/docs/api-reference/overview/introduction.mdx
@@ -23,4 +23,21 @@ Infisical enforces three different types of rate limits:
 - **Write**: For CREATE, UPDATE, and DELETE operations.
 - **Secret**: Specifically for secret management operations such as getting and creating secrets.
 
-By default, the rate limits are 300 for read and secret operations, and 200 for write operations. Enterprise users get custom rate limits.
+**Self-hosted** instances have no limits, these limits apply only to **Infisical Cloud**.
+
+<Tabs>
+  <Tab title="Free Plan">
+    - **Read**: 200/minute
+    - **Write**: 90/minute
+    - **Secret**: 120/minute
+  </Tab>
+  <Tab title="Pro Plan">
+    - **Read**: 350/minute
+    - **Write**: 200/minute
+    - **Secret**: 300/minute
+  </Tab>
+</Tabs>
+
+<Note>
+    Custom rate limits are available for Enterprise customers. If you need higher rate limits, please contact sales@infisical.com.
+</Note>


### PR DESCRIPTION
## Context

Add rate limits section to API reference

## Screenshots

<img width="1689" height="954" alt="image" src="https://github.com/user-attachments/assets/ec2cd2b0-7cac-4413-a8d8-2f30303360fa" />

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)