### PR TITLE
fix: migration error in read-compat-flag

### DIFF
--- a/backend/src/db/migrations/20250824192801_backfill-secret-read-compat-flag.ts
+++ b/backend/src/db/migrations/20250824192801_backfill-secret-read-compat-flag.ts
@@ -15,15 +15,9 @@ export async function up(knex: Knex): Promise<void> {
       for (let i = 0; i < rows.length; i += BATCH_SIZE) {
         const batch = rows.slice(i, i + BATCH_SIZE);
         const ids = batch.map((row) => row.id);
+        // @ts-expect-error because this field got removed later
         // eslint-disable-next-line no-await-in-loop
-        await knex.raw(
-          `
-          UPDATE ??
-          SET ?? = true
-          WHERE ?? IN (${ids.map(() => "?").join(",")})
-          `,
-          [TableName.SecretApprovalPolicy, "shouldCheckSecretPermission", "id", ids]
-        );
+        await knex(TableName.SecretApprovalPolicy).whereIn("id", ids).update({ shouldCheckSecretPermission: true });
       }
     }
   }


### PR DESCRIPTION
## Context

This PR fixes an error in raw query where the array was treated as parameterized items (so if there were more items in the array it would be greater than the expected params count). Switched it back to normal query instead of raw. This was converted to raw query to avoid ts error that happened due to later removing this field. Suppressed with with ts-expect-error command. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)