### PR TITLE
feat: added query to remove orphan user org membership

### DIFF
--- a/backend/src/db/migrations/20251005152640_simplify-membership.ts
+++ b/backend/src/db/migrations/20251005152640_simplify-membership.ts
@@ -201,6 +201,8 @@ const createAdditionalPrivilegeTable = async (knex: Knex) => {
 };
 
 const migrateMembershipData = async (knex: Knex) => {
+  await knex(TableName.OrgMembership).whereNull("userId").del();
+
   await knex
     .insert(
       knex(TableName.OrgMembership).select(


### PR DESCRIPTION
## Context

This PR removes orphan organisation membership user data where the user field is null. This caused the simplify membership migration to fail because it expects the user ID to be available. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)