### PR TITLE
feat: added cleanup query to remove orphan identity

### DIFF
--- a/backend/src/db/migrations/20251005152640_simplify-membership.ts
+++ b/backend/src/db/migrations/20251005152640_simplify-membership.ts
@@ -240,6 +240,11 @@ const migrateMembershipData = async (knex: Knex) => {
       ])
     );
 
+  // clear orphaned identity project memberships
+  await knex(TableName.IdentityOrgMembership)
+    .whereNotIn("identityId", knex.select("id").from(TableName.Identity))
+    .del();
+
   await knex
     .insert(
       knex(TableName.IdentityOrgMembership).select(
@@ -308,6 +313,11 @@ const migrateMembershipData = async (knex: Knex) => {
         "scope"
       ])
     );
+
+  // clear orphaned identity project memberships
+  await knex(TableName.IdentityProjectMembership)
+    .whereNotIn("identityId", knex.select("id").from(TableName.Identity))
+    .del();
 
   await knex
     .insert(


### PR DESCRIPTION
## Context

This PR removes the orphan identity in project and organisation membership identity table that doesn't exist in identity table.  When we were running migration for a usecase we found out there was orphan rows and this is to handle that edge case gracefully. The FK didn't exist in both. tables for the identities.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)