### PR TITLE
fix(sign-up): implement email notification for existing accounts during signup

### DIFF
--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -76,8 +76,20 @@ export const authSignupServiceFactory = ({
     let user =
       usersByUsername?.length > 1 ? usersByUsername.find((el) => el.username === sanitizedEmail) : usersByUsername?.[0];
     if (user && user.isAccepted) {
-      // TODO(akhilmhdh-pg): copy as old one. this needs to be changed due to security issues
-      throw new BadRequestError({ message: "Failed to send verification code for complete account" });
+      // Send informational email for existing accounts instead of throwing error
+      // This prevents user enumeration vulnerability
+      const appCfg = getConfig();
+      await smtpService.sendMail({
+        template: SmtpTemplates.SignupExistingAccount,
+        subjectLine: "Sign-up Request for Your Infisical Account",
+        recipients: [sanitizedEmail],
+        substitutions: {
+          email: sanitizedEmail,
+          loginUrl: `${appCfg.SITE_URL}/login`,
+          resetPasswordUrl: `${appCfg.SITE_URL}/verify-email`
+        }
+      });
+      return;
     }
     if (!user) {
       user = await userDAL.create({

--- a/backend/src/services/smtp/emails/SignupExistingAccountTemplate.tsx
+++ b/backend/src/services/smtp/emails/SignupExistingAccountTemplate.tsx
@@ -1,0 +1,73 @@
+import { Heading, Section, Text } from "@react-email/components";
+import React from "react";
+
+import { BaseButton } from "./BaseButton";
+import { BaseEmailWrapper, BaseEmailWrapperProps } from "./BaseEmailWrapper";
+import { BaseLink } from "./BaseLink";
+
+interface SignupExistingAccountTemplateProps extends Omit<BaseEmailWrapperProps, "title" | "preview" | "children"> {
+  email: string;
+  loginUrl: string;
+  resetPasswordUrl: string;
+  isCloud: boolean;
+}
+
+export const SignupExistingAccountTemplate = ({
+  email,
+  loginUrl,
+  resetPasswordUrl,
+  isCloud,
+  siteUrl
+}: SignupExistingAccountTemplateProps) => {
+  return (
+    <BaseEmailWrapper
+      title="Sign-up Request Received"
+      preview="You already have an Infisical account."
+      siteUrl={siteUrl}
+    >
+      <Heading className="text-black text-[18px] leading-[28px] text-center font-normal p-0 mx-0">
+        <strong>Sign-up Request Received</strong>
+      </Heading>
+      <Section className="px-[24px] mb-[28px] mt-[36px] pt-[12px] pb-[8px] border border-solid border-gray-200 rounded-md bg-gray-50">
+        <Text className="text-[14px]">
+          We received a sign-up request for your Infisical account (<strong>{email}</strong>).
+        </Text>
+        <Text className="text-[14px]">
+          Since you already have an account, you can sign in or reset your password using the options below:
+        </Text>
+      </Section>
+      <Section className="text-center">
+        <BaseButton href={loginUrl}>Sign in to your account</BaseButton>
+      </Section>
+      <Section className="text-center">
+        <BaseButton href={resetPasswordUrl}>Reset your password</BaseButton>
+      </Section>
+      <Section className="px-[24px] mb-[28px] mt-[28px] pt-[12px] pb-[8px] border border-solid border-gray-200 rounded-md bg-gray-50">
+        <Text className="text-[14px]">If you did not request this, you can ignore this message.</Text>
+      </Section>
+      <Section className="mt-[24px] bg-gray-50 pt-[2px] pb-[16px] border border-solid border-gray-200 px-[24px] rounded-md text-gray-800">
+        <Text className="mb-[0px]">
+          <strong>Need help?</strong>{" "}
+          {isCloud ? (
+            <>
+              Contact us at <BaseLink href="mailto:support@infisical.com">support@infisical.com</BaseLink>
+            </>
+          ) : (
+            "Contact your administrator"
+          )}
+          .
+        </Text>
+      </Section>
+    </BaseEmailWrapper>
+  );
+};
+
+export default SignupExistingAccountTemplate;
+
+SignupExistingAccountTemplate.PreviewProps = {
+  email: "user@example.com",
+  loginUrl: "https://app.infisical.com/login",
+  resetPasswordUrl: "https://app.infisical.com/forgot-password",
+  isCloud: true,
+  siteUrl: "https://infisical.com"
+} as SignupExistingAccountTemplateProps;

--- a/backend/src/services/smtp/emails/index.ts
+++ b/backend/src/services/smtp/emails/index.ts
@@ -32,5 +32,6 @@ export * from "./SecretScanningSecretsDetectedTemplate";
 export * from "./SecretSyncFailedTemplate";
 export * from "./ServiceTokenExpiryNoticeTemplate";
 export * from "./SignupEmailVerificationTemplate";
+export * from "./SignupExistingAccountTemplate";
 export * from "./SubOrganizationInvitationTemplate";
 export * from "./UnlockAccountTemplate";

--- a/backend/src/services/smtp/smtp-service.ts
+++ b/backend/src/services/smtp/smtp-service.ts
@@ -41,6 +41,7 @@ import {
   SecretSyncFailedTemplate,
   ServiceTokenExpiryNoticeTemplate,
   SignupEmailVerificationTemplate,
+  SignupExistingAccountTemplate,
   SubOrganizationInvitationTemplate,
   UnlockAccountTemplate
 } from "./emails";
@@ -57,6 +58,7 @@ export type TSmtpService = ReturnType<typeof smtpServiceFactory>;
 
 export enum SmtpTemplates {
   SignupEmailVerification = "signupEmailVerification",
+  SignupExistingAccount = "signupExistingAccount",
   EmailVerification = "emailVerification",
   SecretReminder = "secretReminder",
   EmailMfa = "emailMfa",
@@ -112,6 +114,7 @@ const EmailTemplateMap: Record<SmtpTemplates, React.FC<any>> = {
   [SmtpTemplates.OrgAssignment]: OrganizationAssignmentTemplate,
   [SmtpTemplates.NewDeviceJoin]: NewDeviceLoginTemplate,
   [SmtpTemplates.SignupEmailVerification]: SignupEmailVerificationTemplate,
+  [SmtpTemplates.SignupExistingAccount]: SignupExistingAccountTemplate,
   [SmtpTemplates.EmailMfa]: EmailMfaTemplate,
   [SmtpTemplates.AccessApprovalRequest]: AccessApprovalRequestTemplate,
   [SmtpTemplates.AccessApprovalRequestUpdated]: AccessApprovalRequestUpdatedTemplate,

--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import ReactCodeInput from "react-code-input";
 import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
 
 import { useSendVerificationEmail } from "@app/hooks/api";
 
@@ -146,6 +147,14 @@ export default function CodeInputStep({
           </div>
         </div>
         <p className="pb-2 text-sm text-bunker-400">{t("signup.step2-spam-alert")}</p>
+        <p className="text-sm text-bunker-400">
+          <Link
+            to="/login"
+            className="cursor-pointer duration-200 hover:text-bunker-200 hover:underline hover:decoration-primary-700 hover:underline-offset-4"
+          >
+            Have an account? Log in
+          </Link>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Context

The sign-up page is vulnerable to user enumeration. It returns an error if the user already exists and redirects to the validation code screen if they don’t.

To fix this, we send the users to the same screen, but we send a different email if the user already exists.

## Screenshots

This is the new email:
<img width="2100" height="1008" alt="image" src="https://github.com/user-attachments/assets/683be969-5429-4ec1-a6e3-b48af4a944c6" />

This is the updated validation code page:
<img width="1905" height="877" alt="image" src="https://github.com/user-attachments/assets/1641e728-2c6d-4077-8429-530445f9b490" />

## Steps to verify the change

Try to sign-up with an existing user and with a new user.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)