### PR TITLE
fix(vault-migration): handle soft deleted secrets

### DIFF
--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -133,11 +133,11 @@ const vaultFactory = (gatewayService: Pick<TGatewayServiceFactory, "fnGetGateway
         .catch((err) => {
           if (axios.isAxiosError(err)) {
             // handle soft-deleted secrets (Vault returns 404 with metadata for soft deleted secrets)
-            const { data: vaultResponse } = err.response?.data as { data: { metadata: { deletion_time: string } } };
+            const vaultResponse = err.response?.data as { data?: { metadata?: { deletion_time?: string } } };
 
-            if (err.response?.status === 404 && vaultResponse?.metadata?.deletion_time) {
+            if (err.response?.status === 404 && vaultResponse?.data?.metadata?.deletion_time) {
               logger.info(
-                { secretPath, deletion_time: vaultResponse.metadata.deletion_time },
+                { secretPath, deletion_time: vaultResponse.data?.metadata?.deletion_time },
                 "External migration: Skipping soft-deleted Vault secret"
               );
               return null;


### PR DESCRIPTION
## Context

Vault KV v2 supports soft deleting secrets (v1 does not, hence no changes to how we handle v1 secrets). Vault will return a `deletion_timestamp` when querying for deleted secrets and throw a 404 error. The 404 error was treated as a failure and caused the whole migration to fail if there were any soft-deleted secrets.

You can try soft deleting a secret using the Vault CLI: 
```
vault kv delete -mount=<kv-name> <secret-path-to-soft-delete>
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)