### PR TITLE
improvement(pki): add error tooltip for failed cert requests and restrict actions to issued certificates

### DIFF
--- a/frontend/src/pages/cert-manager/CertificateRequestsPage/components/CertificateRequestRow.tsx
+++ b/frontend/src/pages/cert-manager/CertificateRequestsPage/components/CertificateRequestRow.tsx
@@ -43,7 +43,7 @@ export const CertificateRequestRow = ({ request, onViewCertificates }: Props) =>
           <Tooltip
             position="top"
             content={errorMessage || "Certificate request failed"}
-            className="max-w-sm"
+            className="max-w-sm break-words"
           >
             <div>
               <Badge variant="danger">Failed</Badge>


### PR DESCRIPTION
## Context

Earlier we only showed the status as Failed in the certificate request page, now there will be a tooltip through which the error message/reason of failure can be checked. 

Apart from this, the dropdown menu/options will only be available to the rows having status as Issued.

## Screenshots

<img width="1728" height="993" alt="image" src="https://github.com/user-attachments/assets/dd439cdd-715b-4d81-9073-25641677013d" />

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)