### PR TITLE
fix(pki): disable the policy selector with a message that no policies are available

### DIFF
--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
@@ -804,10 +804,14 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                     }
                     onChange(value);
                   }}
-                  placeholder="Select a certificate policy"
+                  placeholder={
+                    certificatePolicies.length === 0
+                      ? "No certificate policies available"
+                      : "Select a certificate policy"
+                  }
                   className="w-full"
                   position="popper"
-                  isDisabled={Boolean(isEdit)}
+                  isDisabled={Boolean(isEdit) || certificatePolicies.length === 0}
                 >
                   {certificatePolicies.map((policy) => (
                     <SelectItem key={policy.id} value={policy.id}>


### PR DESCRIPTION
## Context

Disabled the policy selector with a message that no policies are available

## Screenshots

<img width="1728" height="990" alt="Screenshot 2026-01-27 at 9 22 01 PM" src="https://github.com/user-attachments/assets/95312a6a-71c9-4f0b-81cc-ccc1e178d32c" />

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)