### PR TITLE
fix: resolved failing approval generation on update and delete with metadata

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -319,7 +319,7 @@ export const secretApprovalRequestServiceFactory = ({
         version: el.version,
         secretMetadata: (
           el.secretMetadata as { key: string; value?: string | null; encryptedValue?: string | null }[]
-        ).map((meta) => ({
+        )?.map((meta) => ({
           key: meta.key,
           isEncrypted: Boolean(meta.encryptedValue),
           value: meta.encryptedValue
@@ -382,7 +382,7 @@ export const secretApprovalRequestServiceFactory = ({
                 ? secretManagerDecryptor({ cipherTextBlob: el.secretVersion.encryptedComment }).toString()
                 : "",
               tags: el.secretVersion.tags,
-              secretMetadata: el.oldSecretMetadata.map((meta) => ({
+              secretMetadata: el.oldSecretMetadata?.map((meta) => ({
                 key: meta.key,
                 isEncrypted: Boolean(meta.encryptedValue),
                 value: meta.encryptedValue
@@ -696,7 +696,7 @@ export const secretApprovalRequestServiceFactory = ({
                 key: el.key,
                 secretMetadata: (
                   el.secretMetadata as { key: string; value?: string | null; encryptedValue?: string | null }[]
-                ).map((meta) => ({
+                )?.map((meta) => ({
                   key: meta.key,
                   [meta.encryptedValue ? "encryptedValue" : "value"]: meta.encryptedValue
                     ? Buffer.from(meta.encryptedValue, "base64")
@@ -753,7 +753,7 @@ export const secretApprovalRequestServiceFactory = ({
                     tags: el?.tags.map(({ id }) => id),
                     secretMetadata: (
                       el.secretMetadata as { key: string; value?: string | null; encryptedValue?: string | null }[]
-                    ).map((meta) => ({
+                    )?.map((meta) => ({
                       key: meta.key,
                       [meta.encryptedValue ? "encryptedValue" : "value"]: meta.encryptedValue
                         ? Buffer.from(meta.encryptedValue, "base64")

--- a/backend/src/services/folder-commit/folder-commit-service.ts
+++ b/backend/src/services/folder-commit/folder-commit-service.ts
@@ -1053,7 +1053,7 @@ export const folderCommitServiceFactory = ({
                 userId: secretVersion.userId,
                 actorType: actorInfo.actorType,
                 envId: secretVersion.envId,
-                metadata: JSON.stringify(metadata),
+                metadata: metadata ? JSON.stringify(metadata) : null,
                 ...(actorInfo.actorType === ActorType.IDENTITY && { identityActorId: actorInfo.actorId }),
                 ...(actorInfo.actorType === ActorType.USER && { userActorId: actorInfo.actorId })
               },


### PR DESCRIPTION
## Context

Secret approval request was failing for secrets with encrypted metadata on update and delete when encrypted value existed

## Screenshots


## Steps to verify the change

1. Update and delete with encrypted metadata should work fine with approval

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)