### PR TITLE
fix: clarify bootstrap message when using docker port mapping

### DIFF
--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -14,11 +14,15 @@ type BootstrapOpt = {
 const bootstrapCb = async () => {
   const appCfg = getConfig();
   const serverCfg = await getServerCfg();
+  const portNote =
+   "Note: If running in Docker, the exposed host port may differ from the port shown above.";
   if (!serverCfg.initialized) {
     console.info(`Welcome to Infisical
 
 Create your Infisical administrator account at:
 http://localhost:${appCfg.PORT}/admin/signup
+
+${portNote}
 `);
   } else {
     console.info(`Welcome back!
@@ -28,6 +32,8 @@ http://localhost:${appCfg.PORT}/admin
 
 To access Infisical server
 http://localhost:${appCfg.PORT}
+
+${portNote}
 `);
   }
 };


### PR DESCRIPTION
### What
Clarifies the bootstrap startup messages to avoid misleading port information when running Infisical with Docker port mappings.

### Why
When Infisical is run using Docker port mapping (for example `-p 8080:3000` or behind a reverse proxy), the bootstrap message displays the container port (`appCfg.PORT`). This can confuse users because the externally accessible URL may differ, even though Infisical itself works correctly.

### How
Added a clarification note to the bootstrap messages indicating that the exposed host port may differ when running in Docker, instead of assuming a specific external URL.

### Testing
- Change is limited to log message clarification only
- No runtime or functional behavior was modified

fixes #5295 