### PR TITLE
chore: add basic constraints deduction for sign certificate

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1233,7 +1233,7 @@ export const certificateV3ServiceFactory = ({
     const csrHasKeyCertSign = certificateRequest.keyUsages?.includes(CertKeyUsageType.KEY_CERT_SIGN) ?? false;
     const effectiveBasicConstraints = basicConstraints ?? certificateRequest.basicConstraints;
     const shouldIssueAsCA = effectiveBasicConstraints?.isCA === true || csrHasKeyCertSign;
-    
+
     // Compute the final basicConstraints to store/use
     const resolvedBasicConstraints = shouldIssueAsCA
       ? { isCA: true, pathLength: effectiveBasicConstraints?.pathLength }


### PR DESCRIPTION
## Context
This PR ensures that when certKeySign is requested then isCA basic constraints is treated as true. This is needed because some clients like [cert-manager](https://github.com/cert-manager/cert-manager/blob/master/pkg/util/pki/csr.go) do not pass in basic constraints extension in the CSR



<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)