### PR TITLE
improvement: use placeholder color for empty value on secret input

### DIFF
--- a/frontend/src/components/v2/SecretInput/SecretInput.tsx
+++ b/frontend/src/components/v2/SecretInput/SecretInput.tsx
@@ -179,12 +179,7 @@ export const SecretInput = forwardRef<HTMLTextAreaElement, Props>(
         <div className="relative overflow-hidden">
           <pre aria-hidden className="pointer-events-none relative z-10 m-0">
             <code className={`inline-block w-full ${commonClassName}`}>
-              <span
-                className={twMerge(
-                  "whitespace-break-spaces",
-                  placeholder && !value && "text-gray-500/50"
-                )}
-              >
+              <span className={twMerge("whitespace-break-spaces", !value && "text-muted")}>
                 {syntaxHighlight(
                   value,
                   isVisible || (isSecretFocused && !valueAlwaysHidden),


### PR DESCRIPTION
## Context

This PR updates the EMPTY placeholder display on the secret input component to use a muted color
 
## Screenshots

<img width="3370" height="1814" alt="CleanShot 2026-01-29 at 13 11 24@2x" src="https://github.com/user-attachments/assets/6cd7b7a7-870f-4a97-878c-f1d39f31053b" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)