### PR TITLE
fix(api): include create secrets when resolving tags in bulk upsert

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -2036,9 +2036,7 @@ export const secretV2BridgeServiceFactory = ({
         // get all tags (include create + update in upsert)
         const allInputSecrets = [...secretsToUpdate, ...secretsToCreate];
 
-        const sanitizedTagIds = [
-          ...new Set(allInputSecrets.flatMap(({ tagIds = [] }) => tagIds))
-        ];
+        const sanitizedTagIds = [...new Set(allInputSecrets.flatMap(({ tagIds = [] }) => tagIds))];
 
         const tags = sanitizedTagIds.length ? await secretTagDAL.findManyTagsById(projectId, sanitizedTagIds, tx) : [];
         if (tags.length !== sanitizedTagIds.length) throw new NotFoundError({ message: "Tag not found" });


### PR DESCRIPTION
Fixes a crash in bulk upsert by resolving tags for both created and updated secrets before permission checks.
fixes #5268 