### PR TITLE
feat(ui): allow change request submitter to cancel their own request

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestAction.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestAction.tsx
@@ -27,6 +27,7 @@ type Props = {
   status: "close" | "open";
   approvals: number;
   canApprove?: boolean;
+  isCommitter?: boolean;
   isBypasser: boolean;
   statusChangeByEmail?: string;
   enforcementLevel: EnforcementLevel;
@@ -41,6 +42,7 @@ export const SecretApprovalRequestAction = ({
   statusChangeByEmail,
   enforcementLevel,
   canApprove,
+  isCommitter,
   isBypasser
 }: Props) => {
   const { projectId } = useProject();
@@ -111,7 +113,7 @@ export const SecretApprovalRequestAction = ({
             </span>
           </div>
           <div className="mt-4 flex items-center justify-end space-x-2 px-4 xl:mt-0">
-            {canApprove || isSoftEnforcement ? (
+            {canApprove || isSoftEnforcement || isCommitter ? (
               <div className="flex items-center space-x-4">
                 <Button
                   onClick={() => handleSecretApprovalStatusChange("close")}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -150,9 +150,9 @@ export const SecretApprovalRequestChanges = ({ approvalRequestId, onGoBack }: Pr
   } = useForm<TReviewFormSchema>({
     resolver: zodResolver(reviewFormSchema)
   });
+  const isCommitter = secretApprovalRequestDetails?.committerUserId === userSession.id;
   const shouldBlockSelfReview =
-    secretApprovalRequestDetails?.policy?.allowedSelfApprovals === false &&
-    secretApprovalRequestDetails?.committerUserId === userSession.id;
+    secretApprovalRequestDetails?.policy?.allowedSelfApprovals === false && isCommitter;
   const isApproving = variables?.status === ApprovalStatus.APPROVED && isUpdatingRequestStatus;
   const isRejecting = variables?.status === ApprovalStatus.REJECTED && isUpdatingRequestStatus;
 
@@ -551,6 +551,7 @@ export const SecretApprovalRequestChanges = ({ approvalRequestId, onGoBack }: Pr
         <div className="mt-2 flex items-center space-x-6 rounded-lg border border-mineshaft-600 bg-mineshaft-800">
           <SecretApprovalRequestAction
             canApprove={canApprove}
+            isCommitter={isCommitter}
             isBypasser={isBypasser === undefined ? true : isBypasser}
             approvalRequestId={secretApprovalRequestDetails.id}
             hasMerged={hasMerged}


### PR DESCRIPTION
## Context

Previously, the "Close request" button in the Secret Approval Request UI was only visible to:
- Users who are approvers, OR
- When soft enforcement is enabled

This meant that CR submitters who are not in the approvers list could not cancel their own change requests from the UI, even though the backend already supports this operation.

This PR adds the `isCommitter` prop to enable the Close button for the CR submitter, allowing them to cancel their own requests.

Related: SECRETS-73

## Screenshots

<img width="1298" height="759" alt="image" src="https://github.com/user-attachments/assets/9e5bf015-5dc2-4bc8-95ac-b479a93d2f5c" />

## Steps to verify the change

1. Create a user who is NOT an approver for a secret approval policy
2. Have that user create a secret change that triggers a change request
3. Navigate to the Secret Approvals page and view the change request
4. Verify the "Close request" button is now visible and functional
5. Verify the "Merge" button is still disabled (as expected - user is not an approver)

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)