### PR TITLE
fix(pki): return helpful error for malformed JSON on certificate endpoint for CSR

### DIFF
--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -270,6 +270,7 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
       });
     } else if (
       error instanceof SyntaxError &&
+      req.method === "POST" &&
       (req.url === "/api/v1/cert-manager/certificates" || req.url === "/api/v1/cert-manager/certificates/")
     ) {
       // JSON parsing error on certificate endpoint - likely malformed CSR with literal newlines


### PR DESCRIPTION
## Context

When users send a CSR (Certificate Signing Request) to `POST /api/v1/cert-manager/certificates` with literal newlines instead of escaped `\n` characters, the JSON parser fails before reaching the route handler. This is a common user mistake when copying/pasting CSR content directly into JSON.

**Before:** Returns a generic 500 Internal Server Error with "Something went wrong" message, which provides no indication of what went wrong.

**After:** Returns a 400 Bad Request with a helpful message: "Invalid JSON in request body. If you are sending a Certificate Signing Request (CSR), ensure newlines are escaped as \n characters, not literal line breaks."

Example of the issue:
```json
// Invalid - literal newlines break JSON parsing
{ "csr": "-----BEGIN CERTIFICATE REQUEST-----
MIIB..." }

// Valid - newlines escaped
{ "csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIIB..." }
```

## Screenshots

N/A - API-only change

## Steps to verify the change

1. Send a POST request to `/api/v1/cert-manager/certificates` with a properly escaped CSR (newlines as `\n`) - should work normally (200)
2. Send a POST request with literal newlines in the CSR - should return 400 with the helpful error message:
   ```json
   {
     "statusCode": 400,
     "message": "Invalid JSON in request body. If you are sending a Certificate Signing Request (CSR), ensure newlines are escaped as \\n characters, not literal line breaks.",
     "error": "BadRequestError"
   }
   ```

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
