### PR TITLE
feature(frontend): manage tags on overview page

### DIFF
--- a/frontend/src/components/v3/generic/CreatableSelect/CreatableSelect.tsx
+++ b/frontend/src/components/v3/generic/CreatableSelect/CreatableSelect.tsx
@@ -1,0 +1,94 @@
+import {
+  ClearIndicatorProps,
+  components,
+  DropdownIndicatorProps,
+  GroupBase,
+  MultiValueRemoveProps,
+  OptionProps
+} from "react-select";
+import ReactSelectCreatable, { CreatableProps } from "react-select/creatable";
+import { CheckIcon, ChevronDownIcon, XIcon } from "lucide-react";
+
+import { cn } from "../../utils";
+
+const DropdownIndicator = <T,>(props: DropdownIndicatorProps<T>) => (
+  <components.DropdownIndicator {...props}>
+    <ChevronDownIcon />
+  </components.DropdownIndicator>
+);
+
+const ClearIndicator = <T,>(props: ClearIndicatorProps<T>) => (
+  <components.ClearIndicator {...props}>
+    <XIcon />
+  </components.ClearIndicator>
+);
+
+const MultiValueRemove = (props: MultiValueRemoveProps) => {
+  // eslint-disable-next-line react/destructuring-assignment
+  return props.selectProps?.isDisabled ? null : (
+    <components.MultiValueRemove {...props}>
+      <XIcon />
+    </components.MultiValueRemove>
+  );
+};
+
+const Option = <T,>({ isSelected, children, ...props }: OptionProps<T>) => (
+  <components.Option isSelected={isSelected} {...props}>
+    <div className="flex flex-row items-center justify-between">
+      <p className="truncate">{children}</p>
+      {isSelected && <CheckIcon className="ml-2 size-4" />}
+    </div>
+  </components.Option>
+);
+
+export const CreatableSelect = <T,>({
+  isMulti,
+  closeMenuOnSelect,
+  ...props
+}: CreatableProps<T, boolean, GroupBase<T>>) => {
+  return (
+    <ReactSelectCreatable
+      isMulti={isMulti}
+      closeMenuOnSelect={closeMenuOnSelect ?? !isMulti}
+      hideSelectedOptions={false}
+      unstyled
+      data-slot="creatable-select"
+      styles={{
+        control: (base) => ({ ...base, minHeight: "unset" })
+      }}
+      components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, Option }}
+      classNames={{
+        control: ({ isFocused }) =>
+          cn(
+            "!min-h-9 w-full cursor-pointer rounded-md border bg-transparent py-1 pr-1 pl-2 text-sm",
+            isFocused
+              ? "border-ring ring-[3px] ring-ring/50"
+              : "border-border hover:border-foreground/20"
+          ),
+        placeholder: () => "text-muted text-sm",
+        input: () => "text-foreground text-sm",
+        valueContainer: () =>
+          "gap-1 max-h-40 !pointer-events-auto !overflow-y-auto thin-scrollbar flex-wrap",
+        multiValue: () => "bg-foreground/10 rounded px-1.5 py-0.5 gap-1 text-xs items-center",
+        multiValueLabel: () => "text-foreground/85",
+        multiValueRemove: () => "[&>svg]:size-3 hover:text-danger text-muted cursor-pointer ml-0.5",
+        menu: () => "my-2 rounded-[6px] border border-border bg-popover p-1 shadow-md",
+        menuList: () => "max-h-48 text-sm overflow-y-auto thin-scrollbar",
+        option: ({ isFocused }) =>
+          cn(
+            "cursor-pointer rounded-sm px-2 py-1.5 text-sm text-foreground",
+            isFocused && "bg-foreground/5"
+          ),
+        dropdownIndicator: () =>
+          "opacity-50 p-1 hover:bg-foreground/10 cursor-pointer rounded-md [&>svg]:size-4",
+        indicatorsContainer: () => "gap-1 flex items-center",
+        indicatorSeparator: () => "bg-accent/20",
+        clearIndicator: () =>
+          "opacity-50 hover:opacity-100 hover:bg-foreground/10 cursor-pointer rounded-md p-1 text-danger [&>svg]:size-4",
+        noOptionsMessage: () => "text-muted p-2 text-sm",
+        loadingMessage: () => "text-muted p-2 text-sm"
+      }}
+      {...props}
+    />
+  );
+};

--- a/frontend/src/components/v3/generic/CreatableSelect/index.ts
+++ b/frontend/src/components/v3/generic/CreatableSelect/index.ts
@@ -1,0 +1,1 @@
+export * from "./CreatableSelect";

--- a/frontend/src/components/v3/generic/index.ts
+++ b/frontend/src/components/v3/generic/index.ts
@@ -7,6 +7,7 @@ export * from "./ButtonGroup";
 export * from "./Card";
 export * from "./Checkbox";
 export * from "./Command";
+export * from "./CreatableSelect";
 export * from "./Detail";
 export * from "./Dialog";
 export * from "./Dropdown";

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -344,6 +344,7 @@ export const SecretTableRow = ({
                             importedBy={importedBy}
                             isSecretPresent={Boolean(secret)}
                             comment={secret?.comment}
+                            tags={secret?.tags}
                           />
                         </UnstableTableCell>
                       </UnstableTableRow>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
@@ -1,0 +1,165 @@
+import { Controller, useForm } from "react-hook-form";
+import { subject } from "@casl/ability";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import { Button, CreatableSelect } from "@app/components/v3";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSub,
+  useProject,
+  useProjectPermission
+} from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
+import { useCreateWsTag, useGetWsTags, useUpdateSecretV3 } from "@app/hooks/api";
+import { SecretType, WsTag } from "@app/hooks/api/types";
+import { slugSchema } from "@app/lib/schemas";
+
+const formSchema = z.object({
+  tags: z.array(z.object({ label: z.string(), value: z.string() })).default([])
+});
+
+type TFormSchema = z.infer<typeof formSchema>;
+
+type Props = {
+  tags?: WsTag[];
+  secretKey: string;
+  environment: string;
+  secretPath: string;
+  isOverride?: boolean;
+  onClose?: () => void;
+};
+
+export const SecretTagForm = ({
+  tags,
+  secretKey,
+  environment,
+  secretPath,
+  isOverride,
+  onClose
+}: Props) => {
+  const { projectId } = useProject();
+  const { mutateAsync: updateSecretV3, isPending } = useUpdateSecretV3();
+  const { mutateAsync: createWsTag } = useCreateWsTag();
+
+  const { permission } = useProjectPermission();
+  const canAddTags = permission.can(ProjectPermissionActions.Create, ProjectPermissionSub.Tags);
+  const canEditSecret = permission.can(
+    ProjectPermissionSecretActions.Edit,
+    subject(ProjectPermissionSub.Secrets, {
+      environment,
+      secretPath,
+      secretName: secretKey,
+      secretTags: tags?.map((tag) => tag.slug) ?? ["*"]
+    })
+  );
+  const { data: projectTags, isPending: isTagsLoading } = useGetWsTags(projectId);
+
+  const {
+    handleSubmit,
+    control,
+    setValue,
+    getValues,
+    formState: { isDirty }
+  } = useForm<TFormSchema>({
+    defaultValues: {
+      tags: tags?.map((tag) => ({ label: tag.slug, value: tag.id })) ?? []
+    },
+    resolver: zodResolver(formSchema)
+  });
+
+  const handleCreateTag = async (inputValue: string) => {
+    const parsedSlug = slugSchema().safeParse(inputValue);
+    if (!parsedSlug.success) return;
+
+    const newTag = await createWsTag({
+      projectId,
+      tagSlug: parsedSlug.data,
+      tagColor: ""
+    });
+    const currentTags = getValues("tags");
+    setValue("tags", [...currentTags, { label: newTag.slug, value: newTag.id }], {
+      shouldDirty: true
+    });
+  };
+
+  const onSubmit = async (data: TFormSchema) => {
+    const result = await updateSecretV3({
+      environment,
+      projectId,
+      secretPath,
+      secretKey,
+      type: isOverride ? SecretType.Personal : SecretType.Shared,
+      tagIds: data.tags.map((tag) => tag.value)
+    });
+
+    if ("approval" in result) {
+      createNotification({
+        type: "info",
+        text: "Requested change has been sent for review"
+      });
+    } else {
+      createNotification({
+        type: "success",
+        text: "Successfully updated tags"
+      });
+    }
+    onClose?.();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+      <p className="text-sm font-medium">Tags</p>
+      <Controller
+        name="tags"
+        control={control}
+        render={({ field }) => (
+          <CreatableSelect
+            menuPlacement="top"
+            isMulti
+            noOptionsMessage={({ inputValue }) =>
+              inputValue && !slugSchema().safeParse(inputValue)
+                ? "Tag must be slug-friendly"
+                : "No tags match search"
+            }
+            isDisabled={!canEditSecret}
+            isLoading={isTagsLoading}
+            placeholder="Select or create tags..."
+            options={projectTags?.map((tag) => ({ label: tag.slug, value: tag.id }))}
+            value={field.value}
+            onChange={(newValue) => field.onChange(newValue)}
+            onCreateOption={handleCreateTag}
+            isValidNewOption={(inputValue) =>
+              !canAddTags
+                ? false
+                : slugSchema().safeParse(inputValue).success &&
+                  !projectTags?.map((tag) => tag.slug).includes(inputValue)
+            }
+          />
+        )}
+      />
+      {!canEditSecret && (
+        <p className="text-xs text-muted">
+          You do not have permission to edit tags on this secret.
+        </p>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="xs" type="button" onClick={onClose}>
+          Close
+        </Button>
+        {canEditSecret && (
+          <Button
+            variant="project"
+            size="xs"
+            type="submit"
+            isDisabled={!isDirty || isPending}
+            isPending={isPending}
+          >
+            Save Tags
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+};


### PR DESCRIPTION
## Context

- This PR adds tag management to the overview page
- adds v3 createable select component

## Screenshots

<img width="3456" height="1912" alt="CleanShot 2026-01-31 at 12 17 05@2x" src="https://github.com/user-attachments/assets/4c2cf379-0611-409d-9a26-757d0355bd2d" />

## Steps to verify the change

- Test adding / removing tags from secret
- test adding creating tags
- test permission behavior on tag popover (read tags, create tags, edit secret)

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)