### PR TITLE
feature(frontend): toggle multi-line encoding from overview page

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -346,6 +346,7 @@ export const SecretTableRow = ({
                             comment={secret?.comment}
                             tags={secret?.tags}
                             secretMetadata={secret?.secretMetadata}
+                            skipMultilineEncoding={secret?.skipMultilineEncoding}
                           />
                         </UnstableTableCell>
                       </UnstableTableRow>


### PR DESCRIPTION
## Context

This PR adds the ability to view and toggle multiline encoding from the overview page

## Screenshots

<img width="3456" height="1912" alt="CleanShot 2026-01-31 at 18 58 06@2x" src="https://github.com/user-attachments/assets/1953b376-a296-4329-a50c-c24ecb4c68ee" />

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)