### PR TITLE
docs: fix inconsistent security email address

### DIFF
--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -33,7 +33,7 @@ Before raising a new issue, please search existing ones to make sure you're not 
 
 <Info>
   If the issue is related to security, please email us directly at
-  team@infisical.com.
+  security@infisical.com.
 </Info>
 
 ## Deciding what to work on


### PR DESCRIPTION
## Description

This PR fixes the inconsistency in the documentation regarding the email address for reporting security issues.

### Problem (Issue #4704)
- In the Contributing docs: `team@infisical.com`
- In the GitHub Security Policy: `security@infisical.com`

### Solution
Updated the security email in `docs/contributing/getting-started/overview.mdx` from `team@infisical.com` to `security@infisical.com` to match the GitHub Security Policy.

Fixes #4704