### PR TITLE
fix: added more cleanup for event service

### DIFF
--- a/backend/src/ee/services/project-events/project-events-sse-types.ts
+++ b/backend/src/ee/services/project-events/project-events-sse-types.ts
@@ -44,6 +44,7 @@ export type TSSEClient = {
   actorId: string;
   ping: () => void;
   close: () => void;
+  unsubscribe: () => void;
 };
 
 // SSE Event format


### PR DESCRIPTION
## Context

This PR tries to fix the memory leak happening in the event subscription service. This does the cleanups missing and de-referencing variables. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)