### PR TITLE
fix: add not-before and not-after check in sign CSR

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1225,7 +1225,15 @@ export const certificateV3ServiceFactory = ({
 
     mappedCertificateRequest.keyAlgorithm = extractedKeyAlgorithm;
     mappedCertificateRequest.signatureAlgorithm = extractedSignatureAlgorithm;
-    mappedCertificateRequest.validity = validity;
+
+    // When notAfter is explicitly provided, validate using date range (notAfter overrides TTL in cert generation).
+    // Otherwise, validate using TTL. These are mutually exclusive to avoid "Cannot specify both" validation error.
+    if (notAfter) {
+      mappedCertificateRequest.notBefore = notBefore;
+      mappedCertificateRequest.notAfter = notAfter;
+    } else {
+      mappedCertificateRequest.validity = validity;
+    }
 
     // Determine effective basicConstraints early (before approval flow)
     // so it's available for both the approval path and direct signing path.


### PR DESCRIPTION
## Context
This ensures that not after and not before values are validated against the certificate policy during for sign certificate from profile flow 

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)