### PR TITLE
improvement: clarify authorized emails must have an infisical account for secret sharing

### DIFF
--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -396,7 +396,18 @@ export const ShareSecretForm = ({
                     <FormControl
                       label="Authorized Emails"
                       isOptional
-                      tooltipText="Unique secret links will be emailed to each individual. The secret will only be accessible to those links."
+                      helperText="Recipients must have an Infisical account to verify identity"
+                      tooltipText={
+                        <>
+                          <p>
+                            Unique secret links will be emailed to each individual. The secret will
+                            only be accessible to those links.
+                          </p>
+                          <p className="mt-2">
+                            Recipients must have an Infisical account to verify their identity.
+                          </p>
+                        </>
+                      }
                       tooltipClassName="max-w-sm"
                       isError={Boolean(error)}
                       errorText={error?.message}


### PR DESCRIPTION
## Context

This PR adds helper text and tooltip text to clarify that authorized email recipients for secret sharing must have an Infisical account

## Screenshots

<img width="3456" height="1912" alt="CleanShot 2026-02-02 at 12 04 18@2x" src="https://github.com/user-attachments/assets/209e9299-816d-4b7f-8d08-3e44ec4948b7" />

## Steps to verify the change

Perceive the text with your eyes

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)