### PR TITLE
fix(backend): correct SAML user complete check & always verify email on provision

### DIFF
--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -729,7 +729,7 @@ export const samlConfigServiceFactory = ({
     }
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
-    const isUserCompleted = Boolean(user.isAccepted && user.isEmailVerified && userAlias.isEmailVerified);
+    const isUserCompleted = Boolean(user.isAccepted && userAlias.isEmailVerified);
     const providerAuthToken = crypto.jwt().sign(
       {
         authTokenType: AuthTokenType.PROVIDER_TOKEN,

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -487,6 +487,14 @@ export const scimServiceFactory = ({
             },
             tx
           );
+        } else if (!user.isEmailVerified && trustScimEmails) {
+          await userDAL.updateById(
+            user.id,
+            {
+              isEmailVerified: trustScimEmails
+            },
+            tx
+          );
         }
 
         await userAliasDAL.create(


### PR DESCRIPTION
## Context

This PR fixes two SAML and SCIM bugs:

- When logging in via SAML we now only check whether the user alias email is verified
- When a user is provisioned via SCIM, we now verify their email even if the user already exists

## Screenshots

N/A 

## Steps to verify the change

- Verify you can login via SAML even if you were invited via email without verifying and then provisioned via SCIM
- Verify email is verified on provision

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)