### PR TITLE
improvement(frontend): update change request label depending on review/merge status

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
@@ -269,12 +269,18 @@ export const SecretApprovalRequest = () => {
             status,
             committerUser,
             hasMerged,
-            updatedAt
+            updatedAt,
+            policy
           } = secretApproval;
-          const isReviewed = reviewers.some(
-            ({ status: reviewStatus, userId }) =>
-              userId === userSession.id && reviewStatus === ApprovalStatus.APPROVED
-          );
+
+          const isMergable =
+            reviewers.filter(({ status: reviewStatus }) => reviewStatus === ApprovalStatus.APPROVED)
+              .length >= policy.approvals;
+
+          const requiresUserReview =
+            policy.approvers.find((approver) => approver.userId === userSession.id) &&
+            !reviewers.find(({ userId }) => userId === userSession.id);
+
           return (
             <div
               key={reqId}
@@ -308,7 +314,13 @@ export const SecretApprovalRequest = () => {
                   ) : (
                     <span className="text-gray-600">Deleted User</span>
                   )}
-                  {!isReviewed && status === "open" && " - Review required"}
+                  {status === "open" &&
+                    // eslint-disable-next-line no-nested-ternary
+                    (isMergable
+                      ? " - Pending merge"
+                      : requiresUserReview
+                        ? " - Review required"
+                        : " - Review in progress")}
                 </span>
               </div>
               {status === "close" && (


### PR DESCRIPTION
## Context

This PR updates the change request table row label to display a more informative and accurate status of whether the review is pending merge, review required by user or the review is in progress

## Screenshots

<img width="3374" height="1914" alt="CleanShot 2026-02-03 at 14 27 20@2x" src="https://github.com/user-attachments/assets/39fb8dbe-1be6-41f3-8793-d2936f5bae53" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)