### PR TITLE
docs: fix GitHub app connection callback URL

### DIFF
--- a/docs/integrations/app-connections/github.mdx
+++ b/docs/integrations/app-connections/github.mdx
@@ -19,7 +19,7 @@ Infisical supports three methods for connecting to GitHub.
 
                     ![integrations github app create](/images/integrations/github/app/self-hosted-github-app-create.png)
 
-                    Give the application a name, a homepage URL (your self-hosted domain i.e. `https://your-domain.com`), and a callback URL (i.e. `https://your-domain.com/organization/app-connections/github/oauth/callback`).
+                    Give the application a name, a homepage URL (your self-hosted domain i.e. `https://your-domain.com`), and a callback URL (i.e. `https://your-domain.com/integrations/github/oauth2/callback`).
 
                     ![integrations github app basic details](/images/integrations/github/app/self-hosted-github-app-basic-details.png)
 
@@ -128,7 +128,7 @@ Infisical supports three methods for connecting to GitHub.
                     ![integrations github config](../../images/integrations/github/integrations-github-config-new-app.png)
 
                     Create the OAuth application. As part of the form, set the **Homepage URL** to your self-hosted domain `https://your-domain.com`
-                    and the **Authorization callback URL** to `https://your-domain.com/organization/app-connections/github/oauth/callback`.
+                    and the **Authorization callback URL** to `https://your-domain.com/integrations/github/oauth2/callback`.
 
                     ![integrations github config](../../images/integrations/github/integrations-github-config-new-app-form.png)
 


### PR DESCRIPTION
Fix incorrect callback URL in GitHub App Connections documentation.
Fixes #5336

