### PR TITLE
feat: add access insights to overview page 

### DIFF
--- a/backend/src/ee/routes/v1/secret-router.ts
+++ b/backend/src/ee/routes/v1/secret-router.ts
@@ -11,7 +11,8 @@ const AccessListEntrySchema = z
   .object({
     allowedActions: z.nativeEnum(ProjectPermissionSecretActions).array(),
     id: z.string(),
-    name: z.string()
+    name: z.string(),
+    membershipId: z.string()
   })
   .array();
 

--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -77,6 +77,7 @@ export interface TPermissionDALFactory {
         temporaryAccessEndTime: Date | null | undefined;
         isTemporary: boolean;
       }[];
+      id: string;
       userId: string;
       username: string;
       metadata: {
@@ -514,6 +515,7 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         })
         .select(
           db.ref("id").withSchema(TableName.Users).as("userId"),
+          db.ref("id").withSchema(TableName.Membership).as("membershipId"),
           db.ref("username").withSchema(TableName.Users).as("username"),
           db.ref("slug").withSchema(TableName.Role).as("roleSlug"),
           db.ref("permissions").withSchema(TableName.Role).as("customRolePermission"),
@@ -558,10 +560,11 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
       const userPermissions = sqlNestRelationships({
         data: docs,
         key: "userId",
-        parentMapper: ({ username, userId }) => ({
+        parentMapper: ({ username, userId, membershipId }) => ({
           userId,
           projectId,
-          username
+          username,
+          id: membershipId
         }),
         childrenMapper: [
           {

--- a/backend/src/ee/services/permission/permission-service-types.ts
+++ b/backend/src/ee/services/permission/permission-service-types.ts
@@ -68,16 +68,19 @@ export type TPermissionServiceFactory = {
       permission: MongoAbility<ProjectPermissionSet, MongoQuery>;
       id: string;
       name: string;
+      membershipId: string;
     }[];
     identityPermissions: {
       permission: MongoAbility<ProjectPermissionSet, MongoQuery>;
       id: string;
       name: string;
+      membershipId: string;
     }[];
     groupPermissions: {
       permission: MongoAbility<ProjectPermissionSet, MongoQuery>;
       id: string;
       name: string;
+      membershipId: string;
     }[];
   }>;
   getOrgPermissionByRoles: (

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -496,6 +496,7 @@ export const permissionServiceFactory = ({
       return {
         permission,
         id: userProjectPermission.userId,
+        membershipId: userProjectPermission.id,
         name: userProjectPermission.username
       };
     });
@@ -541,6 +542,7 @@ export const permissionServiceFactory = ({
       return {
         permission,
         id: identityProjectPermission.identityId,
+        membershipId: identityProjectPermission.id,
         name: identityProjectPermission.username
       };
     });
@@ -558,6 +560,7 @@ export const permissionServiceFactory = ({
       return {
         permission,
         id: groupProjectPermission.groupId,
+        membershipId: groupProjectPermission.id,
         name: groupProjectPermission.username
       };
     });

--- a/frontend/src/components/v3/generic/Item/Item.tsx
+++ b/frontend/src/components/v3/generic/Item/Item.tsx
@@ -32,12 +32,12 @@ function ItemSeparator({ className, ...props }: React.ComponentProps<typeof Sepa
 }
 
 const itemVariants = cva(
-  "[a]:hover:bg-muted rounded-lg border text-sm w-full group/item focus-visible:border-ring focus-visible:ring-ring/50 flex items-center flex-wrap outline-none transition-colors duration-100 focus-visible:ring-[3px] [a]:transition-colors",
+  "[a]:hover:bg-foreground/5 rounded-lg border text-sm w-full group/item focus-visible:border-ring focus-visible:ring-ring/50 flex items-center flex-wrap outline-none transition-colors duration-100 focus-visible:ring-[3px] [a]:transition-colors",
   {
     variants: {
       variant: {
         default: "border-transparent",
-        outline: "border-border",
+        outline: "border-border bg-container",
         muted: "bg-muted/50 border-transparent"
       },
       size: {

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -282,5 +282,6 @@ export type TSecretReference = {
 export type SecretAccessListEntry = {
   allowedActions: ProjectPermissionActions[];
   id: string;
+  membershipId: string;
   name: string;
 };

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
@@ -1,0 +1,223 @@
+import { Link } from "@tanstack/react-router";
+import { HardDriveIcon, UserIcon, UsersIcon } from "lucide-react";
+
+import {
+  Badge,
+  EmptyMedia,
+  Item,
+  ItemContent,
+  ItemFooter,
+  ItemGroup,
+  ItemTitle,
+  Skeleton,
+  UnstableEmpty,
+  UnstableEmptyDescription,
+  UnstableEmptyHeader,
+  UnstableEmptyTitle
+} from "@app/components/v3";
+import { useOrganization, useProject } from "@app/context";
+import { getProjectBaseURL } from "@app/helpers/project";
+import { useGetSecretAccessList } from "@app/hooks/api/secrets/queries";
+import { SecretAccessListEntry } from "@app/hooks/api/secrets/types";
+import { camelCaseToSpaces } from "@app/lib/fn/string";
+
+type Props = {
+  secretKey: string;
+  environment: string;
+  secretPath: string;
+};
+
+function AccessCard({
+  entry,
+
+  linkTo,
+  linkParams
+}: {
+  entry: SecretAccessListEntry;
+  linkTo?: string;
+  linkParams?: Record<string, string>;
+}) {
+  const cardContent = (
+    <>
+      <ItemContent className="overflow-hidden">
+        <ItemTitle className="w-full overflow-hidden">
+          <span className="truncate">{entry.name}</span>
+        </ItemTitle>
+      </ItemContent>
+      <ItemFooter>
+        <div className="flex flex-wrap gap-2">
+          {entry.allowedActions.map((action) => (
+            <Badge key={action} className="capitalize" variant="neutral">
+              {camelCaseToSpaces(action)}
+            </Badge>
+          ))}
+        </div>
+      </ItemFooter>
+    </>
+  );
+
+  if (linkTo && linkParams) {
+    return (
+      <Item variant="outline" asChild>
+        <Link to={linkTo as "."} params={linkParams}>
+          {cardContent}
+        </Link>
+      </Item>
+    );
+  }
+
+  return <Item variant="outline">{cardContent}</Item>;
+}
+
+function SectionHeader({
+  icon,
+  title,
+  count
+}: {
+  icon: React.ReactNode;
+  title: string;
+  count: number;
+}) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      {icon}
+      <span className="text-sm font-medium tracking-wide text-label">{title}</span>
+      <Badge variant="neutral" className="text-xs">
+        {count}
+      </Badge>
+    </div>
+  );
+}
+
+export function SecretAccessInsights({ secretKey, environment, secretPath }: Props) {
+  const { currentOrg } = useOrganization();
+  const { currentProject } = useProject();
+
+  const { data: secretAccessList, isLoading } = useGetSecretAccessList({
+    projectId: currentProject.id,
+    environment,
+    secretPath,
+    secretKey
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6 p-4">
+        {Array.from({ length: 3 }).map((_, sectionIndex) => (
+          <div key={`section-skeleton-${String(sectionIndex)}`}>
+            <div className="mb-3 flex items-center gap-2">
+              <Skeleton className="size-4 rounded" />
+              <Skeleton className="h-4 w-24 rounded" />
+              <Skeleton className="h-5 w-6 rounded" />
+            </div>
+            <div className="flex flex-col gap-4">
+              {Array.from({ length: 2 }).map((__, itemIndex) => (
+                <Skeleton
+                  key={`section-skeleton-${String(itemIndex)}`}
+                  className="h-[69.25px] rounded-md"
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const hasUsers = secretAccessList && secretAccessList.users.length > 0;
+  const hasIdentities = secretAccessList && secretAccessList.identities.length > 0;
+  const hasGroups = secretAccessList && secretAccessList.groups.length > 0;
+  const hasAnyAccess = hasUsers || hasIdentities || hasGroups;
+
+  if (!hasAnyAccess) {
+    return (
+      <UnstableEmpty className="bg-transparent">
+        <UnstableEmptyHeader>
+          <EmptyMedia variant="icon">
+            <UsersIcon />
+          </EmptyMedia>
+          <UnstableEmptyTitle>No Access Found</UnstableEmptyTitle>
+          <UnstableEmptyDescription>
+            No users, groups, or identities have direct access to this secret.
+          </UnstableEmptyDescription>
+        </UnstableEmptyHeader>
+      </UnstableEmpty>
+    );
+  }
+
+  return (
+    <div className="flex thin-scrollbar flex-col gap-6 overflow-y-auto p-4">
+      {hasUsers && (
+        <div>
+          <SectionHeader
+            icon={<UserIcon className="size-4 text-accent" />}
+            title="Users"
+            count={secretAccessList.users.length}
+          />
+          <ItemGroup>
+            {secretAccessList.users.map((user) => (
+              <AccessCard
+                key={user.id}
+                entry={user}
+                linkTo={`${getProjectBaseURL(currentProject.type)}/members/$membershipId`}
+                linkParams={{
+                  orgId: currentOrg.id,
+                  projectId: currentProject.id,
+                  membershipId: user.membershipId
+                }}
+              />
+            ))}
+          </ItemGroup>
+        </div>
+      )}
+
+      {hasIdentities && (
+        <div>
+          <SectionHeader
+            icon={<HardDriveIcon className="size-4 text-accent" />}
+            title="Machine Identities"
+            count={secretAccessList.identities.length}
+          />
+          <ItemGroup>
+            {secretAccessList.identities.map((identity) => (
+              <AccessCard
+                key={identity.id}
+                entry={identity}
+                linkTo={`${getProjectBaseURL(currentProject.type)}/identities/$identityId`}
+                linkParams={{
+                  orgId: currentOrg.id,
+                  projectId: currentProject.id,
+                  identityId: identity.id
+                }}
+              />
+            ))}
+          </ItemGroup>
+        </div>
+      )}
+
+      {hasGroups && (
+        <div>
+          <SectionHeader
+            icon={<UsersIcon className="size-4 text-accent" />}
+            title="Groups"
+            count={secretAccessList.groups.length}
+          />
+          <ItemGroup>
+            {secretAccessList.groups.map((group) => (
+              <AccessCard
+                key={group.id}
+                entry={group}
+                linkTo={`${getProjectBaseURL(currentProject.type)}/groups/$groupId`}
+                linkParams={{
+                  orgId: currentOrg.id,
+                  projectId: currentProject.id,
+                  groupId: group.id
+                }}
+              />
+            ))}
+          </ItemGroup>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Context

This PR adds access insights to the overview page with v3 components and expands the API so that users can navigate to the respective entities page to manage access.

## Screenshots

<img width="3456" height="1910" alt="CleanShot 2026-02-04 at 16 12 35@2x" src="https://github.com/user-attachments/assets/4eba8caf-bb01-4954-827b-5b5ffb5a8f29" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- Verify sheet only opens if subscription includes secret access insights
- verify permissions displayed are correct
- verify clicking each entity properly links to it's page

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)