### PR TITLE
fix(frontend): remove secret ID being set as secret comment

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -519,8 +519,7 @@ export const OverviewPage = () => {
     key: string,
     value: string,
     secretValueHidden: boolean,
-    type = SecretType.Shared,
-    secretComment?: string
+    type = SecretType.Shared
   ) => {
     let secretValue: string | undefined = value;
 
@@ -537,8 +536,7 @@ export const OverviewPage = () => {
       secretPath,
       secretKey: key,
       secretValue,
-      type,
-      secretComment
+      type
     });
 
     if ("approval" in result) {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -87,8 +87,7 @@ type Props = {
     value: string,
     secretValueHidden: boolean,
     type?: SecretType,
-    secretId?: string,
-    comment?: string
+    secretId?: string
   ) => Promise<void>;
   onSecretDelete: (env: string, key: string, secretId?: string) => Promise<void>;
   isRotatedSecret?: boolean;


### PR DESCRIPTION
## Context

This PR fixes the overview page accidentally setting the secret comment to the secret ID due to incorrect parameter

## Screenshots

N/A

## Steps to verify the change

- verify comment is not overwritten with secret ID when updating the value via the overview dashboard

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)