### PR TITLE
fix: add autoComplete attribute for Apple 2FA autofill

### DIFF
--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -102,6 +102,7 @@ export default function CodeInputStep({
           onChange={setCode}
           {...props}
           className="mt-6 mb-2"
+          autoComplete="one-time-code"
         />
       </div>
       <div className="mx-auto mt-4 block w-max md:hidden">
@@ -113,6 +114,7 @@ export default function CodeInputStep({
           onChange={setCode}
           {...propsPhone}
           className="mt-2 mb-2"
+          autoComplete="one-time-code"
         />
       </div>
       {codeError && <Error text={t("signup.step2-code-error")} />}

--- a/frontend/src/components/auth/Mfa.tsx
+++ b/frontend/src/components/auth/Mfa.tsx
@@ -441,6 +441,7 @@ export const Mfa = ({ successCallback, closeMfa, hideLogo, email, method }: Prop
                   onChange={setMfaCode}
                   className="mt-6 mb-2"
                   {...codeInputProps}
+                  autoComplete="one-time-code"
                 />
               </div>
             )}
@@ -455,6 +456,7 @@ export const Mfa = ({ successCallback, closeMfa, hideLogo, email, method }: Prop
                   onChange={setMfaCode}
                   className="mb-2"
                   {...codeInputProps}
+                  autoComplete="one-time-code"
                 />
               </div>
             )}
@@ -470,6 +472,7 @@ export const Mfa = ({ successCallback, closeMfa, hideLogo, email, method }: Prop
                   onChange={setMfaCode}
                   className="mt-2 mb-2"
                   {...codeInputPropsPhone}
+                  autoComplete="one-time-code"
                 />
               </div>
             )}
@@ -484,6 +487,7 @@ export const Mfa = ({ successCallback, closeMfa, hideLogo, email, method }: Prop
                   onChange={setMfaCode}
                   className="mb-2"
                   {...codeInputPropsPhone}
+                  autoComplete="one-time-code"
                 />
               </div>
             )}


### PR DESCRIPTION
Fixes #1167

## Problem

Apple's auto-fill feature fills "I n f i s i" instead of the verification code because the input fields are missing the `autoComplete="one-time-code"` attribute.

## Solution

Added `autoComplete="one-time-code"` to all `ReactCodeInput` components in:
- `CodeInputStep.tsx` (email verification during signup)
- `Mfa.tsx` (MFA code input during login)

This tells Apple's autofill system that these fields expect one-time codes from emails/SMS.