### PR TITLE
fix: update aws sm sync to properly handle key schema when using many-to-one mapping

### DIFF
--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -28,6 +28,7 @@ import {
 import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
 import { TKmsServiceFactory } from "../kms/kms-service";
 import { ONEPASS_SYNC_LIST_OPTION, OnePassSyncFns } from "./1password";
+import { AwsSecretsManagerSyncMappingBehavior } from "./aws-secrets-manager/aws-secrets-manager-sync-enums";
 import { AZURE_APP_CONFIGURATION_SYNC_LIST_OPTION, azureAppConfigurationSyncFactory } from "./azure-app-configuration";
 import { AZURE_DEVOPS_SYNC_LIST_OPTION, azureDevOpsSyncFactory } from "./azure-devops";
 import { AZURE_KEY_VAULT_SYNC_LIST_OPTION, azureKeyVaultSyncFactory } from "./azure-key-vault";
@@ -113,6 +114,23 @@ type TSyncSecretDeps = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+};
+
+export const getKeyWithSchema = ({
+  key,
+  environment,
+  schema
+}: {
+  key: string;
+  environment: string;
+  schema?: string;
+}) => {
+  if (!schema) return key;
+
+  return handlebars.compile(schema)({
+    secretKey: key,
+    environment
+  });
 };
 
 // Add schema to secret keys
@@ -229,7 +247,7 @@ export const SecretSyncFns = {
       case SecretSync.AWSParameterStore:
         return AwsParameterStoreSyncFns.syncSecrets(secretSync, schemaSecretMap);
       case SecretSync.AWSSecretsManager:
-        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, schemaSecretMap, secretMap);
       case SecretSync.GitHub:
         return GithubSyncFns.syncSecrets(secretSync, schemaSecretMap, gatewayService, gatewayV2Service);
       case SecretSync.GCPSecretManager:
@@ -328,6 +346,9 @@ export const SecretSyncFns = {
         break;
       case SecretSync.AWSSecretsManager:
         secretMap = await AwsSecretsManagerSyncFns.getSecrets(secretSync);
+        // if many-to-one we don't check for/strip schema, as schema is only applied to the secret name
+        if (secretSync.destinationConfig.mappingBehavior === AwsSecretsManagerSyncMappingBehavior.ManyToOne)
+          return secretMap;
         break;
       case SecretSync.GitHub:
         secretMap = await GithubSyncFns.getSecrets(secretSync);


### PR DESCRIPTION

## Context

This PR fixes aws secrets manager sync, import and deletion behavior when using a key schema with many-to-one mapping sync option

## Screenshots

N/A

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- Verify syncing, importing and removing secrets with and without a key schema when using many-to-one mapping works as expected

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)