### PR TITLE
docs: updated information on operator default value

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
@@ -81,7 +81,7 @@ When `hostAPI` is not defined the operator fetches secrets from Infisical Cloud.
   - `d` for days
   - `w` for weeks
 
-  The default value is `1m` _(1 minute)_.
+  The default value is `1m` _(1 minute)_ when `instantUpdates` is set to `false`, and `1h` _(1 hour)_ when `instantUpdates` is set to `true`. 
 
   Valid expressions for the `resyncInterval` field:
   ```yaml


### PR DESCRIPTION
## Context

Updates information on k8s operator resync interval value based of instant updates

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)