### PR TITLE
fix: queue PKI Alert V2 run once a day

### DIFF
--- a/backend/src/services/pki-alert-v2/pki-alert-v2-queue.ts
+++ b/backend/src/services/pki-alert-v2/pki-alert-v2-queue.ts
@@ -211,7 +211,7 @@ export const pkiAlertV2QueueServiceFactory = ({
       }
     );
 
-    await queueService.schedulePg(QueueJobs.DailyPkiAlertV2Processing, "* * * * *", undefined, { tz: "UTC" });
+    await queueService.schedulePg(QueueJobs.DailyPkiAlertV2Processing, "0 0 * * *", undefined, { tz: "UTC" });
   };
 
   return {


### PR DESCRIPTION
## Context

Small fix on the PKI alert v2 queue where it was mistakenly set to run every minute in a previous commit instead of at 00:00 every day

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)