### PR TITLE
fix: resolved failing enotfound error in hcp vault app connection

### DIFF
--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -133,7 +133,7 @@ export const requestWithHCVaultGateway = async <T>(
 
   const url = new URL(requestConfig.url as string);
   await blockLocalAndPrivateIpAddresses(url.toString(), Boolean(gatewayId));
-  
+
   // If gateway isn't set up, don't proxy request
   if (!gatewayId) {
     return request.request(requestConfig);


### PR DESCRIPTION
## Context

This PR fixes ENOTFOUND error with gateway usage ofr hcp vault app connection. This was because the gateway boolean flag was not getting passed to the function.

Removed check `blockLocalAndPrivateIpAddresses` from getInstanceURl` as it's already done in main request function

## Screenshots

1. Create an app connection for vault with gateway that can only be reached by gateway

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)