### PR TITLE
security: use parameterized queries for password in ALTER USER statem…

### DIFF
--- a/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue-fn.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue-fn.ts
@@ -159,35 +159,35 @@ export const secretRotationHttpSetFn = async (func: THttpProviderFunction, varia
 export const getDbSetQuery = (db: TDbProviderClients, variables: { username: string; password: string }) => {
   if (db === TDbProviderClients.Pg) {
     return {
-      query: `ALTER USER ?? WITH PASSWORD '${variables.password}'`,
-      variables: [variables.username]
+      query: `ALTER USER ?? WITH PASSWORD ?`,
+      variables: [variables.username, variables.password]
     };
   }
 
   if (db === TDbProviderClients.MsSqlServer) {
     return {
-      query: `ALTER LOGIN ?? WITH PASSWORD = '${variables.password}'`,
-      variables: [variables.username]
+      query: `ALTER LOGIN ?? WITH PASSWORD = ?`,
+      variables: [variables.username, variables.password]
     };
   }
 
   if (db === TDbProviderClients.MySql) {
     return {
-      query: `ALTER USER ??@'%' IDENTIFIED BY '${variables.password}'`,
-      variables: [variables.username]
+      query: `ALTER USER ??@'%' IDENTIFIED BY ?`,
+      variables: [variables.username, variables.password]
     };
   }
 
   if (db === TDbProviderClients.OracleDB) {
     return {
-      query: `ALTER USER ?? IDENTIFIED BY "${variables.password}"`,
-      variables: [variables.username]
+      query: `ALTER USER ?? IDENTIFIED BY ?`,
+      variables: [variables.username, variables.password]
     };
   }
 
   // add more based on client
   return {
-    query: `ALTER USER ?? IDENTIFIED BY '${variables.password}'`,
-    variables: [variables.username]
+    query: `ALTER USER ?? IDENTIFIED BY ?`,
+    variables: [variables.username, variables.password]
   };
 };


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Context

The `getDbSetQuery` function in the secret rotation queue interpolates password values directly into SQL `ALTER USER` statements using template literals (e.g., `ALTER USER ?? WITH PASSWORD '${variables.password}'`). This enables SQL injection if passwords contain SQL metacharacters, quotes, or malicious payloads. While the current caller generates alphanumeric-only passwords via `alphaNumericNanoId(32)`, the function signature accepts any string — making it unsafe if the calling code changes or the function is reused elsewhere.

**Location:** `backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue-fn.ts` (lines 162-192)

**Affected database providers:** PostgreSQL, MSSQL, MySQL, OracleDB, and the default fallback.

**Fix:** Replaced direct string interpolation of password values with knex `?` value binding placeholders across all database providers. The password is now passed as a parameterized binding in the `variables` array alongside the existing username identifier binding (`??`). This ensures knex properly escapes password values through the database driver, preventing SQL injection regardless of password content.

## Steps to verify the change

1. Confirm that `getDbSetQuery` no longer uses template literal interpolation for passwords
2. Verify each database provider branch uses `?` placeholder and includes `variables.password` in the bindings array
3. Confirm `secretRotationDbFn` passes the query and variables to `db.raw(query, variables)` which handles both `??` (identifier) and `?` (value) bindings

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Tests/Linters Ran

- **ESLint** (`npm run lint`): Passed with zero warnings
- **TypeScript** (`npm run type:check`): Passed with no errors
- **Unit tests** (`npm run test:unit`): 40/40 tests passed (9 test files failed due to pre-existing native module build issues with `re2` and `bcrypt`, unrelated to this change). No unit tests exist for the `getDbSetQuery` function specifically.

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

## Contribution Notes

- This is a security fix targeting a SQL injection vulnerability in DDL query construction
- No new dependencies introduced; uses existing knex parameterized binding capabilities
- The change is backwards-compatible — the function signature and return type are unchanged