### PR TITLE
feat: updated permission error message

### DIFF
--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -212,7 +212,7 @@ export const permissionServiceFactory = ({
     });
     if (!permissionData?.length)
       throw new ForbiddenRequestError({
-        message: `You are not a member of this organization with ID ${actorOrgId}. Please make sure this ${actor} is assigned to the organization with the required role.`
+        message: `You are not a member of this organization with ID ${actorOrgId}. Please assign this ${actor} to the organization with the appropriate permissions, then try again.`
       });
 
     const rootOrgId = permissionData?.[0]?.rootOrgId;
@@ -380,7 +380,7 @@ export const permissionServiceFactory = ({
     });
     if (!permissionData?.length)
       throw new ForbiddenRequestError({
-        message: `You are not a member of this project with ID ${projectId}. Please make sure this ${actor} is assigned to the project with the required role.`
+        message: `You are not a member of this project with ID ${projectId}. Please assign this ${actor} to the project with the appropriate permissions, then try again.`
       });
 
     const permissionFromRoles = permissionData.flatMap((membership) => {


### PR DESCRIPTION
## Context
This PR updates the error message shown when you have valid credentials, but not part of the required project or organization

Additionally we were putting the value in `name` field instead of the `message` field. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)