### PR TITLE
fix(permissions): add a check for empty glob paths

### DIFF
--- a/backend/src/lib/casl/index.ts
+++ b/backend/src/lib/casl/index.ts
@@ -15,7 +15,7 @@ const $glob: FieldInstruction<string> = {
 const glob: JsInterpreter<FieldCondition<string>> = (node, object, context) => {
   const secretPath = context.get(object, node.field) as string;
   const permissionSecretGlobPath = node.value;
-  if (permissionSecretGlobPath === "") return false;
+  if (permissionSecretGlobPath.trim() === "") return false;
   return picomatch.isMatch(secretPath, permissionSecretGlobPath, { strictSlashes: false });
 };
 

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -210,7 +210,7 @@ const ServiceTokenForm = () => {
           onClick={() =>
             append({
               environment: currentProject?.environments?.[0]?.slug || "",
-              secretPath: ""
+              secretPath: "/"
             })
           }
           leftIcon={<FontAwesomeIcon icon={faPlus} />}


### PR DESCRIPTION
## Context

If the service token has an empty path, it would cause an error in the glob processor.

- Added a check in the CASL index to prevent empty glob paths from being processed.
- Added a simple validation to prevent empty secretPaths in the UI

## Screenshots

<img width="647" height="787" alt="image" src="https://github.com/user-attachments/assets/b6cb2134-6f02-4bf8-afaf-83197039f308" />

## Steps to verify the change

Create a Service Token with an empty Secrets Path and try to call the secrets endpoints with that token.
- You'll have to update the path in the db because we are blocking this in the UI now
- If you have an empty path, it will return nothing "{"secrets":[],"imports":[]}%"
- If you have a non-empty path, it will do the query

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)