### PR TITLE
chore: removed lint stage check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,6 +9,4 @@ if ! command -v infisical >/dev/null 2>&1; then
     exit 1
 fi
 
-npx lint-staged
-
 infisical scan git-changes --staged -v

--- a/package.json
+++ b/package.json
@@ -13,14 +13,6 @@
   "scripts": {
     "prepare": "husky install"
   },
-  "lint-staged": {
-    "./frontend/**/*.{js,jsx,ts,tsx}": [
-      "bash -c 'cd frontend && npx eslint --fix --max-warnings 0 ${@#frontend/}' _"
-    ],
-    "./backend/**/*.{js,jsx,ts,tsx}": [
-      "bash -c 'cd backend && npx eslint --fix --max-warnings 0 ${@#backend/}' _"
-    ]
-  },
   "devDependencies": {
     "@types/uuid": "^9.0.7",
     "eslint": "^8.57.1",


### PR DESCRIPTION
## Context

This PR removes the lint stage check that run backend and frontend type check and lint. This is making each commit takes longer to run.

We have a PR workflow that ensures all PRs have both ts and lint errors fixed. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)