### PR TITLE
fix(server): use SITE_URL in bootstrap startup message

### DIFF
--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -14,20 +14,21 @@ type BootstrapOpt = {
 const bootstrapCb = async () => {
   const appCfg = getConfig();
   const serverCfg = await getServerCfg();
+  const baseUrl = appCfg.SITE_URL || `http://localhost:${appCfg.PORT}`;
   if (!serverCfg.initialized) {
     console.info(`Welcome to Infisical
 
 Create your Infisical administrator account at:
-http://localhost:${appCfg.PORT}/admin/signup
+${baseUrl}/admin/signup
 `);
   } else {
     console.info(`Welcome back!
 
 To access Infisical Administrator Panel open
-http://localhost:${appCfg.PORT}/admin
+${baseUrl}/admin
 
 To access Infisical server
-http://localhost:${appCfg.PORT}
+${baseUrl}
 `);
   }
 };


### PR DESCRIPTION
## Summary

Fixes #5295 and #4268.

The bootstrap check message in `boot-strap-check.ts` always displays `http://localhost:{PORT}` as the URL for accessing the admin panel and server. When using Docker port mapping (e.g. `-p 80:8080`) or a reverse proxy, the internal container port (8080) doesn't match the externally accessible port/domain, causing confusion.

## Fix

Use `SITE_URL` from the environment configuration when available, falling back to `http://localhost:{PORT}` only when `SITE_URL` is not configured. `SITE_URL` is already a standard configuration option that self-hosted users set to their externally accessible URL.

## Test Plan

- Verified the startup message renders correctly with `SITE_URL` set
- Verified the fallback to `localhost:{PORT}` when `SITE_URL` is not set