### PR TITLE
fix(auth): allow dots in Alibaba Cloud STS AccessKeyId validation

### DIFF
--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -36,8 +36,8 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
           .describe(ALICLOUD_AUTH.LOGIN.Version),
         AccessKeyId: z
           .string()
-          .refine((val) => new RE2("^[A-Za-z0-9]+$").test(val), {
-            message: "AccessKeyId must be alphanumeric"
+          .refine((val) => new RE2("^[A-Za-z0-9.]+$").test(val), {
+            message: "AccessKeyId must contain only alphanumeric characters and dots"
           })
           .describe(ALICLOUD_AUTH.LOGIN.AccessKeyId),
         organizationSlug: slugSchema().optional().describe(ALICLOUD_AUTH.LOGIN.organizationSlug),


### PR DESCRIPTION
## Summary

Fixes #4937.

Alibaba Cloud STS (Security Token Service) issues temporary `AccessKeyId` values with a `STS.` prefix (e.g. `STS.NUxxxxxxxx`), which contain a dot (`.`) character. The current Zod validation regex `^[A-Za-z0-9]+$` in the Alibaba Cloud auth login endpoint rejects these valid credentials with a 422 `ValidationFailure` error, completely blocking STS-based authentication.

## Root Cause

The regex `^[A-Za-z0-9]+$` only allows alphanumeric characters but Alibaba Cloud's STS format includes a dot separator between the `STS` prefix and the key identifier. This is documented in [Alibaba Cloud's credential configuration guide](https://www.alibabacloud.com/help/en/cli/configure-credentials).

## Fix

Updated the regex to `^[A-Za-z0-9.]+$` to accept the dot character, matching Alibaba Cloud's official STS AccessKeyId format. Also updated the error message to reflect the new allowed character set.

## Test Plan

- Verified that `STS.NUxxxxxxxx` format AccessKeyIds pass validation
- Verified that standard alphanumeric AccessKeyIds still pass
- Verified that other special characters (spaces, slashes, etc.) are still rejected