### PR TITLE
fix(docker): exclude test private keys and BDD files from production images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,9 @@ backend/frontend-build
 README.md
 .dockerignore
 **/Dockerfile
+
+# Exclude test directories and test private keys from production images
+backend/bdd
+backend/e2e-test
+**/*.test.ts
+**/*.spec.ts

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -109,7 +109,7 @@ RUN apt-get update && apt-get install -y \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 COPY --from=backend-build /app .
-RUN rm -rf ./node_modules
+RUN rm -rf ./node_modules ./bdd ./e2e-test
 RUN npm ci --omit=dev
 
 RUN mkdir frontend-build

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -110,7 +110,7 @@ RUN apt-get update && apt-get install -y \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 COPY --from=backend-build /app .
-RUN rm -rf ./node_modules
+RUN rm -rf ./node_modules ./bdd ./e2e-test
 RUN npm ci --omit=dev
 
 RUN mkdir frontend-build

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -78,6 +78,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN npm ci --only-production && npm cache clean --force
 
 COPY --from=build /app .
+RUN rm -rf ./bdd ./e2e-test
 
 # Install smbclient for Windows SMB operations
 RUN apt-get update && apt-get install -y smbclient


### PR DESCRIPTION
## Summary

Fixes #5007.

Trivy and other security scanners flag the Pebble ACME test private keys (`backend/bdd/pebble/localhost/key.pem`, `backend/bdd/pebble/pebble.minica.key.pem`) as HIGH severity `AsymmetricPrivateKey` findings in production Docker images. These are test certificates used only for BDD testing and serve no purpose in production.

## Root Cause

The `COPY /backend .` in the build stage copies all backend files including the `bdd/` and `e2e-test/` directories. These files then propagate through to the production image via `COPY --from=backend-build /app .`. The `.dockerignore` did not exclude these test directories.

## Fix

Two-layer approach:
1. **`.dockerignore`**: Added `backend/bdd`, `backend/e2e-test`, `**/*.test.ts`, and `**/*.spec.ts` to prevent these files from entering the build context
2. **Dockerfiles**: Added explicit `RUN rm -rf ./bdd ./e2e-test` in all three Dockerfiles (standalone, FIPS, backend) as defense-in-depth

## Test Plan

- Verified that `.dockerignore` patterns correctly exclude the test directories
- Verified that the Dockerfiles contain the cleanup step in the correct stage
- No functional impact — these files are never used at runtime