### PR TITLE
fix(pki): return 404 instead of 500 when fetching non-existent certificate

### DIFF
--- a/backend/src/services/certificate/certificate-service.ts
+++ b/backend/src/services/certificate/certificate-service.ts
@@ -220,6 +220,10 @@ export const certificateServiceFactory = ({
   }: TGetCertPrivateKeyDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
 
+    if (!cert) {
+      throw new NotFoundError({ message: `Certificate not found` });
+    }
+
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -402,6 +406,10 @@ export const certificateServiceFactory = ({
    */
   const getCertBody = async ({ id, serialNumber, actorId, actorAuthMethod, actor, actorOrgId }: TGetCertBodyDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+
+    if (!cert) {
+      throw new NotFoundError({ message: `Certificate not found` });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,
@@ -712,6 +720,10 @@ export const certificateServiceFactory = ({
   }: TGetCertBundleDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
 
+    if (!cert) {
+      throw new NotFoundError({ message: `Certificate not found` });
+    }
+
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -839,6 +851,10 @@ export const certificateServiceFactory = ({
       throw new BadRequestError({ message: "Alias is required for PKCS12 keystore generation" });
     }
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+
+    if (!cert) {
+      throw new NotFoundError({ message: `Certificate not found` });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,


### PR DESCRIPTION
## Summary

Fixes #4639.

When fetching a certificate by serial number via the PKI API endpoints (`/api/v1/pki/certificates/{serialNumber}`, `/body`, `/bundle`, `/private-key`), providing a non-existent serial number causes a 500 Internal Server Error instead of the expected 404.

## Root Cause

The `getCertBody`, `getCertPrivateKey`, `getCertBundle`, and `getCertPkcs12` methods in `certificate-service.ts` perform a database lookup but don't check whether the result is null before accessing `cert.projectId`. When the certificate doesn't exist, this causes:

```
TypeError: Cannot read properties of undefined (reading 'projectId')
```

The `getCert` method already had the proper null check (added previously), but the other four methods were missing it.

## Fix

Added `if (!cert) throw new NotFoundError(...)` checks after the certificate lookup in all four affected methods, consistent with the existing pattern in `getCert`.

## Test Plan

- GET `/api/v1/pki/certificates/non-existent-serial` → 404 (was 500)
- GET `/api/v1/pki/certificates/non-existent-serial/certificate` → 404 (was 500)
- GET `/api/v1/pki/certificates/non-existent-serial/certificate-chain` → 404 (was 500)
- GET `/api/v1/pki/certificates/non-existent-serial/private-key` → 404 (was 500)
- Existing certificate lookups with valid serial numbers continue to work as expected