### PR TITLE
fix(ui): prevent dropdown overlap on KMS overview table

### DIFF
--- a/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
@@ -363,7 +363,7 @@ export const CmekTable = () => {
                                 <FontAwesomeIcon size="lg" icon={faEllipsis} />
                               </IconButton>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent className="min-w-[160px]">
+                            <DropdownMenuContent className="min-w-[160px]" sideOffset={2} align="end">
                               {keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT && (
                                 <>
                                   <Tooltip


### PR DESCRIPTION
## Summary

Fixes #4878.

On the KMS overview page, clicking the ellipsis menu (⋯) on a CMEK key row causes the dropdown to open directly overlapping the trigger button. Because the first menu item sits precisely where the click lands, it gets immediately selected — resulting in accidental actions like opening the encrypt/decrypt dialog.

## Root Cause

The `DropdownMenuContent` component had no `sideOffset` or `align` props, so it rendered at the default position which overlaps the trigger on certain viewport sizes (particularly on Windows/Chromium).

## Fix

Added `sideOffset={2}` and `align="end"` to the `DropdownMenuContent` to ensure the menu opens with a small gap below the trigger and aligned to the right edge, preventing the overlap.

## Test Plan

- Verified that clicking the ellipsis button opens the dropdown without selecting the first item
- Verified that all menu items remain clickable and properly positioned