### PR TITLE
fix(auth): allow special characters in organization names

### DIFF
--- a/backend/src/ee/routes/v1/sub-org-router.ts
+++ b/backend/src/ee/routes/v1/sub-org-router.ts
@@ -5,7 +5,7 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, SUB_ORGANIZATIONS } from "@app/lib/api-docs";
 import { pick } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
-import { GenericResourceNameSchema, slugSchema } from "@app/server/lib/schemas";
+import { OrgNameSchema, slugSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
@@ -35,7 +35,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         }
       ],
       body: z.object({
-        name: GenericResourceNameSchema.describe(SUB_ORGANIZATIONS.CREATE.name),
+        name: OrgNameSchema.describe(SUB_ORGANIZATIONS.CREATE.name),
         slug: slugSchema().optional().describe(SUB_ORGANIZATIONS.CREATE.slug)
       }),
       response: {
@@ -133,7 +133,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
       }),
       body: z
         .object({
-          name: GenericResourceNameSchema.optional().describe(SUB_ORGANIZATIONS.UPDATE.name),
+          name: OrgNameSchema.optional().describe(SUB_ORGANIZATIONS.UPDATE.name),
           slug: slugSchema().optional().describe(SUB_ORGANIZATIONS.UPDATE.slug)
         })
         .refine((data) => data.name !== undefined || data.slug !== undefined, {

--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -40,6 +40,31 @@ export const GenericResourceNameSchema = z
     "Name can only contain alphanumeric characters, dashes, underscores, and spaces"
   );
 
+// More permissive schema for organization names, which commonly contain
+// special characters like & (e.g. "Johnson & Johnson"), periods, commas,
+// apostrophes, and parentheses.
+export const OrgNameSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "Organization name must be at least 1 character" })
+  .max(64, { message: "Organization name must be 64 or fewer characters" })
+  .refine(
+    (val) =>
+      characterValidator([
+        CharacterType.AlphaNumeric,
+        CharacterType.Hyphen,
+        CharacterType.Underscore,
+        CharacterType.Spaces,
+        CharacterType.Ampersand,
+        CharacterType.Period,
+        CharacterType.Comma,
+        CharacterType.SingleQuote,
+        CharacterType.OpenParen,
+        CharacterType.CloseParen
+      ])(val),
+    "Organization name can only contain alphanumeric characters, spaces, and common punctuation (& . , ' - _ ( ))"
+  );
+
 export const BaseSecretNameSchema = z.string().trim().min(1);
 
 export const SecretNameSchema = BaseSecretNameSchema.refine(

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -16,7 +16,7 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { invalidateCacheLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
-import { GenericResourceNameSchema } from "@app/server/lib/schemas";
+import { OrgNameSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifySuperAdmin } from "@app/server/plugins/auth/superAdmin";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -873,7 +873,7 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       body: z.object({
-        name: GenericResourceNameSchema,
+        name: OrgNameSchema,
         inviteAdminEmails: z.string().email().array().min(1)
       }),
       response: {

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -15,7 +15,7 @@ import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-t
 import { ApiDocsTags, AUDIT_LOGS, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getLastMidnightDateISO, removeTrailingSlash } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
-import { GenericResourceNameSchema, slugSchema } from "@app/server/lib/schemas";
+import { OrgNameSchema, slugSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode, MfaMethod } from "@app/services/auth/auth-type";
 import { sanitizedOrganizationSchema } from "@app/services/org/org-schema";
@@ -287,7 +287,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
       operationId: "updateOrganization",
       params: z.object({ organizationId: z.string().trim() }),
       body: z.object({
-        name: GenericResourceNameSchema.optional(),
+        name: OrgNameSchema.optional(),
         slug: slugSchema({ max: 64 }).optional(),
         authEnforced: z.boolean().optional(),
         googleSsoAuthEnforced: z.boolean().optional(),

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -12,7 +12,7 @@ import { ApiDocsTags, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
-import { GenericResourceNameSchema } from "@app/server/lib/schemas";
+import { OrgNameSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 import { sanitizedOrganizationSchema } from "@app/services/org/org-schema";
@@ -409,7 +409,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     schema: {
       operationId: "createOrganization",
       body: z.object({
-        name: GenericResourceNameSchema
+        name: OrgNameSchema
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -5,7 +5,7 @@ import { getConfig } from "@app/lib/config/env";
 import { ForbiddenRequestError } from "@app/lib/errors";
 import { authRateLimit, smtpRateLimit } from "@app/server/config/rateLimiter";
 import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
-import { GenericResourceNameSchema } from "@app/server/lib/schemas";
+import { OrgNameSchema } from "@app/server/lib/schemas";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
@@ -117,7 +117,7 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
               z.object({ useDefaultOrg: z.literal(true) }),
               z.object({
                 useDefaultOrg: z.literal(false),
-                organizationName: GenericResourceNameSchema
+                organizationName: OrgNameSchema
               })
             ])
           )


### PR DESCRIPTION
## Summary

Fixes #3867.

Sign-up fails silently when an organization name contains special characters like `&` (e.g. `&why`). The validation uses `GenericResourceNameSchema` which only allows `[a-zA-Z0-9\-_ ]`, rejecting common business name characters.

## Root Cause

Organization names are validated with `GenericResourceNameSchema`, which was designed for generic resource names (projects, etc.) where restricted characters make sense. Organization names, however, commonly contain characters like `&` (Johnson & Johnson), `.` (Corp.), `,`, `'` (O'Reilly), and parentheses.

## Fix

Introduced `OrgNameSchema` in `schemas.ts` that extends the allowed character set to include `& . , ' ( )` while still blocking dangerous characters. Applied it to all five org name validation points:

- `v3/signup-router.ts` — signup flow
- `v2/organization-router.ts` — create organization
- `v1/organization-router.ts` — update organization
- `v1/admin-router.ts` — admin create organization
- `ee/routes/v1/sub-org-router.ts` — sub-organization create/update

The existing `GenericResourceNameSchema` is unchanged and continues to be used for other resource names.

## Test Plan

- Verified that org names like `&why`, `Johnson & Johnson`, `O'Reilly Media` pass validation
- Verified that existing validator tests still pass (3/3)
- Verified that standard alphanumeric org names still work