### PR TITLE
feat(telemetry): add OTEL_AGGREGATION_TEMPORALITY env var

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -254,6 +254,7 @@ const envSchema = z
     OTEL_COLLECTOR_BASIC_AUTH_USERNAME: zpStr(z.string().optional()),
     OTEL_COLLECTOR_BASIC_AUTH_PASSWORD: zpStr(z.string().optional()),
     OTEL_EXPORT_TYPE: z.enum(["prometheus", "otlp"]).optional(),
+    OTEL_AGGREGATION_TEMPORALITY: z.enum(["delta", "cumulative"]).default("delta"),
 
     PYLON_API_KEY: zpStr(z.string().optional()),
     DISABLE_AUDIT_LOG_GENERATION: zodStrBool.default("false"),
@@ -546,7 +547,8 @@ export const getTelemetryConfig = () => {
       otlpUser: parsedEnv.data.OTEL_COLLECTOR_BASIC_AUTH_USERNAME,
       otlpPassword: parsedEnv.data.OTEL_COLLECTOR_BASIC_AUTH_PASSWORD,
       otlpPushInterval: parsedEnv.data.OTEL_OTLP_PUSH_INTERVAL,
-      exportType: parsedEnv.data.OTEL_EXPORT_TYPE
+      exportType: parsedEnv.data.OTEL_EXPORT_TYPE,
+      aggregationTemporality: parsedEnv.data.OTEL_AGGREGATION_TEMPORALITY
     },
     TRACER: {
       profiling: parsedEnv.data.DATADOG_PROFILING_ENABLED,

--- a/backend/src/lib/telemetry/instrumentation.ts
+++ b/backend/src/lib/telemetry/instrumentation.ts
@@ -18,13 +18,15 @@ const initTelemetryInstrumentation = ({
   otlpURL,
   otlpUser,
   otlpPassword,
-  otlpPushInterval
+  otlpPushInterval,
+  aggregationTemporality
 }: {
   exportType?: string;
   otlpURL?: string;
   otlpUser?: string;
   otlpPassword?: string;
   otlpPushInterval?: number;
+  aggregationTemporality?: string;
 }) => {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
@@ -48,7 +50,10 @@ const initTelemetryInstrumentation = ({
         headers: {
           Authorization: `Basic ${btoa(`${otlpUser}:${otlpPassword}`)}`
         },
-        temporalityPreference: AggregationTemporality.DELTA
+        temporalityPreference:
+          aggregationTemporality === "cumulative"
+            ? AggregationTemporality.CUMULATIVE
+            : AggregationTemporality.DELTA
       });
       metricReaders.push(
         new PeriodicExportingMetricReader({


### PR DESCRIPTION
## Summary

Fixes #4368.

The OTLP metric exporter hardcodes `AggregationTemporality.DELTA`, which is silently dropped by Prometheus-based backends (Prometheus Remote Write, Grafana Alloy targeting Prometheus) that only support `CUMULATIVE` temporality. Users who export metrics via otel-collector to Prometheus lose all metrics with no visible error.

## Fix

- Added `OTEL_AGGREGATION_TEMPORALITY` env var to the configuration schema (values: `"delta"` | `"cumulative"`, default: `"delta"`)
- Updated the OTLP exporter initialization to use the configured temporality instead of the hardcoded DELTA value

Backward compatible — existing deployments that don't set the new env var continue using DELTA (current behavior).

## Test Plan

- Verified that the default behavior (DELTA) is unchanged when env var is not set
- Verified that setting `OTEL_AGGREGATION_TEMPORALITY=cumulative` correctly configures the exporter with CUMULATIVE temporality