### PR TITLE
fix(swagger): use SITE_URL for self-hosted Swagger server entries

### DIFF
--- a/backend/src/server/plugins/swagger.ts
+++ b/backend/src/server/plugins/swagger.ts
@@ -2,9 +2,27 @@ import swagger from "@fastify/swagger";
 import swaggerUI from "@fastify/swagger-ui";
 import fp from "fastify-plugin";
 
+import { getConfig } from "@app/lib/config/env";
+
 import { jsonSchemaTransform } from "./fastify-zod";
 
 export const fastifySwagger = fp(async (fastify) => {
+  const appCfg = getConfig();
+
+  const servers: { url: string; description: string }[] = [];
+
+  // When SITE_URL is set, prioritise it so self-hosted Swagger UI points at
+  // the correct host instead of hardcoded Infisical Cloud URLs.
+  if (appCfg.SITE_URL) {
+    servers.push({ url: appCfg.SITE_URL, description: "Current server" });
+  }
+
+  servers.push(
+    { url: "https://us.infisical.com", description: "Production server (US)" },
+    { url: "https://eu.infisical.com", description: "Production server (EU)" },
+    { url: `http://localhost:${appCfg.PORT || 8080}`, description: "Local server" }
+  );
+
   await fastify.register(swagger, {
     transform: jsonSchemaTransform,
     openapi: {
@@ -13,20 +31,7 @@ export const fastifySwagger = fp(async (fastify) => {
         description: "List of all available APIs that can be consumed",
         version: "0.0.1"
       },
-      servers: [
-        {
-          url: "https://us.infisical.com",
-          description: "Production server (US)"
-        },
-        {
-          url: "https://eu.infisical.com",
-          description: "Production server (EU)"
-        },
-        {
-          url: "http://localhost:8080",
-          description: "Local server"
-        }
-      ],
+      servers,
       components: {
         securitySchemes: {
           bearerAuth: {


### PR DESCRIPTION
## Summary

Fixes #3435.

Self-hosted deployments that set \`SITE_URL\` still see hardcoded \`https://us.infisical.com\` as the first Swagger server entry, making the built-in API docs (\`/api/docs\`) unusable without manual URL editing in the Swagger UI.

## Root Cause

The Swagger plugin has a static list of server URLs that always leads with the Infisical Cloud URLs. Self-hosted instances have no way to make their own URL appear first.

## Fix

- When \`SITE_URL\` is configured, prepend it as the first server entry with description "Current server"
- The Infisical Cloud URLs remain available as subsequent entries
- The local server fallback now uses the configured \`PORT\` env var instead of hardcoded 8080

Backward compatible — cloud deployments without \`SITE_URL\` see the same list as before.

## Test Plan

- Without \`SITE_URL\`: server list is unchanged (US, EU, localhost)
- With \`SITE_URL=https://secrets.example.com\`: first server in Swagger UI is \`https://secrets.example.com\`