### PR TITLE
fix(ui): remove max-h-screen from auth pages to prevent content cutoff

### DIFF
--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -71,7 +71,7 @@ export const SignUpPage = () => {
   }
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
+    <div className="flex min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>
         <link rel="icon" href="/infisical.ico" />

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -64,7 +64,7 @@ export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
   };
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
+    <div className="flex min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
       <Helmet>
         <title>{t("common.head-title", { title: t("login.title") })}</title>
         <link rel="icon" href="/infisical.ico" />

--- a/frontend/src/pages/auth/LoginPage/components/PasswordStep/PasswordStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/PasswordStep/PasswordStep.tsx
@@ -301,7 +301,7 @@ export const PasswordStep = ({
 
   if (shouldShowMfa) {
     return (
-      <div className="flex max-h-screen min-h-screen flex-col items-center justify-center gap-2 overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-2 overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
         <Mfa
           email={email}
           successCallback={mfaSuccessCallback}

--- a/frontend/src/pages/auth/SelectOrgPage/EmailDuplicationConfirmation.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/EmailDuplicationConfirmation.tsx
@@ -37,7 +37,7 @@ export const EmailDuplicationConfirmation = ({ onRemoveDuplicateLater }: Props) 
   }, [logout, navigate]);
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
+    <div className="flex min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
       <Helmet>
         <title>{t("common.head-title", { title: t("login.title") })}</title>
         <link rel="icon" href="/infisical.ico" />

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
@@ -267,7 +267,7 @@ export const SelectOrganizationSection = () => {
   }
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
+    <div className="flex min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700">
       <Helmet>
         <title>{t("common.head-title", { title: t("login.title") })}</title>
         <link rel="icon" href="/infisical.ico" />

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -125,7 +125,7 @@ export const SignUpPage = () => {
   };
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6 pb-28">
+    <div className="flex min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6 pb-28">
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>
         <link rel="icon" href="/infisical.ico" />


### PR DESCRIPTION
## Summary

Fixes #1411.

The signup card (and login, org-selection, admin signup pages) gets cut off at the bottom on desktop displays, hiding the submit button. This happens because the container uses both \`max-h-screen\` and \`min-h-screen\`, clamping it to exactly the viewport height. When form content is taller than the viewport (smaller screens, browser zoom, many fields), the overflow is hidden despite \`overflow-y-auto\` because the flex parent has a fixed max height.

## Fix

Remove \`max-h-screen\` from all affected auth page containers while keeping \`min-h-screen\` and \`overflow-y-auto\`. This allows the page to fill at least the viewport but grow naturally when content exceeds it.

**Files changed:**
- \`frontend/src/pages/auth/SignUpPage/SignUpPage.tsx\`
- \`frontend/src/pages/auth/LoginPage/LoginPage.tsx\`
- \`frontend/src/pages/auth/LoginPage/components/PasswordStep/PasswordStep.tsx\`
- \`frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx\`
- \`frontend/src/pages/auth/SelectOrgPage/EmailDuplicationConfirmation.tsx\`
- \`frontend/src/pages/admin/SignUpPage/SignUpPage.tsx\`

## Test Plan

- Verified that the signup page is fully scrollable when content exceeds viewport height
- All auth pages maintain the same visual appearance on normal-sized screens
- Bottom padding and submit buttons are now accessible on all screen sizes