### PR TITLE
fix(ui): apply auto-capitalization when importing/pasting secrets

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
@@ -25,7 +25,7 @@ import {
   SelectItem
 } from "@app/components/v2";
 import { Badge } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
 import { usePopUp, useToggle } from "@app/hooks";
 import { PendingAction } from "@app/hooks/api/secretFolders/types";
 import { fetchProjectSecrets, mergePersonalSecrets } from "@app/hooks/api/secrets/queries";
@@ -143,6 +143,7 @@ export const SecretDropzone = ({
   secretPath
 }: Props): JSX.Element => {
   const { t } = useTranslation();
+  const { currentProject } = useProject();
   const [isDragActive, setDragActive] = useToggle();
   const [isLoading, setIsLoading] = useToggle();
 
@@ -245,7 +246,14 @@ export const SecretDropzone = ({
     }
   };
 
-  const handleParsedEnv = async (env: TParsedEnv) => {
+  const handleParsedEnv = async (rawEnv: TParsedEnv) => {
+    // Apply auto-capitalization to secret keys when the project setting is enabled
+    const env: TParsedEnv = currentProject?.autoCapitalization
+      ? Object.fromEntries(
+          Object.entries(rawEnv).map(([key, val]) => [key.toUpperCase(), val])
+        )
+      : rawEnv;
+
     const envSecretKeys = Object.keys(env);
 
     if (!envSecretKeys.length) {


### PR DESCRIPTION
## Summary

Fixes #2693.

When a project has auto-capitalization enabled, pasting or importing secrets via file upload or the "Paste Secrets" modal bypasses the capitalization logic. Secret keys are stored in lowercase, contradicting the project setting.

## Root Cause

The \`SecretDropzone\` component's \`handleParsedEnv\` function processes imported/pasted secrets but never checks the project's \`autoCapitalization\` setting. The capitalization logic only existed in the individual secret creation form's paste handler.

## Fix

- Import \`useProject\` context in \`SecretDropzone\`
- In \`handleParsedEnv\`, apply \`toUpperCase()\` to all secret keys when \`currentProject.autoCapitalization\` is enabled
- This covers all import paths: file drag-and-drop, file upload, paste modal, and copy-from-environment

## Test Plan

- Enable auto-capitalization in project settings
- Paste secrets with lowercase keys via the "Paste Secrets" modal -> keys are now uppercased
- Import a .env file with lowercase keys via drag-and-drop -> keys are now uppercased
- Disable auto-capitalization -> keys remain as-is