### PR TITLE
fix(logging): downgrade noisy background task logs from INFO to DEBUG

### DIFF
--- a/backend/src/services/health-alert/health-alert-queue.ts
+++ b/backend/src/services/health-alert/health-alert-queue.ts
@@ -33,10 +33,10 @@ export const healthAlertServiceFactory = ({
 
     queueService.start(QueueName.HealthAlert, async () => {
       try {
-        logger.info(`${QueueName.HealthAlert}: health check alert task started`);
+        logger.debug(`${QueueName.HealthAlert}: health check alert task started`);
         await gatewayV2Service.healthcheckNotify();
         await relayService.healthcheckNotify();
-        logger.info(`${QueueName.HealthAlert}: health check alert task completed`);
+        logger.debug(`${QueueName.HealthAlert}: health check alert task completed`);
       } catch (error) {
         logger.error(error, `${QueueName.HealthAlert}: health check alert failed`);
         throw error;

--- a/backend/src/services/microsoft-teams/microsoft-teams-service.ts
+++ b/backend/src/services/microsoft-teams/microsoft-teams-service.ts
@@ -133,7 +133,7 @@ export const microsoftTeamsServiceFactory = ({
       }
 
       if (lastKnownUpdatedAt.getTime() === serverCfg.updatedAt.getTime()) {
-        logger.info("No changes to Microsoft Teams integration configuration, skipping sync");
+        logger.debug("No changes to Microsoft Teams integration configuration, skipping sync");
         return;
       }
 

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -286,7 +286,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     for (const eventType of POSTHOG_AGGREGATED_EVENTS) {
       let totalProcessed = 0;
 
-      logger.info(`Starting bucket processing for ${eventType}`);
+      logger.debug(`Starting bucket processing for ${eventType}`);
 
       // Process each bucket sequentially to control memory usage
       for (const bucketId of TELEMETRY_BUCKET_NAMES) {
@@ -299,7 +299,11 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
         }
       }
 
-      logger.info(`Completed processing ${totalProcessed} total events for ${eventType}`);
+      if (totalProcessed > 0) {
+        logger.info(`Completed processing ${totalProcessed} total events for ${eventType}`);
+      } else {
+        logger.debug(`Completed processing 0 events for ${eventType}`);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #5074.

Several periodic background tasks log at INFO level on every invocation, even when there is nothing to do. On self-hosted instances with default log level, this floods stdout/stderr and generates significant network TX (~5GB+) when logs are shipped to a remote collector.

## Changes

| File | Message | Before | After |
|------|---------|--------|-------|
| \`microsoft-teams-service.ts\` | "No changes to Microsoft Teams integration configuration, skipping sync" | INFO | DEBUG |
| \`telemetry-service.ts\` | "Starting bucket processing for ..." | INFO | DEBUG |
| \`telemetry-service.ts\` | "Completed processing 0 events for ..." | INFO | DEBUG (only when 0; non-zero stays INFO) |
| \`health-alert-queue.ts\` | "health check alert task started/completed" | INFO | DEBUG |

## Test Plan

- Default log level (INFO): these messages no longer appear in logs
- Setting log level to DEBUG: messages appear as before
- Non-zero telemetry events still log at INFO level