### PR TITLE
fix(docker-swarm): update bitnami Redis images from 6.2.10 to 7.2

### DIFF
--- a/docker-swarm/stack.yaml
+++ b/docker-swarm/stack.yaml
@@ -147,7 +147,7 @@ services:
 
 
   redis_replica0:
-    image: bitnami/redis:6.2.10
+    image: bitnami/redis:7.2
     environment:
       - REDIS_REPLICATION_MODE=master
       - REDIS_PASSWORD=123456
@@ -159,7 +159,7 @@ services:
           - node.labels.name == node1
 
   redis_replica1:
-    image: bitnami/redis:6.2.10
+    image: bitnami/redis:7.2
     environment:
       - REDIS_REPLICATION_MODE=slave
       - REDIS_MASTER_HOST=redis_replica0
@@ -174,7 +174,7 @@ services:
           - node.labels.name == node2
 
   redis_replica2:
-    image: bitnami/redis:6.2.10
+    image: bitnami/redis:7.2
     environment:
       - REDIS_REPLICATION_MODE=slave
       - REDIS_MASTER_HOST=redis_replica0
@@ -189,7 +189,7 @@ services:
           - node.labels.name == node3
 
   redis_sentinel1:
-    image: bitnami/redis-sentinel:6.2.10
+    image: bitnami/redis-sentinel:7.2
     environment:
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
@@ -206,7 +206,7 @@ services:
           - node.labels.name == node1
 
   redis_sentinel2:
-    image: bitnami/redis-sentinel:6.2.10
+    image: bitnami/redis-sentinel:7.2
     environment:
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
@@ -223,7 +223,7 @@ services:
           - node.labels.name == node2
 
   redis_sentinel3:
-    image: bitnami/redis-sentinel:6.2.10
+    image: bitnami/redis-sentinel:7.2
     environment:
       - REDIS_SENTINEL_QUORUM=2
       - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000

--- a/docs/self-hosting/deployment-options/docker-swarm.mdx
+++ b/docs/self-hosting/deployment-options/docker-swarm.mdx
@@ -147,12 +147,12 @@ The [Docker stack file](https://github.com/Infisical/infisical/tree/main/docker-
     t8vbkrasy8fz   infisical_etcd3             replicated   1/1        ghcr.io/zalando/spilo-16:3.2-p2        
     77iei42fcf6q   infisical_haproxy           global       4/4        haproxy:latest                         *:5002-5003->5433-5434/tcp, *:6379->6379/tcp, *:7001->7000/tcp, *:8080->8080/tcp
     jaewzqy8md56   infisical_infisical         replicated   5/5        infisical/infisical:v0.60.1-postgres   
-    58w4zablfbtb   infisical_redis_replica0    replicated   1/1        bitnami/redis:6.2.10                   
-    w4yag2whq0un   infisical_redis_replica1    replicated   1/1        bitnami/redis:6.2.10                   
-    w03mriy0jave   infisical_redis_replica2    replicated   1/1        bitnami/redis:6.2.10                   
-    ppo6rk47hc9t   infisical_redis_sentinel1   replicated   1/1        bitnami/redis-sentinel:6.2.10          
-    ub29vd0lnq7f   infisical_redis_sentinel2   replicated   1/1        bitnami/redis-sentinel:6.2.10          
-    szg3yky7yji2   infisical_redis_sentinel3   replicated   1/1        bitnami/redis-sentinel:6.2.10          
+    58w4zablfbtb   infisical_redis_replica0    replicated   1/1        bitnami/redis:7.2                   
+    w4yag2whq0un   infisical_redis_replica1    replicated   1/1        bitnami/redis:7.2                   
+    w03mriy0jave   infisical_redis_replica2    replicated   1/1        bitnami/redis:7.2                   
+    ppo6rk47hc9t   infisical_redis_sentinel1   replicated   1/1        bitnami/redis-sentinel:7.2          
+    ub29vd0lnq7f   infisical_redis_sentinel2   replicated   1/1        bitnami/redis-sentinel:7.2          
+    szg3yky7yji2   infisical_redis_sentinel3   replicated   1/1        bitnami/redis-sentinel:7.2          
     eqtocpf5tiy0   infisical_spolo1            replicated   1/1        ghcr.io/zalando/spilo-16:3.2-p2        
     3lznscvk7k5t   infisical_spolo2            replicated   1/1        ghcr.io/zalando/spilo-16:3.2-p2        
     v04ml7rz2j5q   infisical_spolo3            replicated   1/1        ghcr.io/zalando/spilo-16:3.2-p2


### PR DESCRIPTION
## Summary

Fixes #5081.

The \`bitnami/redis:6.2.10\` and \`bitnami/redis-sentinel:6.2.10\` images referenced in the Docker Swarm stack configuration and documentation are no longer available on Docker Hub, causing deployment failures for users following the self-hosting guide.

## Changes

- Updated all bitnami Redis image references from \`6.2.10\` to \`7.2\` in:
  - \`docker-swarm/stack.yaml\` (6 image references)
  - \`docs/self-hosting/deployment-options/docker-swarm.mdx\` (6 references in example output)

## Test Plan

- Verified that \`bitnami/redis:7.2\` and \`bitnami/redis-sentinel:7.2\` are available on Docker Hub
- The Redis 7.x line is backward compatible with the 6.x configuration used in the stack file