### PR TITLE
fix(api): reject whitespace-only user names

### DIFF
--- a/backend/src/server/routes/v2/user-router.ts
+++ b/backend/src/server/routes/v2/user-router.ts
@@ -94,8 +94,8 @@ export const registerUserRouter = async (server: FastifyZodProvider) => {
     schema: {
       operationId: "updateUserName",
       body: z.object({
-        firstName: z.string().trim(),
-        lastName: z.string().trim()
+        firstName: z.string().trim().min(1, { message: "First name is required" }),
+        lastName: z.string().trim().min(1, { message: "Last name is required" })
       }),
       response: {
         200: z.object({


### PR DESCRIPTION
## Summary

Fixes #4650.

The update-name endpoint (\`PATCH /api/v2/users/me/name\`) accepts whitespace-only strings like \`"    "\` as valid names. The Zod schema applies \`.trim()\` but does not validate minimum length, so the trimmed empty string passes validation and is stored in the database.

## Fix

Added \`.min(1)\` validation after \`.trim()\` for both \`firstName\` and \`lastName\` fields in the request body schema, so whitespace-only inputs are rejected with a clear error message.

## Test Plan

- \`firstName: "John"\` -> accepted (unchanged behavior)
- \`firstName: "    "\` -> rejected with "First name is required"
- \`firstName: ""\` -> rejected with "First name is required"
- Same for \`lastName\`