### PR TITLE
fix: correct typos across frontend and backend

### DIFF
--- a/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
+++ b/backend/src/ee/services/secret-rotation/secret-rotation-queue/secret-rotation-queue.ts
@@ -204,7 +204,7 @@ export const secretRotationQueueFactory = ({
 
       /*
        * Rotation Function For AWS Services
-       * Due to complexity in AWS Authorization hashing signature process we keep it as seperate entity instead of http template mode
+       * Due to complexity in AWS Authorization hashing signature process we keep it as separate entity instead of http template mode
        * We first delete old key before creating a new one because aws iam has a quota limit of 2 keys
        * */
       if (provider.template.type === TProviderFunctionTypes.AWS) {

--- a/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
+++ b/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
@@ -40,7 +40,7 @@ export const snapshotDALFactory = (db: TDbClient) => {
         .first();
       if (data) {
         const { envId, envName, envSlug } = data;
-        return { ...data, envId, enviroment: { id: envId, name: envName, slug: envSlug } };
+        return { ...data, envId, environment: { id: envId, name: envName, slug: envSlug } };
       }
     } catch (error) {
       throw new DatabaseError({ error, name: "FindById" });

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -770,7 +770,7 @@ export const orgServiceFactory = ({
   };
   /*
    * Org membership management
-   * Not another service because it has close ties with how an org works doesn't make sense to seperate them
+   * Not another service because it has close ties with how an org works doesn't make sense to separate them
    * */
   const updateOrgMembership = async ({
     role,

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -557,7 +557,7 @@ export const secretQueueFactory = ({
   };
 
   const syncSecrets = async <T extends boolean = false>({
-    // seperate de-dupe queue for integration sync and replication sync
+    // separate de-dupe queue for integration sync and replication sync
     _deDupeQueue: deDupeQueue = {},
     _depth: depth = 0,
     _deDupeReplicationQueue: deDupeReplicationQueue = {},

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/PasteSecretEnvModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/PasteSecretEnvModal.tsx
@@ -150,7 +150,7 @@ export const PasteSecretEnvModal = ({
       </ModalTrigger>
       <ModalContent
         className="max-w-2xl"
-        title="Past Secret Values"
+        title="Paste Secret Values"
         subTitle="Paste values in .env, .json or .yml format"
       >
         <PasteEnvForm


### PR DESCRIPTION
## Summary

Corrects several typos found across the codebase:

| File | Before | After |
|------|--------|-------|
| \`PasteSecretEnvModal.tsx\` | "Past Secret Values" (modal title) | "Paste Secret Values" |
| \`secret-queue.ts\` | "seperate de-dupe queue" | "separate de-dupe queue" |
| \`org-service.ts\` | "seperate them" | "separate them" |
| \`snapshot-dal.ts\` | \`enviroment\` (property name) | \`environment\` |
| \`secret-rotation-queue.ts\` | "seperate entity" | "separate entity" |

The \`enviroment\` -> \`environment\` fix in the snapshot DAL aligns the returned property name with how all consumers already access it (e.g. \`.environment.id\`, \`.environment.slug\`).

## Test Plan

- Comment-only changes require no testing
- The \`enviroment\` property rename was verified to match all existing consumer access patterns in \`secret-snapshot-service.ts\`