### PR TITLE
fix(server): correct x-cluster-client-ip header name in IP detection

### DIFF
--- a/backend/src/server/plugins/ip.ts
+++ b/backend/src/server/plugins/ip.ts
@@ -11,7 +11,7 @@ const headersOrder = [
   "fastly-client-ip",
   "true-client-ip", // Akamai and Cloudflare
   "x-real-ip", // Nginx
-  "x-cluser-client-ip", // Rackspace LB
+  "x-cluster-client-ip", // Rackspace LB
   "forwarded-for",
   "x-forwarded",
   "forwarded",


### PR DESCRIPTION
## Summary

The real-IP detection plugin (\`ip.ts\`) checks for the Rackspace LB header \`x-cluser-client-ip\` (missing 't' in "cluster"), which never matches the actual header \`x-cluster-client-ip\`. This causes requests behind Rackspace load balancers to fall through to \`req.ip\`, producing incorrect client IPs for:

- Rate limiting (wrong IP gets rate-limited)
- Audit logs (wrong IP recorded)
- Trusted IP access policies (wrong IP checked)

## Fix

Corrected the header name from \`x-cluser-client-ip\` to \`x-cluster-client-ip\`.

## Test Plan

- Requests with \`x-cluster-client-ip\` header now correctly extract the client IP
- Other header detection paths are unaffected (order-based, first-match logic)