### PR TITLE
fix(app-connection): hashicorp vault https gateway usage

### DIFF
--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -142,7 +142,10 @@ export const requestWithHCVaultGateway = async <T>(
   }
 
   const [targetHost] = await verifyHostInputValidity({ host: url.hostname, isGateway: true, isDynamicSecret: false });
-  const targetPort = url.port ? Number(url.port) : 8200; // 8200 is the default port for Vault self-hosted/dedicated
+
+  // port is empty string when using protocol's default port (443 for https, 80 for http)
+  // eslint-disable-next-line no-nested-ternary
+  const targetPort = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
 
   const gatewayConnectionDetails = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
     gatewayId,


### PR DESCRIPTION
## Context

Fixed vault connection when using gateway against instances that are not running on port 8200.

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)