### PR TITLE
feat(frontend): add upload support to overview page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -159,7 +159,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -204,7 +205,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -497,7 +497,6 @@
       "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.2.tgz",
       "integrity": "sha512-KjKXlcjKbUz8dKw7PY56F7qlfOFgxTU6tnlJ8YrbDyWkJMIlHa6VRWzCD8RU20zbJUC1hExhOFggZjm6tf1mUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -556,7 +555,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1334,7 +1332,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.1.tgz",
       "integrity": "sha512-8dBIHbfsKlCk2jHQ9PoRBg2Z+4TwyE3vZICSnoDlnsHA6SiMlTwfmW6yX0lHsRmWJugkeb92sA0hZdkXJhuz+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.1"
       },
@@ -2025,7 +2022,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -4539,7 +4535,6 @@
       "integrity": "sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.13.0",
         "eslint-visitor-keys": "^4.2.0",
@@ -5165,7 +5160,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.95.1.tgz",
       "integrity": "sha512-P5x4yNhcdkYsCEoYeGZP8Q9Jlxf0WXJa4G/xvbmM905seZc9FqJqvCSRvX3dWTPOXRABhl4g+8DHqfft0c/AvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.95.0",
         "@tanstack/react-store": "^0.7.0",
@@ -5377,6 +5371,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5397,6 +5392,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5407,6 +5403,7 @@
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -5426,7 +5423,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
@@ -5434,6 +5432,7 @@
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -5454,7 +5453,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5507,6 +5507,7 @@
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -5580,7 +5581,8 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
@@ -5716,7 +5718,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
       "integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5728,7 +5729,6 @@
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5776,7 +5776,6 @@
       "integrity": "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.34.0",
@@ -5817,7 +5816,6 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -6089,6 +6087,7 @@
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.4",
@@ -6106,6 +6105,7 @@
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
@@ -6133,6 +6133,7 @@
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -6143,6 +6144,7 @@
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -6156,6 +6158,7 @@
       "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -6169,6 +6172,7 @@
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
@@ -6191,8 +6195,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@xyflow/react": {
       "version": "12.4.4",
@@ -6258,7 +6261,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6375,6 +6377,7 @@
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6423,6 +6426,7 @@
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6503,6 +6507,7 @@
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -6590,6 +6595,7 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6600,6 +6606,7 @@
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6612,7 +6619,8 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -6662,6 +6670,7 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6763,6 +6772,7 @@
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -6999,7 +7009,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7181,6 +7190,7 @@
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -7251,6 +7261,7 @@
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -8082,7 +8093,8 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -8101,8 +8113,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cva": {
       "name": "class-variance-authority",
@@ -8174,7 +8185,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8228,7 +8238,8 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -8344,6 +8355,7 @@
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8378,6 +8390,7 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8508,7 +8521,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8718,6 +8732,7 @@
       "integrity": "sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8801,7 +8816,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8843,6 +8857,7 @@
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8879,7 +8894,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8936,7 +8950,6 @@
       "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^15.0.0",
         "object.assign": "^4.1.2",
@@ -8959,7 +8972,6 @@
       "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -8990,7 +9002,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9090,7 +9101,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -9220,6 +9230,7 @@
       "integrity": "sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9253,7 +9264,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9277,6 +9287,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -9290,6 +9301,7 @@
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -9308,6 +9320,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9469,6 +9482,7 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -10499,7 +10513,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       },
@@ -10593,6 +10606,7 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10860,6 +10874,7 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -11181,6 +11196,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -11216,6 +11232,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -11227,6 +11244,7 @@
       "integrity": "sha512-x4WH0BWmrMmg4oHHl+duwubhrvczGlyuGAZu3nvrf0UXOfPu8IhZObFEr7DE/iv01YgVZrsOiRcqw2srkKEDIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-object-atoms": "^1.0.0",
@@ -11376,6 +11394,7 @@
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -11410,7 +11429,8 @@
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
       "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
@@ -11418,6 +11438,7 @@
       "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "language-subtag-registry": "^0.3.20"
       },
@@ -11450,6 +11471,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.102.tgz",
       "integrity": "sha512-g70kydI0I1sZU0ChO8mBbhw0oUW/8U0GHzygpvEIx8k+jgOpqnTSb/E+70toYVqHxBhrERD21TwD5QcZJQ40ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -11774,7 +11796,8 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -11801,6 +11824,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12492,6 +12516,7 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -12840,6 +12865,7 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -13109,6 +13135,7 @@
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -13260,7 +13287,6 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13377,6 +13403,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13392,6 +13419,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13404,7 +13432,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -13605,7 +13634,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13633,7 +13661,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -13738,7 +13765,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13789,7 +13815,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.3.tgz",
       "integrity": "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14039,6 +14064,7 @@
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -14056,6 +14082,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14072,6 +14099,7 @@
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -14086,6 +14114,7 @@
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -14300,7 +14329,6 @@
       "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -14821,6 +14849,7 @@
       "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14836,6 +14865,7 @@
       "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14863,6 +14893,7 @@
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -15083,8 +15114,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -15188,6 +15218,7 @@
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15198,6 +15229,7 @@
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15492,7 +15524,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15878,7 +15909,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -16296,6 +16326,7 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16340,7 +16371,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
       "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16491,7 +16521,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
       "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -52,7 +52,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-background p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}
@@ -61,7 +61,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -109,7 +109,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-accent", className)}
       {...props}
     />
   );

--- a/frontend/src/components/v3/generic/Field/Field.tsx
+++ b/frontend/src/components/v3/generic/Field/Field.tsx
@@ -95,7 +95,7 @@ function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>)
     <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit items-center gap-1.5 leading-snug text-accent group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 [&>*]:data-[slot=field]:p-2.5",
+        "group/field-label peer/field-label flex w-fit items-center gap-1.5 text-xs leading-snug text-accent group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10 [&>*]:data-[slot=field]:p-2.5",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className
       )}
@@ -202,7 +202,7 @@ function FieldError({
     <div
       role="alert"
       data-slot="field-error"
-      className={cn("text-xs font-normal text-danger", className)}
+      className={cn("mt-1 text-xs font-normal text-danger", className)}
       {...props}
     >
       {content}

--- a/frontend/src/components/v3/generic/ReactSelect/components.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/components.tsx
@@ -31,7 +31,7 @@ export const MultiValueRemove = (props: MultiValueRemoveProps) => {
 
 export const Option = <T,>({ isSelected, children, ...props }: OptionProps<T>) => (
   <components.Option isSelected={isSelected} {...props}>
-    <div className="flex flex-row items-center justify-between">
+    <div className="flex cursor-pointer flex-row items-center justify-between">
       <p className="truncate">{children}</p>
       {isSelected && <CheckIcon className="ml-2 size-4" />}
     </div>

--- a/frontend/src/components/v3/generic/TextArea/TextArea.tsx
+++ b/frontend/src/components/v3/generic/TextArea/TextArea.tsx
@@ -3,17 +3,22 @@ import * as React from "react";
 
 import { cn } from "../../utils";
 
-function TextArea({ className, ...props }: React.ComponentProps<"textarea">) {
-  return (
-    <textarea
-      data-slot="textarea"
-      className={cn(
-        "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className
-      )}
-      {...props}
-    />
-  );
-}
+const TextArea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        className={cn(
+          "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+TextArea.displayName = "TextArea";
 
 export { TextArea };

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -46,7 +46,10 @@ import {
   useProjectPermission,
   useSubscription
 } from "@app/context";
-import { ProjectPermissionSecretRotationActions } from "@app/context/ProjectPermissionContext/types";
+import {
+  ProjectPermissionSecretActions,
+  ProjectPermissionSecretRotationActions
+} from "@app/context/ProjectPermissionContext/types";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -88,6 +91,7 @@ import {
 } from "../SecretDashboardPage/components/SecretListView/SecretItem";
 import { AddResourceButtons } from "./components/AddResourceButtons/AddResourceButtons";
 import { CreateSecretForm } from "./components/CreateSecretForm";
+import { ImportSecretsModal, SecretDropzone } from "./components/SecretDropzone";
 import { SecretV2MigrationSection } from "./components/SecretV2MigrationSection";
 import { SelectionPanel } from "./components/SelectionPanel/SelectionPanel";
 import {
@@ -355,6 +359,11 @@ export const OverviewPage = () => {
   const { mutateAsync: getOrCreateFolder } = useGetOrCreateFolder();
   const { mutateAsync: updateFolderBatch } = useUpdateFolderBatch();
 
+  const [importParsedSecrets, setImportParsedSecrets] = useState<Record<
+    string,
+    { value: string; comments: string[] }
+  > | null>(null);
+
   const { handlePopUpOpen, handlePopUpToggle, handlePopUpClose, popUp } = usePopUp([
     "addSecretsInAllEnvs",
     "addFolder",
@@ -367,7 +376,8 @@ export const OverviewPage = () => {
     "viewSecretRotationGeneratedCredentials",
     "deleteSecretRotation",
     "upgradePlan",
-    "reconcileSecretRotation"
+    "reconcileSecretRotation",
+    "importSecrets"
   ] as const);
 
   const handleFolderCreate = async (folderName: string, description: string | null) => {
@@ -884,7 +894,7 @@ export const OverviewPage = () => {
   // This is needed to also show imports from other paths – right now those are missing.
   // const combinedKeys = [...secKeys, ...secretImports.map((impSecrets) => impSecrets?.data?.map((impSec) => impSec.secrets?.map((impSecKey) => impSecKey.key))).flat().flat()];
 
-  const isTableFiltered = isFilteredByResources || filteredEnvs.length > 0;
+  const isTableFiltered = isFilteredByResources;
 
   if (!isProjectV3)
     return (
@@ -979,6 +989,7 @@ export const OverviewPage = () => {
                     onAddFolder={() => {
                       handlePopUpOpen("addFolder");
                     }}
+                    onImportSecrets={() => handlePopUpOpen("importSecrets")}
                     onAddDyanamicSecret={() => {
                       if (subscription?.dynamicSecret) {
                         handlePopUpOpen("addDynamicSecret");
@@ -1006,239 +1017,258 @@ export const OverviewPage = () => {
             </div>
           </UnstableCardHeader>
           <UnstableCardContent>
-            {isTableEmpty ? (
-              <EmptyResourceDisplay
-                isFiltered={Boolean(isTableFiltered || debouncedSearchFilter)}
-                onAddSecret={() => handlePopUpOpen("addSecretsInAllEnvs")}
-              />
-            ) : (
-              <>
-                <UnstableTable ref={tableRef} className="border-separate border-spacing-0">
-                  <UnstableTableHeader>
-                    <UnstableTableRow className="h-10">
-                      <UnstableTableHead className="sticky left-0 z-10 w-[40px] max-w-[40px] min-w-[40px] bg-container">
-                        <Checkbox
-                          variant="project"
-                          isDisabled={totalCount === 0}
-                          id="checkbox-select-all-rows"
-                          isChecked={allRowsSelectedOnPage.isChecked}
-                          isIndeterminate={allRowsSelectedOnPage.isIndeterminate}
-                          onCheckedChange={toggleSelectAllRows}
-                        />
-                      </UnstableTableHead>
-                      <UnstableTableHead
-                        className="sticky left-10 z-10 max-w-60 min-w-60 border-r bg-container lg:max-w-none lg:min-w-96"
-                        onClick={() =>
-                          setOrderDirection((prev) =>
-                            prev === OrderByDirection.ASC
-                              ? OrderByDirection.DESC
-                              : OrderByDirection.ASC
-                          )
-                        }
-                      >
-                        Name
-                        <ChevronDownIcon
-                          className={twMerge(
-                            orderDirection === OrderByDirection.DESC && "rotate-180",
-                            "transition-transform"
+            {
+              // eslint-disable-next-line no-nested-ternary
+              isTableEmpty ? (
+                isTableFiltered ||
+                debouncedSearchFilter ||
+                permission.cannot(
+                  ProjectPermissionSecretActions.Create,
+                  ProjectPermissionSub.Secrets
+                ) ? (
+                  <EmptyResourceDisplay
+                    isFiltered={isTableFiltered || Boolean(debouncedSearchFilter)}
+                  />
+                ) : (
+                  <SecretDropzone
+                    onParsedSecrets={(env) => {
+                      setImportParsedSecrets(env);
+                      handlePopUpOpen("importSecrets");
+                    }}
+                    onAddSecret={() => handlePopUpOpen("addSecretsInAllEnvs")}
+                  />
+                )
+              ) : (
+                <>
+                  <UnstableTable ref={tableRef} className="border-separate border-spacing-0">
+                    <UnstableTableHeader>
+                      <UnstableTableRow className="h-10">
+                        <UnstableTableHead className="sticky left-0 z-10 w-[40px] max-w-[40px] min-w-[40px] bg-container">
+                          <Checkbox
+                            variant="project"
+                            isDisabled={totalCount === 0}
+                            id="checkbox-select-all-rows"
+                            isChecked={allRowsSelectedOnPage.isChecked}
+                            isIndeterminate={allRowsSelectedOnPage.isIndeterminate}
+                            onCheckedChange={toggleSelectAllRows}
+                          />
+                        </UnstableTableHead>
+                        <UnstableTableHead
+                          className="sticky left-10 z-10 max-w-60 min-w-60 border-r bg-container lg:max-w-none lg:min-w-96"
+                          onClick={() =>
+                            setOrderDirection((prev) =>
+                              prev === OrderByDirection.ASC
+                                ? OrderByDirection.DESC
+                                : OrderByDirection.ASC
+                            )
+                          }
+                        >
+                          Name
+                          <ChevronDownIcon
+                            className={twMerge(
+                              orderDirection === OrderByDirection.DESC && "rotate-180",
+                              "transition-transform"
+                            )}
+                          />
+                        </UnstableTableHead>
+                        {visibleEnvs?.map(({ name, slug }, index) => {
+                          return (
+                            <UnstableTableHead
+                              className="w-40 max-w-40 border-r p-0 text-center last:border-r-0"
+                              isTruncatable
+                              key={`secret-overview-${name}-${index + 1}`}
+                            >
+                              <UnstableDropdownMenu>
+                                <Tooltip>
+                                  <TooltipTrigger className="h-full">
+                                    <UnstableDropdownMenuTrigger asChild>
+                                      <div className="flex h-full w-40 cursor-pointer items-center justify-center gap-x-2 px-3 hover:bg-foreground/5">
+                                        <span className="truncate">{name}</span>
+                                        <SettingsIcon className="size-3.5 shrink-0" />
+                                      </div>
+                                    </UnstableDropdownMenuTrigger>
+                                  </TooltipTrigger>
+                                  <TooltipContent>{name}</TooltipContent>
+                                </Tooltip>
+                                <UnstableDropdownMenuContent align="end">
+                                  <UnstableDropdownMenuItem
+                                    onClick={() => handleExploreEnvClick(slug)}
+                                  >
+                                    <LogInIcon />
+                                    Explore Environment
+                                  </UnstableDropdownMenuItem>
+                                  <UnstableDropdownMenuItem
+                                    onClick={() => {
+                                      navigator.clipboard.writeText(slug);
+                                      createNotification({
+                                        type: "info",
+                                        text: "Environment slug copied to clipboard"
+                                      });
+                                    }}
+                                  >
+                                    <CopyIcon />
+                                    Copy Environment Slug
+                                  </UnstableDropdownMenuItem>
+                                </UnstableDropdownMenuContent>
+                              </UnstableDropdownMenu>
+                            </UnstableTableHead>
+                          );
+                        })}
+                      </UnstableTableRow>
+                    </UnstableTableHeader>
+                    <UnstableTableBody className="transition-all duration-500">
+                      {isOverviewLoading || isPlaceholderData ? (
+                        Array.from({ length: prevPageSize.current || perPage }).map((_, index) => (
+                          <UnstableTableRow className="group" key={`loading-row-${index + 1}`}>
+                            <UnstableTableCell className="sticky left-0 z-10 bg-container group-hover:bg-container-hover">
+                              <Skeleton className="h-4 w-full" />
+                            </UnstableTableCell>
+                            <UnstableTableCell className="sticky left-10 z-10 border-r bg-container group-hover:bg-container-hover">
+                              <Skeleton className="h-4 w-full" />
+                            </UnstableTableCell>
+                            {visibleEnvs.map((env) => {
+                              return (
+                                <UnstableTableCell
+                                  className="border-r last:border-r-0"
+                                  key={`loading-env-row-${env.slug}+${index + 1}`}
+                                >
+                                  <Skeleton className="h-4 w-full" />
+                                </UnstableTableCell>
+                              );
+                            })}
+                          </UnstableTableRow>
+                        ))
+                      ) : (
+                        <>
+                          {folderNamesAndDescriptions.map(
+                            ({ name: folderName, description }, index) => (
+                              <FolderTableRow
+                                folderName={folderName}
+                                isFolderPresentInEnv={isFolderPresentInEnv}
+                                isSelected={Boolean(selectedEntries.folder[folderName])}
+                                onToggleFolderSelect={() =>
+                                  toggleSelectedEntry(EntryType.FOLDER, folderName)
+                                }
+                                environments={visibleEnvs}
+                                key={`overview-${folderName}-${index + 1}`}
+                                onClick={handleFolderClick}
+                                onToggleFolderEdit={(name: string) =>
+                                  handlePopUpOpen("updateFolder", { name, description })
+                                }
+                              />
+                            )
                           )}
-                        />
-                      </UnstableTableHead>
-                      {visibleEnvs?.map(({ name, slug }, index) => {
-                        return (
-                          <UnstableTableHead
-                            className="w-40 max-w-40 border-r p-0 text-center last:border-r-0"
-                            isTruncatable
-                            key={`secret-overview-${name}-${index + 1}`}
-                          >
-                            <UnstableDropdownMenu>
-                              <Tooltip>
-                                <TooltipTrigger className="h-full">
-                                  <UnstableDropdownMenuTrigger asChild>
-                                    <div className="flex h-full w-40 cursor-pointer items-center justify-center gap-x-2 px-3 hover:bg-foreground/5">
-                                      <span className="truncate">{name}</span>
-                                      <SettingsIcon className="size-3.5 shrink-0" />
-                                    </div>
-                                  </UnstableDropdownMenuTrigger>
-                                </TooltipTrigger>
-                                <TooltipContent>{name}</TooltipContent>
-                              </Tooltip>
-                              <UnstableDropdownMenuContent align="end">
-                                <UnstableDropdownMenuItem
-                                  onClick={() => handleExploreEnvClick(slug)}
-                                >
-                                  <LogInIcon />
-                                  Explore Environment
-                                </UnstableDropdownMenuItem>
-                                <UnstableDropdownMenuItem
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(slug);
-                                    createNotification({
-                                      type: "info",
-                                      text: "Environment slug copied to clipboard"
-                                    });
-                                  }}
-                                >
-                                  <CopyIcon />
-                                  Copy Environment Slug
-                                </UnstableDropdownMenuItem>
-                              </UnstableDropdownMenuContent>
-                            </UnstableDropdownMenu>
-                          </UnstableTableHead>
-                        );
-                      })}
-                    </UnstableTableRow>
-                  </UnstableTableHeader>
-                  <UnstableTableBody className="transition-all duration-500">
-                    {isOverviewLoading || isPlaceholderData ? (
-                      Array.from({ length: prevPageSize.current || perPage }).map((_, index) => (
-                        <UnstableTableRow className="group" key={`loading-row-${index + 1}`}>
-                          <UnstableTableCell className="sticky left-0 z-10 bg-container group-hover:bg-container-hover">
-                            <Skeleton className="h-4 w-full" />
-                          </UnstableTableCell>
-                          <UnstableTableCell className="sticky left-10 z-10 border-r bg-container group-hover:bg-container-hover">
-                            <Skeleton className="h-4 w-full" />
-                          </UnstableTableCell>
-                          {visibleEnvs.map((env) => {
-                            return (
-                              <UnstableTableCell
-                                className="border-r last:border-r-0"
-                                key={`loading-env-row-${env.slug}+${index + 1}`}
-                              >
-                                <Skeleton className="h-4 w-full" />
-                              </UnstableTableCell>
-                            );
-                          })}
-                        </UnstableTableRow>
-                      ))
-                    ) : (
-                      <>
-                        {folderNamesAndDescriptions.map(
-                          ({ name: folderName, description }, index) => (
-                            <FolderTableRow
-                              folderName={folderName}
-                              isFolderPresentInEnv={isFolderPresentInEnv}
-                              isSelected={Boolean(selectedEntries.folder[folderName])}
-                              onToggleFolderSelect={() =>
-                                toggleSelectedEntry(EntryType.FOLDER, folderName)
-                              }
+                          {dynamicSecretNames.map((dynamicSecretName, index) => (
+                            <DynamicSecretTableRow
+                              dynamicSecretName={dynamicSecretName}
+                              isDynamicSecretInEnv={isDynamicSecretPresentInEnv}
                               environments={visibleEnvs}
-                              key={`overview-${folderName}-${index + 1}`}
-                              onClick={handleFolderClick}
-                              onToggleFolderEdit={(name: string) =>
-                                handlePopUpOpen("updateFolder", { name, description })
+                              key={`overview-${dynamicSecretName}-${index + 1}`}
+                            />
+                          ))}
+                          {secretRotationNames.map((secretRotationName, index) => (
+                            <SecretRotationTableRow
+                              secretRotationName={secretRotationName}
+                              isSecretRotationInEnv={isSecretRotationPresentInEnv}
+                              environments={visibleEnvs}
+                              getSecretRotationByName={getSecretRotationByName}
+                              getSecretRotationStatusesByName={getSecretRotationStatusesByName}
+                              key={`overview-${secretRotationName}-${index + 1}`}
+                              tableWidth={tableWidth}
+                              onEdit={(secretRotation) =>
+                                handlePopUpOpen("editSecretRotation", secretRotation)
+                              }
+                              onRotate={(secretRotation) =>
+                                handlePopUpOpen("rotateSecretRotation", secretRotation)
+                              }
+                              onReconcile={(secretRotation) =>
+                                handlePopUpOpen("reconcileSecretRotation", secretRotation)
+                              }
+                              onViewGeneratedCredentials={(secretRotation) =>
+                                handlePopUpOpen(
+                                  "viewSecretRotationGeneratedCredentials",
+                                  secretRotation
+                                )
+                              }
+                              onDelete={(secretRotation) =>
+                                handlePopUpOpen("deleteSecretRotation", secretRotation)
                               }
                             />
-                          )
-                        )}
-                        {dynamicSecretNames.map((dynamicSecretName, index) => (
-                          <DynamicSecretTableRow
-                            dynamicSecretName={dynamicSecretName}
-                            isDynamicSecretInEnv={isDynamicSecretPresentInEnv}
-                            environments={visibleEnvs}
-                            key={`overview-${dynamicSecretName}-${index + 1}`}
-                          />
-                        ))}
-                        {secretRotationNames.map((secretRotationName, index) => (
-                          <SecretRotationTableRow
-                            secretRotationName={secretRotationName}
-                            isSecretRotationInEnv={isSecretRotationPresentInEnv}
-                            environments={visibleEnvs}
-                            getSecretRotationByName={getSecretRotationByName}
-                            getSecretRotationStatusesByName={getSecretRotationStatusesByName}
-                            key={`overview-${secretRotationName}-${index + 1}`}
-                            tableWidth={tableWidth}
-                            onEdit={(secretRotation) =>
-                              handlePopUpOpen("editSecretRotation", secretRotation)
-                            }
-                            onRotate={(secretRotation) =>
-                              handlePopUpOpen("rotateSecretRotation", secretRotation)
-                            }
-                            onReconcile={(secretRotation) =>
-                              handlePopUpOpen("reconcileSecretRotation", secretRotation)
-                            }
-                            onViewGeneratedCredentials={(secretRotation) =>
-                              handlePopUpOpen(
-                                "viewSecretRotationGeneratedCredentials",
-                                secretRotation
-                              )
-                            }
-                            onDelete={(secretRotation) =>
-                              handlePopUpOpen("deleteSecretRotation", secretRotation)
-                            }
-                          />
-                        ))}
-                        {secKeys.map((key, index) => (
-                          <SecretTableRow
-                            isSelected={Boolean(selectedEntries.secret[key])}
-                            onToggleSecretSelect={() => toggleSelectedEntry(EntryType.SECRET, key)}
-                            secretPath={secretPath}
-                            getImportedSecretByKey={getImportedSecretByKey}
-                            isImportedSecretPresentInEnv={handleIsImportedSecretPresentInEnv}
-                            onSecretCreate={handleSecretCreate}
-                            onSecretDelete={handleSecretDelete}
-                            onSecretUpdate={handleSecretUpdate}
-                            key={`overview-${key}-${index + 1}`}
-                            environments={visibleEnvs}
-                            secretKey={key}
-                            getSecretByKey={getSecretByKey}
-                            tableWidth={tableWidth}
-                            importedBy={importedBy}
-                          />
-                        ))}
-                        <SecretNoAccessTableRow
-                          environments={visibleEnvs}
-                          count={Math.max(
-                            (page * perPage > totalCount ? totalCount % perPage : perPage) -
-                              (totalUniqueFoldersInPage || 0) -
-                              (totalUniqueDynamicSecretsInPage || 0) -
-                              (totalUniqueSecretsInPage || 0) -
-                              (totalUniqueSecretImportsInPage || 0) -
-                              (totalUniqueSecretRotationsInPage || 0),
-                            0
-                          )}
-                        />
-                        <UnstableTableRow className="hover:bg-container">
-                          <UnstableTableCell className="sticky left-0 z-10 bg-container" />
-                          <UnstableTableCell className="sticky left-10 z-10 border-r bg-container" />
-                          {visibleEnvs?.map(({ slug }) => (
-                            <UnstableTableCell
-                              className="border-r last:border-r-0"
-                              key={`explore-${slug}`}
-                            >
-                              <Button
-                                onClick={() => handleExploreEnvClick(slug)}
-                                isFullWidth
-                                variant="project"
-                                size="xs"
-                              >
-                                Explore <LogInIcon />
-                              </Button>
-                            </UnstableTableCell>
                           ))}
-                        </UnstableTableRow>
-                      </>
-                    )}
-                  </UnstableTableBody>
-                </UnstableTable>
-                <UnstablePagination
-                  startAdornment={
-                    <ResourceCount
-                      dynamicSecretCount={totalDynamicSecretCount}
-                      secretCount={totalSecretCount}
-                      folderCount={totalFolderCount}
-                      importCount={totalImportCount}
-                      secretRotationCount={totalSecretRotationCount}
-                    />
-                  }
-                  count={totalCount}
-                  page={page}
-                  perPage={perPage}
-                  onChangePage={(newPage) => setPage(newPage)}
-                  onChangePerPage={handlePerPageChange}
-                />
-              </>
-            )}
+                          {secKeys.map((key, index) => (
+                            <SecretTableRow
+                              isSelected={Boolean(selectedEntries.secret[key])}
+                              onToggleSecretSelect={() =>
+                                toggleSelectedEntry(EntryType.SECRET, key)
+                              }
+                              secretPath={secretPath}
+                              getImportedSecretByKey={getImportedSecretByKey}
+                              isImportedSecretPresentInEnv={handleIsImportedSecretPresentInEnv}
+                              onSecretCreate={handleSecretCreate}
+                              onSecretDelete={handleSecretDelete}
+                              onSecretUpdate={handleSecretUpdate}
+                              key={`overview-${key}-${index + 1}`}
+                              environments={visibleEnvs}
+                              secretKey={key}
+                              getSecretByKey={getSecretByKey}
+                              tableWidth={tableWidth}
+                              importedBy={importedBy}
+                            />
+                          ))}
+                          <SecretNoAccessTableRow
+                            environments={visibleEnvs}
+                            count={Math.max(
+                              (page * perPage > totalCount ? totalCount % perPage : perPage) -
+                                (totalUniqueFoldersInPage || 0) -
+                                (totalUniqueDynamicSecretsInPage || 0) -
+                                (totalUniqueSecretsInPage || 0) -
+                                (totalUniqueSecretImportsInPage || 0) -
+                                (totalUniqueSecretRotationsInPage || 0),
+                              0
+                            )}
+                          />
+                          <UnstableTableRow className="hover:bg-container">
+                            <UnstableTableCell className="sticky left-0 z-10 bg-container" />
+                            <UnstableTableCell className="sticky left-10 z-10 border-r bg-container" />
+                            {visibleEnvs?.map(({ slug }) => (
+                              <UnstableTableCell
+                                className="border-r last:border-r-0"
+                                key={`explore-${slug}`}
+                              >
+                                <Button
+                                  onClick={() => handleExploreEnvClick(slug)}
+                                  isFullWidth
+                                  variant="project"
+                                  size="xs"
+                                >
+                                  Explore <LogInIcon />
+                                </Button>
+                              </UnstableTableCell>
+                            ))}
+                          </UnstableTableRow>
+                        </>
+                      )}
+                    </UnstableTableBody>
+                  </UnstableTable>
+                  <UnstablePagination
+                    startAdornment={
+                      <ResourceCount
+                        dynamicSecretCount={totalDynamicSecretCount}
+                        secretCount={totalSecretCount}
+                        folderCount={totalFolderCount}
+                        importCount={totalImportCount}
+                        secretRotationCount={totalSecretRotationCount}
+                      />
+                    }
+                    count={totalCount}
+                    page={page}
+                    perPage={perPage}
+                    onChangePage={(newPage) => setPage(newPage)}
+                    onChangePerPage={handlePerPageChange}
+                  />
+                </>
+              )
+            }
           </UnstableCardContent>
         </UnstableCard>
       </div>
@@ -1336,6 +1366,17 @@ export const OverviewPage = () => {
         isOpen={popUp.deleteSecretRotation.isOpen}
         secretRotation={popUp.deleteSecretRotation.data as TSecretRotationV2}
         onOpenChange={(isOpen) => handlePopUpToggle("deleteSecretRotation", isOpen)}
+      />
+      <ImportSecretsModal
+        isOpen={popUp.importSecrets.isOpen}
+        onOpenChange={(isOpen) => {
+          handlePopUpToggle("importSecrets", isOpen);
+          if (!isOpen) setImportParsedSecrets(null);
+        }}
+        environments={userAvailableEnvs}
+        projectId={projectId}
+        secretPath={secretPath}
+        initialParsedSecrets={importParsedSecrets}
       />
     </div>
   );

--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -1,4 +1,11 @@
-import { ChevronDown, FingerprintIcon, FolderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import {
+  ChevronDown,
+  FingerprintIcon,
+  FolderIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  UploadIcon
+} from "lucide-react";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
@@ -20,6 +27,7 @@ type Props = {
   onAddFolder: () => void;
   onAddDyanamicSecret: () => void;
   onAddSecretRotation: () => void;
+  onImportSecrets: () => void;
   isDyanmicSecretAvailable: boolean;
   isSecretRotationAvailable: boolean;
 };
@@ -29,15 +37,30 @@ export function AddResourceButtons({
   onAddFolder,
   onAddDyanamicSecret,
   onAddSecretRotation,
+  onImportSecrets,
   isDyanmicSecretAvailable,
   isSecretRotationAvailable
 }: Props) {
   return (
     <UnstableButtonGroup>
-      <Button variant="project" onClick={onAddSecret}>
-        <PlusIcon />
-        Add Secret
-      </Button>
+      <ProjectPermissionCan I={ProjectPermissionActions.Create} a={ProjectPermissionSub.Secrets}>
+        {(isAllowed) => (
+          <Tooltip open={!isAllowed ? undefined : false}>
+            <TooltipTrigger>
+              <Button
+                className="rounded-r-none"
+                isDisabled={!isAllowed}
+                variant="project"
+                onClick={onAddSecret}
+              >
+                <PlusIcon />
+                Add Secret
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Access Denied</TooltipContent>
+          </Tooltip>
+        )}
+      </ProjectPermissionCan>
       <UnstableDropdownMenu>
         <UnstableDropdownMenuTrigger asChild>
           <UnstableIconButton variant="project">
@@ -85,6 +108,22 @@ export function AddResourceButtons({
             </TooltipTrigger>
             <TooltipContent side="left">Access restricted</TooltipContent>
           </Tooltip>
+          <ProjectPermissionCan
+            I={ProjectPermissionActions.Create}
+            a={ProjectPermissionSub.Secrets}
+          >
+            {(isAllowed) => (
+              <Tooltip open={!isAllowed ? undefined : false}>
+                <TooltipTrigger className="block w-full">
+                  <UnstableDropdownMenuItem onClick={onImportSecrets} isDisabled={!isAllowed}>
+                    <UploadIcon className="text-accent" />
+                    Upload Secrets
+                  </UnstableDropdownMenuItem>
+                </TooltipTrigger>
+                <TooltipContent side="left">Access Restricted</TooltipContent>
+              </Tooltip>
+            )}
+          </ProjectPermissionCan>
         </UnstableDropdownMenuContent>
       </UnstableDropdownMenu>
     </UnstableButtonGroup>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
@@ -1,10 +1,8 @@
-import { FolderPlusIcon, PlusIcon, SearchIcon } from "lucide-react";
+import { FolderPlusIcon, SearchIcon } from "lucide-react";
 
 import {
-  Button,
   EmptyMedia,
   UnstableEmpty,
-  UnstableEmptyContent,
   UnstableEmptyDescription,
   UnstableEmptyHeader,
   UnstableEmptyTitle
@@ -12,14 +10,13 @@ import {
 
 type Props = {
   isFiltered?: boolean;
-  onAddSecret?: () => void;
 };
 
-export function EmptyResourceDisplay({ isFiltered, onAddSecret }: Props) {
+export function EmptyResourceDisplay({ isFiltered }: Props) {
   const { title, description } = isFiltered
     ? {
         title: "No resources match your search",
-        description: "Add a secret now"
+        description: "Adjust your search and try again"
       }
     : {
         title: "This project doesn't have any secrets",
@@ -33,12 +30,6 @@ export function EmptyResourceDisplay({ isFiltered, onAddSecret }: Props) {
         <UnstableEmptyTitle>{title}</UnstableEmptyTitle>
         <UnstableEmptyDescription>{description}</UnstableEmptyDescription>
       </UnstableEmptyHeader>
-      <UnstableEmptyContent className="flex-row justify-center">
-        <Button onClick={onAddSecret} variant="project">
-          <PlusIcon />
-          Add Secret
-        </Button>
-      </UnstableEmptyContent>
     </UnstableEmpty>
   );
 }

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/CsvColumnMapDialog.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/CsvColumnMapDialog.tsx
@@ -1,0 +1,220 @@
+import { Dispatch, SetStateAction, useState } from "react";
+import { ArrowRightIcon, AsteriskIcon, KeyIcon, MessageSquareIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { FormLabel } from "@app/components/v2";
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
+
+type TParsedEnv = Record<string, { value: string; comments: string[] }>;
+
+type SecretMatrixMap = {
+  key: number;
+  value: number | null;
+  comment: number | null;
+};
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  headers: string[];
+  matrix: string[][];
+  onParsedSecrets: (env: TParsedEnv) => void;
+};
+
+const MatrixImportModalTableRow = ({
+  importSecretMatrixMap,
+  setImportSecretMatrixMap,
+  headers,
+  mapKey
+}: {
+  importSecretMatrixMap: SecretMatrixMap;
+  setImportSecretMatrixMap: Dispatch<SetStateAction<SecretMatrixMap>>;
+  headers: string[];
+  mapKey: keyof SecretMatrixMap;
+}) => {
+  return (
+    <tr>
+      <td className="w-full py-2">
+        <Select
+          value={importSecretMatrixMap[mapKey]?.toString() || (null as unknown as string)}
+          onValueChange={(v) =>
+            setImportSecretMatrixMap((ism) => ({
+              ...ism,
+              [mapKey]: v ? parseInt(v, 10) : null
+            }))
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select an option..." />
+          </SelectTrigger>
+          <SelectContent position="popper" className="max-w-none">
+            {mapKey !== "key" && <SelectItem value={null as unknown as string}>None</SelectItem>}
+            {headers.map((header, col) => (
+              <SelectItem value={col.toString()} key={`${mapKey}-${header}`}>
+                {header}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </td>
+      <td className="pr-5 pl-5 whitespace-nowrap">
+        <div className="flex items-center justify-center">
+          <ArrowRightIcon className="size-5 text-accent" />
+        </div>
+      </td>
+      <td className="whitespace-nowrap">
+        <div className="flex h-full items-start justify-center">
+          <Badge isFullWidth variant="neutral">
+            {mapKey === "key" && (
+              <>
+                <KeyIcon />
+                Secret Key
+              </>
+            )}
+            {mapKey === "value" && (
+              <>
+                <AsteriskIcon />
+                Secret Value
+              </>
+            )}
+            {mapKey === "comment" && (
+              <>
+                <MessageSquareIcon />
+                Comment
+              </>
+            )}
+          </Badge>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+type ContentProps = {
+  headers: string[];
+  matrix: string[][];
+  onParsedSecrets: (env: TParsedEnv) => void;
+  onClose: () => void;
+};
+
+const CsvColumnMapContent = ({ headers, matrix, onParsedSecrets, onClose }: ContentProps) => {
+  const [importSecretMatrixMap, setImportSecretMatrixMap] = useState<SecretMatrixMap>({
+    key: 0,
+    value: null,
+    comment: null
+  });
+
+  const handleImport = () => {
+    if (!matrix.length) {
+      createNotification({
+        text: "Invalid secret matrix.",
+        type: "error"
+      });
+      return;
+    }
+
+    const env: TParsedEnv = {};
+    matrix.forEach((row) => {
+      const key = row[importSecretMatrixMap.key];
+      if (key) {
+        env[key] = {
+          value: importSecretMatrixMap.value !== null ? row[importSecretMatrixMap.value] || "" : "",
+          comments:
+            importSecretMatrixMap.comment !== null ? [row[importSecretMatrixMap.comment] || ""] : []
+        };
+      }
+    });
+
+    setImportSecretMatrixMap({ key: 0, value: null, comment: null });
+    onClose();
+    onParsedSecrets(env);
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Import Column Mapping</DialogTitle>
+        <p className="text-sm text-accent">
+          Map your data columns to different parts of the secret
+        </p>
+      </DialogHeader>
+      <div className="w-full overflow-hidden">
+        <table className="w-full table-auto">
+          <thead>
+            <tr className="text-left">
+              <th>
+                <FormLabel tooltipClassName="max-w-sm" label="Import Column" />
+              </th>
+              <th />
+              <th className="whitespace-nowrap">
+                <FormLabel label="Resulting Import" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <MatrixImportModalTableRow
+              importSecretMatrixMap={importSecretMatrixMap}
+              setImportSecretMatrixMap={setImportSecretMatrixMap}
+              headers={headers}
+              mapKey="key"
+            />
+            <MatrixImportModalTableRow
+              importSecretMatrixMap={importSecretMatrixMap}
+              setImportSecretMatrixMap={setImportSecretMatrixMap}
+              headers={headers}
+              mapKey="value"
+            />
+            <MatrixImportModalTableRow
+              importSecretMatrixMap={importSecretMatrixMap}
+              setImportSecretMatrixMap={setImportSecretMatrixMap}
+              headers={headers}
+              mapKey="comment"
+            />
+          </tbody>
+        </table>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="project" onClick={handleImport}>
+          Confirm Mapping
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+export const CsvColumnMapDialog = ({
+  isOpen,
+  onOpenChange,
+  headers,
+  matrix,
+  onParsedSecrets
+}: Props) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <CsvColumnMapContent
+          headers={headers}
+          matrix={matrix}
+          onParsedSecrets={onParsedSecrets}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
@@ -1,0 +1,646 @@
+import { ChangeEvent, DragEvent, useCallback, useState } from "react";
+import { subject } from "@casl/ability";
+import {
+  ClipboardPasteIcon,
+  EyeIcon,
+  EyeOffIcon,
+  InfoIcon,
+  MessageSquareIcon,
+  UploadIcon
+} from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import {
+  parseCsvToMatrix,
+  parseDotEnv,
+  parseJson,
+  parseYaml
+} from "@app/components/utilities/parseSecrets";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyMedia,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  UnstableEmpty,
+  UnstableEmptyDescription,
+  UnstableEmptyHeader,
+  UnstableEmptyTitle,
+  UnstableIconButton,
+  UnstableTable,
+  UnstableTableBody,
+  UnstableTableCell,
+  UnstableTableHead,
+  UnstableTableHeader,
+  UnstableTableRow
+} from "@app/components/v3";
+import { FilterableSelect } from "@app/components/v3/generic/ReactSelect";
+import { ProjectPermissionActions, ProjectPermissionSub, useProjectPermission } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
+import { useToggle } from "@app/hooks";
+import { useCreateSecretBatch, useGetOrCreateFolder, useUpdateSecretBatch } from "@app/hooks/api";
+import { fetchProjectSecrets, mergePersonalSecrets } from "@app/hooks/api/secrets/queries";
+import { SecretType } from "@app/hooks/api/types";
+
+import { CsvColumnMapDialog } from "./CsvColumnMapDialog";
+import { PasteSecretsDialog } from "./PasteSecretsDialog";
+
+type TParsedEnv = Record<string, { value: string; comments: string[] }>;
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  environments: { name: string; slug: string }[];
+  projectId: string;
+  secretPath: string;
+  initialParsedSecrets?: TParsedEnv | null;
+  onComplete?: () => void;
+};
+
+type ContentProps = {
+  environments: { name: string; slug: string }[];
+  projectId: string;
+  secretPath: string;
+  initialParsedSecrets?: TParsedEnv | null;
+  onComplete?: () => void;
+  onClose: () => void;
+};
+
+const ImportSecretsContent = ({
+  environments,
+  projectId,
+  secretPath,
+  initialParsedSecrets,
+  onComplete,
+  onClose
+}: ContentProps) => {
+  const { permission } = useProjectPermission();
+  const [parsedSecrets, setParsedSecrets] = useState<TParsedEnv | null>(null);
+  const [selectedEnvs, setSelectedEnvs] = useState<{ name: string; slug: string }[]>([]);
+  const [isDragActive, setDragActive] = useToggle();
+  const [isImporting, setIsImporting] = useToggle();
+  const [isPasteOpen, setIsPasteOpen] = useState(false);
+  const [csvData, setCsvData] = useState<{ headers: string[]; matrix: string[][] } | null>(null);
+  const [visibleSecretKeys, setVisibleSecretKeys] = useState<Set<string>>(new Set());
+  const [shouldOverwrite, setShouldOverwrite] = useState(false);
+
+  const { mutateAsync: createSecretBatch } = useCreateSecretBatch();
+  const { mutateAsync: updateSecretBatch } = useUpdateSecretBatch();
+  const { mutateAsync: getOrCreateFolder } = useGetOrCreateFolder();
+
+  const allowedEnvironments = environments.filter((env) =>
+    permission.can(
+      ProjectPermissionSecretActions.Create,
+      subject(ProjectPermissionSub.Secrets, {
+        environment: env.slug,
+        secretPath,
+        secretName: "*",
+        secretTags: ["*"]
+      })
+    )
+  );
+
+  const activeSecrets = initialParsedSecrets || parsedSecrets;
+  const secretCount = activeSecrets ? Object.keys(activeSecrets).length : 0;
+
+  const handleParsedSecrets = useCallback((env: TParsedEnv) => {
+    if (!Object.keys(env).length) {
+      createNotification({
+        type: "error",
+        text: "No secrets found in the provided data."
+      });
+      return;
+    }
+    setParsedSecrets(env);
+  }, []);
+
+  const parseFile = useCallback(
+    (file?: File) => {
+      if (!file) {
+        createNotification({
+          text: "You can't inject files from VS Code. Click 'Reveal in finder', and drag your file directly from the directory where it's located.",
+          type: "error"
+        });
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        if (!event?.target?.result) {
+          createNotification({
+            type: "error",
+            text: "Invalid file contents."
+          });
+          return;
+        }
+
+        const src = event.target.result as ArrayBuffer;
+
+        switch (file.type) {
+          case "application/json":
+            handleParsedSecrets(parseJson(src));
+            break;
+          case "text/yaml":
+          case "application/x-yaml":
+          case "application/yaml":
+            handleParsedSecrets(parseYaml(src));
+            break;
+          case "text/csv": {
+            const fullMatrix = parseCsvToMatrix(src);
+            if (!fullMatrix.length) {
+              createNotification({
+                type: "error",
+                text: "Failed to find secrets in CSV file. File might be empty."
+              });
+              return;
+            }
+            setCsvData({ headers: fullMatrix[0], matrix: fullMatrix.slice(1) });
+            return;
+          }
+          default:
+            handleParsedSecrets(parseDotEnv(src));
+            break;
+        }
+      };
+
+      try {
+        reader.readAsText(file);
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    [handleParsedSecrets]
+  );
+
+  const handleDrag = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive.on();
+    } else if (e.type === "dragleave") {
+      setDragActive.off();
+    }
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!e.dataTransfer) return;
+    e.dataTransfer.dropEffect = "copy";
+    setDragActive.off();
+    parseFile(e.dataTransfer.files[0]);
+  };
+
+  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    parseFile(e.target?.files?.[0]);
+  };
+
+  const handleImport = async () => {
+    if (!activeSecrets || !selectedEnvs.length) return;
+
+    setIsImporting.on();
+
+    try {
+      const envPromises = selectedEnvs.map(async (env) => {
+        // Ensure folder exists if not root
+        if (secretPath !== "/") {
+          const pathSegment = secretPath.split("/").filter(Boolean);
+          const parentPath = `/${pathSegment.slice(0, -1).join("/")}`;
+          const folderName = pathSegment.at(-1);
+          const canCreateFolder = permission.can(
+            ProjectPermissionActions.Create,
+            subject(ProjectPermissionSub.SecretFolders, {
+              environment: env.slug,
+              secretPath: parentPath
+            })
+          );
+
+          if (folderName && parentPath && canCreateFolder) {
+            await getOrCreateFolder({
+              projectId,
+              path: parentPath,
+              environment: env.slug,
+              name: folderName
+            });
+          }
+        }
+
+        // Fetch existing secrets to detect conflicts
+        const { secrets: rawExisting } = await fetchProjectSecrets({
+          projectId,
+          environment: env.slug,
+          secretPath,
+          viewSecretValue: false
+        });
+
+        const existingSecrets = mergePersonalSecrets(rawExisting);
+        const existingMap = existingSecrets.reduce<Record<string, boolean>>(
+          (acc, s) => ({ ...acc, [s.key]: true }),
+          {}
+        );
+
+        // Split secrets into creates vs updates
+        const secretsToCreate = Object.entries(activeSecrets)
+          .filter(([key]) => !existingMap[key])
+          .map(([secretKey, secretData]) => ({
+            secretKey,
+            secretValue: secretData.value,
+            secretComment: secretData.comments.join("\n") || "",
+            type: SecretType.Shared
+          }));
+
+        const secretsToUpdate = Object.entries(activeSecrets)
+          .filter(([key]) => existingMap[key])
+          .map(([secretKey, secretData]) => ({
+            secretKey,
+            secretValue: secretData.value,
+            secretComment: secretData.comments.join("\n") || undefined,
+            type: SecretType.Shared
+          }));
+
+        const results = await Promise.allSettled([
+          ...(secretsToCreate.length
+            ? [
+                createSecretBatch({
+                  projectId,
+                  environment: env.slug,
+                  secretPath,
+                  secrets: secretsToCreate
+                })
+              ]
+            : []),
+          ...(shouldOverwrite && secretsToUpdate.length
+            ? [
+                updateSecretBatch({
+                  projectId,
+                  environment: env.slug,
+                  secretPath,
+                  secrets: secretsToUpdate
+                })
+              ]
+            : [])
+        ]);
+        const hasApproval = results.some(
+          (r) => r.status === "fulfilled" && "approval" in (r.value as object)
+        );
+        const failCount = results.filter((r) => r.status === "rejected").length;
+
+        return { environment: env.name, slug: env.slug, hasApproval, failCount };
+      });
+
+      const envResults = await Promise.allSettled(envPromises);
+
+      const successEnvs: string[] = [];
+      const approvalEnvs: string[] = [];
+      const failedEnvs: string[] = [];
+
+      envResults.forEach((result) => {
+        if (result.status === "fulfilled" && result.value) {
+          if (result.value.failCount > 0) {
+            failedEnvs.push(result.value.environment);
+          } else if (result.value.hasApproval) {
+            approvalEnvs.push(result.value.environment);
+          } else {
+            successEnvs.push(result.value.environment);
+          }
+        } else if (result.status === "rejected") {
+          failedEnvs.push("unknown");
+        }
+      });
+
+      if (successEnvs.length) {
+        createNotification({
+          type: "success",
+          text: `Successfully uploaded ${secretCount} secret${secretCount > 1 ? "s" : ""} into ${successEnvs.join(", ")}`
+        });
+      }
+
+      if (approvalEnvs.length) {
+        createNotification({
+          type: "info",
+          text: `Change request submitted for ${approvalEnvs.join(", ")}`
+        });
+      }
+
+      if (failedEnvs.length) {
+        createNotification({
+          type: "error",
+          text: `Failed to upload secrets into ${failedEnvs.join(", ")}`
+        });
+      }
+
+      onClose();
+      onComplete?.();
+    } catch (err) {
+      console.error(err);
+      createNotification({
+        type: "error",
+        text: "Failed to upload secrets"
+      });
+    } finally {
+      setIsImporting.off();
+    }
+  };
+
+  const handleBack = () => {
+    setParsedSecrets(null);
+    setVisibleSecretKeys(new Set());
+  };
+
+  const toggleSecretVisibility = (key: string) => {
+    setVisibleSecretKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const allSecretKeys = activeSecrets ? Object.keys(activeSecrets) : [];
+  const areAllVisible =
+    allSecretKeys.length > 0 && allSecretKeys.every((k) => visibleSecretKeys.has(k));
+
+  const toggleAllSecretVisibility = () => {
+    if (areAllVisible) {
+      setVisibleSecretKeys(new Set());
+    } else {
+      setVisibleSecretKeys(new Set(allSecretKeys));
+    }
+  };
+
+  const showUploadStep = !activeSecrets;
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{showUploadStep ? "Upload Secrets" : "Review & Upload Secrets"}</DialogTitle>
+        <DialogDescription>
+          {showUploadStep
+            ? "Upload a file or paste secrets to upload them across environments"
+            : `${secretCount} secret${secretCount !== 1 ? "s" : ""} found. Select environments to upload to.`}
+        </DialogDescription>
+      </DialogHeader>
+
+      {showUploadStep ? (
+        <div className="flex flex-col gap-4">
+          <ProjectPermissionCan
+            I={ProjectPermissionActions.Create}
+            a={subject(ProjectPermissionSub.Secrets, {
+              environment: environments[0]?.slug || "",
+              secretPath,
+              secretName: "*",
+              secretTags: ["*"]
+            })}
+          >
+            {(isAllowed) => (
+              <UnstableEmpty
+                className={twMerge(
+                  "relative cursor-pointer border transition-colors duration-75",
+                  isDragActive && "bg-container-hover"
+                )}
+                onDragEnter={handleDrag}
+                onDragLeave={handleDrag}
+                onDragOver={handleDrag}
+                onDrop={handleDrop}
+              >
+                <UnstableEmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <UploadIcon />
+                  </EmptyMedia>
+                  <UnstableEmptyTitle>
+                    {isDragActive ? "Drop your file here" : "Upload your secrets"}
+                  </UnstableEmptyTitle>
+                  <UnstableEmptyDescription>
+                    Drag and drop your .env, .json, .yml, or .csv files here, or click to browse
+                  </UnstableEmptyDescription>
+                </UnstableEmptyHeader>
+                <input
+                  type="file"
+                  disabled={!isAllowed}
+                  className="absolute top-0 left-0 h-full w-full cursor-pointer opacity-0"
+                  accept=".txt,.env,.yml,.yaml,.json,.csv"
+                  onChange={handleFileUpload}
+                />
+              </UnstableEmpty>
+            )}
+          </ProjectPermissionCan>
+
+          <div className="flex items-center gap-3">
+            <div className="flex-1 border-t border-muted/50" />
+            <span className="text-xs text-muted/50">OR</span>
+            <div className="flex-1 border-t border-muted/50" />
+          </div>
+
+          <Button variant="outline" className="w-full" onClick={() => setIsPasteOpen(true)}>
+            <ClipboardPasteIcon className="mr-2 size-4" />
+            Paste Secrets
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="relative flex flex-col gap-2">
+            <UnstableTable
+              className="border-collapse"
+              containerClassName="max-h-[60vh] overflow-y-auto overflow-x-hidden"
+            >
+              <UnstableTableHeader className="sticky top-0 z-[1] after:pointer-events-none after:absolute after:inset-x-0 after:-top-px after:h-px after:bg-container">
+                <UnstableTableRow className="relative h-9">
+                  <UnstableTableHead className="bg-container shadow-[inset_0_-1px_0_var(--color-border)]">
+                    Key
+                  </UnstableTableHead>
+                  <UnstableTableHead className="bg-container shadow-[inset_0_-1px_0_var(--color-border)]">
+                    Value
+                  </UnstableTableHead>
+                  <UnstableTableHead className="w-10 bg-container shadow-[inset_0_-1px_0_var(--color-border)]">
+                    <UnstableIconButton
+                      variant="ghost"
+                      size="xs"
+                      onClick={toggleAllSecretVisibility}
+                    >
+                      {areAllVisible ? <EyeOffIcon /> : <EyeIcon />}
+                    </UnstableIconButton>
+                  </UnstableTableHead>
+                </UnstableTableRow>
+              </UnstableTableHeader>
+              <UnstableTableBody>
+                {Object.entries(activeSecrets!).map(([key, secretData]) => {
+                  const isVisible = visibleSecretKeys.has(key);
+                  const hasComments = secretData.comments.length > 0;
+                  return (
+                    <UnstableTableRow key={key}>
+                      <UnstableTableCell
+                        isTruncatable
+                        className="w-1/2 overflow-hidden font-mono text-xs"
+                      >
+                        <div className="flex w-full items-center gap-1.5">
+                          <p className="truncate">{key}</p>
+                          {hasComments && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <MessageSquareIcon className="size-3.5 text-muted" />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p className="max-w-xs whitespace-pre-wrap">
+                                  {secretData.comments.join("\n")}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </div>
+                      </UnstableTableCell>
+                      <UnstableTableCell isTruncatable className="w-1/2 font-mono text-xs">
+                        {isVisible ? (
+                          secretData.value || <span className="text-muted">EMPTY</span>
+                        ) : (
+                          <span className="tracking-widest">••••••••••••••••••••••</span>
+                        )}
+                      </UnstableTableCell>
+                      <UnstableTableCell className="w-10">
+                        <UnstableIconButton
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => toggleSecretVisibility(key)}
+                        >
+                          {isVisible ? <EyeOffIcon /> : <EyeIcon />}
+                        </UnstableIconButton>
+                      </UnstableTableCell>
+                    </UnstableTableRow>
+                  );
+                })}
+              </UnstableTableBody>
+            </UnstableTable>
+          </div>
+          <Field>
+            <FieldLabel>
+              Target Environments
+              <Tooltip>
+                <TooltipTrigger>
+                  <InfoIcon className="mb-0.5 inline-block size-3 text-accent" />
+                </TooltipTrigger>
+                <TooltipContent>The environments the secrets should be added to</TooltipContent>
+              </Tooltip>
+            </FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                isMulti
+                menuPlacement="top"
+                options={allowedEnvironments}
+                value={selectedEnvs}
+                onChange={(val) => setSelectedEnvs(val as { name: string; slug: string }[])}
+                placeholder="Select environments to upload to..."
+                getOptionLabel={(option) => option.name}
+                getOptionValue={(option) => option.slug}
+              />
+            </FieldContent>
+          </Field>
+          <Field orientation="horizontal" className="w-fit">
+            <FieldLabel>
+              Overwrite Existing Secrets
+              <Tooltip>
+                <TooltipTrigger>
+                  <InfoIcon className="mb-0.5 inline-block size-3 text-accent" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-md text-center">
+                  When enabled, secrets that already exist in the target environment will be updated
+                  with the imported values. When disabled, existing secrets will be skipped and only
+                  new secrets will be created.
+                </TooltipContent>
+              </Tooltip>
+            </FieldLabel>
+            <Switch
+              checked={shouldOverwrite}
+              variant="danger"
+              onCheckedChange={setShouldOverwrite}
+            />
+          </Field>
+        </div>
+      )}
+
+      <DialogFooter>
+        {!showUploadStep && !initialParsedSecrets && (
+          <Button variant="ghost" onClick={handleBack} className="mr-auto">
+            Back
+          </Button>
+        )}
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        {!showUploadStep && (
+          <Button
+            variant="project"
+            onClick={handleImport}
+            isDisabled={!selectedEnvs.length || isImporting}
+            isPending={isImporting}
+          >
+            Upload {secretCount} Secret{secretCount !== 1 ? "s" : ""}
+          </Button>
+        )}
+      </DialogFooter>
+
+      <PasteSecretsDialog
+        isOpen={isPasteOpen}
+        onOpenChange={setIsPasteOpen}
+        onParsedSecrets={handleParsedSecrets}
+      />
+
+      {csvData && (
+        <CsvColumnMapDialog
+          isOpen={Boolean(csvData)}
+          onOpenChange={(open) => {
+            if (!open) setCsvData(null);
+          }}
+          headers={csvData.headers}
+          matrix={csvData.matrix}
+          onParsedSecrets={(env) => {
+            setCsvData(null);
+            handleParsedSecrets(env);
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export const ImportSecretsModal = ({
+  isOpen,
+  onOpenChange,
+  environments,
+  projectId,
+  secretPath,
+  initialParsedSecrets,
+  onComplete
+}: Props) => {
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onOpenChange(false);
+        else onOpenChange(open);
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <ImportSecretsContent
+          environments={environments}
+          projectId={projectId}
+          secretPath={secretPath}
+          initialParsedSecrets={initialParsedSecrets}
+          onComplete={onComplete}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/PasteSecretsDialog.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/PasteSecretsDialog.tsx
@@ -1,0 +1,143 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { InfoIcon } from "lucide-react";
+import { z } from "zod";
+
+import { parseDotEnv, parseJson } from "@app/components/utilities/parseSecrets";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  TextArea
+} from "@app/components/v3";
+import { Field, FieldContent, FieldError, FieldLabel } from "@app/components/v3/generic/Field";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3/generic/Tooltip";
+
+type TParsedEnv = Record<string, { value: string; comments: string[] }>;
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  onParsedSecrets: (env: TParsedEnv) => void;
+};
+
+const formSchema = z.object({
+  value: z.string().trim()
+});
+
+type TForm = z.infer<typeof formSchema>;
+
+type ContentProps = {
+  onParsedSecrets: (env: TParsedEnv) => void;
+  onClose: () => void;
+};
+
+const PasteSecretsContent = ({ onParsedSecrets, onClose }: ContentProps) => {
+  const {
+    handleSubmit,
+    register,
+    formState: { isDirty, errors },
+    setError,
+    setFocus,
+    reset
+  } = useForm<TForm>({ defaultValues: { value: "" }, resolver: zodResolver(formSchema) });
+
+  const onSubmit = ({ value }: TForm) => {
+    let env: TParsedEnv;
+    try {
+      env = parseJson(value);
+    } catch {
+      env = parseDotEnv(value);
+    }
+
+    if (!Object.keys(env).length) {
+      setError("value", {
+        message: "No secrets found. Please make sure the provided format is valid."
+      });
+      setFocus("value");
+      return;
+    }
+
+    reset();
+    onClose();
+    onParsedSecrets(env);
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Paste Secret Values</DialogTitle>
+        <DialogDescription>Paste values in .env, .json or .yml format</DialogDescription>
+      </DialogHeader>
+      <form className="flex min-w-0 flex-col" onSubmit={handleSubmit(onSubmit)}>
+        <Field>
+          <FieldLabel>
+            Secret Values
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="size-3 text-muted" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-lg py-3 whitespace-pre-line">
+                <div className="flex flex-col gap-2">
+                  <p>Example Formats:</p>
+                  <pre className="rounded-md bg-container p-3 text-xs">
+                    {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
+                    <p className="text-mineshaft-400">// .json</p>
+                    {JSON.stringify(
+                      {
+                        APP_NAME: "example-service",
+                        APP_VERSION: "1.2.3",
+                        NODE_ENV: "production"
+                      },
+                      null,
+                      2
+                    )}
+                  </pre>
+                  <pre className="rounded-md bg-container p-3 text-xs">
+                    <p className="text-mineshaft-400"># .env</p>
+                    <p>APP_NAME=&quot;example-service&quot;</p>
+                    <p>APP_VERSION=&quot;1.2.3&quot;</p>
+                    <p>NODE_ENV=&quot;production&quot;</p>
+                  </pre>
+                  <pre className="rounded-md bg-container p-3 text-xs">
+                    <p className="text-mineshaft-400"># .yml</p>
+                    <p>APP_NAME: example-service</p>
+                    <p>APP_VERSION: 1.2.3</p>
+                    <p>NODE_ENV: production</p>
+                  </pre>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </FieldLabel>
+          <FieldContent>
+            <TextArea
+              {...register("value")}
+              placeholder="Paste secrets in .json, .yml or .env format..."
+              className="h-[60vh] resize-none!"
+            />
+            <FieldError errors={[errors.value]} />
+          </FieldContent>
+        </Field>
+        <Button className="mt-4 ml-auto" variant="project" isDisabled={!isDirty} type="submit">
+          Parse Secrets
+        </Button>
+      </form>
+    </>
+  );
+};
+
+export const PasteSecretsDialog = ({ isOpen, onOpenChange, onParsedSecrets }: Props) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <PasteSecretsContent
+          onParsedSecrets={onParsedSecrets}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
@@ -1,0 +1,215 @@
+import { ChangeEvent, DragEvent, useState } from "react";
+import { ClipboardPasteIcon, PlusIcon, UploadIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import {
+  parseCsvToMatrix,
+  parseDotEnv,
+  parseJson,
+  parseYaml
+} from "@app/components/utilities/parseSecrets";
+import {
+  Button,
+  EmptyMedia,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  UnstableEmpty,
+  UnstableEmptyContent,
+  UnstableEmptyDescription,
+  UnstableEmptyHeader,
+  UnstableEmptyTitle
+} from "@app/components/v3";
+import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
+import { useToggle } from "@app/hooks";
+
+import { CsvColumnMapDialog } from "./CsvColumnMapDialog";
+import { PasteSecretsDialog } from "./PasteSecretsDialog";
+
+type TParsedEnv = Record<string, { value: string; comments: string[] }>;
+
+type Props = {
+  onParsedSecrets: (env: TParsedEnv) => void;
+  onAddSecret: () => void;
+};
+
+export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
+  const [isDragActive, setDragActive] = useToggle();
+  const [isPasteOpen, setIsPasteOpen] = useState(false);
+  const [csvData, setCsvData] = useState<{ headers: string[]; matrix: string[][] } | null>(null);
+
+  const handleParsedSecrets = (env: TParsedEnv) => {
+    if (!Object.keys(env).length) {
+      createNotification({
+        type: "error",
+        text: "No secrets found in the provided data."
+      });
+      return;
+    }
+    onParsedSecrets(env);
+  };
+
+  const parseFile = (file?: File) => {
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      if (!event?.target?.result) {
+        createNotification({
+          type: "error",
+          text: "Invalid file contents."
+        });
+        return;
+      }
+
+      const src = event.target.result as ArrayBuffer;
+
+      switch (file.type) {
+        case "application/json":
+          handleParsedSecrets(parseJson(src));
+          break;
+        case "text/yaml":
+        case "application/x-yaml":
+        case "application/yaml":
+          handleParsedSecrets(parseYaml(src));
+          break;
+        case "text/csv": {
+          const fullMatrix = parseCsvToMatrix(src);
+          if (!fullMatrix.length) {
+            createNotification({
+              type: "error",
+              text: "Failed to find secrets in CSV file. File might be empty."
+            });
+            return;
+          }
+          setCsvData({ headers: fullMatrix[0], matrix: fullMatrix.slice(1) });
+          return;
+        }
+        default:
+          handleParsedSecrets(parseDotEnv(src));
+          break;
+      }
+    };
+
+    try {
+      reader.readAsText(file);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const handleDrag = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive.on();
+    } else if (e.type === "dragleave") {
+      setDragActive.off();
+    }
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!e.dataTransfer) return;
+    e.dataTransfer.dropEffect = "copy";
+    setDragActive.off();
+    parseFile(e.dataTransfer.files[0]);
+  };
+
+  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    parseFile(e.target?.files?.[0]);
+    e.target.value = "";
+  };
+
+  return (
+    <>
+      <ProjectPermissionCan I={ProjectPermissionActions.Create} a={ProjectPermissionSub.Secrets}>
+        {(isAllowed) => (
+          <UnstableEmpty
+            className={twMerge(
+              "relative border !pb-20 transition-colors duration-75",
+              isAllowed && isDragActive && "bg-container-hover"
+            )}
+            onDragEnter={handleDrag}
+            onDragLeave={handleDrag}
+            onDragOver={handleDrag}
+            onDrop={isAllowed ? handleDrop : undefined}
+          >
+            <UnstableEmptyHeader>
+              <EmptyMedia variant="icon">
+                <UploadIcon />
+              </EmptyMedia>
+              <UnstableEmptyTitle>
+                {isDragActive ? "Drop your file here" : "Upload your secrets"}
+              </UnstableEmptyTitle>
+              <UnstableEmptyDescription>
+                Drag and drop your .env, .json, .yml, or .csv files here or click to browse
+              </UnstableEmptyDescription>
+            </UnstableEmptyHeader>
+            <UnstableEmptyContent>
+              {isAllowed && (
+                <input
+                  type="file"
+                  disabled={!isAllowed}
+                  className="absolute top-0 left-0 z-10 h-full w-full cursor-pointer opacity-0"
+                  accept=".txt,.env,.yml,.yaml,.json,.csv"
+                  onChange={handleFileUpload}
+                />
+              )}
+              <div className="absolute z-20 flex flex-row justify-center gap-3">
+                <Tooltip open={!isAllowed ? undefined : false}>
+                  <TooltipTrigger>
+                    <Button
+                      variant="outline"
+                      isDisabled={!isAllowed}
+                      onClick={() => setIsPasteOpen(true)}
+                    >
+                      <ClipboardPasteIcon />
+                      Paste Secrets
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Access Denied</TooltipContent>
+                </Tooltip>
+                <Tooltip open={!isAllowed ? undefined : false}>
+                  <TooltipTrigger>
+                    <Button variant="project" isDisabled={!isAllowed} onClick={onAddSecret}>
+                      <PlusIcon />
+                      Add a New Secret
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Access Denied</TooltipContent>
+                </Tooltip>
+              </div>
+            </UnstableEmptyContent>
+          </UnstableEmpty>
+        )}
+      </ProjectPermissionCan>
+      <PasteSecretsDialog
+        isOpen={isPasteOpen}
+        onOpenChange={setIsPasteOpen}
+        onParsedSecrets={handleParsedSecrets}
+      />
+
+      {csvData && (
+        <CsvColumnMapDialog
+          isOpen={Boolean(csvData)}
+          onOpenChange={(open) => {
+            if (!open) setCsvData(null);
+          }}
+          headers={csvData.headers}
+          matrix={csvData.matrix}
+          onParsedSecrets={(env) => {
+            setCsvData(null);
+            handleParsedSecrets(env);
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/index.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/index.ts
@@ -1,0 +1,2 @@
+export { ImportSecretsModal } from "./ImportSecretsModal";
+export { SecretDropzone } from "./SecretDropzone";

--- a/frontend/src/pages/secret-manager/OverviewPage/components/index.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/index.ts
@@ -7,5 +7,6 @@ export * from "./FolderTableRow";
 export * from "./ResourceCount";
 export * from "./ResourceFilter";
 export * from "./ResourceSearchInput";
+export * from "./SecretDropzone";
 export * from "./SecretRotationTableRow";
 export * from "./SecretTableRow";


### PR DESCRIPTION
## Context

This PR adds upload support to the overview page; enabling drag n drop or pasting .env, csv, json or yml files and uploading them to one or more environments.

## Screenshots

<img width="3456" height="2234" alt="CleanShot 2026-02-11 at 14 06 57@2x" src="https://github.com/user-attachments/assets/b780afeb-6d2f-4d68-b206-bef1484104a5" />
<img width="1258" height="526" alt="CleanShot 2026-02-11 at 14 07 36@2x" src="https://github.com/user-attachments/assets/0bb5c5ae-e2ea-4fea-8478-aa515a18fa7d" />
<img width="3456" height="2234" alt="CleanShot 2026-02-11 at 14 07 13@2x" src="https://github.com/user-attachments/assets/921cd944-db87-4c78-8962-310fa286b4c7" />


## Steps to verify the change

- Verify you can drag and drop, file select and parse all file types (csv, env, json and yml)
- verify empty display (no resources in env and dropdown upload button)
- verify you can upload to one or more environments
- verify the overwrite toggle behavior (enabled and disabled)
- verify lacking permissions disable relevant actions

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)