### PR TITLE
chore: added redis reconnect on error

### DIFF
--- a/backend/src/lib/config/redis.ts
+++ b/backend/src/lib/config/redis.ts
@@ -25,7 +25,7 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
         // Reconnect when hitting a read-only replica during failover
         const targetError = "READONLY";
         if (err.message.includes(targetError)) {
-          return true; // Reconnect
+          return 2; // Reconnect and resend command
         }
         return false;
       }
@@ -45,7 +45,7 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
         reconnectOnError(err) {
           const targetError = "READONLY";
           if (err.message.includes(targetError)) {
-            return true;
+            return 2; // Reconnect and resend command
           }
           return false;
         }
@@ -67,7 +67,7 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
       // Reconnect when hitting a read-only replica during failover
       const targetError = "READONLY";
       if (err.message.includes(targetError)) {
-        return true; // Reconnect
+        return 2; // Reconnect and resend command
       }
       return false;
     }


### PR DESCRIPTION
## Context

This PR implements redis reconnect when there is a redeployment of redis happens in platforms like aws elasticache. This does a reconnection with the DNS instead of keeping the same connection.

Reference: https://github.com/redis/ioredis?tab=readme-ov-file#reconnect-on-error

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)