### PR TITLE
docs: sprig for export command

### DIFF
--- a/docs/cli/commands/export.mdx
+++ b/docs/cli/commands/export.mdx
@@ -103,7 +103,7 @@ infisical export --template=<path to template>
   </Accordion>
 
   <Accordion title="--template">
-    The `--template` flag specifies the path to the template file used for rendering secrets. When using templates, you can omit the other format flags.
+    The `--template` flag specifies the path to the Go template file used for rendering secrets. When using templates, you can omit the other format flags.
 
     	```text my-template-file
     {{$secrets := secret "<infisical-project-id>" "<environment-slug>" "<folder-path>"}}
@@ -121,6 +121,11 @@ infisical export --template=<path to template>
     # Example
     infisical export --template="/path/to/template/file"
     ```
+
+    <Tip>
+      The Infisical CLI templating engine also supports Sprig library templating functions to help you transform your secrets further.
+      You can read more about the available functions [here](/integrations/platforms/kubernetes/overview#available-helper-functions).
+    </Tip>
 
   </Accordion>
   


### PR DESCRIPTION
## Context

Added sprig callout to `template` export flag

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)