### PR TITLE
improvement(api): disable wait_for_async_insert for clickhouse audit logs insert now

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -99,7 +99,15 @@ const envSchema = z
           if (!val || val.trim() === "")
             return {
               async_insert: 1,
-              wait_for_async_insert: 1,
+              // !!!NOTICE!!! by disabling wait_for_async_insert, we shouldn't suffer from the audit log queue piles up jobs
+              //              issues anymore as now insert won't be blocked until the data is written to disk.
+              //              However, this works at the cost of DATA LOSS if the ClickHouse server crashes
+              //              before the data is written to disk.
+              //              Because our Redis queue if without AOF + Fsync, may already suffer data loss issues,
+              //              so it's not worsening the issue at least for now.
+              //              Let's have this rolled out in production and see how things go for now,
+              //              in the meantime, we should think about a better solution to handle this.
+              wait_for_async_insert: 0,
               date_time_input_format: "best_effort"
             } as Record<string, string | number | boolean>;
           return JSON.parse(val) as Record<string, string | number | boolean>;


### PR DESCRIPTION
## Context

https://linear.app/infisical/issue/ENG-4567/update-infisical-platform-backend-code-to-allow-sending-audit-logs-to

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)