### PR TITLE
fix(audit-log-stream): remove AbortSignal.timeout to fix retry failures and memory pressure

### DIFF
--- a/backend/src/ee/services/audit-log-stream/azure/azure-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/azure/azure-provider-factory.ts
@@ -57,8 +57,7 @@ export const AzureProviderFactory = () => {
         createPayload({ ping: "ok" }),
         {
           headers: streamHeaders,
-          timeout: AUDIT_LOG_STREAM_TIMEOUT,
-          signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+          timeout: AUDIT_LOG_STREAM_TIMEOUT
         }
       )
       .catch((err) => {
@@ -85,8 +84,7 @@ export const AzureProviderFactory = () => {
       createPayload(auditLog),
       {
         headers: streamHeaders,
-        timeout: AUDIT_LOG_STREAM_TIMEOUT,
-        signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+        timeout: AUDIT_LOG_STREAM_TIMEOUT
       }
     );
   };

--- a/backend/src/ee/services/audit-log-stream/cribl/cribl-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/cribl/cribl-provider-factory.ts
@@ -24,8 +24,7 @@ export const CriblProviderFactory = () => {
     await request
       .post(url, JSON.stringify({ ping: "ok" }), {
         headers: streamHeaders,
-        timeout: AUDIT_LOG_STREAM_TIMEOUT,
-        signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+        timeout: AUDIT_LOG_STREAM_TIMEOUT
       })
       .catch((err) => {
         throw new BadRequestError({ message: `Failed to connect with Cribl: ${(err as Error)?.message}` });
@@ -46,8 +45,7 @@ export const CriblProviderFactory = () => {
 
     await request.post(url, JSON.stringify(auditLog), {
       headers: streamHeaders,
-      timeout: AUDIT_LOG_STREAM_TIMEOUT,
-      signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+      timeout: AUDIT_LOG_STREAM_TIMEOUT
     });
   };
 

--- a/backend/src/ee/services/audit-log-stream/custom/custom-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/custom/custom-provider-factory.ts
@@ -29,8 +29,7 @@ export const CustomProviderFactory = () => {
         { ping: "ok" },
         {
           headers: streamHeaders,
-          timeout: AUDIT_LOG_STREAM_TIMEOUT,
-          signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+          timeout: AUDIT_LOG_STREAM_TIMEOUT
         }
       )
       .catch((err) => {
@@ -55,8 +54,7 @@ export const CustomProviderFactory = () => {
 
     await request.post(url, auditLog, {
       headers: streamHeaders,
-      timeout: AUDIT_LOG_STREAM_TIMEOUT,
-      signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+      timeout: AUDIT_LOG_STREAM_TIMEOUT
     });
   };
 

--- a/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
@@ -36,8 +36,7 @@ export const DatadogProviderFactory = () => {
     await request
       .post(url, createPayload({ ping: "ok" }), {
         headers: streamHeaders,
-        timeout: AUDIT_LOG_STREAM_TIMEOUT,
-        signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+        timeout: AUDIT_LOG_STREAM_TIMEOUT
       })
       .catch((err) => {
         throw new BadRequestError({ message: `Failed to connect with Datadog: ${(err as Error)?.message}` });
@@ -55,8 +54,7 @@ export const DatadogProviderFactory = () => {
 
     await request.post(url, createPayload(auditLog), {
       headers: streamHeaders,
-      timeout: AUDIT_LOG_STREAM_TIMEOUT,
-      signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+      timeout: AUDIT_LOG_STREAM_TIMEOUT
     });
   };
 

--- a/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
@@ -50,8 +50,7 @@ export const SplunkProviderFactory = () => {
     await request
       .post(url, createPayload({ ping: "ok" }), {
         headers: streamHeaders,
-        timeout: AUDIT_LOG_STREAM_TIMEOUT,
-        signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+        timeout: AUDIT_LOG_STREAM_TIMEOUT
       })
       .catch((err) => {
         throw new BadRequestError({ message: `Failed to connect with Splunk: ${(err as Error)?.message}` });
@@ -72,8 +71,7 @@ export const SplunkProviderFactory = () => {
 
     await request.post(url, createPayload(auditLog), {
       headers: streamHeaders,
-      timeout: AUDIT_LOG_STREAM_TIMEOUT,
-      signal: AbortSignal.timeout(AUDIT_LOG_STREAM_TIMEOUT)
+      timeout: AUDIT_LOG_STREAM_TIMEOUT
     });
   };
 


### PR DESCRIPTION
## Context

Audit log streaming to external providers (Splunk, Datadog, Azure, Cribl, Custom) was causing memory pressure and `ERR_CANCELED` errors when downstream services returned errors (e.g., 503s).

**Root cause:** `AbortSignal.timeout()` was used alongside axios's `timeout` option. When `axios-retry` retried failed requests, it reused the same `AbortSignal` which had already started its countdown (or expired), causing immediate cancellation of retry attempts.

**Before:** Retries failed with `ERR_CANCELED`, accumulated timer handles caused memory pressure.

**After:** Retries work correctly with fresh timeouts per attempt. The axios `timeout` option is sufficient for request timeouts.

## Steps to verify the change

1. Configure an audit log stream (e.g., Splunk)
2. Simulate a failing endpoint (503 responses)
3. Verify retries complete without `ERR_CANCELED` errors
4. Monitor memory usage under load - should remain stable

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)