### PR TITLE
fix: improve dnsDeleteTxtRecord logic to handle propagation delays

### DIFF
--- a/backend/src/services/certificate-authority/acme/dns-providers/cloudflare.ts
+++ b/backend/src/services/certificate-authority/acme/dns-providers/cloudflare.ts
@@ -104,23 +104,23 @@ export const cloudflareDeleteTxtRecord = async (
       }
 
       // Record not found - might not have propagated yet, retry with backoff
-      retryCount += 1;
-      if (retryCount < maxRetries) {
-        const delay = initialDelay * 2 ** (retryCount - 1);
+      if (retryCount + 1 < maxRetries) {
+        const delay = initialDelay * 2 ** retryCount;
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
       }
+      retryCount += 1;
     } catch (error) {
       lastError = error as Error;
-      retryCount += 1;
 
-      if (retryCount < maxRetries) {
-        const delay = initialDelay * 2 ** (retryCount - 1);
+      if (retryCount + 1 < maxRetries) {
+        const delay = initialDelay * 2 ** retryCount;
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
       }
+      retryCount += 1;
     }
   }
 

--- a/backend/src/services/certificate-authority/acme/dns-providers/dns-made-easy.ts
+++ b/backend/src/services/certificate-authority/acme/dns-providers/dns-made-easy.ts
@@ -98,23 +98,23 @@ export const dnsMadeEasyDeleteTxtRecord = async (
       }
 
       // Record not found - might not have propagated yet, retry with backoff
-      retryCount += 1;
-      if (retryCount < maxRetries) {
-        const delay = initialDelay * 2 ** (retryCount - 1);
+      if (retryCount + 1 < maxRetries) {
+        const delay = initialDelay * 2 ** retryCount;
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
       }
+      retryCount += 1;
     } catch (error) {
       lastError = error as Error;
-      retryCount += 1;
 
-      if (retryCount < maxRetries) {
-        const delay = initialDelay * 2 ** (retryCount - 1);
+      if (retryCount + 1 < maxRetries) {
+        const delay = initialDelay * 2 ** retryCount;
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
       }
+      retryCount += 1;
     }
   }
 

--- a/backend/src/services/certificate-authority/acme/dns-providers/route54.ts
+++ b/backend/src/services/certificate-authority/acme/dns-providers/route54.ts
@@ -50,6 +50,8 @@ export const route53DeleteTxtRecord = async (
 ) => {
   const config = await getAwsConnectionConfig(connection, AWSRegion.US_WEST_1); // REGION is irrelevant because Route53 is global
   const route53Client = new Route53Client({
+    sha256: CustomAWSHasher,
+    useFipsEndpoint: crypto.isFipsModeEnabled(),
     credentials: config.credentials!,
     region: config.region
   });
@@ -84,14 +86,14 @@ export const route53DeleteTxtRecord = async (
       return;
     } catch (error) {
       lastError = error as Error;
-      retryCount += 1;
 
-      if (retryCount < maxRetries) {
-        const delay = initialDelay * 2 ** (retryCount - 1);
+      if (retryCount + 1 < maxRetries) {
+        const delay = initialDelay * 2 ** retryCount;
         await new Promise((resolve) => {
           setTimeout(resolve, delay);
         });
       }
+      retryCount += 1;
     }
   }
 


### PR DESCRIPTION
## Context

Add a retry mechanism to DNS Made Easy and Route53 dnsDeleteTxtRecord functions, so if these providers take longer to propagate the TXT records on the DNS the process does not fail too soon

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)