### PR TITLE
feat(overview): add commit history access to overview page

### DIFF
--- a/frontend/src/components/v3/generic/Button/Button.tsx
+++ b/frontend/src/components/v3/generic/Button/Button.tsx
@@ -48,7 +48,7 @@ const buttonVariants = cva(
       }
     },
     defaultVariants: {
-      variant: "neutral",
+      variant: "outline",
       size: "md"
     }
   }
@@ -75,7 +75,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       className,
-      variant = "neutral",
+      variant = "outline",
       size = "md",
       isPending = false,
       isFullWidth = false,

--- a/frontend/src/pages/secret-manager/CommitsPage/CommitsPage.tsx
+++ b/frontend/src/pages/secret-manager/CommitsPage/CommitsPage.tsx
@@ -57,12 +57,12 @@ export const CommitsPage = () => {
     <div className="mx-auto mb-4 flex h-full w-full max-w-8xl justify-center bg-bunker-800 text-white">
       <div className="w-full">
         <Link
-          to="/organizations/$orgId/projects/secret-management/$projectId/secrets/$envSlug"
+          to="/organizations/$orgId/projects/secret-management/$projectId/overview"
           params={{
             orgId,
-            projectId: currentProject.id,
-            envSlug
+            projectId: currentProject.id
           }}
+          search={{ secretPath, environments: [envSlug] }}
           className="mb-4 flex items-center gap-x-2 text-sm text-mineshaft-400"
         >
           <FontAwesomeIcon icon={faChevronLeft} />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
@@ -68,18 +68,18 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs }: Props) {
             variant="outline"
             role="combobox"
             aria-expanded={isOpen}
-            className="w-[200px] justify-between"
+            className="w-[180px] justify-between"
           >
             <span className="truncate">{label}</span>
             <ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-[200px] p-0">
+        <PopoverContent align="start" className="w-[180px] p-0">
           <Command>
             <CommandInput
               value={inputValue}
               onValueChange={setInputValue}
-              placeholder="Filter environments..."
+              placeholder="Filter environments"
             />
             <CommandList>
               <CommandEmpty>No environment found.</CommandEmpty>
@@ -89,7 +89,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs }: Props) {
                     <CommandItem forceMount keywords={[]} onSelect={handleSelectAll}>
                       <CheckIcon
                         className={cn(
-                          "mr-2 h-4 w-4",
+                          "h-4 w-4",
                           !selectedEnvs.length ? "opacity-100" : "opacity-0"
                         )}
                       />
@@ -110,7 +110,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs }: Props) {
                   >
                     <CheckIcon
                       className={cn(
-                        "mr-2 h-4 w-4 shrink-0",
+                        "h-4 w-4 shrink-0",
                         selectedEnvs.map((e) => e.id).includes(env.id) ? "opacity-100" : "opacity-0"
                       )}
                     />

--- a/frontend/src/pages/secret-manager/OverviewPage/route.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/route.tsx
@@ -8,7 +8,8 @@ const SecretOverviewPageQuerySchema = z.object({
   search: z.string().catch(""),
   secretPath: z.string().catch("/"),
   connectionId: z.string().optional(),
-  connectionName: z.string().optional()
+  connectionName: z.string().optional(),
+  environments: z.array(z.string()).catch([])
 });
 
 export const Route = createFileRoute(
@@ -17,7 +18,7 @@ export const Route = createFileRoute(
   component: OverviewPage,
   validateSearch: zodValidator(SecretOverviewPageQuerySchema),
   search: {
-    middlewares: [stripSearchParams({ secretPath: "/", search: "" })]
+    middlewares: [stripSearchParams({ secretPath: "/", search: "", environments: [] })]
   },
   beforeLoad: ({ context, params }) => ({
     ...context,


### PR DESCRIPTION
## Context

This PR adds commit history access to the overview page, improves responsiveness and updates the back link on the commit page to navigate to the overview page

## Screenshots
<img width="3456" height="1924" alt="CleanShot 2026-02-13 at 20 24 27@2x" src="https://github.com/user-attachments/assets/e3ca716b-0738-45dd-b9e8-e8152877fef2" />
<img width="3456" height="1924" alt="CleanShot 2026-02-13 at 20 24 12@2x" src="https://github.com/user-attachments/assets/4e1417a4-3c75-4a25-8a30-f5381ef996ff" />

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)