### PR TITLE
fix(docs):a minor indentation fix in docs

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-secret-crd.mdx
@@ -249,13 +249,13 @@ spec:
             **1.3.** Next, create a long-lived service account JWT token (i.e. the token reviewer JWT token) for the service account using this configuration file for a new `Secret` resource:
 
             ```yaml service-account-reviewer-token.yaml
-              apiVersion: v1
-              kind: Secret
-              type: kubernetes.io/service-account-token
-              metadata:
-                name: infisical-token-reviewer-token
-                annotations:
-                  kubernetes.io/service-account.name: "infisical-token-reviewer"
+            apiVersion: v1
+            kind: Secret
+            type: kubernetes.io/service-account-token
+            metadata:
+              name: infisical-token-reviewer-token
+              annotations:
+                kubernetes.io/service-account.name: "infisical-token-reviewer"
             ```
 
 


### PR DESCRIPTION
## Context
In the docs (Kubernetes -> InfisicalSecret CRD -> Authentication with KubernetesAuth), the file `service-account-reviewer-token.yaml` contains an extra indentation.

Really not a major issue, just noticed it while setting up Infisical on my cluster

## Steps to verify the change
- https://infisical.com/docs/integrations/platforms/kubernetes/infisical-secret-crd#authentication-kubernetesauth
- The `service-account-reviewer-token.yaml` file should copy a yaml with one level of extra indentation while coping
- The fix should copy the yaml with right level of indentatino
## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)