### PR TITLE
docs(python): add LDAP authentication method to Python SDK documentation

### DIFF
--- a/docs/sdks/languages/python.mdx
+++ b/docs/sdks/languages/python.mdx
@@ -124,7 +124,11 @@ response = client.auth.ldap_auth.login(
 - `username` (str): Your LDAP username.
 - `password` (str): Your LDAP password.
 
-This authentication method is used for machine identities configured with LDAP-based authentication, enabling integration with corporate directory services like Active Directory.
+<Info>
+  Please note that this authentication method requires LDAP credentials. Please
+  [read more](/documentation/platform/identities/ldap-auth/general) about this
+  authentication method.
+</Info>
 
 #### Token Auth
 


### PR DESCRIPTION
## Context

Updated the Python SDK documentation with LDAP auth.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)