### PR TITLE
feat(frontend): add support for adding environments on the overview page

### DIFF
--- a/frontend/src/components/v3/generic/Command/Command.tsx
+++ b/frontend/src/components/v3/generic/Command/Command.tsx
@@ -90,7 +90,7 @@ function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className="py-6 text-center text-sm text-accent"
+      className="py-2.5 text-center text-sm text-accent"
       {...props}
     />
   );

--- a/frontend/src/hooks/api/secretImports/queries.tsx
+++ b/frontend/src/hooks/api/secretImports/queries.tsx
@@ -150,6 +150,31 @@ export const useGetImportedSecretsAllEnvs = ({
   environments,
   path = "/"
 }: TGetSecretImportsAllEnvs) => {
+  const selectImportedSecrets = useCallback(
+    ({ data, env }: { data: Awaited<ReturnType<typeof fetchImportedSecrets>>; env: string }) => {
+      return data.map((el) => ({
+        environment: el.environment,
+        secretPath: el.secretPath,
+        environmentInfo: el.environmentInfo,
+        folderId: el.folderId,
+        secrets: el.secrets.map((encSecret) => ({
+          id: encSecret.id,
+          env: encSecret.environment,
+          key: encSecret.secretKey,
+          isEmpty: encSecret.isEmpty,
+          secretValueHidden: encSecret.secretValueHidden,
+          tags: encSecret.tags,
+          comment: encSecret.secretComment,
+          createdAt: encSecret.createdAt,
+          updatedAt: encSecret.updatedAt,
+          version: encSecret.version,
+          sourceEnv: env
+        }))
+      }));
+    },
+    []
+  );
+
   const secretImports = useQueries({
     queries: environments.map((env) => ({
       queryKey: secretImportKeys.getImportedFoldersAllEnvs({
@@ -157,34 +182,12 @@ export const useGetImportedSecretsAllEnvs = ({
         projectId,
         path
       }),
-      queryFn: () => fetchImportedSecrets(projectId, env, path).catch(() => []),
+      queryFn: () =>
+        fetchImportedSecrets(projectId, env, path)
+          .catch(() => [])
+          .then((data) => ({ data, env })),
       enabled: Boolean(projectId) && Boolean(env),
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      select: useCallback(
-        (data: Awaited<ReturnType<typeof fetchImportedSecrets>>) =>
-          data.map((el) => ({
-            environment: el.environment,
-            secretPath: el.secretPath,
-            environmentInfo: el.environmentInfo,
-            folderId: el.folderId,
-            secrets: el.secrets.map((encSecret) => {
-              return {
-                id: encSecret.id,
-                env: encSecret.environment,
-                key: encSecret.secretKey,
-                isEmpty: encSecret.isEmpty,
-                secretValueHidden: encSecret.secretValueHidden,
-                tags: encSecret.tags,
-                comment: encSecret.secretComment,
-                createdAt: encSecret.createdAt,
-                updatedAt: encSecret.updatedAt,
-                version: encSecret.version,
-                sourceEnv: env
-              };
-            })
-          })),
-        []
-      )
+      select: selectImportedSecrets
     }))
   });
 


### PR DESCRIPTION
## Context

This PR adds the ability to create environments from the overview page.

It also corrects the secret import callback usage to prevent an error on environment addition

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-02-18 at 17 13 56@2x" src="https://github.com/user-attachments/assets/d131134b-1d9e-4caf-81dd-09ec5713e681" />

## Steps to verify the change

- test adding an environment

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)