### PR TITLE
improvement(dockerfile): increase Node.js memory limit from 1024MB to 2048MB

### DIFF
--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -221,7 +221,7 @@ ENV HTTPS_ENABLED false
 ENV NODE_ENV production
 ENV STANDALONE_BUILD true
 ENV STANDALONE_MODE true
-ENV NODE_OPTIONS="--max-old-space-size=1024"
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 ENV ChrystokiConfigurationPath=/usr/safenet/lunaclient/
 
 WORKDIR /backend


### PR DESCRIPTION
## Context

Set the default Node memory limit to 2GB.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)