### PR TITLE
fix(frontend): display generate lease for totp dynamic secret on overview page

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
@@ -126,36 +126,34 @@ export const DynamicSecretTableRow = ({
 
     return (
       <div className="flex items-center transition-all duration-500 group-hover:ml-2 group-hover:space-x-1.5">
-        {dynamicSecret.type !== DynamicSecretProviders.Totp && (
-          <ProjectPermissionCan
-            I={ProjectPermissionDynamicSecretActions.Lease}
-            a={subject(ProjectPermissionSub.DynamicSecrets, {
-              environment: dynamicSecret.environment,
-              secretPath,
-              metadata: dynamicSecret.metadata
-            })}
-          >
-            {(isAllowed) => (
-              <Tooltip>
-                <TooltipTrigger>
-                  <UnstableIconButton
-                    variant="ghost"
-                    size="xs"
-                    className="w-0 overflow-hidden border-0 opacity-0 group-hover:w-7 group-hover:opacity-100"
-                    isDisabled={!isAllowed || isRevoking}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onGenerateLease(dynamicSecret);
-                    }}
-                  >
-                    <FileKeyIcon />
-                  </UnstableIconButton>
-                </TooltipTrigger>
-                <TooltipContent>Generate Lease</TooltipContent>
-              </Tooltip>
-            )}
-          </ProjectPermissionCan>
-        )}
+        <ProjectPermissionCan
+          I={ProjectPermissionDynamicSecretActions.Lease}
+          a={subject(ProjectPermissionSub.DynamicSecrets, {
+            environment: dynamicSecret.environment,
+            secretPath,
+            metadata: dynamicSecret.metadata
+          })}
+        >
+          {(isAllowed) => (
+            <Tooltip>
+              <TooltipTrigger>
+                <UnstableIconButton
+                  variant="ghost"
+                  size="xs"
+                  className="w-0 overflow-hidden border-0 opacity-0 group-hover:w-7 group-hover:opacity-100"
+                  isDisabled={!isAllowed || isRevoking}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onGenerateLease(dynamicSecret);
+                  }}
+                >
+                  <FileKeyIcon />
+                </UnstableIconButton>
+              </TooltipTrigger>
+              <TooltipContent>Generate Lease</TooltipContent>
+            </Tooltip>
+          )}
+        </ProjectPermissionCan>
         <ProjectPermissionCan
           I={ProjectPermissionDynamicSecretActions.EditRootCredential}
           a={subject(ProjectPermissionSub.DynamicSecrets, {


### PR DESCRIPTION
## Context

This PR removes an incorrect if check that hide the generate lease button for TOTP dynamic secrets

## Screenshots

<img width="2700" height="83" alt="CleanShot 2026-02-19 at 15 36 42@2x" src="https://github.com/user-attachments/assets/7d930186-b010-456e-8ac9-af4270fe6962" />

## Steps to verify the change

- add totp dynamic secret and test issuance

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)