### PR TITLE
fix(audit-log): guard against NaN expiresAt when retention days are undefined

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-queue.ts
+++ b/backend/src/ee/services/audit-log/audit-log-queue.ts
@@ -1,6 +1,9 @@
+import type { ClickHouseClient } from "@clickhouse/client";
 import { randomUUID } from "crypto";
 
+import type { TProjects } from "@app/db/schemas";
 import { TAuditLogStreamServiceFactory } from "@app/ee/services/audit-log-stream/audit-log-stream-service";
+import { getConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 import { QueueJobs, QueueName, TQueueServiceFactory } from "@app/queue";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -15,6 +18,7 @@ type TAuditLogQueueServiceFactoryDep = {
   queueService: TQueueServiceFactory;
   projectDAL: Pick<TProjectDALFactory, "findById">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+  clickhouseClient: ClickHouseClient | null;
 };
 
 export type TAuditLogQueueServiceFactory = {
@@ -30,8 +34,12 @@ export const auditLogQueueServiceFactory = async ({
   queueService,
   projectDAL,
   licenseService,
-  auditLogStreamService
+  auditLogStreamService,
+  clickhouseClient
 }: TAuditLogQueueServiceFactoryDep): Promise<TAuditLogQueueServiceFactory> => {
+  const { CLICKHOUSE_AUDIT_LOG_ENABLED, CLICKHOUSE_AUDIT_LOG_TABLE_NAME, CLICKHOUSE_AUDIT_LOG_INSERT_SETTINGS } =
+    getConfig();
+
   const pushToLog = async (data: TCreateAuditLogDTO) => {
     await queueService.queue<QueueName.AuditLog>(QueueName.AuditLog, QueueJobs.AuditLog, data, {
       removeOnFail: {
@@ -46,7 +54,7 @@ export const auditLogQueueServiceFactory = async ({
     const { actor, event, ipAddress, projectId, userAgent, userAgentType } = job.data;
     let { orgId } = job.data;
     const MS_IN_DAY = 24 * 60 * 60 * 1000;
-    let project;
+    let project: TProjects | undefined;
 
     if (!orgId) {
       // it will never be undefined for both org and project id
@@ -91,8 +99,38 @@ export const auditLogQueueServiceFactory = async ({
         eventMetadata: event.metadata,
         userAgentType
       });
-
       await auditLogStreamService.streamLog(orgId, auditLog);
+
+      if (clickhouseClient && CLICKHOUSE_AUDIT_LOG_ENABLED) {
+        try {
+          await clickhouseClient.insert({
+            table: CLICKHOUSE_AUDIT_LOG_TABLE_NAME,
+            clickhouse_settings: CLICKHOUSE_AUDIT_LOG_INSERT_SETTINGS,
+            values: [
+              {
+                // with the same id as the audit log in clickhouse, so that it's much easier to
+                // find the corresponding audit log in postgres
+                id: auditLog.id,
+                actor: actor.type,
+                actorMetadata: actor.metadata ?? {},
+                ipAddress: ipAddress ?? "",
+                eventType: event.type,
+                eventMetadata: event.metadata ?? {},
+                userAgent: userAgent ?? "",
+                userAgentType: userAgentType ?? "",
+                // with the same createdAt as the audit log from postgres, so that it's much easier to
+                // deduplicate the audit logs
+                createdAt: auditLog.createdAt,
+                projectId: projectId ?? "",
+                orgId
+              }
+            ],
+            format: "JSONEachRow"
+          });
+        } catch (error) {
+          logger.error(error, `Failed to insert audit log to ClickHouse [auditLogId=${auditLog.id}]`);
+        }
+      }
     }
   });
 


### PR DESCRIPTION
Adds a guard for undefined/NaN retention days before TTL calculation to avoid invalid expiresAt dates.