### PR TITLE
fix(pki): send profile default KU/EKU values on certificate submit

### DIFF
--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -336,72 +336,82 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
           }
         };
 
-        if (
-          constraints.shouldShowSubjectSection &&
-          subjectAttributes &&
-          subjectAttributes.length > 0
-        ) {
+        if (constraints.shouldShowSubjectSection) {
           const defaults = actualSelectedProfile?.defaults;
 
-          const cnAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.COMMON_NAME
-          );
-          if (cnAttr?.value) {
-            request.attributes.commonName = cnAttr.value;
-          } else if (defaults?.commonName) {
-            request.attributes.commonName = null;
-          }
+          if (subjectAttributes && subjectAttributes.length > 0) {
+            const cnAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.COMMON_NAME
+            );
+            if (cnAttr?.value) {
+              request.attributes.commonName = cnAttr.value;
+            } else if (defaults?.commonName) {
+              request.attributes.commonName = null;
+            }
 
-          const orgAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.ORGANIZATION
-          );
-          if (orgAttr?.value) {
-            request.attributes.organization = orgAttr.value;
-          } else if (defaults?.organization) {
-            request.attributes.organization = null;
-          }
+            const orgAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.ORGANIZATION
+            );
+            if (orgAttr?.value) {
+              request.attributes.organization = orgAttr.value;
+            } else if (defaults?.organization) {
+              request.attributes.organization = null;
+            }
 
-          const ouAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.ORGANIZATIONAL_UNIT
-          );
-          if (ouAttr?.value) {
-            request.attributes.organizationUnit = ouAttr.value;
-          } else if (defaults?.organizationalUnit) {
-            request.attributes.organizationUnit = null;
-          }
+            const ouAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.ORGANIZATIONAL_UNIT
+            );
+            if (ouAttr?.value) {
+              request.attributes.organizationUnit = ouAttr.value;
+            } else if (defaults?.organizationalUnit) {
+              request.attributes.organizationUnit = null;
+            }
 
-          const countryAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.COUNTRY
-          );
-          if (countryAttr?.value) {
-            request.attributes.country = countryAttr.value;
-          } else if (defaults?.country) {
-            request.attributes.country = null;
-          }
+            const countryAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.COUNTRY
+            );
+            if (countryAttr?.value) {
+              request.attributes.country = countryAttr.value;
+            } else if (defaults?.country) {
+              request.attributes.country = null;
+            }
 
-          const stateAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.STATE
-          );
-          if (stateAttr?.value) {
-            request.attributes.state = stateAttr.value;
-          } else if (defaults?.state) {
-            request.attributes.state = null;
-          }
+            const stateAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.STATE
+            );
+            if (stateAttr?.value) {
+              request.attributes.state = stateAttr.value;
+            } else if (defaults?.state) {
+              request.attributes.state = null;
+            }
 
-          const localityAttr = subjectAttributes.find(
-            (attr) => attr.type === CertSubjectAttributeType.LOCALITY
-          );
-          if (localityAttr?.value) {
-            request.attributes.locality = localityAttr.value;
-          } else if (defaults?.locality) {
-            request.attributes.locality = null;
+            const localityAttr = subjectAttributes.find(
+              (attr) => attr.type === CertSubjectAttributeType.LOCALITY
+            );
+            if (localityAttr?.value) {
+              request.attributes.locality = localityAttr.value;
+            } else if (defaults?.locality) {
+              request.attributes.locality = null;
+            }
+          } else if (defaults) {
+            // No subject attributes provided; send null overrides for profile defaults
+            if (defaults.commonName) request.attributes.commonName = null;
+            if (defaults.organization) request.attributes.organization = null;
+            if (defaults.organizationalUnit) request.attributes.organizationUnit = null;
+            if (defaults.country) request.attributes.country = null;
+            if (defaults.state) request.attributes.state = null;
+            if (defaults.locality) request.attributes.locality = null;
           }
         }
 
-        if (constraints.shouldShowSanSection && subjectAltNames && subjectAltNames.length > 0) {
-          const formattedSans = formatSubjectAltNames(subjectAltNames);
-          if (formattedSans && formattedSans.length > 0) {
-            request.attributes.altNames = formattedSans;
+        if (constraints.shouldShowSanSection) {
+          if (subjectAltNames && subjectAltNames.length > 0) {
+            const formattedSans = formatSubjectAltNames(subjectAltNames);
+            if (formattedSans && formattedSans.length > 0) {
+              request.attributes.altNames = formattedSans;
+            }
+          } else {
+            request.attributes.altNames = [];
           }
         }
 
@@ -575,7 +585,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                   <Controller
                     control={control}
                     name="csr"
-                    shouldUnregister
                     render={({ field, fieldState: { error } }) => (
                       <FormControl
                         label="Certificate Signing Request (CSR)"
@@ -617,7 +626,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                         (formState.errors as { subjectAttributes?: { message?: string } })
                           .subjectAttributes?.message
                       }
-                      shouldUnregister
                     />
                   )}
 
@@ -629,7 +637,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                       (formState.errors as { subjectAltNames?: { message?: string } })
                         .subjectAltNames?.message
                     }
-                    shouldUnregister
                   />
                 )}
 
@@ -662,7 +669,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                         (formState.errors as { keyAlgorithm?: { message?: string } }).keyAlgorithm
                           ?.message
                       }
-                      shouldUnregister
                     />
 
                     <Accordion type="single" collapsible className="w-full">
@@ -673,7 +679,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                         namePrefix="keyUsages"
                         options={filteredKeyUsages}
                         requiredUsages={constraints.requiredKeyUsages}
-                        shouldUnregister
                       />
                       <KeyUsageSection
                         control={control}
@@ -682,7 +687,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                         namePrefix="extendedKeyUsages"
                         options={filteredExtendedKeyUsages}
                         requiredUsages={constraints.requiredExtendedKeyUsages}
-                        shouldUnregister
                       />
                       {constraints.templateAllowsCA && (
                         <AccordionItem value="basic-constraints">
@@ -692,7 +696,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                               <Controller
                                 control={control}
                                 name="basicConstraints.isCA"
-                                shouldUnregister
                                 render={({ field: { value, onChange } }) => (
                                   <div className="flex items-center gap-3">
                                     <Checkbox
@@ -726,7 +729,6 @@ export const CertificateIssuanceModal = ({ popUp, handlePopUpToggle, profileId }
                                 <Controller
                                   control={control}
                                   name="basicConstraints.pathLength"
-                                  shouldUnregister
                                   render={({ field, fieldState: { error } }) => {
                                     const isPathLengthRequired =
                                       typeof constraints.maxPathLength === "number" &&


### PR DESCRIPTION
## Context

Profile default KU/EKU values appeared checked but submitted as [] because shouldUnregister overwrites setValue data on Controller mount — removed it along with the pendingDefaults workaround and fixed empty subject/SAN null overrides.

## Screenshots


## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)