### PR TITLE
feat: this pr re-orders the permission on loading up to make forbid rule to have higher priority

### DIFF
--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -61,7 +61,8 @@ const buildOrgPermissionRules = (orgUserRoles: TBuildOrgPermissionDTO) => {
           throw new NotFoundError({ name: "OrgRoleInvalid", message: `Organization role '${role}' not found` });
       }
     })
-    .reduce((prev, curr) => prev.concat(curr), []);
+    .reduce((prev, curr) => prev.concat(curr), [])
+    .sort((a, b) => Number(Boolean(a.inverted)) - Number(Boolean(b.inverted)));
 
   return rules;
 };
@@ -94,7 +95,8 @@ const buildProjectPermissionRules = (projectUserRoles: TBuildProjectPermissionDT
           });
       }
     })
-    .reduce((prev, curr) => prev.concat(curr), []);
+    .reduce((prev, curr) => prev.concat(curr), [])
+    .sort((a, b) => Number(Boolean(a.inverted)) - Number(Boolean(b.inverted)));
 
   return rules;
 };

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -1,10 +1,9 @@
-import { cloneElement, ReactNode, useState } from "react";
+import { cloneElement, ReactNode } from "react";
 import { Control, Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import {
   faChevronDown,
   faChevronRight,
   faDiagramProject,
-  faGripVertical,
   faInfoCircle,
   faPlus,
   faTrash
@@ -77,7 +76,7 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
   onShowAccessTree
 }: Props<T>) => {
   const { control, watch } = useFormContext<TFormSchema>();
-  const { fields, remove, insert, move } = useFieldArray({
+  const { fields, remove, insert } = useFieldArray({
     control,
     name: `permissions.${subject}`
   });
@@ -89,39 +88,8 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
   });
 
   const [isOpen, setIsOpen] = useToggle();
-  const [draggedItem, setDraggedItem] = useState<number | null>(null);
-  const [dragOverItem, setDragOverItem] = useState<number | null>(null);
 
   if (!watchFields || !Array.isArray(watchFields) || watchFields.length === 0) return null;
-
-  const handleDragStart = (_: React.DragEvent, index: number) => {
-    setDraggedItem(index);
-  };
-
-  const handleDragOver = (e: React.DragEvent, index: number) => {
-    e.preventDefault();
-    setDragOverItem(index);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-
-    if (draggedItem === null || dragOverItem === null || draggedItem === dragOverItem) {
-      setDraggedItem(null);
-      setDragOverItem(null);
-      return;
-    }
-
-    move(draggedItem, dragOverItem);
-
-    setDraggedItem(null);
-    setDragOverItem(null);
-  };
-
-  const handleDragEnd = () => {
-    setDraggedItem(null);
-    setDragOverItem(null);
-  };
 
   return (
     <div className="overflow-clip border border-mineshaft-600 bg-mineshaft-800 first:rounded-t-md last:rounded-b-md hover:bg-mineshaft-700">
@@ -194,12 +162,8 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
                 key={el.id}
                 className={twMerge(
                   "relative rounded-md border-l-[6px] bg-mineshaft-800 px-5 py-4 transition-colors duration-300",
-                  isInverted ? "border-l-red-600/50" : "border-l-green-600/50",
-                  dragOverItem === rootIndex ? "border-2 border-primary/50" : "",
-                  draggedItem === rootIndex ? "opacity-50" : ""
+                  isInverted ? "border-l-red-600/50" : "border-l-green-600/50"
                 )}
-                onDragOver={(e) => handleDragOver(e, rootIndex)}
-                onDrop={handleDrop}
               >
                 {isConditionalSubjects(subject) && (
                   <div className="mb-4 flex items-center gap-3">
@@ -253,18 +217,6 @@ export const GeneralPermissionPolicies = <T extends keyof NonNullable<TFormSchem
                           >
                             <FontAwesomeIcon icon={faTrash} />
                           </IconButton>
-                        </Tooltip>
-                      )}
-                      {!isDisabled && (
-                        <Tooltip position="left" content="Drag to reorder permission">
-                          <div
-                            draggable
-                            onDragStart={(e) => handleDragStart(e, rootIndex)}
-                            onDragEnd={handleDragEnd}
-                            className="cursor-move text-bunker-300 hover:text-bunker-200"
-                          >
-                            <FontAwesomeIcon icon={faGripVertical} />
-                          </div>
                         </Tooltip>
                       )}
                     </div>


### PR DESCRIPTION
## Context

Previously users had to re-order to ensure that the forbid takes priority. This would cause undesired results when the permission are connected together using additional privileges if the users doesn't keep it consistent.

We have address this by changing the ordering so that - on permission loading all the forbid rules comes last when loading permission.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Create a rule that forbids some operation
2. Create a broder rule that allows the same

It will be restricted and forbidden will take priority

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)