### PR TITLE
feat(infisical-gateway): add support for creating secrets from values for GitOps workflows

### DIFF
--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.4"
+appVersion: "1.1.0"

--- a/helm-charts/infisical-gateway/templates/secret.yaml
+++ b/helm-charts/infisical-gateway/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secret.create -}}
+{{- if not .Values.secret.data }}
+{{- fail "secret.data is required when secret.create is true. Please provide key-value pairs for the secret." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secret.name }}
+  labels:
+    {{- include "infisical-gateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secret.data }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -4,8 +4,24 @@ image:
   pullPolicy: IfNotPresent
 
 secret:
-  # The secret that contains the environment variables to be used by the gateway, such as INFISICAL_API_URL and TOKEN
+  # Set create=true to create the secret from data below
+  # Set create=false (default) to use an existing secret
+  create: false
+
+  # The name of the secret to use/create
   name: "infisical-gateway-environment"
+
+  # Key-value pairs for the secret (only used when create=true)
+  # Define any environment variables you need here
+  # Example:
+  #data:
+  #  INFISICAL_AUTH_METHOD: "universal-auth"
+  #  INFISICAL_UNIVERSAL_AUTH_CLIENT_ID: "your-client-id"
+  #  INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET: "your-secret"
+  #  INFISICAL_GATEWAY_NAME: "your-gateway"
+  #  INFISICAL_RELAY_NAME: "your-relay"
+  #  INFISICAL_API_URL: "https://eu.infisical.com"
+  data: {}
 
 gateway:
   # Specify where to save PAM session recordings. This directory will always be created when the gateway starts.


### PR DESCRIPTION
## Context

Fixes #5538

- Add secret.create flag to enable secret creation from values (defaults to false for backward compatibility)
- Add secret.data map for flexible key-value secret definition
- Create templates/secret.yaml to generate secrets when secret.create=true
- Add validation to ensure secret.data is provided when creating secrets
- Support SOPS encryption of sensitive values like INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET

This allows users to manage Infisical Gateway secrets declaratively in GitOps workflows while maintaining full backward compatibility with existing deployments that reference external secrets.

## Steps to verify the change

```bash

helm template infisical-gateway .
...
...
...
```

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)