### PR TITLE
fix: certificate profile CA selector to display the CA name

### DIFF
--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
@@ -1151,11 +1151,7 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                               onChange("");
                             }
                           }}
-                          getOptionLabel={(ca) =>
-                            ca.type === "internal" && ca.configuration.friendlyName
-                              ? ca.configuration.friendlyName
-                              : ca.name
-                          }
+                          getOptionLabel={(ca) => ca.name}
                           getOptionValue={(ca) => ca.id}
                           options={certificateAuthorities}
                           groupBy="groupType"


### PR DESCRIPTION
## Context

Small fix on the UI, now the certificate profile modal will show the CA name which will be more clear than showing the details (which could be duplicated between different CAs)

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)