### PR TITLE
fix(project-templates): add 1000 limit

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/EditProjectTemplateSection/components/ProjectTemplateIdentitiesSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/EditProjectTemplateSection/components/ProjectTemplateIdentitiesSection.tsx
@@ -103,7 +103,8 @@ export const ProjectTemplateIdentitiesSection = ({ projectTemplate }: Props) => 
 
   const { data: orgIdentitiesResponse, isPending: isMembershipsLoading } =
     useSearchOrgIdentityMemberships({
-      search: {}
+      search: {},
+      limit: 1000
     });
   const orgIdentities = orgIdentitiesResponse
     ? orgIdentitiesResponse.identities.map((v) => v.identity)


### PR DESCRIPTION
## Context

Adds a 1000 limit to fetch as a temporary fix for frontend filters not working

## Steps to verify the change

Make more than 50 identities, and search for the 51st identity. Previously the default limit was 50

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)