### PR TITLE
fix: use request environment for approval notifications 

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1185,7 +1185,7 @@ export const secretApprovalRequestServiceFactory = ({
 
     if (isSoftEnforcement) {
       const cfg = getConfig();
-      const env = await projectEnvDAL.findOne({ id: policy.envId });
+      const env = await projectEnvDAL.findOne({ slug: environment, projectId });
       const requestedByUser = await userDAL.findOne({ id: actorId });
       const approverUsers = await userDAL.find({
         $in: {
@@ -1615,7 +1615,7 @@ export const secretApprovalRequestServiceFactory = ({
       return { ...doc, commits: approvalCommits };
     });
 
-    const env = await projectEnvDAL.findOne({ id: policy.envId });
+    const env = await projectEnvDAL.findOne({ slug: environment, projectId });
     const user = await userDAL.findById(actorId);
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${projectId}`;
@@ -2023,7 +2023,7 @@ export const secretApprovalRequestServiceFactory = ({
       : await secretApprovalRequestDAL.transaction(executeApprovalRequestCreation);
 
     const user = await userDAL.findById(actorId);
-    const env = await projectEnvDAL.findOne({ id: policy.envId });
+    const env = await projectEnvDAL.findOne({ slug: environment, projectId });
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${project.id}`;
     const approvalPath = `${projectPath}/approval`;


### PR DESCRIPTION
## Context

Approval request notifications (Slack, etc) pull the environment name from `policy.envId`, a column that doesn't represent multi-environment policies since #4220. For policies that span multiple environments, this column only ever points to one of them, so notifications end up saying one environment even when the requests are for different environments.

Switched all three call sites to look up the environment from the request context instead.

## Screenshots

N/A

## Steps to verify the change

1. Create an approval policy covering multiple environments
2. Delete/update a secret across environments from the overview page
3. Check that each notification shows the right environment

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)