### PR TITLE
fix: only send bypass notification when no approval

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1183,7 +1183,7 @@ export const secretApprovalRequestServiceFactory = ({
       events
     });
 
-    if (isSoftEnforcement) {
+    if (isSoftEnforcement && !hasMinApproval) {
       const cfg = getConfig();
       const env = await projectEnvDAL.findOne({ id: policy.envId });
       const requestedByUser = await userDAL.findOne({ id: actorId });


### PR DESCRIPTION
## Context

When a secret change policy has soft enforcement, the bypass notification email fires on every merge — even when the approver legitimately approved and merged the request. This is because the notification block only checks `isSoftEnforcement` without also checking whether the minimum approval count was actually satisfied.

Added `!hasMinApproval` to the condition so the bypass email is only sent when someone actually bypasses the policy (merges without enough approvals), not on normal approved merges.

## Steps to verify the change

1. Set up a change policy with soft enforcement and at least one approver
2. Have another user create a secret change request
3. As the approver, approve and merge the request
4. Confirm no bypass notification is sent
5. Now merge a request _without_ the required approvals — confirm the bypass notification is sent as expected

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
