### PR TITLE
fix(ui): apply auto-capitalization when importing/pasting secrets via SecretDropzone

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
@@ -22,7 +22,7 @@ import {
   UnstableEmptyHeader,
   UnstableEmptyTitle
 } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
 import { useToggle } from "@app/hooks";
 
 import { CsvColumnMapDialog } from "./CsvColumnMapDialog";
@@ -36,11 +36,19 @@ type Props = {
 };
 
 export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
+  const { currentProject } = useProject();
   const [isDragActive, setDragActive] = useToggle();
   const [isPasteOpen, setIsPasteOpen] = useState(false);
   const [csvData, setCsvData] = useState<{ headers: string[]; matrix: string[][] } | null>(null);
 
-  const handleParsedSecrets = (env: TParsedEnv) => {
+  const handleParsedSecrets = (inputEnv: TParsedEnv) => {
+    // Apply auto-capitalization to secret keys when enabled for the project
+    const env: TParsedEnv = currentProject?.autoCapitalization
+      ? (Object.fromEntries(
+          Object.entries(inputEnv).map(([key, value]) => [key.toUpperCase(), value])
+        ) as TParsedEnv)
+      : inputEnv;
+
     if (!Object.keys(env).length) {
       createNotification({
         type: "error",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx
@@ -25,7 +25,7 @@ import {
   SelectItem
 } from "@app/components/v2";
 import { Badge } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
 import { usePopUp, useToggle } from "@app/hooks";
 import { PendingAction } from "@app/hooks/api/secretFolders/types";
 import { fetchProjectSecrets, mergePersonalSecrets } from "@app/hooks/api/secrets/queries";
@@ -143,6 +143,7 @@ export const SecretDropzone = ({
   secretPath
 }: Props): JSX.Element => {
   const { t } = useTranslation();
+  const { currentProject } = useProject();
   const [isDragActive, setDragActive] = useToggle();
   const [isLoading, setIsLoading] = useToggle();
 
@@ -245,7 +246,14 @@ export const SecretDropzone = ({
     }
   };
 
-  const handleParsedEnv = async (env: TParsedEnv) => {
+  const handleParsedEnv = async (inputEnv: TParsedEnv) => {
+    // Apply auto-capitalization to secret keys when enabled for the project
+    const env: TParsedEnv = currentProject?.autoCapitalization
+      ? (Object.fromEntries(
+          Object.entries(inputEnv).map(([key, value]) => [key.toUpperCase(), value])
+        ) as TParsedEnv)
+      : inputEnv;
+
     const envSecretKeys = Object.keys(env);
 
     if (!envSecretKeys.length) {


### PR DESCRIPTION
## Summary

Fixes #2693

When a project has auto-capitalization enabled, secrets imported via file drop or the "Paste Secrets" modal were not having their keys uppercased. The `CreateSecretForm` component already handles this correctly (line 184 in OverviewPage variant, line 143 in SecretDashboardPage variant), but the `SecretDropzone` components in both pages were missing the auto-capitalization check.

### Root Cause

The `handleParsedEnv` function in `SecretDashboardPage/SecretDropzone` and the `handleParsedSecrets` function in `OverviewPage/SecretDropzone` process imported/pasted secrets without checking the project's `autoCapitalization` setting. Keys are used verbatim regardless of the setting.

### Changes

- **`SecretDashboardPage/components/SecretDropzone/SecretDropzone.tsx`**: Added `useProject()` hook and auto-capitalization transform at the start of `handleParsedEnv`, applying `toUpperCase()` to all secret keys when `autoCapitalization` is enabled.
- **`OverviewPage/components/SecretDropzone/SecretDropzone.tsx`**: Same fix in `handleParsedSecrets`.

Both changes follow the same pattern already used in `CreateSecretForm.tsx`:
```ts
const keyStr = currentProject.autoCapitalization ? key.toUpperCase() : key;
```

### Input paths covered by this fix

| Input Path | Before | After |
|-----------|--------|-------|
| Typing in CreateSecretForm | ✅ Already capitalized | ✅ |
| Pasting in CreateSecretForm | ✅ Already capitalized | ✅ |
| File drop (SecretDropzone) | ❌ Not capitalized | ✅ Fixed |
| Paste modal (SecretDropzone) | ❌ Not capitalized | ✅ Fixed |
| CSV import (SecretDropzone) | ❌ Not capitalized | ✅ Fixed |

### Testing

- TypeScript type check passes (`tsc --noEmit`)
- ESLint passes on both modified files
- No new dependencies added