### PR TITLE
feat(kubernetes-auth): add wildcard and regex support for kube auth

### DIFF
--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -2,6 +2,7 @@ import { ForbiddenError, subject } from "@casl/ability";
 import { requestContext } from "@fastify/request-context";
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import https from "https";
+import picomatch from "picomatch";
 import RE2 from "re2";
 
 import {
@@ -501,7 +502,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const isNamespaceAllowed = identityKubernetesAuth.allowedNamespaces
           .split(",")
           .map((namespace) => namespace.trim())
-          .some((namespace) => namespace === targetNamespace);
+          .some((namespace) => namespace === targetNamespace || picomatch.isMatch(targetNamespace, namespace));
 
         if (!isNamespaceAllowed)
           throw new UnauthorizedError({
@@ -515,7 +516,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const isNameAllowed = identityKubernetesAuth.allowedNames
           .split(",")
           .map((name) => name.trim())
-          .some((name) => name === targetName);
+          .some((name) => name === targetName || picomatch.isMatch(targetName, name));
 
         if (!isNameAllowed)
           throw new UnauthorizedError({

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -219,22 +219,14 @@ export const IdentityKubernetesAuthForm = ({
       });
 
       if (role.bound_service_account_names?.length > 0) {
-        // In Vault, "*" means allow all; in Infisical, empty field means allow any
-        const allowedNames = role.bound_service_account_names.includes("*")
-          ? ""
-          : role.bound_service_account_names.join(", ");
-        setValue("allowedNames", allowedNames, {
+        setValue("allowedNames", role.bound_service_account_names.join(", "), {
           shouldDirty: true,
           shouldTouch: true
         });
       }
 
       if (role.bound_service_account_namespaces?.length > 0) {
-        // In Vault, "*" means allow all; in Infisical, empty field means allow any
-        const allowedNamespaces = role.bound_service_account_namespaces.includes("*")
-          ? ""
-          : role.bound_service_account_namespaces.join(", ");
-        setValue("allowedNamespaces", allowedNamespaces, {
+        setValue("allowedNamespaces", role.bound_service_account_namespaces.join(", "), {
           shouldDirty: true,
           shouldTouch: true
         });
@@ -575,11 +567,27 @@ export const IdentityKubernetesAuthForm = ({
                 label="Allowed Namespaces"
                 isError={Boolean(error)}
                 errorText={error?.message}
-                tooltipText="A comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical."
+                tooltipText={
+                  <div className="flex flex-col gap-1">
+                    <p>
+                      A comma-separated list of trusted namespaces that service accounts must belong
+                      to authenticate with Infisical.
+                    </p>
+                    <p>
+                      Regex and Wildcard patterns are supported. Use{" "}
+                      <span className="font-mono">*</span> to explicitly allow all.
+                    </p>
+                    <p className="text-sm">
+                      Examples: <span className="font-mono">dev-*</span>,{" "}
+                      <span className="font-mono">staging-*</span>,{" "}
+                      <span className="font-mono">team-{"{a,b}"}</span>
+                    </p>
+                  </div>
+                }
               >
                 <Input
                   {...field}
-                  placeholder="namespaceA, namespaceB"
+                  placeholder="namespaceA, namespaceB, dev-*"
                   type="text"
                   autoComplete="off"
                 />
@@ -594,12 +602,29 @@ export const IdentityKubernetesAuthForm = ({
               <FormControl
                 label="Allowed Service Account Names"
                 isError={Boolean(error)}
-                tooltipText="An optional comma-separated list of trusted service account names that are allowed to authenticate with Infisical. Leave empty to allow any service account."
+                tooltipText={
+                  <div className="flex flex-col gap-1">
+                    <p>
+                      An optional comma-separated list of trusted service account names that are
+                      allowed to authenticate with Infisical. Leave empty to allow any service
+                      account.
+                    </p>
+                    <p>
+                      Regex and Wildcard patterns are supported. Use{" "}
+                      <span className="font-mono">*</span> to explicitly allow all.
+                    </p>
+                    <p className="text-sm">
+                      Examples: <span className="font-mono">dev-*</span>,{" "}
+                      <span className="font-mono">staging-*</span>,{" "}
+                      <span className="font-mono">team-{"{a,b}"}</span>
+                    </p>
+                  </div>
+                }
                 errorText={error?.message}
               >
                 <Input
                   {...field}
-                  placeholder="service-account-1-name, service-account-1-name"
+                  placeholder="service-account-1-name, sa-*, app-*-prod"
                   autoComplete="off"
                 />
               </FormControl>


### PR DESCRIPTION
## Context

Add wildcard and regex support for the names and namespaces for the kubernetes auth method. 
Closes ENG-4611

## Screenshots

<img width="649" height="893" alt="image" src="https://github.com/user-attachments/assets/90bb7a96-a573-4298-b27f-2104e087d4b9" />

## Steps to verify the change

- Create a Kubernetes auth method with a wildcard namespace (_dev-*_ for example).
- Verify all namespace prefix with `dev-` are allowed, while namespaces that do not match continue to be denied. 

## Type

- [ ] Fix
- [X] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [X] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [X] Tested locally
- [ ] Updated docs (if needed)
- [X] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)