### PR TITLE
feat: add delete environment action to env col dropdown on overview page

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -2217,7 +2217,6 @@ export const OverviewPage = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-<<<<<<< HEAD
       <AlertDialog
         open={popUp.deleteEnv.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("deleteEnv", isOpen)}
@@ -2244,7 +2243,6 @@ export const OverviewPage = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-=======
       {!!pathPolicies && pathPolicies.length > 0 && (
         <RequestAccessModal
           policies={pathPolicies}
@@ -2256,7 +2254,6 @@ export const OverviewPage = () => {
           secretPath={pathPolicies[0].secretPath}
         />
       )}
->>>>>>> main
     </div>
   );
 };


### PR DESCRIPTION
## Context

This PR adds the ability to delete environments to the overview page 

## Screenshots

<img width="3398" height="1922" alt="CleanShot 2026-03-02 at 14 52 32@2x" src="https://github.com/user-attachments/assets/74f2e938-d4a8-4f12-9a19-ca709201903d" />

## Steps to verify the change

1. test env deletion action deletes env
2. verify query invalidates after deletion
3. verify permission disable / tooltip display

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)