### PR TITLE
feat(platform-214): add support for org-slug and login method query params

### DIFF
--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -44,6 +44,7 @@ export const InitialStep = ({
   const [loginError, setLoginError] = useState(false);
   const { config } = useServerConfig();
   const queryParams = new URLSearchParams(window.location.search);
+  const queryOrgSlug = queryParams.get("organization_slug");
   const [captchaToken, setCaptchaToken] = useState("");
   const [shouldShowCaptcha, setShouldShowCaptcha] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -77,16 +78,18 @@ export const InitialStep = ({
   }, [serverDetails?.samlDefaultOrgSlug]);
 
   const handleSaml = () => {
-    if (config.defaultAuthOrgSlug) {
-      redirectToSaml(config.defaultAuthOrgSlug);
+    const effectiveOrgSlug = queryOrgSlug || config.defaultAuthOrgSlug;
+    if (effectiveOrgSlug) {
+      redirectToSaml(effectiveOrgSlug);
     } else {
       setStep(2);
     }
   };
 
   const handleOidc = () => {
-    if (config.defaultAuthOrgSlug) {
-      redirectToOidc(config.defaultAuthOrgSlug);
+    const effectiveOrgSlug = queryOrgSlug || config.defaultAuthOrgSlug;
+    if (effectiveOrgSlug) {
+      redirectToOidc(effectiveOrgSlug);
     } else {
       setStep(3);
     }
@@ -94,6 +97,18 @@ export const InitialStep = ({
 
   const shouldDisplayLoginMethod = (method: LoginMethod) =>
     isAdmin || !config.enabledLoginMethods || config.enabledLoginMethods.includes(method);
+
+  useEffect(() => {
+    const method = queryParams.get("method") ?? "";
+
+    if (method === "saml" && shouldDisplayLoginMethod(LoginMethod.SAML)) {
+      handleSaml();
+      return;
+    }
+    if (method === "oidc" && shouldDisplayLoginMethod(LoginMethod.OIDC)) {
+      handleOidc();
+    }
+  }, []);
 
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## Context

- Accept the query param for organizational-slug and method from the CLI
- Relies on https://github.com/Infisical/cli/pull/140 

## Steps to verify the change

- update CLI with latest changes from PR-140
- run cli `login --method saml/odic --organization-slug SLUG` 
- Ensure that a browser opens with everything prefilled and redirecting to you login.

## Type

- [ ] Fix
- [ ] Feature
- [X] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [X] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [X] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)