### PR TITLE
feat(secrets-overview): add hashicorp vault import capability

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -65,6 +65,7 @@ import {
   ProjectPermissionActions,
   ProjectPermissionDynamicSecretActions,
   ProjectPermissionSub,
+  useOrgPermission,
   useProject,
   useProjectPermission,
   useSubscription
@@ -75,6 +76,7 @@ import {
   ProjectPermissionSecretRotationActions
 } from "@app/context/ProjectPermissionContext/types";
 import { downloadSecretEnvFile } from "@app/helpers/download";
+import { OrgMembershipRole } from "@app/helpers/roles";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -105,6 +107,11 @@ import { DashboardSecretsOrderBy, ProjectSecretsImportedBy } from "@app/hooks/ap
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 import { useGetFolderCommitsCount } from "@app/hooks/api/folderCommits";
 import { OrderByDirection } from "@app/hooks/api/generic/types";
+import {
+  useGetVaultExternalMigrationConfigs,
+  useImportVaultSecrets
+} from "@app/hooks/api/migration";
+import { VaultImportStatus } from "@app/hooks/api/migration/types";
 import { ProjectType, ProjectVersion } from "@app/hooks/api/projects/types";
 import { useUpdateFolderBatch } from "@app/hooks/api/secretFolders/queries";
 import { TUpdateFolderBatchDTO } from "@app/hooks/api/secretFolders/types";
@@ -133,6 +140,7 @@ import {
 import { CreateDynamicSecretForm } from "../SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm";
 import { CreateSecretImportForm } from "../SecretDashboardPage/components/ActionBar/CreateSecretImportForm";
 import { FolderForm } from "../SecretDashboardPage/components/ActionBar/FolderForm";
+import { VaultSecretImportModal } from "../SecretDashboardPage/components/ActionBar/VaultSecretImportModal";
 import { CreateDynamicSecretLease } from "../SecretDashboardPage/components/DynamicSecretListView/CreateDynamicSecretLease";
 import { EditDynamicSecretForm } from "../SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm";
 import {
@@ -216,6 +224,11 @@ export const OverviewPage = () => {
   const [debouncedSearchFilter, setDebouncedSearchFilter] = useDebounce(searchFilter);
   const secretPath = (routerSearch?.secretPath as string) || "/";
   const { subscription } = useSubscription();
+  const { hasOrgRole } = useOrgPermission();
+  const isOrgAdmin = hasOrgRole(OrgMembershipRole.Admin);
+  const { data: vaultConfigs = [] } = useGetVaultExternalMigrationConfigs();
+  const hasVaultConnection = vaultConfigs.some((config) => config.connectionId);
+  const { mutateAsync: importVaultSecrets } = useImportVaultSecrets();
   const prevPageSize = useRef(0);
 
   const canReadCommits = permission.can(
@@ -544,7 +557,8 @@ export const OverviewPage = () => {
     "deleteDynamicSecret",
     "snapshots",
     "deleteSecretImport",
-    "addSecretImport"
+    "addSecretImport",
+    "importFromVault"
   ] as const);
 
   const handleViewCommitHistory = async (envSlug: string, preloadedFolderId?: string) => {
@@ -580,6 +594,28 @@ export const OverviewPage = () => {
 
   const handleAddSecretImport = () => {
     handlePopUpOpen("addSecretImport");
+  };
+
+  const handleVaultImport = async (vaultPath: string, namespace: string) => {
+    const result = await importVaultSecrets({
+      projectId,
+      environment: singleEnvSlug,
+      secretPath,
+      vaultNamespace: namespace,
+      vaultSecretPath: vaultPath
+    });
+
+    if (result.status === VaultImportStatus.ApprovalRequired) {
+      createNotification({
+        type: "info",
+        text: "Secret change request created successfully. Awaiting approval."
+      });
+    } else {
+      createNotification({
+        type: "success",
+        text: "Successfully imported secrets from HashiCorp Vault"
+      });
+    }
   };
 
   const handleFolderCreate = async (folderName: string, description: string | null) => {
@@ -1362,6 +1398,9 @@ export const OverviewPage = () => {
                     onAddSecretImport={handleAddSecretImport}
                     isSecretImportAvailable={userAvailableSecretImportEnvs.length > 0}
                     isSingleEnvSelected={isSingleEnvView}
+                    hasVaultConnection={hasVaultConnection}
+                    isOrgAdmin={isOrgAdmin}
+                    onImportFromVault={() => handlePopUpOpen("importFromVault")}
                   />
                 )}
               </div>
@@ -1992,6 +2031,13 @@ export const OverviewPage = () => {
         projectId={projectId}
         secretPath={secretPath}
         initialParsedSecrets={importParsedSecrets}
+      />
+      <VaultSecretImportModal
+        isOpen={popUp.importFromVault.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("importFromVault", isOpen)}
+        environment={singleEnvSlug}
+        secretPath={secretPath}
+        onImport={handleVaultImport}
       />
       <AlertDialog
         open={popUp.deleteFolder.isOpen}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -30,10 +30,13 @@ type Props = {
   onAddSecretRotation: () => void;
   onAddSecretImport: () => void;
   onImportSecrets: () => void;
+  onImportFromVault: () => void;
   isDyanmicSecretAvailable: boolean;
   isSecretRotationAvailable: boolean;
   isSecretImportAvailable: boolean;
   isSingleEnvSelected: boolean;
+  hasVaultConnection: boolean;
+  isOrgAdmin: boolean;
 };
 
 export function AddResourceButtons({
@@ -43,10 +46,13 @@ export function AddResourceButtons({
   onAddSecretRotation,
   onAddSecretImport,
   onImportSecrets,
+  onImportFromVault,
   isDyanmicSecretAvailable,
   isSecretRotationAvailable,
   isSecretImportAvailable,
-  isSingleEnvSelected
+  isSingleEnvSelected,
+  hasVaultConnection,
+  isOrgAdmin
 }: Props) {
   return (
     <UnstableButtonGroup>
@@ -147,6 +153,42 @@ export function AddResourceButtons({
               </Tooltip>
             )}
           </ProjectPermissionCan>
+          {hasVaultConnection && (
+            <ProjectPermissionCan
+              I={ProjectPermissionActions.Create}
+              a={ProjectPermissionSub.Secrets}
+            >
+              {(isAllowed) => (
+                <Tooltip
+                  open={!isAllowed || !isOrgAdmin || !isSingleEnvSelected ? undefined : false}
+                >
+                  <TooltipTrigger className="block w-full">
+                    <UnstableDropdownMenuItem
+                      onClick={onImportFromVault}
+                      isDisabled={!isAllowed || !isOrgAdmin || !isSingleEnvSelected}
+                    >
+                      <div className="flex w-4.5 justify-center rounded-full bg-foreground/75">
+                        <img
+                          src="/images/integrations/Vault.png"
+                          alt="HashiCorp Vault"
+                          className="mt-0.5 h-4 w-4"
+                        />
+                      </div>
+                      Add from HashiCorp Vault
+                    </UnstableDropdownMenuItem>
+                  </TooltipTrigger>
+                  <TooltipContent side="left">
+                    {/* eslint-disable-next-line no-nested-ternary */}
+                    {!isOrgAdmin
+                      ? "Only organization admins can import secrets from HashiCorp Vault"
+                      : !isSingleEnvSelected
+                        ? "Select a single environment to import from HashiCorp Vault"
+                        : "Access Restricted"}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </ProjectPermissionCan>
+          )}
         </UnstableDropdownMenuContent>
       </UnstableDropdownMenu>
     </UnstableButtonGroup>


### PR DESCRIPTION
## Context

This PR adds the vault import functionality to the overview page 

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-03-03 at 17 02 15@2x" src="https://github.com/user-attachments/assets/21fa39bd-af0d-44c7-8de3-6826fd90f498" />

## Steps to verify the change

- verify the menu item properly displays when a config is available 
- verify disabled when more than one env is selected with tooltip
- verify import functionality works and invalidates dashboard query

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)