### PR TITLE
improvement: Add project name to secret approval notifications

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1623,6 +1623,7 @@ export const secretApprovalRequestServiceFactory = ({
     const cfg = getConfig();
     const approvalUrl = `${cfg.SITE_URL}${approvalPath}?requestId=${secretApprovalRequest.id}`;
 
+    const project = await projectDAL.findById(projectId);
     await triggerWorkflowIntegrationNotification({
       input: {
         projectId,
@@ -1633,6 +1634,7 @@ export const secretApprovalRequestServiceFactory = ({
             environment: env.name,
             secretPath,
             projectId,
+            projectName: project.name,
             requestId: secretApprovalRequest.id,
             secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretName) ?? []))],
             approvalUrl
@@ -2040,6 +2042,7 @@ export const secretApprovalRequestServiceFactory = ({
             environment: env.name,
             secretPath,
             projectId,
+            projectName: project.name,
             requestId: secretApprovalRequest.id,
             secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretKey) ?? []))],
             approvalUrl

--- a/backend/src/lib/workflow-integrations/types.ts
+++ b/backend/src/lib/workflow-integrations/types.ts
@@ -20,6 +20,7 @@ export type TNotification =
         secretPath: string;
         requestId: string;
         projectId: string;
+        projectName: string;
         secretKeys: string[];
         approvalUrl: string;
       };

--- a/backend/src/services/microsoft-teams/microsoft-teams-fns.ts
+++ b/backend/src/services/microsoft-teams/microsoft-teams-fns.ts
@@ -384,6 +384,10 @@ export const buildTeamsPayload = (orgId: string, notification: TNotification) =>
             type: "FactSet",
             facts: [
               {
+                title: "Project",
+                value: payload.projectName
+              },
+              {
                 title: "Environment",
                 value: payload.environment
               },

--- a/backend/src/services/slack/slack-fns.ts
+++ b/backend/src/services/slack/slack-fns.ts
@@ -49,6 +49,7 @@ const buildSlackPayload = (notification: TNotification) => {
     case TriggerFeature.SECRET_APPROVAL: {
       const { payload } = notification;
       const messageBody = `A secret approval request has been opened by ${payload.userEmail}.
+*Project*: ${payload.projectName}
 *Environment*: ${payload.environment}
 *Secret path*: ${payload.secretPath || "/"}
 *Secret Key${payload.secretKeys.length > 1 ? "s" : ""}*: ${payload.secretKeys.join(", ")}`;


### PR DESCRIPTION
## Context

Secret approval request notifications (Slack, Teams) didn't include the project name, making it hard to tell which project the request belongs to when you have multiple projects using one channel. Added `projectName` to the notification payload so it shows alongside environment, secret path, and secret keys.

## Steps to verify the change

1. Set up a Slack or Teams workflow integration for a project with an approval policy
2. Trigger a secret approval request
3. Confirm the notification now includes the project name

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
