### PR TITLE
feat(secrets-overview): overview page dynamic secret leases and notification reference

### DIFF
--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-queue.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-queue.ts
@@ -31,7 +31,7 @@ type TDynamicSecretLeaseQueueServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findById">;
   dynamicSecretProviders: Record<DynamicSecretProviders, TDynamicProviderFns>;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
-  folderDAL: Pick<TSecretFolderDALFactory, "findById">;
+  folderDAL: Pick<TSecretFolderDALFactory, "findById" | "findSecretPathByFolderIds">;
 };
 
 export type TDynamicSecretLeaseQueueServiceFactory = {
@@ -296,6 +296,9 @@ export const dynamicSecretLeaseQueueServiceFactory = ({
       const folder = await folderDAL.findById(lease.dynamicSecret.folderId);
       if (!folder) throw new NotFoundError({ message: `Failed to find folder with ${lease.dynamicSecret.folderId}` });
 
+      const [folderWithPath] = await folderDAL.findSecretPathByFolderIds(folder.projectId, [folder.id]);
+      const secretPath = folderWithPath?.path ?? "/";
+
       const project = await projectDAL.findById(folder.projectId);
       const projectMembers = await projectMembershipDAL.findAllProjectMembers(project.id);
 
@@ -308,7 +311,7 @@ export const dynamicSecretLeaseQueueServiceFactory = ({
         template: SmtpTemplates.DynamicSecretLeaseRevocationFailed,
         subjectLine: "Dynamic Secret Lease Revocation Failed",
         substitutions: {
-          dynamicSecretLeaseUrl: `${appCfg.SITE_URL}/organizations/${project.orgId}/projects/secret-management/${project.id}/secrets/${folder.environment.envSlug}?dynamicSecretId=${lease.dynamicSecret.id}&filterBy=dynamic&search=${lease.dynamicSecret.name}`,
+          dynamicSecretLeaseUrl: `${appCfg.SITE_URL}/organizations/${project.orgId}/projects/secret-management/${project.id}/overview?search=${encodeURIComponent(lease.dynamicSecret.name)}&secretPath=${encodeURIComponent(secretPath)}&environments=${folder.environment.envSlug}&filterBy=dynamic&dynamicSecretId=${lease.dynamicSecret.id}`,
           dynamicSecretName: lease.dynamicSecret.name,
           projectName: project.name,
           environmentSlug: folder.environment.envSlug,

--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-queue.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-queue.ts
@@ -146,7 +146,7 @@ export const secretRotationV2QueueServiceFactory = async ({
 
         const rotationType = SECRET_ROTATION_NAME_MAP[type as SecretRotation];
 
-        const rotationPath = `/organizations/${project.orgId}/projects/secret-management/${projectId}/secrets/${environment.slug}`;
+        const rotationPath = `/organizations/${project.orgId}/projects/secret-management/${projectId}/overview`;
 
         await notificationService.createUserNotifications(
           projectAdmins.map((admin) => ({
@@ -171,6 +171,7 @@ export const secretRotationV2QueueServiceFactory = async ({
             ).toISOString()}. Please check the rotation status in Infisical for more details.`,
             secretPath: folder.path,
             environment: environment.name,
+            environmentSlug: environment.slug,
             projectName: project.name,
             rotationUrl: encodeURI(`${appCfg.SITE_URL}${rotationPath}`)
           }

--- a/backend/src/services/smtp/emails/SecretRotationFailedTemplate.tsx
+++ b/backend/src/services/smtp/emails/SecretRotationFailedTemplate.tsx
@@ -10,6 +10,7 @@ interface SecretRotationFailedTemplateProps extends Omit<BaseEmailWrapperProps, 
   rotationUrl: string;
   projectName: string;
   environment: string;
+  environmentSlug: string;
   secretPath: string;
   content: string;
 }
@@ -21,6 +22,7 @@ export const SecretRotationFailedTemplate = ({
   projectName,
   siteUrl,
   environment,
+  environmentSlug,
   secretPath,
   content
 }: SecretRotationFailedTemplateProps) => {
@@ -44,7 +46,7 @@ export const SecretRotationFailedTemplate = ({
         <Text className="text-[14px] text-red-600 mt-[4px]">{content}</Text>
       </Section>
       <Section className="text-center">
-        <BaseButton href={`${rotationUrl}?search=${rotationName}&secretPath=${secretPath}`}>
+        <BaseButton href={`${rotationUrl}?search=${encodeURIComponent(rotationName)}&secretPath=${encodeURIComponent(secretPath)}&environments=${encodeURIComponent(environmentSlug)}&filterBy=rotation`}>
           View in Infisical
         </BaseButton>
       </Section>
@@ -61,6 +63,7 @@ SecretRotationFailedTemplate.PreviewProps = {
   projectName: "Example Project",
   secretPath: "/api/secrets",
   environment: "Production",
+  environmentSlug: "production",
   rotationName: "my-auth0-rotation",
   siteUrl: "https://infisical.com"
 } as SecretRotationFailedTemplateProps;

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -142,6 +142,7 @@ import { CreateSecretImportForm } from "../SecretDashboardPage/components/Action
 import { FolderForm } from "../SecretDashboardPage/components/ActionBar/FolderForm";
 import { VaultSecretImportModal } from "../SecretDashboardPage/components/ActionBar/VaultSecretImportModal";
 import { CreateDynamicSecretLease } from "../SecretDashboardPage/components/DynamicSecretListView/CreateDynamicSecretLease";
+import { DynamicSecretLease } from "../SecretDashboardPage/components/DynamicSecretListView/DynamicSecretLease";
 import { EditDynamicSecretForm } from "../SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm";
 import {
   HIDDEN_SECRET_VALUE,
@@ -207,7 +208,9 @@ export const OverviewPage = () => {
     select: (el) => ({
       secretPath: el.secretPath,
       search: el.search,
-      environments: el.environments
+      environments: el.environments,
+      dynamicSecretId: el.dynamicSecretId,
+      filterBy: el.filterBy
     })
   });
 
@@ -553,6 +556,7 @@ export const OverviewPage = () => {
     "reconcileSecretRotation",
     "importSecrets",
     "editDynamicSecret",
+    "dynamicSecretLeases",
     "createDynamicSecretLease",
     "deleteDynamicSecret",
     "snapshots",
@@ -560,6 +564,40 @@ export const OverviewPage = () => {
     "addSecretImport",
     "importFromVault"
   ] as const);
+
+  // Auto-open dynamic secret leases modal when linked via notification/email
+  useEffect(() => {
+    if (routerSearch.dynamicSecretId && dynamicSecrets?.length) {
+      const match = dynamicSecrets.find((ds) => ds.id === routerSearch.dynamicSecretId);
+      if (match) {
+        handlePopUpOpen("dynamicSecretLeases", match);
+        navigate({ search: (prev) => ({ ...prev, dynamicSecretId: undefined }), replace: true });
+      }
+    }
+  }, [routerSearch.dynamicSecretId, dynamicSecrets?.map((ds) => ds.id).join(",")]);
+
+  // Apply search and/or resource type filter when linked via notification/email
+  useEffect(() => {
+    if (routerSearch.search || routerSearch.filterBy) {
+      const { search, filterBy, ...query } = routerSearch;
+      // temp workaround until we transition state to query params
+      navigate({ search: query, replace: true });
+
+      const initialFilter = { ...DEFAULT_FILTER_STATE };
+      if (filterBy) {
+        const rowType = Object.values(RowType).find((rt) => rt === filterBy);
+        if (rowType) {
+          initialFilter[rowType] = true;
+        }
+      }
+      setFilter(initialFilter);
+
+      if (search) {
+        setSearchFilter(search as string);
+        setDebouncedSearchFilter(search as string);
+      }
+    }
+  }, [routerSearch.search, routerSearch.filterBy]);
 
   const handleViewCommitHistory = async (envSlug: string, preloadedFolderId?: string) => {
     if (!subscription?.pitRecovery) {
@@ -1017,7 +1055,10 @@ export const OverviewPage = () => {
       }
     }
 
-    const query: Record<string, string | string[]> = { ...routerSearch, search: searchFilter };
+    const query: Record<string, string | string[] | undefined> = {
+      ...routerSearch,
+      search: searchFilter
+    };
     const envIndex = visibleEnvs.findIndex((el) => slug === el.slug);
     if (envIndex !== -1) {
       navigate({
@@ -1121,19 +1162,6 @@ export const OverviewPage = () => {
 
     setSelectedEntries(newChecks);
   };
-
-  useEffect(() => {
-    if (routerSearch.search) {
-      const { search, ...query } = routerSearch;
-      // temp workaround until we transition state to query params
-      navigate({
-        search: query
-      });
-      setFilter(DEFAULT_FILTER_STATE);
-      setSearchFilter(routerSearch.search as string);
-      setDebouncedSearchFilter(routerSearch.search as string);
-    }
-  }, [routerSearch.search]);
 
   const selectedKeysCount = Object.keys(selectedEntries.secret).length;
 
@@ -1279,6 +1307,11 @@ export const OverviewPage = () => {
         <SecretV2MigrationSection />
       </div>
     );
+
+  const dynamicSecretLeaseData = popUp.dynamicSecretLeases?.data as
+    | (TDynamicSecret & { environment: string })
+    | undefined;
+
   return (
     <div className="">
       <Helmet>
@@ -1695,6 +1728,9 @@ export const OverviewPage = () => {
                                 onEdit={(dynamicSecret) =>
                                   handlePopUpOpen("editDynamicSecret", dynamicSecret)
                                 }
+                                onViewLeases={(dynamicSecret) =>
+                                  handlePopUpOpen("dynamicSecretLeases", dynamicSecret)
+                                }
                                 onGenerateLease={(dynamicSecret) =>
                                   handlePopUpOpen("createDynamicSecretLease", dynamicSecret)
                                 }
@@ -1873,6 +1909,36 @@ export const OverviewPage = () => {
         environments={userAvailableDynamicSecretEnvs}
         secretPath={secretPath}
       />
+      <Modal
+        isOpen={popUp.dynamicSecretLeases.isOpen}
+        onOpenChange={(state) => handlePopUpToggle("dynamicSecretLeases", state)}
+      >
+        <ModalContent
+          title={
+            <div className="flex items-center space-x-2">
+              <p>Dynamic secret leases</p>
+              <Badge variant="neutral">{dynamicSecretLeaseData?.name}</Badge>
+            </div>
+          }
+          subTitle="Revoke or renew your secret leases"
+          className="max-w-3xl"
+        >
+          {dynamicSecretLeaseData && (
+            <DynamicSecretLease
+              dynamicSecret={dynamicSecretLeaseData}
+              onClickNewLease={() =>
+                handlePopUpOpen("createDynamicSecretLease", dynamicSecretLeaseData)
+              }
+              onClose={() => handlePopUpClose("dynamicSecretLeases")}
+              projectSlug={projectSlug}
+              key={dynamicSecretLeaseData.id}
+              dynamicSecretName={dynamicSecretLeaseData.name}
+              secretPath={secretPath}
+              environment={dynamicSecretLeaseData.environment}
+            />
+          )}
+        </ModalContent>
+      </Modal>
       <Modal
         isOpen={popUp.editDynamicSecret.isOpen}
         onOpenChange={(state) => handlePopUpToggle("editDynamicSecret", state)}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
@@ -5,6 +5,7 @@ import {
   EditIcon,
   FileKeyIcon,
   FingerprintIcon,
+  ListIcon,
   TrashIcon,
   XIcon
 } from "lucide-react";
@@ -73,6 +74,7 @@ type Props = {
   secretPath: string;
   onEdit: (dynamicSecret: DynamicSecretWithEnv) => void;
   onGenerateLease: (dynamicSecret: DynamicSecretWithEnv) => void;
+  onViewLeases: (dynamicSecret: DynamicSecretWithEnv) => void;
   onDelete: (dynamicSecret: DynamicSecretWithEnv) => void;
   onForceDelete: (dynamicSecret: DynamicSecretWithEnv) => void;
 };
@@ -87,6 +89,7 @@ export const DynamicSecretTableRow = ({
   secretPath,
   onEdit,
   onGenerateLease,
+  onViewLeases,
   onDelete,
   onForceDelete
 }: Props) => {
@@ -127,6 +130,34 @@ export const DynamicSecretTableRow = ({
 
     return (
       <div className="flex items-center transition-all duration-500 group-hover:ml-2 group-hover:space-x-1.5">
+        <ProjectPermissionCan
+          I={ProjectPermissionDynamicSecretActions.Lease}
+          a={subject(ProjectPermissionSub.DynamicSecrets, {
+            environment: dynamicSecret.environment,
+            secretPath,
+            metadata: dynamicSecret.metadata
+          })}
+        >
+          {(isAllowed) => (
+            <Tooltip>
+              <TooltipTrigger>
+                <UnstableIconButton
+                  variant="ghost"
+                  size="xs"
+                  className="w-0 overflow-hidden border-0 opacity-0 group-hover:w-7 group-hover:opacity-100"
+                  isDisabled={!isAllowed || isRevoking}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onViewLeases(dynamicSecret);
+                  }}
+                >
+                  <ListIcon />
+                </UnstableIconButton>
+              </TooltipTrigger>
+              <TooltipContent>View Leases</TooltipContent>
+            </Tooltip>
+          )}
+        </ProjectPermissionCan>
         <ProjectPermissionCan
           I={ProjectPermissionDynamicSecretActions.Lease}
           a={subject(ProjectPermissionSub.DynamicSecrets, {

--- a/frontend/src/pages/secret-manager/OverviewPage/route.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/route.tsx
@@ -9,7 +9,9 @@ const SecretOverviewPageQuerySchema = z.object({
   secretPath: z.string().catch("/"),
   connectionId: z.string().optional(),
   connectionName: z.string().optional(),
-  environments: z.array(z.string()).catch([])
+  environments: z.array(z.string()).catch([]),
+  dynamicSecretId: z.string().optional(),
+  filterBy: z.string().optional()
 });
 
 export const Route = createFileRoute(


### PR DESCRIPTION
## Context

This PR adds dynamic secret lease modal to the overview page and updates dynamic secret and secret rotation notifications to reference and resolve on the secret overview page

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-03-04 at 14 29 03@2x" src="https://github.com/user-attachments/assets/0fc5ac2b-bb87-4766-b08b-5e0244ad5f01" />

<img width="3456" height="1920" alt="CleanShot 2026-03-04 at 14 29 28@2x" src="https://github.com/user-attachments/assets/4c7df4be-fe9c-4044-af80-c6765f56b8ec" />


## Steps to verify the change

- verify you can access dynamic secret leases in both single env and multi env view
- verify dynamic secret lease revocation failure email links to and resolves properly on the overview page
- verify secret rotation failure email links to and resolves properly on overview page

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)