### PR TITLE
feat: add redact secret functionality to the overview page and update redacted display

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretVersionHistory.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretVersionHistory.tsx
@@ -193,58 +193,42 @@ function VersionItem({
   };
 
   const handleRestore = async () => {
-    try {
-      // For redacted versions, restore with empty string
-      const value = version.isRedacted ? "" : await handleFetchSecretValue();
+    // For redacted versions, restore with empty string
+    const value = version.isRedacted ? "" : await handleFetchSecretValue();
 
-      const result = await updateSecret({
-        projectId: currentProject.id,
-        environment,
-        secretPath,
-        secretKey,
-        secretValue: value,
-        type: SecretType.Shared
-      });
+    const result = await updateSecret({
+      projectId: currentProject.id,
+      environment,
+      secretPath,
+      secretKey,
+      secretValue: value,
+      type: SecretType.Shared
+    });
 
-      if ("approval" in result) {
-        createNotification({
-          type: "info",
-          text: "Requested change has been sent for review"
-        });
-      } else {
-        createNotification({
-          type: "success",
-          text: `Secret restored to version ${version.version}`
-        });
-      }
-
-      setIsRestoreDialogOpen(false);
-      onRestoreSuccess();
-    } catch (e) {
-      console.error(e);
+    if ("approval" in result) {
       createNotification({
-        type: "error",
-        text: "Failed to restore secret version"
+        type: "info",
+        text: "Requested change has been sent for review"
+      });
+    } else {
+      createNotification({
+        type: "success",
+        text: `Secret restored to version ${version.version}`
       });
     }
+
+    setIsRestoreDialogOpen(false);
+    onRestoreSuccess();
   };
 
   const handleRedact = async () => {
-    try {
-      await redactSecretValue({ versionId: version.id, secretId });
-      createNotification({
-        type: "success",
-        text: "The secret value has been redacted successfully and is no longer persisted or viewable."
-      });
-      setIsRedactDialogOpen(false);
-      onRestoreSuccess();
-    } catch (e) {
-      console.error(e);
-      createNotification({
-        type: "error",
-        text: "Failed to redact secret version"
-      });
-    }
+    await redactSecretValue({ versionId: version.id, secretId });
+    createNotification({
+      type: "success",
+      text: "The secret value has been redacted successfully and is no longer persisted or viewable."
+    });
+    setIsRedactDialogOpen(false);
+    onRestoreSuccess();
   };
 
   return (


### PR DESCRIPTION
## Context

This PR adds redact secret functionality to the version history sheet on the overview page and updates the display of redacted secrets

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-03-05 at 14 38 20@2x" src="https://github.com/user-attachments/assets/6bba79be-aab7-45d1-bc91-d5e9b8641411" />

## Steps to verify the change

- Verify redacted secrets display correctly
- verify you can redact secrets

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)