### PR TITLE
fix: change encryption key from .env.dev.example to have a 32 bytes size

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,7 +1,7 @@
 # Keys
 # Required key for platform encryption/decryption ops
 # THIS IS A SAMPLE ENCRYPTION KEY AND SHOULD NEVER BE USED FOR PRODUCTION
-ENCRYPTION_KEY=VVHnGZ0w98WLgISK4XSJcagezuG6EWRFTk48KE4Y5Mw=
+ENCRYPTION_KEY=f13dbc92aaaf86fa7cb0ed8ac3265f47
 
 # JWT
 # Required secrets to sign JWT tokens


### PR DESCRIPTION
## Context

I tried to execute the README locally, but I was always getting the following error, which is caused because of the length of the key:

<img width="2112" height="334" alt="image" src="https://github.com/user-attachments/assets/aa3f6b84-344c-485b-a7a8-f6def20c1274" />

But if I change the .env value to use a 32 bytes `ENCRYPTION_KEY`, it works flawlessly. I changed the `.env.dev.example` to use the same from `.env.example`. This change is more of a quality of life for new users that want to try the platform locally. 


## Steps to verify the change
- Change the .env to use a 32 bytes `ENCRYPTION_KEY`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)