### PR TITLE
chore: order secrets for batch endpoint

### DIFF
--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -1043,6 +1043,10 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const { environment, secretPath, secrets: inputSecrets } = req.body;
+
+      // Sort by secretKey to ensure consistent lock ordering and prevent deadlocks
+      const sortedSecrets = [...inputSecrets].sort((a, b) => a.secretKey.localeCompare(b.secretKey));
+
       const secretOperation = await server.services.secret.updateManySecretsRaw({
         actorId: req.permission.id,
         actor: req.permission.type,
@@ -1051,7 +1055,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         secretPath,
         environment,
         projectId: req.body.projectId,
-        secrets: inputSecrets,
+        secrets: sortedSecrets,
         mode: req.body.mode
       });
       if (secretOperation.type === SecretProtectionType.Approval) {
@@ -1195,6 +1199,10 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const { environment, secretPath, secrets: inputSecrets } = req.body;
+
+      // Sort by secretKey to ensure consistent lock ordering and prevent deadlocks
+      const sortedSecrets = [...inputSecrets].sort((a, b) => a.secretKey.localeCompare(b.secretKey));
+
       const secretOperation = await server.services.secret.deleteManySecretsRaw({
         actorId: req.permission.id,
         actor: req.permission.type,
@@ -1203,7 +1211,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         environment,
         secretPath,
         projectId: req.body.projectId,
-        secrets: inputSecrets
+        secrets: sortedSecrets
       });
       if (secretOperation.type === SecretProtectionType.Approval) {
         await server.services.auditLog.createAuditLog({
@@ -1217,7 +1225,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
               secretApprovalRequestSlug: secretOperation.approval.slug,
               secretPath,
               environment,
-              secrets: inputSecrets.map((secret) => ({
+              secrets: sortedSecrets.map((secret) => ({
                 secretKey: secret.secretKey
               })),
               eventType: SecretApprovalEvent.DeleteMany


### PR DESCRIPTION
## Context
Add ordering for secrets for the BATCH endpoint to prevent deadlock

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)