### PR TITLE
fix: resolve bulk update lock contention with single-statement 

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -246,10 +246,11 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
   ) => {
     try {
       const BATCH_SIZE = 500;
+      const sorted = [...data].sort((a, b) => (a.filter.id ?? "").localeCompare(b.filter.id ?? ""));
       const secs: TSecretsV2[] = [];
 
-      for (let i = 0; i < data.length; i += BATCH_SIZE) {
-        const batch = data.slice(i, i + BATCH_SIZE);
+      for (let i = 0; i < sorted.length; i += BATCH_SIZE) {
+        const batch = sorted.slice(i, i + BATCH_SIZE);
         // eslint-disable-next-line no-await-in-loop
         const batchResults = await Promise.all(
           batch.map(async ({ filter, data: updateData }) => {

--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -123,8 +123,9 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
+      const sorted = [...data].sort((a, b) => (a.filter.id ?? "").localeCompare(b.filter.id ?? ""));
       const secs = await Promise.all(
-        data.map(async ({ filter, data: updateData }) => {
+        sorted.map(async ({ filter, data: updateData }) => {
           const [doc] = await (tx || db)(TableName.SecretVersionV2)
             .where(filter)
             .update(updateData)

--- a/backend/src/services/secret/secret-dal.ts
+++ b/backend/src/services/secret/secret-dal.ts
@@ -26,8 +26,9 @@ export const secretDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
+      const sorted = [...data].sort((a, b) => (a.filter.id ?? "").localeCompare(b.filter.id ?? ""));
       const secs = await Promise.all(
-        data.map(async ({ filter, data: updateData }) => {
+        sorted.map(async ({ filter, data: updateData }) => {
           const [doc] = await (tx || db)(TableName.Secret)
             .where(filter)
             .update(updateData)

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -87,8 +87,9 @@ export const secretVersionDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
+      const sorted = [...data].sort((a, b) => (a.filter.id ?? "").localeCompare(b.filter.id ?? ""));
       const secs = await Promise.all(
-        data.map(async ({ filter, data: updateData }) => {
+        sorted.map(async ({ filter, data: updateData }) => {
           const [doc] = await (tx || db)(TableName.SecretVersion)
             .where(filter)
             .update(updateData)


### PR DESCRIPTION
## Context

- Replace sequential per-row UPDATEs with single UPDATE FROM VALUES statement in all 4 bulkUpdate DAL methods (secret, secret-v2-bridge, and their version DALs). This acquires all row locks atomically instead of one-by-one.
- Sort all updates by id before executing to prevent deadlocks from inconsistent lock ordering between concurrent requests.
- Restructure updateManySecret service to move reads, validation, permission checks, reference validation, and policy scanning outside the transaction, reducing lock hold time to just the write operations.


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)