### PR TITLE
fix: resolved template discriminated union error

### DIFF
--- a/frontend/src/hooks/api/projectTemplates/queries.tsx
+++ b/frontend/src/hooks/api/projectTemplates/queries.tsx
@@ -54,7 +54,15 @@ export const useGetProjectTemplateById = (
         `/api/v1/project-templates/${templateId}`
       );
 
-      return data.projectTemplate;
+      // This is because we removed secret-events to another permission subject. This was breaking template
+      const formattedTemplate = {
+        ...data.projectTemplate,
+        roles: data.projectTemplate.roles.map((role) => ({
+          ...role,
+          permissions: role.permissions.filter((perm) => perm.subject !== "secret-events")
+        }))
+      };
+      return formattedTemplate;
     },
     ...options
   });


### PR DESCRIPTION
## Context

This PR fixes the project template edit functionality broken due to previous rename we made for `secret-events` to `secret-event-subscriptions` . To fix this - we just filter out `secrets-events` from template before using it in UI. This is ok because secret-events was not used by anyone. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)