### PR TITLE
docs: add Node.js version requirements for Node.js SDK v5

### DIFF
--- a/docs/sdks/languages/node.mdx
+++ b/docs/sdks/languages/node.mdx
@@ -12,8 +12,8 @@ Starting from **v5**, the Node.js SDK requires **Node.js 20 or higher**.
 
 | SDK version | Node.js version |
 |-------------|-----------------|
-| >= v5       | >= 20           |
-| <= v4       | >= 14           |
+| `>= v5`     | `>= 20`         |
+| `<= v4`     | `>= 14`         |
 
 ## Deprecation Notice
 


### PR DESCRIPTION
## Context

The Node.js SDK v5 bumped AWS SDK dependencies (`@aws-sdk/credential-providers`, `@smithy/protocol-http`, `@smithy/signature-v4`) which require Node.js 20 or higher. This PR documents the Node.js version requirements per SDK version.

## Screenshots

<img width="917" height="352" alt="image" src="https://github.com/user-attachments/assets/5565dc19-62f7-4b8f-9fea-0fb3aaf1b79f" />

## Steps to verify the change

- [ ] Check the Node.js SDK docs page renders the requirements table correctly.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)