### PR TITLE
chore(docs): fix infisical agent item pointing to wrong page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3185,7 +3185,7 @@
         "items": [
           {
             "label": "Infisical Agent",
-            "href": "https://infisical.com/docs/documentation/getting-started/introduction"
+            "href": "https://infisical.com/docs/integrations/platforms/infisical-agent"
           },
           {
             "label": "Infisical Proxy",


### PR DESCRIPTION
## Context

Infisical Agent item under `USE CASES` in doc's footer is pointing to Getting Started page instead. This correctly points it to the Agent's page.

## Screenshots

<img width="523" height="332" alt="image" src="https://github.com/user-attachments/assets/a734d848-4109-4c78-bc33-7bce23ce2b2a" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)