### PR TITLE
fix: move secrets should now include tags

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -2880,7 +2880,8 @@ export const secretV2BridgeServiceFactory = ({
           tx
         );
 
-        const commits = locallyCreatedSecrets.concat(locallyUpdatedSecrets).map((doc) => {
+        const secretsForApproval = locallyCreatedSecrets.concat(locallyUpdatedSecrets);
+        const commits = secretsForApproval.map((doc) => {
           const { operation } = doc;
           const localSecret = destinationSecretsGroupedByKey[doc.key]?.[0];
 
@@ -2911,7 +2912,18 @@ export const secretV2BridgeServiceFactory = ({
               : {})
           };
         });
-        await secretApprovalRequestSecretDAL.insertV2Bridge(commits, tx);
+        const approvalCommits = await secretApprovalRequestSecretDAL.insertV2Bridge(commits, tx);
+
+        const approvalCommitsGroupedByKey = groupBy(approvalCommits, (i) => i.key);
+        const approvalSecretTags = secretsForApproval.flatMap((doc) =>
+          doc.tags.map((tag) => ({
+            secretId: approvalCommitsGroupedByKey[doc.key][0].id,
+            tagId: tag.id
+          }))
+        );
+        if (approvalSecretTags.length) {
+          await secretApprovalRequestSecretDAL.insertApprovalSecretV2Tags(approvalSecretTags, tx);
+        }
       } else {
         // apply changes directly
         let createdSecrets: { id: string; key: string }[] = [];
@@ -2946,7 +2958,8 @@ export const secretV2BridgeServiceFactory = ({
                   value: value || undefined,
                   encryptedValue: encryptedValue || undefined
                 })) as { key: string; value?: string; encryptedValue?: Buffer }[] | undefined,
-                references: doc.value ? getAllSecretReferences(doc.value).nestedReferences : []
+                references: doc.value ? getAllSecretReferences(doc.value).nestedReferences : [],
+                tagIds: doc.tags.map((tag) => tag.id)
               };
             })
           });
@@ -2982,6 +2995,7 @@ export const secretV2BridgeServiceFactory = ({
                     value,
                     encryptedValue
                   })) as { key: string; value?: string; encryptedValue?: Buffer }[] | undefined,
+                  tags: doc.tags.map((tag) => tag.id),
                   ...(doc.encryptedValue
                     ? {
                         encryptedValue: doc.encryptedValue,


### PR DESCRIPTION
## Context
This PR ensures that moving secrets would include the appropriate tags

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)