### PR TITLE
improvement: use commit endpoint to batch folder deletion from overview

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
@@ -148,7 +148,7 @@ export const SelectionPanel = ({
               secrets: [],
               folders: folderDeletes
             },
-            message: ""
+            message: `Deleted ${folderDeletes.length} folder${folderDeletes.length === 1 ? "" : "s"}`
           });
         }
       }


### PR DESCRIPTION
## Context

This PR updates the overview page bulk selection to use the commit endpoint to batch folder deletion instead of making individual API calls

## Screenshots

N/A

## Steps to verify the change

- Ensure bulk folder deletion works properly and one request per environment is posted

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)