### PR TITLE
fix(frontend): correct committed label typo in commit details

### DIFF
--- a/frontend/src/pages/secret-manager/CommitDetailsPage/components/CommitDetailsTab/CommitDetailsTab.tsx
+++ b/frontend/src/pages/secret-manager/CommitDetailsPage/components/CommitDetailsTab/CommitDetailsTab.tsx
@@ -269,7 +269,7 @@ export const CommitDetailsTab = ({
         description={
           <div className="flex items-center gap-2">
             <div>
-              Commited by {actorDisplay === ActorType.PLATFORM ? "Platform" : actorDisplay} on{" "}
+              Committed by {actorDisplay === ActorType.PLATFORM ? "Platform" : actorDisplay} on{" "}
               {formatDisplayDate(
                 parsedCommitDetails.changes?.createdAt || new Date().toISOString()
               )}


### PR DESCRIPTION
## Context

This fixes a user-facing typo in the Secret Manager commit details view.

Before this change, the commit metadata text displayed `Commited by ... on ...`.
After this change, it correctly displays `Committed by ... on ...`.

## Screenshots
| Before    | After     |
|-----------|-----------|
| <img width="3004" height="1910" alt="image" src="https://github.com/user-attachments/assets/490575b0-e34d-4342-9551-899eb63b4b3a" /> | <img width="3010" height="1874" alt="image" src="https://github.com/user-attachments/assets/c1fbf37d-44af-4334-ab3c-3fd86bdcb5f4" /> |

## Steps to verify the change

1. Run the app locally.
2. Open a Secret Management project.
3. Navigate to a commit details page:
   `/organizations/<orgId>/projects/secret-management/<projectId>/commits/<environment>/<folderId>/<commitId>`
4. Confirm the metadata text now reads `Committed by ... on ...`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
