### PR TITLE
fix: bdd tests timeout

### DIFF
--- a/.github/workflows/run-backend-bdd-tests.yml
+++ b/.github/workflows/run-backend-bdd-tests.yml
@@ -14,7 +14,7 @@ jobs:
   run-backend-bdd-tests:
     name: Run BDD tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Free up disk space
         run: |


### PR DESCRIPTION
## Context

Most PR's checks fail due to the BDD tests timing out. Increasing the job timeout to 30 minutes should do the trick.

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)