### PR TITLE
fix: allow string for scim user response active property

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -25,7 +25,7 @@ const ScimUserSchema = z.object({
     )
     .optional(),
   displayName: z.string().trim(),
-  active: z.boolean()
+  active: z.union([z.boolean(), z.string().transform((v) => v.toLowerCase() === "true")])
 });
 
 const ScimGroupSchema = z.object({


### PR DESCRIPTION
## Context

This PR updates the SCIM user response schema active property to allow string

## Screenshots

N/A

## Steps to verify the change

- set up scim (tested with azure) and  add/remove a user from provisioning users, the patch request updating activity will be processed but the response will throw a zod error

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)