### PR TITLE
fix(frontend): guard window.__toCdnUrl against SES lockdown and script load failures

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,7 @@
   "
     />
     <title>Infisical</title>
+    <script>window.__toCdnUrl = function(f) { return "/" + f; };</script>
     <script src="/runtime-ui-env.js"></script>
   </head>
   <body>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -55,9 +55,10 @@ export default defineConfig(({ mode }) => {
     experimental: {
       renderBuiltUrl(filename, { hostType }) {
         if (hostType === "js") {
-          return { runtime: `window.__toCdnUrl(${JSON.stringify(filename)})` };
+          const fallback = `function(f){ return "/" + f; }`;
+          const fn = `(typeof window.__toCdnUrl === "function" ? window.__toCdnUrl : ${fallback})`;
+          return { runtime: `${fn}(${JSON.stringify(filename)})` };
         }
-
         return { relative: true };
       }
     },


### PR DESCRIPTION
## Context

Fixes #5675

Self-hosted deployments on Helm chart v1.7.4 / app v0.158.x show a blank white screen:

```
Uncaught TypeError: window.__toCdnUrl is not a function
```

Vite's `experimental.renderBuiltUrl` bakes bare `window.__toCdnUrl(filename)` calls into every compiled JS chunk. `window.__toCdnUrl` is defined at runtime by `/runtime-ui-env.js`, but if it's unavailable when chunks evaluate — due to SES lockdown from browser extensions (MetaMask etc.), a load race, or a fetch failure — every dynamic import throws and the app fails to render.

**Fix — two small changes:**

- **`vite.config.ts`**: Add an inline fallback in `renderBuiltUrl` so chunks fall back to `"/" + filename` if `window.__toCdnUrl` is not a function. Infisical Cloud is unaffected — the CDN path works as before when the function is defined.
- **`index.html`**: Add a synchronous inline `<script>` before `runtime-ui-env.js` that sets a safe default. `runtime-ui-env.js` overwrites it with the real CDN-aware implementation when it loads. No CSP changes needed — `'unsafe-inline'` is already present.

## Screenshots

N/A

## Steps to verify the change

1. Deploy using `infisical-standalone` Helm chart v1.7.4 — confirm UI loads normally
2. Locally: run `npx vite build && npx vite preview`, open DevTools, set `window.__toCdnUrl = undefined` and confirm the app falls back gracefully
3. Confirm Infisical Cloud CDN path is unchanged when `window.__toCdnUrl` is defined

## Type
- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist
- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix(frontend): guard window.__toCdnUrl against undefined to fix self-hosted blank screen`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)