### PR TITLE
fix(frontend): make modal cancel actions close tax and revocation dialogs

### DIFF
--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateRevocationModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateRevocationModal.tsx
@@ -3,7 +3,15 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Modal, ModalContent, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  FormControl,
+  Modal,
+  ModalClose,
+  ModalContent,
+  Select,
+  SelectItem
+} from "@app/components/v2";
 import { useProject } from "@app/context";
 import { useRevokeCert } from "@app/hooks/api";
 import { crlReasons } from "@app/hooks/api/certificates/constants";
@@ -112,9 +120,11 @@ export const CertificateRevocationModal = ({ popUp, handlePopUpToggle }: Props) 
             >
               Revoke
             </Button>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
+            <ModalClose asChild>
+              <Button colorSchema="secondary" variant="plain">
+                Cancel
+              </Button>
+            </ModalClose>
           </div>
         </form>
       </ModalContent>

--- a/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/TaxIDModal.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/TaxIDModal.tsx
@@ -8,6 +8,7 @@ import {
   FormControl,
   Input,
   Modal,
+  ModalClose,
   ModalContent,
   Select,
   SelectItem
@@ -163,9 +164,11 @@ export const TaxIDModal = ({ popUp, handlePopUpClose, handlePopUpToggle }: Props
             >
               Add
             </Button>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
+            <ModalClose asChild>
+              <Button colorSchema="secondary" variant="plain">
+                Cancel
+              </Button>
+            </ModalClose>
           </div>
         </form>
       </ModalContent>


### PR DESCRIPTION
Fixes #5725 

## Context

This PR fixes inconsistent Cancel button behavior in two modals where clicking **Cancel** did not close the modal.

### Problem
Some modals use `ModalClose` (or explicit close handlers), while these two used a plain `Button` without close logic:
- `frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/TaxIDModal.tsx`
- `frontend/src/pages/cert-manager/CertificatesPage/components/CertificateRevocationModal.tsx`

### Before
Clicking **Cancel** in these modals did nothing.

### After
Both Cancel buttons are wrapped with `ModalClose asChild`, so they now close the modal and correctly trigger existing modal close lifecycle (`onOpenChange`), including cleanup/reset behavior.

### Scope
- No API/backend changes
- No visual changes
- Behavior-only fix for modal close actions

## Screenshots

### Tax ID Modal Cancel

**Before**
<video src="https://github.com/user-attachments/assets/810594c1-5c63-4d72-8089-37099687e416" controls muted playsinline width="960"></video>

**After**
<video src="https://github.com/user-attachments/assets/7e6a1a52-9215-4d7d-af6a-5bd6c00344f7" controls muted playsinline width="960"></video>

### Certificate Revocation Modal Cancel

**Before**
<video src="https://github.com/user-attachments/assets/d3cb605f-21c4-49e1-b7a2-31dd9bc022d3" controls muted playsinline width="960"></video>

**After**
<video src="https://github.com/user-attachments/assets/bf150c99-85e5-404e-9801-96f5c9a83413" controls muted playsinline width="960"></video>

## Steps to verify the change

1. Open Billing page: `/organizations/:orgId/billing`.
2. Go to **Billing details** tab.
3. In **Tax ID** section, click **Add method** to open modal.
4. Click **Cancel**.
5. Confirm modal closes.
6. Open Cert Manager project.
7. Open a certificate row action menu and click **Revoke Certificate**.
8. In the revoke modal, click **Cancel**.
9. Confirm modal closes.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
