### PR TITLE
improvement: default to first env in new projects

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -390,7 +390,7 @@ const OverviewPageContent = () => {
 
   const [storedEnvIds, setStoredEnvIds] = useLocalStorageState<string[]>(
     `overview-selected-envs-${projectId}`,
-    []
+    userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Context

This PR updates the environment select to default to the first available env when opening a project for the first time

## Screenshots

N/A

## Steps to verify the change

- create new project, verify dev is selected
- change env selection, refresh and verify the change persisted

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)