### PR TITLE
fix: send new device login email only after MFA verification

### DIFF
--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -146,8 +146,10 @@ export const authLoginServiceFactory = ({
   };
 
   /*
-   * Check user device and send mail if new device
-   * generate the auth and refresh token. fn shared by mfa verification and login verification with mfa disabled
+   * Generate the auth and refresh token.
+   * Shared by mfa verification, login verification with mfa disabled, and select organization.
+   * Note: device tracking (updateUserDeviceSession) is intentionally NOT called here —
+   * it must only run after full authentication (including MFA) is complete.
    */
   const generateUserTokens = async (
     {
@@ -172,7 +174,6 @@ export const authLoginServiceFactory = ({
     tx?: Knex
   ) => {
     const cfg = getConfig();
-    await updateUserDeviceSession(user, ip, userAgent, tx);
     const tokenSession = await tokenService.getUserTokenSession(
       {
         userAgent,
@@ -662,6 +663,8 @@ export const authLoginServiceFactory = ({
 
       return { isMfaEnabled: true, mfa: mfaToken, mfaMethod } as const;
     }
+
+    await updateUserDeviceSession(user as TUsers, ipAddress, userAgent);
 
     const tokens = await generateUserTokens({
       authMethod: decodedToken.authMethod,


### PR DESCRIPTION
## Summary

The "Successful login from new device" email and in-app notification were being sent **before MFA was completed**, causing users to receive false login alerts when only the password step had passed.

### Root cause

In Oct 2024 ([`8da2213`](https://github.com/Infisical/infisical/commit/8da2213bf1)), MFA verification was moved from `loginExchangeClientProof` into `selectOrganization` to support org-level MFA enforcement. However, `updateUserDeviceSession` (which sends the new device email) remained inside `generateUserTokens` — a shared function called during the initial login step, **before** `selectOrganization` and MFA are ever reached.

### Fix

- Removed `updateUserDeviceSession` from `generateUserTokens`
- Added it to `selectOrganization`, **after** the MFA gate — the only point where full authentication (password + MFA) is guaranteed complete

This also has the side benefit of no longer sending unnecessary device emails during token refresh (org deletion) and initial server setup, where they were never appropriate.

## Test plan

- [ ] Login with MFA enabled from a new device → verify email is sent only **after** MFA succeeds
- [ ] Login without MFA from a new device → verify email is still sent on org selection
- [ ] Login from a known device → verify no email is sent
- [ ] CLI login (browser flow) → verify device email is sent after org selection
- [ ] SSO login → verify device email is sent after org selection


Made with [Cursor](https://cursor.com)