### PR TITLE
fix(auth): skip OIDC re-auth redirect when user is already authenticated via OIDC

### DIFF
--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgSection.tsx
@@ -127,9 +127,11 @@ export const SelectOrganizationSection = () => {
             }
           }
         } else if (organization.orgAuthMethod === AuthMethod.OIDC) {
-          url = `/api/v1/sso/oidc/login?orgSlug=${organization.slug}${
-            callbackPort ? `&callbackPort=${callbackPort}` : ""
-          }`;
+          if (authToken.authMethod !== AuthMethod.OIDC) {
+            url = `/api/v1/sso/oidc/login?orgSlug=${organization.slug}${
+              callbackPort ? `&callbackPort=${callbackPort}` : ""
+            }`;
+          }
         } else if (organization.orgAuthMethod === AuthMethod.SAML) {
           if (
             !SAML_AUTH_METHODS.includes(authToken.authMethod as (typeof SAML_AUTH_METHODS)[number])


### PR DESCRIPTION
## Summary

- Users logged in via OIDC on an OIDC-enforced org were hitting a `Failed to find refresh token` error when selecting their organization
- Root cause: `SelectOrgSection` was unconditionally setting a redirect URL back to the OIDC login for any OIDC-enforced org, regardless of the user's current auth method
- The Google and SAML branches both guard against this (only redirect if the user is *not* already using the required auth method), but the OIDC branch was missing this guard entirely
- Fix: add the same `authToken.authMethod !== AuthMethod.OIDC` check so already-OIDC-authenticated users skip the redirect and proceed directly to `selectOrganization`

**Why `Failed to find refresh token`?**
The redirect path calls `logout.mutateAsync()` before navigating to the OIDC IdP. Logout requires the `jid` refresh token cookie, which is only set *after* `selectOrganization` succeeds. Since the user never reached `selectOrganization` (intercepted by the unconditional OIDC redirect), `jid` was never set, causing the logout call to fail with that error.

**Why only OIDC and not SAML/Google?**
Unlike SAML which has multiple provider variants (`okta-saml`, `azure-saml`, etc.) covered by `SAML_AUTH_METHODS`, OIDC is a single `AuthMethod.OIDC` value — so a simple equality check is sufficient.

## Test plan

- [ ] Log in via OIDC on an org with SSO enforced + OIDC as the auth method — should land on the dashboard without errors
- [ ] Log in via a non-OIDC method on an OIDC-enforced org — should still be redirected to the OIDC IdP