### PR TITLE
feat: manual gateway health check trigger

### DIFF
--- a/backend/src/db/migrations/20260324152230_add-gateway-last-health-check-status.ts
+++ b/backend/src/db/migrations/20260324152230_add-gateway-last-health-check-status.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.GatewayV2, "lastHealthCheckStatus"))) {
+    await knex.schema.alterTable(TableName.GatewayV2, (t) => {
+      t.string("lastHealthCheckStatus").nullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.GatewayV2, "lastHealthCheckStatus")) {
+    await knex.schema.alterTable(TableName.GatewayV2, (t) => {
+      t.dropColumn("lastHealthCheckStatus");
+    });
+  }
+}

--- a/backend/src/db/schemas/gateways-v2.ts
+++ b/backend/src/db/schemas/gateways-v2.ts
@@ -19,7 +19,8 @@ export const GatewaysV2Schema = z.object({
   name: z.string(),
   heartbeat: z.date().nullable().optional(),
   encryptedPamSessionKey: zodBuffer.nullable().optional(),
-  healthAlertedAt: z.date().nullable().optional()
+  healthAlertedAt: z.date().nullable().optional(),
+  lastHealthCheckStatus: z.string().nullable().optional()
 });
 
 export type TGatewaysV2 = z.infer<typeof GatewaysV2Schema>;

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -13,7 +13,8 @@ const SanitizedGatewayV2Schema = GatewaysV2Schema.pick({
   name: true,
   createdAt: true,
   updatedAt: true,
-  heartbeat: true
+  heartbeat: true,
+  lastHealthCheckStatus: true
 });
 
 export const registerGatewayV2Router = async (server: FastifyZodProvider) => {

--- a/backend/src/ee/services/gateway-v2/gateway-v2-dal.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-dal.ts
@@ -5,6 +5,8 @@ import { GatewaysV2Schema, TableName, TGatewaysV2 } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 import { buildFindFilter, ormify, selectAllTableCols, TFindFilter, TFindOpt } from "@app/lib/knex";
 
+import { GatewayHealthCheckStatus } from "./gateway-v2-types";
+
 export type TGatewayV2DALFactory = ReturnType<typeof gatewayV2DalFactory>;
 
 export const gatewayV2DalFactory = (db: TDbClient) => {
@@ -26,7 +28,11 @@ export const gatewayV2DalFactory = (db: TDbClient) => {
 
       if (isHeartbeatStale) {
         const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-        void query.where(`${TableName.GatewayV2}.heartbeat`, "<", oneHourAgo);
+        void query.where((builder) => {
+          void builder
+            .where(`${TableName.GatewayV2}.heartbeat`, "<", oneHourAgo)
+            .orWhere(`${TableName.GatewayV2}.lastHealthCheckStatus`, GatewayHealthCheckStatus.Failed);
+        });
         void query.where((v) => {
           void v
             .whereNull(`${TableName.GatewayV2}.healthAlertedAt`)

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -34,7 +34,7 @@ import { TRelayDALFactory } from "../relay/relay-dal";
 import { TRelayServiceFactory } from "../relay/relay-service";
 import { GATEWAY_ACTOR_OID, GATEWAY_ROUTING_INFO_OID, PAM_INFO_OID } from "./gateway-v2-constants";
 import { TGatewayV2DALFactory } from "./gateway-v2-dal";
-import { TGatewayV2ConnectionDetails } from "./gateway-v2-types";
+import { GatewayHealthCheckStatus, TGatewayV2ConnectionDetails } from "./gateway-v2-types";
 import { TOrgGatewayConfigV2DALFactory } from "./org-gateway-config-v2-dal";
 
 type TGatewayV2ServiceFactoryDep = {
@@ -707,71 +707,87 @@ export const gatewayV2ServiceFactory = ({
       throw new NotFoundError({ message: `Gateway connection details for gateway ${gatewayId} not found.` });
     }
 
-    const isGatewayReachable = await withGatewayV2Proxy(
-      async (port) => {
-        return new Promise<boolean>((resolve, reject) => {
-          const socket = new net.Socket();
-          let responseReceived = false;
-          let isResolved = false;
+    let isGatewayReachable = false;
+    try {
+      isGatewayReachable = await withGatewayV2Proxy(
+        async (port) => {
+          return new Promise<boolean>((resolve, reject) => {
+            const socket = new net.Socket();
+            let responseReceived = false;
+            let isResolved = false;
 
-          socket.setTimeout(10000);
+            socket.setTimeout(10000);
 
-          const cleanup = () => {
-            if (!socket.destroyed) {
-              socket.destroy();
-            }
-          };
+            const cleanup = () => {
+              if (!socket.destroyed) {
+                socket.destroy();
+              }
+            };
 
-          socket.on("data", (data: Buffer) => {
-            const response = data.toString().trim();
-            if (response === "PONG" && !isResolved) {
-              isResolved = true;
-              responseReceived = true;
-              cleanup();
-              resolve(true);
-            }
+            socket.on("data", (data: Buffer) => {
+              const response = data.toString().trim();
+              if (response === "PONG" && !isResolved) {
+                isResolved = true;
+                responseReceived = true;
+                cleanup();
+                resolve(true);
+              }
+            });
+
+            socket.on("error", (err: Error) => {
+              if (!isResolved) {
+                isResolved = true;
+                cleanup();
+                reject(new Error(`TCP connection error: ${err.message}`));
+              }
+            });
+
+            socket.on("timeout", () => {
+              if (!isResolved) {
+                isResolved = true;
+                cleanup();
+                reject(new Error("TCP connection timeout"));
+              }
+            });
+
+            socket.on("close", () => {
+              if (!isResolved && !responseReceived) {
+                isResolved = true;
+                cleanup();
+                reject(new Error("Connection closed without receiving PONG"));
+              }
+            });
+
+            socket.connect(port, "localhost");
           });
-
-          socket.on("error", (err: Error) => {
-            if (!isResolved) {
-              isResolved = true;
-              cleanup();
-              reject(new Error(`TCP connection error: ${err.message}`));
-            }
-          });
-
-          socket.on("timeout", () => {
-            if (!isResolved) {
-              isResolved = true;
-              cleanup();
-              reject(new Error("TCP connection timeout"));
-            }
-          });
-
-          socket.on("close", () => {
-            if (!isResolved && !responseReceived) {
-              isResolved = true;
-              cleanup();
-              reject(new Error("Connection closed without receiving PONG"));
-            }
-          });
-
-          socket.connect(port, "localhost");
-        });
-      },
-      {
-        protocol: GatewayProxyProtocol.Ping,
-        relayHost: gatewayV2ConnectionDetails.relayHost,
-        gateway: gatewayV2ConnectionDetails.gateway,
-        relay: gatewayV2ConnectionDetails.relay
-      }
-    );
+        },
+        {
+          protocol: GatewayProxyProtocol.Ping,
+          relayHost: gatewayV2ConnectionDetails.relayHost,
+          gateway: gatewayV2ConnectionDetails.gateway,
+          relay: gatewayV2ConnectionDetails.relay
+        }
+      );
+    } catch (err) {
+      await gatewayV2DAL.updateById(gatewayId, {
+        heartbeat: new Date(),
+        lastHealthCheckStatus: GatewayHealthCheckStatus.Failed
+      });
+      throw err;
+    }
 
     if (!isGatewayReachable) {
+      await gatewayV2DAL.updateById(gatewayId, {
+        heartbeat: new Date(),
+        lastHealthCheckStatus: GatewayHealthCheckStatus.Failed
+      });
       throw new BadRequestError({ message: `Gateway ${gatewayId} is not reachable` });
     }
 
-    await gatewayV2DAL.updateById(gatewayId, { heartbeat: new Date() });
+    await gatewayV2DAL.updateById(gatewayId, {
+      heartbeat: new Date(),
+      lastHealthCheckStatus: GatewayHealthCheckStatus.Healthy
+    });
   };
 
   const triggerHeartbeat = async ({ orgPermission, id }: { orgPermission: OrgServiceActor; id: string }) => {

--- a/backend/src/ee/services/gateway-v2/gateway-v2-types.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-types.ts
@@ -1,3 +1,8 @@
+export enum GatewayHealthCheckStatus {
+  Healthy = "healthy",
+  Failed = "failed"
+}
+
 export type TGatewayV2ConnectionDetails = {
   relayHost: string;
   gateway: {

--- a/frontend/src/hooks/api/gateways-v2/mutations.tsx
+++ b/frontend/src/hooks/api/gateways-v2/mutations.tsx
@@ -22,7 +22,7 @@ export const useTriggerGatewayV2Heartbeat = () => {
     mutationFn: (id: string) => {
       return apiRequest.post(`/api/v2/gateways/${id}/heartbeat`);
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries(gatewaysQueryKeys.list());
     }
   });

--- a/frontend/src/hooks/api/gateways-v2/types.ts
+++ b/frontend/src/hooks/api/gateways-v2/types.ts
@@ -1,3 +1,8 @@
+export enum GatewayHealthCheckStatus {
+  Healthy = "healthy",
+  Failed = "failed"
+}
+
 export type TGatewayV2 = {
   id: string;
   identityId: string;
@@ -5,6 +10,7 @@ export type TGatewayV2 = {
   createdAt: string;
   updatedAt: string;
   heartbeat: string;
+  lastHealthCheckStatus: GatewayHealthCheckStatus | null;
   identity: {
     name: string;
     id: string;

--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
@@ -47,19 +47,25 @@ import { withPermission } from "@app/hoc";
 import { usePopUp } from "@app/hooks";
 import { gatewaysQueryKeys, useDeleteGatewayById } from "@app/hooks/api/gateways";
 import { useDeleteGatewayV2ById, useTriggerGatewayV2Heartbeat } from "@app/hooks/api/gateways-v2";
+import { GatewayHealthCheckStatus } from "@app/hooks/api/gateways-v2/types";
 
 import { EditGatewayDetailsModal } from "./components/EditGatewayDetailsModal";
 import { GatewayDeployModal } from "./components/GatewayDeployModal";
 
-const GatewayHealthStatus = ({ heartbeat }: { heartbeat?: string }) => {
+const GatewayHealthStatus = ({
+  heartbeat,
+  lastHealthCheckStatus
+}: {
+  heartbeat?: string;
+  lastHealthCheckStatus?: GatewayHealthCheckStatus | null;
+}) => {
   const heartbeatDate = heartbeat ? new Date(heartbeat) : null;
-  const now = new Date();
-  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
 
-  const isHealthy = heartbeatDate && heartbeatDate >= oneHourAgo;
+  const isHealthy = lastHealthCheckStatus === GatewayHealthCheckStatus.Healthy;
+
   const tooltipContent = heartbeatDate
-    ? `Last heartbeat: ${heartbeatDate.toLocaleString()}`
-    : "No heartbeat data available";
+    ? `Last health check: ${heartbeatDate.toLocaleString()}`
+    : "No health check data available";
 
   return (
     <Tooltip content={tooltipContent}>
@@ -181,7 +187,12 @@ export const GatewayTab = withPermission(
                       </div>
                     </Td>
                     <Td>
-                      <GatewayHealthStatus heartbeat={el.heartbeat} />
+                      <GatewayHealthStatus
+                        heartbeat={el.heartbeat}
+                        lastHealthCheckStatus={
+                          "lastHealthCheckStatus" in el ? el.lastHealthCheckStatus : null
+                        }
+                      />
                     </Td>
                     <Td className="w-5">
                       <Tooltip className="max-w-sm text-center" content="Options">


### PR DESCRIPTION
## Context
This PR adds support for manually triggering gateway health check

<img width="1493" height="731" alt="image" src="https://github.com/user-attachments/assets/240b41b8-269b-4832-bef0-0e45e0cad4b1" />
<img width="563" height="222" alt="image" src="https://github.com/user-attachments/assets/8cd3bcd4-f2de-4ba3-be16-9b25f8285088" />


<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)