### PR TITLE
fix(backend): include decoded identity auth property in token renewal

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -150,7 +150,8 @@ export const identityAccessTokenServiceFactory = ({
         identityId: decodedToken.identityId,
         clientSecretId: decodedToken.clientSecretId,
         identityAccessTokenId: decodedToken.identityAccessTokenId,
-        authTokenType: AuthTokenType.IDENTITY_ACCESS_TOKEN
+        authTokenType: AuthTokenType.IDENTITY_ACCESS_TOKEN,
+        identityAuth: decodedToken.identityAuth
       } as TIdentityAccessTokenJwtPayload,
       appCfg.AUTH_SECRET,
       expiresIn !== undefined ? { expiresIn } : undefined


### PR DESCRIPTION
## Context

This PR fixes the renew access token function for MIs to include the identityAuth property issued in the original token

## Screenshots

N?A

## Steps to verify the change

- issue token, verify token payload matches after renewal

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)