### PR TITLE
feat(permissions): Contains All (`$all`) operator support

### DIFF
--- a/backend/src/ee/services/permission/permission-types.ts
+++ b/backend/src/ee/services/permission/permission-types.ts
@@ -5,6 +5,7 @@ import { PermissionConditionOperators } from "@app/lib/casl";
 
 export const PermissionConditionSchema = {
   [PermissionConditionOperators.$IN]: z.string().trim().min(1).array(),
+  [PermissionConditionOperators.$ALL]: z.string().trim().min(1).array(),
   [PermissionConditionOperators.$EQ]: z.string().min(1),
   [PermissionConditionOperators.$NEQ]: z.string().min(1),
   [PermissionConditionOperators.$GLOB]: z

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -869,7 +869,8 @@ const SecretConditionV2Schema = z
     ]),
     secretTags: z
       .object({
-        [PermissionConditionOperators.$IN]: PermissionConditionSchema[PermissionConditionOperators.$IN]
+        [PermissionConditionOperators.$IN]: PermissionConditionSchema[PermissionConditionOperators.$IN],
+        [PermissionConditionOperators.$ALL]: PermissionConditionSchema[PermissionConditionOperators.$ALL]
       })
       .partial(),
     eventType: z.union([

--- a/backend/src/lib/casl/index.ts
+++ b/backend/src/lib/casl/index.ts
@@ -23,6 +23,7 @@ export const conditionsMatcher = buildMongoQueryMatcher({ $glob }, { glob });
 
 export enum PermissionConditionOperators {
   $IN = "$in",
+  $ALL = "$all",
   $EQ = "$eq",
   $NEQ = "$ne",
   $GLOB = "$glob",

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/PermissionConditionHelpers.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/PermissionConditionHelpers.tsx
@@ -10,6 +10,8 @@ export const getConditionOperatorHelperInfo = (type: PermissionConditionOperator
       return "Value should not equal specified value.";
     case PermissionConditionOperators.$IN:
       return "List of comma-separated values that match a given value.";
+    case PermissionConditionOperators.$ALL:
+      return "List of comma-separated values that must all be present.";
     case PermissionConditionOperators.$GLOB:
       return <GlobPermissionInfo />;
     default:
@@ -21,7 +23,12 @@ export const getConditionOperatorHelperInfo = (type: PermissionConditionOperator
 export const renderOperatorSelectItems = (type: string) => {
   switch (type) {
     case "secretTags":
-      return <SelectItem value={PermissionConditionOperators.$IN}>Contains</SelectItem>;
+      return (
+        <>
+          <SelectItem value={PermissionConditionOperators.$IN}>Contains</SelectItem>
+          <SelectItem value={PermissionConditionOperators.$ALL}>Contains All</SelectItem>
+        </>
+      );
     case "identityId":
     case "connectionId":
     case "metadataKey":


### PR DESCRIPTION
## Context

Added a new `Contains All` operator to the secret tags condition on the secrets permission subject. The existing `Contains` operator functions as an OR operator, meaning that if a secret contains one of the tags in the Contains array, it will allow access.

The `Contains All` operator is exactly the same as the `Contains` operator, except it requires the secrets to have ALL the tags defined in the condition.

It's built on the `$all` mongo2js operator which is natively supported in CASL, so no extra work for us!

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)