### PR TITLE
feature(azure-auth): increase azure auth spid max length

### DIFF
--- a/backend/src/db/migrations/20260318200000_increase-azure-spid-field-size.ts
+++ b/backend/src/db/migrations/20260318200000_increase-azure-spid-field-size.ts
@@ -15,7 +15,7 @@ export async function down(knex: Knex): Promise<void> {
   const hasColumn = await knex.schema.hasColumn(TableName.IdentityAzureAuth, "allowedServicePrincipalIds");
   if (hasColumn) {
     await knex.schema.alterTable(TableName.IdentityAzureAuth, (t) => {
-      t.string("allowedServicePrincipalIds").notNullable().alter();
+      t.string("allowedServicePrincipalIds", 255).notNullable().alter();
     });
   }
 }


### PR DESCRIPTION
## Context

This PR updates the max length of the azure `allowedServicePrincipalIds` field to accommodate more IDs

## Screenshots

N/A

## Steps to verify the change

Create an azure auth with more than 255 length `allowedServicePrincipalIds` field

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)