### PR TITLE
fix: correct operator subset check to be more restrictive and add tests

### DIFF
--- a/backend/src/lib/casl/boundary.test.ts
+++ b/backend/src/lib/casl/boundary.test.ts
@@ -309,7 +309,7 @@ describe("Validate Permission Boundary: Checking Parent $eq operator", () => {
           action: ["create"],
           subject: "secrets",
           conditions: {
-            environment: { [PermissionConditionOperators.$GLOB]: "staging" }
+            environment: { [PermissionConditionOperators.$NEQ]: "staging" }
           }
         }
       ])
@@ -317,6 +317,81 @@ describe("Validate Permission Boundary: Checking Parent $eq operator", () => {
   ])("Child $operator falsy cases", ({ childPermission }) => {
     const permissionBoundary = validatePermissionBoundary(parentPermission, childPermission);
     expect(permissionBoundary.isValid).toBeFalsy();
+  });
+});
+
+describe("Validate Permission Boundary: $ne child cannot bypass $eq/$in parent", () => {
+  test("Child $ne should not be subset of parent $eq with different value", () => {
+    // Parent: can read secrets ONLY in "qa"
+    // Child: can read secrets in ALL environments EXCEPT "dev" — much broader
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$EQ]: "qa" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$NEQ]: "dev" }
+        }
+      }
+    ]);
+    const result = validatePermissionBoundary(parentPermission, childPermission);
+    expect(result.isValid).toBeFalsy();
+  });
+
+  test("Child $ne should not be subset of parent $eq with same value", () => {
+    // Parent: only "dev", Child: everything except "dev" — completely disjoint
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$EQ]: "dev" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$NEQ]: "dev" }
+        }
+      }
+    ]);
+    const result = validatePermissionBoundary(parentPermission, childPermission);
+    expect(result.isValid).toBeFalsy();
+  });
+
+  test("Child $ne should not be subset of parent $in when value is outside $in list", () => {
+    // Parent: only ["dev", "staging"], Child: everything except "prod" — much broader
+    const parentPermission = createMongoAbility([
+      {
+        action: ["edit"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$IN]: ["dev", "staging"] }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["edit"],
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$NEQ]: "prod" }
+        }
+      }
+    ]);
+    const result = validatePermissionBoundary(parentPermission, childPermission);
+    expect(result.isValid).toBeFalsy();
   });
 });
 

--- a/backend/src/lib/casl/boundary.ts
+++ b/backend/src/lib/casl/boundary.ts
@@ -30,6 +30,11 @@ const isOperatorsASubset = (parentSet: TPermissionConditionShape, subset: TPermi
   if (subset[PermissionConditionOperators.$EQ] || subset[PermissionConditionOperators.$NEQ]) {
     const subsetOperatorValue = subset[PermissionConditionOperators.$EQ] || subset[PermissionConditionOperators.$NEQ];
     const isInverted = !subset[PermissionConditionOperators.$EQ];
+
+    if (isInverted && (parentSet[PermissionConditionOperators.$EQ] || parentSet[PermissionConditionOperators.$IN])) {
+      return false;
+    }
+
     if (
       parentSet[PermissionConditionOperators.$EQ] &&
       invertTheOperation(isInverted, parentSet[PermissionConditionOperators.$EQ] !== subsetOperatorValue)


### PR DESCRIPTION
## Context

This PR improves the casl sub-operator boundary check and adds relevant test cases

## Screenshots

N/A

## Steps to verify the change

- comment out addition, watch tests fail, add back - pass

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)