### PR TITLE
fix: correct audit log spread ordering to prevent org id being set undefined

### DIFF
--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -146,8 +146,8 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
 
       if (sharedSecret.orgId) {
         await server.services.auditLog.createAuditLog({
-          orgId: sharedSecret.orgId,
           ...req.auditLogInfo,
+          orgId: sharedSecret.orgId,
           event: {
             type: EventType.READ_SHARED_SECRET,
             metadata: {


### PR DESCRIPTION
## Context

This PR fixes a bug where sharing a secret from an org to a non-org user was encountering an error due to the spread order overwriting the audit log org Id

## Screenshots

N/A

## Steps to verify the change

- BEFORE PULLING PR - share a secret from an org, open the link in incognito, see error
- pull changes, refresh, no error

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)