### PR TITLE
chore: bump backend timeout as it frequently timesout with 15 minutes

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -14,7 +14,7 @@ jobs:
   check-be-pr:
     name: Run integration test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Free up disk space
         run: |
@@ -23,7 +23,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           docker system prune -af
-          
+
       - name: ☁️ Checkout source
         uses: actions/checkout@v3
       - uses: KengoTODA/actions-setup-docker-compose@v1
@@ -62,4 +62,3 @@ jobs:
       - name: cleanup
         run: |
           docker compose -f "docker-compose.dev.yml" down
-


### PR DESCRIPTION
## Context

This PR bumps the backend test workflow timeout to 30 minutes as it frequently times out with 15 minutes

## Screenshots

N/A

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)