### PR TITLE
feat(org-invite): allow selecting custom roles during org invite flow

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -28,7 +28,7 @@ import { UsePopUpState } from "@app/hooks/usePopUp";
 
 import { OrgInviteLink } from "./OrgInviteLink";
 
-const DEFAULT_PROJECT_ROLE = { slug: "member", name: "Member" };
+const DEFAULT_PROJECT_ROLE = { slug: "member", name: "Developer" };
 
 const BUILT_IN_PROJECT_ROLES = [
   { slug: "admin", name: "Admin", description: "Full administrative access over a project" },


### PR DESCRIPTION
## Context

When inviting users to an organization (and optionally to projects in the same flow), the project role dropdown was hardcoded to only show built-in roles (`admin`, `member`, `viewer`, `no-access`) via a static enum. Custom project roles were never surfaced, blocking orgs that rely on custom roles from assigning the correct permissions during the invite flow.

This PR replaces the hardcoded `<Select>` with a `<FilterableSelect>` backed by `useGetProjectRoles()`, so all roles — built-in and custom — are available when assigning a project role during an org invite.

Fixes: https://linear.app/infisical/issue/PLATFRM-221

**Note on org role dropdown:** The org role dropdown (`Assign organization role`) was already correctly wired to `useGetOrgRoles()` which returns both built-in and custom org roles. For custom org roles to appear there, the custom role must include the `Role > Read` permission — this is by design and requires no code change.

## Screenshots

<!-- UI changes are in the project role selector within the invite modal — it now shows custom project roles when exactly one project is selected. -->

## Steps to verify the change

1. Create a custom project role in any project
2. Go to **Organization > Access Control > Members** and click **Invite Member**
3. Select a project in the **Assign users to projects** field
4. Confirm the **Role** dropdown now shows built-in roles **and** the custom role you created
5. Select the custom role and complete the invite — verify the invited user receives the correct role in the project
6. Select two or more projects — confirm the **Role** dropdown falls back to built-in roles only

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)