### PR TITLE
fix(acme): add GET /new-nonce support per RFC 8555

### DIFF
--- a/backend/src/ee/routes/v1/pki-acme-router.ts
+++ b/backend/src/ee/routes/v1/pki-acme-router.ts
@@ -149,7 +149,7 @@ export const registerPkiAcmeRouter = async (server: FastifyZodProvider) => {
       const nonce = await server.services.pkiAcme.getAcmeNewNonce(req.params.profileId);
       res.header("Replay-Nonce", nonce);
       res.header("Cache-Control", "no-store");
-      void res.status(204).send("");
+      return res.status(204).send();
     }
   });
 


### PR DESCRIPTION
## Context

ACME clients like Proxmox use GET for `/new-nonce`, but we only had a HEAD handler, so they got a 404. RFC 8555 Section 7.2 says we MUST support both GET and HEAD. Added the GET route (returns 204 with `Replay-Nonce` header) and also added the missing `Cache-Control: no-store` header to both routes.

Fixes https://github.com/Infisical/infisical/issues/5695

## Screenshots

## Steps to verify the change


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
