### PR TITLE
fix: allow application/json with an empty body

### DIFF
--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -99,6 +99,22 @@ export const main = async ({
       done(error, undefined);
     }
   });
+  server.addContentTypeParser("application/json", { parseAs: "string" }, (_, body, done) => {
+    try {
+      const strBody = body instanceof Buffer ? body.toString() : body;
+
+      if (!strBody || strBody.trim().length === 0) {
+        done(null, {});
+        return;
+      }
+
+      const json: unknown = JSON.parse(strBody);
+      done(null, json);
+    } catch (err) {
+      const error = err as Error;
+      done(error, undefined);
+    }
+  });
 
   try {
     await server.register<FastifyCookieOptions>(cookie, {


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->
When running Infisical behind specific proxies such as Cloudflare Tunnels or Zoraxy fastify refuses to handle POST requests that do not contain a body. Problematically a lot of POST requests dont send a body thus infisical becomes unusable through the web ui
https://github.com/Infisical/infisical/issues/5411

## Screenshots

## Steps to verify the change
Run infisical behind a proxy like cloudflare tunnels or zoraxy. Login will succeed

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)