### PR TITLE
fix: auto-capitalize secret keys on paste

### DIFF
--- a/frontend/src/components/v2/Input/Input.tsx
+++ b/frontend/src/components/v2/Input/Input.tsx
@@ -93,15 +93,17 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       autoCapitalization,
       warning,
       autoComplete,
+      onChange,
       ...props
     },
     ref
   ): JSX.Element => {
-    const handleInput = (event: ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
       if (autoCapitalization) {
         // eslint-disable-next-line no-param-reassign
         event.target.value = event.target.value.toUpperCase();
       }
+      onChange?.(event);
     };
 
     return (
@@ -122,7 +124,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           readOnly={isReadOnly}
           disabled={isDisabled}
-          onInput={handleInput}
+          onChange={handleChange}
           autoComplete={autoComplete}
           data-1p-ignore={data1pIgnore(autoComplete)}
           className={twMerge(


### PR DESCRIPTION
## Context

Fixes #2693

When auto-capitalization is enabled for a project, pasting a lowercase key into the secret name field does not capitalize it. The key stays lowercase in the form state even though it may appear uppercase in the DOM.

**Root cause:** The `Input` component used `onInput` to uppercase values, but React Hook Form captures values via `onChange`, which fires before `onInput`. So the form state always received the original lowercase value.

**Fix:** Move the capitalization logic from `onInput` to `onChange`, intercepting the event before passing it to the parent handler. This ensures React Hook Form (and any other `onChange` consumer) receives the uppercased value.

## Screenshots

N/A — no visual changes, behavior fix only.

## Steps to verify the change

1. Create a project with auto-capitalization enabled (Project Settings > Auto Capitalization)
2. Add a new secret
3. Paste a lowercase key (e.g. `my_secret_key`)
4. Verify the key is capitalized to `MY_SECRET_KEY` in both the input and the saved secret

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)