### PR TITLE
fix(security): upgrade @casl/ability to 6.7.5 to remediate CVE-2026-1774 prototype pollution

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@aws-sdk/client-route-53": "^3.810.0",
         "@aws-sdk/client-secrets-manager": "^3.504.0",
         "@aws-sdk/client-sts": "^3.600.0",
-        "@casl/ability": "^6.5.0",
+        "@casl/ability": "^6.7.5",
         "@clickhouse/client": "^1.17.0",
         "@elastic/elasticsearch": "^9.1.1",
         "@fastify/cookie": "^9.3.1",
@@ -11948,9 +11948,10 @@
       }
     },
     "node_modules/@casl/ability": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.5.0.tgz",
-      "integrity": "sha512-3guc94ugr5ylZQIpJTLz0CDfwNi0mxKVECj1vJUPAvs+Lwunh/dcuUjwzc4MHM9D8JOYX0XUZMEPedpB3vIbOw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.8.0.tgz",
+      "integrity": "sha512-Ipt4mzI4gSgnomFdaPjaLgY2MWuXqAEZLrU6qqWBB7khGiBBuuEp6ytYDnq09bRXqcjaeeHiaCvCGFbBA2SpvA==",
+      "license": "MIT",
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -14025,9 +14026,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
-      "optional": true
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -136,7 +136,7 @@
     "@aws-sdk/client-secrets-manager": "^3.504.0",
     "@aws-sdk/client-sts": "^3.600.0",
     "aws-sdk": "^2.1553.0",
-    "@casl/ability": "^6.5.0",
+    "@casl/ability": "^6.7.5",
     "@clickhouse/client": "^1.17.0",
     "@elastic/elasticsearch": "^9.1.1",
     "@fastify/cookie": "^9.3.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend-v2",
       "version": "0.0.0",
       "dependencies": {
-        "@casl/ability": "^6.7.2",
+        "@casl/ability": "^6.7.5",
         "@casl/react": "^4.0.0",
         "@dagrejs/dagre": "^1.1.4",
         "@dnd-kit/core": "^6.3.1",
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@casl/ability": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.2.tgz",
-      "integrity": "sha512-KjKXlcjKbUz8dKw7PY56F7qlfOFgxTU6tnlJ8YrbDyWkJMIlHa6VRWzCD8RU20zbJUC1hExhOFggZjm6tf1mUw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.8.0.tgz",
+      "integrity": "sha512-Ipt4mzI4gSgnomFdaPjaLgY2MWuXqAEZLrU6qqWBB7khGiBBuuEp6ytYDnq09bRXqcjaeeHiaCvCGFbBA2SpvA==",
       "license": "MIT",
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
@@ -5429,6 +5429,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "sha.js": "2.4.12"
   },
   "dependencies": {
-    "@casl/ability": "^6.7.2",
+    "@casl/ability": "^6.7.5",
     "@casl/react": "^4.0.0",
     "@dagrejs/dagre": "^1.1.4",
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Remediate prototype pollution vulnerability in CASL ability rules deserialization affecting both backend (6.5.0) and frontend (6.7.2).

Vulnerability: CWE-1321 Prototype Pollution
CVSS: 9.8 (Critical)
Real Risk Score: 8.55/10 (Critical Actionable)

The unpackRules() function in @casl/ability/extra does not sanitize incoming rule objects before passing them to createMongoAbility(). Infisical's permission-service.ts calls unpackRules() on every authenticated request to deserialize custom RBAC rules stored in PostgreSQL. A malicious __proto__ key in a crafted role definition can pollute Object.prototype, potentially bypassing all permission checks and enabling privilege escalation to access any secret.

Changes:
- backend/package.json: @casl/ability ^6.5.0 -> ^6.7.5
- frontend/package.json: @casl/ability ^6.7.2 -> ^6.7.5

Breaking changes: None (patch/minor upgrade within 6.x series)

Refs: GHSA-j3qh-pxxh-hxhp, CVE-2026-1774

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)