### PR TITLE
fix(security): [CVE-2026-25223] Add Content-Type tab injection mitiga…

### DIFF
--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -161,6 +161,24 @@ export const main = async ({
 
     await server.register(helmet, { contentSecurityPolicy: false });
 
+    // CVE-2026-25223: Reject Content-Type headers containing tab characters
+    // Fastify v4 content-type-parser splits on semicolons before routing to body parser.
+    // A tab character before a semicolon causes the parser to see a different MIME type
+    // than the validator, allowing schema validation to be bypassed entirely.
+    // This preValidation hook blocks the attack vector until Fastify v5 upgrade.
+    // See: https://github.com/fastify/fastify/security/advisories/GHSA-jx2c-rxcm-jvmq
+    server.addHook("onRequest", async (request, reply) => {
+      const contentType = request.headers["content-type"];
+      if (contentType && /\t/.test(contentType)) {
+        return reply.status(400).send({
+          statusCode: 400,
+          error: "Bad Request",
+          message: "Invalid Content-Type header"
+        });
+      }
+    });
+
+
     await server.register(maintenanceMode);
 
     await server.register(fastifyRequestContext, {


### PR DESCRIPTION


Add preValidation hook to reject HTTP requests with Content-Type headers containing tab characters, mitigating the Fastify v4 schema validation bypass (CVE-2026-25223, CWE-436).

Vulnerability: Fastify v4 content-type-parser splits Content-Type on semicolons before routing to the body parser. A tab character appended before a semicolon causes the parser to see a different MIME type than the validator, allowing request body schema validation to be bypassed entirely. This affects ALL POST/PUT/PATCH endpoints.

Real Risk Score: 7.90/10 (HIGH ACTIONABLE)
- Reachability: 9/10 (every API endpoint affected)
- Exploitability: 7/10 (trivial - just append \t to Content-Type)
- Impact: 7/10 (bypasses Zod/Fastify schema validation)
- Exposure: 9/10 (publicly reachable, no auth required)

This is an interim mitigation. The full fix requires upgrading Fastify from v4 to v5 (major breaking change, separate effort).

Refs: GHSA-jx2c-rxcm-jvmq, CVE-2026-25223

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)