### PR TITLE
fix: hubSpot UTK tracking for cloud instances signup

### DIFF
--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -210,7 +210,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
         password: z.string(),
         firstName: z.string().trim(),
         lastName: z.string().trim().optional(),
-        tokenMetadata: z.string().optional()
+        tokenMetadata: z.string().optional(),
+        hubspotUtk: z.string().trim().max(512).optional()
       }),
       response: {
         200: z.object({
@@ -238,7 +239,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           user.email,
           "invite",
           user.firstName || "",
-          user.lastName || ""
+          user.lastName || "",
+          req.body.hubspotUtk
         );
       }
 

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -104,7 +104,7 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           providerAuthToken: z.string().trim().optional().nullish(),
           attributionSource: z.string().trim().optional(),
           password: z.string(),
-          hubspotUtk: z.string().trim().optional()
+          hubspotUtk: z.string().trim().max(512).optional()
         })
         .and(
           z.preprocess(

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -103,7 +103,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           lastName: z.string().trim().optional(),
           providerAuthToken: z.string().trim().optional().nullish(),
           attributionSource: z.string().trim().optional(),
-          password: z.string()
+          password: z.string(),
+          hubspotUtk: z.string().trim().optional()
         })
         .and(
           z.preprocess(
@@ -150,7 +151,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           user.email,
           authMethod,
           user.firstName || "",
-          user.lastName || ""
+          user.lastName || "",
+          req.body.hubspotUtk
         );
       }
 

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -106,7 +106,8 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     email: string,
     signupMethod: HubSpotSignupMethod,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    hubspotUtk?: string
   ) => {
     const instanceType = licenseService.getInstanceType();
     if (
@@ -130,14 +131,22 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
           if (value) fields.push({ name, value });
         }
 
+        const context: Record<string, string> = {
+          pageUri: `${appCfg.SITE_URL || "https://app.infisical.com"}/signup`,
+          pageName: "App Signup"
+        };
+
+        // Include the HubSpot tracking cookie to link this submission
+        // to the visitor's browsing session for proper attribution
+        if (hubspotUtk) {
+          context.hutk = hubspotUtk;
+        }
+
         await request.post(
           `https://api.hsforms.com/submissions/v3/integration/submit/${appCfg.HUBSPOT_PORTAL_ID}/${appCfg.HUBSPOT_SIGNUP_FORM_ID}`,
           {
             fields,
-            context: {
-              pageUri: `${appCfg.SITE_URL || "https://app.infisical.com"}/signup`,
-              pageName: "App Signup"
-            }
+            context
           },
           {
             headers: {

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -21,6 +21,7 @@ import {
   UnstableInput
 } from "@app/components/v3";
 import { useServerConfig } from "@app/context";
+import { preserveHubSpotUtk } from "@app/helpers/utmTracking";
 import { useSendVerificationEmail } from "@app/hooks/api";
 import { LoginMethod } from "@app/hooks/api/admin/types";
 
@@ -59,6 +60,7 @@ export default function InitialSignupStep({
   };
 
   const handleSocialSignup = (method: LoginMethod) => {
+    preserveHubSpotUtk();
     const popup = window.open(`/api/v1/sso/redirect/${method}`);
     if (popup) {
       window.close();

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/components/v3";
 import { isInfisicalCloud } from "@app/helpers/platform";
 import { initProjectHelper } from "@app/helpers/project";
+import { getHubSpotUtk } from "@app/helpers/utmTracking";
 import { completeAccountSignup, useSelectOrganization } from "@app/hooks/api/auth/queries";
 import { fetchOrganizations } from "@app/hooks/api/organization/queries";
 import { onRequestError } from "@app/hooks/api/reactQuery";
@@ -118,7 +119,8 @@ export default function UserInfoStep({
           lastName: name.split(" ").slice(1).join(" "),
           providerAuthToken,
           organizationName,
-          attributionSource
+          attributionSource,
+          hubspotUtk: getHubSpotUtk()
         });
 
         // unset signup JWT token and set JWT token

--- a/frontend/src/helpers/utmTracking.ts
+++ b/frontend/src/helpers/utmTracking.ts
@@ -1,0 +1,7 @@
+/**
+ * Reads the HubSpot tracking cookie (hubspotutk) if present.
+ */
+export const getHubSpotUtk = (): string | undefined => {
+  const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]*)/);
+  return match?.[1] || undefined;
+};

--- a/frontend/src/helpers/utmTracking.ts
+++ b/frontend/src/helpers/utmTracking.ts
@@ -1,7 +1,23 @@
+const HUBSPOT_UTK_STORAGE_KEY = "infisical__hubspot-utk";
+
 /**
- * Reads the HubSpot tracking cookie (hubspotutk) if present.
+ * Reads the HubSpot tracking cookie (hubspotutk) if present,
+ * falling back to localStorage for cases where cookies may have
+ * been cleared during OAuth redirects (e.g. Safari ITP).
  */
 export const getHubSpotUtk = (): string | undefined => {
   const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]*)/);
-  return match?.[1] || undefined;
+  return match?.[1] || localStorage.getItem(HUBSPOT_UTK_STORAGE_KEY) || undefined;
+};
+
+/**
+ * Persists the current hubspotutk cookie value to localStorage
+ * so it survives OAuth redirects that may clear cookies.
+ * Call this before navigating away for OAuth.
+ */
+export const preserveHubSpotUtk = (): void => {
+  const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]*)/);
+  if (match?.[1]) {
+    localStorage.setItem(HUBSPOT_UTK_STORAGE_KEY, match[1]);
+  }
 };

--- a/frontend/src/hooks/api/auth/types.ts
+++ b/frontend/src/hooks/api/auth/types.ts
@@ -100,6 +100,7 @@ export type CompleteAccountDTO = {
   lastName: string;
   password: string;
   tokenMetadata?: string;
+  hubspotUtk?: string;
 };
 
 export type CompleteAccountSignupDTO = CompleteAccountDTO & {

--- a/frontend/src/hooks/api/auth/types.ts
+++ b/frontend/src/hooks/api/auth/types.ts
@@ -107,6 +107,7 @@ export type CompleteAccountSignupDTO = CompleteAccountDTO & {
   attributionSource?: string;
   organizationName: string;
   useDefaultOrg?: boolean;
+  hubspotUtk?: string;
 };
 
 export type VerifySignupInviteDTO = {

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -26,6 +26,7 @@ import {
 } from "@app/components/v3";
 import { envConfig } from "@app/config/env";
 import { useServerConfig } from "@app/context";
+import { preserveHubSpotUtk } from "@app/helpers/utmTracking";
 import { useFetchServerStatus } from "@app/hooks/api";
 import { LoginMethod } from "@app/hooks/api/admin/types";
 import { AuthMethod } from "@app/hooks/api/users/types";
@@ -110,6 +111,7 @@ export const InitialStep = ({
   };
 
   const handleSocialLogin = (method: LoginMethod) => {
+    preserveHubSpotUtk();
     const searchParams = new URLSearchParams();
     if (callbackPort) {
       searchParams.append("callback_port", callbackPort);

--- a/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
+++ b/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
@@ -10,6 +10,7 @@ import InputField from "@app/components/basic/InputField";
 import checkPassword from "@app/components/utilities/checks/password/checkPassword";
 import SecurityClient from "@app/components/utilities/SecurityClient";
 import { Button } from "@app/components/v2";
+import { getHubSpotUtk } from "@app/helpers/utmTracking";
 import { useToggle } from "@app/hooks";
 import {
   completeAccountSignupInvite,
@@ -88,7 +89,8 @@ export const SignupInvitePage = () => {
           password,
           firstName,
           lastName,
-          tokenMetadata: metadata
+          tokenMetadata: metadata,
+          hubspotUtk: getHubSpotUtk()
         });
 
         // unset temporary signup JWT token and set JWT token

--- a/frontend/src/pages/auth/SignUpSsoPage/components/UserInfoSSOStep/UserInfoSSOStep.tsx
+++ b/frontend/src/pages/auth/SignUpSsoPage/components/UserInfoSSOStep/UserInfoSSOStep.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/components/v3";
 import { isInfisicalCloud } from "@app/helpers/platform";
 import { initProjectHelper } from "@app/helpers/project";
+import { getHubSpotUtk } from "@app/helpers/utmTracking";
 import { useToggle } from "@app/hooks";
 import { completeAccountSignup, useSelectOrganization } from "@app/hooks/api/auth/queries";
 import { MfaMethod } from "@app/hooks/api/auth/types";
@@ -90,7 +91,8 @@ export const UserInfoSSOStep = ({
           providerAuthToken,
           organizationName,
           attributionSource,
-          useDefaultOrg: forceDefaultOrg
+          useDefaultOrg: forceDefaultOrg,
+          hubspotUtk: getHubSpotUtk()
         });
 
         // unset signup JWT token and set JWT token


### PR DESCRIPTION
## Context

Small fix on Cloud instances to correctly send the UTK HubSpot token on signups

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)