### PR TITLE
feat(frontend): add 12h/24h clock preference for audit logs

### DIFF
--- a/frontend/src/helpers/datetime.ts
+++ b/frontend/src/helpers/datetime.ts
@@ -5,6 +5,17 @@ export enum Timezone {
   UTC = "UTC"
 }
 
+export enum ClockFormat {
+  TwelveHour = "12",
+  TwentyFourHour = "24"
+}
+
+export const getAuditLogTableDateFormat = (clock: ClockFormat) =>
+  clock === ClockFormat.TwentyFourHour ? "MMM do yyyy, HH:mm" : "MMM do yyyy, hh:mm a";
+
+export const getAuditLogRangeDateFormat = (clock: ClockFormat) =>
+  clock === ClockFormat.TwentyFourHour ? "yyyy/MM/dd HH:mm" : "yyyy/MM/dd hh:mm a";
+
 export const formatDateTime = ({
   timezone,
   timestamp,

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsDateFilter.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsDateFilter.tsx
@@ -17,7 +17,12 @@ import {
   Select,
   SelectItem
 } from "@app/components/v2";
-import { formatDateTime, Timezone } from "@app/helpers/datetime";
+import {
+  ClockFormat,
+  formatDateTime,
+  getAuditLogRangeDateFormat,
+  Timezone
+} from "@app/helpers/datetime";
 
 import {
   auditLogDateFilterFormSchema,
@@ -30,6 +35,8 @@ type Props = {
   filter: TAuditLogDateFilterFormData;
   setTimezone: (timezone: Timezone) => void;
   timezone: Timezone;
+  clockFormat: ClockFormat;
+  setClockFormat: (clockFormat: ClockFormat) => void;
 };
 const RELATIVE_VALUES = ["5m", "30m", "1h", "3h", "12h"];
 
@@ -40,7 +47,15 @@ const RELATIVE_OPTIONS = [
   { label: "Weeks", unit: "w", values: [1, 2, 3, 4] }
 ];
 
-export const LogsDateFilter = ({ setFilter, filter, timezone, setTimezone }: Props) => {
+export const LogsDateFilter = ({
+  setFilter,
+  filter,
+  timezone,
+  setTimezone,
+  clockFormat,
+  setClockFormat
+}: Props) => {
+  const rangeDateFormat = getAuditLogRangeDateFormat(clockFormat);
   const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
   const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
   const [isPopupOpen, setIsPopOpen] = useState(false);
@@ -98,22 +113,22 @@ export const LogsDateFilter = ({ setFilter, filter, timezone, setTimezone }: Pro
               ))}
             </>
           ) : (
-            <div className="flex w-[19.1rem] items-center justify-between rounded-l-md border border-transparent bg-mineshaft-600 px-5 py-2 text-sm text-bunker-200">
-              <div>
+            <div className="flex min-w-[19.1rem] max-w-[26rem] flex-1 items-center justify-between gap-2 rounded-l-md border border-transparent bg-mineshaft-600 px-4 py-2 text-sm text-bunker-200">
+              <div className="truncate">
                 {formatDateTime({
                   timezone,
                   timestamp: filter.startDate,
-                  dateFormat: "yyyy/MM/dd HH:mm"
+                  dateFormat: rangeDateFormat
                 })}
               </div>
-              <div>
+              <div className="shrink-0">
                 <FontAwesomeIcon className="text-bunker-300" size="sm" icon={faChevronRight} />
               </div>
-              <div>
+              <div className="truncate">
                 {formatDateTime({
                   timezone,
                   timestamp: filter.endDate,
-                  dateFormat: "yyyy/MM/dd HH:mm"
+                  dateFormat: rangeDateFormat
                 })}
               </div>
             </div>
@@ -336,6 +351,19 @@ export const LogsDateFilter = ({ setFilter, filter, timezone, setTimezone }: Pro
             {tz} Timezone
           </SelectItem>
         ))}
+      </Select>
+      <Select
+        value={clockFormat}
+        onValueChange={(val) => setClockFormat(val as ClockFormat)}
+        className="w-[10.6rem] border border-mineshaft-500! bg-mineshaft-600!"
+        dropdownContainerClassName="max-w-none"
+        position="popper"
+        dropdownContainerStyle={{
+          width: "100%"
+        }}
+      >
+        <SelectItem value={ClockFormat.TwelveHour}>12-hour</SelectItem>
+        <SelectItem value={ClockFormat.TwentyFourHour}>24-hour</SelectItem>
       </Select>
     </>
   );

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsSection.tsx
@@ -10,7 +10,6 @@ import {
   ProjectPermissionSub,
   useSubscription
 } from "@app/context";
-import { Timezone } from "@app/helpers/datetime";
 import { withPermission, withProjectPermission } from "@app/hoc";
 import { Project } from "@app/hooks/api/projects/types";
 import { usePopUp } from "@app/hooks/usePopUp";
@@ -24,6 +23,7 @@ import {
 import { LogsDateFilter } from "./LogsDateFilter";
 import { LogsFilter } from "./LogsFilter";
 import { LogsTable } from "./LogsTable";
+import { useAuditLogsDateTimePreferences } from "./useAuditLogsDateTimePreferences";
 import {
   AuditLogDateFilterType,
   Presets,
@@ -53,7 +53,7 @@ const LogsSectionComponent = ({
     actor: presets?.actorId,
     eventMetadata: presets?.eventMetadata
   });
-  const [timezone, setTimezone] = useState<Timezone>(Timezone.Local);
+  const { timezone, clockFormat, setTimezone, setClockFormat } = useAuditLogsDateTimePreferences();
 
   const [searchFilters, setSearchFilters] = useState<AppliedFilter[]>(() =>
     logFilterToAppliedFilters({
@@ -102,6 +102,8 @@ const LogsSectionComponent = ({
                 setFilter={setDateFilter}
                 timezone={timezone}
                 setTimezone={setTimezone}
+                clockFormat={clockFormat}
+                setClockFormat={setClockFormat}
               />
             )}
           </div>
@@ -140,6 +142,7 @@ const LogsSectionComponent = ({
               limit: 15
             }}
             timezone={timezone}
+            clockFormat={clockFormat}
           />
           <UpgradePlanModal
             isOpen={popUp.upgradePlan.isOpen}
@@ -161,6 +164,8 @@ const LogsSectionComponent = ({
             setFilter={setDateFilter}
             timezone={timezone}
             setTimezone={setTimezone}
+            clockFormat={clockFormat}
+            setClockFormat={setClockFormat}
           />
         )}
         {showFilters && (
@@ -184,6 +189,7 @@ const LogsSectionComponent = ({
           actor: logFilter?.actor
         }}
         timezone={timezone}
+        clockFormat={clockFormat}
       />
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTable.tsx
@@ -15,7 +15,7 @@ import {
   THead,
   Tr
 } from "@app/components/v2";
-import { Timezone } from "@app/helpers/datetime";
+import { ClockFormat, Timezone } from "@app/helpers/datetime";
 import { useFetchServerStatus, useGetAuditLogs } from "@app/hooks/api";
 import { TGetAuditLogsFilter } from "@app/hooks/api/auditLogs/types";
 
@@ -25,11 +25,12 @@ type Props = {
   filter: TGetAuditLogsFilter;
   refetchInterval?: number;
   timezone: Timezone;
+  clockFormat: ClockFormat;
 };
 
 const AUDIT_LOG_LIMIT = 30;
 
-export const LogsTable = ({ filter, refetchInterval, timezone }: Props) => {
+export const LogsTable = ({ filter, refetchInterval, timezone, clockFormat }: Props) => {
   const { data: status } = useFetchServerStatus();
 
   // Determine the project ID for filtering
@@ -75,6 +76,7 @@ export const LogsTable = ({ filter, refetchInterval, timezone }: Props) => {
                       auditLog={auditLog}
                       key={`audit-log-${auditLog.id}`}
                       timezone={timezone}
+                      clockFormat={clockFormat}
                     />
                   ))}
                 </Fragment>

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
@@ -3,7 +3,12 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { InfoIcon } from "lucide-react";
 
 import { Td, Tooltip, Tr } from "@app/components/v2";
-import { formatDateTime, Timezone } from "@app/helpers/datetime";
+import {
+  ClockFormat,
+  formatDateTime,
+  getAuditLogTableDateFormat,
+  Timezone
+} from "@app/helpers/datetime";
 import { useToggle } from "@app/hooks";
 import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { AuditLog } from "@app/hooks/api/auditLogs/types";
@@ -12,6 +17,7 @@ type Props = {
   auditLog: AuditLog;
   rowNumber: number;
   timezone: Timezone;
+  clockFormat: ClockFormat;
 };
 
 type TagProps = {
@@ -38,7 +44,7 @@ const Tag = ({ label, value }: TagProps) => {
   );
 };
 
-export const LogsTableRow = ({ auditLog, rowNumber, timezone }: Props) => {
+export const LogsTableRow = ({ auditLog, rowNumber, timezone, clockFormat }: Props) => {
   const [isOpen, setIsOpen] = useToggle();
 
   return (
@@ -57,7 +63,13 @@ export const LogsTableRow = ({ auditLog, rowNumber, timezone }: Props) => {
           <FontAwesomeIcon icon={isOpen ? faCaretDown : faCaretRight} />
           {rowNumber}
         </Td>
-        <Td className="align-top">{formatDateTime({ timestamp: auditLog.createdAt, timezone })}</Td>
+        <Td className="align-top">
+          {formatDateTime({
+            timestamp: auditLog.createdAt,
+            timezone,
+            dateFormat: getAuditLogTableDateFormat(clockFormat)
+          })}
+        </Td>
         <Td>
           <div className="flex flex-wrap items-center gap-2 text-sm">
             <Tag label="event" value={auditLog.event.type} />

--- a/frontend/src/pages/organization/AuditLogsPage/components/useAuditLogsDateTimePreferences.ts
+++ b/frontend/src/pages/organization/AuditLogsPage/components/useAuditLogsDateTimePreferences.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from "react";
+
+import { ClockFormat, Timezone } from "@app/helpers/datetime";
+
+const STORAGE_KEY = "infisical-audit-logs-datetime-v1";
+
+type StoredPrefs = {
+  timezone?: string;
+  clockFormat?: string;
+};
+
+const DEFAULT_TIMEZONE = Timezone.Local;
+const DEFAULT_CLOCK_FORMAT = ClockFormat.TwelveHour;
+
+const isTimezone = (v: unknown): v is Timezone =>
+  typeof v === "string" && (Object.values(Timezone) as string[]).includes(v);
+
+const isClockFormat = (v: unknown): v is ClockFormat =>
+  typeof v === "string" && (Object.values(ClockFormat) as string[]).includes(v);
+
+const readStored = (): { timezone: Timezone; clockFormat: ClockFormat } => {
+  if (typeof window === "undefined") {
+    return { timezone: DEFAULT_TIMEZONE, clockFormat: DEFAULT_CLOCK_FORMAT };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { timezone: DEFAULT_TIMEZONE, clockFormat: DEFAULT_CLOCK_FORMAT };
+    }
+    const parsed = JSON.parse(raw) as StoredPrefs;
+    return {
+      timezone: isTimezone(parsed.timezone) ? parsed.timezone : DEFAULT_TIMEZONE,
+      clockFormat: isClockFormat(parsed.clockFormat) ? parsed.clockFormat : DEFAULT_CLOCK_FORMAT
+    };
+  } catch {
+    return { timezone: DEFAULT_TIMEZONE, clockFormat: DEFAULT_CLOCK_FORMAT };
+  }
+};
+
+type AuditLogsDateTimePrefs = ReturnType<typeof readStored>;
+
+const writeStored = (prefs: AuditLogsDateTimePrefs) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ timezone: prefs.timezone, clockFormat: prefs.clockFormat })
+  );
+};
+
+export const useAuditLogsDateTimePreferences = () => {
+  const [prefs, setPrefs] = useState<AuditLogsDateTimePrefs>(() => readStored());
+
+  const setTimezone = useCallback((timezone: Timezone) => {
+    setPrefs((prev: AuditLogsDateTimePrefs) => {
+      const next = { ...prev, timezone };
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
+  const setClockFormat = useCallback((clockFormat: ClockFormat) => {
+    setPrefs((prev: AuditLogsDateTimePrefs) => {
+      const next = { ...prev, clockFormat };
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
+  return {
+    timezone: prefs.timezone,
+    clockFormat: prefs.clockFormat,
+    setTimezone,
+    setClockFormat
+  };
+};

--- a/frontend/src/pages/organization/AuditLogsPage/components/useAuditLogsDateTimePreferences.ts
+++ b/frontend/src/pages/organization/AuditLogsPage/components/useAuditLogsDateTimePreferences.ts
@@ -50,21 +50,23 @@ const writeStored = (prefs: AuditLogsDateTimePrefs) => {
 export const useAuditLogsDateTimePreferences = () => {
   const [prefs, setPrefs] = useState<AuditLogsDateTimePrefs>(() => readStored());
 
-  const setTimezone = useCallback((timezone: Timezone) => {
-    setPrefs((prev: AuditLogsDateTimePrefs) => {
-      const next = { ...prev, timezone };
+  const setTimezone = useCallback(
+    (timezone: Timezone) => {
+      const next = { ...prefs, timezone };
       writeStored(next);
-      return next;
-    });
-  }, []);
+      setPrefs(next);
+    },
+    [prefs]
+  );
 
-  const setClockFormat = useCallback((clockFormat: ClockFormat) => {
-    setPrefs((prev: AuditLogsDateTimePrefs) => {
-      const next = { ...prev, clockFormat };
+  const setClockFormat = useCallback(
+    (clockFormat: ClockFormat) => {
+      const next = { ...prefs, clockFormat };
       writeStored(next);
-      return next;
-    });
-  }, []);
+      setPrefs(next);
+    },
+    [prefs]
+  );
 
   return {
     timezone: prefs.timezone,


### PR DESCRIPTION
Users can choose 12-hour or 24-hour timestamps next to the existing Local/UTC timezone control. Preferences (timezone + clock format) persist in localStorage. The absolute date range bar uses the same clock format as the table.

Closes https://github.com/Infisical/infisical/issues/4767

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [X] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)