### PR TITLE
fix: correct total count in user, group, and org identity membership list queries

### DIFF
--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -427,12 +427,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
             : `${TableName.Identity}.${orderBy}`,
           orderDirection
         )
-        .select(`${TableName.Membership}.id`)
-        .select<{ id: string; total_count: string }>(
-          db.raw(
-            `count(${TableName.Membership}."actorIdentityId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total_count`
-          )
-        )
+        .distinct(`${TableName.Membership}.id`)
         .as("searchedIdentities");
 
       if (searchFilter) {
@@ -447,6 +442,10 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           }
         });
       }
+
+      const countQuery = await (tx || db.replicaNode())
+        .count("* as total")
+        .from(searchQuery.clone().as("distinctMemberships"));
 
       if (limit) {
         void searchQuery.offset(offset).limit(limit);
@@ -667,7 +666,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         ]
       });
 
-      return { docs: formattedDocs, totalCount: Number(formattedDocs?.[0]?.total_count ?? 0) };
+      return { docs: formattedDocs, totalCount: Number((countQuery?.[0] as unknown as { total: number })?.total ?? 0) };
     } catch (error) {
       throw new DatabaseError({ error, name: "FindByOrgId" });
     }

--- a/backend/src/services/membership-group/membership-group-dal.ts
+++ b/backend/src/services/membership-group/membership-group-dal.ts
@@ -153,9 +153,6 @@ export const membershipGroupDALFactory = (db: TDbClient) => {
           }
         });
 
-      if (filter.limit) void paginatedGroups.limit(filter.limit);
-      if (filter.offset) void paginatedGroups.offset(filter.offset);
-
       if (filter.name || filter.role) {
         buildKnexFilterForSearchResource(
           paginatedGroups,
@@ -175,6 +172,13 @@ export const membershipGroupDALFactory = (db: TDbClient) => {
           }
         );
       }
+
+      const countQuery = await (tx || db.replicaNode())
+        .count("* as total")
+        .from(paginatedGroups.clone().as("distinctMemberships"));
+
+      if (filter.limit) void paginatedGroups.limit(filter.limit);
+      if (filter.offset) void paginatedGroups.offset(filter.offset);
 
       const docs = await (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorGroupId`)
@@ -208,11 +212,6 @@ export const membershipGroupDALFactory = (db: TDbClient) => {
             .as("membershipRoleTemporaryAccessEndTime"),
           db.ref("createdAt").withSchema(TableName.MembershipRole).as("membershipRoleCreatedAt"),
           db.ref("updatedAt").withSchema(TableName.MembershipRole).as("membershipRoleUpdatedAt")
-        )
-        .select(
-          db.raw(
-            `count(${TableName.Membership}."actorGroupId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total`
-          )
         );
 
       const data = sqlNestRelationships({
@@ -262,7 +261,7 @@ export const membershipGroupDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((data?.[0] as unknown as { total: number })?.total ?? 0) };
+      return { data, totalCount: Number((countQuery?.[0] as unknown as { total: number })?.total ?? 0) };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindGroup" });
     }

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -167,9 +167,6 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         });
 
-      if (filter.limit) void paginatedUsers.limit(filter.limit);
-      if (filter.offset) void paginatedUsers.offset(filter.offset);
-
       if (filter.username || filter.role) {
         buildKnexFilterForSearchResource(
           paginatedUsers,
@@ -189,6 +186,13 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         );
       }
+
+      const countQuery = await (tx || db.replicaNode())
+        .count("* as total")
+        .from(paginatedUsers.clone().as("distinctMemberships"));
+
+      if (filter.limit) void paginatedUsers.limit(filter.limit);
+      if (filter.offset) void paginatedUsers.offset(filter.offset);
 
       const docs = await (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
@@ -223,11 +227,6 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           db.ref("firstName").withSchema(TableName.Users).as("userFirstName"),
           db.ref("lastName").withSchema(TableName.Users).as("userLastName"),
           db.ref("id").withSchema(TableName.Users).as("userId")
-        )
-        .select(
-          db.raw(
-            `count(${TableName.Membership}."actorUserId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total`
-          )
         );
 
       const data = sqlNestRelationships({
@@ -277,7 +276,7 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((data?.[0] as unknown as { total: number })?.total ?? 0) };
+      return { data, totalCount: Number((countQuery?.[0] as unknown as { total: number })?.total ?? 0) };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindUser" });
     }


### PR DESCRIPTION
## Context

PR #5850 fixed the total count for project identity memberships -- the window function count was running over JOINed `membership_roles` rows, so members with multiple roles got counted once per role instead of once per member.

The same bug exists in three sibling queries that weren't covered by that fix:

- `membership-user-dal.ts` (`findUsers`) -- user list total inflated by roles
- `membership-group-dal.ts` (`findGroups`) -- group list total inflated by roles
- `identity-org-dal.ts` (`searchIdentities`) -- org identity search total inflated by roles

Applied the same fix from #5850: replaced the window function with a subquery count over the distinct membership set, and moved limit/offset after the count so the total reflects all matching records, not just the current page.

Fixes #5885

## Screenshots

N/A

## Steps to verify the change

1. Create an org with several users, assign multiple roles to some of them
2. List users via the membership list endpoint
3. Confirm `totalCount` matches the number of unique users, not the sum of role assignments
4. Same for groups and org identities

For reference, tested with 5 users where 2 had multiple roles: buggy query returned 8, fixed query returns 5.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)