### PR TITLE
improvement(secrets): new query parameter filterInaccessibleSecrets

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1257,7 +1257,9 @@ export const RAW_SECRETS = {
     metadataFilter:
       "Unencrypted secret metadata key-value pairs used to filter secrets. Only metadata with unencrypted values is supported. When querying for multiple metadata pairs, the query is treated as an AND operation. Secret metadata format is key=value1,value=value2|key=value3,value=value4.",
     includePersonalOverrides:
-      "Whether or not to include personal secrets in the response. When enabled, personal secrets will be included in the response. Shared secrets will still be included, but personal secrets will take priority, and the corresponding shared secrets will be replaced with the personal secrets."
+      "Whether or not to include personal secrets in the response. When enabled, personal secrets will be included in the response. Shared secrets will still be included, but personal secrets will take priority, and the corresponding shared secrets will be replaced with the personal secrets.",
+    filterInaccessibleSecrets:
+      "Whether or not to filter out secrets that the user does not have access to read the value of. When enabled, secrets that the user does not have the ReadValue permission for will be removed entirely from the response."
   },
   CREATE: {
     secretName: "The name of the secret to create.",

--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -130,6 +130,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         recursive: convertStringBoolean().describe(RAW_SECRETS.LIST.recursive),
         includePersonalOverrides: convertStringBoolean().describe(RAW_SECRETS.LIST.includePersonalOverrides),
         includeImports: convertStringBoolean(true).describe(RAW_SECRETS.LIST.includeImports),
+        filterInaccessibleSecrets: convertStringBoolean().describe(RAW_SECRETS.LIST.filterInaccessibleSecrets),
         tagSlugs: z
           .string()
           .describe(RAW_SECRETS.LIST.tagSlugs)
@@ -200,6 +201,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         includeImports: req.query.includeImports,
         recursive: req.query.recursive,
         tagSlugs: req.query.tagSlugs,
+        filterInaccessibleSecrets: req.query.filterInaccessibleSecrets,
         ifNoneMatch: req.headers["if-none-match"]
       });
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1151,6 +1151,7 @@ export const secretV2BridgeServiceFactory = ({
       expandSecretReferences: shouldExpandSecretReferences,
       expandPersonalOverrides,
       personalOverridesBehavior,
+      filterInaccessibleSecrets,
       throwOnMissingReadValuePermission = true,
       ifNoneMatch,
       ...params
@@ -1328,6 +1329,23 @@ export const secretV2BridgeServiceFactory = ({
 
         if (!canDescribeSecret) {
           return false;
+        }
+
+        if (filterInaccessibleSecrets) {
+          const canReadValue = hasSecretReadValueOrDescribePermission(
+            permission,
+            ProjectPermissionSecretActions.ReadValue,
+            {
+              environment,
+              secretPath: groupedPaths[el.folderId][0].path,
+              secretName: el.key,
+              secretTags: el.tags.map((i) => i.slug)
+            }
+          );
+
+          if (!canReadValue) {
+            return false;
+          }
         }
 
         if (viewSecretValue) {
@@ -1547,7 +1565,7 @@ export const secretV2BridgeServiceFactory = ({
           }
         );
 
-        return viewSecretValue ? canDescribe && canReadValue : canDescribe;
+        return viewSecretValue || filterInaccessibleSecrets ? canDescribe && canReadValue : canDescribe;
       }
     });
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-types.ts
@@ -46,6 +46,7 @@ export type TGetSecretsDTO = {
   recursive?: boolean;
   tagSlugs?: string[];
   viewSecretValue: boolean;
+  filterInaccessibleSecrets?: boolean;
   throwOnMissingReadValuePermission?: boolean;
   metadataFilter?: {
     key?: string;

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -1431,6 +1431,7 @@ export const secretServiceFactory = ({
     expandPersonalOverrides,
     recursive,
     tagSlugs = [],
+    filterInaccessibleSecrets = false,
     throwOnMissingReadValuePermission = true,
     ifNoneMatch,
     ...paramsV2
@@ -1447,7 +1448,8 @@ export const secretServiceFactory = ({
         actor,
         actorOrgId,
         viewSecretValue,
-        throwOnMissingReadValuePermission,
+        filterInaccessibleSecrets,
+        throwOnMissingReadValuePermission: filterInaccessibleSecrets ? false : throwOnMissingReadValuePermission,
         environment,
         path,
         recursive,

--- a/backend/src/services/secret/secret-types.ts
+++ b/backend/src/services/secret/secret-types.ts
@@ -212,6 +212,7 @@ export type TGetSecretsRawDTO = {
   path: string;
   environment: string;
   viewSecretValue: boolean;
+  filterInaccessibleSecrets?: boolean;
   throwOnMissingReadValuePermission?: boolean;
   includeImports?: boolean;
   recursive?: boolean;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This query parameter `filterInaccessibleSecrets` will only fetch secrets the identity has access to. It modifies the secret list endpoint so it is possible to only check the secrets your identity has access (can see the value), not the one that it can describe (they exist and you can check it, but you don't have access)   

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Create a new machine identity
- Define a role and define it is only possible to describe the secrets 
- Authenticate with the machine identity using: `http://localhost:8080/api/v1/auth/universal-auth/login` (use universal access to be more easy)
- Query the list endpoint 
- check that the secret was not returned 
- Modify the role to also has read access 
- Query again and check that the secret was returned.  

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)