### PR TITLE
fix(secrets-overview): keep filters when navigating folders

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -314,9 +314,6 @@ const OverviewPageContent = () => {
 
   const [filter, setFilter] = useState<Filter>(DEFAULT_FILTER_STATE);
   const [tagFilter, setTagFilter] = useState<Record<string, boolean>>({});
-  const [filterHistory, setFilterHistory] = useState<
-    Map<string, { filter: Filter; searchFilter: string }>
-  >(new Map());
 
   const [selectedEntries, setSelectedEntries] = useState<{
     // selectedEntries[name/key][envSlug][resource]
@@ -1990,33 +1987,14 @@ const OverviewPageContent = () => {
     handlePopUpClose("confirmDisableBatchMode");
   }, [singleVisibleEnv, clearAllPendingChanges, projectId, secretPath, handlePopUpClose]);
 
-  const handleResetSearch = (path: string) => {
-    const restore = filterHistory.get(path);
-    setFilter(restore?.filter ?? DEFAULT_FILTER_STATE);
-    const el = restore?.searchFilter ?? "";
-    setSearchFilter(el);
-    setDebouncedSearchFilter(el);
-  };
-
   const handleFolderClick = (path: string) => {
     if (isOverviewFetching) return;
-
-    // store for breadcrumb nav to restore previously used filters
-    setFilterHistory((prev) => {
-      const curr = new Map(prev);
-      curr.set(secretPath, { filter, searchFilter });
-      return curr;
-    });
 
     navigate({
       search: (prev) => ({
         ...prev,
         secretPath: `${routerSearch.secretPath === "/" ? "" : routerSearch.secretPath}/${path}`
       })
-    }).then(() => {
-      setFilter(DEFAULT_FILTER_STATE);
-      setSearchFilter("");
-      setDebouncedSearchFilter("");
     });
   };
 
@@ -2379,7 +2357,7 @@ const OverviewPageContent = () => {
                     (pendingChanges.secrets.length > 0 || pendingChanges.folders.length > 0)
                   }
                 />
-                <FolderBreadcrumb secretPath={secretPath} onResetSearch={handleResetSearch} />
+                <FolderBreadcrumb secretPath={secretPath} />
               </div>
               <div className="flex flex-wrap items-center gap-3">
                 {userAvailableEnvs.length > 0 && (

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
@@ -18,7 +18,6 @@ import {
 
 type Props = {
   secretPath?: string;
-  onResetSearch: (secretPath: string) => void;
 };
 
 type Measurements = {
@@ -29,7 +28,7 @@ type Measurements = {
   separatorWidth: number;
 };
 
-export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
+export function FolderBreadcrumb({ secretPath = "" }: Props) {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
@@ -53,9 +52,9 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
       if (secretPath === newSecPath) return;
       navigate({
         search: (prev) => ({ ...prev, secretPath: newSecPath })
-      }).then(() => onResetSearch(newSecPath));
+      });
     },
-    [secretPath, navigate, onResetSearch]
+    [secretPath, navigate]
   );
 
   // Measure all elements and track container width


### PR DESCRIPTION
## Context
Keep the filters the same when getting in folders. Remove the filter history and the onResetSearch callback, so the filters are kept when navigating the folders. 

## Screenshots


https://github.com/user-attachments/assets/d508ebd3-78e9-49c4-a95c-84bcbf55aab1



## Steps to verify the change
- Go into secrets overview 
- Be sure that you have secrets and folders. 
- Add a filter and navigate inside it
- Make sure the filters are not changing and still being applied 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)