### PR TITLE
fix(assume-privilege): enforce identity-scoped conditions when checking assume privileges

### DIFF
--- a/backend/src/ee/services/assume-privilege/assume-privilege-service.ts
+++ b/backend/src/ee/services/assume-privilege/assume-privilege-service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from "@casl/ability";
+import { ForbiddenError, subject } from "@casl/ability";
 
 import { ActionProjectType } from "@app/db/schemas";
 import { getConfig } from "@app/lib/config/env";
@@ -50,7 +50,7 @@ export const assumePrivilegeServiceFactory = ({
     } else {
       ForbiddenError.from(permission).throwUnlessCan(
         ProjectPermissionIdentityActions.AssumePrivileges,
-        ProjectPermissionSub.Identity
+        subject(ProjectPermissionSub.Identity, { identityId: targetActorId })
       );
     }
 


### PR DESCRIPTION
## Context

Fixes a high-severity authorization gap in identity assume-privilege checks.

Before this change, when checking `AssumePrivileges` for `IDENTITY`, the backend passed only the subject type (`ProjectPermissionSub.Identity`) to CASL:

```ts
ForbiddenError.from(permission).throwUnlessCan(
  ProjectPermissionIdentityActions.AssumePrivileges,
  ProjectPermissionSub.Identity
);
```

Because no subject instance was provided, condition-based rules (for example `identityId`-scoped conditions) were not enforced as intended and could be treated as unconditional allows.  
This could allow a role meant to assume only specific identities to assume any identity in the project.

After this change, the check uses a concrete subject instance:

```ts
ForbiddenError.from(permission).throwUnlessCan(
  ProjectPermissionIdentityActions.AssumePrivileges,
  subject(ProjectPermissionSub.Identity, { identityId: targetActorId })
);
```

This ensures CASL evaluates `identityId` conditions against the actual target identity, preventing privilege escalation.

Related area: `backend/src/ee/services/permission/project-permission.ts` (identity condition keys).

## Screenshots

N/A (backend-only authorization fix).

## Steps to verify the change

1. Seed/run the repro scenario (e.g. using `backend/scripts/seed-additional-privilege-identity-bug-repro.ts`).
2. Configure a role/additional privilege that allows `AssumePrivileges` only for specific `identityId` values.
3. Attempt assume-privilege for:
   - an allowed identity ID → should succeed.
   - a different identity ID in the same project → should be denied (`ForbiddenError`).
4. Run targeted tests for assume privilege flow:
   - `backend/src/ee/services/assume-privilege/assume-privilege-service.test.ts`

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

Suggested title: `fix(assume-privilege): enforce identity-scoped conditions for assume privileges`