### PR TITLE
feature(request-context): implement request-scoped memoization for optimized DB reads

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -124,6 +124,43 @@ Uses CASL (`@casl/ability`) with MongoDB-style rules. Permission logic lives in 
 
 Built-in roles: `Admin`, `Member`, `Viewer`, `NoAccess`. Custom roles use unpacked CASL rules stored in the database. Rules can include conditions with operators `$IN`, `$EQ`, `$NEQ`, `$GLOB` (for pattern matching like `prod-*`). See `PermissionConditionSchema` in `permission-types.ts`.
 
+### Request-Scoped Memoization
+
+A per-request in-memory cache that eliminates redundant DB reads within a single HTTP request. Defined in `src/lib/request-context/request-memoizer.ts`, attached to Fastify's `@fastify/request-context` as the `memoizer` field (initialized in `src/server/app.ts`). Cache is automatically garbage-collected when the request ends — zero staleness risk, zero infrastructure.
+
+**How it works**: `RequestMemoizer` wraps a `Map<string, unknown>` with an async `getOrSet(key, fetcher)` method. Concurrent calls for the same key coalesce onto a single fetcher invocation (in-flight deduplication). The `requestMemoize(key, fetcher)` helper reads the memoizer from request context and falls back to direct execution when no context exists (e.g. queue workers).
+
+**Currently memoized**:
+- `getProjectPermission` — full-function result (keyed by projectId + actor + actorId + actorOrgId + actorAuthMethod + actionProjectType). Eliminates redundant permission checks in batch secret operations (50 secrets → 1 DB round-trip instead of 50).
+- `getOrgPermission` — full-function result (keyed by orgId + actor + actorId + actorOrgId + actorAuthMethod + scope).
+- `projectDAL.findById` — in permission-service.ts and project-bot-fns.ts. Deduplicates 4 of the 5 redundant project lookups seen per secret read request.
+- `userDAL.findById` / `identityDAL.findById` — in permission-service.ts. Eliminates the redundant actor lookup during permission resolution.
+
+**Usage pattern**:
+```ts
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+
+// In a service or function called during request handling:
+const project = await requestMemoize(
+  `project:findById:${projectId}`,
+  () => projectDAL.findById(projectId)
+);
+```
+
+**When to add more items to request-scoped memoization**:
+- The data is **read-only within the request** — no mutations to the same record happen between reads.
+- The same DAL call (same table, same ID) is made **2+ times in the same request** across different services or functions. Check with Datadog traces or by searching for the DAL method across call sites in the hot path.
+- The call does **NOT use a DB transaction** (`trx` parameter). Transactional reads may see different data than read-replica results; memoizing them could return stale data.
+- The call is on a **hot path** (auth, permissions, secret CRUD). Low-frequency admin endpoints don't benefit enough to justify the added indirection.
+
+**When NOT to use**:
+- Inside DB transactions — pass `trx` directly, skip memoization.
+- For data mutated within the request and re-read (e.g. KMS key creation writes to the project row, then re-reads it).
+- In queue workers or background jobs — the helper falls back gracefully, but there's no request lifecycle to scope the cache.
+- For write operations — only memoize reads.
+
+**Key format convention**: `<entity>:<method>:<id>` for DAL calls (e.g. `project:findById:${projectId}`), `permission:<scope>:<id>:...` for permission results.
+
 ### Queue System (BullMQ)
 
 Queue infrastructure in `src/queue/queue-service.ts`. Defines 30+ named queues via `QueueName` enum (e.g., `SecretRotation`, `AuditLog`, `IntegrationSync`, `SecretReplication`, `SecretSync`, `DynamicSecretRevocation`). Each queue has typed payloads defined in `TQueueJobTypes`.

--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -61,6 +61,7 @@ import { TSshHostServiceFactory } from "@app/ee/services/ssh-host/ssh-host-servi
 import { TSshHostGroupServiceFactory } from "@app/ee/services/ssh-host-group/ssh-host-group-service";
 import { TSubOrgServiceFactory } from "@app/ee/services/sub-org/sub-org-service";
 import { TTrustedIpServiceFactory } from "@app/ee/services/trusted-ip/trusted-ip-types";
+import { RequestMemoizer } from "@app/lib/request-context/request-memoizer";
 import { TAuthMode } from "@app/server/plugins/auth/inject-identity";
 import { TAccountRecoveryServiceFactory } from "@app/services/account-recovery/account-recovery-service";
 import { TAdditionalPrivilegeServiceFactory } from "@app/services/additional-privilege/additional-privilege-service";
@@ -196,6 +197,7 @@ declare module "@fastify/request-context" {
     };
     identityPermissionMetadata?: Record<string, unknown>; // filled by permission service
     assumedPrivilegeDetails?: { requesterId: string; actorId: string; actorType: ActorType; projectId: string };
+    memoizer?: RequestMemoizer;
   }
 }
 

--- a/backend/src/ee/routes/v1/assume-privilege-router.ts
+++ b/backend/src/ee/routes/v1/assume-privilege-router.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -91,7 +91,7 @@ export const registerAssumePrivilegeRouter = async (server: FastifyZodProvider) 
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req, res) => {
-      const assumedPrivilegeDetails = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
+      const assumedPrivilegeDetails = requestContext.get(RequestContextKey.AssumedPrivilegeDetails);
       if (req.auth.authMode === AuthMode.JWT && assumedPrivilegeDetails) {
         const appCfg = getConfig();
         void res.setCookie("infisical-project-assume-privileges", "", {

--- a/backend/src/ee/routes/v1/assume-privilege-router.ts
+++ b/backend/src/ee/routes/v1/assume-privilege-router.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -90,7 +91,7 @@ export const registerAssumePrivilegeRouter = async (server: FastifyZodProvider) 
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req, res) => {
-      const assumedPrivilegeDetails = requestContext.get("assumedPrivilegeDetails");
+      const assumedPrivilegeDetails = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
       if (req.auth.authMode === AuthMode.JWT && assumedPrivilegeDetails) {
         const appCfg = getConfig();
         void res.setCookie("infisical-project-assume-privileges", "", {

--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -18,7 +18,7 @@ import { ApiDocsTags, SamlSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
@@ -172,8 +172,8 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
               "infisical.organization.name": organization.name,
               "infisical.auth.method": AuthAttemptAuthMethod.SAML,
               "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-              "client.address": requestContext.get(requestContextKeys.ip),
-              "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+              "client.address": requestContext.get(RequestContextKey.Ip),
+              "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
             });
           }
 
@@ -184,8 +184,8 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
               "infisical.user.email": email.toLowerCase(),
               "infisical.auth.method": AuthAttemptAuthMethod.SAML,
               "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-              "client.address": requestContext.get(requestContextKeys.ip),
-              "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+              "client.address": requestContext.get(RequestContextKey.Ip),
+              "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
             });
           }
 

--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -18,6 +18,7 @@ import { ApiDocsTags, SamlSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
@@ -171,8 +172,8 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
               "infisical.organization.name": organization.name,
               "infisical.auth.method": AuthAttemptAuthMethod.SAML,
               "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-              "client.address": requestContext.get("ip"),
-              "user_agent.original": requestContext.get("userAgent")
+              "client.address": requestContext.get(requestContextKeys.ip),
+              "user_agent.original": requestContext.get(requestContextKeys.userAgent)
             });
           }
 
@@ -183,8 +184,8 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
               "infisical.user.email": email.toLowerCase(),
               "infisical.auth.method": AuthAttemptAuthMethod.SAML,
               "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-              "client.address": requestContext.get("ip"),
-              "user_agent.original": requestContext.get("userAgent")
+              "client.address": requestContext.get(requestContextKeys.ip),
+              "user_agent.original": requestContext.get(requestContextKeys.userAgent)
             });
           }
 

--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -5,6 +5,7 @@ import { ActionProjectType, OrganizationActionScope } from "@app/db/schemas";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 
 import { OrgPermissionAuditLogsActions, OrgPermissionSubjects } from "../permission/org-permission";
@@ -122,7 +123,7 @@ export const auditLogServiceFactory = ({
     }
     const el = { ...data };
     if (el.actor.type === ActorType.USER || el.actor.type === ActorType.IDENTITY) {
-      const permissionMetadata = requestContext.get("identityPermissionMetadata");
+      const permissionMetadata = requestContext.get(requestContextKeys.identityPermissionMetadata);
       el.actor.metadata.permission = permissionMetadata;
     }
     return auditLogQueue.pushToLog(el);

--- a/backend/src/ee/services/audit-log/audit-log-service.ts
+++ b/backend/src/ee/services/audit-log/audit-log-service.ts
@@ -5,7 +5,7 @@ import { ActionProjectType, OrganizationActionScope } from "@app/db/schemas";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 
 import { OrgPermissionAuditLogsActions, OrgPermissionSubjects } from "../permission/org-permission";
@@ -123,7 +123,7 @@ export const auditLogServiceFactory = ({
     }
     const el = { ...data };
     if (el.actor.type === ActorType.USER || el.actor.type === ActorType.IDENTITY) {
-      const permissionMetadata = requestContext.get(requestContextKeys.identityPermissionMetadata);
+      const permissionMetadata = requestContext.get(RequestContextKey.IdentityPermissionMetadata);
       el.actor.metadata.permission = permissionMetadata;
     }
     return auditLogQueue.pushToLog(el);

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -16,6 +16,7 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError, ForbiddenRequestError, NotFoundError, OidcAuthError } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { OrgServiceActor } from "@app/lib/types";
 import { blockLocalAndPrivateIpAddresses, matchesAllowedEmailDomain } from "@app/lib/validator";
@@ -823,8 +824,8 @@ export const oidcConfigServiceFactory = ({
                 "infisical.organization.name": org.name,
                 "infisical.auth.method": AuthAttemptAuthMethod.OIDC,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 
@@ -838,8 +839,8 @@ export const oidcConfigServiceFactory = ({
                 "infisical.organization.name": org.name,
                 "infisical.auth.method": AuthAttemptAuthMethod.OIDC,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -16,7 +16,7 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError, ForbiddenRequestError, NotFoundError, OidcAuthError } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { OrgServiceActor } from "@app/lib/types";
 import { blockLocalAndPrivateIpAddresses, matchesAllowedEmailDomain } from "@app/lib/validator";
@@ -824,8 +824,8 @@ export const oidcConfigServiceFactory = ({
                 "infisical.organization.name": org.name,
                 "infisical.auth.method": AuthAttemptAuthMethod.OIDC,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 
@@ -839,8 +839,8 @@ export const oidcConfigServiceFactory = ({
                 "infisical.organization.name": org.name,
                 "infisical.auth.method": AuthAttemptAuthMethod.OIDC,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -25,6 +25,9 @@ import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/
 import { conditionsMatcher } from "@app/lib/casl";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { objectify } from "@app/lib/fn";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -248,54 +251,64 @@ export const permissionServiceFactory = ({
       });
     }
 
-    const permissionData = await permissionDAL.getPermission({
-      scopeData: {
-        scope: AccessScope.Organization,
-        orgId
-      },
+    // Request-scoped memoization: deduplicates org permission checks within the same request
+    const memoKey = requestMemoKeys.orgPermission({
+      orgId,
+      actor,
       actorId,
-      actorType: actor
+      actorAuthMethod,
+      scope
     });
-    if (!permissionData?.length)
-      throw new ForbiddenRequestError({
-        message: `You are not a member of this organization with ID ${actorOrgId}. Please assign this ${actor} to the organization with the appropriate permissions, then try again.`
+    return requestMemoize(memoKey, async () => {
+      const permissionData = await permissionDAL.getPermission({
+        scopeData: {
+          scope: AccessScope.Organization,
+          orgId
+        },
+        actorId,
+        actorType: actor
+      });
+      if (!permissionData?.length)
+        throw new ForbiddenRequestError({
+          message: `You are not a member of this organization with ID ${actorOrgId}. Please assign this ${actor} to the organization with the appropriate permissions, then try again.`
+        });
+
+      const rootOrgId = permissionData?.[0]?.rootOrgId;
+      const isChild = Boolean(rootOrgId);
+      if (scope === OrganizationActionScope.ParentOrganization && isChild) {
+        throw new ForbiddenRequestError({ message: `Child organization cannot do this operation` });
+      } else if (scope === OrganizationActionScope.ChildOrganization && !isChild) {
+        throw new ForbiddenRequestError({ message: `Parent organization cannot do this operation` });
+      }
+
+      const permissionFromRoles = flattenActiveRolesFromMemberships(permissionData, OrgMembershipRole.Custom);
+
+      const hasRole = (role: string) =>
+        permissionData.some((memberships) => memberships.roles.some((el) => role === (el.customRoleSlug || el.role)));
+
+      const permission = createMongoAbility<OrgPermissionSet>(buildOrgPermissionRules(permissionFromRoles), {
+        conditionsMatcher
       });
 
-    const rootOrgId = permissionData?.[0]?.rootOrgId;
-    const isChild = Boolean(rootOrgId);
-    if (scope === OrganizationActionScope.ParentOrganization && isChild) {
-      throw new ForbiddenRequestError({ message: `Child organization cannot do this operation` });
-    } else if (scope === OrganizationActionScope.ChildOrganization && !isChild) {
-      throw new ForbiddenRequestError({ message: `Parent organization cannot do this operation` });
-    }
+      const canBypassSso = permission.can(OrgPermissionSsoActions.BypassSsoEnforcement, OrgPermissionSubjects.Sso);
 
-    const permissionFromRoles = flattenActiveRolesFromMemberships(permissionData, OrgMembershipRole.Custom);
+      // SSO enforcement applies only to users
+      if (actor === ActorType.USER) {
+        validateOrgSSO(
+          actorAuthMethod,
+          permissionData?.[0].orgAuthEnforced,
+          Boolean(permissionData?.[0].orgGoogleSsoAuthEnforced),
+          Boolean(permissionData?.[0].bypassOrgAuthEnabled),
+          canBypassSso
+        );
+      }
 
-    const hasRole = (role: string) =>
-      permissionData.some((memberships) => memberships.roles.some((el) => role === (el.customRoleSlug || el.role)));
-
-    const permission = createMongoAbility<OrgPermissionSet>(buildOrgPermissionRules(permissionFromRoles), {
-      conditionsMatcher
+      return {
+        permission,
+        memberships: permissionData,
+        hasRole
+      };
     });
-
-    const canBypassSso = permission.can(OrgPermissionSsoActions.BypassSsoEnforcement, OrgPermissionSubjects.Sso);
-
-    // SSO enforcement applies only to users
-    if (actor === ActorType.USER) {
-      validateOrgSSO(
-        actorAuthMethod,
-        permissionData?.[0].orgAuthEnforced,
-        Boolean(permissionData?.[0].orgGoogleSsoAuthEnforced),
-        Boolean(permissionData?.[0].bypassOrgAuthEnabled),
-        canBypassSso
-      );
-    }
-
-    return {
-      permission,
-      memberships: permissionData,
-      hasRole
-    };
   };
 
   const $checkProjectEnforcement = (projectDetails: TProjects) => {
@@ -367,7 +380,7 @@ export const permissionServiceFactory = ({
       });
     }
 
-    const assumedPrivilegeDetailsCtx = requestContext.get("assumedPrivilegeDetails");
+    const assumedPrivilegeDetailsCtx = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
     if (
       assumedPrivilegeDetailsCtx &&
       actor === ActorType.USER &&
@@ -385,16 +398,42 @@ export const permissionServiceFactory = ({
       });
     }
 
-    const projectDetails = await projectDAL.findById(projectId);
+    // Request-scoped full-function memoization: identical permission checks within
+    // the same request (e.g. batch secret operations) resolve in O(1) after the first call.
+    const memoKey = requestMemoKeys.projectPermission({
+      projectId,
+      actor,
+      actorId,
+      actorAuthMethod,
+      actionProjectType
+    });
+    const memoizer = requestContext.get(requestContextKeys.memoizer);
+    const cached = memoizer?.get<{
+      result: Awaited<ReturnType<TPermissionServiceFactory["getProjectPermission"]>>;
+      projectDetailsCtx: { id: string; name: string; slug: string };
+      identityPermissionMetadataCtx: Record<string, unknown>;
+    }>(memoKey);
+    if (cached) {
+      requestContext.set(requestContextKeys.projectDetails, cached.projectDetailsCtx);
+      requestContext.set(requestContextKeys.identityPermissionMetadata, cached.identityPermissionMetadataCtx);
+      return cached.result;
+    }
+
+    // DAL-level memoization: deduplicates projectDAL.findById across services
+    // (permission service, getBotKey, KMS) within the same request.
+    const projectDetails = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!projectDetails) {
       throw new NotFoundError({ message: `Project with ${projectId} not found` });
     }
 
-    requestContext.set("projectDetails", {
+    const projectDetailsCtx = {
       id: projectDetails.id,
       name: projectDetails.name,
       slug: projectDetails.slug
-    });
+    };
+    requestContext.set(requestContextKeys.projectDetails, projectDetailsCtx);
 
     if (projectDetails.orgId !== actorOrgId) {
       throw new ForbiddenRequestError({ name: "This project does not belong to your selected organization." });
@@ -465,18 +504,21 @@ export const permissionServiceFactory = ({
       (i) => i.value
     );
     const metadataKeyValuePair = escapeHandlebarsMissingDict(unescapedMetadata, "identity.metadata");
-    requestContext.set("identityPermissionMetadata", { metadata: unescapedMetadata });
+    const identityPermissionMetadataCtx = { metadata: unescapedMetadata };
+    requestContext.set(requestContextKeys.identityPermissionMetadata, identityPermissionMetadataCtx);
 
     let username = "";
     if (actor === ActorType.USER) {
-      const userDetails = await userDAL.findById(actorId);
+      const userDetails = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
       username = userDetails?.username;
     } else {
-      const identityDetails = await identityDAL.findById(actorId);
+      const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(actorId), () =>
+        identityDAL.findById(actorId)
+      );
       username = identityDetails?.name;
     }
 
-    const unescapedIdentityAuthInfo = requestContext.get("identityAuthInfo");
+    const unescapedIdentityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
     const identityAuthInfo =
       unescapedIdentityAuthInfo?.identityId === actorId && unescapedIdentityAuthInfo
         ? escapeHandlebarsMissingDict(unescapedIdentityAuthInfo as never, "identity.auth")
@@ -501,12 +543,21 @@ export const permissionServiceFactory = ({
       }
     );
 
-    return {
+    const result = {
       permission,
       memberships: permissionData,
       hasRole,
       hasProjectEnforcement: $checkProjectEnforcement(projectDetails)
     };
+
+    // Cache the full result with side-effect data for replay on cache hit
+    memoizer?.set(memoKey, {
+      result,
+      projectDetailsCtx,
+      identityPermissionMetadataCtx
+    });
+
+    return result;
   };
 
   const getProjectPermissions: TPermissionServiceFactory["getProjectPermissions"] = async (projectId, orgId) => {

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -398,166 +398,173 @@ export const permissionServiceFactory = ({
       });
     }
 
-    // Request-scoped full-function memoization: identical permission checks within
-    // the same request (e.g. batch secret operations) resolve in O(1) after the first call.
+    // Request-scoped full-function memoization: identical permission checks within the same request
     const memoKey = requestMemoKeys.projectPermission({
       projectId,
       actor,
       actorId,
       actorAuthMethod,
-      actionProjectType
+      actionProjectType,
+      actorOrgId
     });
     const memoizer = requestContext.get(requestContextKeys.memoizer);
-    const cached = memoizer?.get<{
+
+    type TProjectPermissionMemoPayload = {
       result: Awaited<ReturnType<TPermissionServiceFactory["getProjectPermission"]>>;
       projectDetailsCtx: { id: string; name: string; slug: string };
       identityPermissionMetadataCtx: Record<string, unknown>;
-    }>(memoKey);
-    if (cached) {
-      requestContext.set(requestContextKeys.projectDetails, cached.projectDetailsCtx);
-      requestContext.set(requestContextKeys.identityPermissionMetadata, cached.identityPermissionMetadataCtx);
-      return cached.result;
-    }
-
-    // DAL-level memoization: deduplicates projectDAL.findById across services
-    // (permission service, getBotKey, KMS) within the same request.
-    const projectDetails = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
-      projectDAL.findById(projectId)
-    );
-    if (!projectDetails) {
-      throw new NotFoundError({ message: `Project with ${projectId} not found` });
-    }
-
-    const projectDetailsCtx = {
-      id: projectDetails.id,
-      name: projectDetails.name,
-      slug: projectDetails.slug
     };
-    requestContext.set(requestContextKeys.projectDetails, projectDetailsCtx);
 
-    if (projectDetails.orgId !== actorOrgId) {
-      throw new ForbiddenRequestError({ name: "This project does not belong to your selected organization." });
-    }
+    const loadProjectPermission = async (): Promise<TProjectPermissionMemoPayload> => {
+      // DAL-level memoization: deduplicates projectDAL.findById across services
+      // (permission service, getBotKey, KMS) within the same request.
+      const projectDetails = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+        projectDAL.findById(projectId)
+      );
+      if (!projectDetails) {
+        throw new NotFoundError({ message: `Project with ${projectId} not found` });
+      }
 
-    if (actionProjectType !== ActionProjectType.Any && actionProjectType !== projectDetails.type) {
-      throw new BadRequestError({
-        message: `The project is of type ${projectDetails.type}. Operations of type ${actionProjectType} are not allowed.`
-      });
-    }
+      const projectDetailsCtx = {
+        id: projectDetails.id,
+        name: projectDetails.name,
+        slug: projectDetails.slug
+      };
 
-    const permissionData = await permissionDAL.getPermission({
-      scopeData: {
-        scope: AccessScope.Project,
-        orgId: projectDetails.orgId,
-        projectId
-      },
-      actorId,
-      actorType: actor
-    });
-    if (!permissionData?.length)
-      throw new ForbiddenRequestError({
-        message: `You are not a member of this project with ID ${projectId}. Please assign this ${actor} to the project with the appropriate permissions, then try again.`
-      });
+      if (projectDetails.orgId !== actorOrgId) {
+        throw new ForbiddenRequestError({ name: "This project does not belong to your selected organization." });
+      }
 
-    const permissionFromRoles = flattenActiveRolesFromMemberships(permissionData, ProjectMembershipRole.Custom);
-
-    const hasRole = (role: string) =>
-      permissionData.some((memberships) => memberships.roles.some((el) => role === (el.customRoleSlug || el.role)));
-
-    // SSO enforcement applies only to users; use org-level bypass criteria (Org Admin or BypassSsoEnforcement permission)
-    // When project is in sub-org, use root org for bypass check (SSO enforced at root; user's bypass permission is in root org)
-    if (actor === ActorType.USER) {
-      let canBypassSso = false;
-      const enforceSsoAndBypassEnabled =
-        permissionData?.[0].orgAuthEnforced ||
-        (permissionData?.[0].orgGoogleSsoAuthEnforced && permissionData?.[0].bypassOrgAuthEnabled);
-
-      if (enforceSsoAndBypassEnabled) {
-        const orgIdForBypass = permissionData?.[0].rootOrgId ?? projectDetails.orgId;
-        const orgPermissionData = await permissionDAL.getPermission({
-          scopeData: { scope: AccessScope.Organization, orgId: orgIdForBypass },
-          actorId,
-          actorType: ActorType.USER
+      if (actionProjectType !== ActionProjectType.Any && actionProjectType !== projectDetails.type) {
+        throw new BadRequestError({
+          message: `The project is of type ${projectDetails.type}. Operations of type ${actionProjectType} are not allowed.`
         });
-        if (orgPermissionData?.length) {
-          const orgPermissionFromRoles = flattenActiveRolesFromMemberships(orgPermissionData, OrgMembershipRole.Custom);
-          const orgPermission = createMongoAbility<OrgPermissionSet>(buildOrgPermissionRules(orgPermissionFromRoles), {
-            conditionsMatcher
+      }
+
+      const permissionData = await permissionDAL.getPermission({
+        scopeData: {
+          scope: AccessScope.Project,
+          orgId: projectDetails.orgId,
+          projectId
+        },
+        actorId,
+        actorType: actor
+      });
+      if (!permissionData?.length)
+        throw new ForbiddenRequestError({
+          message: `You are not a member of this project with ID ${projectId}. Please assign this ${actor} to the project with the appropriate permissions, then try again.`
+        });
+
+      const permissionFromRoles = flattenActiveRolesFromMemberships(permissionData, ProjectMembershipRole.Custom);
+
+      const hasRole = (role: string) =>
+        permissionData.some((memberships) => memberships.roles.some((el) => role === (el.customRoleSlug || el.role)));
+
+      // SSO enforcement applies only to users; use org-level bypass criteria (Org Admin or BypassSsoEnforcement permission)
+      // When project is in sub-org, use root org for bypass check (SSO enforced at root; user's bypass permission is in root org)
+      if (actor === ActorType.USER) {
+        let canBypassSso = false;
+        const enforceSsoAndBypassEnabled =
+          permissionData?.[0].orgAuthEnforced ||
+          (permissionData?.[0].orgGoogleSsoAuthEnforced && permissionData?.[0].bypassOrgAuthEnabled);
+
+        if (enforceSsoAndBypassEnabled) {
+          const orgIdForBypass = permissionData?.[0].rootOrgId ?? projectDetails.orgId;
+          const orgPermissionData = await permissionDAL.getPermission({
+            scopeData: { scope: AccessScope.Organization, orgId: orgIdForBypass },
+            actorId,
+            actorType: ActorType.USER
           });
-          canBypassSso = orgPermission.can(OrgPermissionSsoActions.BypassSsoEnforcement, OrgPermissionSubjects.Sso);
+          if (orgPermissionData?.length) {
+            const orgPermissionFromRoles = flattenActiveRolesFromMemberships(
+              orgPermissionData,
+              OrgMembershipRole.Custom
+            );
+            const orgPermission = createMongoAbility<OrgPermissionSet>(
+              buildOrgPermissionRules(orgPermissionFromRoles),
+              {
+                conditionsMatcher
+              }
+            );
+            canBypassSso = orgPermission.can(OrgPermissionSsoActions.BypassSsoEnforcement, OrgPermissionSubjects.Sso);
+          }
         }
+        validateOrgSSO(
+          actorAuthMethod,
+          permissionData?.[0].orgAuthEnforced,
+          Boolean(permissionData?.[0].orgGoogleSsoAuthEnforced),
+          Boolean(permissionData?.[0].bypassOrgAuthEnabled),
+          canBypassSso
+        );
       }
-      validateOrgSSO(
-        actorAuthMethod,
-        permissionData?.[0].orgAuthEnforced,
-        Boolean(permissionData?.[0].orgGoogleSsoAuthEnforced),
-        Boolean(permissionData?.[0].bypassOrgAuthEnabled),
-        canBypassSso
+
+      const rules = buildProjectPermissionRules(permissionFromRoles);
+      const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false });
+      const unescapedMetadata = objectify(
+        permissionData?.[0]?.metadata,
+        (i) => i.key,
+        (i) => i.value
       );
-    }
+      const metadataKeyValuePair = escapeHandlebarsMissingDict(unescapedMetadata, "identity.metadata");
+      const identityPermissionMetadataCtx = { metadata: unescapedMetadata };
 
-    const rules = buildProjectPermissionRules(permissionFromRoles);
-    const templatedRules = handlebars.compile(JSON.stringify(rules), { data: false });
-    const unescapedMetadata = objectify(
-      permissionData?.[0]?.metadata,
-      (i) => i.key,
-      (i) => i.value
-    );
-    const metadataKeyValuePair = escapeHandlebarsMissingDict(unescapedMetadata, "identity.metadata");
-    const identityPermissionMetadataCtx = { metadata: unescapedMetadata };
-    requestContext.set(requestContextKeys.identityPermissionMetadata, identityPermissionMetadataCtx);
+      let username = "";
+      if (actor === ActorType.USER) {
+        const userDetails = await requestMemoize(requestMemoKeys.userFindById(actorId), () =>
+          userDAL.findById(actorId)
+        );
+        username = userDetails?.username;
+      } else {
+        const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(actorId), () =>
+          identityDAL.findById(actorId)
+        );
+        username = identityDetails?.name;
+      }
 
-    let username = "";
-    if (actor === ActorType.USER) {
-      const userDetails = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
-      username = userDetails?.username;
-    } else {
-      const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(actorId), () =>
-        identityDAL.findById(actorId)
+      const unescapedIdentityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+      const identityAuthInfo =
+        unescapedIdentityAuthInfo?.identityId === actorId && unescapedIdentityAuthInfo
+          ? escapeHandlebarsMissingDict(unescapedIdentityAuthInfo as never, "identity.auth")
+          : {};
+
+      const interpolateRules = templatedRules(
+        {
+          identity: {
+            id: actorId,
+            username,
+            metadata: metadataKeyValuePair,
+            auth: identityAuthInfo
+          }
+        },
+        { data: false }
       );
-      username = identityDetails?.name;
-    }
 
-    const unescapedIdentityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
-    const identityAuthInfo =
-      unescapedIdentityAuthInfo?.identityId === actorId && unescapedIdentityAuthInfo
-        ? escapeHandlebarsMissingDict(unescapedIdentityAuthInfo as never, "identity.auth")
-        : {};
-
-    const interpolateRules = templatedRules(
-      {
-        identity: {
-          id: actorId,
-          username,
-          metadata: metadataKeyValuePair,
-          auth: identityAuthInfo
+      const permission = createMongoAbility<ProjectPermissionSet>(
+        JSON.parse(interpolateRules) as RawRuleOf<MongoAbility<ProjectPermissionSet>>[],
+        {
+          conditionsMatcher
         }
-      },
-      { data: false }
-    );
+      );
 
-    const permission = createMongoAbility<ProjectPermissionSet>(
-      JSON.parse(interpolateRules) as RawRuleOf<MongoAbility<ProjectPermissionSet>>[],
-      {
-        conditionsMatcher
-      }
-    );
+      const result = {
+        permission,
+        memberships: permissionData,
+        hasRole,
+        hasProjectEnforcement: $checkProjectEnforcement(projectDetails)
+      };
 
-    const result = {
-      permission,
-      memberships: permissionData,
-      hasRole,
-      hasProjectEnforcement: $checkProjectEnforcement(projectDetails)
+      return {
+        result,
+        projectDetailsCtx,
+        identityPermissionMetadataCtx
+      };
     };
 
-    // Cache the full result with side-effect data for replay on cache hit
-    memoizer?.set(memoKey, {
-      result,
-      projectDetailsCtx,
-      identityPermissionMetadataCtx
-    });
+    const payload = memoizer ? await memoizer.getOrSet(memoKey, loadProjectPermission) : await loadProjectPermission();
 
-    return result;
+    requestContext.set(requestContextKeys.projectDetails, payload.projectDetailsCtx);
+    requestContext.set(requestContextKeys.identityPermissionMetadata, payload.identityPermissionMetadataCtx);
+    return payload.result;
   };
 
   const getProjectPermissions: TPermissionServiceFactory["getProjectPermissions"] = async (projectId, orgId) => {

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -398,6 +398,9 @@ export const permissionServiceFactory = ({
       });
     }
 
+    const projectPermissionActor: ActorType.USER | ActorType.IDENTITY =
+      actor === ActorType.USER ? ActorType.USER : ActorType.IDENTITY;
+
     // Request-scoped full-function memoization: identical permission checks within the same request
     const memoKey = requestMemoKeys.projectPermission({
       projectId,
@@ -448,11 +451,11 @@ export const permissionServiceFactory = ({
           projectId
         },
         actorId,
-        actorType: actor
+        actorType: projectPermissionActor
       });
       if (!permissionData?.length)
         throw new ForbiddenRequestError({
-          message: `You are not a member of this project with ID ${projectId}. Please assign this ${actor} to the project with the appropriate permissions, then try again.`
+          message: `You are not a member of this project with ID ${projectId}. Please assign this ${projectPermissionActor} to the project with the appropriate permissions, then try again.`
         });
 
       const permissionFromRoles = flattenActiveRolesFromMemberships(permissionData, ProjectMembershipRole.Custom);

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -26,7 +26,7 @@ import { conditionsMatcher } from "@app/lib/casl";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { objectify } from "@app/lib/fn";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
@@ -380,7 +380,7 @@ export const permissionServiceFactory = ({
       });
     }
 
-    const assumedPrivilegeDetailsCtx = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
+    const assumedPrivilegeDetailsCtx = requestContext.get(RequestContextKey.AssumedPrivilegeDetails);
     if (
       assumedPrivilegeDetailsCtx &&
       actor === ActorType.USER &&
@@ -410,7 +410,7 @@ export const permissionServiceFactory = ({
       actionProjectType,
       actorOrgId
     });
-    const memoizer = requestContext.get(requestContextKeys.memoizer);
+    const memoizer = requestContext.get(RequestContextKey.Memoizer);
 
     type TProjectPermissionMemoPayload = {
       result: Awaited<ReturnType<TPermissionServiceFactory["getProjectPermission"]>>;
@@ -524,7 +524,7 @@ export const permissionServiceFactory = ({
         username = identityDetails?.name;
       }
 
-      const unescapedIdentityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+      const unescapedIdentityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
       const identityAuthInfo =
         unescapedIdentityAuthInfo?.identityId === actorId && unescapedIdentityAuthInfo
           ? escapeHandlebarsMissingDict(unescapedIdentityAuthInfo as never, "identity.auth")
@@ -565,8 +565,8 @@ export const permissionServiceFactory = ({
 
     const payload = memoizer ? await memoizer.getOrSet(memoKey, loadProjectPermission) : await loadProjectPermission();
 
-    requestContext.set(requestContextKeys.projectDetails, payload.projectDetailsCtx);
-    requestContext.set(requestContextKeys.identityPermissionMetadata, payload.identityPermissionMetadataCtx);
+    requestContext.set(RequestContextKey.ProjectDetails, payload.projectDetailsCtx);
+    requestContext.set(RequestContextKey.IdentityPermissionMetadata, payload.identityPermissionMetadataCtx);
     return payload.result;
   };
 

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -435,7 +435,7 @@ export const permissionServiceFactory = ({
       };
 
       if (projectDetails.orgId !== actorOrgId) {
-        throw new ForbiddenRequestError({ name: "This project does not belong to your selected organization." });
+        throw new ForbiddenRequestError({ message: "This project does not belong to your selected organization." });
       }
 
       if (actionProjectType !== ActionProjectType.Any && actionProjectType !== projectDetails.type) {

--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -6,6 +6,8 @@ import { requestContext } from "@fastify/request-context";
 import pino, { Logger } from "pino";
 import { z } from "zod";
 
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+
 const logLevelToSeverityLookup: Record<string, string> = {
   "10": "TRACE",
   "20": "DEBUG",
@@ -95,7 +97,7 @@ const UNKNOWN_REQUEST_ID = "UNKNOWN_REQUEST_ID";
 
 const extractReqId = () => {
   try {
-    return requestContext.get("reqId") || UNKNOWN_REQUEST_ID;
+    return requestContext.get(requestContextKeys.reqId) || UNKNOWN_REQUEST_ID;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.log("failed to get request context", err);
@@ -105,7 +107,7 @@ const extractReqId = () => {
 
 const extractOrgId = () => {
   try {
-    return requestContext.get("orgId");
+    return requestContext.get(requestContextKeys.orgId);
   } catch {
     return "";
   }

--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -6,7 +6,7 @@ import { requestContext } from "@fastify/request-context";
 import pino, { Logger } from "pino";
 import { z } from "zod";
 
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 
 const logLevelToSeverityLookup: Record<string, string> = {
   "10": "TRACE",
@@ -97,7 +97,7 @@ const UNKNOWN_REQUEST_ID = "UNKNOWN_REQUEST_ID";
 
 const extractReqId = () => {
   try {
-    return requestContext.get(requestContextKeys.reqId) || UNKNOWN_REQUEST_ID;
+    return requestContext.get(RequestContextKey.ReqId) || UNKNOWN_REQUEST_ID;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.log("failed to get request context", err);
@@ -107,7 +107,7 @@ const extractReqId = () => {
 
 const extractOrgId = () => {
   try {
-    return requestContext.get(requestContextKeys.orgId);
+    return requestContext.get(RequestContextKey.OrgId);
   } catch {
     return "";
   }

--- a/backend/src/lib/request-context/memo-keys.ts
+++ b/backend/src/lib/request-context/memo-keys.ts
@@ -1,0 +1,42 @@
+import { ActionProjectType, OrganizationActionScope } from "@app/db/schemas";
+import { ActorAuthMethod, ActorType } from "@app/services/auth/auth-type";
+
+/**
+ * Builders for {@link requestMemoize} string keys. Centralizes formats so call sites
+ * cannot drift (e.g. `project:findById` vs `project:findbyId`).
+ */
+export const requestMemoKeys = {
+  orgPermission: ({
+    orgId,
+    actor,
+    actorId,
+    actorAuthMethod,
+    scope
+  }: {
+    orgId: string;
+    actor: ActorType;
+    actorId: string;
+    actorAuthMethod: ActorAuthMethod;
+    scope?: OrganizationActionScope | null;
+  }) => `permission:org:${orgId}:${actor}:${actorId}:${actorAuthMethod}:${scope ?? "any"}`,
+
+  projectPermission: ({
+    projectId,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actionProjectType
+  }: {
+    projectId: string;
+    actor: ActorType;
+    actorId: string;
+    actorAuthMethod: ActorAuthMethod;
+    actionProjectType: ActionProjectType;
+  }) => `permission:project:${projectId}:${actor}:${actorId}:${actorAuthMethod}:${actionProjectType}`,
+
+  projectFindById: (projectId: string) => `project:findById:${projectId}`,
+
+  userFindById: (userId: string) => `user:findById:${userId}`,
+
+  identityFindById: (identityId: string) => `identity:findById:${identityId}`
+};

--- a/backend/src/lib/request-context/memo-keys.ts
+++ b/backend/src/lib/request-context/memo-keys.ts
@@ -25,14 +25,17 @@ export const requestMemoKeys = {
     actor,
     actorId,
     actorAuthMethod,
-    actionProjectType
+    actionProjectType,
+    actorOrgId
   }: {
     projectId: string;
     actor: ActorType;
     actorId: string;
     actorAuthMethod: ActorAuthMethod;
     actionProjectType: ActionProjectType;
-  }) => `permission:project:${projectId}:${actor}:${actorId}:${actorAuthMethod}:${actionProjectType}`,
+    actorOrgId?: string;
+  }) =>
+    `permission:project:${projectId}:${actor}:${actorId}:${actorAuthMethod}:${actionProjectType}:${actorOrgId ?? ""}`,
 
   projectFindById: (projectId: string) => `project:findById:${projectId}`,
 

--- a/backend/src/lib/request-context/request-context-keys.ts
+++ b/backend/src/lib/request-context/request-context-keys.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime string keys for `@fastify/request-context`.
+ * Keep in sync with `RequestContextData` in `src/@types/fastify.d.ts`.
+ */
+export const requestContextKeys = {
+  assumedPrivilegeDetails: "assumedPrivilegeDetails",
+  identityAuthInfo: "identityAuthInfo",
+  identityPermissionMetadata: "identityPermissionMetadata",
+  ip: "ip",
+  memoizer: "memoizer",
+  orgId: "orgId",
+  orgName: "orgName",
+  projectDetails: "projectDetails",
+  reqId: "reqId",
+  userAgent: "userAgent",
+  userAuthInfo: "userAuthInfo"
+} as const;

--- a/backend/src/lib/request-context/request-context-keys.ts
+++ b/backend/src/lib/request-context/request-context-keys.ts
@@ -2,16 +2,16 @@
  * Runtime string keys for `@fastify/request-context`.
  * Keep in sync with `RequestContextData` in `src/@types/fastify.d.ts`.
  */
-export const requestContextKeys = {
-  assumedPrivilegeDetails: "assumedPrivilegeDetails",
-  identityAuthInfo: "identityAuthInfo",
-  identityPermissionMetadata: "identityPermissionMetadata",
-  ip: "ip",
-  memoizer: "memoizer",
-  orgId: "orgId",
-  orgName: "orgName",
-  projectDetails: "projectDetails",
-  reqId: "reqId",
-  userAgent: "userAgent",
-  userAuthInfo: "userAuthInfo"
-} as const;
+export enum RequestContextKey {
+  AssumedPrivilegeDetails = "assumedPrivilegeDetails",
+  IdentityAuthInfo = "identityAuthInfo",
+  IdentityPermissionMetadata = "identityPermissionMetadata",
+  Ip = "ip",
+  Memoizer = "memoizer",
+  OrgId = "orgId",
+  OrgName = "orgName",
+  ProjectDetails = "projectDetails",
+  ReqId = "reqId",
+  UserAgent = "userAgent",
+  UserAuthInfo = "userAuthInfo"
+}

--- a/backend/src/lib/request-context/request-memoizer.test.ts
+++ b/backend/src/lib/request-context/request-memoizer.test.ts
@@ -4,7 +4,7 @@ import { ActionProjectType } from "@app/db/schemas";
 import { ActorType } from "@app/services/auth/auth-type";
 
 import { requestMemoKeys } from "./memo-keys";
-import { requestContextKeys } from "./request-context-keys";
+import { RequestContextKey } from "./request-context-keys";
 import { requestMemoize, RequestMemoizer } from "./request-memoizer";
 
 // Mock @fastify/request-context — the module is resolved at import time,
@@ -121,7 +121,7 @@ describe("requestMemoize", () => {
     expect(r1).toBe("cached-value");
     expect(r2).toBe("cached-value");
     expect(fetcher).toHaveBeenCalledOnce();
-    expect(mockGet).toHaveBeenCalledWith(requestContextKeys.memoizer);
+    expect(mockGet).toHaveBeenCalledWith(RequestContextKey.Memoizer);
   });
 
   it("should fall back to direct execution when no memoizer in context", async () => {

--- a/backend/src/lib/request-context/request-memoizer.test.ts
+++ b/backend/src/lib/request-context/request-memoizer.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ActionProjectType } from "@app/db/schemas";
+import { ActorType } from "@app/services/auth/auth-type";
+
+import { requestMemoKeys } from "./memo-keys";
+import { requestContextKeys } from "./request-context-keys";
+import { requestMemoize, RequestMemoizer } from "./request-memoizer";
+
+// Mock @fastify/request-context — the module is resolved at import time,
+// so vi.mock must be at the top level before any import that touches it.
+const mockGet = vi.fn((key: string): RequestMemoizer | undefined => {
+  void key;
+  return undefined;
+});
+vi.mock("@fastify/request-context", () => ({
+  requestContext: {
+    get: (key: string): RequestMemoizer | undefined => mockGet(key),
+    set: vi.fn()
+  }
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// RequestMemoizer (pure class, no dependency on requestContext)
+// ---------------------------------------------------------------------------
+describe("RequestMemoizer", () => {
+  let memoizer: RequestMemoizer;
+
+  beforeEach(() => {
+    memoizer = new RequestMemoizer();
+  });
+
+  describe("getOrSet", () => {
+    it("should call the fetcher on first access and return its result", async () => {
+      const fetcher = vi.fn().mockResolvedValue({ id: "proj-1", name: "Test Project" });
+
+      const result = await memoizer.getOrSet("project:findById:proj-1", fetcher);
+
+      expect(fetcher).toHaveBeenCalledOnce();
+      expect(result).toEqual({ id: "proj-1", name: "Test Project" });
+    });
+
+    it("should return the cached result on subsequent calls without re-executing the fetcher", async () => {
+      const fetcher = vi.fn().mockResolvedValue({ id: "proj-1" });
+
+      const first = await memoizer.getOrSet("project:findById:proj-1", fetcher);
+      const second = await memoizer.getOrSet("project:findById:proj-1", fetcher);
+      const third = await memoizer.getOrSet("project:findById:proj-1", fetcher);
+
+      expect(fetcher).toHaveBeenCalledOnce();
+      expect(first).toBe(second);
+      expect(second).toBe(third);
+    });
+
+    it("should cache null and undefined values", async () => {
+      const nullFetcher = vi.fn().mockResolvedValue(null);
+      const undefinedFetcher = vi.fn().mockResolvedValue(undefined);
+
+      const r1 = await memoizer.getOrSet("key-null", nullFetcher);
+      const r2 = await memoizer.getOrSet("key-null", nullFetcher);
+      expect(r1).toBeNull();
+      expect(r2).toBeNull();
+      expect(nullFetcher).toHaveBeenCalledOnce();
+
+      const r3 = await memoizer.getOrSet("key-undef", undefinedFetcher);
+      const r4 = await memoizer.getOrSet("key-undef", undefinedFetcher);
+      expect(r3).toBeUndefined();
+      expect(r4).toBeUndefined();
+      expect(undefinedFetcher).toHaveBeenCalledOnce();
+    });
+
+    it("should keep entries for different keys independent", async () => {
+      const fetcherA = vi.fn().mockResolvedValue("A");
+      const fetcherB = vi.fn().mockResolvedValue("B");
+
+      const a = await memoizer.getOrSet("key-a", fetcherA);
+      const b = await memoizer.getOrSet("key-b", fetcherB);
+
+      expect(a).toBe("A");
+      expect(b).toBe("B");
+      expect(fetcherA).toHaveBeenCalledOnce();
+      expect(fetcherB).toHaveBeenCalledOnce();
+      expect(memoizer.get("key-a")).toBe("A");
+      expect(memoizer.get("key-b")).toBe("B");
+    });
+
+    it("should not cache the result when the fetcher throws", async () => {
+      const fetcher = vi.fn().mockRejectedValueOnce(new Error("db-down")).mockResolvedValueOnce("recovered");
+
+      await expect(memoizer.getOrSet("flaky", fetcher)).rejects.toThrow("db-down");
+      const result = await memoizer.getOrSet("flaky", fetcher);
+
+      expect(result).toBe("recovered");
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("get / set", () => {
+    it("should return undefined for missing keys", () => {
+      expect(memoizer.get("missing")).toBeUndefined();
+    });
+
+    it("should store and retrieve values via set/get", () => {
+      memoizer.set("k", 42);
+      expect(memoizer.get("k")).toBe(42);
+    });
+
+    it("should keep distinct keys via getOrSet and set", async () => {
+      expect(memoizer.get("a")).toBeUndefined();
+      await memoizer.getOrSet("a", async () => 1);
+      expect(memoizer.get("a")).toBe(1);
+      memoizer.set("b", 2);
+      expect(memoizer.get("b")).toBe(2);
+      expect(memoizer.get("a")).toBe(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requestMemoize (integration with @fastify/request-context)
+// ---------------------------------------------------------------------------
+describe("requestMemoize", () => {
+  it("should use the memoizer from request context when available", async () => {
+    const memoizer = new RequestMemoizer();
+    mockGet.mockReturnValue(memoizer);
+
+    const fetcher = vi.fn().mockResolvedValue("cached-value");
+
+    const r1 = await requestMemoize("key", fetcher);
+    const r2 = await requestMemoize("key", fetcher);
+
+    expect(r1).toBe("cached-value");
+    expect(r2).toBe("cached-value");
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(mockGet).toHaveBeenCalledWith(requestContextKeys.memoizer);
+  });
+
+  it("should fall back to direct execution when no memoizer in context", async () => {
+    mockGet.mockReturnValue(undefined);
+
+    const fetcher = vi.fn().mockResolvedValue("direct");
+
+    const r1 = await requestMemoize("key", fetcher);
+    const r2 = await requestMemoize("key", fetcher);
+
+    expect(r1).toBe("direct");
+    expect(r2).toBe("direct");
+    // Called twice because there's no memoizer to cache the result
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Simulated integration: DAL deduplication pattern
+// ---------------------------------------------------------------------------
+describe("request-scoped DAL deduplication", () => {
+  it("should deduplicate projectDAL.findById calls across services within a request", async () => {
+    const memoizer = new RequestMemoizer();
+    type SimulatedProject = { id: string; name: string; orgId: string };
+    const mockFindById = vi.fn(async (id: string): Promise<SimulatedProject> => {
+      void id;
+      return { id: "proj-1", name: "My Project", orgId: "org-1" };
+    });
+
+    // Simulate the permission service calling findById
+    const fromPermission = await memoizer.getOrSet("project:findById:proj-1", () => mockFindById("proj-1"));
+
+    // Simulate getBotKey calling findById for the same project
+    const fromBot = await memoizer.getOrSet("project:findById:proj-1", () => mockFindById("proj-1"));
+
+    // Simulate a different projectId (should hit DB)
+    const fromOther = await memoizer.getOrSet("project:findById:proj-2", () => mockFindById("proj-2"));
+
+    expect(mockFindById).toHaveBeenCalledTimes(2); // proj-1 once, proj-2 once
+    expect(fromPermission).toBe(fromBot); // same reference
+    expect(fromOther).toEqual({ id: "proj-1", name: "My Project", orgId: "org-1" }); // different call
+  });
+
+  it("should deduplicate getProjectPermission calls for batch operations", async () => {
+    const memoizer = new RequestMemoizer();
+
+    const mockPermissionResult = {
+      permission: { can: vi.fn() },
+      memberships: [{ roles: [] }],
+      hasRole: vi.fn()
+    };
+
+    const permissionFetcher = vi.fn().mockResolvedValue(mockPermissionResult);
+
+    // Simulate 50 secret operations each checking the same project permission
+    const cacheKey = requestMemoKeys.projectPermission({
+      projectId: "proj-1",
+      actor: ActorType.IDENTITY,
+      actorId: "id-1",
+      actorAuthMethod: null,
+      actionProjectType: ActionProjectType.SecretManager
+    });
+    const results = await Promise.all(Array.from({ length: 50 }, () => memoizer.getOrSet(cacheKey, permissionFetcher)));
+
+    expect(permissionFetcher).toHaveBeenCalledOnce();
+    // All 50 results should be the same reference
+    expect(results.every((r) => r === mockPermissionResult)).toBe(true);
+  });
+
+  it("should isolate caches between different memoizer instances (different requests)", async () => {
+    const request1Memoizer = new RequestMemoizer();
+    const request2Memoizer = new RequestMemoizer();
+
+    const fetcher1 = vi.fn().mockResolvedValue("request-1-data");
+    const fetcher2 = vi.fn().mockResolvedValue("request-2-data");
+
+    const r1 = await request1Memoizer.getOrSet(requestMemoKeys.projectFindById("proj-1"), fetcher1);
+    const r2 = await request2Memoizer.getOrSet(requestMemoKeys.projectFindById("proj-1"), fetcher2);
+
+    expect(r1).toBe("request-1-data");
+    expect(r2).toBe("request-2-data");
+    expect(fetcher1).toHaveBeenCalledOnce();
+    expect(fetcher2).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/lib/request-context/request-memoizer.test.ts
+++ b/backend/src/lib/request-context/request-memoizer.test.ts
@@ -84,8 +84,13 @@ describe("RequestMemoizer", () => {
       expect(b).toBe("B");
       expect(fetcherA).toHaveBeenCalledOnce();
       expect(fetcherB).toHaveBeenCalledOnce();
-      expect(memoizer.get("key-a")).toBe("A");
-      expect(memoizer.get("key-b")).toBe("B");
+
+      const spyA = vi.fn().mockResolvedValue("should-not-run");
+      const spyB = vi.fn().mockResolvedValue("should-not-run");
+      expect(await memoizer.getOrSet("key-a", spyA)).toBe("A");
+      expect(await memoizer.getOrSet("key-b", spyB)).toBe("B");
+      expect(spyA).not.toHaveBeenCalled();
+      expect(spyB).not.toHaveBeenCalled();
     });
 
     it("should not cache the result when the fetcher throws", async () => {
@@ -96,26 +101,6 @@ describe("RequestMemoizer", () => {
 
       expect(result).toBe("recovered");
       expect(fetcher).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe("get / set", () => {
-    it("should return undefined for missing keys", () => {
-      expect(memoizer.get("missing")).toBeUndefined();
-    });
-
-    it("should store and retrieve values via set/get", () => {
-      memoizer.set("k", 42);
-      expect(memoizer.get("k")).toBe(42);
-    });
-
-    it("should keep distinct keys via getOrSet and set", async () => {
-      expect(memoizer.get("a")).toBeUndefined();
-      await memoizer.getOrSet("a", async () => 1);
-      expect(memoizer.get("a")).toBe(1);
-      memoizer.set("b", 2);
-      expect(memoizer.get("b")).toBe(2);
-      expect(memoizer.get("a")).toBe(1);
     });
   });
 });
@@ -197,7 +182,8 @@ describe("request-scoped DAL deduplication", () => {
       actor: ActorType.IDENTITY,
       actorId: "id-1",
       actorAuthMethod: null,
-      actionProjectType: ActionProjectType.SecretManager
+      actionProjectType: ActionProjectType.SecretManager,
+      actorOrgId: "org-1"
     });
     const results = await Promise.all(Array.from({ length: 50 }, () => memoizer.getOrSet(cacheKey, permissionFetcher)));
 

--- a/backend/src/lib/request-context/request-memoizer.ts
+++ b/backend/src/lib/request-context/request-memoizer.ts
@@ -1,0 +1,77 @@
+import { requestContext } from "@fastify/request-context";
+
+import { requestContextKeys } from "./request-context-keys";
+
+/**
+ * Request-scoped memoization cache.
+ *
+ * Attached to each Fastify request via @fastify/request-context.
+ * Automatically garbage-collected when the request ends — no TTL or
+ * invalidation logic required.
+ *
+ * Use this for read-only data that is fetched multiple times within
+ * a single request (e.g. projectDAL.findById, identityDAL.findById).
+ */
+export class RequestMemoizer {
+  private cache = new Map<string, unknown>();
+
+  // Tracks in-flight promises so concurrent calls for the same key
+  // coalesce onto a single fetcher execution (e.g. Promise.all in batch ops).
+  private inflight = new Map<string, Promise<unknown>>();
+
+  /**
+   * Return the cached value for `key`, or call `fetcher`, cache the result, and return it.
+   * Concurrent calls for the same key share a single fetcher invocation.
+   * If the fetcher throws, nothing is cached and the error propagates.
+   */
+  async getOrSet<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+    if (this.cache.has(key)) {
+      return this.cache.get(key) as T;
+    }
+
+    const existing = this.inflight.get(key);
+    if (existing) {
+      return existing as Promise<T>;
+    }
+
+    const promise = fetcher()
+      .then((result) => {
+        this.cache.set(key, result);
+        this.inflight.delete(key);
+        return result;
+      })
+      .catch((err) => {
+        this.inflight.delete(key);
+        throw err;
+      });
+
+    this.inflight.set(key, promise);
+    return promise;
+  }
+
+  get<T>(key: string): T | undefined {
+    if (!this.cache.has(key)) return undefined;
+    return this.cache.get(key) as T;
+  }
+
+  set(key: string, value: unknown): void {
+    this.cache.set(key, value);
+  }
+}
+
+/**
+ * Memoize an async operation within the current request scope.
+ *
+ * Falls back to direct execution when no request context is available
+ * (e.g. inside queue workers or background jobs).
+ *
+ * Do NOT use for:
+ * - Calls inside a DB transaction (pass `trx`) — the transaction may see
+ *   different data than the memoized read-replica result.
+ * - Data that is mutated within the same request and re-read afterwards.
+ */
+export const requestMemoize = async <T>(key: string, fetcher: () => Promise<T>): Promise<T> => {
+  const memoizer = requestContext.get(requestContextKeys.memoizer);
+  if (!memoizer) return fetcher();
+  return memoizer.getOrSet(key, fetcher);
+};

--- a/backend/src/lib/request-context/request-memoizer.ts
+++ b/backend/src/lib/request-context/request-memoizer.ts
@@ -1,6 +1,6 @@
 import { requestContext } from "@fastify/request-context";
 
-import { requestContextKeys } from "./request-context-keys";
+import { RequestContextKey } from "./request-context-keys";
 
 /**
  * Request-scoped memoization cache.
@@ -62,7 +62,7 @@ export class RequestMemoizer {
  * - Data that is mutated within the same request and re-read afterwards.
  */
 export const requestMemoize = async <T>(key: string, fetcher: () => Promise<T>): Promise<T> => {
-  const memoizer = requestContext.get(requestContextKeys.memoizer);
+  const memoizer = requestContext.get(RequestContextKey.Memoizer);
   if (!memoizer) return fetcher();
   return memoizer.getOrSet(key, fetcher);
 };

--- a/backend/src/lib/request-context/request-memoizer.ts
+++ b/backend/src/lib/request-context/request-memoizer.ts
@@ -48,15 +48,6 @@ export class RequestMemoizer {
     this.inflight.set(key, promise);
     return promise;
   }
-
-  get<T>(key: string): T | undefined {
-    if (!this.cache.has(key)) return undefined;
-    return this.cache.get(key) as T;
-  }
-
-  set(key: string, value: unknown): void {
-    this.cache.set(key, value);
-  }
 }
 
 /**

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -1,7 +1,7 @@
 import { requestContext } from "@fastify/request-context";
 import opentelemetry from "@opentelemetry/api";
 
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 
 import { getConfig } from "../config/env";
 
@@ -54,17 +54,17 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       ...(params.name ? { "infisical.secret.name": params.name } : {})
     };
 
-    const orgId = requestContext.get(requestContextKeys.orgId);
+    const orgId = requestContext.get(RequestContextKey.OrgId);
     if (orgId) {
       attributes["infisical.organization.id"] = orgId;
     }
 
-    const orgName = requestContext.get(requestContextKeys.orgName);
+    const orgName = requestContext.get(RequestContextKey.OrgName);
     if (orgName) {
       attributes["infisical.organization.name"] = orgName;
     }
 
-    const projectDetails = requestContext.get(requestContextKeys.projectDetails);
+    const projectDetails = requestContext.get(RequestContextKey.ProjectDetails);
     if (projectDetails?.id) {
       attributes["infisical.project.id"] = projectDetails.id;
     }
@@ -72,7 +72,7 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.project.name"] = projectDetails.name;
     }
 
-    const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
+    const userAuthInfo = requestContext.get(RequestContextKey.UserAuthInfo);
     if (userAuthInfo?.userId) {
       attributes["infisical.user.id"] = userAuthInfo.userId;
     }
@@ -80,7 +80,7 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.user.email"] = userAuthInfo.email;
     }
 
-    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+    const identityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
     if (identityAuthInfo?.identityId) {
       attributes["infisical.identity.id"] = identityAuthInfo.identityId;
     }
@@ -88,12 +88,12 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.identity.name"] = identityAuthInfo.identityName;
     }
 
-    const userAgent = requestContext.get(requestContextKeys.userAgent);
+    const userAgent = requestContext.get(RequestContextKey.UserAgent);
     if (userAgent) {
       attributes["user_agent.original"] = userAgent;
     }
 
-    const ip = requestContext.get(requestContextKeys.ip);
+    const ip = requestContext.get(RequestContextKey.Ip);
     if (ip) {
       attributes["client.address"] = ip;
     }
@@ -144,7 +144,7 @@ export const recordKmipOperationMetric = (params: {
       attributes["infisical.kmip.object.name"] = params.objectName;
     }
 
-    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+    const identityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
     if (identityAuthInfo?.identityId) {
       attributes["infisical.identity.id"] = identityAuthInfo.identityId;
     }
@@ -152,12 +152,12 @@ export const recordKmipOperationMetric = (params: {
       attributes["infisical.identity.name"] = identityAuthInfo.identityName;
     }
 
-    const userAgent = requestContext.get(requestContextKeys.userAgent);
+    const userAgent = requestContext.get(RequestContextKey.UserAgent);
     if (userAgent) {
       attributes["user_agent.original"] = userAgent;
     }
 
-    const ip = requestContext.get(requestContextKeys.ip);
+    const ip = requestContext.get(RequestContextKey.Ip);
     if (ip) {
       attributes["client.address"] = ip;
     }

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -1,6 +1,8 @@
 import { requestContext } from "@fastify/request-context";
 import opentelemetry from "@opentelemetry/api";
 
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+
 import { getConfig } from "../config/env";
 
 const infisicalMeter = opentelemetry.metrics.getMeter("Infisical");
@@ -52,17 +54,17 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       ...(params.name ? { "infisical.secret.name": params.name } : {})
     };
 
-    const orgId = requestContext.get("orgId");
+    const orgId = requestContext.get(requestContextKeys.orgId);
     if (orgId) {
       attributes["infisical.organization.id"] = orgId;
     }
 
-    const orgName = requestContext.get("orgName");
+    const orgName = requestContext.get(requestContextKeys.orgName);
     if (orgName) {
       attributes["infisical.organization.name"] = orgName;
     }
 
-    const projectDetails = requestContext.get("projectDetails");
+    const projectDetails = requestContext.get(requestContextKeys.projectDetails);
     if (projectDetails?.id) {
       attributes["infisical.project.id"] = projectDetails.id;
     }
@@ -70,7 +72,7 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.project.name"] = projectDetails.name;
     }
 
-    const userAuthInfo = requestContext.get("userAuthInfo");
+    const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
     if (userAuthInfo?.userId) {
       attributes["infisical.user.id"] = userAuthInfo.userId;
     }
@@ -78,7 +80,7 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.user.email"] = userAuthInfo.email;
     }
 
-    const identityAuthInfo = requestContext.get("identityAuthInfo");
+    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
     if (identityAuthInfo?.identityId) {
       attributes["infisical.identity.id"] = identityAuthInfo.identityId;
     }
@@ -86,12 +88,12 @@ export const recordSecretReadMetric = (params: { environment: string; secretPath
       attributes["infisical.identity.name"] = identityAuthInfo.identityName;
     }
 
-    const userAgent = requestContext.get("userAgent");
+    const userAgent = requestContext.get(requestContextKeys.userAgent);
     if (userAgent) {
       attributes["user_agent.original"] = userAgent;
     }
 
-    const ip = requestContext.get("ip");
+    const ip = requestContext.get(requestContextKeys.ip);
     if (ip) {
       attributes["client.address"] = ip;
     }
@@ -142,7 +144,7 @@ export const recordKmipOperationMetric = (params: {
       attributes["infisical.kmip.object.name"] = params.objectName;
     }
 
-    const identityAuthInfo = requestContext.get("identityAuthInfo");
+    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
     if (identityAuthInfo?.identityId) {
       attributes["infisical.identity.id"] = identityAuthInfo.identityId;
     }
@@ -150,12 +152,12 @@ export const recordKmipOperationMetric = (params: {
       attributes["infisical.identity.name"] = identityAuthInfo.identityName;
     }
 
-    const userAgent = requestContext.get("userAgent");
+    const userAgent = requestContext.get(requestContextKeys.userAgent);
     if (userAgent) {
       attributes["user_agent.original"] = userAgent;
     }
 
-    const ip = requestContext.get("ip");
+    const ip = requestContext.get(requestContextKeys.ip);
     if (ip) {
       attributes["client.address"] = ip;
     }

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -22,7 +22,7 @@ import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED, TEnvConfig } from "@app/lib/config/env";
 import { CustomLogger } from "@app/lib/logger/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { RequestMemoizer } from "@app/lib/request-context/request-memoizer";
 import { TQueueServiceFactory } from "@app/queue";
 import { TKmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
@@ -171,7 +171,7 @@ export const main = async ({
         log: req.log.child({ reqId: req.id }),
         ip: req.realIp,
         userAgent: req.headers["user-agent"],
-        [requestContextKeys.memoizer]: new RequestMemoizer()
+        [RequestContextKey.Memoizer]: new RequestMemoizer()
       })
     });
 

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -22,6 +22,8 @@ import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED, TEnvConfig } from "@app/lib/config/env";
 import { CustomLogger } from "@app/lib/logger/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestMemoizer } from "@app/lib/request-context/request-memoizer";
 import { TQueueServiceFactory } from "@app/queue";
 import { TKmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
 import { TSmtpService } from "@app/services/smtp/smtp-service";
@@ -168,7 +170,8 @@ export const main = async ({
         reqId: req.id,
         log: req.log.child({ reqId: req.id }),
         ip: req.realIp,
-        userAgent: req.headers["user-agent"]
+        userAgent: req.headers["user-agent"],
+        [requestContextKeys.memoizer]: new RequestMemoizer()
       })
     });
 

--- a/backend/src/server/plugins/api-metrics.ts
+++ b/backend/src/server/plugins/api-metrics.ts
@@ -2,7 +2,7 @@ import { requestContext } from "@fastify/request-context";
 import opentelemetry from "@opentelemetry/api";
 import fp from "fastify-plugin";
 
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 
 const apiMeter = opentelemetry.metrics.getMeter("API");
 
@@ -34,13 +34,13 @@ export const apiMetrics = fp(async (fastify) => {
       statusCode
     });
 
-    const orgId = requestContext.get(requestContextKeys.orgId);
-    const orgName = requestContext.get(requestContextKeys.orgName);
-    const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
-    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
-    const projectDetails = requestContext.get(requestContextKeys.projectDetails);
-    const userAgent = requestContext.get(requestContextKeys.userAgent);
-    const ip = requestContext.get(requestContextKeys.ip);
+    const orgId = requestContext.get(RequestContextKey.OrgId);
+    const orgName = requestContext.get(RequestContextKey.OrgName);
+    const userAuthInfo = requestContext.get(RequestContextKey.UserAuthInfo);
+    const identityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
+    const projectDetails = requestContext.get(RequestContextKey.ProjectDetails);
+    const userAgent = requestContext.get(RequestContextKey.UserAgent);
+    const ip = requestContext.get(RequestContextKey.Ip);
 
     const attributes: Record<string, string | number> = {
       "http.request.method": method,

--- a/backend/src/server/plugins/api-metrics.ts
+++ b/backend/src/server/plugins/api-metrics.ts
@@ -2,6 +2,8 @@ import { requestContext } from "@fastify/request-context";
 import opentelemetry from "@opentelemetry/api";
 import fp from "fastify-plugin";
 
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+
 const apiMeter = opentelemetry.metrics.getMeter("API");
 
 const latencyHistogram = apiMeter.createHistogram("API_latency", {
@@ -32,13 +34,13 @@ export const apiMetrics = fp(async (fastify) => {
       statusCode
     });
 
-    const orgId = requestContext.get("orgId");
-    const orgName = requestContext.get("orgName");
-    const userAuthInfo = requestContext.get("userAuthInfo");
-    const identityAuthInfo = requestContext.get("identityAuthInfo");
-    const projectDetails = requestContext.get("projectDetails");
-    const userAgent = requestContext.get("userAgent");
-    const ip = requestContext.get("ip");
+    const orgId = requestContext.get(requestContextKeys.orgId);
+    const orgName = requestContext.get(requestContextKeys.orgName);
+    const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
+    const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+    const projectDetails = requestContext.get(requestContextKeys.projectDetails);
+    const userAgent = requestContext.get(requestContextKeys.userAgent);
+    const ip = requestContext.get(requestContextKeys.ip);
 
     const attributes: Record<string, string | number> = {
       "http.request.method": method,

--- a/backend/src/server/plugins/audit-log.ts
+++ b/backend/src/server/plugins/audit-log.ts
@@ -3,7 +3,7 @@ import fp from "fastify-plugin";
 
 import { UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 
 export const getUserAgentType = (userAgent: string | undefined) => {
@@ -68,7 +68,7 @@ export const injectAuditLogInfo = fp(async (server: FastifyZodProvider) => {
         }
       };
     } else if (req.auth.actor === ActorType.IDENTITY) {
-      const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+      const identityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
 
       payload.actor = {
         type: ActorType.IDENTITY,

--- a/backend/src/server/plugins/audit-log.ts
+++ b/backend/src/server/plugins/audit-log.ts
@@ -3,6 +3,7 @@ import fp from "fastify-plugin";
 
 import { UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 
 export const getUserAgentType = (userAgent: string | undefined) => {
@@ -67,7 +68,7 @@ export const injectAuditLogInfo = fp(async (server: FastifyZodProvider) => {
         }
       };
     } else if (req.auth.actor === ActorType.IDENTITY) {
-      const identityAuthInfo = requestContext.get("identityAuthInfo");
+      const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
 
       payload.actor = {
         type: ActorType.IDENTITY,

--- a/backend/src/server/plugins/auth/inject-assume-privilege.ts
+++ b/backend/src/server/plugins/auth/inject-assume-privilege.ts
@@ -1,7 +1,7 @@
 import { requestContext } from "@fastify/request-context";
 import fp from "fastify-plugin";
 
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthMode } from "@app/services/auth/auth-type";
 
 export const injectAssumePrivilege = fp(async (server: FastifyZodProvider) => {
@@ -14,7 +14,7 @@ export const injectAssumePrivilege = fp(async (server: FastifyZodProvider) => {
           req.auth.tokenVersionId
         );
         if (decodedToken) {
-          requestContext.set(requestContextKeys.assumedPrivilegeDetails, decodedToken);
+          requestContext.set(RequestContextKey.AssumedPrivilegeDetails, decodedToken);
         }
       }
     } catch (error) {

--- a/backend/src/server/plugins/auth/inject-assume-privilege.ts
+++ b/backend/src/server/plugins/auth/inject-assume-privilege.ts
@@ -1,6 +1,7 @@
 import { requestContext } from "@fastify/request-context";
 import fp from "fastify-plugin";
 
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthMode } from "@app/services/auth/auth-type";
 
 export const injectAssumePrivilege = fp(async (server: FastifyZodProvider) => {
@@ -13,7 +14,7 @@ export const injectAssumePrivilege = fp(async (server: FastifyZodProvider) => {
           req.auth.tokenVersionId
         );
         if (decodedToken) {
-          requestContext.set("assumedPrivilegeDetails", decodedToken);
+          requestContext.set(requestContextKeys.assumedPrivilegeDetails, decodedToken);
         }
       }
     } catch (error) {

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -8,6 +8,7 @@ import { TScimTokenJwtPayload } from "@app/ee/services/scim/scim-types";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { ActorType, AuthMethod, AuthMode, AuthModeJwtTokenPayload, AuthTokenType } from "@app/services/auth/auth-type";
 import { TIdentityAccessTokenJwtPayload } from "@app/services/identity-access-token/identity-access-token-types";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
@@ -181,9 +182,9 @@ export const injectIdentity = fp(
         case AuthMode.JWT: {
           const { user, tokenVersionId, orgId, orgName, rootOrgId, parentOrgId } =
             await server.services.authToken.fnValidateJwtIdentity(token);
-          requestContext.set("orgId", orgId);
-          requestContext.set("orgName", orgName);
-          requestContext.set("userAuthInfo", { userId: user.id, email: user.email || "" });
+          requestContext.set(requestContextKeys.orgId, orgId);
+          requestContext.set(requestContextKeys.orgName, orgName);
+          requestContext.set(requestContextKeys.userAuthInfo, { userId: user.id, email: user.email || "" });
           req.auth = {
             authMode: AuthMode.JWT,
             user,
@@ -203,9 +204,9 @@ export const injectIdentity = fp(
         case AuthMode.MCP_JWT: {
           const { user, tokenVersionId, orgId, orgName, rootOrgId, parentOrgId } =
             await server.services.authToken.fnValidateJwtIdentity(token);
-          requestContext.set("orgId", orgId);
-          requestContext.set("orgName", orgName);
-          requestContext.set("userAuthInfo", { userId: user.id, email: user.email || "" });
+          requestContext.set(requestContextKeys.orgId, orgId);
+          requestContext.set(requestContextKeys.orgName, orgName);
+          requestContext.set(requestContextKeys.userAuthInfo, { userId: user.id, email: user.email || "" });
           req.auth = {
             authMode: AuthMode.MCP_JWT,
             user,
@@ -225,8 +226,8 @@ export const injectIdentity = fp(
         case AuthMode.IDENTITY_ACCESS_TOKEN: {
           const identity = await server.services.identityAccessToken.fnValidateIdentityAccessToken(token, req.realIp);
           const serverCfg = await getServerCfg();
-          requestContext.set("orgId", identity.orgId);
-          requestContext.set("orgName", identity.orgName);
+          requestContext.set(requestContextKeys.orgId, identity.orgId);
+          requestContext.set(requestContextKeys.orgName, identity.orgName);
           req.auth = {
             authMode: AuthMode.IDENTITY_ACCESS_TOKEN,
             actor,
@@ -255,7 +256,7 @@ export const injectIdentity = fp(
             identityAuthInfo.aws = token?.identityAuth?.aws;
           }
 
-          requestContext.set("identityAuthInfo", identityAuthInfo);
+          requestContext.set(requestContextKeys.identityAuthInfo, identityAuthInfo);
 
           // Fire-and-forget: enrich PostHog person record for this machine identity
           void server.services.telemetry
@@ -271,7 +272,7 @@ export const injectIdentity = fp(
         }
         case AuthMode.SERVICE_TOKEN: {
           const serviceToken = await server.services.serviceToken.fnValidateServiceToken(token);
-          requestContext.set("orgId", serviceToken.orgId);
+          requestContext.set(requestContextKeys.orgId, serviceToken.orgId);
 
           req.auth = {
             orgId: serviceToken.orgId,
@@ -293,7 +294,7 @@ export const injectIdentity = fp(
         }
         case AuthMode.SCIM_TOKEN: {
           const { orgId, scimTokenId } = await server.services.scim.fnValidateScimToken(token);
-          requestContext.set("orgId", orgId);
+          requestContext.set(requestContextKeys.orgId, orgId);
 
           req.auth = {
             authMode: AuthMode.SCIM_TOKEN,

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -8,7 +8,7 @@ import { TScimTokenJwtPayload } from "@app/ee/services/scim/scim-types";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { ActorType, AuthMethod, AuthMode, AuthModeJwtTokenPayload, AuthTokenType } from "@app/services/auth/auth-type";
 import { TIdentityAccessTokenJwtPayload } from "@app/services/identity-access-token/identity-access-token-types";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
@@ -182,9 +182,9 @@ export const injectIdentity = fp(
         case AuthMode.JWT: {
           const { user, tokenVersionId, orgId, orgName, rootOrgId, parentOrgId } =
             await server.services.authToken.fnValidateJwtIdentity(token);
-          requestContext.set(requestContextKeys.orgId, orgId);
-          requestContext.set(requestContextKeys.orgName, orgName);
-          requestContext.set(requestContextKeys.userAuthInfo, { userId: user.id, email: user.email || "" });
+          requestContext.set(RequestContextKey.OrgId, orgId);
+          requestContext.set(RequestContextKey.OrgName, orgName);
+          requestContext.set(RequestContextKey.UserAuthInfo, { userId: user.id, email: user.email || "" });
           req.auth = {
             authMode: AuthMode.JWT,
             user,
@@ -204,9 +204,9 @@ export const injectIdentity = fp(
         case AuthMode.MCP_JWT: {
           const { user, tokenVersionId, orgId, orgName, rootOrgId, parentOrgId } =
             await server.services.authToken.fnValidateJwtIdentity(token);
-          requestContext.set(requestContextKeys.orgId, orgId);
-          requestContext.set(requestContextKeys.orgName, orgName);
-          requestContext.set(requestContextKeys.userAuthInfo, { userId: user.id, email: user.email || "" });
+          requestContext.set(RequestContextKey.OrgId, orgId);
+          requestContext.set(RequestContextKey.OrgName, orgName);
+          requestContext.set(RequestContextKey.UserAuthInfo, { userId: user.id, email: user.email || "" });
           req.auth = {
             authMode: AuthMode.MCP_JWT,
             user,
@@ -226,8 +226,8 @@ export const injectIdentity = fp(
         case AuthMode.IDENTITY_ACCESS_TOKEN: {
           const identity = await server.services.identityAccessToken.fnValidateIdentityAccessToken(token, req.realIp);
           const serverCfg = await getServerCfg();
-          requestContext.set(requestContextKeys.orgId, identity.orgId);
-          requestContext.set(requestContextKeys.orgName, identity.orgName);
+          requestContext.set(RequestContextKey.OrgId, identity.orgId);
+          requestContext.set(RequestContextKey.OrgName, identity.orgName);
           req.auth = {
             authMode: AuthMode.IDENTITY_ACCESS_TOKEN,
             actor,
@@ -256,7 +256,7 @@ export const injectIdentity = fp(
             identityAuthInfo.aws = token?.identityAuth?.aws;
           }
 
-          requestContext.set(requestContextKeys.identityAuthInfo, identityAuthInfo);
+          requestContext.set(RequestContextKey.IdentityAuthInfo, identityAuthInfo);
 
           // Fire-and-forget: enrich PostHog person record for this machine identity
           void server.services.telemetry
@@ -272,7 +272,7 @@ export const injectIdentity = fp(
         }
         case AuthMode.SERVICE_TOKEN: {
           const serviceToken = await server.services.serviceToken.fnValidateServiceToken(token);
-          requestContext.set(requestContextKeys.orgId, serviceToken.orgId);
+          requestContext.set(RequestContextKey.OrgId, serviceToken.orgId);
 
           req.auth = {
             orgId: serviceToken.orgId,
@@ -294,7 +294,7 @@ export const injectIdentity = fp(
         }
         case AuthMode.SCIM_TOKEN: {
           const { orgId, scimTokenId } = await server.services.scim.fnValidateScimToken(token);
-          requestContext.set(requestContextKeys.orgId, orgId);
+          requestContext.set(RequestContextKey.OrgId, orgId);
 
           req.auth = {
             authMode: AuthMode.SCIM_TOKEN,

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -22,7 +22,7 @@ import {
   ScimRequestError,
   UnauthorizedError
 } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 
 enum JWTErrors {
   JwtExpired = "jwt expired",
@@ -72,11 +72,11 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         name: error.name
       });
 
-      const orgId = requestContext.get(requestContextKeys.orgId);
-      const orgName = requestContext.get(requestContextKeys.orgName);
-      const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
-      const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
-      const projectDetails = requestContext.get(requestContextKeys.projectDetails);
+      const orgId = requestContext.get(RequestContextKey.OrgId);
+      const orgName = requestContext.get(RequestContextKey.OrgName);
+      const userAuthInfo = requestContext.get(RequestContextKey.UserAuthInfo);
+      const identityAuthInfo = requestContext.get(RequestContextKey.IdentityAuthInfo);
+      const projectDetails = requestContext.get(RequestContextKey.ProjectDetails);
 
       const attributes: Record<string, string | number> = {
         "http.request.method": method,

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -22,6 +22,7 @@ import {
   ScimRequestError,
   UnauthorizedError
 } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 
 enum JWTErrors {
   JwtExpired = "jwt expired",
@@ -71,11 +72,11 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         name: error.name
       });
 
-      const orgId = requestContext.get("orgId");
-      const orgName = requestContext.get("orgName");
-      const userAuthInfo = requestContext.get("userAuthInfo");
-      const identityAuthInfo = requestContext.get("identityAuthInfo");
-      const projectDetails = requestContext.get("projectDetails");
+      const orgId = requestContext.get(requestContextKeys.orgId);
+      const orgName = requestContext.get(requestContextKeys.orgName);
+      const userAuthInfo = requestContext.get(requestContextKeys.userAuthInfo);
+      const identityAuthInfo = requestContext.get(requestContextKeys.identityAuthInfo);
+      const projectDetails = requestContext.get(requestContextKeys.projectDetails);
 
       const attributes: Record<string, string | number> = {
         "http.request.method": method,

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -21,7 +21,7 @@ import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { fetchGithubEmails, fetchGithubUser } from "@app/lib/requests/github";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { authRateLimit } from "@app/server/config/rateLimiter";
@@ -101,8 +101,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GOOGLE,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 
@@ -114,8 +114,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GOOGLE,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
             cb(error as Error, false);
@@ -188,8 +188,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITHUB,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 
@@ -200,8 +200,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITHUB,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
             logger.error(err);
@@ -267,8 +267,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITLAB,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 
@@ -279,8 +279,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITLAB,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get(requestContextKeys.ip),
-                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+                "client.address": requestContext.get(RequestContextKey.Ip),
+                "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
               });
             }
 

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -21,6 +21,7 @@ import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { fetchGithubEmails, fetchGithubUser } from "@app/lib/requests/github";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { authRateLimit } from "@app/server/config/rateLimiter";
@@ -100,8 +101,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GOOGLE,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 
@@ -113,8 +114,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GOOGLE,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
             cb(error as Error, false);
@@ -187,8 +188,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITHUB,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 
@@ -199,8 +200,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITHUB,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
             logger.error(err);
@@ -266,8 +267,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.organization.name": orgName,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITLAB,
                 "infisical.auth.result": AuthAttemptAuthResult.SUCCESS,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 
@@ -278,8 +279,8 @@ export const registerOauthMiddlewares = (server: FastifyZodProvider) => {
                 "infisical.user.email": email,
                 "infisical.auth.method": AuthAttemptAuthMethod.GITLAB,
                 "infisical.auth.result": AuthAttemptAuthResult.FAILURE,
-                "client.address": requestContext.get("ip"),
-                "user_agent.original": requestContext.get("userAgent")
+                "client.address": requestContext.get(requestContextKeys.ip),
+                "user_agent.original": requestContext.get(requestContextKeys.userAgent)
               });
             }
 

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -4,6 +4,8 @@ import { OrgMembershipStatus, TAuthTokens, TAuthTokenSessions } from "@app/db/sc
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, ForbiddenRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 
 import { ActorType, AuthModeJwtTokenPayload, AuthModeRefreshJwtTokenPayload, AuthTokenType } from "../auth/auth-type";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
@@ -219,7 +221,9 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL }: TAuthTokenSer
       throw new UnauthorizedError({ name: "StaleSession", message: "User session is stale, please re-authenticate" });
     }
 
-    const user = await userDAL.findById(session.userId);
+    const user = await requestMemoize(requestMemoKeys.userFindById(session.userId), () =>
+      userDAL.findById(session.userId)
+    );
     if (!user || !user.isAccepted) throw new NotFoundError({ message: `User with ID '${session.userId}' not found` });
 
     let orgId = "";

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -24,6 +24,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -205,8 +206,8 @@ export const identityAliCloudAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.ALICLOUD_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -225,8 +226,8 @@ export const identityAliCloudAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.ALICLOUD_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -24,7 +24,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -206,8 +206,8 @@ export const identityAliCloudAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.ALICLOUD_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -226,8 +226,8 @@ export const identityAliCloudAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.ALICLOUD_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -308,8 +309,8 @@ export const identityAwsAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AWS_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -323,8 +324,8 @@ export const identityAwsAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AWS_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -25,7 +25,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -309,8 +309,8 @@ export const identityAwsAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AWS_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -324,8 +324,8 @@ export const identityAwsAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AWS_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -20,7 +20,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -211,8 +211,8 @@ export const identityAzureAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AZURE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -226,8 +226,8 @@ export const identityAzureAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AZURE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -20,6 +20,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -210,8 +211,8 @@ export const identityAzureAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AZURE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -225,8 +226,8 @@ export const identityAzureAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.AZURE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -20,7 +20,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -253,8 +253,8 @@ export const identityGcpAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.GCP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -268,8 +268,8 @@ export const identityGcpAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.GCP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -20,6 +20,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -252,8 +253,8 @@ export const identityGcpAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.GCP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -267,8 +268,8 @@ export const identityGcpAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.GCP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -29,6 +29,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { getValueByDot } from "@app/lib/template/dot-access";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
@@ -367,8 +368,8 @@ export const identityJwtAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.JWT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -382,8 +383,8 @@ export const identityJwtAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.JWT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -29,7 +29,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { getValueByDot } from "@app/lib/template/dot-access";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
@@ -368,8 +368,8 @@ export const identityJwtAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.JWT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -383,8 +383,8 @@ export const identityJwtAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.JWT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -42,7 +42,7 @@ import { GatewayHttpProxyActions, GatewayProxyProtocol, withGatewayProxy } from 
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -668,8 +668,8 @@ export const identityKubernetesAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.KUBERNETES_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -683,8 +683,8 @@ export const identityKubernetesAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.KUBERNETES_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -42,6 +42,7 @@ import { GatewayHttpProxyActions, GatewayProxyProtocol, withGatewayProxy } from 
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -667,8 +668,8 @@ export const identityKubernetesAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.KUBERNETES_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -682,8 +683,8 @@ export const identityKubernetesAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.KUBERNETES_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -31,6 +31,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
@@ -273,8 +274,8 @@ export const identityLdapAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.LDAP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -288,8 +289,8 @@ export const identityLdapAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.LDAP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -31,7 +31,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
@@ -274,8 +274,8 @@ export const identityLdapAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.LDAP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -289,8 +289,8 @@ export const identityLdapAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.LDAP_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -217,8 +218,8 @@ export const identityOciAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OCI_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -237,8 +238,8 @@ export const identityOciAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OCI_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -25,7 +25,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -218,8 +218,8 @@ export const identityOciAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OCI_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -238,8 +238,8 @@ export const identityOciAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OCI_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -31,7 +31,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { getValueByDot } from "@app/lib/template/dot-access";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
@@ -219,7 +219,7 @@ export const identityOidcAuthServiceFactory = ({
       } else {
         // If kid is not provided, try all available signing keys
         logger.warn(
-          `OIDC login without KID header [identityId=${identityOidcAuth.identityId}] [orgId=${org.id}] [ip=${requestContext.get(requestContextKeys.ip)}]`
+          `OIDC login without KID header [identityId=${identityOidcAuth.identityId}] [orgId=${org.id}] [ip=${requestContext.get(RequestContextKey.Ip)}]`
         );
 
         let allSigningKeys;
@@ -484,8 +484,8 @@ export const identityOidcAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OIDC_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -499,8 +499,8 @@ export const identityOidcAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OIDC_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -31,6 +31,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { getValueByDot } from "@app/lib/template/dot-access";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
@@ -218,7 +219,7 @@ export const identityOidcAuthServiceFactory = ({
       } else {
         // If kid is not provided, try all available signing keys
         logger.warn(
-          `OIDC login without KID header [identityId=${identityOidcAuth.identityId}] [orgId=${org.id}] [ip=${requestContext.get("ip")}]`
+          `OIDC login without KID header [identityId=${identityOidcAuth.identityId}] [orgId=${org.id}] [ip=${requestContext.get(requestContextKeys.ip)}]`
         );
 
         let allSigningKeys;
@@ -483,8 +484,8 @@ export const identityOidcAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OIDC_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -498,8 +499,8 @@ export const identityOidcAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.OIDC_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -29,6 +29,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
@@ -449,8 +450,8 @@ export const identitySpiffeAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.SPIFFE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -464,8 +465,8 @@ export const identitySpiffeAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.SPIFFE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -29,7 +29,7 @@ import {
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
@@ -450,8 +450,8 @@ export const identitySpiffeAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.SPIFFE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -465,8 +465,8 @@ export const identitySpiffeAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.SPIFFE_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -21,6 +21,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -252,8 +253,8 @@ export const identityTlsCertAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.TLS_CERT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -272,8 +273,8 @@ export const identityTlsCertAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.TLS_CERT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -21,7 +21,7 @@ import {
   UnauthorizedError
 } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -253,8 +253,8 @@ export const identityTlsCertAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.TLS_CERT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -273,8 +273,8 @@ export const identityTlsCertAuthServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.TLS_CERT_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -23,7 +23,7 @@ import {
 } from "@app/lib/errors";
 import { checkIPAgainstBlocklist, extractIPDetails, isValidIpOrCidr, TIp } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -362,8 +362,8 @@ export const identityUaServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.UNIVERSAL_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
 
@@ -384,8 +384,8 @@ export const identityUaServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.UNIVERSAL_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get(requestContextKeys.ip),
-          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
+          "client.address": requestContext.get(RequestContextKey.Ip),
+          "user_agent.original": requestContext.get(RequestContextKey.UserAgent)
         });
       }
       throw error;

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/lib/errors";
 import { checkIPAgainstBlocklist, extractIPDetails, isValidIpOrCidr, TIp } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { AuthAttemptAuthMethod, AuthAttemptAuthResult, authAttemptCounter } from "@app/lib/telemetry/metrics";
 
 import { ActorType, AuthTokenType } from "../auth/auth-type";
@@ -361,8 +362,8 @@ export const identityUaServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.UNIVERSAL_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.SUCCESS,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
 
@@ -383,8 +384,8 @@ export const identityUaServiceFactory = ({
           "infisical.organization.name": org.name,
           "infisical.identity.auth_method": AuthAttemptAuthMethod.UNIVERSAL_AUTH,
           "infisical.identity.auth_result": AuthAttemptAuthResult.FAILURE,
-          "client.address": requestContext.get("ip"),
-          "user_agent.original": requestContext.get("userAgent")
+          "client.address": requestContext.get(requestContextKeys.ip),
+          "user_agent.original": requestContext.get(requestContextKeys.userAgent)
         });
       }
       throw error;

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -648,7 +648,8 @@ export const kmsServiceFactory = ({
     return key.id;
   };
 
-  const getProjectSecretManagerKmsKeyId = async (projectId: string, trx?: Knex) => {
+  /** Single project row read; reuses snapshot for data-key path to avoid duplicate findById. */
+  const $getProjectSecretManagerKmsKeyIdAndProject = async (projectId: string, trx?: Knex) => {
     const project = await projectDAL.findById(projectId, trx);
     if (!project) {
       throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
@@ -658,7 +659,8 @@ export const kmsServiceFactory = ({
       if (trx) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         await trx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.KmsProjectKeyCreation(projectId)]);
-        return $createProjectKmsKey(projectId, trx);
+        const kmsKeyId = await $createProjectKmsKey(projectId, trx);
+        return { kmsKeyId, project };
       }
 
       const kmsKeyId = await projectDAL.transaction(async (tx) => {
@@ -667,10 +669,15 @@ export const kmsServiceFactory = ({
         return $createProjectKmsKey(projectId, tx);
       });
 
-      return kmsKeyId;
+      return { kmsKeyId, project };
     }
 
-    return project.kmsSecretManagerKeyId;
+    return { kmsKeyId: project.kmsSecretManagerKeyId, project };
+  };
+
+  const getProjectSecretManagerKmsKeyId = async (projectId: string, trx?: Knex) => {
+    const { kmsKeyId } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, trx);
+    return kmsKeyId;
   };
 
   // Helper function to create project data key within a transaction
@@ -690,8 +697,8 @@ export const kmsServiceFactory = ({
   };
 
   const $getProjectSecretManagerKmsDataKey = async (projectId: string, trx?: Knex) => {
-    const kmsKeyId = await getProjectSecretManagerKmsKeyId(projectId, trx);
-    let project = await projectDAL.findById(projectId, trx);
+    const { kmsKeyId, project: projectSnapshot } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, trx);
+    let project = projectSnapshot;
 
     if (!project.kmsSecretManagerEncryptedDataKey) {
       let projectDataKey: Buffer | undefined;

--- a/backend/src/services/project-bot/project-bot-fns.ts
+++ b/backend/src/services/project-bot/project-bot-fns.ts
@@ -1,6 +1,8 @@
 import { SecretKeyEncoding } from "@app/db/schemas";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { NotFoundError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TProjectBotDALFactory } from "@app/services/project-bot/project-bot-dal";
 
 import { TProjectDALFactory } from "../project/project-dal";
@@ -23,7 +25,9 @@ export const getBotKeyFnFactory = (
   projectDAL: Pick<TProjectDALFactory, "findById">
 ) => {
   const getBotKeyFn = async (projectId: string, shouldGetBotKey?: boolean) => {
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!project)
       throw new NotFoundError({
         message: `Project with ID '${projectId}' not found during bot lookup. Are you sure you are using the correct project ID?`

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -5,7 +5,7 @@ import { AccessScope, ActionProjectType, OrganizationActionScope, TableName } fr
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 import { UnpackedPermissionSchema, unpackPermissions } from "@app/server/routes/sanitizedSchema/permission";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
@@ -270,7 +270,7 @@ export const roleServiceFactory = ({
         actorOrgId: dto.permission.orgId
       });
 
-      const assumedPrivilegeDetailsCtx = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
+      const assumedPrivilegeDetailsCtx = requestContext.get(RequestContextKey.AssumedPrivilegeDetails);
       const isAssumingPrivilege = assumedPrivilegeDetailsCtx?.projectId === dto.scopeData.projectId;
       const assumedPrivilegeDetails = isAssumingPrivilege
         ? {

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -5,6 +5,7 @@ import { AccessScope, ActionProjectType, OrganizationActionScope, TableName } fr
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 import { UnpackedPermissionSchema, unpackPermissions } from "@app/server/routes/sanitizedSchema/permission";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
@@ -269,7 +270,7 @@ export const roleServiceFactory = ({
         actorOrgId: dto.permission.orgId
       });
 
-      const assumedPrivilegeDetailsCtx = requestContext.get("assumedPrivilegeDetails");
+      const assumedPrivilegeDetailsCtx = requestContext.get(requestContextKeys.assumedPrivilegeDetails);
       const isAssumingPrivilege = assumedPrivilegeDetailsCtx?.projectId === dto.scopeData.projectId;
       const assumedPrivilegeDetails = isAssumingPrivilege
         ? {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -41,6 +41,8 @@ import { diff, groupBy } from "@app/lib/fn";
 import { setKnexStringValue } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { recordSecretReadMetric } from "@app/lib/telemetry/metrics";
 
 import { ActorType } from "../auth/auth-type";
@@ -345,7 +347,9 @@ export const secretV2BridgeServiceFactory = ({
       })
     );
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     await scanSecretPolicyViolations(
       projectId,
       secretPath,
@@ -603,7 +607,9 @@ export const secretV2BridgeServiceFactory = ({
     const { secretName, secretValue } = inputSecret;
 
     if (secretValue) {
-      const project = await projectDAL.findById(projectId);
+      const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+        projectDAL.findById(projectId)
+      );
       await scanSecretPolicyViolations(
         projectId,
         secretPath,
@@ -1946,7 +1952,9 @@ export const secretV2BridgeServiceFactory = ({
     if (secrets.length)
       throw new BadRequestError({ message: `Secret already exists: ${secrets.map((el) => el.key).join(",")}` });
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     await scanSecretPolicyViolations(
       projectId,
       secretPath,
@@ -2310,7 +2318,9 @@ export const secretV2BridgeServiceFactory = ({
         });
         await $validateSecretReferences(projectId, permission, secretReferences, tx);
 
-        const project = await projectDAL.findById(projectId);
+        const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+          projectDAL.findById(projectId)
+        );
         await scanSecretPolicyViolations(
           projectId,
           secretPath,

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -795,8 +795,7 @@ export const createManySecretsRawFnFactory = ({
     secrets,
     userId
   }: TCreateManySecretsRawFn) => {
-    const { botKey, shouldUseSecretV2Bridge } = await getBotKeyFn(projectId);
-    const project = await projectDAL.findById(projectId);
+    const { botKey, shouldUseSecretV2Bridge, project } = await getBotKeyFn(projectId);
     const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
     if (!folder)
       throw new NotFoundError({
@@ -979,8 +978,7 @@ export const updateManySecretsRawFnFactory = ({
     secrets, // consider accepting instead ciphertext secrets
     userId
   }: TUpdateManySecretsRawFn): Promise<Array<{ id: string }>> => {
-    const { botKey, shouldUseSecretV2Bridge } = await getBotKeyFn(projectId);
-    const project = await projectDAL.findById(projectId);
+    const { botKey, shouldUseSecretV2Bridge, project } = await getBotKeyFn(projectId);
 
     const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
     if (!folder)

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -37,6 +37,8 @@ import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/
 import { groupBy, pick } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { OrgServiceActor } from "@app/lib/types";
 import {
   SecretUpdateMode,
@@ -1709,7 +1711,9 @@ export const secretServiceFactory = ({
     secretMetadata
   }: TCreateSecretRawDTO) => {
     const { botKey, shouldUseSecretV2Bridge } = await projectBotService.getBotKey(projectId);
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (project.enforceCapitalization) {
       if (secretName !== secretName.toUpperCase()) {
         throw new BadRequestError({
@@ -1889,7 +1893,9 @@ export const secretServiceFactory = ({
     secretMetadata
   }: TUpdateSecretRawDTO) => {
     const { botKey, shouldUseSecretV2Bridge } = await projectBotService.getBotKey(projectId);
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (project.enforceCapitalization) {
       if (newSecretName && newSecretName !== newSecretName.toUpperCase()) {
         throw new BadRequestError({
@@ -2183,7 +2189,9 @@ export const secretServiceFactory = ({
         : undefined;
 
     if (shouldUseSecretV2Bridge) {
-      const project = await projectDAL.findById(projectId);
+      const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+        projectDAL.findById(projectId)
+      );
       if (project.enforceCapitalization) {
         const caseViolatingSecretKeys = inputSecrets
           .filter((sec) => sec.secretKey !== sec.secretKey.toUpperCase())
@@ -2346,7 +2354,9 @@ export const secretServiceFactory = ({
         ? await secretApprovalPolicyService.getSecretApprovalPolicy(projectId, environment, secretPath)
         : undefined;
     if (shouldUseSecretV2Bridge) {
-      const project = await projectDAL.findById(projectId);
+      const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+        projectDAL.findById(projectId)
+      );
       if (project.enforceCapitalization) {
         const caseViolatingSecretKeys = inputSecrets
           .filter((sec) => sec.newSecretName && sec.newSecretName !== sec.newSecretName.toUpperCase())

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -8,6 +8,7 @@ import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { logger } from "@app/lib/logger";
+import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
@@ -209,7 +210,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     if (!postHog) return;
 
     // Resolve org name: prefer explicit value, fall back to request context
-    const resolvedOrgName = event.organizationName ?? requestContext.get("orgName");
+    const resolvedOrgName = event.organizationName ?? requestContext.get(requestContextKeys.orgName);
 
     if (POSTHOG_AGGREGATED_EVENTS.includes(event.event)) {
       const eventKey = createTelemetryEventKey(event.event, event.distinctId);

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -8,7 +8,7 @@ import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { logger } from "@app/lib/logger";
-import { requestContextKeys } from "@app/lib/request-context/request-context-keys";
+import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
@@ -210,7 +210,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     if (!postHog) return;
 
     // Resolve org name: prefer explicit value, fall back to request context
-    const resolvedOrgName = event.organizationName ?? requestContext.get(requestContextKeys.orgName);
+    const resolvedOrgName = event.organizationName ?? requestContext.get(RequestContextKey.OrgName);
 
     if (POSTHOG_AGGREGATED_EVENTS.includes(event.event)) {
       const eventKey = createTelemetryEventKey(event.event, event.distinctId);


### PR DESCRIPTION
## Context

Adds **request-scoped memoization** so repeated read-only work in a single HTTP request (permissions, project/user/identity lookups) hits the database once instead of many times—especially on batch secret paths.

**Before:** Each call path could repeat `getProjectPermission` / `getOrgPermission`, `projectDAL.findById`, and actor lookups independently within the same request.

**After:**

- Introduces `RequestMemoizer` (`getOrSet` with in-flight deduplication) stored on `@fastify/request-context` as `memoizer` (wired in `app.ts` per existing pattern in the branch).
- Adds `requestMemoize(key, fetcher)` which uses the memoizer when present and falls back to a direct fetch when there is no request context (e.g. workers).
- Centralizes memo key strings in `src/lib/request-context/memo-keys.ts` and request-context string keys in `request-context-keys.ts` (kept in sync with `RequestContextData` in `fastify.d.ts`).
- **Permission service:** `getOrgPermission` wrapped with `requestMemoize`; `getProjectPermission` uses `memoizer.getOrSet` for full-function memoization (key includes `actorOrgId`) and defers `requestContext.set` for `projectDetails` / `identityPermissionMetadata` until after the memoized load completes. DAL reads use `requestMemoize` for `projectFindById`, `userFindById`, and `identityFindById`.
- Replaces raw `requestContext.get("…")` / `set` string literals with `requestContextKeys` in touched files (logger, audit log, SAML/OIDC telemetry, assume-privilege router, permission service).
- Documents the pattern in `backend/CLAUDE.md` (Request-Scoped Memoization section).
- Unit tests in `request-memoizer.test.ts` for caching, in-flight coalescing, error behavior, and cross-request isolation.

## Steps to verify the change

1. **Knex query logging (temporary):** Enable SQL logging (e.g. Knex `debug` against the dev DB) while exercising a hot path that previously repeated lookups (e.g. batch secret read/list for one project).

`backend/src/db/instance.ts`

<img width="849" height="750" alt="image" src="https://github.com/user-attachments/assets/a8d090b3-ed27-438d-b998-fd5a0150d180" />

2. **API call:** Issue the same request shape you use in production or staging (same `projectId`, same auth) and compare **number of `SELECT` statements** (or log lines) before vs after—project load, permission resolution, and actor lookups should collapse to a single round-trip per distinct key within one request.

For example:

```
# Create a machine identity + access token if you don't have one
# Then fetch a single secret:
curl -H "Authorization: Bearer <identity-access-token>" \
  http://localhost:8080/api/v3/secrets/raw/<secretName>?workspaceId=<projectId>&environment=dev
```
  
```
# List all secrets (triggers getProjectPermission once, reused for all):
curl -H "Authorization: Bearer <identity-access-token>" \
  "http://localhost:8080/api/v3/secrets/raw?workspaceId=<projectId>&environment=dev"
```

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).  
  _Suggested title:_ `perf(backend): request-scoped memoization for permissions and project lookups`
- [x] Tested locally
- [x] Updated docs (if needed) — `backend/CLAUDE.md` updated for memoization
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)