### PR TITLE
fix(clickhouse): pin direct dynamic secret connections to validated host

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
@@ -209,7 +209,7 @@ export const ClickhouseProvider = ({
     const providerInputs = await validateProviderInputs(inputs);
     let isConnected = false;
 
-    const gatewayCallback = async (host = providerInputs.host, port = providerInputs.port) => {
+    const gatewayCallback = async (host = providerInputs.hostIp, port = providerInputs.port) => {
       const client = await $getClient({
         ...providerInputs,
         host,
@@ -263,7 +263,7 @@ export const ClickhouseProvider = ({
 
     const password = generatePassword(providerInputs.passwordRequirements);
 
-    const gatewayCallback = async (host = providerInputs.host, port = providerInputs.port) => {
+    const gatewayCallback = async (host = providerInputs.hostIp, port = providerInputs.port) => {
       const client = await $getClient({
         ...providerInputs,
         host,
@@ -310,7 +310,7 @@ export const ClickhouseProvider = ({
     const username = entityId;
     const { database } = providerInputs;
 
-    const gatewayCallback = async (host = providerInputs.host, port = providerInputs.port) => {
+    const gatewayCallback = async (host = providerInputs.hostIp, port = providerInputs.port) => {
       const client = await $getClient({
         ...providerInputs,
         host,
@@ -352,7 +352,7 @@ export const ClickhouseProvider = ({
     const providerInputs = await validateProviderInputs(inputs);
     if (!providerInputs.renewStatement) return { entityId };
 
-    const gatewayCallback = async (host = providerInputs.host, port = providerInputs.port) => {
+    const gatewayCallback = async (host = providerInputs.hostIp, port = providerInputs.port) => {
       const client = await $getClient({
         ...providerInputs,
         host,


### PR DESCRIPTION
### Motivation
- The ClickHouse dynamic secret provider validated the resolved `hostIp` but then used the original hostname for direct connections, creating a DNS rebinding TOCTOU that could bypass internal/reserved-IP checks. 
- The change aims to eliminate that window by ensuring direct (non-gateway) connections use the already-validated IP.