### PR TITLE
fix(additional-privileges): validate omitted permissions on user project additional privilege update

### DIFF
--- a/backend/src/services/additional-privilege/additional-privilege-service.ts
+++ b/backend/src/services/additional-privilege/additional-privilege-service.ts
@@ -46,6 +46,7 @@ export const additionalPrivilegeServiceFactory = ({
   const scopeFactory: Record<AccessScope, TAdditionalPrivilegesScopeFactory> = {
     [AccessScope.Organization]: newOrgAdditionalPrivilegesFactory({}),
     [AccessScope.Project]: newProjectAdditionalPrivilegesFactory({
+      additionalPrivilegeDAL,
       membershipDAL,
       orgDAL,
       permissionService,

--- a/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
+++ b/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
@@ -12,7 +12,7 @@ import {
   ProjectPermissionSet,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
-import { BadRequestError, PermissionBoundaryError } from "@app/lib/errors";
+import { BadRequestError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
 import { OrgServiceActor } from "@app/lib/types";
 import { unpackPermissions } from "@app/server/routes/sanitizedSchema/permission";
 import { ActorType } from "@app/services/auth/auth-type";
@@ -474,12 +474,16 @@ export const newProjectAdditionalPrivilegesFactory = ({
       // permissions so that grant boundary validation still runs against them.
       let permissionsToValidate = dto.data.permissions;
       if (!permissionsToValidate && shouldUseNewPrivilegeSystem) {
+        const dbActorField = actorType === ActorType.IDENTITY ? "actorIdentityId" : "actorUserId";
         const existingPrivilege = await additionalPrivilegeDAL.findOne({
           id: dto.selector.id,
+          [dbActorField]: actorId,
           [scope.key]: scope.value
         });
         if (!existingPrivilege) {
-          throw new BadRequestError({ message: "Additional privilege not found" });
+          throw new NotFoundError({
+            message: `Additional privilege with id ${dto.selector.id} doesn't exist`
+          });
         }
         if (existingPrivilege.permissions) {
           permissionsToValidate = unpackPermissions(existingPrivilege.permissions);

--- a/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
+++ b/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
@@ -478,7 +478,10 @@ export const newProjectAdditionalPrivilegesFactory = ({
           id: dto.selector.id,
           [scope.key]: scope.value
         });
-        if (existingPrivilege?.permissions) {
+        if (!existingPrivilege) {
+          throw new BadRequestError({ message: "Additional privilege not found" });
+        }
+        if (existingPrivilege.permissions) {
           permissionsToValidate = unpackPermissions(existingPrivilege.permissions);
         }
       }

--- a/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
+++ b/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
@@ -14,11 +14,13 @@ import {
 } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, PermissionBoundaryError } from "@app/lib/errors";
 import { OrgServiceActor } from "@app/lib/types";
+import { unpackPermissions } from "@app/server/routes/sanitizedSchema/permission";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
+import { TAdditionalPrivilegeDALFactory } from "../additional-privilege-dal";
 import { TAdditionalPrivilegesScopeFactory } from "../additional-privilege-types";
 
 type TPermissionRule = RawRule & {
@@ -28,6 +30,7 @@ type TPermissionRule = RawRule & {
 
 type TProjectAdditionalPrivilegesScopeFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
+  additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "findOne">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   membershipDAL: Pick<TMembershipDALFactory, "findOne">;
   userDAL: Pick<TUserDALFactory, "findById">;
@@ -35,6 +38,7 @@ type TProjectAdditionalPrivilegesScopeFactoryDep = {
 
 export const newProjectAdditionalPrivilegesFactory = ({
   permissionService,
+  additionalPrivilegeDAL,
   orgDAL,
   membershipDAL,
   userDAL
@@ -466,10 +470,23 @@ export const newProjectAdditionalPrivilegesFactory = ({
         }
       }
 
+      // When permissions are omitted from the update request, fetch the existing privilege's
+      // permissions so that grant boundary validation still runs against them.
+      let permissionsToValidate = dto.data.permissions;
+      if (!permissionsToValidate && shouldUseNewPrivilegeSystem) {
+        const existingPrivilege = await additionalPrivilegeDAL.findOne({
+          id: dto.selector.id,
+          [scope.key]: scope.value
+        });
+        if (existingPrivilege?.permissions) {
+          permissionsToValidate = unpackPermissions(existingPrivilege.permissions);
+        }
+      }
+
       await $validateAdditionalPrivilegesGuard({
         actorType,
         actorId,
-        permissions: dto.data.permissions,
+        permissions: permissionsToValidate,
         permission,
         targetUserPermission,
         memberships,


### PR DESCRIPTION
## Context

Updating a **user project additional privilege** with a PATCH body that omits `permissions` (e.g. only `type`) left grant-boundary validation without the current rules, so behavior could be wrong or inconsistent compared to updates that send `permissions`.

**Change:** In the project-scope update guard, when `permissions` is missing and the org uses the new privilege system, load the existing row (scoped by `id` + `projectId`), unpack stored `permissions`, and run the same validation path as when permissions are provided.

## Steps to verify the change

Do a PATCH without `permissions` and confirm the request succeeds when only non-permission fields change (and that invalid grants would still be rejected when validation applies).

```bash
curl -X PATCH 'http://localhost:8080/api/v1/user-project-additional-privilege/<uuid_of _the_additional_privilege>' \
  -H 'Authorization: Bearer <your-token>' \
  -H 'Content-Type: application/json' \
  -d '{"type":{"isTemporary":false}}'
```

Replace `<your-token>` and the UUID with a real privilege id in your environment.

- The user endpoint is not in the API docs, the machine identity one is.
- The same should work for machine identities additional privileges.
- These are the permissions, validate when the user has access and when they don't have access to change the additional privileges. Use the conditions for that.
- It has to be done through the API, the UI always sends the `permissions` field.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)