### PR TITLE
fix: support escaped dots in secret reference names (#5962)

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
@@ -1,0 +1,77 @@
+import { getAllSecretReferences, splitOnUnescapedDots } from "./secret-reference-fns";
+
+describe("splitOnUnescapedDots", () => {
+  it("should split on regular dots", () => {
+    expect(splitOnUnescapedDots("dev.folder.SECRET")).toEqual(["dev", "folder", "SECRET"]);
+  });
+
+  it("should treat escaped dots as literal dots", () => {
+    expect(splitOnUnescapedDots("Secret\\.Reference")).toEqual(["Secret.Reference"]);
+  });
+
+  it("should handle mixed escaped and unescaped dots", () => {
+    expect(splitOnUnescapedDots("dev.folder.Secret\\.Name")).toEqual(["dev", "folder", "Secret.Name"]);
+  });
+
+  it("should handle multiple escaped dots in a single segment", () => {
+    expect(splitOnUnescapedDots("a\\.b\\.c")).toEqual(["a.b.c"]);
+  });
+
+  it("should handle string with no dots", () => {
+    expect(splitOnUnescapedDots("SECRET_KEY")).toEqual(["SECRET_KEY"]);
+  });
+
+  it("should handle escaped dot at end of segment followed by unescaped dot", () => {
+    expect(splitOnUnescapedDots("dev.key\\.with\\.dots.SECRET")).toEqual(["dev", "key.with.dots", "SECRET"]);
+  });
+});
+
+describe("getAllSecretReferences", () => {
+  it("should parse a simple local reference", () => {
+    const result = getAllSecretReferences("${MY_SECRET}");
+    expect(result.localReferences).toEqual(["MY_SECRET"]);
+    expect(result.nestedReferences).toEqual([]);
+  });
+
+  it("should parse a nested cross-environment reference", () => {
+    const result = getAllSecretReferences("${dev.folder.SECRET_NAME}");
+    expect(result.nestedReferences).toEqual([
+      { environment: "dev", secretPath: "/folder", secretKey: "SECRET_NAME" }
+    ]);
+    expect(result.localReferences).toEqual([]);
+  });
+
+  it("should treat escaped-dot reference as a local reference", () => {
+    const result = getAllSecretReferences("${Secret\\.Reference}");
+    expect(result.localReferences).toEqual(["Secret.Reference"]);
+    expect(result.nestedReferences).toEqual([]);
+  });
+
+  it("should handle nested reference with escaped dot in secret key", () => {
+    const result = getAllSecretReferences("${dev.folder.Secret\\.Name}");
+    expect(result.nestedReferences).toEqual([
+      { environment: "dev", secretPath: "/folder", secretKey: "Secret.Name" }
+    ]);
+    expect(result.localReferences).toEqual([]);
+  });
+
+  it("should handle multiple references with mixed types", () => {
+    const result = getAllSecretReferences("${SIMPLE} and ${dev.folder.KEY} and ${Dotted\\.Name}");
+    expect(result.localReferences).toEqual(["SIMPLE", "Dotted.Name"]);
+    expect(result.nestedReferences).toEqual([
+      { environment: "dev", secretPath: "/folder", secretKey: "KEY" }
+    ]);
+  });
+
+  it("should return empty arrays for string without references", () => {
+    const result = getAllSecretReferences("no references here");
+    expect(result.localReferences).toEqual([]);
+    expect(result.nestedReferences).toEqual([]);
+  });
+
+  it("should not match bare backslashes that are not escaping dots", () => {
+    const result = getAllSecretReferences("${FOO\\BAR}");
+    expect(result.localReferences).toEqual([]);
+    expect(result.nestedReferences).toEqual([]);
+  });
+});

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
@@ -7,8 +7,48 @@ import { ForbiddenRequestError } from "@app/lib/errors";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretV2BridgeDALFactory } from "./secret-v2-bridge-dal";
 
-const INTERPOLATION_PATTERN_STRING = String.raw`\${([a-zA-Z0-9-_.]+)}`;
+// Allow backslash-escaped dots (\.) in secret references so that secret names
+// containing literal dots can be referenced, e.g. ${Secret\.Name} or
+// ${dev.folder.Secret\.Name}
+// Only \. is recognized as an escape sequence; bare backslashes are not matched.
+const INTERPOLATION_PATTERN_STRING = String.raw`\${((?:[a-zA-Z0-9_-]|\\\.)+(?:\.(?:[a-zA-Z0-9_-]|\\\.)+)*)}`;
 const INTERPOLATION_TEST_REGEX = new RE2(INTERPOLATION_PATTERN_STRING);
+
+/**
+ * Split a reference key on unescaped dots and unescape \\. sequences.
+ * e.g. "dev.folder.Secret\\.Name" => ["dev", "folder", "Secret.Name"]
+ *      "Secret\\.Reference"       => ["Secret.Reference"]
+ */
+export const splitOnUnescapedDots = (str: string): string[] => {
+  const parts: string[] = [];
+  let current = "";
+  for (let i = 0; i < str.length; i += 1) {
+    if (str[i] === "\\" && i + 1 < str.length && str[i + 1] === ".") {
+      current += ".";
+      i += 1;
+    } else if (str[i] === ".") {
+      parts.push(current);
+      current = "";
+    } else {
+      current += str[i];
+    }
+  }
+  parts.push(current);
+  return parts;
+};
+
+/** Returns true when the string contains at least one dot NOT preceded by a backslash. */
+const hasUnescapedDot = (str: string): boolean => {
+  for (let i = 0; i < str.length; i += 1) {
+    if (str[i] === "\\" && i + 1 < str.length && str[i + 1] === ".") {
+      i += 1;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (str[i] === ".") return true;
+  }
+  return false;
+};
 
 /**
  * Grabs and processes nested secret references from a string
@@ -17,6 +57,11 @@ const INTERPOLATION_TEST_REGEX = new RE2(INTERPOLATION_PATTERN_STRING);
  * It filters out references that include nested paths, splits them into environment and
  * secret path parts, and then returns an array of objects with the environment and the
  * joined secret path.
+ *
+ * Escaped dots (\\.) are treated as literal dots in secret names, not as path separators.
+ * e.g. ${Secret\\.Reference} is a local reference to a secret named "Secret.Reference"
+ *      ${dev.folder.Secret\\.Name} is a nested reference with key "Secret.Name"
+ *
  * @example
  * const value = "Hello ${dev.someFolder.OtherFolder.SECRET_NAME} and ${prod.anotherFolder.SECRET_NAME}";
  * const result = getAllNestedSecretReferences(value);
@@ -37,16 +82,19 @@ export const getAllSecretReferences = (maybeSecretReference: string) => {
   }
 
   const nestedReferences = references
-    .filter((el) => el.includes("."))
+    .filter((el) => hasUnescapedDot(el))
     .map((el) => {
-      const [environment, ...secretPathList] = el.split(".");
+      const entities = splitOnUnescapedDots(el);
+      const [environment, ...secretPathList] = entities;
       return {
         environment,
         secretPath: path.join("/", ...secretPathList.slice(0, -1)),
         secretKey: secretPathList[secretPathList.length - 1]
       };
     });
-  const localReferences = references.filter((el) => !el.includes("."));
+  const localReferences = references
+    .filter((el) => !hasUnescapedDot(el))
+    .map((el) => splitOnUnescapedDots(el).join(""));
   return { nestedReferences, localReferences };
 };
 
@@ -163,7 +211,7 @@ export const expandSecretReferencesFactory = ({
       if (refs.length > 0) {
         for (const interpolationSyntax of refs) {
           const interpolationKey = interpolationSyntax.slice(2, interpolationSyntax.length - 1);
-          const entities = interpolationKey.trim().split(".");
+          const entities = splitOnUnescapedDots(interpolationKey.trim());
 
           // eslint-disable-next-line no-continue
           if (!entities.length) continue;

--- a/backend/src/services/secret/secret-fns.ts
+++ b/backend/src/services/secret/secret-fns.ts
@@ -21,7 +21,7 @@ import { crypto, SymmetricKeySize } from "@app/lib/crypto/cryptography";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy, unique } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
-import { getAllSecretReferences } from "@app/services/secret-v2-bridge/secret-reference-fns";
+import { getAllSecretReferences, splitOnUnescapedDots } from "@app/services/secret-v2-bridge/secret-reference-fns";
 import {
   fnSecretBulkInsert as fnSecretV2BridgeBulkInsert,
   fnSecretBulkUpdate as fnSecretV2BridgeBulkUpdate
@@ -215,7 +215,7 @@ type TInterpolateSecretArg = {
 };
 
 const MAX_SECRET_REFERENCE_DEPTH = 5;
-const INTERPOLATION_PATTERN_STRING = String.raw`\${([a-zA-Z0-9-_.]+)}`;
+const INTERPOLATION_PATTERN_STRING = String.raw`\${((?:[a-zA-Z0-9_-]|\\\.)+(?:\.(?:[a-zA-Z0-9_-]|\\\.)+)*)}`;
 const INTERPOLATION_TEST_REGEX = new RE2(INTERPOLATION_PATTERN_STRING);
 
 export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderDAL }: TInterpolateSecretArg) => {
@@ -287,7 +287,7 @@ export const interpolateSecrets = ({ projectId, secretEncKey, secretDAL, folderD
     if (refs.length > 0) {
       for (const interpolationSyntax of refs) {
         const interpolationKey = interpolationSyntax.slice(2, interpolationSyntax.length - 1);
-        const entities = interpolationKey.trim().split(".");
+        const entities = splitOnUnescapedDots(interpolationKey.trim());
 
         if (entities.length === 1) {
           const [secretKey] = entities;
@@ -477,9 +477,21 @@ export const getAllNestedSecretReferences = (maybeSecretReference: string) => {
   const references = matches.map((m) => m[1]);
 
   return references
-    .filter((el) => el.includes("."))
+    .filter((el) => {
+      // Check for unescaped dots (dots not preceded by backslash)
+      for (let i = 0; i < el.length; i += 1) {
+        if (el[i] === "\\" && i + 1 < el.length && el[i + 1] === ".") {
+          i += 1;
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        if (el[i] === ".") return true;
+      }
+      return false;
+    })
     .map((el) => {
-      const [environment, ...secretPathList] = el.split(".");
+      const entities = splitOnUnescapedDots(el);
+      const [environment, ...secretPathList] = entities;
       return { environment, secretPath: path.join("/", ...secretPathList.slice(0, -1)) };
     });
 };


### PR DESCRIPTION
Secret names containing dots (e.g. `Secret.Name`) broke secret references because the dot was always treated as a path separator (`environment.path.key`).

Closes #5962

## Context

When a secret name contains a `.` character (e.g. `Secret.Reference`), referencing it via `${Secret.Reference}` fails because the parser splits on `.` and interprets `Secret` as an environment slug and `Reference` as the secret key. This is a real problem for users who need dotted secret names (e.g. .NET `appsettings.json` variable substitution uses `Level1.Level2` naming).

Maintainer @akhilmhdh confirmed the need for "an encoded way of saying the key reference for a key with dot."

This PR adds support for backslash-escaped dots (`\.`) in secret references:
- `${Secret\.Reference}` → local reference to secret named `Secret.Reference`
- `${dev.folder.Secret\.Name}` → nested reference with key `Secret.Name`

**Before:** `${Secret.Reference}` → parsed as env=`Secret`, key=`Reference` → fails with "No Value"
**After:** `${Secret\.Reference}` → parsed as local ref to `Secret.Reference` → resolves correctly

## Screenshots

N/A — backend-only change

## Steps to verify the change

1. Create a secret named `Secret.Reference` with value `test`
2. Create a secret named `Secret_Test` with value `${Secret\.Reference}`
3. Verify `Secret_Test` resolves to `test`
4. Run unit tests: `cd backend && npm run test:unit`

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix: support escaped dots in secret reference names`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)