### PR TITLE
improvement(frontend): reduce default integration and approval polling intervals

### DIFF
--- a/frontend/src/hooks/api/admin/queries.ts
+++ b/frontend/src/hooks/api/admin/queries.ts
@@ -153,7 +153,7 @@ export const useGetInvalidatingCacheStatus = (enabled = true) => {
       return data.invalidating;
     },
     enabled,
-    refetchInterval: (data) => (data ? 3000 : false)
+    refetchInterval: (data) => (data ? 10_000 : false)
   });
 };
 

--- a/frontend/src/hooks/api/admin/queries.ts
+++ b/frontend/src/hooks/api/admin/queries.ts
@@ -153,7 +153,7 @@ export const useGetInvalidatingCacheStatus = (enabled = true) => {
       return data.invalidating;
     },
     enabled,
-    refetchInterval: (data) => (data ? 10_000 : false)
+    refetchInterval: (query) => (query.state.data ? 10_000 : false)
   });
 };
 

--- a/frontend/src/hooks/api/ca/queries.tsx
+++ b/frontend/src/hooks/api/ca/queries.tsx
@@ -249,7 +249,7 @@ export const useGetCaAutoRenewal = (caId: string, options?: { enabled?: boolean 
     enabled: options?.enabled !== undefined ? options.enabled : Boolean(caId),
     refetchInterval: (query) => {
       const { data } = query.state;
-      if (data?.lastRenewalStatus === CaRenewalStatus.PENDING) return 3000;
+      if (data?.lastRenewalStatus === CaRenewalStatus.PENDING) return 10_000;
       return false;
     }
   });

--- a/frontend/src/hooks/api/projects/queries.tsx
+++ b/frontend/src/hooks/api/projects/queries.tsx
@@ -199,7 +199,7 @@ export const useGetWorkspaceIntegrations = (
     queryKey: projectKeys.getProjectIntegrations(projectId),
     queryFn: () => fetchWorkspaceIntegrations(projectId),
     enabled: Boolean(projectId) && (options?.enabled ?? true),
-    refetchInterval: options?.refetchInterval ?? 4000
+    refetchInterval: options?.refetchInterval ?? 30_000
   });
 
 export const createWorkspace = (

--- a/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
@@ -155,7 +155,8 @@ export const useGetSecretApprovalRequestCount = ({
 }) =>
   useQuery({
     queryKey: secretApprovalRequestKeys.count({ projectId, policyId }),
-    refetchInterval: 30_000,
     queryFn: () => fetchSecretApprovalRequestCount({ projectId, policyId }),
-    enabled: Boolean(projectId) && (options?.enabled ?? true)
+    enabled: Boolean(projectId) && (options?.enabled ?? true),
+    ...options,
+    refetchInterval: options?.refetchInterval ?? 30_000
   });

--- a/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
@@ -155,7 +155,7 @@ export const useGetSecretApprovalRequestCount = ({
 }) =>
   useQuery({
     queryKey: secretApprovalRequestKeys.count({ projectId, policyId }),
-    refetchInterval: 15000,
+    refetchInterval: 30_000,
     queryFn: () => fetchSecretApprovalRequestCount({ projectId, policyId }),
     enabled: Boolean(projectId) && (options?.enabled ?? true)
   });

--- a/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
@@ -156,7 +156,7 @@ export const useGetSecretApprovalRequestCount = ({
   useQuery({
     queryKey: secretApprovalRequestKeys.count({ projectId, policyId }),
     queryFn: () => fetchSecretApprovalRequestCount({ projectId, policyId }),
-    enabled: Boolean(projectId) && (options?.enabled ?? true),
     ...options,
+    enabled: Boolean(projectId) && (options?.enabled ?? true),
     refetchInterval: options?.refetchInterval ?? 30_000
   });

--- a/frontend/src/pages/cert-manager/PkiSubscriberDetailsByIDPage/components/PkiSubscriberCertificatesTable.tsx
+++ b/frontend/src/pages/cert-manager/PkiSubscriberDetailsByIDPage/components/PkiSubscriberCertificatesTable.tsx
@@ -59,7 +59,7 @@ export const PkiSubscriberCertificatesTable = ({ subscriberName, handlePopUpOpen
       limit: perPage
     },
     {
-      refetchInterval: 5000
+      refetchInterval: 30_000
     }
   );
 

--- a/frontend/src/pages/cert-manager/PkiSubscriberDetailsByIDPage/components/PkiSubscriberDetailsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSubscriberDetailsByIDPage/components/PkiSubscriberDetailsSection.tsx
@@ -59,7 +59,7 @@ export const PkiSubscriberDetailsSection = ({ subscriberName, handlePopUpOpen }:
       projectId
     },
     {
-      refetchInterval: 5000
+      refetchInterval: 30_000
     }
   );
 

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncAuditLogsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncAuditLogsSection.tsx
@@ -35,7 +35,7 @@ export const PkiSyncAuditLogsSection = ({ pkiSync }: Props) => {
       </div>
       {subscription.auditLogs ? (
         <LogsSection
-          refetchInterval={4000}
+          refetchInterval={15_000}
           showFilters={false}
           project={currentProject}
           presets={{

--- a/frontend/src/pages/pam/PamDiscoveryDetailPage/PamDiscoveryDetailPage.tsx
+++ b/frontend/src/pages/pam/PamDiscoveryDetailPage/PamDiscoveryDetailPage.tsx
@@ -418,7 +418,7 @@ const RunsTab = ({
     discoverySourceId,
     discoveryType,
     { offset, limit: perPage },
-    { refetchInterval: isPolling ? 3000 : false }
+    { refetchInterval: isPolling ? 10_000 : false }
   );
 
   const runs = data?.runs || [];

--- a/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/IntegrationsDetailsByIDPage.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/IntegrationsDetailsByIDPage.tsx
@@ -40,7 +40,7 @@ export const IntegrationDetailsByIDPage = () => {
   });
 
   const { data: integration } = useGetIntegration(integrationId, {
-    refetchInterval: 4000
+    refetchInterval: 30_000
   });
 
   const [shouldDeleteSecrets, setShouldDeleteSecrets] = useToggle(false);

--- a/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsDetailsByIDPage/components/IntegrationAuditLogsSection.tsx
@@ -30,7 +30,7 @@ export const IntegrationAuditLogsSection = ({ integration }: Props) => {
         </p>
       </div>
       <LogsSection
-        refetchInterval={4000}
+        refetchInterval={15_000}
         showFilters={false}
         project={currentProject}
         presets={{

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncAuditLogsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncAuditLogsSection.tsx
@@ -36,7 +36,7 @@ export const SecretSyncAuditLogsSection = ({ secretSync }: Props) => {
       </div>
       {subscription.auditLogs ? (
         <LogsSection
-          refetchInterval={4000}
+          refetchInterval={15_000}
           showFilters={false}
           project={currentProject}
           presets={{


### PR DESCRIPTION
## Context

**Polling / refetch intervals (frontend)**

- **Admin — invalidating cache status** (`useGetInvalidatingCacheStatus`): `refetchInterval` while invalidation is in progress **3s → 10s** to reduce request volume.
- **Workspace integrations** (`useGetWorkspaceIntegrations`): default **`refetchInterval` 4s → 30s** (callers can still override via `options.refetchInterval`).
- **Secret approval request count** (`useGetSecretApprovalRequestCount`): **`refetchInterval` 15s → 30s**.

Goal: fewer background XHRs on busy pages while keeping status reasonably up to date.

## Steps to verify the change

1. **Admin console** — trigger or observe **cache invalidation** in progress: Network should poll the invalidating status about every **10s** (not 3s) while active.
2. **Project → Integrations** — with default options, integration sync polling should be about every **30s** (not 4s); confirm UI still updates and overrides still work if passed.
3. **Secret approval** — badge/count polling should be about every **30s** (not 15s); approve/reject flows that rely on **mutations + invalidation** should still feel instant.

## Type

- [x] Improvement  
- [ ] Fix  
- [ ] Feature  
- [ ] Breaking  
- [ ] Docs  
- [ ] Chore (if compose/license are accidental, treat those as “don’t merge” noise)

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)