### PR TITLE
fix: restrict admin config response and harden webhook/integration validation

### DIFF
--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -89,10 +89,6 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
 
       const isSuperAdminUser = req.auth && isSuperAdmin(req.auth);
 
-      console.log("isSuperAdminUser");
-      console.log(JSON.stringify(req.auth));
-      console.log(isSuperAdminUser);
-
       if (!isSuperAdminUser) {
         // Only return fields the frontend needs before authentication
         return {

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -22,6 +22,7 @@ import { verifySuperAdmin } from "@app/server/plugins/auth/superAdmin";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { RootKeyEncryptionStrategy } from "@app/services/kms/kms-types";
+import { isSuperAdmin } from "@app/services/super-admin/super-admin-fns";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 import { CacheType, LoginMethod } from "@app/services/super-admin/super-admin-types";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
@@ -50,26 +51,66 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
             encryptedGitHubAppConnectionSlug: true,
             encryptedGitHubAppConnectionId: true,
             encryptedGitHubAppConnectionPrivateKey: true,
-            encryptedEnvOverrides: true
+            encryptedEnvOverrides: true,
+            // Fields below are only returned for super admins
+            instanceId: true,
+            trustSamlEmails: true,
+            trustLdapEmails: true,
+            trustOidcEmails: true,
+            adminIdentityIds: true,
+            fipsEnabled: true
           }).extend({
-            isMigrationModeOn: z.boolean(),
+            // Super admin-only fields (omitted for non-super-admin callers)
+            instanceId: z.string().uuid().optional(),
+            trustSamlEmails: z.boolean().nullish(),
+            trustLdapEmails: z.boolean().nullish(),
+            trustOidcEmails: z.boolean().nullish(),
+            adminIdentityIds: z.string().array().nullable().optional(),
+            fipsEnabled: z.boolean().optional(),
+            isMigrationModeOn: z.boolean().optional(),
+            isSecretScanningDisabled: z.boolean().optional(),
+            kubernetesAutoFetchServiceAccountToken: z.boolean().optional(),
+            paramsFolderSecretDetectionEnabled: z.boolean().optional(),
+            isOfflineUsageReportsEnabled: z.boolean().optional(),
+            // Always returned
             defaultAuthOrgSlug: z.string().nullable(),
             defaultAuthOrgAuthEnforced: z.boolean().nullish(),
-            defaultAuthOrgAuthMethod: z.string().nullish(),
-            isSecretScanningDisabled: z.boolean(),
-            kubernetesAutoFetchServiceAccountToken: z.boolean(),
-            paramsFolderSecretDetectionEnabled: z.boolean(),
-            isOfflineUsageReportsEnabled: z.boolean()
+            defaultAuthOrgAuthMethod: z.string().nullish()
           })
         })
       }
     },
-    handler: async () => {
+    handler: async (req) => {
       const config = await getServerCfg();
       const serverEnvs = getConfig();
 
       const licenseKeyConfig = getLicenseKeyConfig();
       const hasOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
+
+      const isSuperAdminUser = req.auth && isSuperAdmin(req.auth);
+
+      console.log("isSuperAdminUser");
+      console.log(JSON.stringify(req.auth));
+      console.log(isSuperAdminUser);
+
+      if (!isSuperAdminUser) {
+        // Only return fields the frontend needs before authentication
+        return {
+          config: {
+            id: config.id,
+            initialized: config.initialized,
+            allowSignUp: config.allowSignUp,
+            allowedSignUpDomain: config.allowedSignUpDomain,
+            defaultAuthOrgId: config.defaultAuthOrgId,
+            defaultAuthOrgSlug: config.defaultAuthOrgSlug,
+            defaultAuthOrgAuthEnforced: config.defaultAuthOrgAuthEnforced,
+            defaultAuthOrgAuthMethod: config.defaultAuthOrgAuthMethod,
+            enabledLoginMethods: config.enabledLoginMethods,
+            authConsentContent: config.authConsentContent,
+            pageFrameContent: config.pageFrameContent
+          }
+        };
+      }
 
       return {
         config: {

--- a/backend/src/services/integration-auth/integration-auth-service.ts
+++ b/backend/src/services/integration-auth/integration-auth-service.ts
@@ -178,6 +178,10 @@ export const integrationAuthServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.Integrations);
 
+    if (url) {
+      await blockLocalAndPrivateIpAddresses(url);
+    }
+
     const tokenExchange = await exchangeCode({ integration, code, url, installationId });
     const updateDoc: TIntegrationAuthsInsert = {
       projectId,

--- a/backend/src/services/integration-auth/integration-auth-service.ts
+++ b/backend/src/services/integration-auth/integration-auth-service.ts
@@ -20,6 +20,7 @@ import { BadRequestError, InternalServerError, NotFoundError } from "@app/lib/er
 import { groupBy } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { TGenericPermission, TProjectPermission } from "@app/lib/types";
+import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { TIntegrationDALFactory } from "../integration/integration-dal";
 import { TKmsServiceFactory } from "../kms/kms-service";
@@ -296,6 +297,10 @@ export const integrationAuthServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.Integrations);
 
+    if (url) {
+      await blockLocalAndPrivateIpAddresses(url);
+    }
+
     const updateDoc: TIntegrationAuthsInsert = {
       projectId,
       namespace,
@@ -453,6 +458,10 @@ export const integrationAuthServiceFactory = ({
 
     const { projectId } = integrationAuth;
     const integration = newIntegration || integrationAuth.integration;
+
+    if (url) {
+      await blockLocalAndPrivateIpAddresses(url);
+    }
 
     const updateDoc: TIntegrationAuthsInsert = {
       projectId,

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -53,7 +53,8 @@ export const triggerWebhookRequest = async (
   const req = await request.post(url, payload, {
     headers,
     timeout: WEBHOOK_TRIGGER_TIMEOUT,
-    signal: AbortSignal.timeout(WEBHOOK_TRIGGER_TIMEOUT)
+    signal: AbortSignal.timeout(WEBHOOK_TRIGGER_TIMEOUT),
+    maxRedirects: 0
   });
 
   return req;

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -55,12 +55,6 @@ export type TServerConfig = {
   allowSignUp: boolean;
   allowedSignUpDomain?: string | null;
   disableAuditLogStorage: boolean;
-  isMigrationModeOn?: boolean;
-  trustSamlEmails: boolean;
-  trustLdapEmails: boolean;
-  trustOidcEmails: boolean;
-  isSecretScanningDisabled: boolean;
-  kubernetesAutoFetchServiceAccountToken: boolean;
   defaultAuthOrgSlug: string | null;
   defaultAuthOrgId: string | null;
   defaultAuthOrgAuthMethod?: string | null;
@@ -69,10 +63,18 @@ export type TServerConfig = {
   authConsentContent?: string;
   pageFrameContent?: string;
   invalidatingCache: boolean;
-  fipsEnabled: boolean;
   envOverrides?: Record<string, string>;
-  paramsFolderSecretDetectionEnabled: boolean;
-  isOfflineUsageReportsEnabled: boolean;
+  // Super admin-only fields (omitted for non-super-admin callers)
+  instanceId?: string;
+  trustSamlEmails?: boolean;
+  trustLdapEmails?: boolean;
+  trustOidcEmails?: boolean;
+  isSecretScanningDisabled?: boolean;
+  kubernetesAutoFetchServiceAccountToken?: boolean;
+  isMigrationModeOn?: boolean;
+  fipsEnabled?: boolean;
+  paramsFolderSecretDetectionEnabled?: boolean;
+  isOfflineUsageReportsEnabled?: boolean;
 };
 
 export type TUpdateServerConfigDTO = {

--- a/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
+++ b/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
@@ -51,9 +51,9 @@ export const GeneralPageForm = () => {
       // eslint-disable-next-line
       signUpMode: config.allowSignUp ? SignUpModes.Anyone : SignUpModes.Disabled,
       allowedSignUpDomain: config.allowedSignUpDomain,
-      trustSamlEmails: config.trustSamlEmails,
-      trustLdapEmails: config.trustLdapEmails,
-      trustOidcEmails: config.trustOidcEmails,
+      trustSamlEmails: config.trustSamlEmails ?? false,
+      trustLdapEmails: config.trustLdapEmails ?? false,
+      trustOidcEmails: config.trustOidcEmails ?? false,
       defaultAuthOrgId: config.defaultAuthOrgId ?? "",
       authConsentContent: config.authConsentContent ?? "",
       pageFrameContent: config.pageFrameContent ?? ""


### PR DESCRIPTION
## Context

restrict admin config response and harden webhook/integration URL validation

## Steps to verify the change

To test patches to admin config endpoint:
- Verify config request DOES NOT return `instanceId` (and other excluded fields) as part of request on login page
- Verify config request DOES return `instanceId` (and other needed fields) as part of request on server console page (and that toggles like "Trust SAML emails" work)

To test webhook patches:

Create webhook
```
curl -X POST 'http://localhost:8080/api/v1/webhooks' \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{"projectId":"<id>","environment":"dev","secretPath":"/","webhookUrl":"http://httpbin.org/redirect-to?url=http%3A%2F%2F127.0.0.1%3A80%2F","webhookSecretKey":"test"}'
```

Test webhook
```
curl -X POST 'http://localhost:8080/api/v1/webhooks/<webhook-id>/test' \
  -H "Authorization: Bearer <jwt>"
```

Should see 302 (redirect error)

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)