### PR TITLE
fix: batch queries in listSshHosts to avoid N+1

### DIFF
--- a/backend/src/ee/services/ssh-host/ssh-host-service.ts
+++ b/backend/src/ee/services/ssh-host/ssh-host-service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError, subject } from "@casl/ability";
 
-import { ActionProjectType } from "@app/db/schemas";
+import { ActionProjectType, ProjectType } from "@app/db/schemas";
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionSshHostActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
@@ -97,12 +97,13 @@ export const sshHostServiceFactory = ({
     }
 
     const sshProjects = await projectDAL.find({
-      orgId: actorOrgId
+      orgId: actorOrgId,
+      type: ProjectType.SSH
     });
 
-    const allowedHosts = [];
+    const permittedProjectIds: string[] = [];
 
-    for await (const project of sshProjects) {
+    for (const project of sshProjects) {
       try {
         await permissionService.getProjectPermission({
           actor,
@@ -113,15 +114,17 @@ export const sshHostServiceFactory = ({
           actionProjectType: ActionProjectType.SSH
         });
 
-        const projectHosts = await sshHostDAL.findUserAccessibleSshHosts([project.id], actorId);
-
-        allowedHosts.push(...projectHosts);
+        permittedProjectIds.push(project.id);
       } catch {
-        // intentionally ignore projects where user lacks access
+        // user lacks access to this project, skip it
       }
     }
 
-    return allowedHosts;
+    if (permittedProjectIds.length === 0) {
+      return [];
+    }
+
+    return sshHostDAL.findUserAccessibleSshHosts(permittedProjectIds, actorId);
   };
 
   const createSshHost = async ({


### PR DESCRIPTION
## Problem

The `listSshHosts` method in `ssh-host-service.ts` fetches all projects in an organization, then loops over each one with individual permission checks and host queries. For an org with 100 projects (5 SSH, 95 non-SSH), this runs 300-400 queries. Most are wasted on non-SSH projects that get rejected by the permission check.

The `findUserAccessibleSshHosts` DAL method already accepts an array of project IDs and uses `whereIn`, but the service calls it with a single ID per iteration.

## Fix

Two changes:

1. Filter projects to SSH type at the database level by adding `type: ProjectType.SSH` to the `projectDAL.find` query. This skips permission checks and host queries for all non-SSH projects.

2. Batch the `findUserAccessibleSshHosts` call. Collect permitted project IDs during the permission check loop, then make a single DAL call with all of them.

Before (100 projects, 5 SSH): ~300-400 queries
After: ~20 queries (1 project query + ~15 permission queries for 5 SSH projects + 1 batched host query)