### PR TITLE
fix(scim): toggle deleteScimToken modal state on close

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/ScimTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/ScimTokenModal.tsx
@@ -293,7 +293,7 @@ export const ScimTokenModal = ({ popUp, handlePopUpOpen, handlePopUpToggle }: Pr
         <DeleteActionModal
           isOpen={popUp.deleteScimToken.isOpen}
           title="Are you sure you want to delete the SCIM token?"
-          onChange={(isOpen) => handlePopUpToggle("scimToken", isOpen)}
+          onChange={(isOpen) => handlePopUpToggle("deleteScimToken", isOpen)}
           deleteKey="confirm"
           onDeleteApproved={() => {
             const deleteScimTokenData = popUp?.deleteScimToken?.data as {


### PR DESCRIPTION
## Context

This fixes a modal state wiring bug in SCIM token deletion flow.

### Problem
When closing the **Delete SCIM token** confirmation modal (click outside / `Esc`), the code was toggling the wrong popup key:
- It toggled `scimToken` (parent modal)
- Instead of `deleteScimToken` (child delete modal)

### Impact before
- Parent **Manage SCIM credentials** modal could close unexpectedly.
- Delete modal state could become inconsistent and feel flaky.

### Behavior now
- Closing/opening the delete confirmation modal updates only `deleteScimToken` state.
- Parent SCIM modal stays stable unless explicitly closed.

### Change
- File: `frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/ScimTokenModal.tsx`
- Updated:
  - `handlePopUpToggle("scimToken", isOpen)`
  - to `handlePopUpToggle("deleteScimToken", isOpen)`


## Screen Recordings

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/408c7bb7-1f21-4fb8-ab68-68ba3b31efce" controls muted playsinline width="480"></video> | <video src="https://github.com/user-attachments/assets/dffecb48-d43f-4e1f-bdb4-a4e71a8be25f" controls muted playsinline width="480"></video> |

---

## Steps to verify the change

1. Go to `Organization Settings -> Provisioning`.
2. Click **Configure** in the SCIM section.
3. In **SCIM Tokens**, click delete (`X`) on any token.
4. Close the delete modal using click-outside or `Esc`.
5. Verify:
   - Delete modal closes correctly.
   - Parent **Manage SCIM credentials** modal remains open.
6. Re-open delete modal and confirm delete flow still works.

---

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

---

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix(scim): toggle deleteScimToken modal state on close`
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

If you want, I can also give you a version with real `<source type="video/mp4">` tags (GitHub-safe fallback format).