### PR TITLE
fix(pki): certificate profile creation form validation

### DIFF
--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
@@ -121,389 +121,286 @@ const FORM_STEPS = [
   }
 ];
 
-const createSchema = z
-  .object({
-    slug: z
-      .string()
-      .trim()
-      .min(1, "Profile slug is required")
-      .max(255, "Profile slug must be less than 255 characters")
-      .regex(
-        /^[a-zA-Z0-9-_]+$/,
-        "Profile slug must contain only letters, numbers, hyphens, and underscores"
-      ),
-    description: z
-      .string()
-      .trim()
-      .max(1000, "Description must be less than 1000 characters")
-      .optional(),
-    enrollmentType: z.nativeEnum(EnrollmentType),
-    issuerType: z.nativeEnum(IssuerType),
-    certificateAuthorityId: z.string().nullable().optional(),
-    certificatePolicyId: z.string().min(1, "Certificate Policy is required"),
-    estConfig: z
-      .object({
-        disableBootstrapCaValidation: z.boolean().optional(),
-        passphrase: z.string().min(1, "EST passphrase is required"),
-        caChain: z.string().min(1, "EST CA chain is required").optional()
-      })
-      .refine(
-        (data) => {
-          if (!data.disableBootstrapCaValidation && !data.caChain) {
-            return false;
-          }
-          return true;
-        },
-        {
-          message: "EST CA chain is required when bootstrap CA validation is enabled",
-          path: ["caChain"]
-        }
-      )
-      .optional(),
-    apiConfig: z
-      .object({
-        autoRenew: z.boolean().optional(),
-        renewBeforeDays: z.number().min(1).max(365).optional()
-      })
-      .optional(),
-    acmeConfig: z
-      .object({
-        skipDnsOwnershipVerification: z.boolean().optional(),
-        skipEabBinding: z.boolean().optional()
-      })
-      .optional(),
-    scepConfig: z
-      .object({
-        challengePassword: z.string().min(8, "Challenge password must be at least 8 characters"),
-        includeCaCertInResponse: z.boolean().optional(),
-        allowCertBasedRenewal: z.boolean().optional()
-      })
-      .optional(),
-    externalConfigs: z
-      .object({
-        template: z.string().min(1, "Azure ADCS template is required")
-      })
-      .optional(),
-    defaults: certificateDefaultsSchema
-  })
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.EST) {
-        return !!data.estConfig;
-      }
-      return true;
-    },
-    {
-      message: "EST enrollment type requires EST configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.API) {
-        return !!data.apiConfig;
-      }
-      return true;
-    },
-    {
-      message: "API enrollment type requires API configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME) {
-        return !!data.acmeConfig;
-      }
-      return true;
-    },
-    {
-      message: "ACME enrollment type requires ACME configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.SCEP) {
-        return !!data.scepConfig;
-      }
-      return true;
-    },
-    {
-      message: "SCEP enrollment type requires SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.EST) {
-        return !data.apiConfig && !data.acmeConfig && !data.scepConfig;
-      }
-      return true;
-    },
-    {
-      message: "EST enrollment type cannot have API, ACME, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.API) {
-        return !data.estConfig && !data.acmeConfig && !data.scepConfig;
-      }
-      return true;
-    },
-    {
-      message: "API enrollment type cannot have EST, ACME, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME) {
-        return !data.estConfig && !data.apiConfig && !data.scepConfig;
-      }
-      return true;
-    },
-    {
-      message: "ACME enrollment type cannot have EST, API, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.SCEP) {
-        return !data.estConfig && !data.apiConfig && !data.acmeConfig;
-      }
-      return true;
-    },
-    {
-      message: "SCEP enrollment type cannot have EST, API, or ACME configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME && data.acmeConfig) {
-        return !(data.acmeConfig.skipEabBinding && data.acmeConfig.skipDnsOwnershipVerification);
-      }
-      return true;
-    },
-    {
-      message: "Cannot skip both EAB and DNS ownership validation."
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.CA) {
-        return !!data.certificateAuthorityId;
-      }
-      return true;
-    },
-    {
-      message: "CA issuer type requires a certificate authority"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.SELF_SIGNED) {
-        return !data.certificateAuthorityId;
-      }
-      return true;
-    },
-    {
-      message: "Self-signed issuer type cannot have a certificate authority"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.SELF_SIGNED) {
-        return data.enrollmentType === EnrollmentType.API;
-      }
-      return true;
-    },
-    {
-      message: "Self-signed issuer type only supports API enrollment"
-    }
-  );
+const stripInactiveEnrollmentConfigs = (val: unknown) => {
+  const data = val as Record<string, unknown>;
+  return {
+    ...data,
+    estConfig: data.enrollmentType === EnrollmentType.EST ? data.estConfig : undefined,
+    apiConfig: data.enrollmentType === EnrollmentType.API ? data.apiConfig : undefined,
+    acmeConfig: data.enrollmentType === EnrollmentType.ACME ? data.acmeConfig : undefined,
+    scepConfig: data.enrollmentType === EnrollmentType.SCEP ? data.scepConfig : undefined
+  };
+};
 
-const editSchema = z
-  .object({
-    slug: z
-      .string()
-      .trim()
-      .min(1, "Profile slug is required")
-      .max(255, "Profile slug must be less than 255 characters")
-      .regex(
-        /^[a-zA-Z0-9-_]+$/,
-        "Profile slug must contain only letters, numbers, hyphens, and underscores"
-      ),
-    description: z
-      .string()
-      .trim()
-      .max(1000, "Description must be less than 1000 characters")
-      .optional(),
-    enrollmentType: z.nativeEnum(EnrollmentType),
-    issuerType: z.nativeEnum(IssuerType),
-    certificateAuthorityId: z.string().nullable().optional(),
-    certificatePolicyId: z.string().optional(),
-    estConfig: z
-      .object({
-        disableBootstrapCaValidation: z.boolean().optional(),
-        passphrase: z.string().optional(),
-        caChain: z.string().optional()
-      })
-      .optional(),
-    apiConfig: z
-      .object({
-        autoRenew: z.boolean().optional(),
-        renewBeforeDays: z.number().min(1).max(365).optional()
-      })
-      .optional(),
-    acmeConfig: z
-      .object({
-        skipDnsOwnershipVerification: z.boolean().optional(),
-        skipEabBinding: z.boolean().optional()
-      })
-      .optional(),
-    scepConfig: z
-      .object({
-        challengePassword: z.string().min(8, "Challenge password must be at least 8 characters"),
-        includeCaCertInResponse: z.boolean().optional(),
-        allowCertBasedRenewal: z.boolean().optional()
-      })
-      .optional(),
-    externalConfigs: z
-      .object({
-        template: z.string().optional()
-      })
-      .optional(),
-    defaults: certificateDefaultsSchema
-  })
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.EST) {
-        return !!data.estConfig;
+const createSchema = z.preprocess(
+  stripInactiveEnrollmentConfigs,
+  z
+    .object({
+      slug: z
+        .string()
+        .trim()
+        .min(1, "Profile slug is required")
+        .max(255, "Profile slug must be less than 255 characters")
+        .regex(
+          /^[a-zA-Z0-9-_]+$/,
+          "Profile slug must contain only letters, numbers, hyphens, and underscores"
+        ),
+      description: z
+        .string()
+        .trim()
+        .max(1000, "Description must be less than 1000 characters")
+        .optional(),
+      enrollmentType: z.nativeEnum(EnrollmentType),
+      issuerType: z.nativeEnum(IssuerType),
+      certificateAuthorityId: z.string().nullable().optional(),
+      certificatePolicyId: z.string().min(1, "Certificate Policy is required"),
+      estConfig: z
+        .object({
+          disableBootstrapCaValidation: z.boolean().optional(),
+          passphrase: z.string().min(1, "EST passphrase is required"),
+          caChain: z.string().min(1, "EST CA chain is required").optional()
+        })
+        .refine(
+          (data) => {
+            if (!data.disableBootstrapCaValidation && !data.caChain) {
+              return false;
+            }
+            return true;
+          },
+          {
+            message: "EST CA chain is required when bootstrap CA validation is enabled",
+            path: ["caChain"]
+          }
+        )
+        .optional(),
+      apiConfig: z
+        .object({
+          autoRenew: z.boolean().optional(),
+          renewBeforeDays: z.number().min(1).max(365).optional()
+        })
+        .optional(),
+      acmeConfig: z
+        .object({
+          skipDnsOwnershipVerification: z.boolean().optional(),
+          skipEabBinding: z.boolean().optional()
+        })
+        .optional(),
+      scepConfig: z
+        .object({
+          challengePassword: z.string().min(8, "Challenge password must be at least 8 characters"),
+          includeCaCertInResponse: z.boolean().optional(),
+          allowCertBasedRenewal: z.boolean().optional()
+        })
+        .optional(),
+      externalConfigs: z
+        .object({
+          template: z.string().min(1, "Azure ADCS template is required")
+        })
+        .optional(),
+      defaults: certificateDefaultsSchema
+    })
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.EST) {
+          return !!data.estConfig;
+        }
+        return true;
+      },
+      {
+        message: "EST enrollment type requires EST configuration",
+        path: ["estConfig"]
       }
-      return true;
-    },
-    {
-      message: "EST enrollment type requires EST configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.API) {
-        return !!data.apiConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.API) {
+          return !!data.apiConfig;
+        }
+        return true;
+      },
+      {
+        message: "API enrollment type requires API configuration",
+        path: ["apiConfig"]
       }
-      return true;
-    },
-    {
-      message: "API enrollment type requires API configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME) {
-        return !!data.acmeConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.ACME) {
+          return !!data.acmeConfig;
+        }
+        return true;
+      },
+      {
+        message: "ACME enrollment type requires ACME configuration",
+        path: ["acmeConfig"]
       }
-      return true;
-    },
-    {
-      message: "ACME enrollment type requires ACME configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.SCEP) {
-        return !!data.scepConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.SCEP) {
+          return !!data.scepConfig;
+        }
+        return true;
+      },
+      {
+        message: "SCEP enrollment type requires SCEP configuration",
+        path: ["scepConfig"]
       }
-      return true;
-    },
-    {
-      message: "SCEP enrollment type requires SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.EST) {
-        return !data.apiConfig && !data.acmeConfig && !data.scepConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.ACME && data.acmeConfig) {
+          return !(data.acmeConfig.skipEabBinding && data.acmeConfig.skipDnsOwnershipVerification);
+        }
+        return true;
+      },
+      {
+        message: "Cannot skip both EAB and DNS ownership validation.",
+        path: ["acmeConfig", "skipEabBinding"]
       }
-      return true;
-    },
-    {
-      message: "EST enrollment type cannot have API, ACME, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.API) {
-        return !data.estConfig && !data.acmeConfig && !data.scepConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.CA) {
+          return !!data.certificateAuthorityId;
+        }
+        return true;
+      },
+      {
+        message: "Certificate Authority is required",
+        path: ["certificateAuthorityId"]
       }
-      return true;
-    },
-    {
-      message: "API enrollment type cannot have EST, ACME, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME) {
-        return !data.estConfig && !data.apiConfig && !data.scepConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.SELF_SIGNED) {
+          return !data.certificateAuthorityId;
+        }
+        return true;
+      },
+      {
+        message: "Self-signed issuer type cannot have a certificate authority",
+        path: ["certificateAuthorityId"]
       }
-      return true;
-    },
-    {
-      message: "ACME enrollment type cannot have EST, API, or SCEP configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.SCEP) {
-        return !data.estConfig && !data.apiConfig && !data.acmeConfig;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.SELF_SIGNED) {
+          return data.enrollmentType === EnrollmentType.API;
+        }
+        return true;
+      },
+      {
+        message: "Self-signed issuer type only supports API enrollment",
+        path: ["enrollmentType"]
       }
-      return true;
-    },
-    {
-      message: "SCEP enrollment type cannot have EST, API, or ACME configuration"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.enrollmentType === EnrollmentType.ACME && data.acmeConfig) {
-        return !(data.acmeConfig.skipEabBinding && data.acmeConfig.skipDnsOwnershipVerification);
+    )
+);
+
+const editSchema = z.preprocess(
+  stripInactiveEnrollmentConfigs,
+  z
+    .object({
+      slug: z
+        .string()
+        .trim()
+        .min(1, "Profile slug is required")
+        .max(255, "Profile slug must be less than 255 characters")
+        .regex(
+          /^[a-zA-Z0-9-_]+$/,
+          "Profile slug must contain only letters, numbers, hyphens, and underscores"
+        ),
+      description: z
+        .string()
+        .trim()
+        .max(1000, "Description must be less than 1000 characters")
+        .optional(),
+      enrollmentType: z.nativeEnum(EnrollmentType),
+      issuerType: z.nativeEnum(IssuerType),
+      certificateAuthorityId: z.string().nullable().optional(),
+      certificatePolicyId: z.string().optional(),
+      estConfig: z
+        .object({
+          disableBootstrapCaValidation: z.boolean().optional(),
+          passphrase: z.string().optional(),
+          caChain: z.string().optional()
+        })
+        .optional(),
+      apiConfig: z
+        .object({
+          autoRenew: z.boolean().optional(),
+          renewBeforeDays: z.number().min(1).max(365).optional()
+        })
+        .optional(),
+      acmeConfig: z
+        .object({
+          skipDnsOwnershipVerification: z.boolean().optional(),
+          skipEabBinding: z.boolean().optional()
+        })
+        .optional(),
+      scepConfig: z
+        .object({
+          challengePassword: z.string().min(8, "Challenge password must be at least 8 characters"),
+          includeCaCertInResponse: z.boolean().optional(),
+          allowCertBasedRenewal: z.boolean().optional()
+        })
+        .optional(),
+      externalConfigs: z
+        .object({
+          template: z.string().optional()
+        })
+        .optional(),
+      defaults: certificateDefaultsSchema
+    })
+    .refine(
+      (data) => {
+        if (data.enrollmentType === EnrollmentType.ACME && data.acmeConfig) {
+          return !(data.acmeConfig.skipEabBinding && data.acmeConfig.skipDnsOwnershipVerification);
+        }
+        return true;
+      },
+      {
+        message: "Cannot skip both EAB and DNS ownership validation.",
+        path: ["acmeConfig", "skipEabBinding"]
       }
-      return true;
-    },
-    {
-      message: "Cannot skip both EAB and DNS ownership validation."
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.CA) {
-        return !!data.certificateAuthorityId;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.CA) {
+          return !!data.certificateAuthorityId;
+        }
+        return true;
+      },
+      {
+        message: "Certificate Authority is required",
+        path: ["certificateAuthorityId"]
       }
-      return true;
-    },
-    {
-      message: "CA issuer type requires a certificate authority"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.SELF_SIGNED) {
-        return !data.certificateAuthorityId;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.SELF_SIGNED) {
+          return !data.certificateAuthorityId;
+        }
+        return true;
+      },
+      {
+        message: "Self-signed issuer type cannot have a certificate authority",
+        path: ["certificateAuthorityId"]
       }
-      return true;
-    },
-    {
-      message: "Self-signed issuer type cannot have a certificate authority"
-    }
-  )
-  .refine(
-    (data) => {
-      if (data.issuerType === IssuerType.SELF_SIGNED) {
-        return data.enrollmentType === EnrollmentType.API;
+    )
+    .refine(
+      (data) => {
+        if (data.issuerType === IssuerType.SELF_SIGNED) {
+          return data.enrollmentType === EnrollmentType.API;
+        }
+        return true;
+      },
+      {
+        message: "Self-signed issuer type only supports API enrollment",
+        path: ["enrollmentType"]
       }
-      return true;
-    },
-    {
-      message: "Self-signed issuer type only supports API enrollment"
-    }
-  );
+    )
+);
 
 export type FormData = z.infer<typeof createSchema>;
 
@@ -695,7 +592,7 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
     }
   };
 
-  const { control, handleSubmit, reset, watch, setValue, trigger, formState } = useForm<FormData>({
+  const { control, handleSubmit, reset, watch, setValue, trigger } = useForm<FormData>({
     resolver: zodResolver(isEdit ? editSchema : createSchema),
     defaultValues: isEdit
       ? {
@@ -1186,12 +1083,6 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                               autoRenew: false,
                               renewBeforeDays: 30
                             });
-                            setValue("estConfig", undefined);
-                            setValue("acmeConfig", {
-                              skipDnsOwnershipVerification: false,
-                              skipEabBinding: false
-                            });
-                            setValue("scepConfig", undefined);
                           }
                           onChange(value);
                         }}
@@ -1310,41 +1201,6 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
 
                           // Reset defaults when policy changes
                           setValue("defaults", undefined);
-
-                          if (watchedEnrollmentType === EnrollmentType.EST) {
-                            setValue("apiConfig", undefined);
-                            setValue("estConfig", {
-                              disableBootstrapCaValidation: false,
-                              passphrase: ""
-                            });
-                            setValue("acmeConfig", undefined);
-                            setValue("scepConfig", undefined);
-                          } else if (watchedEnrollmentType === EnrollmentType.API) {
-                            setValue("apiConfig", {
-                              autoRenew: false,
-                              renewBeforeDays: 30
-                            });
-                            setValue("estConfig", undefined);
-                            setValue("acmeConfig", undefined);
-                            setValue("scepConfig", undefined);
-                          } else if (watchedEnrollmentType === EnrollmentType.ACME) {
-                            setValue("estConfig", undefined);
-                            setValue("apiConfig", undefined);
-                            setValue("acmeConfig", {
-                              skipDnsOwnershipVerification: false,
-                              skipEabBinding: false
-                            });
-                            setValue("scepConfig", undefined);
-                          } else if (watchedEnrollmentType === EnrollmentType.SCEP) {
-                            setValue("estConfig", undefined);
-                            setValue("apiConfig", undefined);
-                            setValue("acmeConfig", undefined);
-                            setValue("scepConfig", {
-                              challengePassword: "",
-                              includeCaCertInResponse: true,
-                              allowCertBasedRenewal: true
-                            });
-                          }
                         }}
                         options={policyOptions}
                         getOptionLabel={(option) => option.name}
@@ -1375,33 +1231,21 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                         {...field}
                         onValueChange={(value) => {
                           if (value === EnrollmentType.EST) {
-                            setValue("apiConfig", undefined);
                             setValue("estConfig", {
                               disableBootstrapCaValidation: false,
                               passphrase: ""
                             });
-                            setValue("acmeConfig", undefined);
-                            setValue("scepConfig", undefined);
                           } else if (value === EnrollmentType.API) {
                             setValue("apiConfig", {
                               autoRenew: false,
                               renewBeforeDays: 30
                             });
-                            setValue("estConfig", undefined);
-                            setValue("acmeConfig", undefined);
-                            setValue("scepConfig", undefined);
                           } else if (value === EnrollmentType.ACME) {
-                            setValue("apiConfig", undefined);
-                            setValue("estConfig", undefined);
                             setValue("acmeConfig", {
                               skipDnsOwnershipVerification: false,
                               skipEabBinding: false
                             });
-                            setValue("scepConfig", undefined);
                           } else if (value === EnrollmentType.SCEP) {
-                            setValue("apiConfig", undefined);
-                            setValue("estConfig", undefined);
-                            setValue("acmeConfig", undefined);
                             setValue("scepConfig", {
                               challengePassword: "",
                               includeCaCertInResponse: true,
@@ -1530,6 +1374,41 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                         </FormControl>
                       )}
                     />
+                    {watchedAutoRenew && (
+                      <Controller
+                        control={control}
+                        name="apiConfig.renewBeforeDays"
+                        render={({ field, fieldState: { error } }) => (
+                          <FormControl
+                            label="Auto-Renewal Days Before Expiration"
+                            isError={Boolean(error)}
+                            errorText={error?.message}
+                          >
+                            <Input
+                              {...field}
+                              type="number"
+                              placeholder="30"
+                              min="1"
+                              max="365"
+                              className="w-full"
+                              onChange={(e) => {
+                                const { value } = e.target;
+                                if (value === "") {
+                                  field.onChange("");
+                                } else {
+                                  const parsed = parseInt(value, 10);
+                                  if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 365) {
+                                    field.onChange(parsed);
+                                  } else {
+                                    field.onChange(field.value || "");
+                                  }
+                                }
+                              }}
+                            />
+                          </FormControl>
+                        )}
+                      />
+                    )}
                   </div>
                 )}
 
@@ -1678,44 +1557,6 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                               </p>
                             </div>
                           </div>
-                        </FormControl>
-                      )}
-                    />
-                  </div>
-                )}
-                {watchedAutoRenew && (
-                  <div className="mb-4 space-y-4">
-                    <Controller
-                      control={control}
-                      name="apiConfig.renewBeforeDays"
-                      render={({ field, fieldState: { error } }) => (
-                        <FormControl
-                          label="Auto-Renewal Days Before Expiration"
-                          isError={Boolean(error)}
-                          errorText={error?.message}
-                        >
-                          <Input
-                            {...field}
-                            type="number"
-                            placeholder="30"
-                            min="1"
-                            max="365"
-                            className="w-full"
-                            isDisabled={!watchedAutoRenew}
-                            onChange={(e) => {
-                              const { value } = e.target;
-                              if (value === "") {
-                                field.onChange("");
-                              } else {
-                                const parsed = parseInt(value, 10);
-                                if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 365) {
-                                  field.onChange(parsed);
-                                } else {
-                                  field.onChange(field.value || "");
-                                }
-                              }
-                            }}
-                          />
                         </FormControl>
                       )}
                     />
@@ -1908,11 +1749,7 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
               type="button"
               onClick={handleNext}
               isLoading={createProfile.isPending || updateProfile.isPending}
-              isDisabled={
-                createProfile.isPending ||
-                updateProfile.isPending ||
-                (!formState.isValid && isFinalStep)
-              }
+              isDisabled={createProfile.isPending || updateProfile.isPending}
             >
               {isFinalStep && (isEdit ? "Update" : "Create")}
               {!isFinalStep && "Next"}


### PR DESCRIPTION
## Context

Create button was disabled/non-functional when creating certificate profiles with inline policy creation. Switching enrollment types could also cause silent submit failures.

## Screenshots

## Steps to verify the change

- Create a certificate profile with inline policy creation
- Switch between enrollment types and submit

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)