### PR TITLE
feat: add infisical version on side menu for dedicated and on-prem

### DIFF
--- a/frontend/src/components/navigation/SidebarVersionFooter.tsx
+++ b/frontend/src/components/navigation/SidebarVersionFooter.tsx
@@ -1,0 +1,18 @@
+import { envConfig } from "@app/config/env";
+import { isInfisicalCloud } from "@app/helpers/platform";
+
+export const SidebarVersionFooter = () => {
+  const version = envConfig.PLATFORM_VERSION;
+
+  const shouldNotDisplay = !version || isInfisicalCloud() || window.location.origin.includes("http://localhost:8080");
+
+  if (shouldNotDisplay) return null;
+
+  return (
+    <div className="py-2 group-data-[collapsible=icon]:hidden">
+      <div className="flex w-full cursor-default items-center gap-2 px-4 py-1.5 text-xs text-muted select-none">
+        <span>{`Version: ${version}`}</span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/layouts/AdminLayout/AdminSidebar.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminSidebar.tsx
@@ -16,6 +16,7 @@ import {
   User
 } from "lucide-react";
 
+import { SidebarVersionFooter } from "@app/components/navigation/SidebarVersionFooter";
 import {
   Sidebar,
   SidebarContent,
@@ -201,6 +202,7 @@ export const AdminSidebar = () => {
           )}
         </AnimatePresence>
       </SidebarContent>
+      <SidebarVersionFooter />
       <SidebarFooter className="border-t border-border p-2">
         <SidebarTrigger variant="ghost" className="w-full" />
       </SidebarFooter>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSidebar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSidebar.tsx
@@ -1,5 +1,6 @@
 import { useParams } from "@tanstack/react-router";
 
+import { SidebarVersionFooter } from "@app/components/navigation/SidebarVersionFooter";
 import { Sidebar, SidebarContent, SidebarFooter, SidebarTrigger } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 
@@ -23,6 +24,7 @@ export const OrgSidebar = () => {
   return (
     <Sidebar scope={scope} collapsible="none" side="left">
       <SidebarContent>{isInsideProject ? <ProjectNav /> : <OrgNavWrapper />}</SidebarContent>
+      <SidebarVersionFooter />
       <SidebarFooter className="border-t border-border p-2">
         <SidebarTrigger variant="ghost" className="w-full" />
       </SidebarFooter>


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

**Org dashboard**

<img width="814" height="1325" alt="image" src="https://github.com/user-attachments/assets/f4e38e52-cea0-4acc-8a03-c909c62fcbd2" />

**Super Admin dashboard**

<img width="814" height="1325" alt="image" src="https://github.com/user-attachments/assets/1c755e36-110e-42ec-86e7-220ce14e12da" />


**When sidebar is collapsed, the version is not displayed**

<img width="340" height="1324" alt="image" src="https://github.com/user-attachments/assets/6c1cd064-9a0e-495a-ad03-da6d36be55c7" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)