### PR TITLE
fix(identity): enforce delete protection in scoped identity delete

### DIFF
--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -203,7 +203,7 @@ export const identityV2ServiceFactory = ({
     if (!existingIdentity)
       throw new NotFoundError({ message: `Identity with id ${dto.selector.identityId} not found` });
     if (existingIdentity.hasDeleteProtection) {
-      throw new BadRequestError({ message: "Identity has delete protection" });
+      throw new BadRequestError({ message: "Cannot delete identity while delete protection is enabled" });
     }
 
     const deletedIdentity = await identityDAL.deleteById(dto.selector.identityId);

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -202,6 +202,9 @@ export const identityV2ServiceFactory = ({
     });
     if (!existingIdentity)
       throw new NotFoundError({ message: `Identity with id ${dto.selector.identityId} not found` });
+    if (existingIdentity.hasDeleteProtection) {
+      throw new BadRequestError({ message: "Identity has delete protection" });
+    }
 
     const deletedIdentity = await identityDAL.deleteById(dto.selector.identityId);
 


### PR DESCRIPTION
Fixes #6015 

## Context

This PR fixes a bug where project-scoped machine identities could be deleted even when `Delete Protection` was enabled.

### Problem
Project identity deletion (`DELETE /api/v1/projects/:projectId/identities/:identityId`) used the scoped v2 delete service, which did not check `hasDeleteProtection` before deleting.

### Before
- Project-managed identity with `hasDeleteProtection = true` could still be deleted via project identity delete flow.

### After
- Scoped identity delete now blocks deletion when `hasDeleteProtection` is enabled and returns:
  - `400 BadRequest`
  - `"Identity has delete protection"`

### Implementation summary
- Added delete protection check in:
  - `backend/src/services/identity-v2/identity-service.ts`
- Behavior is now consistent with legacy identity deletion protection semantics.

## Screen Recordings

### Before vs After

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/cb619d78-89d3-415f-a047-8af53c73a817" controls muted playsinline width="100%"></video> | <video src="https://github.com/user-attachments/assets/819cc990-25fb-4241-b48c-0ea8ff2b42fc" controls muted playsinline width="100%"></video> |

## Steps to verify the change

1. Create a **project-managed** machine identity from Project Access Control → Identities.
2. Enable **Delete Protection** for that identity.
3. Attempt to delete it from:
   - Project identities table (`Delete Machine Identity`) or
   - Project identity details page delete action.
4. Confirm API response for delete request:
   - `DELETE /api/v1/projects/:projectId/identities/:identityId`
   - Returns `400` with message `"Identity has delete protection"`.
5. Confirm identity remains present in UI after the failed delete.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)