### PR TITLE
feat(workflows): add support for MS teams

### DIFF
--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -125,7 +125,7 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                       { title: "Secret Path", value: secretPath || "" },
                       { title: "Modified By", value: changedBy || "" },
                       {
-                        title: "Modified By Actor Type",
+                        title: "Actor Type",
                         value: changedByActorType?.toString() || "Unknown Actor Type"
                       }
                     ]

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -101,6 +101,40 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
             }
           ]
         };
+      case WebhookType.MICROSOFT_TEAMS:
+        return {
+          type: "message",
+          attachments: [
+            {
+              contentType: "application/vnd.microsoft.card.adaptive",
+              content: {
+                type: "AdaptiveCard",
+                version: "1.2",
+                body: [
+                  {
+                    type: "TextBlock",
+                    size: "Medium",
+                    weight: "Bolder",
+                    text: "A secret value has been added or modified."
+                  },
+                  {
+                    type: "FactSet",
+                    facts: [
+                      { title: "Project", value: projectName || "" },
+                      { title: "Environment", value: environment },
+                      { title: "Secret Path", value: secretPath || "" },
+                      { title: "Modified By", value: changedBy || "" },
+                      {
+                        title: "Modified By Actor Type",
+                        value: changedByActorType?.toString() || "Unknown Actor Type"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        };
       case WebhookType.GENERAL:
       default:
         return {
@@ -164,6 +198,39 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
             }
           ]
         };
+      case WebhookType.MICROSOFT_TEAMS:
+        return {
+          type: "message",
+          attachments: [
+            {
+              contentType: "application/vnd.microsoft.card.adaptive",
+              contentUrl: null,
+              content: {
+                type: "AdaptiveCard",
+                version: "1.2",
+                body: [
+                  {
+                    type: "TextBlock",
+                    size: "Medium",
+                    weight: "Bolder",
+                    text: "A secret rotation has failed."
+                  },
+                  {
+                    type: "FactSet",
+                    facts: [
+                      { title: "Rotation Name", value: rotationName || "" },
+                      { title: "Project", value: projectName || "" },
+                      { title: "Environment", value: environment },
+                      { title: "Secret Path", value: secretPath || "" },
+                      { title: "Error Message", value: errorMessage || "" },
+                      { title: "Triggered Manually", value: triggeredManually ? "Yes" : "No" }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        };
       case WebhookType.GENERAL:
       default:
         return {
@@ -217,6 +284,38 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                 short: false
               }
             ]
+          }
+        ]
+      };
+    case WebhookType.MICROSOFT_TEAMS:
+      return {
+        type: "message",
+        attachments: [
+          {
+            contentType: "application/vnd.microsoft.card.adaptive",
+            contentUrl: null,
+            content: {
+              type: "AdaptiveCard",
+              version: "1.2",
+              body: [
+                {
+                  type: "TextBlock",
+                  size: "Medium",
+                  weight: "Bolder",
+                  text: "You have a secret reminder"
+                },
+                {
+                  type: "FactSet",
+                  facts: [
+                    { title: "Project", value: projectName || "" },
+                    { title: "Environment", value: environment },
+                    { title: "Secret Path", value: secretPath || "" },
+                    { title: "Secret Name", value: secretName },
+                    { title: "Reminder Note", value: reminderNote || "" }
+                  ]
+                }
+              ]
+            }
           }
         ]
       };
@@ -281,6 +380,7 @@ export const fnTriggerWebhook = async ({
         type: event.type,
         payload: { ...event.payload, type: hook.type, projectName }
       } as TWebhookPayloads;
+
       return triggerWebhookRequest(hook, secretManagerDecryptor, getWebhookPayload(formattedEvent));
     })
   );

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -310,7 +310,6 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                     { title: "Project", value: projectName || "" },
                     { title: "Environment", value: environment },
                     { title: "Secret Path", value: secretPath || "" },
-                    { title: "Secret Name", value: secretName },
                     { title: "Reminder Note", value: reminderNote || "" }
                   ]
                 }

--- a/backend/src/services/webhook/webhook-types.ts
+++ b/backend/src/services/webhook/webhook-types.ts
@@ -30,7 +30,8 @@ export type TListWebhookDTO = {
 
 export enum WebhookType {
   GENERAL = "general",
-  SLACK = "slack"
+  SLACK = "slack",
+  MICROSOFT_TEAMS = "microsoft-teams"
 }
 
 export enum WebhookEvents {

--- a/docs/documentation/platform/webhooks.mdx
+++ b/docs/documentation/platform/webhooks.mdx
@@ -9,7 +9,7 @@ Webhooks can be used to trigger changes to your integrations when secrets are mo
 
 To create a webhook for a particular project, go to `Project Settings > Webhooks`.
 
-Infisical supports three webhook types: General, Slack, and Microsoft Teams. Use General for any HTTPS endpoint; use **Slack** with a Slack [Incoming Webhook](https://api.slack.com/messaging/webhooks); use **Microsoft Teams** with an [incoming webhook with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498). When you create a webhook, you can limit it to an environment and optional folder path so it runs only when secrets change in that scope.
+Infisical supports three webhook types: General, Slack, and Microsoft Teams. Use General for any HTTPS endpoint; use Slack with [Incoming Webhook](https://api.slack.com/messaging/webhooks); use Microsoft Teams with an [incoming webhook (with Workflows)](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498). When you create a webhook, you can limit it to an environment and optional folder path so it runs only when secrets change in that scope.
 
 ![webhook-create](../../images/webhook-create.png)
 

--- a/docs/documentation/platform/webhooks.mdx
+++ b/docs/documentation/platform/webhooks.mdx
@@ -9,7 +9,7 @@ Webhooks can be used to trigger changes to your integrations when secrets are mo
 
 To create a webhook for a particular project, go to `Project Settings > Webhooks`.
 
-Infisical supports two webhook types - General and Slack. If you need to integrate with Slack, use the Slack type with an [Incoming Webhook](https://api.slack.com/messaging/webhooks). When creating a webhook, you can specify an environment and folder path to trigger only specific integrations.
+Infisical supports three webhook types: General, Slack, and Microsoft Teams. Use General for any HTTPS endpoint; use **Slack** with a Slack [Incoming Webhook](https://api.slack.com/messaging/webhooks); use **Microsoft Teams** with an [incoming webhook with Workflows](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498). When you create a webhook, you can limit it to an environment and optional folder path so it runs only when secrets change in that scope.
 
 ![webhook-create](../../images/webhook-create.png)
 

--- a/frontend/src/hooks/api/webhooks/types.ts
+++ b/frontend/src/hooks/api/webhooks/types.ts
@@ -1,6 +1,7 @@
 export enum WebhookType {
   GENERAL = "general",
-  SLACK = "slack"
+  SLACK = "slack",
+  MICROSOFT_TEAMS = "microsoft-teams"
 }
 
 export type TWebhook = {

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -98,6 +98,31 @@ export const AddWebhookForm = ({
     </FormControl>
   );
 
+  const microsoftTeamsFormFields = (
+    <FormControl
+      label="Incoming Webhook URL"
+      isRequired
+      isError={Boolean(errors?.webhookUrl)}
+      errorText={errors?.webhookUrl?.message}
+    >
+      <Input
+        placeholder="https://<tenant>.webhook.office.com/webhookb2/..."
+        {...register("webhookUrl")}
+      />
+    </FormControl>
+  );
+
+  const renderFormFields = () => {
+    switch (selectedWebhookType) {
+      case WebhookType.SLACK:
+        return slackFormFields;
+      case WebhookType.MICROSOFT_TEAMS:
+        return microsoftTeamsFormFields;
+      default:
+        return generalFormFields;
+    }
+  };
+
   useEffect(() => {
     if (!isOpen) {
       reset();
@@ -130,6 +155,12 @@ export const AddWebhookForm = ({
                     </SelectItem>
                     <SelectItem value={WebhookType.SLACK} key={WebhookType.SLACK}>
                       Slack
+                    </SelectItem>
+                    <SelectItem
+                      value={WebhookType.MICROSOFT_TEAMS}
+                      key={WebhookType.MICROSOFT_TEAMS}
+                    >
+                      Microsoft Teams
                     </SelectItem>
                   </Select>
                 </FormControl>
@@ -176,7 +207,7 @@ export const AddWebhookForm = ({
                 </FormControl>
               )}
             />
-            {selectedWebhookType === WebhookType.SLACK ? slackFormFields : generalFormFields}
+            {renderFormFields()}
           </div>
           <div className="mt-8 flex items-center">
             <Button


### PR DESCRIPTION
## Context

Some user also want to send webhooks using Teams, since a lot of companies run their communication there. To do so, we need to have a template that fits Teams' incoming webhook ([source](https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498))


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="663" height="537" alt="image" src="https://github.com/user-attachments/assets/0692c926-2be5-4dfa-80bc-68d92600088a" />

<img width="932" height="746" alt="image" src="https://github.com/user-attachments/assets/755e1840-856a-46d9-94f3-dce89598fbac" />

<img width="604" height="227" alt="image" src="https://github.com/user-attachments/assets/d1cdb43d-403c-4f31-9bb3-79aaa7d12976" />




## Steps to verify the change
Maybe it is better to do this sync. Feel free to ping me. 

- Create a new webhook to send messages to teams 
- Create a new workflow in teams 
- Make sure the event was sent to the channel (or chat)

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)