### PR TITLE
fix(hp-ilo): increase connection timeout for HP iLO rotation functions

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/hp-ilo-rotation/hp-ilo-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/hp-ilo-rotation/hp-ilo-rotation-fns.ts
@@ -40,7 +40,7 @@ const HP_ILO_DEFAULT_PASSWORD_REQUIREMENTS = {
 const ILO_PROMPT = "hpiLO->";
 const COMMAND_COMPLETED = "status_tag=COMMAND COMPLETED";
 const COMMAND_FAILED = "COMMAND PROCESSING FAILED";
-const CONNECTION_TIMEOUT = 15000;
+const CONNECTION_TIMEOUT = 45000;
 const MAX_BUFFER_SIZE = 64 * 1024;
 
 const executeIloShell = (conn: Client, command: string): Promise<string> => {


### PR DESCRIPTION
## Context

Increase connection timeout for HP iLO rotation functions

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)