### PR TITLE
docs(dockerswarm): consolidate self-hosting overview cards into single grid

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -13,25 +13,23 @@ Self-hosting Infisical lets you retain data on your own infrastructure and netwo
 
 Choose from a number of deployment options listed below to get started.
 
-<CardGroup cols={2}>
-<Card
-  title="Docker"
-  color="#000000"
-  icon="docker"
-  href="./deployment-options/standalone-infisical"
->
-  Use the fully packaged docker image to deploy Infisical anywhere.
-</Card>
-<Card
-  title="Kubernetes"
-  color="#000000"
-  icon="kubernetes"
-  href="./deployment-options/kubernetes-helm"
->
-  Deploy Infisical on Kubernetes using our Helm chart.
-</Card>
-</CardGroup>
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card
+    title="Docker"
+    color="#000000"
+    icon="docker"
+    href="./deployment-options/standalone-infisical"
+  >
+    Use the fully packaged docker image to deploy Infisical anywhere.
+  </Card>
+  <Card
+    title="Kubernetes"
+    color="#000000"
+    icon="kubernetes"
+    href="./deployment-options/kubernetes-helm"
+  >
+    Deploy Infisical on Kubernetes using our Helm chart.
+  </Card>
   <Card
     title="Docker Compose"
     color="#000000"
@@ -40,9 +38,6 @@ Choose from a number of deployment options listed below to get started.
   >
     Install Infisical using our Docker Compose template.
   </Card>
-</CardGroup>
-
-<CardGroup cols={2}>
   <Card
     title="AWS"
     color="#000000"
@@ -59,13 +54,12 @@ Choose from a number of deployment options listed below to get started.
   >
     Deploy Infisical on GCP using GKE.
   </Card>
-</CardGroup>
-
-<Card
+  <Card
     title="Linux package"
     color="#000000"
     icon="linux"
     href="./deployment-options/native/linux-package/installation"
   >
     Install Infisical on your system without containers using our Linux package.
-</Card>
+  </Card>
+</CardGroup>


### PR DESCRIPTION
The Docker Swarm card removal left Docker Compose alone in its own CardGroup and Linux package outside any group, creating visual gaps.



## Steps to verify the change
n/a

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ x] Docs
- [ ] Chore

## Checklist

- [ x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ x] Tested locally
- [ x] Updated docs (if needed)
- [ x] Updated CLAUDE.md files (if needed)
- [ x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)