### PR TITLE
fix: made totp verify lax

### DIFF
--- a/backend/src/services/totp/totp-service.ts
+++ b/backend/src/services/totp/totp-service.ts
@@ -22,6 +22,8 @@ type TTotpServiceFactoryDep = {
   kmsService: TKmsServiceFactory;
 };
 
+authenticator.options = { window: 1 };
+
 export type TTotpServiceFactory = ReturnType<typeof totpServiceFactory>;
 
 const MAX_RECOVERY_CODE_LIMIT = 10;


### PR DESCRIPTION
## Context
This PR makes it so that a 30 second TOTP code can be used +/- 30 sec after its expiry to account for client-server clock skew

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)