### PR TITLE
improvement: make email verifcation required banner less spooky

### DIFF
--- a/frontend/src/components/v3/generic/Alert/Alert.tsx
+++ b/frontend/src/components/v3/generic/Alert/Alert.tsx
@@ -53,7 +53,7 @@ function UnstableAlertDescription({ className, ...props }: React.ComponentProps<
     <div
       data-slot="alert-description"
       className={cn(
-        "col-start-2 grid justify-items-start gap-1 text-sm text-foreground/75 [&_p]:leading-relaxed",
+        "col-start-2 grid justify-items-start gap-1 text-xs text-foreground/75 [&_p]:leading-relaxed",
         className
       )}
       {...props}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgSsoTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgSsoTab.tsx
@@ -1,7 +1,9 @@
+import { InfoIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
-import { Alert, AlertDescription, Button, ContentLoader, EmptyState } from "@app/components/v2";
+import { Button, ContentLoader, EmptyState } from "@app/components/v2";
+import { UnstableAlert, UnstableAlertDescription, UnstableAlertTitle } from "@app/components/v3";
 import {
   OrgPermissionEmailDomainActions,
   OrgPermissionSsoActions,
@@ -92,11 +94,14 @@ export const OrgSsoTab = withPermission(
                 OIDC, and LDAP.
               </p>
               {subscription?.emailDomainVerification && !isPending && !emailDomains?.length && (
-                <Alert hideTitle iconClassName="text-yellow-500" variant="warning">
-                  <AlertDescription>
-                    Email domain verification is required to use an identity provider.
-                  </AlertDescription>
-                </Alert>
+                <UnstableAlert variant="info" className="mt-3 bg-info/10">
+                  <InfoIcon />
+                  <UnstableAlertTitle>Email domain verification required</UnstableAlertTitle>
+                  <UnstableAlertDescription>
+                    You must verify at least one email domain before configuring an identity
+                    provider. Add a domain in the Email Domains section above.
+                  </UnstableAlertDescription>
+                </UnstableAlert>
               )}
             </div>
             {shouldDisplaySection(LoginMethod.SAML) && (
@@ -224,11 +229,14 @@ export const OrgSsoTab = withPermission(
                 ) &&
                 !isPending &&
                 !emailDomains?.length && (
-                  <Alert hideTitle iconClassName="text-yellow-500" variant="warning">
-                    <AlertDescription>
-                      Email domain verification is required to use an identity provider.
-                    </AlertDescription>
-                  </Alert>
+                  <UnstableAlert variant="info" className="mt-3 bg-info/10">
+                    <InfoIcon />
+                    <UnstableAlertTitle>Email domain verification required</UnstableAlertTitle>
+                    <UnstableAlertDescription>
+                      You must verify at least one email domain before configuring an identity
+                      provider. Add a domain in the Email Domains section above.
+                    </UnstableAlertDescription>
+                  </UnstableAlert>
                 )}
               <div>
                 {isSamlConfigured && shouldDisplaySection(LoginMethod.SAML) && <OrgSSOSection />}


### PR DESCRIPTION
## Context

This PR updates the email domain verification banner use an info icon/variant instead of warning

## Screenshots

<img width="2760" height="842" alt="CleanShot 2026-04-16 at 10 50 55@2x" src="https://github.com/user-attachments/assets/1987cce1-e6fb-4a53-89ea-56e8c348b740" />

## Steps to verify the change

- perceive changes with your eyes

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)