### PR TITLE
improvement: add rotation icon to rotated secrets in single env display

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -10,7 +10,8 @@ import {
   GitBranchIcon,
   ImportIcon,
   KeyIcon,
-  RefreshCcwIcon
+  RefreshCcwIcon,
+  RefreshCwIcon
 } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
@@ -224,7 +225,7 @@ export const SecretTableRow = ({
           className={twMerge(
             !isSingleEnvView && "sticky left-0 z-10",
             !singleEnvPendingAction &&
-              "bg-container transition-colors duration-75 group-hover:bg-container-hover",
+              "relative bg-container transition-colors duration-75 group-hover:bg-container-hover",
             !isSingleEnvView && isFormExpanded && "border-b-0 bg-container-hover",
             isSingleEnvView && singleEnvShowOverride && "border-b-border/50",
             isSingleEnvView && "pt-3 align-top",
@@ -256,13 +257,24 @@ export const SecretTableRow = ({
               )}
             />
           ) : (
-            <KeyIcon
-              className={twMerge(
-                "block text-secret",
-                !isSelectionDisabled && "group-hover:!hidden",
-                isSelected && "!hidden"
+            <>
+              <KeyIcon
+                className={twMerge(
+                  "block text-secret",
+                  !isSelectionDisabled && "group-hover:!hidden",
+                  isSelected && "!hidden"
+                )}
+              />
+              {singleEnvSecret?.isRotatedSecret && isSingleEnvView && (
+                <RefreshCwIcon
+                  className={twMerge(
+                    "absolute right-2 bottom-2 !size-2.5 text-secret-rotation",
+                    !isSelectionDisabled && "group-hover:!hidden",
+                    isSelected && "!hidden"
+                  )}
+                />
               )}
-            />
+            </>
           )}
         </UnstableTableCell>
         {isSingleEnvView ? (

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -225,10 +225,10 @@ export const SecretTableRow = ({
           className={twMerge(
             !isSingleEnvView && "sticky left-0 z-10",
             !singleEnvPendingAction &&
-              "relative bg-container transition-colors duration-75 group-hover:bg-container-hover",
+              "bg-container transition-colors duration-75 group-hover:bg-container-hover",
             !isSingleEnvView && isFormExpanded && "border-b-0 bg-container-hover",
             isSingleEnvView && singleEnvShowOverride && "border-b-border/50",
-            isSingleEnvView && "pt-3 align-top",
+            isSingleEnvView && "relative pt-3 align-top",
             pendingActionBorderClass(singleEnvPendingAction)
           )}
         >


### PR DESCRIPTION
## Context

This PR adds a rotation icon to rotated secrets in the single env view of the secrets overview page

## Screenshots

<img width="3456" height="1930" alt="CleanShot 2026-04-16 at 12 11 31@2x" src="https://github.com/user-attachments/assets/bed0e5b5-7435-46fc-b00d-519ec1d0bcef" />

## Steps to verify the change

- look

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)