### PR TITLE
fix(frontend): prevent duplicated 'v' in on-prem version badge

### DIFF
--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -28,6 +28,9 @@ export const envConfig = {
   },
 
   get PLATFORM_VERSION() {
-    return import.meta.env.VITE_INFISICAL_PLATFORM_VERSION;
+    // Release tags (e.g. "v0.159.15") are passed through as INFISICAL_PLATFORM_VERSION
+    // by the release workflow. Strip any leading "v" so consumers can prefix it
+    // themselves without producing "vv0.159.15".
+    return import.meta.env.VITE_INFISICAL_PLATFORM_VERSION?.replace(/^v/i, "");
   }
 };


### PR DESCRIPTION
## Context

On on-premise instances the version was rendered with a duplicated leading `v`, most visibly in the NavBar version badge (`vv0.159.15` instead of `v0.159.15`).

### Root cause

Release tags are named `v0.159.15`, and the Docker release workflow passes `GITHUB_REF_NAME` through unchanged as `INFISICAL_PLATFORM_VERSION`:

```yaml
# .github/workflows/release-standalone-docker-img-postgres-offical.yml
- name: Extract version from tag
  id: extract_version
  run: echo "::set-output name=version::${GITHUB_REF_NAME}"
...
INFISICAL_PLATFORM_VERSION=${{ steps.extract_version.outputs.version }}
```

So `VITE_INFISICAL_PLATFORM_VERSION` — and therefore `envConfig.PLATFORM_VERSION` — already starts with `v`. Two render sites consume it:

- [`VersionBadge.tsx`](frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx) — prepends another `v`: `` `v${version}` `` → `vv0.159.15`
- [`Navbar.tsx`](frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx) (help-menu dropdown) — renders `Version: {envConfig.PLATFORM_VERSION}` → `Version: v0.159.15` (cosmetically inconsistent with the explicit-prefix pattern used elsewhere).

### Fix

Normalize once at the env boundary in [`frontend/src/config/env.ts`](frontend/src/config/env.ts):

```ts
get PLATFORM_VERSION() {
  return import.meta.env.VITE_INFISICAL_PLATFORM_VERSION?.replace(/^v/i, "");
}
```

This way every consumer of `envConfig.PLATFORM_VERSION` receives a clean semver, `VersionBadge`'s existing `` `v${version}` `` is correct without changes, and future consumers don't have to think about the upstream quirk. Works whether `INFISICAL_PLATFORM_VERSION` is set with or without a leading `v` (and is case-insensitive for safety).

Closes #6067.

## Screenshots

Before (on-prem `v0.159.15`):

```html
<span data-slot="badge" class="... mt-[3px] mr-2 hidden md:inline-flex">vv0.159.15</span>
```

After:

```html
<span data-slot="badge" class="... mt-[3px] mr-2 hidden md:inline-flex">v0.159.15</span>
```

## Steps to verify the change

1. Build the frontend with `VITE_INFISICAL_PLATFORM_VERSION=v0.159.15` → badge reads `v0.159.15`, help-menu dropdown reads `Version: 0.159.15`.
2. Build with `VITE_INFISICAL_PLATFORM_VERSION=0.159.15` (no leading `v`) → badge still reads `v0.159.15`, dropdown reads `Version: 0.159.15`.
3. Build without the env var or on Infisical Cloud → badge is not rendered (existing `shouldNotDisplay` logic untouched).
4. Dedicated instance (7-char hex hash version) → badge is not rendered (existing detection untouched).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix(frontend): prevent duplicated 'v' in on-prem version badge`.
- [x] Tested locally
- [ ] Updated docs (if needed) — not applicable
- [ ] Updated CLAUDE.md files (if needed) — not applicable
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
