### PR TITLE
chore: hubSpot UTK tracking for cloud instances signup

### DIFF
--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -106,11 +106,13 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           lastName: z.string().trim().optional(),
           attributionSource: z.string().trim().optional(),
           password: z.string(),
-          organizationName: GenericResourceNameSchema.optional()
+          organizationName: GenericResourceNameSchema.optional(),
+          hubspotUtk: z.string().trim().max(512).optional()
         }),
         z.object({
           type: z.literal(CompleteAccountType.Alias),
-          code: z.string().trim()
+          code: z.string().trim(),
+          hubspotUtk: z.string().trim().max(512).optional()
         })
       ]),
       response: {
@@ -140,7 +142,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           user.email,
           authMethod,
           user.firstName || "",
-          user.lastName || ""
+          user.lastName || "",
+          req.body.hubspotUtk
         );
       }
 

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -135,7 +135,8 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     email: string,
     signupMethod: HubSpotSignupMethod,
     firstName?: string,
-    lastName?: string
+    lastName?: string,
+    hubspotUtk?: string
   ) => {
     const instanceType = licenseService.getInstanceType();
     if (
@@ -159,14 +160,22 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
           if (value) fields.push({ name, value });
         }
 
+        const context: Record<string, string> = {
+          pageUri: `${appCfg.SITE_URL || "https://app.infisical.com"}/signup`,
+          pageName: "App Signup"
+        };
+
+        // Include the HubSpot tracking cookie to link this submission
+        // to the visitor's browsing session for proper attribution
+        if (hubspotUtk) {
+          context.hutk = hubspotUtk;
+        }
+
         await request.post(
           `https://api.hsforms.com/submissions/v3/integration/submit/${appCfg.HUBSPOT_PORTAL_ID}/${appCfg.HUBSPOT_SIGNUP_FORM_ID}`,
           {
             fields,
-            context: {
-              pageUri: `${appCfg.SITE_URL || "https://app.infisical.com"}/signup`,
-              pageName: "App Signup"
-            }
+            context
           },
           {
             headers: {

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -21,6 +21,7 @@ import {
   UnstableInput
 } from "@app/components/v3";
 import { useServerConfig } from "@app/context";
+import { preserveHubSpotUtk } from "@app/helpers/utmTracking";
 import { useSendVerificationEmail } from "@app/hooks/api";
 import { LoginMethod } from "@app/hooks/api/admin/types";
 
@@ -59,6 +60,7 @@ export default function InitialSignupStep({
   };
 
   const handleSocialSignup = (method: LoginMethod) => {
+    preserveHubSpotUtk();
     const popup = window.open(`/api/v1/sso/redirect/${method}`);
     if (popup) {
       window.close();

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -21,6 +21,7 @@ import {
 } from "@app/components/v3";
 import { isInfisicalCloud } from "@app/helpers/platform";
 import { initProjectHelper } from "@app/helpers/project";
+import { getHubSpotUtk } from "@app/helpers/utmTracking";
 import { useCompleteAccountSignup } from "@app/hooks/api/auth/queries";
 import { fetchOrganizations } from "@app/hooks/api/organization/queries";
 
@@ -130,7 +131,8 @@ export default function UserInfoStep({
       firstName: formData.name.split(" ")[0],
       lastName: formData.name.split(" ").slice(1).join(" "),
       organizationName: formData.organizationName || undefined,
-      attributionSource: formData.attributionSource
+      attributionSource: formData.attributionSource,
+      hubspotUtk: getHubSpotUtk()
     });
 
     SecurityClient.setSignupToken("");

--- a/frontend/src/helpers/utmTracking.ts
+++ b/frontend/src/helpers/utmTracking.ts
@@ -1,0 +1,23 @@
+const HUBSPOT_UTK_STORAGE_KEY = "infisical__hubspot-utk";
+
+/**
+ * Reads the HubSpot tracking cookie (hubspotutk) if present,
+ * falling back to localStorage for cases where cookies may have
+ * been cleared during OAuth redirects (e.g. Safari ITP).
+ */
+export const getHubSpotUtk = (): string | undefined => {
+  const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]*)/);
+  return match?.[1] || localStorage.getItem(HUBSPOT_UTK_STORAGE_KEY) || undefined;
+};
+
+/**
+ * Persists the current hubspotutk cookie value to localStorage
+ * so it survives OAuth redirects that may clear cookies.
+ * Call this before navigating away for OAuth.
+ */
+export const preserveHubSpotUtk = (): void => {
+  const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]*)/);
+  if (match?.[1]) {
+    localStorage.setItem(HUBSPOT_UTK_STORAGE_KEY, match[1]);
+  }
+};

--- a/frontend/src/hooks/api/auth/types.ts
+++ b/frontend/src/hooks/api/auth/types.ts
@@ -105,10 +105,12 @@ export type CompleteAccountSignupDTO =
       password: string;
       attributionSource?: string;
       organizationName?: string;
+      hubspotUtk?: string;
     }
   | {
       type: "alias";
       code: string;
+      hubspotUtk?: string;
     };
 
 export type VerifySignupInviteDTO = {

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -28,6 +28,7 @@ import {
 } from "@app/components/v3";
 import { envConfig } from "@app/config/env";
 import { useServerConfig } from "@app/context";
+import { preserveHubSpotUtk } from "@app/helpers/utmTracking";
 import { useFetchServerStatus } from "@app/hooks/api";
 import { LoginMethod } from "@app/hooks/api/admin/types";
 import { AuthMethod } from "@app/hooks/api/users/types";
@@ -120,6 +121,7 @@ export const InitialStep = ({ setSection, isAdmin }: Props) => {
   };
 
   const handleSocialLogin = (method: LoginMethod) => {
+    preserveHubSpotUtk();
     const searchParams = new URLSearchParams();
     if (callbackPort) {
       searchParams.append("callback_port", callbackPort);

--- a/frontend/src/pages/auth/SignUpSsoPage/SignUpSsoPage.tsx
+++ b/frontend/src/pages/auth/SignUpSsoPage/SignUpSsoPage.tsx
@@ -19,6 +19,8 @@ import {
   UnstableCardTitle
 } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
+import { isInfisicalCloud } from "@app/helpers/platform";
+import { getHubSpotUtk } from "@app/helpers/utmTracking";
 import { useSendEmailVerificationCode } from "@app/hooks/api";
 import { useCompleteAccountSignup } from "@app/hooks/api/auth/queries";
 
@@ -87,12 +89,18 @@ export const SignupSsoPage = () => {
   const handleSubmit = async () => {
     const { token: accessToken } = await completeAccountSignup.mutateAsync({
       type: "alias",
-      code
+      code,
+      hubspotUtk: getHubSpotUtk()
     });
 
     SecurityClient.setSignupToken("");
     SecurityClient.setToken(accessToken);
     const { organizationId } = jwtDecode(accessToken) as { organizationId?: string };
+
+    if (isInfisicalCloud()) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ event: "signup_completed" });
+    }
 
     createNotification({
       text: "Successfully verified",


### PR DESCRIPTION
## Context

Small fix on Cloud instances to correctly send the UTK HubSpot token on signups

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)