### PR TITLE
feat(login-v2): flag users that are still using V2 login

### DIFF
--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -5,8 +5,8 @@ import { getConfig } from "@app/lib/config/env";
 import { UnauthorizedError } from "@app/lib/errors";
 import { authRateLimit } from "@app/server/config/rateLimiter";
 import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
-import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { getUserAgentType } from "@app/server/plugins/audit-log";
+import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -183,7 +183,7 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
           event: PostHogEventTypes.UserLoginV2,
           distinctId: loginDistinctId,
           properties: {
-            email: user.email ?? "",
+            email: req.body.email,
             channel: getUserAgentType(userAgent)
           }
         });

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -6,7 +6,9 @@ import { UnauthorizedError } from "@app/lib/errors";
 import { authRateLimit } from "@app/server/config/rateLimiter";
 import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
+import { getUserAgentType } from "@app/server/plugins/audit-log";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 export const registerLoginRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -176,6 +178,15 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
           },
           { skipDedup: true }
         );
+
+        void server.services.telemetry.sendPostHogEvents({
+          event: PostHogEventTypes.UserLoginV2,
+          distinctId: loginDistinctId,
+          properties: {
+            email: user.email ?? "",
+            channel: getUserAgentType(userAgent)
+          }
+        });
       }
 
       void res.setCookie("jid", tokens.refreshToken, {

--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -29,6 +29,7 @@ export enum PostHogEventTypes {
   SecretDeleted = "secrets deleted",
   AdminInit = "admin initialization",
   UserSignedUp = "User Signed Up",
+  UserLoginV2 = "User Login V2",
   SecretRotated = "secrets rotated",
   SecretScannerFull = "historical cloud secret scan",
   SecretScannerPush = "cloud secret scan",
@@ -154,6 +155,14 @@ export type TUserSignedUpEvent = {
     username: string;
     email: string;
     attributionSource?: string;
+  };
+};
+
+export type TUserLoginV2Event = {
+  event: PostHogEventTypes.UserLoginV2;
+  properties: {
+    email: string;
+    channel: string;
   };
 };
 
@@ -816,6 +825,7 @@ export type TPostHogEvent = { distinctId: string; organizationId?: string; organ
   | TSecretModifiedEvent
   | TAdminInitEvent
   | TUserSignedUpEvent
+  | TUserLoginV2Event
   | TSecretScannerEvent
   | TUserOrgInvitedEvent
   | TMachineIdentityCreatedEvent


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We still have a few users using an older CLI (100 logins/month) and we need to let them know we are removing that endpoint. So we are saving their email addresses in Posthog events so we can reach out.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

V2 login event:

<img width="2313" height="531" alt="image" src="https://github.com/user-attachments/assets/faa7ed14-51ff-40bd-8a2f-3a95db57307b" />

`Identity`: v3 login
`V2 Login`: v2 login events

<img width="2313" height="531" alt="image" src="https://github.com/user-attachments/assets/49b3fc0d-17e4-42f5-b799-74909ffefb7a" />

## Steps to verify the change

1. Enable telemetry in your dev env:

```
TELEMETRY_ENABLED=true
```

2. Setup the posthog token
3. Send the following `curl` to emulate a V2 login

```curl
curl -s -X POST http://localhost:8080/api/v3/auth/login2 \
    -H "Content-Type: application/json" \
    -H "User-Agent: cli" \
    -d '{"email": "<valid-email>", "password": "<valid-password>", "clientProof": "dummy"}'
```

4. Go to posthog events and see a new `Login V2` event

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)