### PR TITLE
chore: add order by to force index

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-dal.ts
@@ -85,6 +85,18 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
             `,
           [MAX_TTL, nowTimestamp]
         )
+        .orderByRaw(
+          `(COALESCE(
+              "${TableName.IdentityAccessToken}"."accessTokenLastRenewedAt",
+              "${TableName.IdentityAccessToken}"."createdAt"
+            ) AT TIME ZONE 'UTC')
+            + make_interval(
+                secs => LEAST(
+                  "${TableName.IdentityAccessToken}"."accessTokenTTL",
+                  ${MAX_TTL}
+                )
+              )`
+        )
         .select("id");
 
       // Notice: we broken down the query into multiple queries and union them to avoid index usage issues.


### PR DESCRIPTION
## Context
- This PR adds order by to force index usage during identity access token clean-up

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)