### PR TITLE
fix(platfor-290): remove distinct on lookup

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-dal.ts
@@ -92,8 +92,7 @@ export const identityAccessTokenDALFactory = (db: TDbClient) => {
       //         the query, you need to update the indexes accordingly to avoid performance regressions.
       return dbClient
         .select("id")
-        .from(revokedTokensQuery.unionAll(exceededUsageLimitQuery).unionAll(expiredTTLQuery).as("all_expired_tokens"))
-        .distinct();
+        .from(revokedTokensQuery.unionAll(exceededUsageLimitQuery).unionAll(expiredTTLQuery).as("all_expired_tokens"));
     };
 
     do {


### PR DESCRIPTION
## Context

The DISTINCT on the outer UNION ALL forces a **HashAggregate** that collects all ~4M matching rows before applying `LIMIT 5000`, preventing early termination and causing the planner to choose a parallel seq scan. 

Removing it lets the planner use an **Append node** with early termination, stopping each branch as soon as 5000 total rows are collected, dropping the effective query cost ~1440x. While remaining correct since DELETE WHERE id IN (...) deduplicates internally.

## Type

- [X] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)