### PR TITLE
feat(pki): pqc readiness pie + trend chart and inventory preset views

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -101,6 +101,7 @@ export const KeyStorePrefixes = {
 
   CertDashboardStats: (projectId: string) => `cert-dashboard-stats:${projectId}` as const,
   CertActivityTrend: (projectId: string, range: string) => `cert-activity-trend:${projectId}:${range}` as const,
+  CertPqcTrend: (projectId: string, range: string) => `cert-pqc-trend:${projectId}:${range}` as const,
   RefreshTokenGrace: (sessionId: string) => `refresh-token-grace:${sessionId}` as const,
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const
 };

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1464,6 +1464,51 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "GET",
+    url: "/:projectId/certificates/pqc-trend",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      hide: true,
+      operationId: "getCertificatePqcTrend",
+      tags: [ApiDocsTags.PkiCertificates],
+      description: "Get certificate PQC adoption trend over time.",
+      params: z.object({
+        projectId: z.string().trim()
+      }),
+      querystring: z.object({
+        range: z.enum(["7d", "30d", "6m"]).optional().default("30d")
+      }),
+      response: {
+        200: z.object({
+          periods: z.array(
+            z.object({
+              period: z.string(),
+              pqc: z.number(),
+              nonPqc: z.number()
+            })
+          )
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      return server.services.project.getPqcTrend({
+        filter: {
+          projectId: req.params.projectId,
+          type: ProjectFilterType.ID
+        },
+        range: req.query.range,
+        actorId: req.permission.id,
+        actorOrgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod,
+        actor: req.permission.type
+      });
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/:projectId/pki-alerts",
     config: {
       rateLimit: readLimit

--- a/backend/src/services/certificate-inventory-view/certificate-inventory-view-service.ts
+++ b/backend/src/services/certificate-inventory-view/certificate-inventory-view-service.ts
@@ -6,6 +6,7 @@ import { TProjectPermission } from "@app/lib/types";
 
 import { TPermissionServiceFactory } from "../../ee/services/permission/permission-service-types";
 import { ProjectPermissionActions, ProjectPermissionSub } from "../../ee/services/permission/project-permission";
+import { NON_PQC_KEY_ALGORITHMS, PQC_KEY_ALGORITHMS } from "../certificate/certificate-dal";
 import { TCertificateInventoryViewDALFactory } from "./certificate-inventory-view-dal";
 import {
   TCreateInventoryViewDTO,
@@ -17,6 +18,7 @@ import {
 type TSystemViewFilters = {
   status?: string[];
   notAfterTo?: string;
+  keyAlgorithm?: string[];
 };
 
 type TSystemView = {
@@ -58,6 +60,22 @@ const SYSTEM_VIEWS: TSystemView[] = [
     id: "system-revoked",
     name: "Revoked",
     filters: { status: ["revoked"] },
+    columns: null,
+    isSystem: true,
+    createdByUserId: null
+  },
+  {
+    id: "system-pqc",
+    name: "Post-Quantum (PQC)",
+    filters: { keyAlgorithm: PQC_KEY_ALGORITHMS },
+    columns: null,
+    isSystem: true,
+    createdByUserId: null
+  },
+  {
+    id: "system-non-pqc",
+    name: "Classical (Non-PQC)",
+    filters: { keyAlgorithm: NON_PQC_KEY_ALGORITHMS },
     columns: null,
     isSystem: true,
     createdByUserId: null

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -13,7 +13,23 @@ import { isUuidV4 } from "@app/lib/validator";
 import { applyMetadataFilter } from "@app/services/resource-metadata/resource-metadata-fns";
 
 import { keySizeToAlgorithms } from "./certificate-fns";
-import { CertStatus } from "./certificate-types";
+import { CertKeyAlgorithm, CertStatus } from "./certificate-types";
+
+// Scoped to UI-surfaced algorithms; intentionally narrower than pqc-utils.PQC_ALGORITHMS.
+export const PQC_KEY_ALGORITHMS: string[] = [
+  CertKeyAlgorithm.ML_DSA_44,
+  CertKeyAlgorithm.ML_DSA_65,
+  CertKeyAlgorithm.ML_DSA_87
+];
+
+export const NON_PQC_KEY_ALGORITHMS: string[] = [
+  CertKeyAlgorithm.RSA_2048,
+  CertKeyAlgorithm.RSA_3072,
+  CertKeyAlgorithm.RSA_4096,
+  CertKeyAlgorithm.ECDSA_P256,
+  CertKeyAlgorithm.ECDSA_P384,
+  CertKeyAlgorithm.ECDSA_P521
+];
 
 export type TCertificateDALFactory = ReturnType<typeof certificateDALFactory>;
 
@@ -918,6 +934,77 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
+  const getPqcTrend = async (projectId: string, daysBack: number) => {
+    try {
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - daysBack);
+      startDate.setHours(0, 0, 0, 0);
+      const now = new Date();
+
+      const useDaily = daysBack <= 30;
+      if (!useDaily) {
+        startDate.setDate(1);
+      }
+      const truncUnit = useDaily ? "day" : "month";
+      const dateFormat = useDaily ? "YYYY-MM-DD" : "YYYY-MM";
+
+      const rows = await db
+        .replicaNode()(TableName.Certificate)
+        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+        .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
+        .where(`${TableName.Certificate}.notBefore`, "<=", now)
+        .whereIn(`${TableName.Certificate}.keyAlgorithm`, [...PQC_KEY_ALGORITHMS, ...NON_PQC_KEY_ALGORITHMS])
+        .select(
+          db.raw(`to_char(date_trunc(?, "${TableName.Certificate}"."notBefore"), ?) as period`, [truncUnit, dateFormat])
+        )
+        .select(
+          db.raw(
+            `CASE WHEN "${TableName.Certificate}"."keyAlgorithm" IN (${PQC_KEY_ALGORITHMS.map(() => "?").join(",")}) THEN 'pqc' ELSE 'nonPqc' END as bucket`,
+            [...PQC_KEY_ALGORITHMS]
+          )
+        )
+        .select(db.raw("count(*)::int as count"))
+        .groupBy("period", "bucket")
+        .orderBy("period");
+
+      interface PeriodBucketCount {
+        period: string;
+        bucket: "pqc" | "nonPqc";
+        count: string;
+      }
+      const typed = rows as unknown as PeriodBucketCount[];
+      const pqcMap = new Map<string, number>();
+      const nonPqcMap = new Map<string, number>();
+      typed.forEach((r) => {
+        if (r.bucket === "pqc") pqcMap.set(r.period, Number(r.count));
+        else nonPqcMap.set(r.period, Number(r.count));
+      });
+
+      const periods: Array<{ period: string; pqc: number; nonPqc: number }> = [];
+      const cursor = new Date(startDate);
+      while (cursor <= now) {
+        const periodKey = useDaily
+          ? `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}-${String(cursor.getDate()).padStart(2, "0")}`
+          : `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+        periods.push({
+          period: periodKey,
+          pqc: pqcMap.get(periodKey) ?? 0,
+          nonPqc: nonPqcMap.get(periodKey) ?? 0
+        });
+        if (useDaily) {
+          cursor.setDate(cursor.getDate() + 1);
+        } else {
+          cursor.setMonth(cursor.getMonth() + 1);
+        }
+      }
+
+      return { periods };
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Get PQC trend" });
+    }
+  };
+
   return {
     ...certificateOrm,
     countCertificatesInProject,
@@ -932,6 +1019,7 @@ export const certificateDALFactory = (db: TDbClient) => {
     findWithPrivateKeyInfo,
     findWithFullDetails,
     getDashboardStats,
-    getActivityTrend
+    getActivityTrend,
+    getPqcTrend
   };
 };

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -169,6 +169,7 @@ type TProjectServiceFactoryDep = {
     | "countActiveCertificatesForSync"
     | "getDashboardStats"
     | "getActivityTrend"
+    | "getPqcTrend"
   >;
   certificateTemplateDAL: Pick<TCertificateTemplateDALFactory, "getCertTemplatesByProjectId">;
   pkiAlertDAL: Pick<TPkiAlertDALFactory, "find">;
@@ -1403,6 +1404,42 @@ export const projectServiceFactory = ({
     });
   };
 
+  const getPqcTrend = async ({
+    filter,
+    range = "30d",
+    actorId,
+    actorOrgId,
+    actorAuthMethod,
+    actor
+  }: TGetActivityTrendDTO) => {
+    const project = await projectDAL.findProjectByFilter(filter);
+    const projectId = project.id;
+
+    const { permission } = await permissionService.getProjectPermission({
+      actor,
+      actorId,
+      projectId,
+      actorAuthMethod,
+      actorOrgId,
+      actionProjectType: ActionProjectType.CertificateManager
+    });
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionCertificateActions.Read,
+      ProjectPermissionSub.Certificates
+    );
+
+    const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
+    const daysBack = rangeDaysMap[range];
+
+    return withCache({
+      keyStore,
+      key: KeyStorePrefixes.CertPqcTrend(projectId, range),
+      ttlSeconds: DASHBOARD_CACHE_TTL,
+      fetcher: () => certificateDAL.getPqcTrend(projectId, daysBack)
+    });
+  };
+
   /**
    * Return list of (PKI) alerts configured for project
    */
@@ -2433,6 +2470,7 @@ export const projectServiceFactory = ({
     listProjectCertificates,
     getDashboardStats,
     getActivityTrend,
+    getPqcTrend,
     listProjectAlerts,
     listProjectPkiCollections,
     listProjectCertificateTemplates,

--- a/frontend/src/hooks/api/certificates/constants.tsx
+++ b/frontend/src/hooks/api/certificates/constants.tsx
@@ -28,6 +28,7 @@ export const certKeyAlgorithmToNameMap: { [K in CertKeyAlgorithm]: string } = {
   [CertKeyAlgorithm.RSA_4096]: "RSA 4096",
   [CertKeyAlgorithm.ECDSA_P256]: "ECDSA P256",
   [CertKeyAlgorithm.ECDSA_P384]: "ECDSA P384",
+  [CertKeyAlgorithm.ECDSA_P521]: "ECDSA P521",
   [CertKeyAlgorithm.ML_DSA_44]: "ML-DSA-44",
   [CertKeyAlgorithm.ML_DSA_65]: "ML-DSA-65",
   [CertKeyAlgorithm.ML_DSA_87]: "ML-DSA-87"
@@ -44,6 +45,24 @@ export const certSignatureAlgorithmToNameMap: Record<string, string> = {
   "ML-DSA-65": "ML-DSA-65",
   "ML-DSA-87": "ML-DSA-87"
 };
+
+export const PQC_KEY_ALGORITHMS = [
+  CertKeyAlgorithm.ML_DSA_44,
+  CertKeyAlgorithm.ML_DSA_65,
+  CertKeyAlgorithm.ML_DSA_87
+] as const;
+
+export const NON_PQC_KEY_ALGORITHMS = [
+  CertKeyAlgorithm.RSA_2048,
+  CertKeyAlgorithm.RSA_3072,
+  CertKeyAlgorithm.RSA_4096,
+  CertKeyAlgorithm.ECDSA_P256,
+  CertKeyAlgorithm.ECDSA_P384,
+  CertKeyAlgorithm.ECDSA_P521
+] as const;
+
+export const isPqcAlgorithm = (label: string): boolean =>
+  (PQC_KEY_ALGORITHMS as readonly string[]).includes(label);
 
 export const certKeyAlgorithms = [
   { label: certKeyAlgorithmToNameMap[CertKeyAlgorithm.RSA_2048], value: CertKeyAlgorithm.RSA_2048 },

--- a/frontend/src/hooks/api/certificates/enums.tsx
+++ b/frontend/src/hooks/api/certificates/enums.tsx
@@ -9,6 +9,7 @@ export enum CertKeyAlgorithm {
   RSA_4096 = "RSA_4096",
   ECDSA_P256 = "EC_prime256v1",
   ECDSA_P384 = "EC_secp384r1",
+  ECDSA_P521 = "EC_secp521r1",
   ML_DSA_44 = "ML-DSA-44",
   ML_DSA_65 = "ML-DSA-65",
   ML_DSA_87 = "ML-DSA-87"

--- a/frontend/src/hooks/api/certificates/index.tsx
+++ b/frontend/src/hooks/api/certificates/index.tsx
@@ -17,6 +17,7 @@ export {
   useGetCertDashboardStats,
   useGetCertificateById,
   useGetCertificateRequest,
+  useGetCertPqcTrend,
   useListCertificateRequests
 } from "./queries";
 export type {
@@ -31,5 +32,7 @@ export type {
   TExpirationBucket,
   TListCertificateRequestsParams,
   TListCertificateRequestsResponse,
+  TPqcTrendPoint,
+  TPqcTrendResponse,
   TUpdateCertificateDTO
 } from "./types";

--- a/frontend/src/hooks/api/certificates/queries.tsx
+++ b/frontend/src/hooks/api/certificates/queries.tsx
@@ -9,7 +9,8 @@ import {
   TCertificateRequestDetails,
   TDashboardStats,
   TListCertificateRequestsParams,
-  TListCertificateRequestsResponse
+  TListCertificateRequestsResponse,
+  TPqcTrendResponse
 } from "./types";
 
 export const certKeys = {
@@ -38,7 +39,9 @@ export const certKeys = {
   ],
   getDashboardStats: (projectId: string) => ["cert-dashboard-stats", { projectId }] as const,
   getActivityTrend: (projectId: string, range: string) =>
-    ["cert-activity-trend", { projectId }, { range }] as const
+    ["cert-activity-trend", { projectId }, { range }] as const,
+  getPqcTrend: (projectId: string, range: string) =>
+    ["cert-pqc-trend", { projectId }, { range }] as const
 };
 
 export const useGetCert = (serialNumber: string) => {
@@ -167,6 +170,21 @@ export const useGetCertActivityTrend = (projectId: string, range = "6m") => {
     queryFn: async () => {
       const { data } = await apiRequest.get<TActivityTrendResponse>(
         `/api/v1/projects/${projectId}/certificates/activity-trend`,
+        { params: { range } }
+      );
+      return data;
+    },
+    enabled: Boolean(projectId),
+    staleTime: DASHBOARD_STALE_TIME
+  });
+};
+
+export const useGetCertPqcTrend = (projectId: string, range = "30d") => {
+  return useQuery({
+    queryKey: certKeys.getPqcTrend(projectId, range),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<TPqcTrendResponse>(
+        `/api/v1/projects/${projectId}/certificates/pqc-trend`,
         { params: { range } }
       );
       return data;

--- a/frontend/src/hooks/api/certificates/types.ts
+++ b/frontend/src/hooks/api/certificates/types.ts
@@ -283,3 +283,13 @@ export type TActivityTrendPoint = {
 export type TActivityTrendResponse = {
   periods: TActivityTrendPoint[];
 };
+
+export type TPqcTrendPoint = {
+  period: string;
+  pqc: number;
+  nonPqc: number;
+};
+
+export type TPqcTrendResponse = {
+  periods: TPqcTrendPoint[];
+};

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesSection.tsx
@@ -36,11 +36,13 @@ type CertificatesSectionProps = {
     search?: string;
   };
   dashboardFilters?: FilterRule[];
+  dashboardViewId?: string;
 };
 
 export const CertificatesSection = ({
   externalFilter,
-  dashboardFilters
+  dashboardFilters,
+  dashboardViewId
 }: CertificatesSectionProps) => {
   const { currentProject } = useProject();
   const { mutateAsync: deleteCert } = useDeleteCert();
@@ -152,6 +154,7 @@ export const CertificatesSection = ({
           handlePopUpOpen={handlePopUpOpen}
           externalFilter={externalFilter}
           dashboardFilters={dashboardFilters}
+          dashboardViewId={dashboardViewId}
         />
         <CertificateImportModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
         <CertificateCertModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesTable.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesTable.tsx
@@ -78,6 +78,7 @@ import type {
   TSystemViewFilters
 } from "@app/hooks/api/certificateInventoryViews/types";
 import { useListCertificateProfiles } from "@app/hooks/api/certificateProfiles";
+import { NON_PQC_KEY_ALGORITHMS, PQC_KEY_ALGORITHMS } from "@app/hooks/api/certificates/constants";
 import { CertSource, CertStatus } from "@app/hooks/api/certificates/enums";
 import { useListWorkspaceCertificates } from "@app/hooks/api/projects";
 import { UsePopUpState } from "@app/hooks/usePopUp";
@@ -126,6 +127,7 @@ type Props = {
     search?: string;
   };
   dashboardFilters?: FilterRule[];
+  dashboardViewId?: string;
 };
 
 const PER_PAGE_INIT = 25;
@@ -155,20 +157,48 @@ const SortIcon = ({
   return <Icon className="ml-1 inline-block size-3" />;
 };
 
-export const CertificatesTable = ({ handlePopUpOpen, externalFilter, dashboardFilters }: Props) => {
+export const CertificatesTable = ({
+  handlePopUpOpen,
+  externalFilter,
+  dashboardFilters,
+  dashboardViewId
+}: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(PER_PAGE_INIT);
   const [search, setSearch] = useState(externalFilter?.search || "");
   const [appliedSearch, setAppliedSearch] = useState(externalFilter?.search || "");
 
-  const [appliedFilters, setAppliedFilters] = useState<FilterRule[]>(
-    dashboardFilters?.length ? dashboardFilters : []
-  );
+  const getFiltersForSystemViewId = (viewId: string | undefined): FilterRule[] => {
+    if (viewId === "system-pqc") {
+      return [
+        { id: "sv-pqc", field: "keyAlgorithm", operator: "in", value: [...PQC_KEY_ALGORITHMS] }
+      ];
+    }
+    if (viewId === "system-non-pqc") {
+      return [
+        {
+          id: "sv-non-pqc",
+          field: "keyAlgorithm",
+          operator: "in",
+          value: [...NON_PQC_KEY_ALGORITHMS]
+        }
+      ];
+    }
+    return [];
+  };
+
+  const [appliedFilters, setAppliedFilters] = useState<FilterRule[]>(() => {
+    if (dashboardFilters?.length) return dashboardFilters;
+    return getFiltersForSystemViewId(dashboardViewId);
+  });
   const [pendingFilters, setPendingFilters] = useState<FilterRule[]>([]);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   const hasDashboardFilters = Boolean(dashboardFilters?.length);
+  const hasSynchronousDashboardView =
+    dashboardViewId === "system-pqc" || dashboardViewId === "system-non-pqc";
   const [activeViewId, setActiveViewId] = useState<string | null>(() => {
+    if (dashboardViewId) return dashboardViewId;
     if (hasDashboardFilters) return null;
     try {
       return localStorage.getItem(VIEW_STORAGE_KEY) || "system-all";
@@ -177,7 +207,9 @@ export const CertificatesTable = ({ handlePopUpOpen, externalFilter, dashboardFi
     }
   });
   const [isSaveViewOpen, setIsSaveViewOpen] = useState(false);
-  const [hasRestoredView, setHasRestoredView] = useState(hasDashboardFilters);
+  const [hasRestoredView, setHasRestoredView] = useState(
+    hasDashboardFilters || hasSynchronousDashboardView
+  );
 
   const [sortBy, setSortBy] = useState<string | undefined>(undefined);
   const [sortOrder, setSortOrder] = useState<"asc" | "desc" | undefined>(undefined);
@@ -402,6 +434,24 @@ export const CertificatesTable = ({ handlePopUpOpen, externalFilter, dashboardFi
       } else if (viewId === "system-revoked") {
         setAppliedFilters([
           { id: "sv-status", field: "status", operator: "in", value: ["revoked"] }
+        ]);
+      } else if (viewId === "system-pqc") {
+        setAppliedFilters([
+          {
+            id: "sv-pqc",
+            field: "keyAlgorithm",
+            operator: "in",
+            value: [...PQC_KEY_ALGORITHMS]
+          }
+        ]);
+      } else if (viewId === "system-non-pqc") {
+        setAppliedFilters([
+          {
+            id: "sv-non-pqc",
+            field: "keyAlgorithm",
+            operator: "in",
+            value: [...NON_PQC_KEY_ALGORITHMS]
+          }
         ]);
       } else {
         const customFilters = filters as TInventoryViewFilters;

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/inventory-types.ts
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/inventory-types.ts
@@ -68,7 +68,10 @@ export const FILTER_FIELDS: FilterFieldDefinition[] = [
       { value: "RSA_4096", label: "RSA-4096" },
       { value: "EC_prime256v1", label: "ECDSA-P256" },
       { value: "EC_secp384r1", label: "ECDSA-P384" },
-      { value: "EC_secp521r1", label: "ECDSA-P521" }
+      { value: "EC_secp521r1", label: "ECDSA-P521" },
+      { value: "ML-DSA-44", label: "ML-DSA-44" },
+      { value: "ML-DSA-65", label: "ML-DSA-65" },
+      { value: "ML-DSA-87", label: "ML-DSA-87" }
     ]
   },
   {

--- a/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
@@ -11,7 +11,11 @@ import {
   ProjectPermissionCertificateActions,
   ProjectPermissionSub
 } from "@app/context/ProjectPermissionContext/types";
-import { useGetCertActivityTrend, useGetCertDashboardStats } from "@app/hooks/api/certificates";
+import {
+  useGetCertActivityTrend,
+  useGetCertDashboardStats,
+  useGetCertPqcTrend
+} from "@app/hooks/api/certificates";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 import {
@@ -20,6 +24,8 @@ import {
   DistributionCharts,
   ExpirationTimeline,
   KpiCards,
+  PqcReadinessChart,
+  PqcTrend,
   ValidityReadinessSection
 } from "./components";
 
@@ -28,10 +34,12 @@ export const DashboardPage = () => {
   const { currentProject } = useProject();
   const navigate = useNavigate();
   const [trendRange, setTrendRange] = useState("30d");
+  const [pqcTrendRange, setPqcTrendRange] = useState("30d");
   const { data: stats, isPending: isStatsLoading } = useGetCertDashboardStats(
     currentProject?.id || ""
   );
   const { data: trendData } = useGetCertActivityTrend(currentProject?.id || "", trendRange);
+  const { data: pqcTrendData } = useGetCertPqcTrend(currentProject?.id || "", pqcTrendRange);
   const navigateToInventory = useCallback(
     (filters: Record<string, string | undefined>) => {
       navigate({
@@ -85,6 +93,21 @@ export const DashboardPage = () => {
                   onRangeChange={setTrendRange}
                 />
                 <ValidityReadinessSection stats={stats} />
+                {stats.totals.total > 0 && (
+                  <div className="flex flex-col gap-4">
+                    <h2 className="text-lg font-semibold text-foreground">
+                      Post-Quantum Readiness
+                    </h2>
+                    <div className="flex flex-wrap gap-4">
+                      <PqcReadinessChart stats={stats} onNavigate={navigateToInventory} />
+                      <PqcTrend
+                        data={pqcTrendData?.periods || []}
+                        currentRange={pqcTrendRange}
+                        onRangeChange={setPqcTrendRange}
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             )}
           </ProjectPermissionCan>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/KpiCards.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/KpiCards.tsx
@@ -103,7 +103,7 @@ export const KpiCards = ({ stats, onNavigate }: Props) => {
         return (
           <UnstableCard
             key={card.key}
-            className="min-w-[180px] flex-1 cursor-pointer gap-0 p-0 transition-colors hover:bg-container-hover"
+            className="h-auto min-w-[180px] flex-1 cursor-pointer gap-0 p-0 transition-colors hover:bg-container-hover"
             onClick={() => onNavigate(card.filters)}
           >
             <UnstableCardContent className="flex h-full flex-col p-4">

--- a/frontend/src/pages/cert-manager/DashboardPage/components/PqcReadinessChart.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/PqcReadinessChart.tsx
@@ -1,0 +1,147 @@
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip as RechartsTooltip } from "recharts";
+
+import {
+  UnstableCard,
+  UnstableCardContent,
+  UnstableCardDescription,
+  UnstableCardHeader,
+  UnstableCardTitle,
+  UnstableEmpty,
+  UnstableEmptyHeader,
+  UnstableEmptyTitle
+} from "@app/components/v3";
+import type { TDashboardStats } from "@app/hooks/api/certificates";
+import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
+
+import { CHART_COLORS, CHART_COLORS_HEX } from "./chart-theme";
+
+type Props = {
+  stats: TDashboardStats;
+  onNavigate: (filters: Record<string, string | undefined>) => void;
+};
+
+const PQC_LABEL = "PQC-ready";
+const CLASSICAL_LABEL = "Classical";
+
+export const PqcReadinessChart = ({ stats, onNavigate }: Props) => {
+  const pqcCount = stats.distributions.byAlgorithm
+    .filter((d) => isPqcAlgorithm(d.label))
+    .reduce((s, d) => s + d.count, 0);
+  const nonPqcCount = stats.distributions.byAlgorithm
+    .filter((d) => !isPqcAlgorithm(d.label))
+    .reduce((s, d) => s + d.count, 0);
+
+  const data = [
+    { label: PQC_LABEL, count: pqcCount },
+    { label: CLASSICAL_LABEL, count: nonPqcCount }
+  ];
+  const nonZeroData = data.filter((d) => d.count > 0);
+  const total = pqcCount + nonPqcCount;
+
+  const handleSegmentClick = (label: string) => {
+    onNavigate({ viewId: label === PQC_LABEL ? "system-pqc" : "system-non-pqc" });
+  };
+
+  return (
+    <UnstableCard className="flex h-auto w-full min-w-[280px] shrink-0 flex-col md:w-[320px]">
+      <UnstableCardHeader className="pb-0">
+        <UnstableCardTitle className="text-base font-semibold">PQC Readiness</UnstableCardTitle>
+        <UnstableCardDescription className="text-xs">
+          Post-quantum vs. classical key algorithms
+        </UnstableCardDescription>
+      </UnstableCardHeader>
+      <UnstableCardContent className="flex flex-1 items-center pt-2">
+        {nonZeroData.length === 0 ? (
+          <UnstableEmpty className="h-[200px]">
+            <UnstableEmptyHeader>
+              <UnstableEmptyTitle>No data available</UnstableEmptyTitle>
+            </UnstableEmptyHeader>
+          </UnstableEmpty>
+        ) : (
+          <div className="flex w-full items-center gap-3">
+            <div className="w-[120px] shrink-0">
+              <ResponsiveContainer width="100%" height={120}>
+                <PieChart>
+                  <defs>
+                    {nonZeroData.map((entry, idx) => {
+                      const hex = CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length];
+                      return (
+                        <linearGradient
+                          key={`grad-${entry.label}`}
+                          id={`grad-pqc-readiness-${idx}`}
+                          x1="0"
+                          y1="0"
+                          x2="1"
+                          y2="1"
+                        >
+                          <stop offset="0%" stopColor={hex} stopOpacity={1} />
+                          <stop offset="100%" stopColor={hex} stopOpacity={0.6} />
+                        </linearGradient>
+                      );
+                    })}
+                  </defs>
+                  <Pie
+                    data={nonZeroData}
+                    dataKey="count"
+                    nameKey="label"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={32}
+                    outerRadius={52}
+                    paddingAngle={2}
+                    cursor="pointer"
+                    stroke="none"
+                    onClick={(_entry, idx) => handleSegmentClick(nonZeroData[idx].label)}
+                  >
+                    {nonZeroData.map((entry, idx) => (
+                      <Cell key={entry.label} fill={`url(#grad-pqc-readiness-${idx})`} />
+                    ))}
+                  </Pie>
+                  <RechartsTooltip
+                    contentStyle={{
+                      backgroundColor: "var(--color-popover)",
+                      border: "1px solid var(--color-border)",
+                      borderRadius: "6px",
+                      color: "var(--color-foreground)"
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="space-y-1.5">
+                {nonZeroData.map((entry, idx) => {
+                  const pct = total > 0 ? Math.round((entry.count / total) * 100) : 0;
+                  return (
+                    <button
+                      key={entry.label}
+                      type="button"
+                      className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-xs transition-colors hover:bg-foreground/5"
+                      onClick={() => handleSegmentClick(entry.label)}
+                    >
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: CHART_COLORS[idx % CHART_COLORS.length] }}
+                      />
+                      <span className="min-w-0 flex-1 truncate text-left text-foreground">
+                        {entry.label}
+                      </span>
+                      <span className="shrink-0 text-right text-muted">{pct}%</span>
+                      <span className="shrink-0 text-right font-medium text-foreground">
+                        {entry.count}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="mt-2 flex items-center border-t border-border px-1 pt-2 text-xs">
+                <span className="flex-1 font-medium text-foreground">Total</span>
+                <span className="shrink-0 text-right font-semibold text-foreground">{total}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </UnstableCardContent>
+    </UnstableCard>
+  );
+};

--- a/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
@@ -50,7 +50,7 @@ const renderLegend = (value: string) => (
 export const PqcTrend = ({ data, onRangeChange, currentRange }: Props) => {
   const hasAnyData = data.some((d) => d.pqc > 0 || d.nonPqc > 0);
   return (
-    <UnstableCard className="h-auto min-w-[400px] flex-1">
+    <UnstableCard className="h-auto w-full flex-1 md:w-auto">
       <UnstableCardHeader>
         <UnstableCardTitle>PQC Adoption Trend</UnstableCardTitle>
         <UnstableCardAction>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
@@ -50,7 +50,7 @@ const renderLegend = (value: string) => (
 export const PqcTrend = ({ data, onRangeChange, currentRange }: Props) => {
   const hasAnyData = data.some((d) => d.pqc > 0 || d.nonPqc > 0);
   return (
-    <UnstableCard className="min-w-[400px] flex-1">
+    <UnstableCard className="h-auto min-w-[400px] flex-1">
       <UnstableCardHeader>
         <UnstableCardTitle>PQC Adoption Trend</UnstableCardTitle>
         <UnstableCardAction>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/PqcTrend.tsx
@@ -1,0 +1,129 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+
+import {
+  Button,
+  UnstableCard,
+  UnstableCardAction,
+  UnstableCardContent,
+  UnstableCardHeader,
+  UnstableCardTitle,
+  UnstableEmpty,
+  UnstableEmptyHeader,
+  UnstableEmptyTitle
+} from "@app/components/v3";
+import type { TPqcTrendPoint } from "@app/hooks/api/certificates";
+
+import { formatTickLabel, nonZeroDot, TREND_COLORS } from "./chart-theme";
+
+type Props = {
+  data: TPqcTrendPoint[];
+  onRangeChange: (range: string) => void;
+  currentRange: string;
+};
+
+const SERIES_KEYS = ["pqc", "nonPqc"];
+
+const ranges = [
+  { label: "7D", value: "7d" },
+  { label: "30D", value: "30d" },
+  { label: "6M", value: "6m" }
+];
+
+const legendLabels: Record<string, string> = {
+  pqc: "PQC-ready",
+  nonPqc: "Classical"
+};
+
+const renderLegend = (value: string) => (
+  <span className="text-xs text-muted">{legendLabels[value] ?? value}</span>
+);
+
+export const PqcTrend = ({ data, onRangeChange, currentRange }: Props) => {
+  const hasAnyData = data.some((d) => d.pqc > 0 || d.nonPqc > 0);
+  return (
+    <UnstableCard className="min-w-[400px] flex-1">
+      <UnstableCardHeader>
+        <UnstableCardTitle>PQC Adoption Trend</UnstableCardTitle>
+        <UnstableCardAction>
+          <div className="flex gap-0.5">
+            {ranges.map((r) => (
+              <Button
+                key={r.value}
+                size="xs"
+                variant={currentRange === r.value ? "neutral" : "ghost"}
+                onClick={() => onRangeChange(r.value)}
+              >
+                {r.label}
+              </Button>
+            ))}
+          </div>
+        </UnstableCardAction>
+      </UnstableCardHeader>
+      <UnstableCardContent>
+        {!hasAnyData ? (
+          <UnstableEmpty className="h-[250px]">
+            <UnstableEmptyHeader>
+              <UnstableEmptyTitle>No certificates issued in this period</UnstableEmptyTitle>
+            </UnstableEmptyHeader>
+          </UnstableEmpty>
+        ) : (
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+              <XAxis
+                dataKey="period"
+                tickFormatter={formatTickLabel}
+                tick={{ fill: "var(--color-muted)", fontSize: 12 }}
+                axisLine={{ stroke: "var(--color-border)" }}
+              />
+              <YAxis
+                tick={{ fill: "var(--color-muted)", fontSize: 12 }}
+                axisLine={{ stroke: "var(--color-border)" }}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "var(--color-popover)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "6px",
+                  color: "var(--color-foreground)"
+                }}
+                formatter={(value, name) => [
+                  value as number,
+                  legendLabels[name as string] ?? (name as string)
+                ]}
+              />
+              <Legend formatter={renderLegend} />
+              <Line
+                type="monotone"
+                dataKey="pqc"
+                stroke={TREND_COLORS.pqc}
+                strokeWidth={2}
+                dot={nonZeroDot("pqc", TREND_COLORS.pqc, SERIES_KEYS)}
+                activeDot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="nonPqc"
+                stroke={TREND_COLORS.nonPqc}
+                strokeWidth={2}
+                dot={nonZeroDot("nonPqc", TREND_COLORS.nonPqc, SERIES_KEYS)}
+                activeDot={{ r: 4 }}
+                strokeDasharray="4 2"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </UnstableCardContent>
+    </UnstableCard>
+  );
+};

--- a/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
@@ -29,7 +29,9 @@ export const TREND_COLORS = {
   issued: "var(--color-org)",
   expired: "var(--color-danger)",
   revoked: "var(--color-neutral)",
-  renewed: "var(--color-success)"
+  renewed: "var(--color-success)",
+  pqc: "var(--color-info)",
+  nonPqc: "var(--color-warning)"
 };
 
 export const formatTickLabel = (value: string) => {

--- a/frontend/src/pages/cert-manager/DashboardPage/components/index.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/index.tsx
@@ -3,4 +3,6 @@ export { CodeSigningSection } from "./CodeSigningSection";
 export { DistributionCharts } from "./DistributionCharts";
 export { ExpirationTimeline } from "./ExpirationTimeline";
 export { KpiCards } from "./KpiCards";
+export { PqcReadinessChart } from "./PqcReadinessChart";
+export { PqcTrend } from "./PqcTrend";
 export { ValidityReadinessSection } from "./ValidityReadinessSection";

--- a/frontend/src/pages/cert-manager/PoliciesPage/PoliciesPage.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/PoliciesPage.tsx
@@ -145,6 +145,7 @@ export const PoliciesPage = () => {
               <CertificatesTab
                 externalFilter={certificateFilter}
                 dashboardFilters={dashboardFilters}
+                dashboardViewId={searchParams.viewId}
               />
             ) : (
               <PermissionDeniedBanner />

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatesTab/CertificatesTab.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatesTab/CertificatesTab.tsx
@@ -7,10 +7,15 @@ type Props = {
     search?: string;
   };
   dashboardFilters?: FilterRule[];
+  dashboardViewId?: string;
 };
 
-export const CertificatesTab = ({ externalFilter, dashboardFilters }: Props) => {
+export const CertificatesTab = ({ externalFilter, dashboardFilters, dashboardViewId }: Props) => {
   return (
-    <CertificatesSection externalFilter={externalFilter} dashboardFilters={dashboardFilters} />
+    <CertificatesSection
+      externalFilter={externalFilter}
+      dashboardFilters={dashboardFilters}
+      dashboardViewId={dashboardViewId}
+    />
   );
 };

--- a/frontend/src/pages/cert-manager/PoliciesPage/route.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/route.tsx
@@ -11,7 +11,8 @@ const policiesPageSearchSchema = z.object({
   filterKeyAlgorithm: z.string().optional(),
   filterCaId: z.string().optional(),
   filterExpiresDays: z.string().optional(),
-  filterExpiresAfterDays: z.string().optional()
+  filterExpiresAfterDays: z.string().optional(),
+  viewId: z.string().optional()
 });
 
 export const Route = createFileRoute(


### PR DESCRIPTION
## Context

Adds a PQC readiness pie chart and PQC adoption trend chart at the bottom of the PKI dashboard, plus "Post-Quantum (PQC)" and "Classical (Non-PQC)" preset views in the cert inventory. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
