### PR TITLE
fix(helm-chart/infisical-standalone-postgres): remove `updatedAt: {{ now }}` from Deployment + pod template metadata

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -3,11 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "infisical.fullname" . }}
+  {{- with $infisicalValues.deploymentAnnotations }}
   annotations:
-    updatedAt: {{ now | date "2006-01-01 MST 15:04:05" | quote }}
-    {{- with $infisicalValues.deploymentAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   labels:
     {{- include "infisical.labels" . | nindent 4 }}
 spec:
@@ -19,11 +18,10 @@ spec:
     metadata:
       labels:
         {{- include "infisical.matchLabels" . | nindent 8 }}
+      {{- with $infisicalValues.podAnnotations }}
       annotations:
-        updatedAt: {{ now | date "2006-01-01 MST 15:04:05" | quote }}
-        {{- with $infisicalValues.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "infisical.serviceAccountName" . }}
     {{- with $infisicalValues.topologySpreadConstraints }}


### PR DESCRIPTION
Fixes #6087

## Summary

`helm-charts/infisical-standalone-postgres/templates/infisical.yaml` renders a fresh timestamp into two annotation fields on every render:

```yaml
# line 7 — Deployment metadata
updatedAt: {{ now | date "2006-01-01 MST 15:04:05" | quote }}
# line 23 — pod template metadata
updatedAt: {{ now | date "2006-01-01 MST 15:04:05" | quote }}
```

The second annotation is on `spec.template.metadata`, which Kubernetes hashes into the Deployment's `pod-template-hash` label. Every Helm re-render produces a different timestamp → different hash → new ReplicaSet. Under any GitOps controller that reconciles on a schedule (ArgoCD, Flux, Helmfile + cron), this creates an endless rolling-update loop.

## Observed impact (production, 2026-04-17)

- Chart version 1.8.0, single-replica Deployment
- Revision advanced from 52 to 68 in 17 days (eleven-plus ReplicaSets in an 8-hour window)
- User-visible latency during the readiness gap of every rotation (Node.js bootstrap + the chart's readinessProbe using the Kubernetes-default 1s timeoutSeconds)

## Format-string note (unrelated, but worth fixing at the same time)

The chart uses `"2006-01-01 MST 15:04:05"`. Go's canonical reference is `"2006-01-02 15:04:05"` — the second `01` was likely meant to be `02` (day). It happens to collide with the month placeholder, so both dash-separated positions substitute to the current month, yielding strings like `"2026-04-04 UTC ..."` rather than `"2026-04-17 UTC ..."`. This line is ambiguously broken regardless of the churn issue.

## Fix

Remove both `updatedAt` lines entirely. The chart still supports user-supplied annotations via `deploymentAnnotations` and `podAnnotations` values — those keep working. Users who genuinely need a render timestamp can set one via those value paths (it will still churn on re-render, but that's now an explicit opt-in, not a chart default).

Alternative considered: gate the line behind a value like `emitUpdatedAtAnnotation: false`. Rejected in favour of outright removal because there is no observable operational value (the Deployment's `.status` + `kubectl rollout history` already track revision history) and leaving it behind a gate preserves the footgun for anyone who flips it on later.

## Validation

```bash
$ cd helm-charts/infisical-standalone-postgres
$ helm dependency build
$ helm template t . > /tmp/r1.yaml
$ sleep 2 && helm template t . > /tmp/r2.yaml
$ diff /tmp/r1.yaml /tmp/r2.yaml
141c141
<   postgres-password: "emQ3bXRZeGd6Ug=="
---
>   postgres-password: "ZE9KMjUxbEZKUg=="
```

Only the Bitnami PostgreSQL subchart's random password differs between renders (that field is not on any pod-hash-sensitive surface). The Infisical Deployment's pod template is now byte-identical between renders.

## Related downstream work

Operators who discovered this (`bbi-infrastructure`) shipped:
- ArgoCD `ignoreDifferences` on the two annotation paths with `RespectIgnoreDifferences=true` + `ServerSideApply=true`
- HA fix: replicas=2 + topologySpreadConstraints + PDB selector fix
- CI guard that detects this class of bug in any chart referenced by the repo

All of those become unnecessary once this upstream fix lands and users pin to a chart version that includes it.

## Checklist

- [x] Root cause identified and documented (issue #6087)
- [x] Fix removes the non-deterministic output
- [x] `helm dependency build` + `helm template` succeed
- [x] Two consecutive renders are byte-identical for the Infisical Deployment
- [x] User-supplied `deploymentAnnotations` / `podAnnotations` still respected
- [ ] Chart `version:` bump left for maintainer preference

Happy to iterate on the commit message, format, or approach.