### PR TITLE
fix: resolved recovery account failing in frontend

### DIFF
--- a/backend/src/server/routes/sanitizedSchemas.ts
+++ b/backend/src/server/routes/sanitizedSchemas.ts
@@ -113,6 +113,7 @@ export const SanitizedUserSchema = UsersSchema.pick({
   isEmailVerified: true,
   firstName: true,
   lastName: true,
+  authMethods: true,
   id: true
 }).extend({
   publicKey: z.string().nullable().optional()


### PR DESCRIPTION
## Context

This is patch that was blocking the user recovery due to missing auth method in user recovery token verification. This fixes it.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)