### PR TITLE
fix: add extra validation for vercel sync

### DIFF
--- a/backend/src/services/secret-sync/vercel/vercel-sync-schemas.ts
+++ b/backend/src/services/secret-sync/vercel/vercel-sync-schemas.ts
@@ -46,6 +46,18 @@ const VercelSyncDestinationConfigSchema = z
         path: ["sensitive"]
       });
     }
+
+    if (
+      config.scope === VercelSyncScope.Team &&
+      config.targetEnvironments.every((env) => env === VercelEnvironmentType.Development)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Marking secrets as sensitive in Vercel is not supported for development environments. Add another target environment or disable Sensitive.",
+        path: ["sensitive"]
+      });
+    }
   });
 
 const VercelSyncOptionsConfig: TSyncOptionsConfig = { canImportSecrets: true };

--- a/frontend/src/components/secret-syncs/forms/schemas/vercel-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/vercel-sync-destination-schema.ts
@@ -48,6 +48,18 @@ export const VercelSyncDestinationSchema = BaseSecretSyncSchema().merge(
             path: ["sensitive"]
           });
         }
+
+        if (
+          config.scope === VercelSyncScope.Team &&
+          config.targetEnvironments.every((env) => env === VercelEnvironmentType.Development)
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              "Marking secrets as sensitive in Vercel is not supported for development environments. Add another target environment or disable Sensitive.",
+            path: ["sensitive"]
+          });
+        }
       })
   })
 );


### PR DESCRIPTION
Prevent team scope from marking secret as sensitive when only dev env  is selected  