### PR TITLE
docs(selfhost): render kubernetes logo on self-hosting overview card

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -25,7 +25,7 @@ Choose from a number of deployment options listed below to get started.
   <Card
     title="Kubernetes"
     color="#000000"
-    icon="kubernetes"
+    icon="https://cdn.simpleicons.org/kubernetes/000000"
     href="./deployment-options/kubernetes-helm"
   >
     Deploy Infisical on Kubernetes using our Helm chart.

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -25,7 +25,7 @@ Choose from a number of deployment options listed below to get started.
   <Card
     title="Kubernetes"
     color="#000000"
-    icon="https://cdn.simpleicons.org/kubernetes/000000"
+    icon="https://cdn.simpleicons.org/kubernetes/ffffff"
     href="./deployment-options/kubernetes-helm"
   >
     Deploy Infisical on Kubernetes using our Helm chart.

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -25,7 +25,7 @@ Choose from a number of deployment options listed below to get started.
   <Card
     title="Kubernetes"
     color="#000000"
-    icon="https://cdn.simpleicons.org/kubernetes/ffffff"
+    icon="https://cdn.simpleicons.org/kubernetes/000000"
     href="./deployment-options/kubernetes-helm"
   >
     Deploy Infisical on Kubernetes using our Helm chart.


### PR DESCRIPTION
The Font Awesome kubernetes icon wasn't resolving in Mintlify, leaving the Kubernetes card without a logo while every other card rendered one. Swap to a hosted SVG from simpleicons so the logo shows consistently.


## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ x] Docs
- [ ] Chore

## Checklist

- [x ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ x] Tested locally
- [ x] Updated docs (if needed)
- [ x] Updated CLAUDE.md files (if needed)
- [ x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)