### PR TITLE
feat(auth): store machine identity auth as identity actor

### DIFF
--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -86,6 +86,13 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityAliCloudAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_ALICLOUD_AUTH,

--- a/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
@@ -53,6 +53,13 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityAwsAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_AWS_AUTH,

--- a/backend/src/server/routes/v1/identity-azure-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-azure-auth-router.ts
@@ -48,6 +48,13 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityAzureAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_AZURE_AUTH,

--- a/backend/src/server/routes/v1/identity-gcp-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-gcp-auth-router.ts
@@ -48,6 +48,13 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityGcpAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_GCP_AUTH,

--- a/backend/src/server/routes/v1/identity-jwt-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-jwt-auth-router.ts
@@ -124,6 +124,13 @@ export const registerIdentityJwtAuthRouter = async (server: FastifyZodProvider) 
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityJwtAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_JWT_AUTH,

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -69,6 +69,13 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityKubernetesAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_KUBERNETES_AUTH,

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -195,6 +195,13 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: authIdentityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_LDAP_AUTH,

--- a/backend/src/server/routes/v1/identity-oci-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-oci-auth-router.ts
@@ -65,6 +65,13 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityOciAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_OCI_AUTH,

--- a/backend/src/server/routes/v1/identity-oidc-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-oidc-auth-router.ts
@@ -72,6 +72,13 @@ export const registerIdentityOidcAuthRouter = async (server: FastifyZodProvider)
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityOidcAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_OIDC_AUTH,

--- a/backend/src/server/routes/v1/identity-spiffe-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-spiffe-auth-router.ts
@@ -136,6 +136,13 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identitySpiffeAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_SPIFFE_AUTH,

--- a/backend/src/server/routes/v1/identity-tls-cert-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-tls-cert-auth-router.ts
@@ -79,6 +79,13 @@ export const registerIdentityTlsCertAuthRouter = async (server: FastifyZodProvid
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityTlsCertAuth.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_TLS_CERT_AUTH,

--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -72,6 +72,13 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
 
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: {
+            type: ActorType.IDENTITY,
+            metadata: {
+              identityId: identityUa.identityId,
+              name: identity.name
+            }
+          },
           orgId: identity.orgId,
           event: {
             type: EventType.LOGIN_IDENTITY_UNIVERSAL_AUTH,


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Until now, all identity logins would be stored without an actor, which means that if you tried to investigate all actions from a machine using an identity, it would miss all the logins. Daniel had this issue in the past and requested that feature.

This would solve the issue without needing a query language as it unifies query in one single metadata (no need to check `eventMetadata` and `actorMetadata`)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1869" height="803" alt="image" src="https://github.com/user-attachments/assets/7023a9d7-f559-4e56-bb95-2fe6fc578b8d" />

<img width="1913" height="1157" alt="image" src="https://github.com/user-attachments/assets/2783f95c-b3bb-4688-a111-7224b0dd03d7" />



## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)