### PR TITLE
fix(pki): use CA key algorithm for signing config in signCertFromCa

### DIFF
--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -2164,12 +2164,10 @@ export const internalCertificateAuthorityServiceFactory = ({
       $checkSignature(ca.internalCa.keyAlgorithm, $getSignatureKeyFamily(signatureAlgorithm), signatureAlgorithm);
     }
 
-    const effectiveKeyAlgorithm = (keyAlgorithm || ca.internalCa.keyAlgorithm) as CertKeyAlgorithm;
-
     const alg =
       isPqcAlgorithm(ca.internalCa.keyAlgorithm) || !signatureAlgorithm
         ? keyAlgorithmToAlgCfg(ca.internalCa.keyAlgorithm as CertKeyAlgorithm)
-        : signatureAlgorithmToAlgCfg(signatureAlgorithm, effectiveKeyAlgorithm);
+        : signatureAlgorithmToAlgCfg(signatureAlgorithm, ca.internalCa.keyAlgorithm as CertKeyAlgorithm);
 
     const csrObj = new x509.Pkcs10CertificateRequest(csr);
 


### PR DESCRIPTION
## Context

When using an ECDSA P-384 internal CA hierarchy (root + intermediate both P-384) to issue leaf certificates via ACME (e.g. Traefik requesting P-256 certs), the issuance fails with:

```
DataError: Named curve mismatch
    at Object.ecImportKey (node:internal/crypto/ec:277:11)
    at SubtleCrypto.importKey (node:internal/crypto/webcrypto:587:10)
    at getCaCredentials (certificate-authority-fns.ts:323:57)
    at signCertFromCa (internal-certificate-authority-service.ts:2179:40)
```
Root cause: In signCertFromCa, the algorithm config passed to getCaCredentials (which uses it to importKey the CA's private key) was built using effectiveKeyAlgorithm — a value derived from the leaf cert's key algorithm extracted from the incoming CSR. When the leaf's curve differs from the CA's curve (P-256 leaf from a P-384 CA), the wrong namedCurve is passed to importKey, causing the mismatch.

The bug was masked in the P-256 CA + P-256 leaf case because both curves happened to be the same. It only surfaces when the leaf's curve differs from the signing CA's curve.

Fix: Pass ca.internalCa.keyAlgorithm instead of effectiveKeyAlgorithm to signatureAlgorithmToAlgCfg, so the curve is always derived from the signing CA's own key — consistent with how the sibling function issueCertFromCa already handles this correctly (line 1751).

## Steps to verify the change

1. Create a root CA with ECDSA P-384
2. Create an intermediate CA with ECDSA P-384, signed by the root
3. Configure an ACME profile pointing to the P-384 intermediate CA
4. Issue a certificate via ACME using a client that requests P-256 (e.g. Traefik)
5. Confirm the certificate is issued without DataError: Named curve mismatch
6. Confirm the issued cert validates against the P-384 intermediate CA chain
7. Confirm the same flow still works with a P-256 intermediate CA (regression)

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs - not needed
- [x] Updated CLAUDE.md files - not needed
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)