### PR TITLE
fix(migration): drop queue_jobs trigger before dropping table

### DIFF
--- a/backend/src/db/migrations/20260327210655_drop-queue-persistence.ts
+++ b/backend/src/db/migrations/20260327210655_drop-queue-persistence.ts
@@ -7,8 +7,8 @@ const QUEUE_JOBS_TABLE = "queue_jobs";
 export async function up(knex: Knex): Promise<void> {
   const hasTable = await knex.schema.hasTable(QUEUE_JOBS_TABLE);
   if (hasTable) {
-    await knex.schema.dropTable(QUEUE_JOBS_TABLE);
     await dropOnUpdateTrigger(knex, QUEUE_JOBS_TABLE);
+    await knex.schema.dropTable(QUEUE_JOBS_TABLE);
   }
 }
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Closes #6037.

`20260327210655_drop-queue-persistence` dropped the queue_jobs table before dropping its updatedAt trigger. On fresh/self-hosted deployments, that ordering can fail during bootstrap when the migration attempts DROP TRIGGER IF EXISTS ... ON queue_jobs after the table is already gone.

This change reorders the migration so the trigger is dropped before queue_jobs is dropped.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Start from a fresh database.
2. Run backend migrations through 20260327210655_drop-queue-persistence.
3. Confirm migration/boot completes without the relation "queue_jobs" does not exist error.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)