### PR TITLE
fix: resolved user group addition failing

### DIFF
--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -91,7 +91,7 @@ export const userDALFactory = (db: TDbClient) => {
           isGhost: false
         })
         .whereIn(`${TableName.Users}.id`, userIds)
-        .join(TableName.UserEncryptionKey, `${TableName.Users}.id`, `${TableName.UserEncryptionKey}.userId`);
+        .leftJoin(TableName.UserEncryptionKey, `${TableName.Users}.id`, `${TableName.UserEncryptionKey}.userId`);
     } catch (error) {
       throw new DatabaseError({ error, name: "Find user enc by user ids batch" });
     }


### PR DESCRIPTION
## Context

This PR fixes user group addition failing - this was because user encryption key joining would result in empty set due to auti revamp. It's not needed anymore thus switched to left join and the cases would be skipped for v3

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)