### PR TITLE
improvement(secrets-232): memoize project ID look up and remove unneeded checks.

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -8,6 +8,8 @@ import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/
 import { groupBy } from "@app/lib/fn";
 import { ms } from "@app/lib/ms";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { EnforcementLevel } from "@app/lib/types";
 import { triggerWorkflowIntegrationNotification } from "@app/lib/workflow-integrations/trigger-notification";
 import { TriggerFeature } from "@app/lib/workflow-integrations/types";
@@ -339,7 +341,9 @@ export const accessApprovalRequestServiceFactory = ({
       throw new ForbiddenRequestError({ message: "You are not authorized to modify this request" });
     }
 
-    const project = await projectDAL.findById(accessApprovalRequest.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(accessApprovalRequest.projectId), () =>
+      projectDAL.findById(accessApprovalRequest.projectId)
+    );
 
     if (!project) {
       throw new NotFoundError({
@@ -610,7 +614,9 @@ export const accessApprovalRequestServiceFactory = ({
       throw new ForbiddenRequestError({ message: "You are not authorized to approve this request" });
     }
 
-    const project = await projectDAL.findById(accessApprovalRequest.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(accessApprovalRequest.projectId), () =>
+      projectDAL.findById(accessApprovalRequest.projectId)
+    );
     if (!project) {
       throw new NotFoundError({ message: "The project associated with this access request was not found." });
     }

--- a/backend/src/ee/services/assume-privilege/assume-privilege-service.ts
+++ b/backend/src/ee/services/assume-privilege/assume-privilege-service.ts
@@ -3,9 +3,8 @@ import { ForbiddenError, subject } from "@casl/ability";
 import { ActionProjectType } from "@app/db/schemas";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
-import { ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { ForbiddenRequestError } from "@app/lib/errors";
 import { ActorType } from "@app/services/auth/auth-type";
-import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import {
@@ -16,12 +15,10 @@ import {
 import { TAssumePrivilegeServiceFactory } from "./assume-privilege-types";
 
 type TAssumePrivilegeServiceFactoryDep = {
-  projectDAL: Pick<TProjectDALFactory, "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
 };
 
 export const assumePrivilegeServiceFactory = ({
-  projectDAL,
   permissionService
 }: TAssumePrivilegeServiceFactoryDep): TAssumePrivilegeServiceFactory => {
   const assumeProjectPrivileges: TAssumePrivilegeServiceFactory["assumeProjectPrivileges"] = async ({
@@ -31,8 +28,6 @@ export const assumePrivilegeServiceFactory = ({
     actorPermissionDetails,
     tokenVersionId
   }) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
     const { permission } = await permissionService.getProjectPermission({
       actor: actorPermissionDetails.type,
       actorId: actorPermissionDetails.id,

--- a/backend/src/ee/services/kmip/kmip-operation-service.ts
+++ b/backend/src/ee/services/kmip/kmip-operation-service.ts
@@ -6,7 +6,6 @@ import { KmipOperationType, recordKmipOperationMetric } from "@app/lib/telemetry
 import { TKmsKeyDALFactory } from "@app/services/kms/kms-key-dal";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsKeyUsage } from "@app/services/kms/kms-types";
-import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { OrgPermissionKmipActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
@@ -26,7 +25,6 @@ type TKmipOperationServiceFactoryDep = {
   kmsService: TKmsServiceFactory;
   kmsDAL: TKmsKeyDALFactory;
   kmipClientDAL: TKmipClientDALFactory;
-  projectDAL: Pick<TProjectDALFactory, "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
 };
 
@@ -35,7 +33,6 @@ export type TKmipOperationServiceFactory = ReturnType<typeof kmipOperationServic
 export const kmipOperationServiceFactory = ({
   kmsService,
   kmsDAL,
-  projectDAL,
   kmipClientDAL,
   permissionService
 }: TKmipOperationServiceFactoryDep) => {
@@ -470,8 +467,6 @@ export const kmipOperationServiceFactory = ({
       });
     }
 
-    const project = await projectDAL.findById(projectId);
-
     const kmsKey = await kmsService.importKeyMaterial({
       name,
       key: Buffer.from(key, "base64"),
@@ -479,7 +474,7 @@ export const kmipOperationServiceFactory = ({
       isReserved: false,
       projectId,
       keyUsage: KmsKeyUsage.ENCRYPT_DECRYPT,
-      orgId: project.orgId,
+      orgId: actorOrgId,
       kmipMetadata
     });
 

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -783,6 +783,7 @@ export const pamAccountServiceFactory = ({
       const project = await requestMemoize(requestMemoKeys.projectFindById(account.projectId), () =>
         projectDAL.findById(account.projectId)
       );
+      if (!project) throw new NotFoundError({ message: `Project with ID '${account.projectId}' not found` });
       const org = await orgDAL.findOrgById(project.orgId);
       if (!org) throw new NotFoundError({ message: `Organization with ID '${project.orgId}' not found` });
 

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -33,6 +33,8 @@ import {
   PolicyViolationError
 } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { OrgServiceActor } from "@app/lib/types";
 import { TApprovalPolicyDALFactory } from "@app/services/approval-policy/approval-policy-dal";
 import { ApprovalPolicyType } from "@app/services/approval-policy/approval-policy-enums";
@@ -773,15 +775,14 @@ export const pamAccountServiceFactory = ({
       );
     }
 
-    const project = await projectDAL.findById(account.projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${account.projectId}' not found` });
-
     const actorUser = await userDAL.findById(actor.id);
     if (!actorUser) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });
 
     // If no mfaSessionId is provided, create a new MFA session
     if (!mfaSessionId && account.requireMfa) {
-      // Get organization to check if MFA is enforced at org level
+      const project = await requestMemoize(requestMemoKeys.projectFindById(account.projectId), () =>
+        projectDAL.findById(account.projectId)
+      );
       const org = await orgDAL.findOrgById(project.orgId);
       if (!org) throw new NotFoundError({ message: `Organization with ID '${project.orgId}' not found` });
 
@@ -1055,7 +1056,9 @@ export const pamAccountServiceFactory = ({
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
 
-    const project = await projectDAL.findById(session.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
+      projectDAL.findById(session.projectId)
+    );
     if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
 
     if (actor.type === ActorType.IDENTITY) {
@@ -1580,14 +1583,13 @@ export const pamAccountServiceFactory = ({
     }
 
     if (!mfaSessionId && accountWithParent.requireMfa) {
-      const project = await projectDAL.findById(accountWithParent.projectId);
-      if (!project) throw new NotFoundError({ message: `Project with ID '${accountWithParent.projectId}' not found` });
-
+      // actorOrgId equals project.orgId: getProjectPermission above guarantees project existence
+      // and org membership, so no separate project lookup is needed to resolve the org ID.
       const actorUser = await userDAL.findById(actorId);
       if (!actorUser) throw new NotFoundError({ message: `User with ID '${actorId}' not found` });
 
-      const org = await orgDAL.findOrgById(project.orgId);
-      if (!org) throw new NotFoundError({ message: `Organization with ID '${project.orgId}' not found` });
+      const org = await orgDAL.findOrgById(actorOrgId);
+      if (!org) throw new NotFoundError({ message: `Organization with ID '${actorOrgId}' not found` });
 
       const orgMfaMethod = org.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
       const userMfaMethod = actorUser.isMfaEnabled ? (actorUser.selectedMfaMethod as MfaMethod | null) : undefined;

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -157,10 +157,10 @@ export const pamSessionServiceFactory = ({
       throw new BadRequestError({ message: "Cannot update logs for sessions with existing logs" });
     }
 
-    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
     const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
       projectDAL.findById(session.projectId)
     );
+    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({
@@ -210,10 +210,10 @@ export const pamSessionServiceFactory = ({
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
 
-    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
     const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
       projectDAL.findById(session.projectId)
     );
+    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({
@@ -406,10 +406,10 @@ export const pamSessionServiceFactory = ({
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
 
-    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
     const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
       projectDAL.findById(session.projectId)
     );
+    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({
@@ -448,7 +448,7 @@ export const pamSessionServiceFactory = ({
 
     const { wasInserted } = await pamSessionEventBatchDAL.upsertBatch(sessionId, startOffset, cipherTextBlob);
 
-    return { projectId: project.id, wasInserted };
+    return { projectId: session.projectId, wasInserted };
   };
 
   return { getById, list, getSessionLogs, updateLogsById, endSessionById, terminateSessionById, uploadEventBatch };

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -7,6 +7,8 @@ import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { OrgServiceActor } from "@app/lib/types";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -155,8 +157,10 @@ export const pamSessionServiceFactory = ({
       throw new BadRequestError({ message: "Cannot update logs for sessions with existing logs" });
     }
 
-    const project = await projectDAL.findById(session.projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
+    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
+    const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
+      projectDAL.findById(session.projectId)
+    );
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({
@@ -199,15 +203,17 @@ export const pamSessionServiceFactory = ({
       encryptedLogsBlob: cipherTextBlob
     });
 
-    return { session: updatedSession, projectId: project.id };
+    return { session: updatedSession, projectId: session.projectId };
   };
 
   const endSessionById = async (sessionId: string, actor: OrgServiceActor) => {
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
 
-    const project = await projectDAL.findById(session.projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
+    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
+    const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
+      projectDAL.findById(session.projectId)
+    );
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({
@@ -247,27 +253,24 @@ export const pamSessionServiceFactory = ({
       if (session.status !== PamSessionStatus.Ended && session.status !== PamSessionStatus.Terminated) {
         throw new BadRequestError({ message: "Cannot end sessions that are not active or starting" });
       }
-      return { session, projectId: project.id, alreadyEnded: true };
+      return { session, projectId: session.projectId, alreadyEnded: true };
     }
 
     // Fire-and-forget AI summarization
     void (async () => {
       try {
-        await pamSessionAiSummaryService.queueAiSummary(sessionId, project.id);
+        await pamSessionAiSummaryService.queueAiSummary(sessionId, session.projectId);
       } catch (err) {
         logger.error({ sessionId, err }, `Failed to queue AI summary for ended session [sessionId=${sessionId}]`);
       }
     })();
 
-    return { session: updatedSession, projectId: project.id, alreadyEnded: false };
+    return { session: updatedSession, projectId: session.projectId, alreadyEnded: false };
   };
 
   const terminateSessionById = async (sessionId: string, actor: OrgServiceActor) => {
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
-
-    const project = await projectDAL.findById(session.projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
 
     const { permission } = await permissionService.getProjectPermission({
       actor: actor.type,
@@ -283,16 +286,18 @@ export const pamSessionServiceFactory = ({
       ProjectPermissionSub.PamSessions
     );
 
+    // No project lookup needed: getProjectPermission above throws NotFoundError if the
+    // project doesn't exist, and session.projectId === project.id by definition.
     // Atomic update: only transitions active/starting → terminated
     const updatedSession = await pamSessionDAL.terminateSessionById(sessionId);
     if (!updatedSession) {
-      return { session, projectId: project.id, alreadyEnded: true };
+      return { session, projectId: session.projectId, alreadyEnded: true };
     }
 
     // Fire-and-forget AI summarization
     void (async () => {
       try {
-        await pamSessionAiSummaryService.queueAiSummary(sessionId, project.id);
+        await pamSessionAiSummaryService.queueAiSummary(sessionId, session.projectId);
       } catch (err) {
         logger.error({ sessionId, err }, `Failed to queue AI summary for terminated session [sessionId=${sessionId}]`);
       }
@@ -344,7 +349,7 @@ export const pamSessionServiceFactory = ({
       })();
     }
 
-    return { session: updatedSession, projectId: project.id, alreadyEnded: false };
+    return { session: updatedSession, projectId: session.projectId, alreadyEnded: false };
   };
 
   const getSessionLogs = async (sessionId: string, offset: number, limit: number, actor: OrgServiceActor) => {
@@ -401,8 +406,10 @@ export const pamSessionServiceFactory = ({
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) throw new NotFoundError({ message: `Session with ID '${sessionId}' not found` });
 
-    const project = await projectDAL.findById(session.projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${session.projectId}' not found` });
+    // PamSession.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
+    const project = await requestMemoize(requestMemoKeys.projectFindById(session.projectId), () =>
+      projectDAL.findById(session.projectId)
+    );
 
     if (actor.type === ActorType.IDENTITY) {
       const { permission } = await permissionService.getOrgPermission({

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -16,6 +16,8 @@ import { BadRequestError, NotFoundError, PolicyViolationError } from "@app/lib/e
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection, setupRelayServer } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TApprovalPolicyDALFactory } from "@app/services/approval-policy/approval-policy-dal";
 import { ApprovalPolicyType } from "@app/services/approval-policy/approval-policy-enums";
 import { APPROVAL_POLICY_FACTORY_MAP } from "@app/services/approval-policy/approval-policy-factory";
@@ -243,8 +245,10 @@ export const pamWebAccessServiceFactory = ({
 
     // MFA check
     if (account.requireMfa && !mfaSessionId) {
-      const project = await projectDAL.findById(account.projectId);
-      if (!project) throw new NotFoundError({ message: `Project with ID '${account.projectId}' not found` });
+      // PamAccount.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
+      const project = await requestMemoize(requestMemoKeys.projectFindById(account.projectId), () =>
+        projectDAL.findById(account.projectId)
+      );
 
       const actorUser = await userDAL.findById(actor.id);
       if (!actorUser) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -245,10 +245,10 @@ export const pamWebAccessServiceFactory = ({
 
     // MFA check
     if (account.requireMfa && !mfaSessionId) {
-      // PamAccount.projectId is a FK to Project (ON DELETE CASCADE) — project is guaranteed to exist.
       const project = await requestMemoize(requestMemoKeys.projectFindById(account.projectId), () =>
         projectDAL.findById(account.projectId)
       );
+      if (!project) throw new NotFoundError({ message: `Project with ID '${account.projectId}' not found` });
 
       const actorUser = await userDAL.findById(actor.id);
       if (!actorUser) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -266,7 +266,9 @@ export const permissionServiceFactory = ({
     const serviceToken = await serviceTokenDAL.findById(serviceTokenId);
     if (!serviceToken) throw new NotFoundError({ message: `Service token with ID '${serviceTokenId}' not found` });
 
-    const serviceTokenProject = await projectDAL.findById(serviceToken.projectId);
+    const serviceTokenProject = await requestMemoize(requestMemoKeys.projectFindById(serviceToken.projectId), () =>
+      projectDAL.findById(serviceToken.projectId)
+    );
 
     if (!serviceTokenProject) throw new BadRequestError({ message: "Service token not linked to a project" });
 
@@ -331,7 +333,9 @@ export const permissionServiceFactory = ({
     actor: ActorType.USER | ActorType.IDENTITY,
     actorId: string
   ): Promise<TCachedProjectPermission> => {
-    const projectDetails = await projectDAL.findById(projectId);
+    const projectDetails = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!projectDetails) {
       throw new NotFoundError({ message: `Project with ${projectId} not found` });
     }

--- a/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
@@ -8,9 +8,6 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
-import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
-import { requestMemoize } from "@app/lib/request-context/request-memoizer";
-import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
 import { TPkiDiscoveryConfigDALFactory } from "./pki-discovery-config-dal";
@@ -48,7 +45,6 @@ type TPkiDiscoveryServiceFactoryDep = {
     TPkiDiscoveryScanHistoryDALFactory,
     "findLatestByDiscoveryId" | "findByDiscoveryId" | "countByDiscoveryId"
   >;
-  projectDAL: Pick<TProjectDALFactory, "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getOrgPermission">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "findOne">;
   queuePkiDiscoveryScan: (discoveryId: string) => Promise<void>;
@@ -73,7 +69,6 @@ const validateTargetConfigForType = (discoveryType: PkiDiscoveryType, config: TP
 export const pkiDiscoveryServiceFactory = ({
   pkiDiscoveryConfigDAL,
   pkiDiscoveryScanHistoryDAL,
-  projectDAL,
   permissionService,
   gatewayV2DAL,
   queuePkiDiscoveryScan

--- a/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
@@ -8,6 +8,8 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
@@ -103,11 +105,6 @@ export const pkiDiscoveryServiceFactory = ({
       ProjectPermissionPkiDiscoveryActions.Create,
       ProjectPermissionSub.PkiDiscovery
     );
-
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
-    }
 
     const existingCount = await pkiDiscoveryConfigDAL.countByProjectId(projectId);
     if (existingCount >= MAX_DISCOVERIES_PER_PROJECT) {

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -20,6 +20,8 @@ import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/
 import { groupBy, pick, unique } from "@app/lib/fn";
 import { setKnexStringValue } from "@app/lib/knex";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { EnforcementLevel } from "@app/lib/types";
 import { triggerWorkflowIntegrationNotification } from "@app/lib/workflow-integrations/trigger-notification";
 import { TriggerFeature } from "@app/lib/workflow-integrations/types";
@@ -1630,7 +1632,9 @@ export const secretApprovalRequestServiceFactory = ({
     const cfg = getConfig();
     const approvalUrl = `${cfg.SITE_URL}${approvalPath}?requestId=${secretApprovalRequest.id}`;
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     await triggerWorkflowIntegrationNotification({
       input: {
         projectId,

--- a/backend/src/ee/services/trusted-ip/trusted-ip-service.ts
+++ b/backend/src/ee/services/trusted-ip/trusted-ip-service.ts
@@ -3,6 +3,8 @@ import { ForbiddenError } from "@casl/ability";
 import { ActionProjectType } from "@app/db/schemas";
 import { BadRequestError } from "@app/lib/errors";
 import { extractIPDetails, isValidIpOrCidr } from "@app/lib/ip";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TLicenseServiceFactory } from "../license/license-service";
@@ -66,7 +68,9 @@ export const trustedIpServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.IpAllowList);
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     const plan = await licenseService.getPlan(project.orgId);
     if (!plan.ipAllowlisting)
       throw new BadRequestError({
@@ -112,7 +116,9 @@ export const trustedIpServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.IpAllowList);
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     const plan = await licenseService.getPlan(project.orgId);
     if (!plan.ipAllowlisting)
       throw new BadRequestError({
@@ -158,7 +164,9 @@ export const trustedIpServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.IpAllowList);
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     const plan = await licenseService.getPlan(project.orgId);
     if (!plan.ipAllowlisting)
       throw new BadRequestError({

--- a/backend/src/lib/workflow-integrations/trigger-notification.ts
+++ b/backend/src/lib/workflow-integrations/trigger-notification.ts
@@ -1,4 +1,6 @@
 import { logger } from "../logger";
+import { requestMemoKeys } from "../request-context/memo-keys";
+import { requestMemoize } from "../request-context/request-memoizer";
 import { triggerMicrosoftTeamsNotification } from "./notification-handlers/microsoft-teams";
 import { triggerSlackNotification } from "./notification-handlers/slack";
 import { TTriggerWorkflowNotificationDTO } from "./types";
@@ -9,7 +11,9 @@ export const triggerWorkflowIntegrationNotification = async (dto: TTriggerWorkfl
     const { projectDAL, projectSlackConfigDAL, kmsService, projectMicrosoftTeamsConfigDAL, microsoftTeamsService } =
       dto.dependencies;
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
 
     if (!project) {
       return;

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -697,7 +697,6 @@ export const registerRoutes = async (
   });
 
   const assumePrivilegeService = assumePrivilegeServiceFactory({
-    projectDAL,
     permissionService
   });
 
@@ -877,7 +876,6 @@ export const registerRoutes = async (
   });
   const groupProjectService = groupProjectServiceFactory({
     groupDAL,
-    projectDAL,
     permissionService
   });
 
@@ -1587,7 +1585,6 @@ export const registerRoutes = async (
     projectEnvDAL,
     keyStore,
     licenseService,
-    projectDAL,
     folderDAL,
     accessApprovalPolicyEnvironmentDAL,
     secretApprovalPolicyEnvironmentDAL: sapEnvironmentDAL
@@ -2298,7 +2295,6 @@ export const registerRoutes = async (
     appConnectionService,
     kmsService,
     permissionService,
-    projectDAL,
     orgDAL,
     folderDAL,
     secretSyncQueue,
@@ -2320,7 +2316,6 @@ export const registerRoutes = async (
   const kmipOperationService = kmipOperationServiceFactory({
     kmsService,
     kmsDAL,
-    projectDAL,
     kmipClientDAL,
     permissionService
   });

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2725,7 +2725,6 @@ export const registerRoutes = async (
   const pkiDiscoveryService = pkiDiscoveryServiceFactory({
     pkiDiscoveryConfigDAL,
     pkiDiscoveryScanHistoryDAL,
-    projectDAL,
     permissionService,
     gatewayV2DAL,
     queuePkiDiscoveryScan: pkiDiscoveryQueue.queuePkiDiscoveryScan

--- a/backend/src/services/certificate-profile/certificate-profile-service.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-service.ts
@@ -17,8 +17,6 @@ import { extractX509CertFromChain } from "@app/lib/certificates/extract-certific
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
-import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
-import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 
 import { ActorAuthMethod, ActorType } from "../auth/auth-type";
 import { TCertificateBodyDALFactory } from "../certificate/certificate-body-dal";

--- a/backend/src/services/certificate-profile/certificate-profile-service.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-service.ts
@@ -17,6 +17,8 @@ import { extractX509CertFromChain } from "@app/lib/certificates/extract-certific
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 
 import { ActorAuthMethod, ActorType } from "../auth/auth-type";
 import { TCertificateBodyDALFactory } from "../certificate/certificate-body-dal";
@@ -326,11 +328,6 @@ export const certificateProfileServiceFactory = ({
         slug: data.slug
       })
     );
-
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({ message: "Project not found" });
-    }
 
     // Validate that certificate policy exists and belongs to the same project
     if (data.certificatePolicyId) {

--- a/backend/src/services/group-project/group-project-service.ts
+++ b/backend/src/services/group-project/group-project-service.ts
@@ -4,24 +4,17 @@ import { ActionProjectType } from "@app/db/schemas";
 import { TListProjectGroupUsersDTO } from "@app/ee/services/group/group-types";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionGroupActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
-import { NotFoundError } from "@app/lib/errors";
 
 import { TGroupDALFactory } from "../../ee/services/group/group-dal";
-import { TProjectDALFactory } from "../project/project-dal";
 
 type TGroupProjectServiceFactoryDep = {
   groupDAL: Pick<TGroupDALFactory, "findOne" | "findAllGroupPossibleUsers">;
-  projectDAL: Pick<TProjectDALFactory, "findOne" | "findProjectGhostUser" | "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getProjectPermissionByRoles">;
 };
 
 export type TGroupProjectServiceFactory = ReturnType<typeof groupProjectServiceFactory>;
 
-export const groupProjectServiceFactory = ({
-  groupDAL,
-  projectDAL,
-  permissionService
-}: TGroupProjectServiceFactoryDep) => {
+export const groupProjectServiceFactory = ({ groupDAL, permissionService }: TGroupProjectServiceFactoryDep) => {
   const listProjectGroupUsers = async ({
     id,
     projectId,
@@ -35,12 +28,6 @@ export const groupProjectServiceFactory = ({
     search,
     filter
   }: TListProjectGroupUsersDTO) => {
-    const project = await projectDAL.findById(projectId);
-
-    if (!project) {
-      throw new NotFoundError({ message: `Failed to find project with ID ${projectId}` });
-    }
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -51,8 +38,10 @@ export const groupProjectServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionGroupActions.Read, ProjectPermissionSub.Groups);
 
+    // getProjectPermission above throws NotFoundError if the project doesn't exist and
+    // guarantees actorOrgId === project.orgId — no separate project lookup needed.
     const { members, totalCount } = await groupDAL.findAllGroupPossibleUsers({
-      orgId: project.orgId,
+      orgId: actorOrgId,
       groupId: id,
       offset,
       limit,

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -21,6 +21,8 @@ import { AsymmetricKeyAlgorithm, signingService } from "@app/lib/crypto/sign";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import {
   getByteLengthForSymmetricEncryptionAlgorithm,
   KMS_ROOT_CONFIG_UUID,
@@ -899,7 +901,9 @@ export const kmsServiceFactory = ({
   };
 
   const getProjectKeyBackup = async (projectId: string) => {
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!project) {
       throw new NotFoundError({
         message: `Project with ID '${projectId}' not found`

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -13,6 +13,8 @@ import {
 } from "@app/ee/services/permission/project-permission";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, InternalServerError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
@@ -136,7 +138,9 @@ export const newProjectMembershipUserFactory = ({
 
     const appCfg = getConfig();
     const scope = getScopeField(dto.scopeData);
-    const project = await projectDAL.findById(scope.value);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(scope.value), () =>
+      projectDAL.findById(scope.value)
+    );
 
     const orgMembershipAcceptedUserIds = orgMembershipAccepted.map((el) => el.actorUserId as string);
     const emails = newMembers

--- a/backend/src/services/pki-alert-v2/pki-alert-v2-service.ts
+++ b/backend/src/services/pki-alert-v2/pki-alert-v2-service.ts
@@ -5,6 +5,8 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator/validate-url";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
@@ -729,7 +731,9 @@ export const pkiAlertV2ServiceFactory = ({
       // Send in-app notifications to project admins
       try {
         const projectMembers = await projectMembershipDAL.findAllProjectMembers(projectId);
-        const project = await projectDAL.findById(projectId);
+        const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+          projectDAL.findById(projectId)
+        );
 
         if (project) {
           const projectAdmins = projectMembers.filter((member) =>

--- a/backend/src/services/project-env/project-env-service.ts
+++ b/backend/src/services/project-env/project-env-service.ts
@@ -10,7 +10,6 @@ import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 
-import { TProjectDALFactory } from "../project/project-dal";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TProjectEnvDALFactory } from "./project-env-dal";
 import { TCreateEnvDTO, TDeleteEnvDTO, TGetEnvDTO, TUpdateEnvDTO } from "./project-env-types";
@@ -18,7 +17,6 @@ import { TCreateEnvDTO, TDeleteEnvDTO, TGetEnvDTO, TUpdateEnvDTO } from "./proje
 type TProjectEnvServiceFactoryDep = {
   projectEnvDAL: TProjectEnvDALFactory;
   folderDAL: Pick<TSecretFolderDALFactory, "create">;
-  projectDAL: Pick<TProjectDALFactory, "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "getItem" | "waitTillReady">;
@@ -33,7 +31,6 @@ export const projectEnvServiceFactory = ({
   permissionService,
   licenseService,
   keyStore,
-  projectDAL,
   folderDAL,
   accessApprovalPolicyEnvironmentDAL,
   secretApprovalPolicyEnvironmentDAL
@@ -80,8 +77,9 @@ export const projectEnvServiceFactory = ({
           name: "CreateEnvironment"
         });
 
-      const project = await projectDAL.findById(projectId);
-      const plan = await licenseService.getPlan(project.orgId);
+      // getProjectPermission above guarantees project existence and org membership,
+      // so actorOrgId === project.orgId — no separate project lookup needed.
+      const plan = await licenseService.getPlan(actorOrgId);
       if (plan.environmentLimit !== null && envs.length >= plan.environmentLimit) {
         // case: limit imposed on number of environments allowed
         // case: number of environments used exceeds the number of environments allowed
@@ -178,8 +176,9 @@ export const projectEnvServiceFactory = ({
       }
 
       const envs = await projectEnvDAL.find({ projectId });
-      const project = await projectDAL.findById(projectId);
-      const plan = await licenseService.getPlan(project.orgId);
+      // getProjectPermission above guarantees project existence and org membership,
+      // so actorOrgId === project.orgId — no separate project lookup needed.
+      const plan = await licenseService.getPlan(actorOrgId);
       if (plan.environmentLimit !== null && envs.length > plan.environmentLimit) {
         // case: limit imposed on number of environments allowed
         // case: number of environments used exceeds the number of environments allowed

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -8,6 +8,8 @@ import { ProjectPermissionMemberActions, ProjectPermissionSub } from "@app/ee/se
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 
 import { TAccessApprovalPolicyApproverDALFactory } from "../../ee/services/access-approval-policy/access-approval-policy-approver-dal";
 import { TAccessApprovalPolicyDALFactory } from "../../ee/services/access-approval-policy/access-approval-policy-dal";
@@ -195,9 +197,6 @@ export const projectMembershipServiceFactory = ({
     members,
     sendEmails = true
   }: TAddUsersToWorkspaceDTO) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -207,8 +206,11 @@ export const projectMembershipServiceFactory = ({
       actionProjectType: ActionProjectType.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Create, ProjectPermissionSub.Member);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     const orgMembers = await membershipUserDAL.find({
-      [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: project.orgId,
+      [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: actorOrgId,
       scope: AccessScope.Organization,
       $in: {
         [`${TableName.Membership}.id` as "id"]: members.map(({ orgMembershipId }) => orgMembershipId)
@@ -242,7 +244,7 @@ export const projectMembershipServiceFactory = ({
           scopeProjectId: projectId,
           actorUserId,
           scope: AccessScope.Project,
-          scopeOrgId: project.orgId
+          scopeOrgId: actorOrgId
         })),
         tx
       );
@@ -269,7 +271,7 @@ export const projectMembershipServiceFactory = ({
       await notificationService.createUserNotifications(
         orgMembershipUsernames.map((member) => ({
           userId: member.id,
-          orgId: project.orgId,
+          orgId: actorOrgId,
           type: NotificationType.PROJECT_INVITATION,
           title: "Project Invitation",
           body: `You've been invited to join the project **${project.name}**.`
@@ -308,14 +310,6 @@ export const projectMembershipServiceFactory = ({
       actionProjectType: ActionProjectType.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Delete, ProjectPermissionSub.Member);
-
-    const project = await projectDAL.findById(projectId);
-
-    if (!project) {
-      throw new NotFoundError({
-        message: `Project with ID '${projectId}' not found`
-      });
-    }
 
     const usernamesAndEmails = [...emails, ...usernames];
 
@@ -403,7 +397,9 @@ export const projectMembershipServiceFactory = ({
       throw new BadRequestError({ message: "Only users can leave projects" });
     }
 
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
 
     if (project.version === ProjectVersion.V1) {

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -49,6 +49,8 @@ import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TProjectPermission } from "@app/lib/types";
 import { TPkiSubscriberDALFactory } from "@app/services/pki-subscriber/pki-subscriber-dal";
 
@@ -1855,13 +1857,6 @@ export const projectServiceFactory = ({
     actorAuthMethod,
     projectId
   }: TGetProjectSshConfig) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({
-        message: `Project with ID '${projectId}' not found`
-      });
-    }
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -1874,12 +1869,12 @@ export const projectServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Settings);
 
     const projectSshConfig = await projectSshConfigDAL.findOne({
-      projectId: project.id
+      projectId
     });
 
     if (!projectSshConfig) {
       throw new NotFoundError({
-        message: `Project SSH config with ID '${project.id}' not found`
+        message: `Project SSH config with ID '${projectId}' not found`
       });
     }
 
@@ -1895,13 +1890,6 @@ export const projectServiceFactory = ({
     defaultUserSshCaId,
     defaultHostSshCaId
   }: TUpdateProjectSshConfig) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({
-        message: `Project with ID '${projectId}' not found`
-      });
-    }
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -1914,12 +1902,12 @@ export const projectServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Edit, ProjectPermissionSub.Settings);
 
     let projectSshConfig = await projectSshConfigDAL.findOne({
-      projectId: project.id
+      projectId
     });
 
     if (!projectSshConfig) {
       throw new NotFoundError({
-        message: `Project SSH config with ID '${project.id}' not found`
+        message: `Project SSH config with ID '${projectId}' not found`
       });
     }
 
@@ -1928,7 +1916,7 @@ export const projectServiceFactory = ({
         const userSshCa = await sshCertificateAuthorityDAL.findOne(
           {
             id: defaultUserSshCaId,
-            projectId: project.id
+            projectId
           },
           tx
         );
@@ -1944,7 +1932,7 @@ export const projectServiceFactory = ({
         const hostSshCa = await sshCertificateAuthorityDAL.findOne(
           {
             id: defaultHostSshCaId,
-            projectId: project.id
+            projectId
           },
           tx
         );
@@ -1979,13 +1967,6 @@ export const projectServiceFactory = ({
     projectId,
     integration
   }: TGetProjectWorkflowIntegrationConfig) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({
-        message: `Project with ID '${projectId}' not found`
-      });
-    }
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -1999,7 +1980,7 @@ export const projectServiceFactory = ({
 
     if (integration === WorkflowIntegration.SLACK) {
       const config = await projectSlackConfigDAL.findOne({
-        projectId: project.id
+        projectId
       });
 
       if (!config) {
@@ -2017,7 +1998,7 @@ export const projectServiceFactory = ({
 
     if (integration === WorkflowIntegration.MICROSOFT_TEAMS) {
       const config = await projectMicrosoftTeamsConfigDAL.findOne({
-        projectId: project.id
+        projectId
       });
 
       if (!config) {
@@ -2057,7 +2038,9 @@ export const projectServiceFactory = ({
     isSecretSyncErrorNotificationEnabled?: boolean;
     secretSyncErrorChannels?: string;
   }) => {
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     if (!project) {
       throw new NotFoundError({
         message: `Project with ID '${projectId}' not found`
@@ -2266,13 +2249,6 @@ export const projectServiceFactory = ({
     integrationId,
     integration
   }: TDeleteProjectWorkflowIntegration) => {
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({
-        message: `Project with ID '${projectId}' not found`
-      });
-    }
-
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -2414,7 +2390,9 @@ export const projectServiceFactory = ({
     }
 
     const org = await orgDAL.findOne({ id: permission.orgId });
-    const project = await projectDAL.findById(projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+      projectDAL.findById(projectId)
+    );
     const userDetails = await userDAL.findById(permission.id);
     const appCfg = getConfig();
 

--- a/backend/src/services/role/project/project-role-factory.ts
+++ b/backend/src/services/role/project/project-role-factory.ts
@@ -17,6 +17,8 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { BadRequestError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TRoleScopeFactory } from "../role-types";
@@ -119,7 +121,9 @@ export const newProjectRoleFactory = ({
 
   const getPredefinedRoles: TRoleScopeFactory["getPredefinedRoles"] = async (scopeData) => {
     const scope = getScopeField(scopeData);
-    const project = await projectDAL.findById(scope.value);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(scope.value), () =>
+      projectDAL.findById(scope.value)
+    );
     if (!project) throw new BadRequestError({ message: "Project not found" });
     const projectId = project.id;
 

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -16,7 +16,6 @@ import { deepEqualSkipFields } from "@app/lib/fn/object";
 import { OrgServiceActor } from "@app/lib/types";
 import { TAppConnectionServiceFactory } from "@app/services/app-connection/app-connection-service";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
-import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
 import { SecretSync } from "@app/services/secret-sync/secret-sync-enums";
@@ -63,7 +62,6 @@ type TSecretSyncServiceFactoryDep = {
   appConnectionService: Pick<TAppConnectionServiceFactory, "validateAppConnectionUsageById">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getOrgPermission">;
-  projectDAL: Pick<TProjectDALFactory, "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
   folderDAL: Pick<TSecretFolderDALFactory, "findByProjectId" | "findById" | "findBySecretPath">;
@@ -86,7 +84,6 @@ export const secretSyncServiceFactory = ({
   appConnectionService,
   kmsService,
   permissionService,
-  projectDAL,
   orgDAL,
   projectBotService,
   secretSyncQueue,
@@ -360,12 +357,9 @@ export const secretSyncServiceFactory = ({
         message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${projectId}"`
       });
 
-    const project = await projectDAL.findById(projectId);
-    if (!project) {
-      throw new NotFoundError({ message: "Project not found" });
-    }
-
-    const organization = await orgDAL.findById(project.orgId);
+    // getProjectPermission above throws NotFoundError if the project doesn't exist and
+    // guarantees actor.orgId === project.orgId — no separate project lookup needed.
+    const organization = await orgDAL.findById(actor.orgId);
     if (organization?.blockDuplicateSecretSyncDestinations) {
       const duplicateCheck = await checkDuplicateDestination(
         {
@@ -494,11 +488,9 @@ export const secretSyncServiceFactory = ({
     let { folderId } = secretSync;
 
     if (params.destinationConfig) {
-      const project = await projectDAL.findById(secretSync.projectId);
-      if (!project) {
-        throw new NotFoundError({ message: "Project not found" });
-      }
-      const organization = await orgDAL.findById(project.orgId);
+      // getProjectPermission above throws NotFoundError if the project doesn't exist and
+      // guarantees actor.orgId === project.orgId — no separate project lookup needed.
+      const organization = await orgDAL.findById(actor.orgId);
 
       if (organization?.blockDuplicateSecretSyncDestinations) {
         const duplicateCheck = await checkDuplicateDestination(

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -3055,7 +3055,9 @@ export const secretServiceFactory = ({
     if (projectSlug) {
       project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     } else if (inputProjectId) {
-      project = await projectDAL.findById(inputProjectId);
+      project = await requestMemoize(requestMemoKeys.projectFindById(inputProjectId), () =>
+        projectDAL.findById(inputProjectId)
+      );
     }
 
     if (!project) {
@@ -3592,12 +3594,7 @@ export const secretServiceFactory = ({
       throw new NotFoundError({ message: `Secret version with ID '${versionId}' not found` });
     }
 
-    const project = await projectDAL.findById(version.projectId);
-    if (!project) {
-      throw new NotFoundError({ message: `Project with ID '${version.projectId}' not found` });
-    }
-
-    const { shouldUseSecretV2Bridge } = await projectBotService.getBotKey(project.id);
+    const { shouldUseSecretV2Bridge } = await projectBotService.getBotKey(version.projectId);
     if (!shouldUseSecretV2Bridge) {
       throw new BadRequestError({
         message: "Project version not supported",

--- a/backend/src/services/service-token/service-token-service.ts
+++ b/backend/src/services/service-token/service-token-service.ts
@@ -11,6 +11,8 @@ import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { ForbiddenRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 
 import { TAccessTokenQueueServiceFactory } from "../access-token-queue/access-token-queue";
 import { ActorType } from "../auth/auth-type";
@@ -174,7 +176,9 @@ export const serviceTokenServiceFactory = ({
     const serviceToken = await serviceTokenDAL.findById(tokenIdentifier);
 
     if (!serviceToken) throw new NotFoundError({ message: `Service token with ID '${tokenIdentifier}' not found` });
-    const project = await projectDAL.findById(serviceToken.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(serviceToken.projectId), () =>
+      projectDAL.findById(serviceToken.projectId)
+    );
 
     if (!project) throw new NotFoundError({ message: `Project with ID '${serviceToken.projectId}' not found` });
 

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -7,6 +7,8 @@ import { request } from "@app/lib/config/request";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 import { ActorType } from "@app/services/auth/auth-type";
 
@@ -301,7 +303,9 @@ export const fnTriggerWebhook = async ({
   logger.info({ environment, secretPath, projectId }, "Secret webhook job started");
   let { projectName } = event.payload;
   if (!projectName) {
-    const project = await projectDAL.findById(event.payload.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(event.payload.projectId), () =>
+      projectDAL.findById(event.payload.projectId)
+    );
     projectName = project.name;
   }
 

--- a/backend/src/services/webhook/webhook-service.ts
+++ b/backend/src/services/webhook/webhook-service.ts
@@ -4,6 +4,8 @@ import { ActionProjectType, TWebhooksInsert } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { TKmsServiceFactory } from "../kms/kms-service";
@@ -169,7 +171,9 @@ export const webhookServiceFactory = ({
       actionProjectType: ActionProjectType.Any
     });
 
-    const project = await projectDAL.findById(webhook.projectId);
+    const project = await requestMemoize(requestMemoKeys.projectFindById(webhook.projectId), () =>
+      projectDAL.findById(webhook.projectId)
+    );
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.SecretManager,
       projectId: project.id


### PR DESCRIPTION
## Context

- Memoize the getById project lookup
- Remove getById for redundant calls 

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [X] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)