### PR TITLE
fix: only lockout if identity lockout is enabled

### DIFF
--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -879,7 +879,15 @@ export const identityLdapAuthServiceFactory = ({
       lockout = JSON.parse(lockoutRaw) as LockoutObject;
     }
 
-    if (lockout && lockout?.lockedOut) {
+    const identityLdapAuth = await identityLdapAuthDAL.findOne({ identityId });
+    if (!identityLdapAuth) {
+      throw new UnauthorizedError({
+        message: "Invalid credentials",
+        detail: { reasonCode: "ldap_auth_not_found", identityId, orgId, identityName: identity?.name }
+      });
+    }
+
+    if (lockout && lockout?.lockedOut && identityLdapAuth.lockoutEnabled) {
       throw new UnauthorizedError({
         message: "This identity auth method is temporarily locked, please try again later",
         detail: { reasonCode: "temporarily_locked", identityId, orgId, identityName: identity?.name }
@@ -898,14 +906,6 @@ export const identityLdapAuthServiceFactory = ({
     } catch (error) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       if ((error as any).status === 401 || error instanceof UnauthorizedError) {
-        const identityLdapAuth = await identityLdapAuthDAL.findOne({ identityId });
-        if (!identityLdapAuth) {
-          throw new UnauthorizedError({
-            message: "Invalid credentials",
-            detail: { reasonCode: "ldap_auth_not_found", identityId, orgId, identityName: identity?.name }
-          });
-        }
-
         if (identityLdapAuth.lockoutEnabled) {
           let lock: Awaited<ReturnType<typeof keyStore.acquireLock>> | undefined;
           try {

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -113,7 +113,7 @@ export const identityUaServiceFactory = ({
         lockout = JSON.parse(lockoutRaw) as LockoutObject;
       }
 
-      if (lockout && lockout.lockedOut) {
+      if (lockout && lockout.lockedOut && identityUa.lockoutEnabled) {
         throw new UnauthorizedError({
           message: "This identity auth method is temporarily locked, please try again later",
           detail: {


### PR DESCRIPTION
## Context

Even if the identity auth method is locked, we only want to throw the error if the identity auth method actually has lockout enabled.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)