### PR TITLE
feat: prevent reuse of previous secret values

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1633,7 +1633,8 @@ export const registerRoutes = async (
     permissionService,
     kmsService,
     folderDAL,
-    secretDAL: secretV2BridgeDAL
+    secretDAL: secretV2BridgeDAL,
+    secretVersionV2BridgeDAL
   });
   const folderService = secretFolderServiceFactory({
     permissionService,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -631,7 +631,7 @@ export const secretV2BridgeServiceFactory = ({
         environment,
         envId: folder.envId,
         secretPath,
-        secrets: [{ key: finalKey, value: secretValue }]
+        secrets: [{ key: finalKey, value: secretValue, secretId }]
       });
     }
 
@@ -2337,7 +2337,11 @@ export const secretV2BridgeServiceFactory = ({
         const secretsToValidate = [
           ...secretsToUpdate
             .filter((el) => el.secretValue || el.newSecretName)
-            .map((el) => ({ key: el.newSecretName || el.secretKey, value: el.secretValue })),
+            .map((el) => ({
+              key: el.newSecretName || el.secretKey,
+              value: el.secretValue,
+              secretId: secretsToUpdateInDBGroupedByKey[el.secretKey]?.[0]?.id
+            })),
           ...(updateMode === SecretUpdateMode.Upsert
             ? secretsToCreate.map((el) => ({ key: el.secretKey, value: el.secretValue }))
             : [])

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
@@ -170,7 +170,7 @@ const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.RegexPattern]: "Regex pattern",
   [ConstraintType.RequiredPrefix]: "Required prefix",
   [ConstraintType.RequiredSuffix]: "Required suffix",
-  [ConstraintType.NoValueReuse]: "No reuse of previous values"
+  [ConstraintType.PreventValueReuse]: "Prevent reuse of previous secret values"
 };
 
 const TARGET_LABELS: Record<ConstraintTarget, string> = {
@@ -236,7 +236,7 @@ const evaluateConstraint = (constraint: TConstraint, secret: TSecretToValidate):
       }
       return null;
     }
-    case ConstraintType.NoValueReuse: {
+    case ConstraintType.PreventValueReuse: {
       if (secret.value === undefined || !secret.previousValues?.length) {
         return null;
       }

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
@@ -146,6 +146,7 @@ export const checkForOverlappingRules = ({
 type TSecretToValidate = {
   key: string;
   value?: string;
+  previousValues?: string[];
 };
 
 type TValidationRule = {
@@ -168,7 +169,8 @@ const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.MaxLength]: "Maximum length",
   [ConstraintType.RegexPattern]: "Regex pattern",
   [ConstraintType.RequiredPrefix]: "Required prefix",
-  [ConstraintType.RequiredSuffix]: "Required suffix"
+  [ConstraintType.RequiredSuffix]: "Required suffix",
+  [ConstraintType.NoValueReuse]: "No reuse of previous values"
 };
 
 const TARGET_LABELS: Record<ConstraintTarget, string> = {
@@ -231,6 +233,17 @@ const evaluateConstraint = (constraint: TConstraint, secret: TSecretToValidate):
     case ConstraintType.RequiredSuffix: {
       if (!targetValue.endsWith(constraint.value)) {
         return `${targetLabel} must end with "${constraint.value}"`;
+      }
+      return null;
+    }
+    case ConstraintType.NoValueReuse: {
+      if (secret.value === undefined || !secret.previousValues?.length) {
+        return null;
+      }
+      const versionCount = Number(constraint.value) || 100;
+      const valuesToCheck = secret.previousValues.slice(0, versionCount);
+      if (valuesToCheck.includes(secret.value)) {
+        return `${targetLabel} cannot reuse any of the last ${versionCount} values`;
       }
       return null;
     }

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-fns.ts
@@ -3,6 +3,7 @@ import RE2 from "re2";
 
 import { BadRequestError } from "@app/lib/errors";
 
+import { MAX_PREVENT_VALUE_REUSE_VERSIONS } from "./secret-validation-rule-schemas";
 import {
   ConstraintTarget,
   ConstraintType,
@@ -240,7 +241,7 @@ const evaluateConstraint = (constraint: TConstraint, secret: TSecretToValidate):
       if (secret.value === undefined || !secret.previousValues?.length) {
         return null;
       }
-      const versionCount = Number(constraint.value) || 100;
+      const versionCount = Number(constraint.value) || MAX_PREVENT_VALUE_REUSE_VERSIONS;
       const valuesToCheck = secret.previousValues.slice(0, versionCount);
       if (valuesToCheck.includes(secret.value)) {
         return `${targetLabel} cannot reuse any of the last ${versionCount} values`;

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
@@ -9,11 +9,33 @@ import {
   TSecretValidationRuleInputs
 } from "./secret-validation-rule-types";
 
-export const constraintSchema = z.object({
-  type: z.nativeEnum(ConstraintType),
-  appliesTo: z.nativeEnum(ConstraintTarget),
-  value: z.string().min(1)
-});
+const MAX_NO_REUSE_VERSIONS = 100;
+
+export const constraintSchema = z
+  .object({
+    type: z.nativeEnum(ConstraintType),
+    appliesTo: z.nativeEnum(ConstraintTarget),
+    value: z.string()
+  })
+  .refine((c) => c.type === ConstraintType.NoValueReuse || c.value.length > 0, {
+    message: "Value is required",
+    path: ["value"]
+  })
+  .refine((c) => c.type !== ConstraintType.NoValueReuse || c.appliesTo === ConstraintTarget.SecretValue, {
+    message: "No value reuse constraint can only apply to secret values",
+    path: ["appliesTo"]
+  })
+  .refine(
+    (c) => {
+      if (c.type !== ConstraintType.NoValueReuse) return true;
+      const num = Number(c.value);
+      return !Number.isNaN(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+    },
+    {
+      message: `No value reuse version count must be between 1 and ${MAX_NO_REUSE_VERSIONS}`,
+      path: ["value"]
+    }
+  );
 
 export const staticSecretsInputsSchema = z.object({
   constraints: z.array(constraintSchema).min(1)

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
@@ -29,7 +29,7 @@ export const constraintSchema = z
     (c) => {
       if (c.type !== ConstraintType.NoValueReuse) return true;
       const num = Number(c.value);
-      return !Number.isNaN(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+      return Number.isInteger(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
     },
     {
       message: `No value reuse version count must be between 1 and ${MAX_NO_REUSE_VERSIONS}`,

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
@@ -9,7 +9,7 @@ import {
   TSecretValidationRuleInputs
 } from "./secret-validation-rule-types";
 
-const MAX_NO_REUSE_VERSIONS = 100;
+export const MAX_PREVENT_VALUE_REUSE_VERSIONS = 100;
 
 export const constraintSchema = z
   .object({
@@ -17,22 +17,22 @@ export const constraintSchema = z
     appliesTo: z.nativeEnum(ConstraintTarget),
     value: z.string()
   })
-  .refine((c) => c.type === ConstraintType.NoValueReuse || c.value.length > 0, {
+  .refine((c) => c.type === ConstraintType.PreventValueReuse || c.value.length > 0, {
     message: "Value is required",
     path: ["value"]
   })
-  .refine((c) => c.type !== ConstraintType.NoValueReuse || c.appliesTo === ConstraintTarget.SecretValue, {
+  .refine((c) => c.type !== ConstraintType.PreventValueReuse || c.appliesTo === ConstraintTarget.SecretValue, {
     message: "No value reuse constraint can only apply to secret values",
     path: ["appliesTo"]
   })
   .refine(
     (c) => {
-      if (c.type !== ConstraintType.NoValueReuse) return true;
+      if (c.type !== ConstraintType.PreventValueReuse) return true;
       const num = Number(c.value);
-      return Number.isInteger(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+      return Number.isInteger(num) && num >= 1 && num <= MAX_PREVENT_VALUE_REUSE_VERSIONS;
     },
     {
-      message: `No value reuse version count must be between 1 and ${MAX_NO_REUSE_VERSIONS}`,
+      message: `Prevent value reuse version count must be between 1 and ${MAX_PREVENT_VALUE_REUSE_VERSIONS}`,
       path: ["value"]
     }
   );

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-schemas.ts
@@ -9,7 +9,7 @@ import {
   TSecretValidationRuleInputs
 } from "./secret-validation-rule-types";
 
-export const MAX_PREVENT_VALUE_REUSE_VERSIONS = 100;
+export const MAX_PREVENT_VALUE_REUSE_VERSIONS = 25;
 
 export const constraintSchema = z
   .object({

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
@@ -1,4 +1,5 @@
 import { ForbiddenError } from "@casl/ability";
+import picomatch from "picomatch";
 
 import { ActionProjectType } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -359,8 +360,14 @@ export const secretValidationRuleServiceFactory = ({
       )
     }));
 
+    // filter to rules that actually match this environment + path so we don't trigger expensive version-history lookups for unrelated NoValueReuse rules.
     const MAX_NO_REUSE_VERSIONS = 100;
-    const hasNoValueReuseConstraint = parsedRules.some((r) =>
+    const matchingRules = parsedRules.filter((r) => {
+      if (r.envId && r.envId !== envId) return false;
+      return picomatch.isMatch(secretPath, r.secretPath, { strictSlashes: false });
+    });
+
+    const hasNoValueReuseConstraint = matchingRules.some((r) =>
       r.inputs.constraints?.some(
         (c) => c.type === ConstraintType.NoValueReuse && c.appliesTo === ConstraintTarget.SecretValue
       )

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
@@ -15,7 +15,7 @@ import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-
 import { TSecretVersionV2DALFactory } from "../secret-v2-bridge/secret-version-dal";
 import { TSecretValidationRuleDALFactory } from "./secret-validation-rule-dal";
 import { checkForOverlappingRules, enforceSecretValidationRules } from "./secret-validation-rule-fns";
-import { parseSecretValidationRuleInputs } from "./secret-validation-rule-schemas";
+import { MAX_PREVENT_VALUE_REUSE_VERSIONS, parseSecretValidationRuleInputs } from "./secret-validation-rule-schemas";
 import {
   ConstraintTarget,
   ConstraintType,
@@ -360,28 +360,27 @@ export const secretValidationRuleServiceFactory = ({
       )
     }));
 
-    // filter to rules that actually match this environment + path so we don't trigger expensive version-history lookups for unrelated NoValueReuse rules.
-    const MAX_NO_REUSE_VERSIONS = 100;
+    // filter to rules that actually match this environment + path so we don't trigger expensive version-history lookups for unrelated PreventValueReuse rules.
     const matchingRules = parsedRules.filter((r) => {
       if (r.envId && r.envId !== envId) return false;
       return picomatch.isMatch(secretPath, r.secretPath, { strictSlashes: false });
     });
 
-    const hasNoValueReuseConstraint = matchingRules.some((r) =>
+    const hasPreventValueReuseConstraint = matchingRules.some((r) =>
       r.inputs.constraints?.some(
-        (c) => c.type === ConstraintType.NoValueReuse && c.appliesTo === ConstraintTarget.SecretValue
+        (c) => c.type === ConstraintType.PreventValueReuse && c.appliesTo === ConstraintTarget.SecretValue
       )
     );
 
     const previousValuesMap: Record<string, string[]> = {};
-    if (hasNoValueReuseConstraint) {
+    if (hasPreventValueReuseConstraint) {
       const secretIdsToCheck = secrets.filter((s) => s.secretId).map((s) => s.secretId!);
       if (secretIdsToCheck.length) {
         const allVersions = await Promise.all(
           secretIdsToCheck.map((sId) =>
             secretVersionV2BridgeDAL.find(
               { secretId: sId },
-              { sort: [["version", "desc"]], limit: MAX_NO_REUSE_VERSIONS }
+              { sort: [["version", "desc"]], limit: MAX_PREVENT_VALUE_REUSE_VERSIONS }
             )
           )
         );

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-service.ts
@@ -11,10 +11,13 @@ import { KmsDataKey } from "../kms/kms-types";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { expandSecretReferencesFactory } from "../secret-v2-bridge/secret-reference-fns";
 import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-dal";
+import { TSecretVersionV2DALFactory } from "../secret-v2-bridge/secret-version-dal";
 import { TSecretValidationRuleDALFactory } from "./secret-validation-rule-dal";
 import { checkForOverlappingRules, enforceSecretValidationRules } from "./secret-validation-rule-fns";
 import { parseSecretValidationRuleInputs } from "./secret-validation-rule-schemas";
 import {
+  ConstraintTarget,
+  ConstraintType,
   SecretValidationRuleType,
   TCreateSecretValidationRuleDTO,
   TDeleteSecretValidationRuleDTO,
@@ -27,6 +30,7 @@ type TSecretValidationRuleServiceFactoryDep = {
   projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
   folderDAL: Pick<TSecretFolderDALFactory, "findBySecretPath">;
   secretDAL: TSecretV2BridgeDALFactory;
+  secretVersionV2BridgeDAL: Pick<TSecretVersionV2DALFactory, "find">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   kmsService: TKmsServiceFactory;
 };
@@ -38,6 +42,7 @@ export const secretValidationRuleServiceFactory = ({
   projectEnvDAL,
   folderDAL,
   secretDAL,
+  secretVersionV2BridgeDAL,
   permissionService,
   kmsService
 }: TSecretValidationRuleServiceFactoryDep) => {
@@ -321,7 +326,7 @@ export const secretValidationRuleServiceFactory = ({
     environment: string;
     envId: string;
     secretPath: string;
-    secrets: { key: string; value?: string }[];
+    secrets: { key: string; value?: string; secretId?: string }[];
   }) => {
     if (!secrets.length) return;
 
@@ -341,9 +346,56 @@ export const secretValidationRuleServiceFactory = ({
       canExpandValue: () => true
     });
 
-    let resolvedSecrets = secrets;
+    const { decryptor: ruleInputsDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId
+    });
 
-    resolvedSecrets = await Promise.all(
+    const parsedRules = rules.map((r) => ({
+      ...r,
+      inputs: parseSecretValidationRuleInputs(
+        r.type,
+        JSON.parse(ruleInputsDecryptor({ cipherTextBlob: r.encryptedInputs }).toString()) as unknown
+      )
+    }));
+
+    const MAX_NO_REUSE_VERSIONS = 100;
+    const hasNoValueReuseConstraint = parsedRules.some((r) =>
+      r.inputs.constraints?.some(
+        (c) => c.type === ConstraintType.NoValueReuse && c.appliesTo === ConstraintTarget.SecretValue
+      )
+    );
+
+    const previousValuesMap: Record<string, string[]> = {};
+    if (hasNoValueReuseConstraint) {
+      const secretIdsToCheck = secrets.filter((s) => s.secretId).map((s) => s.secretId!);
+      if (secretIdsToCheck.length) {
+        const allVersions = await Promise.all(
+          secretIdsToCheck.map((sId) =>
+            secretVersionV2BridgeDAL.find(
+              { secretId: sId },
+              { sort: [["version", "desc"]], limit: MAX_NO_REUSE_VERSIONS }
+            )
+          )
+        );
+
+        for (const versions of allVersions) {
+          for (const version of versions) {
+            if (!version.encryptedValue) {
+              // eslint-disable-next-line no-continue
+              continue;
+            }
+            const decryptedValue = secretManagerDecryptor({ cipherTextBlob: version.encryptedValue }).toString();
+            if (!previousValuesMap[version.secretId]) {
+              previousValuesMap[version.secretId] = [];
+            }
+            previousValuesMap[version.secretId].push(decryptedValue);
+          }
+        }
+      }
+    }
+
+    const resolvedSecrets = await Promise.all(
       secrets.map(async (s) => ({
         key: s.key,
         value: await expandSecretReferences({
@@ -351,23 +403,13 @@ export const secretValidationRuleServiceFactory = ({
           secretPath,
           environment,
           secretKey: s.key
-        })
+        }),
+        ...(s.secretId && previousValuesMap[s.secretId] ? { previousValues: previousValuesMap[s.secretId] } : {})
       }))
     );
 
-    const { decryptor: ruleInputsDecryptor } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId
-    });
-
     enforceSecretValidationRules({
-      projectRules: rules.map((r) => ({
-        ...r,
-        inputs: parseSecretValidationRuleInputs(
-          r.type,
-          JSON.parse(ruleInputsDecryptor({ cipherTextBlob: r.encryptedInputs }).toString()) as unknown
-        )
-      })),
+      projectRules: parsedRules,
       envId,
       secretPath,
       secrets: resolvedSecrets

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-types.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-types.ts
@@ -10,7 +10,7 @@ export enum ConstraintType {
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
   RequiredSuffix = "required-suffix",
-  NoValueReuse = "no-value-reuse"
+  PreventValueReuse = "prevent-value-reuse"
 }
 
 export enum ConstraintTarget {

--- a/backend/src/services/secret-validation-rule/secret-validation-rule-types.ts
+++ b/backend/src/services/secret-validation-rule/secret-validation-rule-types.ts
@@ -9,7 +9,8 @@ export enum ConstraintType {
   MaxLength = "max-length",
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
-  RequiredSuffix = "required-suffix"
+  RequiredSuffix = "required-suffix",
+  NoValueReuse = "no-value-reuse"
 }
 
 export enum ConstraintTarget {

--- a/frontend/src/components/v3/generic/PasswordGenerator/PasswordGenerator.tsx
+++ b/frontend/src/components/v3/generic/PasswordGenerator/PasswordGenerator.tsx
@@ -128,7 +128,7 @@ const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.RegexPattern]: "Pattern",
   [ConstraintType.MinLength]: "Min length",
   [ConstraintType.MaxLength]: "Max length",
-  [ConstraintType.NoValueReuse]: "No reuse of previous values"
+  [ConstraintType.PreventValueReuse]: "Prevent reuse of previous values"
 };
 
 const RuleOptionComponent = ({ isSelected, children, ...props }: OptionProps<RuleOption>) => (
@@ -379,12 +379,12 @@ export const PasswordGenerator = ({
                     <span
                       className={twMerge(
                         "font-medium text-muted",
-                        constraint.type === ConstraintType.NoValueReuse && "text-label"
+                        constraint.type === ConstraintType.PreventValueReuse && "text-label"
                       )}
                     >
                       {CONSTRAINT_LABELS[constraint.type]}
                     </span>
-                    {constraint.type !== ConstraintType.NoValueReuse && (
+                    {constraint.type !== ConstraintType.PreventValueReuse && (
                       <>
                         : <span className="font-mono text-label">{constraint.value}</span>
                       </>

--- a/frontend/src/components/v3/generic/PasswordGenerator/PasswordGenerator.tsx
+++ b/frontend/src/components/v3/generic/PasswordGenerator/PasswordGenerator.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import picomatch from "picomatch";
 import RandExp from "randexp";
+import { twMerge } from "tailwind-merge";
 
 import { useTimedReset } from "@app/hooks";
 import {
@@ -126,7 +127,8 @@ const CONSTRAINT_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.RequiredSuffix]: "Suffix",
   [ConstraintType.RegexPattern]: "Pattern",
   [ConstraintType.MinLength]: "Min length",
-  [ConstraintType.MaxLength]: "Max length"
+  [ConstraintType.MaxLength]: "Max length",
+  [ConstraintType.NoValueReuse]: "No reuse of previous values"
 };
 
 const RuleOptionComponent = ({ isSelected, children, ...props }: OptionProps<RuleOption>) => (
@@ -374,10 +376,19 @@ export const PasswordGenerator = ({
               <div className="flex flex-wrap gap-x-4 gap-y-1">
                 {valueConstraints.map((constraint) => (
                   <span key={constraint.type} className="text-xs">
-                    <span className="font-medium text-muted">
-                      {CONSTRAINT_LABELS[constraint.type]}:
-                    </span>{" "}
-                    <span className="font-mono text-label">{constraint.value}</span>
+                    <span
+                      className={twMerge(
+                        "font-medium text-muted",
+                        constraint.type === ConstraintType.NoValueReuse && "text-label"
+                      )}
+                    >
+                      {CONSTRAINT_LABELS[constraint.type]}
+                    </span>
+                    {constraint.type !== ConstraintType.NoValueReuse && (
+                      <>
+                        : <span className="font-mono text-label">{constraint.value}</span>
+                      </>
+                    )}
                   </span>
                 ))}
               </div>

--- a/frontend/src/hooks/api/secretValidationRules/types.ts
+++ b/frontend/src/hooks/api/secretValidationRules/types.ts
@@ -7,7 +7,8 @@ export enum ConstraintType {
   MaxLength = "max-length",
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
-  RequiredSuffix = "required-suffix"
+  RequiredSuffix = "required-suffix",
+  NoValueReuse = "no-value-reuse"
 }
 
 export enum ConstraintTarget {

--- a/frontend/src/hooks/api/secretValidationRules/types.ts
+++ b/frontend/src/hooks/api/secretValidationRules/types.ts
@@ -8,7 +8,7 @@ export enum ConstraintType {
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
   RequiredSuffix = "required-suffix",
-  NoValueReuse = "no-value-reuse"
+  PreventValueReuse = "prevent-value-reuse"
 }
 
 export enum ConstraintTarget {

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { Controller, useFormContext } from "react-hook-form";
-import { TrashIcon } from "lucide-react";
+import { InfoIcon, TrashIcon } from "lucide-react";
 
 import {
   IconButton,
@@ -9,7 +9,10 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 
 import {
@@ -42,6 +45,11 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
 
   const Icon = constraintOption?.icon;
   const placeholder = constraintOption?.placeholder;
+  const isNoValueReuse = constraintType === ConstraintType.NoValueReuse;
+  const isNumericInput =
+    constraintType === ConstraintType.MinLength ||
+    constraintType === ConstraintType.MaxLength ||
+    constraintType === ConstraintType.NoValueReuse;
 
   return (
     <div className="rounded-md border border-border bg-card p-4">
@@ -57,38 +65,65 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
         </IconButton>
       </div>
 
+      {constraintOption?.cardDescription && (
+        <p className="mt-1.5 text-xs text-muted">{constraintOption.cardDescription}</p>
+      )}
+
       <div className="mt-3 grid grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-muted">Applies to</label>
-          <Controller
-            control={control}
-            name={`enforcement.inputs.constraints.${index}.appliesTo`}
-            render={({ field: { value, onChange } }) => (
-              <Select value={value} onValueChange={onChange}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  <SelectItem
-                    value={ConstraintTarget.SecretKey}
-                    disabled={otherTargets.has(ConstraintTarget.SecretKey)}
-                  >
-                    Secret Key
-                  </SelectItem>
-                  <SelectItem
-                    value={ConstraintTarget.SecretValue}
-                    disabled={otherTargets.has(ConstraintTarget.SecretValue)}
-                  >
-                    Secret Value
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            )}
-          />
-        </div>
+        {isNoValueReuse ? (
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-muted">Applies to</label>
+            <Input value="Secret Value" readOnly className="cursor-default opacity-60" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-muted">Applies to</label>
+            <Controller
+              control={control}
+              name={`enforcement.inputs.constraints.${index}.appliesTo`}
+              render={({ field: { value, onChange } }) => (
+                <Select value={value} onValueChange={onChange}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    <SelectItem
+                      value={ConstraintTarget.SecretKey}
+                      disabled={otherTargets.has(ConstraintTarget.SecretKey)}
+                    >
+                      Secret Key
+                    </SelectItem>
+                    <SelectItem
+                      value={ConstraintTarget.SecretValue}
+                      disabled={otherTargets.has(ConstraintTarget.SecretValue)}
+                    >
+                      Secret Value
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+        )}
         <div className="flex flex-col gap-1">
           <label className="text-xs font-medium text-muted">
-            {CONSTRAINT_VALUE_LABELS[constraintType]}
+            <div className="flex items-center gap-1">
+              {CONSTRAINT_VALUE_LABELS[constraintType]}
+              {constraintType === ConstraintType.NoValueReuse && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoIcon className="ml-1 size-3.5 text-muted" />
+                  </TooltipTrigger>
+                  <TooltipContent side="left" align="start" className="max-w-xs">
+                    <p className="text-sm">
+                      When a secret is updated, its new value is compared against this many of its
+                      most recent versions.
+                    </p>
+                    <p className="mt-2 text-xs text-muted">Maximum: 100 versions</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </label>
           <Controller
             control={control}
@@ -97,12 +132,9 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
               <div>
                 <Input
                   {...field}
-                  type={
-                    constraintType === ConstraintType.MinLength ||
-                    constraintType === ConstraintType.MaxLength
-                      ? "number"
-                      : "text"
-                  }
+                  type={isNumericInput ? "number" : "text"}
+                  min={isNoValueReuse ? 1 : undefined}
+                  max={isNoValueReuse ? 100 : undefined}
                   placeholder={placeholder?.toString() || undefined}
                   isError={Boolean(error)}
                 />

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
@@ -45,11 +45,11 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
 
   const Icon = constraintOption?.icon;
   const placeholder = constraintOption?.placeholder;
-  const isNoValueReuse = constraintType === ConstraintType.NoValueReuse;
+  const isPreventValueReuse = constraintType === ConstraintType.PreventValueReuse;
   const isNumericInput =
     constraintType === ConstraintType.MinLength ||
     constraintType === ConstraintType.MaxLength ||
-    constraintType === ConstraintType.NoValueReuse;
+    constraintType === ConstraintType.PreventValueReuse;
 
   return (
     <div className="rounded-md border border-border bg-card p-4">
@@ -70,7 +70,7 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
       )}
 
       <div className="mt-3 grid grid-cols-2 gap-3">
-        {isNoValueReuse ? (
+        {isPreventValueReuse ? (
           <div className="flex flex-col gap-1">
             <label className="text-xs font-medium text-muted">Applies to</label>
             <Input value="Secret Value" readOnly className="cursor-default opacity-60" />
@@ -109,15 +109,15 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
           <label className="text-xs font-medium text-muted">
             <div className="flex items-center gap-1">
               {CONSTRAINT_VALUE_LABELS[constraintType]}
-              {constraintType === ConstraintType.NoValueReuse && (
+              {constraintType === ConstraintType.PreventValueReuse && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <InfoIcon className="ml-1 size-3.5 text-muted" />
                   </TooltipTrigger>
                   <TooltipContent side="left" align="start" className="max-w-xs">
                     <p className="text-sm">
-                      When a secret is updated, its new value is compared against this many of its
-                      most recent versions.
+                      When a secret is updated, its new value is validated against the specified
+                      number of prior versions.
                     </p>
                     <p className="mt-2 text-xs text-muted">Maximum: 100 versions</p>
                   </TooltipContent>
@@ -133,8 +133,8 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
                 <Input
                   {...field}
                   type={isNumericInput ? "number" : "text"}
-                  min={isNoValueReuse ? 1 : undefined}
-                  max={isNoValueReuse ? 100 : undefined}
+                  min={isPreventValueReuse ? 1 : undefined}
+                  max={isPreventValueReuse ? 100 : undefined}
                   placeholder={placeholder?.toString() || undefined}
                   isError={Boolean(error)}
                 />

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/ConstraintCard.tsx
@@ -21,6 +21,7 @@ import {
   CONSTRAINT_VALUE_LABELS,
   ConstraintTarget,
   ConstraintType,
+  MAX_PREVENT_VALUE_REUSE_VERSIONS,
   TRuleForm
 } from "./SecretValidationRulesTab.utils";
 
@@ -119,7 +120,7 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
                       When a secret is updated, its new value is validated against the specified
                       number of prior versions.
                     </p>
-                    <p className="mt-2 text-xs text-muted">Maximum: 100 versions</p>
+                    <p className="mt-2 text-xs text-muted">Maximum: 25 versions</p>
                   </TooltipContent>
                 </Tooltip>
               )}
@@ -134,7 +135,7 @@ export const ConstraintCard = ({ index, onRemove }: Props) => {
                   {...field}
                   type={isNumericInput ? "number" : "text"}
                   min={isPreventValueReuse ? 1 : undefined}
-                  max={isPreventValueReuse ? 100 : undefined}
+                  max={isPreventValueReuse ? MAX_PREVENT_VALUE_REUSE_VERSIONS : undefined}
                   placeholder={placeholder?.toString() || undefined}
                   isError={Boolean(error)}
                 />

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.tsx
@@ -67,6 +67,7 @@ import { ConstraintCard } from "./ConstraintCard";
 import {
   CONSTRAINT_OPTIONS,
   ConstraintTarget,
+  ConstraintType,
   RULE_TYPE_LABELS,
   ruleFormSchema,
   RuleType,
@@ -119,11 +120,13 @@ const RuleFormContent = ({
 
   const watchedConstraints = form.watch("enforcement.inputs.constraints");
   const usedConstraintPairs = new Set(watchedConstraints?.map((c) => `${c.type}:${c.appliesTo}`));
-  const availableConstraintOptions = CONSTRAINT_OPTIONS.filter(
-    (opt) =>
-      !usedConstraintPairs.has(`${opt.type}:${ConstraintTarget.SecretKey}`) ||
-      !usedConstraintPairs.has(`${opt.type}:${ConstraintTarget.SecretValue}`)
-  );
+  const availableConstraintOptions = CONSTRAINT_OPTIONS.filter((opt) => {
+    const targets = opt.allowedTargets || [
+      ConstraintTarget.SecretKey,
+      ConstraintTarget.SecretValue
+    ];
+    return targets.some((target) => !usedConstraintPairs.has(`${opt.type}:${target}`));
+  });
 
   return (
     <FormProvider {...form}>
@@ -266,12 +269,13 @@ const RuleFormContent = ({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     {availableConstraintOptions.map((opt) => {
-                      const valueUsed = usedConstraintPairs.has(
-                        `${opt.type}:${ConstraintTarget.SecretValue}`
-                      );
-                      const defaultTarget = valueUsed
-                        ? ConstraintTarget.SecretKey
-                        : ConstraintTarget.SecretValue;
+                      const targets = opt.allowedTargets || [
+                        ConstraintTarget.SecretValue,
+                        ConstraintTarget.SecretKey
+                      ];
+                      const defaultTarget =
+                        targets.find((t) => !usedConstraintPairs.has(`${opt.type}:${t}`)) ??
+                        targets[0];
 
                       return (
                         <DropdownMenuItem
@@ -280,7 +284,10 @@ const RuleFormContent = ({
                             append({
                               type: opt.type,
                               appliesTo: defaultTarget,
-                              value: ""
+                              value:
+                                opt.type === ConstraintType.NoValueReuse
+                                  ? String(opt.placeholder || 10)
+                                  : ""
                             })
                           }
                         >

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.tsx
@@ -285,7 +285,7 @@ const RuleFormContent = ({
                               type: opt.type,
                               appliesTo: defaultTarget,
                               value:
-                                opt.type === ConstraintType.NoValueReuse
+                                opt.type === ConstraintType.PreventValueReuse
                                   ? String(opt.placeholder || 10)
                                   : ""
                             })

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
@@ -120,7 +120,7 @@ export const constraintSchema = z
     (c) => {
       if (c.type !== ConstraintType.NoValueReuse) return true;
       const num = Number(c.value);
-      return !Number.isNaN(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+      return Number.isInteger(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
     },
     {
       message: `Must be a number between 1 and ${MAX_NO_REUSE_VERSIONS}`,

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
@@ -14,7 +14,7 @@ export enum ConstraintType {
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
   RequiredSuffix = "required-suffix",
-  NoValueReuse = "no-value-reuse"
+  PreventValueReuse = "prevent-value-reuse"
 }
 
 export enum ConstraintTarget {
@@ -67,11 +67,11 @@ export const CONSTRAINT_OPTIONS: {
     icon: TextIcon
   },
   {
-    type: ConstraintType.NoValueReuse,
-    label: "No Value Reuse",
+    type: ConstraintType.PreventValueReuse,
+    label: "Prevent Value Reuse",
     description: "Prevent reusing previous secret values",
     cardDescription:
-      "Prevents secrets from reusing previous values. When a secret is updated, its new value must differ from its most recent versions.",
+      "When a secret is updated, its new value is validated against the specified number of prior versions.",
     placeholder: 10,
     icon: HistoryIcon,
     allowedTargets: [ConstraintTarget.SecretValue]
@@ -84,7 +84,7 @@ export const CONSTRAINT_VALUE_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.RegexPattern]: "Pattern",
   [ConstraintType.RequiredPrefix]: "Text",
   [ConstraintType.RequiredSuffix]: "Text",
-  [ConstraintType.NoValueReuse]: "Previous versions"
+  [ConstraintType.PreventValueReuse]: "Previous versions"
 };
 
 export const CONSTRAINT_TYPE_LABELS: Record<ConstraintType, string> = {
@@ -93,7 +93,7 @@ export const CONSTRAINT_TYPE_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.RegexPattern]: "Regex Pattern",
   [ConstraintType.RequiredPrefix]: "Required Prefix",
   [ConstraintType.RequiredSuffix]: "Required Suffix",
-  [ConstraintType.NoValueReuse]: "No Value Reuse"
+  [ConstraintType.PreventValueReuse]: "Prevent Value Reuse"
 };
 
 export enum RuleType {
@@ -112,13 +112,13 @@ export const constraintSchema = z
     appliesTo: z.nativeEnum(ConstraintTarget),
     value: z.string()
   })
-  .refine((c) => c.type === ConstraintType.NoValueReuse || c.value.length > 0, {
+  .refine((c) => c.type === ConstraintType.PreventValueReuse || c.value.length > 0, {
     message: "Value is required",
     path: ["value"]
   })
   .refine(
     (c) => {
-      if (c.type !== ConstraintType.NoValueReuse) return true;
+      if (c.type !== ConstraintType.PreventValueReuse) return true;
       const num = Number(c.value);
       return Number.isInteger(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
     },

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
@@ -1,4 +1,11 @@
-import { HashIcon, LucideIcon, RulerIcon, TextCursorInputIcon, TextIcon } from "lucide-react";
+import {
+  HashIcon,
+  HistoryIcon,
+  LucideIcon,
+  RulerIcon,
+  TextCursorInputIcon,
+  TextIcon
+} from "lucide-react";
 import { z } from "zod";
 
 export enum ConstraintType {
@@ -6,7 +13,8 @@ export enum ConstraintType {
   MaxLength = "max-length",
   RegexPattern = "regex-pattern",
   RequiredPrefix = "required-prefix",
-  RequiredSuffix = "required-suffix"
+  RequiredSuffix = "required-suffix",
+  NoValueReuse = "no-value-reuse"
 }
 
 export enum ConstraintTarget {
@@ -18,8 +26,10 @@ export const CONSTRAINT_OPTIONS: {
   type: ConstraintType;
   label: string;
   description: string;
+  cardDescription?: string;
   placeholder: string | number;
   icon: LucideIcon;
+  allowedTargets?: ConstraintTarget[];
 }[] = [
   {
     type: ConstraintType.MinLength,
@@ -55,6 +65,16 @@ export const CONSTRAINT_OPTIONS: {
     description: "Must end with specific text",
     placeholder: "-SUFFIX",
     icon: TextIcon
+  },
+  {
+    type: ConstraintType.NoValueReuse,
+    label: "No Value Reuse",
+    description: "Prevent reusing previous secret values",
+    cardDescription:
+      "Prevents secrets from reusing previous values. When a secret is updated, its new value must differ from its most recent versions.",
+    placeholder: 10,
+    icon: HistoryIcon,
+    allowedTargets: [ConstraintTarget.SecretValue]
   }
 ];
 
@@ -63,7 +83,8 @@ export const CONSTRAINT_VALUE_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.MaxLength]: "Characters",
   [ConstraintType.RegexPattern]: "Pattern",
   [ConstraintType.RequiredPrefix]: "Text",
-  [ConstraintType.RequiredSuffix]: "Text"
+  [ConstraintType.RequiredSuffix]: "Text",
+  [ConstraintType.NoValueReuse]: "Previous versions"
 };
 
 export const CONSTRAINT_TYPE_LABELS: Record<ConstraintType, string> = {
@@ -71,7 +92,8 @@ export const CONSTRAINT_TYPE_LABELS: Record<ConstraintType, string> = {
   [ConstraintType.MaxLength]: "Max Length",
   [ConstraintType.RegexPattern]: "Regex Pattern",
   [ConstraintType.RequiredPrefix]: "Required Prefix",
-  [ConstraintType.RequiredSuffix]: "Required Suffix"
+  [ConstraintType.RequiredSuffix]: "Required Suffix",
+  [ConstraintType.NoValueReuse]: "No Value Reuse"
 };
 
 export enum RuleType {
@@ -82,11 +104,29 @@ export const RULE_TYPE_LABELS: Record<RuleType, string> = {
   [RuleType.StaticSecrets]: "Static Secrets"
 };
 
-export const constraintSchema = z.object({
-  type: z.nativeEnum(ConstraintType),
-  appliesTo: z.nativeEnum(ConstraintTarget),
-  value: z.string().min(1, "Value is required")
-});
+const MAX_NO_REUSE_VERSIONS = 100;
+
+export const constraintSchema = z
+  .object({
+    type: z.nativeEnum(ConstraintType),
+    appliesTo: z.nativeEnum(ConstraintTarget),
+    value: z.string()
+  })
+  .refine((c) => c.type === ConstraintType.NoValueReuse || c.value.length > 0, {
+    message: "Value is required",
+    path: ["value"]
+  })
+  .refine(
+    (c) => {
+      if (c.type !== ConstraintType.NoValueReuse) return true;
+      const num = Number(c.value);
+      return !Number.isNaN(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+    },
+    {
+      message: `Must be a number between 1 and ${MAX_NO_REUSE_VERSIONS}`,
+      path: ["value"]
+    }
+  );
 
 const staticSecretsInputsSchema = z.object({
   constraints: z

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretValidationRulesTab/SecretValidationRulesTab.utils.ts
@@ -104,7 +104,7 @@ export const RULE_TYPE_LABELS: Record<RuleType, string> = {
   [RuleType.StaticSecrets]: "Static Secrets"
 };
 
-const MAX_NO_REUSE_VERSIONS = 100;
+export const MAX_PREVENT_VALUE_REUSE_VERSIONS = 25;
 
 export const constraintSchema = z
   .object({
@@ -120,10 +120,10 @@ export const constraintSchema = z
     (c) => {
       if (c.type !== ConstraintType.PreventValueReuse) return true;
       const num = Number(c.value);
-      return Number.isInteger(num) && num >= 1 && num <= MAX_NO_REUSE_VERSIONS;
+      return Number.isInteger(num) && num >= 1 && num <= MAX_PREVENT_VALUE_REUSE_VERSIONS;
     },
     {
-      message: `Must be a number between 1 and ${MAX_NO_REUSE_VERSIONS}`,
+      message: `Must be a number between 1 and ${MAX_PREVENT_VALUE_REUSE_VERSIONS}`,
       path: ["value"]
     }
   );


### PR DESCRIPTION
## Context

Added a new secret validation constraint for disallowing the reuse of previous secret values. We have a hard limit of a maximum of 100 previous secret versions to check, or it might get too heavy on the computational side of things. We allow the user to configure this limit in the UI when they create the new constraints, but have a hard limit of 100 secret versions to check. 

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)