### PR TITLE
fix: resolved the user id going null

### DIFF
--- a/backend/src/ee/services/group/group-fns.ts
+++ b/backend/src/ee/services/group/group-fns.ts
@@ -34,7 +34,7 @@ const addAcceptedUsersToGroup = async ({
 
   await userGroupMembershipDAL.insertMany(
     users.map((user) => ({
-      userId: user.userId,
+      userId: user.id,
       groupId: group.id,
       isPending: false
     })),
@@ -82,7 +82,7 @@ const addAcceptedUsersToGroup = async ({
       continue;
     }
 
-    const usersToAddProjectKeyFor = users.filter((u) => !userKeysSet.has(`${projectId}-${u.userId}`));
+    const usersToAddProjectKeyFor = users.filter((u) => !userKeysSet.has(`${projectId}-${u.id}`));
 
     if (usersToAddProjectKeyFor.length) {
       // there are users who need to be shared keys
@@ -149,7 +149,7 @@ const addAcceptedUsersToGroup = async ({
           encryptedKey,
           nonce,
           senderId: ghostUser.id,
-          receiverId: user.userId,
+          receiverId: user.id,
           projectId
         };
       });

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -91,7 +91,9 @@ export const userDALFactory = (db: TDbClient) => {
           isGhost: false
         })
         .whereIn(`${TableName.Users}.id`, userIds)
-        .leftJoin(TableName.UserEncryptionKey, `${TableName.Users}.id`, `${TableName.UserEncryptionKey}.userId`);
+        .leftJoin(TableName.UserEncryptionKey, `${TableName.Users}.id`, `${TableName.UserEncryptionKey}.userId`)
+        .select(selectAllTableCols(TableName.Users))
+        .select(db.ref("publicKey").withSchema(TableName.UserEncryptionKey));
     } catch (error) {
       throw new DatabaseError({ error, name: "Find user enc by user ids batch" });
     }


### PR DESCRIPTION
## Context

This PR fixes the user id going null for left join user encryption as it's not needed anymore for new users

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)