### PR TITLE
fix(frontend): invalidate approval request queries at project scope

### DIFF
--- a/frontend/src/hooks/api/accessApproval/mutation.tsx
+++ b/frontend/src/hooks/api/accessApproval/mutation.tsx
@@ -136,6 +136,9 @@ export const useCreateAccessRequest = () => {
       queryClient.invalidateQueries({
         queryKey: accessApprovalKeys.getAccessApprovalRequestCount(projectSlug)
       });
+      queryClient.invalidateQueries({
+        queryKey: accessApprovalKeys.getAccessApprovalRequestsAllForProject(projectSlug)
+      });
     }
   });
 };
@@ -153,7 +156,7 @@ export const useUpdateAccessRequest = () => {
     },
     onSuccess: (_, { projectSlug }) => {
       queryClient.invalidateQueries({
-        queryKey: accessApprovalKeys.getAccessApprovalRequests(projectSlug)
+        queryKey: accessApprovalKeys.getAccessApprovalRequestsAllForProject(projectSlug)
       });
     }
   });
@@ -177,7 +180,7 @@ export const useRevokeAccessRequest = () => {
     },
     onSuccess: (_, { projectSlug }) => {
       queryClient.invalidateQueries({
-        queryKey: accessApprovalKeys.getAccessApprovalRequests(projectSlug)
+        queryKey: accessApprovalKeys.getAccessApprovalRequestsAllForProject(projectSlug)
       });
       queryClient.invalidateQueries({
         queryKey: accessApprovalKeys.getAccessApprovalRequestCount(projectSlug)
@@ -210,14 +213,9 @@ export const useReviewAccessRequest = () => {
       );
       return data;
     },
-    onSuccess: (_, { projectSlug, envSlug, requestedBy, bypassReason }) => {
+    onSuccess: (_, { projectSlug }) => {
       queryClient.invalidateQueries({
-        queryKey: accessApprovalKeys.getAccessApprovalRequests(
-          projectSlug,
-          envSlug,
-          requestedBy,
-          bypassReason
-        )
+        queryKey: accessApprovalKeys.getAccessApprovalRequestsAllForProject(projectSlug)
       });
       queryClient.invalidateQueries({
         queryKey: accessApprovalKeys.getAccessApprovalRequestCount(projectSlug)

--- a/frontend/src/hooks/api/accessApproval/mutation.tsx
+++ b/frontend/src/hooks/api/accessApproval/mutation.tsx
@@ -198,8 +198,6 @@ export const useReviewAccessRequest = () => {
       requestId: string;
       status: "approved" | "rejected";
       projectSlug: string;
-      envSlug?: string;
-      requestedBy?: string;
       bypassReason?: string;
     }
   >({

--- a/frontend/src/hooks/api/accessApproval/queries.tsx
+++ b/frontend/src/hooks/api/accessApproval/queries.tsx
@@ -25,6 +25,8 @@ export const accessApprovalKeys = {
     requestedBy?: string,
     bypassReason?: string
   ) => ["access-approvals-requests", projectSlug, envSlug, requestedBy, bypassReason] as const,
+  getAccessApprovalRequestsAllForProject: (projectSlug: string) =>
+    ["access-approvals-requests", projectSlug] as const,
   getAccessApprovalRequestCount: (projectSlug: string, policyId?: string) =>
     [{ projectSlug }, "access-approval-request-count", ...(policyId ? [policyId] : [])] as const
 };

--- a/frontend/src/hooks/api/secretApprovalRequest/mutation.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/mutation.tsx
@@ -22,7 +22,9 @@ export const useUpdateSecretApprovalReviewStatus = () => {
     },
     onSuccess: (_, { id, projectId }) => {
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.detail({ id }) });
-      queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.list({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
     }
   });
@@ -40,6 +42,9 @@ export const useUpdateSecretApprovalRequestStatus = () => {
     },
     onSuccess: (_, { id, projectId }) => {
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.detail({ id }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
     }
   });
@@ -57,7 +62,9 @@ export const usePerformSecretApprovalRequestMerge = () => {
     },
     onSuccess: (_, { id, projectId }) => {
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.detail({ id }) });
-      queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.list({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
     }
   });

--- a/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
+++ b/frontend/src/hooks/api/secretApprovalRequest/queries.tsx
@@ -26,6 +26,8 @@ export const secretApprovalRequestKeys = {
       { projectId, environment, status, committer, offset, limit, search },
       "secret-approval-requests"
     ] as const,
+  listAllForProject: ({ projectId }: { projectId: string }) =>
+    [{ projectId }, "secret-approval-requests"] as const,
   detail: ({ id }: Omit<TGetSecretApprovalRequestDetails, "decryptKey">) =>
     [{ id }, "secret-approval-request-detail"] as const,
   count: ({ projectId, policyId }: TGetSecretApprovalRequestCount) => [

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -80,6 +80,9 @@ export const useCreateSecretV3 = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -151,6 +154,9 @@ export const useUpdateSecretV3 = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -202,6 +208,9 @@ export const useDeleteSecretV3 = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -250,6 +259,9 @@ export const useCreateSecretBatch = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -298,6 +310,9 @@ export const useUpdateSecretBatch = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -348,6 +363,9 @@ export const useDeleteSecretBatch = ({
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     },
     ...options
   });
@@ -438,6 +456,9 @@ export const useMoveSecrets = ({
       });
       queryClient.invalidateQueries({
         queryKey: secretApprovalRequestKeys.count({ projectId })
+      });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
       });
     },
     ...options
@@ -560,6 +581,9 @@ export const useCreateCommit = () => {
         queryKey: commitKeys.history({ projectId, environment, directory: secretPath })
       });
       queryClient.invalidateQueries({ queryKey: secretApprovalRequestKeys.count({ projectId }) });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
     }
   });
 };

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
@@ -633,9 +633,7 @@ export const AccessApprovalRequest = ({
 
       {!!selectedRequest && (
         <ReviewAccessRequestModal
-          selectedEnvSlug={envFilter}
           policies={policies || []}
-          selectedRequester={requestedByFilter}
           projectSlug={projectSlug}
           request={selectedRequest}
           members={members || []}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
@@ -94,8 +94,6 @@ export const ReviewAccessRequestModal = ({
   onOpenChange,
   request,
   projectSlug,
-  selectedRequester,
-  selectedEnvSlug,
   canBypass,
   policies = [],
   members = [],
@@ -110,8 +108,6 @@ export const ReviewAccessRequestModal = ({
     isApprover: boolean;
   };
   projectSlug: string;
-  selectedRequester: string | undefined;
-  selectedEnvSlug: string | undefined;
   canBypass: boolean;
   policies: TAccessApprovalPolicy[];
   members: TWorkspaceUser[];
@@ -216,8 +212,6 @@ export const ReviewAccessRequestModal = ({
           requestId: request.id,
           status,
           projectSlug,
-          envSlug: selectedEnvSlug,
-          requestedBy: selectedRequester,
           bypassReason: bypassApproval ? bypassReason : undefined
         });
 
@@ -234,15 +228,7 @@ export const ReviewAccessRequestModal = ({
       setIsLoading(null);
       onOpenChange(false);
     },
-    [
-      bypassApproval,
-      bypassReason,
-      reviewAccessRequest,
-      request,
-      selectedEnvSlug,
-      selectedRequester,
-      onOpenChange
-    ]
+    [bypassApproval, bypassReason, reviewAccessRequest, request, onOpenChange]
   );
 
   const handleRevoke = useCallback(async () => {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -652,8 +652,10 @@ export const ActionBar = ({
       queryClient.invalidateQueries({
         queryKey: secretApprovalRequestKeys.count({ projectId })
       });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
 
-      // Close the modal and show notification
       handlePopUpClose("confirmUpload");
       createNotification({
         type: "success",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretListView.tsx
@@ -435,6 +435,9 @@ export const SecretListView = ({
       queryClient.invalidateQueries({
         queryKey: secretApprovalRequestKeys.count({ projectId })
       });
+      queryClient.invalidateQueries({
+        queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
+      });
       if (!isReminderEvent) {
         handlePopUpClose("secretDetail");
       }
@@ -544,6 +547,9 @@ export const SecretListView = ({
     });
     queryClient.invalidateQueries({
       queryKey: secretApprovalRequestKeys.count({ projectId })
+    });
+    queryClient.invalidateQueries({
+      queryKey: secretApprovalRequestKeys.listAllForProject({ projectId })
     });
     handlePopUpClose("deleteSecret");
     handlePopUpClose("secretDetail");


### PR DESCRIPTION
## Context

- **Frontend:** Invalidate project-scoped React Query keys for secret approval requests (`listAllForProject`) and access approval requests (`getAccessApprovalRequestsAllForProject`) so lists stay fresh when filters differ from the old narrower keys. Wired from approval mutations, secret mutations, `ActionBar`, and `SecretListView`.

## Steps to verify

1. Secret/access approval flows: act on requests and secrets; confirm approval lists and counts update without reload.

## Type

- [x] Fix  
- [ ] Feature  
- [ ] Improvement  
- [ ] Breaking  
- [ ] Docs  
- [ ] Chore  

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)