### PR TITLE
fix: hiccups found in the application

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
@@ -260,7 +260,7 @@ export interface TAccessApprovalRequestDALFactory extends Omit<TOrmify<TableName
       bypassers: string[];
     }[]
   >;
-  getCount: ({ projectId }: { projectId: string; policyId?: string }) => Promise<{
+  getCount: ({ projectId }: { projectId: string; policyId?: string; requestedByUserId?: string }) => Promise<{
     pendingCount: number;
     finalizedCount: number;
   }>;
@@ -872,7 +872,7 @@ export const accessApprovalRequestDALFactory = (db: TDbClient): TAccessApprovalR
     }
   };
 
-  const getCount: TAccessApprovalRequestDALFactory["getCount"] = async ({ projectId, policyId }) => {
+  const getCount: TAccessApprovalRequestDALFactory["getCount"] = async ({ projectId, policyId, requestedByUserId }) => {
     try {
       const accessRequests = await db
         .replicaNode()(TableName.AccessApprovalRequest)
@@ -895,7 +895,12 @@ export const accessApprovalRequestDALFactory = (db: TDbClient): TAccessApprovalR
         )
         .where(`${TableName.Environment}.projectId`, projectId)
         .where((qb) => {
-          if (policyId) void qb.where(`${TableName.AccessApprovalPolicy}.id`, policyId);
+          if (policyId) {
+            void qb.where(`${TableName.AccessApprovalPolicy}.id`, policyId);
+          }
+          if (requestedByUserId) {
+            void qb.where(`${TableName.AccessApprovalRequest}.requestedByUserId`, requestedByUserId);
+          }
         })
         .select(selectAllTableCols(TableName.AccessApprovalRequest))
         .select(db.ref("status").withSchema(TableName.AccessApprovalRequestReviewer).as("reviewerStatus"))

--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -29,7 +29,11 @@ import { TAccessApprovalPolicyApproverDALFactory } from "../access-approval-poli
 import { TAccessApprovalPolicyDALFactory } from "../access-approval-policy/access-approval-policy-dal";
 import { TGroupDALFactory } from "../group/group-dal";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
-import { ProjectPermissionMemberActions, ProjectPermissionSub } from "../permission/project-permission";
+import {
+  ProjectPermissionApprovalRequestActions,
+  ProjectPermissionMemberActions,
+  ProjectPermissionSub
+} from "../permission/project-permission";
 import { TAccessApprovalRequestDALFactory } from "./access-approval-request-dal";
 import { verifyRequestedPermissions } from "./access-approval-request-fns";
 import { TAccessApprovalRequestReviewerDALFactory } from "./access-approval-request-reviewer-dal";
@@ -502,7 +506,7 @@ export const accessApprovalRequestServiceFactory = ({
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
-    await permissionService.getProjectPermission({
+    const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
       projectId: project.id,
@@ -511,8 +515,17 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
+    const canReadAllApprovalRequests = permission.can(
+      ProjectPermissionApprovalRequestActions.Read,
+      ProjectPermissionSub.ApprovalRequests
+    );
+
     const policies = await accessApprovalPolicyDAL.find({ projectId: project.id });
     let requests = await accessApprovalRequestDAL.findRequestsWithPrivilegeByPolicyIds(policies.map((p) => p.id));
+
+    if (!canReadAllApprovalRequests) {
+      requests = requests.filter((request) => request.requestedByUserId === actorId);
+    }
 
     if (authorUserId) {
       requests = requests.filter((request) => request.requestedByUserId === authorUserId);
@@ -915,7 +928,7 @@ export const accessApprovalRequestServiceFactory = ({
     const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
     if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
 
-    await permissionService.getProjectPermission({
+    const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
       projectId: project.id,
@@ -924,7 +937,16 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
-    const count = await accessApprovalRequestDAL.getCount({ projectId: project.id, policyId });
+    const canReadAllApprovalRequests = permission.can(
+      ProjectPermissionApprovalRequestActions.Read,
+      ProjectPermissionSub.ApprovalRequests
+    );
+
+    const count = await accessApprovalRequestDAL.getCount({
+      projectId: project.id,
+      policyId,
+      requestedByUserId: canReadAllApprovalRequests ? undefined : actorId
+    });
 
     return { count };
   };

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -454,7 +454,7 @@ const envSchema = z
         })
     ),
 
-    /* Reverse Proxy ----------------------------------------------------------------------------- */
+    // Reverse Proxy -----------------------------------------------------------------------------
     // Comma-separated list of trusted proxy CIDRs (e.g. "10.0.0.0/8,172.16.0.0/12") or
     // proxy-addr aliases ("loopback", "linklocal", "uniquelocal"). When set, requests whose
     // socket remote address is NOT in this set will have forwarded-IP headers ignored; the

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -454,6 +454,14 @@ const envSchema = z
         })
     ),
 
+    /* Reverse Proxy ----------------------------------------------------------------------------- */
+    // Comma-separated list of trusted proxy CIDRs (e.g. "10.0.0.0/8,172.16.0.0/12") or
+    // proxy-addr aliases ("loopback", "linklocal", "uniquelocal"). When set, requests whose
+    // socket remote address is NOT in this set will have forwarded-IP headers ignored; the
+    // socket address is used as the real IP. When unset, legacy first-header-wins behavior
+    // is preserved for backwards compatibility.
+    TRUSTED_PROXY_CIDRS: zpStr(z.string().optional()),
+
     /* OracleDB ----------------------------------------------------------------------------- */
     TNS_ADMIN: zpStr(z.string().optional()),
 

--- a/backend/src/lib/knex/scim.ts
+++ b/backend/src/lib/knex/scim.ts
@@ -3,8 +3,8 @@ import { Compare, Filter, parse } from "scim2-parse-filter";
 
 import { TableName } from "@app/db/schemas";
 
-import { sanitizeSqlLikeString } from "../fn";
 import { BadRequestError } from "../errors";
+import { sanitizeSqlLikeString } from "../fn";
 
 const appendParentToGroupingOperator = (parentPath: string, filter: Filter) => {
   if (filter.op !== "[]" && filter.op !== "and" && filter.op !== "or" && filter.op !== "not") {

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -75,7 +75,9 @@ export const main = async ({
   const server = fastify({
     logger: appCfg.NODE_ENV === "test" ? false : logger,
     genReqId: () => `req-${alphaNumericNanoId(14)}`,
-    trustProxy: true,
+    // When TRUSTED_PROXY_CIDRS is configured, only requests from those sources have their
+    // forwarded-IP headers honored. Unset preserves legacy behavior (trust all) for backcompat.
+    trustProxy: appCfg.TRUSTED_PROXY_CIDRS ?? true,
 
     connectionTimeout: 100_000,
     ignoreTrailingSlash: true,

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -176,38 +176,42 @@ export const injectIdentity = fp(
         return;
       }
 
+      // Match against the pathname only — req.url includes the query string, which a
+      // client can use to smuggle matching substrings and skip auth injection.
+      const pathname = req.url.split("?", 1)[0];
+
       if (
-        req.url.startsWith("/.well-known/est") ||
-        (req.url.startsWith("/api/v3/auth/") && !req.url.startsWith("/api/v3/auth/select-organization"))
+        pathname.startsWith("/.well-known/est") ||
+        (pathname.startsWith("/api/v3/auth/") && !pathname.startsWith("/api/v3/auth/select-organization"))
       ) {
         return;
       }
 
-      if (req.url.includes("/scep/") && req.url.includes("pkiclient.exe")) {
+      if (pathname.includes("/scep/") && pathname.includes("pkiclient.exe")) {
         return;
       }
 
-      if (req.url === "/api/v1/ai/mcp/servers/oauth/callback") {
+      if (pathname === "/api/v1/ai/mcp/servers/oauth/callback") {
         return;
       }
 
       // Authentication is handled on a route-level
-      if (req.url === "/api/v1/relays/register-instance-relay") {
+      if (pathname === "/api/v1/relays/register-instance-relay") {
         return;
       }
 
       // Authentication is handled on a route-level (enrollment token in body)
-      if (req.url === "/api/v3/gateways/token-auth/enroll") {
+      if (pathname === "/api/v3/gateways/token-auth/enroll") {
         return;
       }
 
       // Authentication is handled on a route-level
-      if (req.url === "/api/v1/relays/heartbeat-instance-relay") {
+      if (pathname === "/api/v1/relays/heartbeat-instance-relay") {
         return;
       }
 
       // Authentication is handled on a route-level here.
-      if (req.url.startsWith("/api/v1/workflow-integrations/microsoft-teams/message-endpoint")) {
+      if (pathname.startsWith("/api/v1/workflow-integrations/microsoft-teams/message-endpoint")) {
         return;
       }
 

--- a/backend/src/server/plugins/ip.ts
+++ b/backend/src/server/plugins/ip.ts
@@ -1,5 +1,7 @@
 import fp from "fastify-plugin";
 
+import { getConfig } from "@app/lib/config/env";
+
 /*! https://github.com/pbojinov/request-ip/blob/9501cdf6e73059cc70fc6890adb086348d7cca46/src/index.js.
   MIT License. 2022 Petar Bojinov - petarbojinov+github@gmail.com */
 const headersOrder = [
@@ -20,7 +22,18 @@ const headersOrder = [
 
 export const fastifyIp = fp(async (fastify) => {
   fastify.decorateRequest("realIp", null);
+  const { TRUSTED_PROXY_CIDRS } = getConfig();
   fastify.addHook("onRequest", async (req) => {
+    // Strict mode: TRUSTED_PROXY_CIDRS configured → delegate to Fastify's proxy-addr-backed
+    // req.ip, which validates the socket source against the trusted CIDR list and parses
+    // X-Forwarded-For right-to-left, discarding attacker-supplied values.
+    if (TRUSTED_PROXY_CIDRS) {
+      req.realIp = req.ip;
+      return;
+    }
+
+    // Legacy mode: first-matching-header wins. Preserved for backwards compatibility
+    // with self-hosted deployments that haven't configured a trusted proxy list.
     const forwardedIpHeader = headersOrder.find((header) => Boolean(req.headers[header]));
     const forwardedIp = forwardedIpHeader ? req.headers[forwardedIpHeader] : undefined;
     if (forwardedIp) {


### PR DESCRIPTION
## Context

- VULN-236: IP allowlist bypass via spoofed proxy headers 
- VULN-240: Auth identity injection skipped for any URL containing auth-path substrings in query string
- VULN-243: Missing permission read check for access approval requests, scoped down to only show own requests

## Steps to verify the change

## Type

- [X] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [X] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)