### PR TITLE
fix(auth): correct accessTokenTTL fallback in update*Auth validation

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -472,7 +472,7 @@ export const identityAwsAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityAwsAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityAwsAuth.accessTokenTTL) > (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -368,11 +368,11 @@ export const identityAzureAuthServiceFactory = ({
       });
     }
 
-    const identityGcpAuth = await identityAzureAuthDAL.findOne({ identityId });
+    const identityAzureAuth = await identityAzureAuthDAL.findOne({ identityId });
 
     if (
-      (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityGcpAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
+      (accessTokenMaxTTL || identityAzureAuth.accessTokenMaxTTL) > 0 &&
+      (accessTokenTTL || identityAzureAuth.accessTokenTTL) > (accessTokenMaxTTL || identityAzureAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }
@@ -420,7 +420,7 @@ export const identityAzureAuthServiceFactory = ({
       return extractIPDetails(accessTokenTrustedIp.ipAddress);
     });
 
-    const updatedAzureAuth = await identityAzureAuthDAL.updateById(identityGcpAuth.id, {
+    const updatedAzureAuth = await identityAzureAuthDAL.updateById(identityAzureAuth.id, {
       tenantId,
       resource,
       allowedServicePrincipalIds,

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -418,7 +418,7 @@ export const identityGcpAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityGcpAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityGcpAuth.accessTokenTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -564,7 +564,7 @@ export const identityJwtAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityJwtAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityJwtAuth.accessTokenTTL) > (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -933,7 +933,7 @@ export const identityKubernetesAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityKubernetesAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityKubernetesAuth.accessTokenMaxTTL) >
+      (accessTokenTTL || identityKubernetesAuth.accessTokenTTL) >
         (accessTokenMaxTTL || identityKubernetesAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -667,7 +667,7 @@ export const identityOidcAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityOidcAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityOidcAuth.accessTokenTTL) > (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-token-auth/identity-token-auth-service.ts
+++ b/backend/src/services/identity-token-auth/identity-token-auth-service.ts
@@ -208,8 +208,7 @@ export const identityTokenAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityTokenAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityTokenAuth.accessTokenMaxTTL) >
-        (accessTokenMaxTTL || identityTokenAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityTokenAuth.accessTokenTTL) > (accessTokenMaxTTL || identityTokenAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -563,7 +563,7 @@ export const identityUaServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || uaIdentityAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL)
+      (accessTokenTTL || uaIdentityAuth.accessTokenTTL) > (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }


### PR DESCRIPTION
## Context

Fixes incorrect TTL validation in all `update*Auth` functions across 8 identity auth services.

When `accessTokenTTL` is omitted from an update payload, the fallback incorrectly uses `existing.accessTokenMaxTTL` instead of `existing.accessTokenTTL`:

```ts
// Buggy — left side falls back to wrong field
(accessTokenTTL || existing.accessTokenMaxTTL) > (accessTokenMaxTTL || existing.accessTokenMaxTTL)

// Fixed
(accessTokenTTL || existing.accessTokenTTL) > (accessTokenMaxTTL || existing.accessTokenMaxTTL)
```

This turns the check into `existingMaxTTL > newMaxTTL` instead of `existingTTL > newMaxTTL`, causing valid partial updates to be incorrectly rejected.

**Example:** Existing state: `accessTokenTTL=3600`, `accessTokenMaxTTL=7200`. Calling update with only `{ accessTokenMaxTTL: 5000 }` (valid — 3600 < 5000):

- Buggy: `7200 > 5000 → true` → throws `BadRequestError`
- Fixed: `3600 > 5000 → false` → update succeeds

The `attach*Auth` functions in all affected files already use the correct pattern. `identity-ldap-auth-service.ts` and `identity-oci-auth-service.ts` also already have the correct fallback — this PR aligns the remaining 8 services with the existing correct implementation.

**Additionally** - `identity-azure-auth-service.ts` had the DB result variable incorrectly named `identityGcpAuth` instead of `identityAzureAuth`. Renamed for correctness.

## Screenshots

N/A — backend validation logic only, no UI changes.

## Steps to verify the change

1. Configure any affected identity auth method with `accessTokenTTL=3600`, `accessTokenMaxTTL=7200`.
2. Call the update endpoint with only `{ accessTokenMaxTTL: 5000 }` (omit `accessTokenTTL`).
3. **Before:** fails with `Access token TTL cannot be greater than max TTL`
4. **After:** succeeds — `3600 < 5000` is correctly evaluated

## Type
- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [X] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [X] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [X] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)