### PR TITLE
feat(frontend): add button to reveal secret reference values

### DIFF
--- a/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
@@ -1,0 +1,149 @@
+import { AxiosError } from "axios";
+import { ClipboardCheckIcon, CopyIcon, LinkIcon } from "lucide-react";
+
+import {
+  IconButton,
+  Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  SecretInput,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import { useProject } from "@app/context";
+import { useTimedReset } from "@app/hooks";
+import { useGetSecretReferenceTree } from "@app/hooks/api";
+import { ApiErrorTypes, TApiErrors } from "@app/hooks/api/types";
+
+type Props = {
+  environment: string;
+  secretPath: string;
+  secretKey: string;
+};
+
+type PopoverProps = Props & {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isDisabled?: boolean;
+};
+
+const ResolvedValueContent = ({ environment, secretPath, secretKey }: Props) => {
+  const { currentProject } = useProject();
+  const projectId = currentProject?.id || "";
+  const [isCopied, , setIsCopied] = useTimedReset<boolean>({ initialState: false });
+
+  const { data, isPending, isError, error } = useGetSecretReferenceTree({
+    secretPath,
+    environmentSlug: environment,
+    projectId,
+    secretKey
+  });
+
+  if (isPending) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-9 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    const axiosError = error instanceof AxiosError ? error : undefined;
+    const apiError = axiosError?.response?.data as TApiErrors | undefined;
+    const isForbidden = apiError?.error === ApiErrorTypes.CustomForbiddenError;
+
+    return (
+      <p className="text-sm text-danger">
+        {isForbidden
+          ? "You do not have permission to view one of the referenced secrets."
+          : "Failed to resolve secret value."}
+      </p>
+    );
+  }
+
+  const handleCopy = async () => {
+    try {
+      await window.navigator.clipboard.writeText(data?.value ?? "");
+      setIsCopied(true);
+    } catch {
+      // swallow; clipboard unavailable
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <Label className="text-sm font-normal" htmlFor="resolved-secret-value">
+          Resolved value
+        </Label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconButton
+              variant="ghost-muted"
+              size="xs"
+              onClick={handleCopy}
+              aria-label="Copy resolved value"
+            >
+              {isCopied ? <ClipboardCheckIcon /> : <CopyIcon />}
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>{isCopied ? "Copied" : "Copy"}</TooltipContent>
+        </Tooltip>
+      </div>
+      <SecretInput
+        containerClassName="font-mono"
+        id="resolved-secret-value"
+        isReadOnly
+        isVisible
+        value={data?.value ?? ""}
+      />
+    </div>
+  );
+};
+
+export const ResolvedSecretValuePopover = ({
+  environment,
+  secretPath,
+  secretKey,
+  open,
+  onOpenChange,
+  isDisabled
+}: PopoverProps) => {
+  return (
+    <Popover open={open && !isDisabled} onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <IconButton
+              variant="ghost-muted"
+              size="xs"
+              className="absolute -top-1 -left-1"
+              aria-label="View resolved secret value"
+              isDisabled={isDisabled}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              <LinkIcon />
+            </IconButton>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isDisabled ? "Save pending changes to view resolved value" : "View resolved value"}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent align="start" className="w-96" onOpenAutoFocus={(e) => e.preventDefault()}>
+        {open && (
+          <ResolvedValueContent
+            environment={environment}
+            secretPath={secretPath}
+            secretKey={secretKey}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
@@ -79,7 +79,7 @@ const ResolvedValueContent = ({ environment, secretPath, secretKey }: Props) => 
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <Label className="text-sm font-normal" htmlFor="resolved-secret-value">
+        <Label className="text-sm font-normal text-accent" htmlFor="resolved-secret-value">
           Resolved value
         </Label>
         <Tooltip>

--- a/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
@@ -78,9 +78,9 @@ const ResolvedValueContent = ({ environment, secretPath, secretKey }: Props) => 
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between">
-        <Label className="text-sm font-normal text-accent" htmlFor="resolved-secret-value">
-          Resolved value
+      <div className="mb-2 flex items-center justify-between border-b border-border pb-2">
+        <Label className="text-sm font-normal text-foreground" htmlFor="resolved-secret-value">
+          Resolved Value
         </Label>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
@@ -1,5 +1,6 @@
 import { AxiosError } from "axios";
 import { ClipboardCheckIcon, CopyIcon, LinkIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
 
 import {
   IconButton,
@@ -121,10 +122,16 @@ export const ResolvedSecretValuePopover = ({
             <IconButton
               variant="ghost-muted"
               size="xs"
-              className="absolute -top-1 -left-1"
+              className={twMerge(
+                "absolute -top-1 -left-1",
+                isDisabled && "cursor-not-allowed opacity-50"
+              )}
               aria-label="View resolved secret value"
-              isDisabled={isDisabled}
-              onClick={(e) => e.stopPropagation()}
+              aria-disabled={isDisabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (isDisabled) e.preventDefault();
+              }}
               onMouseDown={(e) => e.preventDefault()}
             >
               <LinkIcon />

--- a/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/ResolvedSecretValuePopover.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { AxiosError } from "axios";
 import { ClipboardCheckIcon, CopyIcon, LinkIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
@@ -114,6 +115,10 @@ export const ResolvedSecretValuePopover = ({
   onOpenChange,
   isDisabled
 }: PopoverProps) => {
+  useEffect(() => {
+    if (isDisabled && open) onOpenChange(false);
+  }, [isDisabled, open, onOpenChange]);
+
   return (
     <Popover open={open && !isDisabled} onOpenChange={onOpenChange}>
       <Tooltip>
@@ -142,7 +147,12 @@ export const ResolvedSecretValuePopover = ({
           {isDisabled ? "Save pending changes to view resolved value" : "View resolved value"}
         </TooltipContent>
       </Tooltip>
-      <PopoverContent align="start" className="w-96" onOpenAutoFocus={(e) => e.preventDefault()}>
+      <PopoverContent
+        align="start"
+        className="w-96"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
         {open && (
           <ResolvedValueContent
             environment={environment}

--- a/frontend/src/components/secrets/SecretReferenceDetails/index.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/index.tsx
@@ -1,2 +1,3 @@
+export { ResolvedSecretValuePopover } from "./ResolvedSecretValuePopover";
 export { SecretReferenceCloseContext } from "./SecretReferenceContext";
 export { hasSecretReference, SecretReferenceTree } from "./SecretReferenceDetails";

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -464,7 +464,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
           <Popover.Content
             align="start"
             onOpenAutoFocus={(e) => e.preventDefault()}
-            className="relative top-2 z-100 max-h-64 thin-scrollbar overflow-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md"
+            className="relative top-2 z-100 max-h-64 thin-scrollbar min-w-80 overflow-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md"
             style={{
               width: "var(--radix-popover-trigger-width)"
             }}

--- a/frontend/src/components/v3/generic/Label/Label.tsx
+++ b/frontend/src/components/v3/generic/Label/Label.tsx
@@ -9,7 +9,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium text-accent select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/v3/generic/Label/Label.tsx
+++ b/frontend/src/components/v3/generic/Label/Label.tsx
@@ -9,7 +9,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium text-accent select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/v3/generic/Popover/Popover.tsx
+++ b/frontend/src/components/v3/generic/Popover/Popover.tsx
@@ -9,9 +9,13 @@ function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
-}
+const PopoverTrigger = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Trigger>,
+  React.ComponentProps<typeof PopoverPrimitive.Trigger>
+>(({ ...props }, ref) => (
+  <PopoverPrimitive.Trigger ref={ref} data-slot="popover-trigger" {...props} />
+));
+PopoverTrigger.displayName = "PopoverTrigger";
 
 function PopoverContent({
   className,

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -579,6 +579,11 @@ export const useCreateCommit = () => {
         queryKey: secretKeys.getProjectSecret({ projectId, environment, secretPath })
       });
       queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "secret-reference-tree" &&
+          (query.queryKey[1] as { projectId?: string })?.projectId === projectId
+      });
+      queryClient.invalidateQueries({
         queryKey: secretSnapshotKeys.list({ environment, projectId, directory: secretPath })
       });
       queryClient.invalidateQueries({

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -142,6 +142,11 @@ export const useUpdateSecretV3 = ({
         queryKey: secretKeys.getProjectSecret({ projectId, environment, secretPath })
       });
       queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "secret-reference-tree" &&
+          (query.queryKey[1] as { projectId?: string })?.projectId === projectId
+      });
+      queryClient.invalidateQueries({
         queryKey: secretSnapshotKeys.list({ environment, projectId, directory: secretPath })
       });
       queryClient.invalidateQueries({
@@ -296,6 +301,11 @@ export const useUpdateSecretBatch = ({
       });
       queryClient.invalidateQueries({
         queryKey: secretKeys.getProjectSecret({ projectId, environment, secretPath })
+      });
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "secret-reference-tree" &&
+          (query.queryKey[1] as { projectId?: string })?.projectId === projectId
       });
       queryClient.invalidateQueries({
         queryKey: secretSnapshotKeys.list({ environment, projectId, directory: secretPath })

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -27,7 +27,11 @@ import { twMerge } from "tailwind-merge";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { SecretReferenceTree } from "@app/components/secrets/SecretReferenceDetails";
+import {
+  hasSecretReference,
+  ResolvedSecretValuePopover,
+  SecretReferenceTree
+} from "@app/components/secrets/SecretReferenceDetails";
 import { DeleteActionModal, Input, Modal, ModalContent } from "@app/components/v2";
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import {
@@ -188,6 +192,8 @@ export const SecretEditTableRow = ({
   const batchStore = useBatchStoreApi();
 
   const [isFieldFocused, setIsFieldFocused] = useToggle();
+  const [isResolvedValueOpen, setIsResolvedValueOpen] = useToggle();
+  const isFieldActive = isFieldFocused || isResolvedValueOpen;
   const [isCopied, , setIsCopied] = useTimedReset<boolean>({ initialState: false });
 
   const fetchSharedValueParams =
@@ -214,7 +220,7 @@ export const SecretEditTableRow = ({
     isError: isErrorFetchingSharedValue,
     refetch: refetchSharedValue
   } = useGetSecretValue(fetchSharedValueParams, {
-    enabled: canFetchSharedValue && (isVisible || isFieldFocused)
+    enabled: canFetchSharedValue && (isVisible || isFieldActive)
   });
 
   const isFetchingSharedValue = canFetchSharedValue && isPendingSharedValue;
@@ -880,6 +886,8 @@ export const SecretEditTableRow = ({
   const isDirtyState =
     isDirty && (dirtyFields.key || dirtyFields.value) && !isImportedSecret && !isBatchMode;
 
+  const secretHasReference = hasSecretReference(watchedValue as string);
+
   const valueContent = (
     <>
       <DeleteActionModal
@@ -904,11 +912,21 @@ export const SecretEditTableRow = ({
         )}
         <div
           className={twMerge(
-            "grow pr-2 pl-1",
-            isFieldFocused && !isBatchMode && "pr-16",
-            isFieldFocused && isBatchMode && "pr-6"
+            "relative grow pr-2 pl-1",
+            isFieldActive && !isBatchMode && "pr-16",
+            isFieldActive && isBatchMode && "pr-6"
           )}
         >
+          {isFieldActive && !secretValueHidden && !isCreatable && secretHasReference && (
+            <ResolvedSecretValuePopover
+              environment={environment}
+              secretPath={secretPath}
+              secretKey={secretName}
+              open={isResolvedValueOpen}
+              onOpenChange={setIsResolvedValueOpen.toggle}
+              isDisabled={isDirtyState || hasPendingValueChange}
+            />
+          )}
           <Controller
             control={control}
             name="value"
@@ -926,13 +944,14 @@ export const SecretEditTableRow = ({
                         : (field.value as string)
                 }
                 key="secret-input-shared"
-                isVisible={isVisible}
+                isVisible={isVisible || isResolvedValueOpen}
                 secretPath={secretPath}
                 environment={environment}
                 isImport={isImportedSecret}
                 defaultValue={secretValueHidden ? "" : undefined}
                 canEditButNotView={secretValueHidden}
                 onFocus={() => setIsFieldFocused.on()}
+                containerClassName={secretHasReference && isFieldActive ? "pl-6" : ""}
                 onBlur={() => {
                   field.onBlur();
                   setIsFieldFocused.off();
@@ -941,7 +960,7 @@ export const SecretEditTableRow = ({
             )}
           />
         </div>
-        {!isDirtyState && !isFieldFocused && (
+        {!isDirtyState && !isFieldActive && (
           <div className="flex w-fit items-start justify-end self-start pl-2">
             <div className="flex items-center gap-1">
               {comment && !isImportedSecret && (
@@ -1051,7 +1070,7 @@ export const SecretEditTableRow = ({
           </div>
         </div>
       )}
-      {isFieldFocused &&
+      {isFieldActive &&
         !(
           isDirty &&
           (dirtyFields.key || dirtyFields.value) &&
@@ -1084,10 +1103,10 @@ export const SecretEditTableRow = ({
             "pointer-events-none opacity-0 transition-all duration-300",
             "group-hover:pointer-events-auto group-hover:gap-1 group-hover:opacity-100",
             shouldStayExpanded && "pointer-events-auto gap-1 opacity-100",
-            isFieldFocused &&
+            isFieldActive &&
               !showMenuWhileFocused &&
               "group-hover:pointer-events-none group-hover:gap-0 group-hover:opacity-0",
-            isFieldFocused && showMenuWhileFocused && "pointer-events-auto gap-1 opacity-100",
+            isFieldActive && showMenuWhileFocused && "pointer-events-auto gap-1 opacity-100",
             isSingleEnvView ? "top-0.5 right-0.5" : "-top-[1px] -right-1.5"
           )}
         >


### PR DESCRIPTION
## Context

This PR adds a reveal value button to the secret overview table for secrets with references in their values

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-04-23 at 15 38 22@2x" src="https://github.com/user-attachments/assets/cbc04437-1303-44ad-8d63-2e533db29649" />

## Steps to verify the change

- verify display of reference values in both single and multi env view
- verify edit table row behavior for no regression and responsiveness
- verify copy value behavior

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)