### PR TITLE
fix(vercel-sync): filter team shared env vars to sync-owned set

### DIFF
--- a/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
+++ b/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
@@ -320,6 +320,25 @@ const updateSecret = async (
 
 // ===== Team-scoped shared environment variable functions =====
 
+type TeamDestinationConfig = Extract<TVercelSyncWithCredentials["destinationConfig"], { scope: VercelSyncScope.Team }>;
+
+const setsEqual = (a: readonly string[] | undefined, b: readonly string[] | undefined) => {
+  const av = a ?? [];
+  const bv = b ?? [];
+  if (av.length !== bv.length) return false;
+  const bSet = new Set(bv);
+  return av.every((v) => bSet.has(v));
+};
+
+const isTeamSharedEnvVarOwnedByThisSync = (envVar: VercelSharedEnvVar, destinationConfig: TeamDestinationConfig) => {
+  const isSensitive = destinationConfig.sensitive || envVar.type === "sensitive";
+  const effectiveTargets = isSensitive
+    ? destinationConfig.targetEnvironments?.filter((env) => env !== VercelEnvironmentType.Development)
+    : destinationConfig.targetEnvironments;
+
+  return setsEqual(envVar.target, effectiveTargets) && setsEqual(envVar.projectId, destinationConfig.targetProjects);
+};
+
 const listTeamSharedEnvVarsWithRetries = async (
   secretSync: TVercelSyncWithCredentials
 ): Promise<VercelSharedEnvVar[]> => {
@@ -429,6 +448,19 @@ const getTeamSharedEnvVars = async (secretSync: TVercelSyncWithCredentials): Pro
   );
 
   return envVarsWithValues;
+};
+
+const getOwnedTeamSharedEnvVars = async (secretSync: TVercelSyncWithCredentials): Promise<VercelSharedEnvVar[]> => {
+  if (secretSync.destinationConfig.scope !== VercelSyncScope.Team) {
+    throw new SecretSyncError({
+      message: "Invalid scope for team-level Vercel secret sync",
+      shouldRetry: false
+    });
+  }
+
+  const teamDestinationConfig = secretSync.destinationConfig;
+  const allSharedEnvVars = await getTeamSharedEnvVars(secretSync);
+  return allSharedEnvVars.filter((envVar) => isTeamSharedEnvVarOwnedByThisSync(envVar, teamDestinationConfig));
 };
 
 const createTeamSharedEnvVar = async (
@@ -632,7 +664,7 @@ const deleteTeamSharedEnvVar = async (
 export const VercelSyncFns = {
   syncSecrets: async (secretSync: TVercelSyncWithCredentials, secretMap: TSecretMap) => {
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
-      const sharedEnvVars = await getTeamSharedEnvVars(secretSync);
+      const sharedEnvVars = await getOwnedTeamSharedEnvVars(secretSync);
       const sharedEnvVarsMap = new Map(sharedEnvVars.map((s) => [s.key, s]));
 
       const { targetEnvironments, targetProjects, sensitive } = secretSync.destinationConfig;
@@ -739,7 +771,7 @@ export const VercelSyncFns = {
 
   getSecrets: async (secretSync: TVercelSyncWithCredentials): Promise<TSecretMap> => {
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
-      const sharedEnvVars = await getTeamSharedEnvVars(secretSync);
+      const sharedEnvVars = await getOwnedTeamSharedEnvVars(secretSync);
       return Object.fromEntries(sharedEnvVars.map((s) => [s.key, { value: s.value ?? "" }]));
     }
 
@@ -749,7 +781,7 @@ export const VercelSyncFns = {
 
   removeSecrets: async (secretSync: TVercelSyncWithCredentials, secretMap: TSecretMap) => {
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
-      const sharedEnvVars = await getTeamSharedEnvVars(secretSync);
+      const sharedEnvVars = await getOwnedTeamSharedEnvVars(secretSync);
 
       for await (const sharedEnvVar of sharedEnvVars) {
         if (sharedEnvVar.key in secretMap) {

--- a/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
+++ b/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
@@ -331,8 +331,10 @@ const setsEqual = (a: readonly string[] | undefined, b: readonly string[] | unde
 };
 
 const isTeamSharedEnvVarOwnedByThisSync = (envVar: VercelSharedEnvVar, destinationConfig: TeamDestinationConfig) => {
-  const isSensitive = destinationConfig.sensitive || envVar.type === "sensitive";
-  const effectiveTargets = isSensitive
+  const expectedType = destinationConfig.sensitive ? "sensitive" : "encrypted";
+  if (envVar.type !== expectedType) return false;
+
+  const effectiveTargets = destinationConfig.sensitive
     ? destinationConfig.targetEnvironments?.filter((env) => env !== VercelEnvironmentType.Development)
     : destinationConfig.targetEnvironments;
 


### PR DESCRIPTION
## Context

**Vercel (team scope):** Team-level shared environment variables are now limited to variables that match this sync’s configuration (targets, projects, and sensitivity-derived dev exclusion), so sync/get/remove no longer touches unrelated team shared vars from other syncs or manual Vercel setup.

## Steps to verify the change

1. **Vercel team sync:** Configure two team-scoped syncs (or one sync + manual vars) with different targets/projects; run sync/get/remove and confirm only vars “owned” by each sync’s destination config are read or updated.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)