### PR TITLE
improvement(secrets-overview): remove tooltip delay duration on overview page table actions and add more options tooltip

### DIFF
--- a/frontend/src/components/v3/generic/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/v3/generic/Dropdown/Dropdown.tsx
@@ -16,11 +16,14 @@ function DropdownMenuPortal({
   return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
-function DropdownMenuTrigger({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
-}
+const DropdownMenuTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>
+>(
+  ({ ...props }, ref): JSX.Element => (
+    <DropdownMenuPrimitive.Trigger ref={ref} data-slot="dropdown-menu-trigger" {...props} />
+  )
+);
 
 function DropdownMenuContent({
   className,

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderTableRow/FolderTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderTableRow/FolderTableRow.tsx
@@ -129,7 +129,7 @@ export const FolderTableRow = ({
           )}
         >
           {pendingAction !== PendingAction.Delete && (
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
                   variant="ghost"
@@ -147,7 +147,7 @@ export const FolderTableRow = ({
             </Tooltip>
           )}
           {pendingAction ? (
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
                   variant="ghost"
@@ -164,7 +164,7 @@ export const FolderTableRow = ({
               <TooltipContent>Discard pending changes</TooltipContent>
             </Tooltip>
           ) : (
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
                   variant="ghost"

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -945,7 +945,7 @@ export const SecretEditTableRow = ({
           <div className="flex w-fit items-start justify-end self-start pl-2">
             <div className="flex items-center gap-1">
               {comment && !isImportedSecret && (
-                <Tooltip delayDuration={300}>
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex size-5 items-center justify-center text-muted">
                       <MessageSquareIcon className="size-3.5" />
@@ -955,7 +955,7 @@ export const SecretEditTableRow = ({
                 </Tooltip>
               )}
               {canReadTags && tags?.length && !isImportedSecret ? (
-                <Tooltip delayDuration={300}>
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex size-5 items-center justify-center text-muted">
                       <TagsIcon className="size-3.5" />
@@ -967,7 +967,7 @@ export const SecretEditTableRow = ({
                 </Tooltip>
               ) : null}
               {reminder && !isImportedSecret && (
-                <Tooltip delayDuration={300}>
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex size-5 items-center justify-center text-muted">
                       <BellIcon className="size-3.5" />
@@ -977,7 +977,7 @@ export const SecretEditTableRow = ({
                 </Tooltip>
               )}
               {secretMetadata?.length && !isImportedSecret ? (
-                <Tooltip delayDuration={300}>
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex size-5 items-center justify-center text-muted">
                       <CodeXmlIcon className="size-3.5" />
@@ -987,7 +987,7 @@ export const SecretEditTableRow = ({
                 </Tooltip>
               ) : null}
               {skipMultilineEncoding && !isImportedSecret && (
-                <Tooltip delayDuration={300}>
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="flex size-5 items-center justify-center text-muted">
                       <WrapTextIcon className="size-3.5" />
@@ -1091,7 +1091,7 @@ export const SecretEditTableRow = ({
             isSingleEnvView ? "top-0.5 right-0.5" : "-top-[1px] -right-1.5"
           )}
         >
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 isDisabled={
@@ -1123,7 +1123,7 @@ export const SecretEditTableRow = ({
                     : `${isCreatable ? "Add" : "Edit"} Value`}
             </TooltipContent>
           </Tooltip>
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 isDisabled={isPendingDelete || !canCopySecret}
@@ -1149,7 +1149,7 @@ export const SecretEditTableRow = ({
             </TooltipContent>
           </Tooltip>
           <Popover open={isCommentOpen} onOpenChange={setIsCommentOpen}>
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <PopoverTrigger asChild>
                   <IconButton
@@ -1192,7 +1192,7 @@ export const SecretEditTableRow = ({
             </PopoverContent>
           </Popover>
           <Popover modal open={isTagOpen} onOpenChange={setIsTagOpen}>
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <PopoverTrigger asChild>
                   <IconButton
@@ -1237,7 +1237,7 @@ export const SecretEditTableRow = ({
             </PopoverContent>
           </Popover>
           <Popover open={isReminderOpen} onOpenChange={setIsReminderOpen}>
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <PopoverTrigger asChild>
                   <IconButton
@@ -1287,7 +1287,7 @@ export const SecretEditTableRow = ({
             </PopoverContent>
           </Popover>
           <Popover open={isMetadataOpen} onOpenChange={setIsMetadataOpen}>
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <PopoverTrigger asChild>
                   <IconButton
@@ -1337,7 +1337,7 @@ export const SecretEditTableRow = ({
               />
             </PopoverContent>
           </Popover>
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 variant="ghost"
@@ -1372,7 +1372,7 @@ export const SecretEditTableRow = ({
                       : "Enable Multi-line Encoding"}
             </TooltipContent>
           </Tooltip>
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 isDisabled={
@@ -1427,18 +1427,23 @@ export const SecretEditTableRow = ({
             </Tooltip>
           ) : (
             <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
-              <DropdownMenuTrigger asChild>
-                <IconButton
-                  variant="ghost"
-                  size="xs"
-                  className={twMerge(
-                    "w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7",
-                    shouldStayExpanded && "w-7"
-                  )}
-                >
-                  <EllipsisIcon />
-                </IconButton>
-              </DropdownMenuTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <IconButton
+                      variant="ghost"
+                      size="xs"
+                      className={twMerge(
+                        "w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7",
+                        shouldStayExpanded && "w-7"
+                      )}
+                    >
+                      <EllipsisIcon />
+                    </IconButton>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>More Options</TooltipContent>
+              </Tooltip>
               <DropdownMenuContent align="end">
                 <ProjectPermissionCan
                   I={ProjectPermissionActions.Create}
@@ -1456,7 +1461,6 @@ export const SecretEditTableRow = ({
                           ? undefined
                           : false
                       }
-                      delayDuration={300}
                       disableHoverableContent
                     >
                       <TooltipTrigger className="block w-full">
@@ -1484,7 +1488,6 @@ export const SecretEditTableRow = ({
                 </ProjectPermissionCan>
                 <Tooltip
                   open={!canReadSecretValue || !secretId || isEmpty ? undefined : false}
-                  delayDuration={300}
                   disableHoverableContent
                 >
                   <TooltipTrigger className="block w-full">
@@ -1511,7 +1514,6 @@ export const SecretEditTableRow = ({
                   {(isAllowed) => (
                     <Tooltip
                       open={isImportedSecret || isCreatable || !isAllowed ? undefined : false}
-                      delayDuration={300}
                       disableHoverableContent
                     >
                       <TooltipTrigger className="block w-full">
@@ -1535,7 +1537,6 @@ export const SecretEditTableRow = ({
                 </ProjectPermissionCan>
                 <Tooltip
                   open={isImportedSecret || isCreatable ? undefined : false}
-                  delayDuration={300}
                   disableHoverableContent
                 >
                   <TooltipTrigger className="block w-full">
@@ -1571,7 +1572,6 @@ export const SecretEditTableRow = ({
                   {(isAllowed) => (
                     <Tooltip
                       open={isRotatedSecret || isImportedSecret || isCreatable ? undefined : false}
-                      delayDuration={300}
                       disableHoverableContent
                     >
                       <TooltipTrigger className="block w-full">

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
@@ -305,7 +305,7 @@ export const SecretOverrideRow = ({
             isSingleEnvView ? "-top-[1.5px] -right-2.5" : "-top-[1.5px] -right-1.5"
           )}
         >
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 onClick={() => {
@@ -324,7 +324,7 @@ export const SecretOverrideRow = ({
             <TooltipContent>Edit Override</TooltipContent>
           </Tooltip>
           {!isCreatingOverride && (
-            <Tooltip delayDuration={300} disableHoverableContent>
+            <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
                   isDisabled={!canFetchOverrideValue}
@@ -362,7 +362,7 @@ export const SecretOverrideRow = ({
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
-          <Tooltip delayDuration={300} disableHoverableContent>
+          <Tooltip disableHoverableContent>
             <TooltipTrigger>
               <IconButton
                 onClick={

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -332,7 +332,7 @@ export const SecretTableRow = ({
                 "top-1/2 right-[3px] -translate-y-1/2"
               )}
             >
-              <Tooltip delayDuration={300} disableHoverableContent>
+              <Tooltip disableHoverableContent>
                 <TooltipTrigger>
                   <IconButton
                     variant="ghost"
@@ -349,7 +349,7 @@ export const SecretTableRow = ({
                 </TooltipTrigger>
                 <TooltipContent>Copy Secret Name</TooltipContent>
               </Tooltip>
-              <Tooltip delayDuration={300} disableHoverableContent>
+              <Tooltip disableHoverableContent>
                 <TooltipTrigger>
                   <IconButton
                     variant="ghost"


### PR DESCRIPTION
## Context

This PR removes the delay duration on overview table action tooltips and adds a secret "more options" tooltip
## Screenshots

n/a 

## Steps to verify the change

verify tooltips show faster :pepeok

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)