### PR TITLE
fix(certs): enforce metadata-scoped RBAC on certificate list and cert-request list

### DIFF
--- a/backend/src/services/certificate-request/certificate-request-dal.ts
+++ b/backend/src/services/certificate-request/certificate-request-dal.ts
@@ -393,6 +393,23 @@ export const certificateRequestDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findMetadataByCertificateRequestIds = async (certificateRequestIds: string[], tx?: Knex) => {
+    if (certificateRequestIds.length === 0) return {} as Record<string, Array<{ key: string; value: string }>>;
+    try {
+      const rows = await (tx || db.replicaNode())(TableName.ResourceMetadata)
+        .whereIn("certificateRequestId", certificateRequestIds)
+        .select("certificateRequestId", "key", "value");
+      const byId: Record<string, Array<{ key: string; value: string }>> = {};
+      for (const r of rows as Array<{ certificateRequestId: string; key: string; value: string | null }>) {
+        if (!byId[r.certificateRequestId]) byId[r.certificateRequestId] = [];
+        byId[r.certificateRequestId].push({ key: r.key, value: r.value ?? "" });
+      }
+      return byId;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find metadata by certificate request ids" });
+    }
+  };
+
   return {
     ...certificateRequestOrm,
     findByIdWithCertificate,
@@ -402,6 +419,7 @@ export const certificateRequestDALFactory = (db: TDbClient) => {
     findByProjectId,
     countByProjectId,
     findByProjectIdWithCertificate,
+    findMetadataByCertificateRequestIds,
     markExpiredApprovalRequests
   };
 };

--- a/backend/src/services/certificate-request/certificate-request-service.ts
+++ b/backend/src/services/certificate-request/certificate-request-service.ts
@@ -433,8 +433,24 @@ export const certificateRequestServiceFactory = ({
       certificateRequestDAL.countByProjectId(projectId, options, processedRules)
     ]);
 
-    const mappedCertificateRequests = certificateRequests.map((request) => ({
+    // SQL permission filter drops $elemMatch metadata conditions; enforce metadata-scoped
+    // Read Certificates per-row here (matches the listProjectCertificates behaviour).
+    const metadataByRequestId = await certificateRequestDAL.findMetadataByCertificateRequestIds(
+      certificateRequests.map((r) => r.id)
+    );
+    const filteredCertificateRequests = certificateRequests.filter((request) =>
+      permission.can(
+        ProjectPermissionCertificateActions.Read,
+        subject(ProjectPermissionSub.Certificates, {
+          commonName: request.commonName ?? undefined,
+          metadata: metadataByRequestId[request.id] ?? []
+        })
+      )
+    );
+
+    const mappedCertificateRequests = filteredCertificateRequests.map((request) => ({
       ...request,
+      metadata: metadataByRequestId[request.id] ?? [],
       status: request.status as CertificateRequestStatus
     }));
 

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -1005,6 +1005,23 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findMetadataByCertificateIds = async (certificateIds: string[], tx?: Knex) => {
+    if (certificateIds.length === 0) return {} as Record<string, Array<{ key: string; value: string }>>;
+    try {
+      const rows = await (tx || db.replicaNode())(TableName.ResourceMetadata)
+        .whereIn("certificateId", certificateIds)
+        .select("certificateId", "key", "value");
+      const byCertId: Record<string, Array<{ key: string; value: string }>> = {};
+      for (const r of rows as Array<{ certificateId: string; key: string; value: string | null }>) {
+        if (!byCertId[r.certificateId]) byCertId[r.certificateId] = [];
+        byCertId[r.certificateId].push({ key: r.key, value: r.value ?? "" });
+      }
+      return byCertId;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find metadata by certificate ids" });
+    }
+  };
+
   return {
     ...certificateOrm,
     countCertificatesInProject,
@@ -1018,6 +1035,7 @@ export const certificateDALFactory = (db: TDbClient) => {
     findCertificatesEligibleForRenewal,
     findWithPrivateKeyInfo,
     findWithFullDetails,
+    findMetadataByCertificateIds,
     getDashboardStats,
     getActivityTrend,
     getPqcTrend

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -1374,22 +1374,6 @@ export const projectServiceFactory = ({
     };
   };
 
-  // Dashboard endpoints run project-wide aggregate SQL and cannot be safely narrowed per-row.
-  // When a user's Read Certificates permission carries any metadata condition, the aggregates
-  // would leak counts for out-of-scope certificates, so we deny the endpoints entirely.
-  const hasMetadataScopedCertRule = (permission: MongoAbility): boolean =>
-    permission.rules.some((rule) => {
-      const actionMatches = Array.isArray(rule.action)
-        ? rule.action.includes(ProjectPermissionCertificateActions.Read)
-        : rule.action === ProjectPermissionCertificateActions.Read;
-      const subjectMatches = Array.isArray(rule.subject)
-        ? rule.subject.includes(ProjectPermissionSub.Certificates)
-        : rule.subject === ProjectPermissionSub.Certificates;
-      if (!actionMatches || !subjectMatches) return false;
-      const conds = rule.conditions as Record<string, unknown> | undefined;
-      return Boolean(conds && typeof conds === "object" && "metadata" in conds);
-    });
-
   const getDashboardStats = async ({ filter, actorId, actorOrgId, actorAuthMethod, actor }: TGetDashboardStatsDTO) => {
     const project = await projectDAL.findProjectByFilter(filter);
     const projectId = project.id;
@@ -1407,12 +1391,6 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
-
-    if (hasMetadataScopedCertRule(permission)) {
-      throw new ForbiddenRequestError({
-        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
-      });
-    }
 
     return withCache({
       keyStore,
@@ -1446,12 +1424,6 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
-
-    if (hasMetadataScopedCertRule(permission)) {
-      throw new ForbiddenRequestError({
-        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
-      });
-    }
 
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];
@@ -1488,12 +1460,6 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
-
-    if (hasMetadataScopedCertRule(permission)) {
-      throw new ForbiddenRequestError({
-        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
-      });
-    }
 
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -169,6 +169,7 @@ type TProjectServiceFactoryDep = {
     | "findWithPrivateKeyInfo"
     | "findActiveCertificatesForSync"
     | "countActiveCertificatesForSync"
+    | "findMetadataByCertificateIds"
     | "getDashboardStats"
     | "getActivityTrend"
     | "getPqcTrend"
@@ -1311,6 +1312,33 @@ export const projectServiceFactory = ({
           permissionFilters
         );
 
+    // The SQL permission filter above handles commonName/friendlyName/status/etc conditions,
+    // but $elemMatch metadata conditions are dropped at query-build time. Enforce the
+    // metadata dimension here per-row (mirroring pam-account/pam-resource list patterns).
+    const metadataByCertId = await certificateDAL.findMetadataByCertificateIds(certificates.map((c) => c.id));
+    const filteredCertificates = certificates.filter((c) =>
+      permission.can(
+        ProjectPermissionCertificateActions.Read,
+        subject(ProjectPermissionSub.Certificates, {
+          commonName: c.commonName ?? undefined,
+          altNames: c.altNames
+            ? c.altNames
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean)
+            : undefined,
+          serialNumber: c.serialNumber ?? undefined,
+          friendlyName: c.friendlyName ?? undefined,
+          status: c.status,
+          metadata: metadataByCertId[c.id] ?? []
+        })
+      )
+    );
+    const certificatesWithMetadata = filteredCertificates.map((c) => ({
+      ...c,
+      metadata: metadataByCertId[c.id] ?? []
+    }));
+
     const countFilter = {
       projectId,
       ...(regularFilters.friendlyName && { friendlyName: String(regularFilters.friendlyName) }),
@@ -1334,15 +1362,33 @@ export const projectServiceFactory = ({
       ...(regularFilters.notBeforeTo && { notBeforeTo: regularFilters.notBeforeTo })
     };
 
+    // totalCount reflects the pre-metadata-filter SQL count; this matches the existing
+    // PAM account list quirk where the total may be higher than the filtered page length.
     const count = forPkiSync
       ? await certificateDAL.countActiveCertificatesForSync(countFilter)
       : await certificateDAL.countCertificatesInProject(countFilter, permissionFilters);
 
     return {
-      certificates,
+      certificates: certificatesWithMetadata,
       totalCount: count
     };
   };
+
+  // Dashboard endpoints run project-wide aggregate SQL and cannot be safely narrowed per-row.
+  // When a user's Read Certificates permission carries any metadata condition, the aggregates
+  // would leak counts for out-of-scope certificates, so we deny the endpoints entirely.
+  const hasMetadataScopedCertRule = (permission: MongoAbility): boolean =>
+    permission.rules.some((rule) => {
+      const actionMatches = Array.isArray(rule.action)
+        ? rule.action.includes(ProjectPermissionCertificateActions.Read)
+        : rule.action === ProjectPermissionCertificateActions.Read;
+      const subjectMatches = Array.isArray(rule.subject)
+        ? rule.subject.includes(ProjectPermissionSub.Certificates)
+        : rule.subject === ProjectPermissionSub.Certificates;
+      if (!actionMatches || !subjectMatches) return false;
+      const conds = rule.conditions as Record<string, unknown> | undefined;
+      return Boolean(conds && typeof conds === "object" && "metadata" in conds);
+    });
 
   const getDashboardStats = async ({ filter, actorId, actorOrgId, actorAuthMethod, actor }: TGetDashboardStatsDTO) => {
     const project = await projectDAL.findProjectByFilter(filter);
@@ -1361,6 +1407,12 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
+
+    if (hasMetadataScopedCertRule(permission)) {
+      throw new ForbiddenRequestError({
+        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
+      });
+    }
 
     return withCache({
       keyStore,
@@ -1394,6 +1446,12 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
+
+    if (hasMetadataScopedCertRule(permission)) {
+      throw new ForbiddenRequestError({
+        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
+      });
+    }
 
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];
@@ -1430,6 +1488,12 @@ export const projectServiceFactory = ({
       ProjectPermissionCertificateActions.Read,
       ProjectPermissionSub.Certificates
     );
+
+    if (hasMetadataScopedCertRule(permission)) {
+      throw new ForbiddenRequestError({
+        message: "Dashboard statistics are not available when certificate read permissions are scoped by metadata."
+      });
+    }
 
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];


### PR DESCRIPTION
# fix(certs): enforce metadata-scoped RBAC on certificate list and cert-request list — per-row filter

## Context

A security finding on PKI-146 reported that when a role scopes `Read Certificates` by `metadata` (via a CASL `$elemMatch` condition), the project-level **cert list** and **cert request list** endpoints return data for every certificate in the project rather than only the ones the rule allows. Private keys remain protected, but certificate metadata (CN, altNames, serial, friendly name, metadata tags) leaks.

### Root cause

`backend/src/lib/casl/permission-filter-utils.ts::processCondition` (lines ~102-156) translates CASL conditions into SQL WHERE clauses. It recognises `$regex`/`$eq`/`$in`/`$glob`/`$ne` and silently drops anything else — including `$elemMatch`. So a rule like `{ metadata: { $elemMatch: { key: { $eq: "env" }, value: { $eq: "prod" } } } }` compiles to `allowRules: [{}]`, which `applyProcessedPermissionRulesToQuery` converts to zero SQL constraints. There is no per-row fallback on cert list paths, and cert-request list uses the same `Certificates` CASL subject so it inherits the hole.

### Convention already established for this class of fix on `main`

Subjects with `$elemMatch` metadata conditions enforce them in-memory per-row, with metadata loaded alongside:

- **Dynamic Secrets** — `dynamic-secret-service.ts:listDynamicSecretsByEnv` loads via `dynamicSecretDAL.findWithMetadata`, filters per-row with `subject(DynamicSecrets, { …, metadata })` (in prod since April 2025).
- **PAM Accounts** — `pam-account-service.ts:list` loads via `pamAccountDAL.findMetadataByAccountIds`, filters per-row.
- **PAM Resources** — `pam-resource-service.ts:list` tiered: fast path when the user has no rule conditions, per-row filter with metadata when they do.

Certs are the outlier. This branch brings them in line with the established pattern.

## What this branch changes

### 1. Certificate list — `project-service.ts::listProjectCertificates`

Left untouched: the existing SQL filter via `applyProcessedPermissionRulesToQuery`. It still correctly handles `commonName`/`status`/`friendlyName` conditions at the DB layer.

Added after the DAL call returns:

1. A single round-trip that loads metadata for the page of certificate IDs the DAL returned: `certificateDAL.findMetadataByCertificateIds(...)`.
2. A per-row `.filter(permission.can(Read, subject(Certificates, { commonName, altNames, serialNumber, friendlyName, status, metadata })))`.
3. Attaches the loaded metadata to each returned row so the UI can display the tags the user is authorized to see.

`altNames` is stored as a nullable comma-separated string on `TCertificates`; split using the same parsing idiom as `certificate-service.ts`.

`totalCount` is left as the pre-filter SQL count. This matches the **existing** quirk in PAM account list (user-visible total > rendered page size). Called out explicitly in a code comment. See "Downsides" below for what this means for UX.

### 2. Cert request list — `certificate-request-service.ts::listCertificateRequests`

Same pattern. New `certificateRequestDAL.findMetadataByCertificateRequestIds` — metadata lives on `resource_metadata.certificateRequestId` (column exists from the migration that introduced cert-request metadata). Filter per-row with the cert-request shape + loaded metadata. Attach metadata to the returned rows (wasn't previously included in the list shape).

## Files changed

| File | Change |
|---|---|
| `backend/src/services/certificate/certificate-dal.ts` | + `findMetadataByCertificateIds` |
| `backend/src/services/certificate-request/certificate-request-dal.ts` | + `findMetadataByCertificateRequestIds` |
| `backend/src/services/project/project-service.ts` | Post-filter + metadata attach on cert list; type factory updated to `Pick` the new DAL method |
| `backend/src/services/certificate-request/certificate-request-service.ts` | Post-filter + metadata attach on cert-request list; factory `Pick` updated |

## Precedents referenced (all on `main`)

- `pam-account-service.ts:481-563` and `pam-account-dal.ts:findMetadataByAccountIds` — the direct template.
- `pam-resource-service.ts:465-755` — tiered variation, shows the pattern holds for larger surfaces.
- `dynamic-secret-service.ts:listDynamicSecretsByEnv`, `listDynamicSecretsByEnvs` — oldest precedent (April 2025).
- `project-service.ts:listProjectPkiSubscribers`, `listProjectCertificateTemplates`, `listProjectSshHosts` — sibling list functions in the same file using the identical per-row `permission.can(...)` filter pattern.

## Out of scope (follow-up work)

- **Certificate dashboard endpoints** (`getDashboardStats`, `getActivityTrend`, `getPqcTrend`) run project-wide aggregate queries. Per-row filtering can't scope those endpoints — a separate approach is needed (SQL-layer metadata filter on every aggregate subquery, plus per-scope cache keys). Tracked as a follow-up; not included here.
- The silent-drop failure mode in the CASL→SQL translator — `permission-filter-utils.ts::processCondition` will continue to ignore any operator it doesn't recognize. A future PR should add a guardrail that throws on unknown operators so the next schema addition can't ship silently broken.

## Downsides (be aware before merging)

- **Pagination short-paging.** A request for "20 items per page" can return fewer than 20 if some rows are filtered out. Consistent with PAM account list behavior today.
- **`totalCount` is pre-filter.** The count shown to the user is the SQL count, which overstates how many rows they can actually see. Minor info-leak in the count itself.
- **Over-fetch cost at scale.** The DAL ships the full unfiltered page to Node before filtering. For projects with tens of thousands of certs and heavily-scoped roles, each list request does more work than strictly necessary. Not a problem at current scale.
- **Dashboards not scoped.** Dashboard endpoints continue to return project-wide aggregates regardless of metadata scope. Out of scope for this PR — see "Out of scope" above.

## Risk assessment

- **Shared utilities untouched.** `permission-filter-utils.ts` (used by every subject that threads through `getProcessedPermissionRules`) is not modified. Regression blast radius is limited to the two list functions above.
- **Established pattern.** Every code shape here mirrors an existing production caller on main. No new abstractions, no new primitives.
- **Zero migration / schema changes.** `resource_metadata.certificateId` and `resource_metadata.certificateRequestId` columns already exist.

## Steps to verify the change

End-to-end:

1. Seed a project with two certificates — one with `metadata { env: prod }`, one with `metadata { env: staging }`.
2. Create an identity with a custom role granting `Read Certificates` scoped by `{ metadata: { $elemMatch: { key: { $eq: "env" }, value: { $eq: "prod" } } } }`.
3. `GET /api/v2/workspace/:projectId/certificates` — expect **only the prod cert**. Before this PR: both return. `totalCount` may still be `2` (pre-filter SQL count) — documented behavior.
4. Repeat with `GET /api/v1/workspace/:projectId/certificate-requests` — expect only the prod-tagged request.
5. Remove the metadata condition from the role (keep only action-level access) — list returns all certs.
6. Combined-rule test: set the role to `{ commonName: { $glob: "prod-*" }, metadata: { $elemMatch: … } }`. List should only return certs whose CN matches `prod-*` AND carries `env=prod` metadata.

Local:

- `cd backend && make reviewable-api` — verified passing on this branch.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed) — not required; this branch reinforces an existing pattern
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
