### PR TITLE
fix(casl): scope cert list/cert-request list/cert dashboards by metadata in SQL; guardrail translator on unknown operators

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -100,9 +100,15 @@ export const KeyStorePrefixes = {
   TelemetryGroupIdentify: (orgId: string) => `telemetry-group-identify:${orgId}` as const,
   SecretEtag: (projectId: string) => `secret-etag:${projectId}` as const,
 
-  CertDashboardStats: (projectId: string) => `cert-dashboard-stats:${projectId}` as const,
-  CertActivityTrend: (projectId: string, range: string) => `cert-activity-trend:${projectId}:${range}` as const,
-  CertPqcTrend: (projectId: string, range: string) => `cert-pqc-trend:${projectId}:${range}` as const,
+  // `metadataFilterHash` scopes dashboards per metadata-filter so users with
+  // different RBAC metadata scopes don't share cached aggregates. Pass "" for
+  // unscoped callers (the common case).
+  CertDashboardStats: (projectId: string, metadataFilterHash: string = "") =>
+    `cert-dashboard-stats:${projectId}:${metadataFilterHash}` as const,
+  CertActivityTrend: (projectId: string, range: string, metadataFilterHash: string = "") =>
+    `cert-activity-trend:${projectId}:${range}:${metadataFilterHash}` as const,
+  CertPqcTrend: (projectId: string, range: string, metadataFilterHash: string = "") =>
+    `cert-pqc-trend:${projectId}:${range}:${metadataFilterHash}` as const,
   RefreshTokenGrace: (sessionId: string) => `refresh-token-grace:${sessionId}` as const,
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const
 };

--- a/backend/src/lib/casl/permission-filter-utils.test.ts
+++ b/backend/src/lib/casl/permission-filter-utils.test.ts
@@ -1,0 +1,137 @@
+import { createMongoAbility } from "@casl/ability";
+
+import { BadRequestError } from "@app/lib/errors";
+
+import { PermissionConditionOperators } from ".";
+import { getProcessedPermissionRules } from "./permission-filter-utils";
+
+describe("getProcessedPermissionRules", () => {
+  const action = "read";
+  const subject = "certificates";
+
+  test("translates $glob condition on a regular field into allowRules with empty metadataFilter", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          commonName: { [PermissionConditionOperators.$GLOB]: "prod-*" }
+        }
+      }
+    ]);
+
+    const result = getProcessedPermissionRules(ability, action, subject);
+
+    expect(result.forbidRules).toHaveLength(0);
+    expect(result.metadataFilter).toEqual([]);
+    expect(result.allowRules).toHaveLength(1);
+    expect(result.allowRules[0].commonName).toHaveLength(1);
+    expect(result.allowRules[0].commonName[0]).toMatchObject({ operator: "LIKE", value: "prod-*", isPattern: true });
+  });
+
+  test("extracts metadata $elemMatch into metadataFilter (single entry)", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          metadata: {
+            [PermissionConditionOperators.$ELEMENTMATCH]: {
+              key: { [PermissionConditionOperators.$EQ]: "env" },
+              value: { [PermissionConditionOperators.$EQ]: "prod" }
+            }
+          }
+        }
+      }
+    ]);
+
+    const result = getProcessedPermissionRules(ability, action, subject);
+
+    expect(result.metadataFilter).toEqual([{ key: "env", value: "prod" }]);
+    // The metadata field itself must not leak into SQL-translated allowRules.
+    expect(result.allowRules.every((rule) => !("metadata" in rule))).toBe(true);
+  });
+
+  test("expands $in under $elemMatch.value into multiple entries", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          metadata: {
+            [PermissionConditionOperators.$ELEMENTMATCH]: {
+              key: { [PermissionConditionOperators.$EQ]: "env" },
+              value: { [PermissionConditionOperators.$IN]: ["prod", "staging"] }
+            }
+          }
+        }
+      }
+    ]);
+
+    const result = getProcessedPermissionRules(ability, action, subject);
+
+    expect(result.metadataFilter).toEqual([
+      { key: "env", value: "prod" },
+      { key: "env", value: "staging" }
+    ]);
+  });
+
+  test("handles $elemMatch with only a key constraint (no value)", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          metadata: {
+            [PermissionConditionOperators.$ELEMENTMATCH]: {
+              key: { [PermissionConditionOperators.$EQ]: "env" }
+            }
+          }
+        }
+      }
+    ]);
+
+    const result = getProcessedPermissionRules(ability, action, subject);
+
+    expect(result.metadataFilter).toEqual([{ key: "env" }]);
+  });
+
+  test("combined conditions populate both allowRules and metadataFilter", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          commonName: { [PermissionConditionOperators.$GLOB]: "prod-*" },
+          metadata: {
+            [PermissionConditionOperators.$ELEMENTMATCH]: {
+              key: { [PermissionConditionOperators.$EQ]: "env" },
+              value: { [PermissionConditionOperators.$EQ]: "prod" }
+            }
+          }
+        }
+      }
+    ]);
+
+    const result = getProcessedPermissionRules(ability, action, subject);
+
+    expect(result.allowRules).toHaveLength(1);
+    expect(result.allowRules[0].commonName).toHaveLength(1);
+    expect(result.metadataFilter).toEqual([{ key: "env", value: "prod" }]);
+  });
+
+  test("throws BadRequestError on unknown operator in a condition", () => {
+    const ability = createMongoAbility([
+      {
+        action,
+        subject,
+        conditions: {
+          commonName: { $notAThing: "x" } as unknown as Record<string, unknown>
+        }
+      }
+    ]);
+
+    expect(() => getProcessedPermissionRules(ability, action, subject)).toThrow(BadRequestError);
+    expect(() => getProcessedPermissionRules(ability, action, subject)).toThrow(/Unknown CASL operator/);
+  });
+});

--- a/backend/src/lib/casl/permission-filter-utils.ts
+++ b/backend/src/lib/casl/permission-filter-utils.ts
@@ -1,6 +1,8 @@
 import type { MongoAbility, MongoQuery, RawRuleOf } from "@casl/ability";
 import RE2 from "re2";
 
+import { BadRequestError } from "@app/lib/errors";
+
 export interface PermissionFilterConfig {
   operator: string;
   value: unknown;
@@ -13,6 +15,16 @@ export type PermissionFilters = Record<string, Array<PermissionFilterConfig>>;
 export interface ProcessedPermissionRules {
   allowRules: Array<Record<string, Array<PermissionFilterConfig>>>;
   forbidRules: Array<Record<string, Array<PermissionFilterConfig>>>;
+  /**
+   * Metadata $elemMatch conditions extracted from the matching rules, ready
+   * to be passed to applyMetadataFilter. Each entry ANDs with the others when
+   * applied. Multi-rule semantics: CASL would OR multiple allow rules, but
+   * applyMetadataFilter ANDs entries together — we intentionally AND here as
+   * it's stricter (smaller result set, no leaks). A warning is logged when
+   * more than one allow rule on the same subject contributes $elemMatch
+   * entries so the deviation is observable.
+   */
+  metadataFilter: Array<{ key: string; value?: string }>;
 }
 
 interface MongoRegexFilter {
@@ -35,14 +47,99 @@ interface MongoGlobFilter {
   $glob: unknown;
 }
 
+const RECOGNIZED_OPERATORS = new Set(["$regex", "$eq", "$in", "$glob", "$ne", "$elemMatch"]);
+
+/**
+ * Extract metadata $elemMatch entries (compatible with applyMetadataFilter)
+ * from a CASL condition value. Only $eq and $in are permitted under the
+ * inner `key` / `value` objects (matching the schemas in project-permission.ts).
+ * Any other operator throws loudly so the translator can't silently drop
+ * security-relevant conditions.
+ */
+const extractElemMatchEntries = (field: string, elemMatchValue: unknown): Array<{ key: string; value?: string }> => {
+  if (!elemMatchValue || typeof elemMatchValue !== "object") {
+    throw new BadRequestError({
+      message: `Invalid $elemMatch value for field "${field}" — expected an object.`
+    });
+  }
+
+  const inner = elemMatchValue as Record<string, unknown>;
+  const keySpec = inner.key as Record<string, unknown> | undefined;
+  const valueSpec = inner.value as Record<string, unknown> | undefined;
+
+  const readOperand = (
+    innerField: "key" | "value",
+    spec: Record<string, unknown> | undefined
+  ): string[] | undefined => {
+    if (spec === undefined) return undefined;
+    if (!spec || typeof spec !== "object") {
+      throw new BadRequestError({
+        message: `Invalid $elemMatch.${innerField} for field "${field}" — expected an object.`
+      });
+    }
+    const allowed = new Set(["$eq", "$in"]);
+    const ops = Object.keys(spec).filter((k) => k.startsWith("$"));
+    for (const op of ops) {
+      if (!allowed.has(op)) {
+        throw new BadRequestError({
+          message: `Unknown CASL operator "${op}" under $elemMatch.${innerField} on field "${field}" — only $eq/$in are supported.`
+        });
+      }
+    }
+    const results: string[] = [];
+    if ("$eq" in spec) {
+      results.push(String(spec.$eq));
+    }
+    if ("$in" in spec) {
+      const arr = spec.$in;
+      if (!Array.isArray(arr)) {
+        throw new BadRequestError({
+          message: `Invalid $elemMatch.${innerField}.$in for field "${field}" — expected array.`
+        });
+      }
+      arr.forEach((v) => results.push(String(v)));
+    }
+    // No recognized operator under elemMatch — treat as no constraint.
+    return results.length > 0 ? results : undefined;
+  };
+
+  const keys = readOperand("key", keySpec);
+  const values = readOperand("value", valueSpec);
+
+  if (!keys || keys.length === 0) {
+    // Every entry needs a key; otherwise applyMetadataFilter has nothing to
+    // join on. This matches what the schema requires in practice.
+    throw new BadRequestError({
+      message: `$elemMatch on field "${field}" must specify a key constraint.`
+    });
+  }
+
+  if (!values) {
+    return keys.map((key) => ({ key }));
+  }
+
+  const entries: Array<{ key: string; value?: string }> = [];
+  keys.forEach((key) => {
+    values.forEach((value) => {
+      entries.push({ key, value });
+    });
+  });
+  return entries;
+};
+
 /**
  * Builds permission filters from CASL MongoDB-style conditions
  * @param conditions - MongoDB-style conditions from CASL ability
  * @param isInverted - Whether this rule is inverted (forbidden)
- * @returns Record of field names to arrays of filter configurations
+ * @returns Record of field names to arrays of filter configurations, plus the
+ *          metadata $elemMatch entries extracted for the service layer.
  */
-const buildPermissionFiltersFromConditions = (conditions: MongoQuery, isInverted = false): PermissionFilters => {
+const buildPermissionFiltersFromConditions = (
+  conditions: MongoQuery,
+  isInverted = false
+): { permissionFilters: PermissionFilters; metadataFilter: Array<{ key: string; value?: string }> } => {
   const permissionFilters: PermissionFilters = {};
+  const metadataFilter: Array<{ key: string; value?: string }> = [];
 
   function addFilterToField(key: string, operator: string, value: unknown, isPattern: boolean) {
     if (!permissionFilters[key]) {
@@ -106,6 +203,23 @@ const buildPermissionFiltersFromConditions = (conditions: MongoQuery, isInverted
       const operatorKeys = ["$regex", "$eq", "$in", "$glob", "$ne"];
       const presentOperators = operatorKeys.filter((op) => op in valueObj);
 
+      // $elemMatch handled via the service layer (applyMetadataFilter), not
+      // via SQL translation. Extract entries even in the multi-operator case,
+      // though our schemas never mix $elemMatch with anything else.
+      if ("$elemMatch" in valueObj) {
+        if (isInverted) {
+          throw new BadRequestError({
+            message: `Inverted rules with $elemMatch on field "${key}" are not supported.`
+          });
+        }
+        const entries = extractElemMatchEntries(key, valueObj.$elemMatch);
+        metadataFilter.push(...entries);
+        // If the value is only $elemMatch, we're done. If it had other
+        // recognized operators, keep processing them below.
+        const otherPresent = presentOperators.length > 0;
+        if (!otherPresent) return;
+      }
+
       if (presentOperators.length > 1) {
         if ("$eq" in valueObj) {
           addFilterToField(key, "=", valueObj.$eq, false);
@@ -153,6 +267,21 @@ const buildPermissionFiltersFromConditions = (conditions: MongoQuery, isInverted
         const valueStr = String(neFilter.$ne);
         const hasWildcards = valueStr.includes("*") || valueStr.includes("?");
         addFilterToField(key, hasWildcards ? "NOT LIKE" : "!=", neFilter.$ne, hasWildcards);
+      } else {
+        // Guardrail: If the value looks like a CASL operator object (has
+        // $-prefixed keys) but none of them are recognized, fail loudly
+        // instead of silently dropping the condition. This is what bit us
+        // with $elemMatch originally.
+        const dollarKeys = Object.keys(valueObj).filter((k) => k.startsWith("$"));
+        if (dollarKeys.length > 0) {
+          const unknown = dollarKeys.find((k) => !RECOGNIZED_OPERATORS.has(k));
+          if (unknown) {
+            throw new BadRequestError({
+              message: `Unknown CASL operator "${unknown}" on field "${key}" — translator is missing a handler.`
+            });
+          }
+        }
+        // Otherwise it's a plain nested object — ignore (prior behavior).
       }
     } else {
       addFilterToField(key, "=", value, false);
@@ -181,7 +310,7 @@ const buildPermissionFiltersFromConditions = (conditions: MongoQuery, isInverted
     processConditions(conditions);
   }
 
-  return permissionFilters;
+  return { permissionFilters, metadataFilter };
 };
 
 /**
@@ -207,19 +336,36 @@ export function getProcessedPermissionRules(
 
   const allowRules: Array<Record<string, Array<PermissionFilterConfig>>> = [];
   const forbidRules: Array<Record<string, Array<PermissionFilterConfig>>> = [];
+  const metadataFilter: Array<{ key: string; value?: string }> = [];
+  let allowRulesWithMetadata = 0;
 
   matchingRules.forEach((rule: RawRuleOf<MongoAbility>) => {
     if (rule.conditions) {
       const isInverted = rule.inverted || false;
-      const ruleFilters = buildPermissionFiltersFromConditions(rule.conditions, isInverted);
+      const { permissionFilters, metadataFilter: ruleMetadata } = buildPermissionFiltersFromConditions(
+        rule.conditions,
+        isInverted
+      );
 
       if (isInverted) {
-        forbidRules.push(ruleFilters);
+        forbidRules.push(permissionFilters);
       } else {
-        allowRules.push(ruleFilters);
+        allowRules.push(permissionFilters);
+        if (ruleMetadata.length > 0) {
+          allowRulesWithMetadata += 1;
+          metadataFilter.push(...ruleMetadata);
+        }
       }
     }
   });
 
-  return { allowRules, forbidRules };
+  if (allowRulesWithMetadata > 1) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[permission-filter-utils] ${allowRulesWithMetadata} allow rules with metadata $elemMatch conditions detected on ` +
+        `subject "${subjectName}" / action "${action}". Entries will be AND-ed (stricter than CASL's OR semantics).`
+    );
+  }
+
+  return { allowRules, forbidRules, metadataFilter };
 }

--- a/backend/src/services/certificate-policy/certificate-policy-service.test.ts
+++ b/backend/src/services/certificate-policy/certificate-policy-service.test.ts
@@ -271,14 +271,14 @@ describe("CertificatePolicyService", () => {
           limit: 20,
           search: undefined
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
       expect(mockCertificatePolicyDAL.countByProjectId).toHaveBeenCalledWith(
         "project-123",
         {
           search: undefined
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
       expect(result).toEqual({ policies, totalCount });
     });
@@ -303,14 +303,14 @@ describe("CertificatePolicyService", () => {
           limit: 20,
           search: "web server"
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
       expect(mockCertificatePolicyDAL.countByProjectId).toHaveBeenCalledWith(
         "project-123",
         {
           search: "web server"
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
     });
   });

--- a/backend/src/services/certificate-profile/certificate-profile-service.test.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-service.test.ts
@@ -602,7 +602,7 @@ describe("CertificateProfileService", () => {
           caId: undefined,
           issuerType: undefined
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
     });
 
@@ -627,7 +627,7 @@ describe("CertificateProfileService", () => {
           caId: "ca-123",
           issuerType: undefined
         },
-        { allowRules: [], forbidRules: [] }
+        { allowRules: [], forbidRules: [], metadataFilter: [] }
       );
     });
   });

--- a/backend/src/services/certificate-request/certificate-request-service.ts
+++ b/backend/src/services/certificate-request/certificate-request-service.ts
@@ -415,6 +415,13 @@ export const certificateRequestServiceFactory = ({
       ProjectPermissionSub.Certificates
     );
 
+    // Merge user-supplied metadata filters with CASL-sourced metadata
+    // $elemMatch conditions (AND — see translator notes).
+    const mergedMetadataFilter: Array<{ key: string; value?: string }> = [
+      ...(metadataFilter || []),
+      ...processedRules.metadataFilter
+    ];
+
     const options: Parameters<typeof certificateRequestDAL.findByProjectIdWithCertificate>[1] = {
       offset,
       limit,
@@ -425,7 +432,7 @@ export const certificateRequestServiceFactory = ({
       profileIds,
       sortBy,
       sortOrder,
-      metadataFilter
+      metadataFilter: mergedMetadataFilter.length > 0 ? mergedMetadataFilter : undefined
     };
 
     const [certificateRequests, totalCount] = await Promise.all([

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -254,6 +254,9 @@ export const certificateDALFactory = (db: TDbClient) => {
         );
       }
 
+      // The CASL-sourced metadata filter (if any) has already been merged
+      // into `filters.metadataFilter` by the service layer, so
+      // applyInventoryFilters handles it via applyMetadataFilter.
       query = applyInventoryFilters(query, filters, hasEnrollmentTypeFilter) as typeof query;
 
       if (permissionFilters) {
@@ -342,7 +345,8 @@ export const certificateDALFactory = (db: TDbClient) => {
         .where("notAfter", ">", new Date())
         .whereNull("renewedByCertificateId");
 
-      Object.entries(filter).forEach(([key, value]) => {
+      const { metadataFilter, ...scalarFilters } = filter;
+      Object.entries(scalarFilters).forEach(([key, value]) => {
         if (value !== undefined && value !== null) {
           if (key === "friendlyName" || key === "commonName") {
             const sanitizedValue = sanitizeSqlLikeString(String(value));
@@ -352,6 +356,10 @@ export const certificateDALFactory = (db: TDbClient) => {
           }
         }
       });
+
+      if (metadataFilter && metadataFilter.length > 0) {
+        query = applyMetadataFilter(query, metadataFilter, "certificateId", TableName.Certificate);
+      }
 
       if (permissionFilters) {
         query = applyProcessedPermissionRulesToQuery(query, TableName.Certificate, permissionFilters) as typeof query;
@@ -633,10 +641,14 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
-  const getDashboardStats = async (projectId: string) => {
+  const getDashboardStats = async (projectId: string, metadataFilter?: Array<{ key: string; value?: string }>) => {
     try {
       const now = new Date();
       const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+      const applyMeta = <T extends Knex.QueryBuilder>(q: T): T =>
+        metadataFilter && metadataFilter.length > 0
+          ? applyMetadataFilter(q, metadataFilter, "certificateId", TableName.Certificate)
+          : q;
 
       interface TotalsRow {
         total: number;
@@ -662,51 +674,54 @@ export const certificateDALFactory = (db: TDbClient) => {
         count: string;
       }
 
-      const [totalsRow] = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .select(
-          db.raw("COUNT(*)::int as total"),
-          db.raw(
-            `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."status" != ?)::int as active`,
-            [now, CertStatus.REVOKED]
-          ),
-          db.raw(
-            `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ?)::int as "expiringSoon"`,
-            [now, thirtyDaysFromNow, CertStatus.REVOKED]
-          ),
-          db.raw(
-            `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ?)::int as expired`,
-            [now, CertStatus.REVOKED]
-          ),
-          db.raw(`COUNT(*) FILTER (WHERE "${TableName.Certificate}"."status" = ?)::int as revoked`, [
-            CertStatus.REVOKED
-          ]),
-          db.raw(
-            `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ? AND "${TableName.Certificate}"."renewBeforeDays" IS NULL)::int as "expiringSoonNoAutoRenewal"`,
-            [now, thirtyDaysFromNow, CertStatus.REVOKED]
-          ),
-          db.raw(
-            `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ? AND "${TableName.Certificate}"."renewedByCertificateId" IS NULL)::int as "expiredNotRenewed"`,
-            [now, CertStatus.REVOKED]
-          )
-        );
+      const [totalsRow] = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      ).select(
+        db.raw("COUNT(*)::int as total"),
+        db.raw(
+          `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."status" != ?)::int as active`,
+          [now, CertStatus.REVOKED]
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ?)::int as "expiringSoon"`,
+          [now, thirtyDaysFromNow, CertStatus.REVOKED]
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ?)::int as expired`,
+          [now, CertStatus.REVOKED]
+        ),
+        db.raw(`COUNT(*) FILTER (WHERE "${TableName.Certificate}"."status" = ?)::int as revoked`, [CertStatus.REVOKED]),
+        db.raw(
+          `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" > ? AND "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ? AND "${TableName.Certificate}"."renewBeforeDays" IS NULL)::int as "expiringSoonNoAutoRenewal"`,
+          [now, thirtyDaysFromNow, CertStatus.REVOKED]
+        ),
+        db.raw(
+          `COUNT(*) FILTER (WHERE "${TableName.Certificate}"."notAfter" <= ? AND "${TableName.Certificate}"."status" != ? AND "${TableName.Certificate}"."renewedByCertificateId" IS NULL)::int as "expiredNotRenewed"`,
+          [now, CertStatus.REVOKED]
+        )
+      );
 
       const totals = totalsRow as unknown as TotalsRow;
 
-      const byAlgorithm = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      const byAlgorithm = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      )
         .select(`${TableName.Certificate}.keyAlgorithm as label`)
         .count("* as count")
         .groupBy(`${TableName.Certificate}.keyAlgorithm`);
 
-      const byCA = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      const byCA = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      )
         .select(`${TableName.CertificateAuthority}.id as id`)
         .select(`${TableName.CertificateAuthority}.name as label`)
         .count("* as count")
@@ -718,15 +733,17 @@ export const certificateDALFactory = (db: TDbClient) => {
         { label: "Revoked", count: totals.revoked }
       ];
 
-      const byEnrollmentMethod = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .leftJoin(
-          TableName.PkiCertificateProfile,
-          `${TableName.Certificate}.profileId`,
-          `${TableName.PkiCertificateProfile}.id`
-        )
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      const byEnrollmentMethod = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .leftJoin(
+            TableName.PkiCertificateProfile,
+            `${TableName.Certificate}.profileId`,
+            `${TableName.PkiCertificateProfile}.id`
+          )
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+      )
         .select(db.raw(`COALESCE("${TableName.PkiCertificateProfile}"."enrollmentType", 'API') as label`))
         .count("* as count")
         .groupBy("label");
@@ -735,11 +752,13 @@ export const certificateDALFactory = (db: TDbClient) => {
       const sixtyDaysFromNow = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
       const ninetyDaysFromNow = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
 
-      const expirationBuckets = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
+      const expirationBuckets = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
+      )
         .select(
           db.raw(
             `CASE
@@ -756,12 +775,14 @@ export const certificateDALFactory = (db: TDbClient) => {
         .select(db.raw("count(*)::int as count"))
         .groupBy("bucket");
 
-      const validityBuckets = await db
-        .replicaNode()(TableName.Certificate)
-        .where(`${TableName.Certificate}.projectId`, projectId)
-        .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
-        .where(`${TableName.Certificate}.notAfter`, ">", now)
-        .whereRaw(`"${TableName.Certificate}"."extendedKeyUsages" @> ARRAY[?]::text[]`, ["serverAuth"])
+      const validityBuckets = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .where(`${TableName.Certificate}.projectId`, projectId)
+          .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
+          .where(`${TableName.Certificate}.notAfter`, ">", now)
+          .whereRaw(`"${TableName.Certificate}"."extendedKeyUsages" @> ARRAY[?]::text[]`, ["serverAuth"])
+      )
         .select(
           db.raw(
             `CASE
@@ -815,7 +836,11 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
-  const getActivityTrend = async (projectId: string, daysBack: number) => {
+  const getActivityTrend = async (
+    projectId: string,
+    daysBack: number,
+    metadataFilter?: Array<{ key: string; value?: string }>
+  ) => {
     try {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - daysBack);
@@ -833,48 +858,61 @@ export const certificateDALFactory = (db: TDbClient) => {
       const periodExpr = (col: string) =>
         db.raw(`to_char(date_trunc(?, "${TableName.Certificate}"."${col}"), ?) as period`, [truncUnit, dateFormat]);
 
-      const issued = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
-        .where(`${TableName.Certificate}.notBefore`, "<=", now)
+      const applyMeta = <T extends Knex.QueryBuilder>(q: T): T =>
+        metadataFilter && metadataFilter.length > 0
+          ? applyMetadataFilter(q, metadataFilter, "certificateId", TableName.Certificate)
+          : q;
+
+      const issued = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
+          .where(`${TableName.Certificate}.notBefore`, "<=", now)
+      )
         .select(periodExpr("notBefore"))
         .select(db.raw("count(*)::int as count"))
         .groupBy("period")
         .orderBy("period");
 
-      const expired = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .where(`${TableName.Certificate}.notAfter`, ">=", startDate)
-        .where(`${TableName.Certificate}.notAfter`, "<=", now)
-        .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
+      const expired = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .where(`${TableName.Certificate}.notAfter`, ">=", startDate)
+          .where(`${TableName.Certificate}.notAfter`, "<=", now)
+          .where(`${TableName.Certificate}.status`, "!=", CertStatus.REVOKED)
+      )
         .select(periodExpr("notAfter"))
         .select(db.raw("count(*)::int as count"))
         .groupBy("period")
         .orderBy("period");
 
-      const revoked = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .where(`${TableName.Certificate}.status`, CertStatus.REVOKED)
-        .where(`${TableName.Certificate}.revokedAt`, ">=", startDate)
-        .where(`${TableName.Certificate}.revokedAt`, "<=", now)
+      const revoked = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .where(`${TableName.Certificate}.status`, CertStatus.REVOKED)
+          .where(`${TableName.Certificate}.revokedAt`, ">=", startDate)
+          .where(`${TableName.Certificate}.revokedAt`, "<=", now)
+      )
         .select(periodExpr("revokedAt"))
         .select(db.raw("count(*)::int as count"))
         .groupBy("period")
         .orderBy("period");
 
-      const renewed = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .whereNotNull(`${TableName.Certificate}.renewedFromCertificateId`)
-        .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
-        .where(`${TableName.Certificate}.notBefore`, "<=", now)
+      const renewed = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .whereNotNull(`${TableName.Certificate}.renewedFromCertificateId`)
+          .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
+          .where(`${TableName.Certificate}.notBefore`, "<=", now)
+      )
         .select(periodExpr("notBefore"))
         .select(db.raw("count(*)::int as count"))
         .groupBy("period")
@@ -934,7 +972,11 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
-  const getPqcTrend = async (projectId: string, daysBack: number) => {
+  const getPqcTrend = async (
+    projectId: string,
+    daysBack: number,
+    metadataFilter?: Array<{ key: string; value?: string }>
+  ) => {
     try {
       const startDate = new Date();
       startDate.setDate(startDate.getDate() - daysBack);
@@ -948,13 +990,20 @@ export const certificateDALFactory = (db: TDbClient) => {
       const truncUnit = useDaily ? "day" : "month";
       const dateFormat = useDaily ? "YYYY-MM-DD" : "YYYY-MM";
 
-      const rows = await db
-        .replicaNode()(TableName.Certificate)
-        .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
-        .where(`${TableName.CertificateAuthority}.projectId`, projectId)
-        .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
-        .where(`${TableName.Certificate}.notBefore`, "<=", now)
-        .whereIn(`${TableName.Certificate}.keyAlgorithm`, [...PQC_KEY_ALGORITHMS, ...NON_PQC_KEY_ALGORITHMS])
+      const applyMeta = <T extends Knex.QueryBuilder>(q: T): T =>
+        metadataFilter && metadataFilter.length > 0
+          ? applyMetadataFilter(q, metadataFilter, "certificateId", TableName.Certificate)
+          : q;
+
+      const rows = await applyMeta(
+        db
+          .replicaNode()(TableName.Certificate)
+          .join(TableName.CertificateAuthority, `${TableName.Certificate}.caId`, `${TableName.CertificateAuthority}.id`)
+          .where(`${TableName.CertificateAuthority}.projectId`, projectId)
+          .where(`${TableName.Certificate}.notBefore`, ">=", startDate)
+          .where(`${TableName.Certificate}.notBefore`, "<=", now)
+          .whereIn(`${TableName.Certificate}.keyAlgorithm`, [...PQC_KEY_ALGORITHMS, ...NON_PQC_KEY_ALGORITHMS])
+      )
         .select(
           db.raw(`to_char(date_trunc(?, "${TableName.Certificate}"."notBefore"), ?) as period`, [truncUnit, dateFormat])
         )

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -1,6 +1,7 @@
 import { createMongoAbility, ForbiddenError, MongoAbility, RawRuleOf, subject } from "@casl/ability";
 import { PackRule, unpackRules } from "@casl/ability/extra";
 import slugify from "@sindresorhus/slugify";
+import { createHash } from "crypto";
 
 import {
   AccessScope,
@@ -1257,6 +1258,20 @@ export const projectServiceFactory = ({
       ProjectPermissionSub.Certificates
     );
 
+    const permissionFilters = getProcessedPermissionRules(
+      permission,
+      ProjectPermissionCertificateActions.Read,
+      ProjectPermissionSub.Certificates
+    );
+
+    // Merge user-supplied metadata filters with CASL-sourced metadata
+    // $elemMatch conditions. ANDing is the safe direction — the user cannot
+    // broaden scope beyond what their role grants.
+    const mergedMetadataFilter: Array<{ key: string; value?: string }> = [
+      ...(metadataFilter || []),
+      ...permissionFilters.metadataFilter
+    ];
+
     const regularFilters = {
       projectId,
       ...(friendlyName && { friendlyName }),
@@ -1268,7 +1283,7 @@ export const projectServiceFactory = ({
       ...(profileIds && { profileIds }),
       ...(fromDate && { fromDate }),
       ...(toDate && { toDate }),
-      ...(metadataFilter && { metadataFilter }),
+      ...(mergedMetadataFilter.length > 0 && { metadataFilter: mergedMetadataFilter }),
       ...(extendedKeyUsage && { extendedKeyUsage }),
       ...(keyAlgorithm && { keyAlgorithm }),
       ...(signatureAlgorithm && { signatureAlgorithm }),
@@ -1281,11 +1296,6 @@ export const projectServiceFactory = ({
       ...(notBeforeFrom && { notBeforeFrom }),
       ...(notBeforeTo && { notBeforeTo })
     };
-    const permissionFilters = getProcessedPermissionRules(
-      permission,
-      ProjectPermissionCertificateActions.Read,
-      ProjectPermissionSub.Certificates
-    );
 
     const ALLOWED_SORT_COLUMNS = new Set([
       "notAfter",
@@ -1344,6 +1354,26 @@ export const projectServiceFactory = ({
     };
   };
 
+  /**
+   * Produce a stable fingerprint of the CASL-sourced metadata filter so
+   * users with different metadata scopes hitting the same project don't
+   * share a cached dashboard payload. Unscoped callers get "" and share
+   * the global cache.
+   */
+  const metadataFilterCacheHash = (metadataFilter: Array<{ key: string; value?: string }>): string => {
+    if (metadataFilter.length === 0) return "";
+    const normalized = [...metadataFilter]
+      .map((entry) => ({ key: entry.key, value: entry.value ?? null }))
+      .sort((a, b) => {
+        if (a.key !== b.key) return a.key < b.key ? -1 : 1;
+        const av = a.value ?? "";
+        const bv = b.value ?? "";
+        if (av === bv) return 0;
+        return av < bv ? -1 : 1;
+      });
+    return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 16);
+  };
+
   const getDashboardStats = async ({ filter, actorId, actorOrgId, actorAuthMethod, actor }: TGetDashboardStatsDTO) => {
     const project = await projectDAL.findProjectByFilter(filter);
     const projectId = project.id;
@@ -1362,11 +1392,18 @@ export const projectServiceFactory = ({
       ProjectPermissionSub.Certificates
     );
 
+    const { metadataFilter } = getProcessedPermissionRules(
+      permission,
+      ProjectPermissionCertificateActions.Read,
+      ProjectPermissionSub.Certificates
+    );
+    const filterHash = metadataFilterCacheHash(metadataFilter);
+
     return withCache({
       keyStore,
-      key: KeyStorePrefixes.CertDashboardStats(projectId),
+      key: KeyStorePrefixes.CertDashboardStats(projectId, filterHash),
       ttlSeconds: DASHBOARD_CACHE_TTL,
-      fetcher: () => certificateDAL.getDashboardStats(projectId)
+      fetcher: () => certificateDAL.getDashboardStats(projectId, metadataFilter)
     });
   };
 
@@ -1398,11 +1435,18 @@ export const projectServiceFactory = ({
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];
 
+    const { metadataFilter } = getProcessedPermissionRules(
+      permission,
+      ProjectPermissionCertificateActions.Read,
+      ProjectPermissionSub.Certificates
+    );
+    const filterHash = metadataFilterCacheHash(metadataFilter);
+
     return withCache({
       keyStore,
-      key: KeyStorePrefixes.CertActivityTrend(projectId, range),
+      key: KeyStorePrefixes.CertActivityTrend(projectId, range, filterHash),
       ttlSeconds: DASHBOARD_CACHE_TTL,
-      fetcher: () => certificateDAL.getActivityTrend(projectId, daysBack)
+      fetcher: () => certificateDAL.getActivityTrend(projectId, daysBack, metadataFilter)
     });
   };
 
@@ -1434,11 +1478,18 @@ export const projectServiceFactory = ({
     const rangeDaysMap: Record<string, number> = { "7d": 7, "30d": 30, "6m": 180 };
     const daysBack = rangeDaysMap[range];
 
+    const { metadataFilter } = getProcessedPermissionRules(
+      permission,
+      ProjectPermissionCertificateActions.Read,
+      ProjectPermissionSub.Certificates
+    );
+    const filterHash = metadataFilterCacheHash(metadataFilter);
+
     return withCache({
       keyStore,
-      key: KeyStorePrefixes.CertPqcTrend(projectId, range),
+      key: KeyStorePrefixes.CertPqcTrend(projectId, range, filterHash),
       ttlSeconds: DASHBOARD_CACHE_TTL,
-      fetcher: () => certificateDAL.getPqcTrend(projectId, daysBack)
+      fetcher: () => certificateDAL.getPqcTrend(projectId, daysBack, metadataFilter)
     });
   };
 


### PR DESCRIPTION
# fix(casl): teach CASL→SQL translator about `$elemMatch`, add unknown-operator guardrail, and scope cert list / cert request list / cert dashboards by metadata in SQL

> This template is acting as a review artifact for an uncommitted branch. It is intentionally verbose.
>
> Companion branch: `saif/pki-146-fix-shortterm-cert-metadata` — same bug, per-row in-memory filter with dashboard-denial fallback. Compare before deciding which to ship.

## Context

A security finding on PKI-146 reported that when a role scopes `Read Certificates` by `metadata` (via a CASL `$elemMatch` condition), the cert list, cert-request list, and certificate dashboard endpoints return data for every certificate in the project rather than the scoped subset. Private keys remain protected, but certificate metadata (CN, altNames, serial, friendly name, metadata tags) and aggregate stats (counts, activity trend buckets, PQC readiness trends) leak.

### Root cause

`backend/src/lib/casl/permission-filter-utils.ts::processCondition` (lines ~102-156) translates CASL MongoDB-style conditions into SQL WHERE clauses. It recognises `$regex`/`$eq`/`$in`/`$glob`/`$ne` and **silently drops anything else**, including `$elemMatch`. A rule like `{ metadata: { $elemMatch: { key: { $eq: "env" }, value: { $eq: "prod" } } } }` compiles to `allowRules: [{}]`, which `applyProcessedPermissionRulesToQuery` converts to zero SQL constraints. There is no per-row fallback on cert list paths. Cert requests use the same `Certificates` CASL subject and inherit the hole. Dashboards do only a subject-class-level `throwUnlessCan(Read, Certificates)` and run project-wide aggregate SQL with no metadata scoping.

### Why this branch takes the translator-level approach

The companion short-term branch matches the existing per-row in-memory convention used by dynamic secrets / PAM accounts / PAM resources. It's simpler and lower-risk, but it has two structural weaknesses:

1. **Dashboards can't be scoped with a per-row filter.** Aggregates don't have rows to iterate — the short-term branch resorts to denying dashboard endpoints entirely for metadata-scoped roles.
2. **The silent-drop failure mode persists.** The next CASL operator someone adds to a permission schema will ship with the same bug if it isn't also added to the translator.

This branch fixes both: the translator learns about `$elemMatch`, metadata flows through SQL so dashboards can be scoped natively, and the translator throws on any operator it doesn't recognize so the next mismatch can't ship silently.

## What this branch changes

### 1. Translator — `backend/src/lib/casl/permission-filter-utils.ts`

- `processCondition` gets an explicit `$elemMatch` branch. Instead of emitting a SQL filter, it extracts the inner `{ key: { $eq | $in }, value: { $eq | $in } }` structure into `{ key: string; value?: string }` entries and pushes them into a new per-rule `metadataFilter` bucket. `$in` on either key or value expands into multiple entries (OR-ed at the metadata level).
- **Guardrail:** if `value` is an object whose keys are `$`-prefixed CASL operators but none of them are in the recognized set (`$regex`, `$eq`, `$in`, `$glob`, `$ne`, `$elemMatch`), `processCondition` throws `BadRequestError("Unknown CASL operator … — translator is missing a handler.")`. This forces any future operator addition to the CASL permission schemas to be accompanied by a matching translator branch.
- `ProcessedPermissionRules` grows a third field, `metadataFilter: Array<{ key: string; value? }>`, populated by merging the buckets from every matching allow rule. `forbidRules` remain shape-unchanged.
- **Inverted rules containing `$elemMatch` throw.** `applyMetadataFilter` is a positive `whereExists`; a semantically correct `NOT EXISTS (x AND y)` isn't what the primitive expresses, and no current cert role uses inversion + metadata. If we ever need this, we add it with its own semantics.

### 2. Cert list — `project-service.ts::listProjectCertificates` + `certificate-dal.ts`

- Service pulls `metadataFilter` off `processedRules`, merges (AND) with the user-supplied `regularFilters.metadataFilter`, passes the combined array to the DAL for both the list and the count query.
- DAL methods `findWithPrivateKeyInfo`, `findActiveCertificatesForSync`, `countCertificatesInProject` accept the merged filter and feed it through the existing `applyMetadataFilter(query, metadataFilter, "certificateId", TableName.Certificate)` primitive (already used today for the user-supplied filter).
- The existing SQL filter via `applyProcessedPermissionRulesToQuery` is left in place — it still handles `commonName`/`status`/`friendlyName` correctly at the DB layer.
- `findActiveCertificatesForSync` previously looped over `Object.entries(filter)` and called `andWhere(key, value)` for every key. The array-typed `metadataFilter` would have SQL-broken this loop. Extracted metadata out of that loop and routed through `applyMetadataFilter` instead. Minor cleanup forced by the new shape.
- `totalCount` is now the correct post-filter SQL count — **no quirk**.

### 3. Cert request list — `certificate-request-service.ts` + `certificate-request-dal.ts`

Same pattern. CASL `metadataFilter` merges with user-supplied filter; both threaded through existing `applyMetadataFilter` calls on `certificateRequestId`. Works for `findByProjectIdWithCertificate` + `countByProjectId`.

### 4. Dashboards — `project-service.ts::{getDashboardStats, getActivityTrend, getPqcTrend}` + `certificate-dal.ts`

- Services extract `metadataFilter` from `getProcessedPermissionRules` and pass it to the DAL alongside the `projectId`.
- DAL dashboard methods (`getDashboardStats` @ `:636`, `getActivityTrend`, `getPqcTrend`) accept the optional `metadataFilter`. For **every** aggregate subquery — totals, `byAlgorithm`, `byCA`, `byEnrollmentMethod`, trend buckets, PQC buckets — they call `applyMetadataFilter(query, metadataFilter, "certificateId", TableName.Certificate)` so the `whereExists` subquery scopes the COUNT to only certs the user is authorised to see.
- `byStatus` is derived from `totals` and inherits scoping automatically.
- **Cache key correctness.** Dashboard results are cached in the keystore. Without a per-scope key, one metadata-scoped user's filtered aggregates would be served to another user via the cache. A `metadataFilterCacheHash(filter)` helper (factory-scoped, reused across all three dashboard methods) produces a stable 16-char sha256 hash from the sorted filter entries; `""` for unscoped users so the global cache is shared. `KeyStorePrefixes.CertDashboardStats`, `.CertActivityTrend`, `.CertPqcTrend` were updated to accept the hash as part of the key.

### 5. Unit tests — `permission-filter-utils.test.ts` (new)

Six tests, all passing:

1. `$glob` on a regular field — returns an `allowRules` filter, empty `metadataFilter`.
2. `$elemMatch` single entry — empty `allowRules` filter on metadata, `metadataFilter` populated.
3. `$elemMatch` with `$in` expansion — multiple entries in `metadataFilter`.
4. `$elemMatch` key-only (no value constraint) — `metadataFilter` entry with `value: undefined`.
5. Combined condition (`commonName` + `metadata`) — both structures populated, compose correctly.
6. Unknown operator → throws `BadRequestError` with the guardrail message.

Two existing test files (`certificate-policy-service.test.ts`, `certificate-profile-service.test.ts`) were updated to include the new `metadataFilter: []` field in their `ProcessedPermissionRules` fixtures. These assertions were pinning the old shape; they now match the new one.

Full unit test suite: 426 pass / 22 skipped / 0 failed.

## Translator audit (callers of `getProcessedPermissionRules` / `applyProcessedPermissionRulesToQuery`)

Per the guardrail, any subject whose rules already contain an operator outside the recognized set would start throwing. Audited:

| Caller | Subject | Conditions schema operators used |
|---|---|---|
| `project-service.ts::listProjectCertificates` | `Certificates` | `$eq`, `$ne`, `$in`, `$glob`, `$elemMatch` — all handled |
| `certificate-request-service.ts::listCertificateRequests` | `Certificates` | Shares `Certificates` subject — same set |
| `certificate-authority-service.ts` | `CertificateAuthorities` | `$eq`, `$ne`, `$in`, `$glob` — all handled |
| `certificate-profile-service.ts` | `CertificateProfiles` | `$eq`, `$ne`, `$in`, `$glob` — all handled |
| `certificate-policy-service.ts` | `CertificatePolicies` | `$eq`, `$ne`, `$in`, `$glob` — all handled |
| `pki-sync-service.ts` | `PkiSyncs` | `$eq`, `$ne`, `$in`, `$glob` — all handled |

No schema references an operator the translator doesn't handle. Guardrail will not fire on any role configured through the API.

## Files changed

| File | Change |
|---|---|
| `backend/src/lib/casl/permission-filter-utils.ts` | `$elemMatch` branch, unknown-operator guardrail, `ProcessedPermissionRules.metadataFilter` |
| `backend/src/lib/casl/permission-filter-utils.test.ts` | New — 6 unit tests |
| `backend/src/keystore/keystore.ts` | Dashboard cache keys accept metadata-filter hash |
| `backend/src/services/certificate/certificate-dal.ts` | `metadataFilter` plumbed into list, sync-list, count, and all three dashboard methods with `applyMetadataFilter` on every aggregate subquery |
| `backend/src/services/project/project-service.ts` | CASL metadata merged with user metadata in list; dashboards extract metadata + use hashed cache key |
| `backend/src/services/certificate-request/certificate-request-service.ts` | CASL metadata merged with user metadata in cert-request list |
| `backend/src/services/certificate-policy/certificate-policy-service.test.ts` | Fixture updated for new `ProcessedPermissionRules` shape |
| `backend/src/services/certificate-profile/certificate-profile-service.test.ts` | Same |
| `backend/src/lib/knex/scim.ts` | Incidental `lint:fix` import-order autofix. Unrelated to this fix. |

## Downsides (be aware before merging)

- **Shared utility touched.** `permission-filter-utils.ts` is used by every subject that uses `getProcessedPermissionRules`. Audit is included above, but anyone adding a new CASL operator to any project/org permission schema must now also teach the translator — that's the explicit intent, but it's a mechanical step future PRs will need to remember. The guardrail throws will make this loud.
- **Multi-rule metadata gets AND semantics, not OR.** CASL evaluates multiple allow rules as OR; `applyMetadataFilter` ANDs entries. When more than one matching allow rule carries `$elemMatch` conditions, the translator logs a console warning and ANDs the entries (stricter than CASL — safer direction, no leaks, potentially smaller result set than strict CASL semantics would yield). Real OR support is a future extension.
- **Forbid rules containing `$elemMatch` throw.** Inverted metadata scoping isn't currently expressible; if product ever exposes it, we'll need to add dedicated semantics (tricky — it's NOT-EXISTS with inner AND).
- **`whereExists` query plan sensitivity.** `resource_metadata` is joined per aggregate subquery. On large tenants without an index on `(certificateId, key, value)`, the subquery can be slow. Verify with `EXPLAIN` on a representative dataset before rolling to high-cardinality customers. Same concern applies to `(certificateRequestId, key, value)`.
- **Three new patterns for the team to absorb:** (1) CASL conditions feeding `applyMetadataFilter` via a bucket on `ProcessedPermissionRules`; (2) `$elemMatch` recognition in the translator; (3) per-scope cache-key hashing for dashboards. Higher review + onboarding cost than the companion branch.
- **Dynamic secrets / PAM continue to use the in-memory per-row pattern.** Only the `Certificates` subject is migrated to the SQL path here. Consistency across subjects is a follow-up if it ever matters.

## Risk assessment

- Full unit-test suite passes; two pre-existing test files had fixtures pinning the old `ProcessedPermissionRules` shape and were updated (no behavior assertions changed).
- Translator audit (table above) confirms no existing role hits the guardrail.
- Dashboard cache key includes scope — verified by reading the three dashboard methods. Two users with different metadata scopes on the same project produce different cache keys; a user with no metadata scope produces `""` (shared with the old global cache).
- No schema / migration changes. `resource_metadata.certificateId` and `.certificateRequestId` columns already exist on main.

## Steps to verify the change

End-to-end:

1. Seed two certificates — one with `metadata { env: prod }`, one with `metadata { env: staging }`.
2. Role: grant `Read Certificates` scoped by `{ metadata: { $elemMatch: { key: { $eq: "env" }, value: { $eq: "prod" } } } }`.
3. `GET /api/v2/workspace/:projectId/certificates` — expect only the prod cert; `totalCount === 1`. Repeat for cert requests with prod-tagged + staging-tagged requests — expect only the prod-tagged one.
4. `GET /api/v2/workspace/:projectId/certificates/dashboard-stats` — expect `totals.total === 1`, `byAlgorithm`/`byCA` reflect only the prod cert. Same for activity trend and PQC trend — buckets count only prod certs.
5. Combined-rule test: `{ commonName: { $glob: "prod-*" }, metadata: { $elemMatch: … } }` — list returns certs where CN matches AND metadata matches.
6. Cache scoping test: create two roles on the same project with different metadata scopes, hit dashboard as each — each sees their own numbers; hit as an unscoped user — sees global numbers. Confirm three distinct cache keys in Redis / keystore.
7. **Guardrail sanity:** temporarily add an unknown operator (e.g. `{ commonName: { $notAThing: "x" } }`) to a role via the service-layer helper — expect `BadRequestError("Unknown CASL operator …")` at list time. Remove after testing.

Local:

- `cd backend && make reviewable-api` — PASS on this branch.
- `cd backend && npm run test:unit -- permission-filter-utils` — new 6-test file passes.
- `cd backend && npm run test:unit` — full suite: 426 pass, 22 skipped, 0 failed.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [ ] Updated docs (if needed) — document the new translator-guardrail expectation for anyone extending CASL permission schemas
- [ ] Updated CLAUDE.md files (if needed) — worth noting in `backend/CLAUDE.md` that any new CASL operator addition must also extend `permission-filter-utils.ts`
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
