### PR TITLE
fix(api): use Bitbucket user workspaces endpoint for listing

### DIFF
--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -53,8 +53,12 @@ export const validateBitbucketConnectionCredentials = async (config: TBitbucketC
   return config.credentials;
 };
 
+interface BitbucketWorkspaceMembership {
+  workspace: { slug: string };
+}
+
 interface BitbucketWorkspacesResponse {
-  values: TBitbucketWorkspace[];
+  values: BitbucketWorkspaceMembership[];
   next?: string;
 }
 
@@ -67,7 +71,7 @@ export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnectio
   };
 
   let allWorkspaces: TBitbucketWorkspace[] = [];
-  let nextUrl: string | undefined = `${IntegrationUrls.BITBUCKET_API_URL}/2.0/workspaces?pagelen=100`;
+  let nextUrl: string | undefined = `${IntegrationUrls.BITBUCKET_API_URL}/2.0/user/workspaces?pagelen=100`;
   let iterationCount = 0;
 
   // Limit to 10 iterations, fetching at most 10 * 100 = 1000 workspaces
@@ -77,7 +81,7 @@ export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnectio
       headers
     });
 
-    allWorkspaces = allWorkspaces.concat(data.values.map((workspace) => ({ slug: workspace.slug })));
+    allWorkspaces = allWorkspaces.concat(data.values.map((membership) => ({ slug: membership.workspace.slug })));
     nextUrl = data.next;
     iterationCount += 1;
   }


### PR DESCRIPTION
## Context

Bitbucket workspace listing used `GET /2.0/workspaces`, which does not match how Bitbucket Cloud returns **the authenticated user’s** workspaces in the new API after the old API [sunsetted](https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-2770). The correct resource is `GET /2.0/user/workspaces`, which returns **workspace memberships** (`values[].workspace`), not top-level workspace objects.

## Steps to verify the change

1. Create or use a Bitbucket app connection (email + app password).
2. Trigger any flow that lists Bitbucket workspaces (e.g. integration UI or API that calls this path).
3. Confirm workspaces appear and pagination still works for users with many workspaces (up to existing caps).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)