### PR TITLE
docs(pki-discovery): document ALLOW_INTERNAL_IP_CONNECTIONS option

### DIFF
--- a/backend/src/ee/services/pki-discovery/pki-discovery-fns.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-fns.ts
@@ -103,18 +103,23 @@ export const validateTargetConfig = (
     const singleIps = ipRanges.filter((r) => !r.includes("/"));
 
     if (shouldBlockPrivateIps(!!hasGateway)) {
+      const appCfg = getConfig();
+      const selfHostedHint = appCfg.isCloud
+        ? ""
+        : " If you are self-hosting, you can alternatively set the 'ALLOW_INTERNAL_IP_CONNECTIONS' environment variable to 'true' on your instance to scan private networks without a gateway.";
+
       const privateIp = singleIps.find((ip) => isPrivateIp(ip));
       if (privateIp) {
         return {
           valid: false,
-          error: "Private/internal IP addresses require a gateway. Use a gateway to scan private networks."
+          error: `Private/internal IP addresses require a gateway. Use a gateway to scan private networks.${selfHostedHint}`
         };
       }
       const privateCidr = cidrRanges.find((cidr) => isPrivateIp(cidr.split("/")[0]));
       if (privateCidr) {
         return {
           valid: false,
-          error: "Private/internal CIDR ranges require a gateway. Use a gateway to scan private networks."
+          error: `Private/internal CIDR ranges require a gateway. Use a gateway to scan private networks.${selfHostedHint}`
         };
       }
     }

--- a/docs/documentation/platform/pki/discovery/network.mdx
+++ b/docs/documentation/platform/pki/discovery/network.mdx
@@ -5,6 +5,10 @@ description: "Learn how to configure a Network discovery job to find certificate
 
 Network discovery scans network endpoints over TLS to discover certificates served by hosts across IP ranges and domains. Optionally, you can use an [Infisical Gateway](/documentation/platform/gateways/overview) to reach endpoints in private networks that are not accessible from the internet.
 
+<Note>
+  If you are self-hosting Infisical, you can alternatively set the [`ALLOW_INTERNAL_IP_CONNECTIONS`](/self-hosting/configuration/envars#param-allow-internal-ip-connections) environment variable to `true` on your instance to scan private networks directly without a gateway.
+</Note>
+
 <Tabs>
   <Tab title="Infisical UI">
     1. Navigate to your Certificate Management Project > **Discovery** and press **Add Job**.

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -55,8 +55,8 @@ Example values:
   default="false"
   optional
 >
-  Determines whether App Connections and Dynamic Secrets are permitted to
-  connect with internal/private IP addresses.
+  Determines whether App Connections, Dynamic Secrets, and PKI Certificate
+  Discovery jobs are permitted to connect with internal/private IP addresses.
 </ParamField>
 
 <ParamField

--- a/frontend/src/pages/cert-manager/DiscoveryPage/components/DiscoveryJobModal.tsx
+++ b/frontend/src/pages/cert-manager/DiscoveryPage/components/DiscoveryJobModal.tsx
@@ -15,6 +15,7 @@ import {
   Switch,
   TextArea
 } from "@app/components/v2";
+import { isInfisicalCloud } from "@app/helpers/platform";
 import {
   gatewaysQueryKeys,
   PkiDiscoveryType,
@@ -407,7 +408,26 @@ export const DiscoveryJobModal = ({ isOpen, onClose, projectId, discovery }: Pro
             render={({ field }) => (
               <FormControl
                 label="Gateway"
-                tooltipText="Use a gateway to discover certificates on private networks that are not directly accessible from the internet. The gateway acts as a proxy, routing scan traffic through your infrastructure."
+                tooltipClassName="max-w-lg py-3"
+                tooltipText={
+                  <div className="flex flex-col gap-3">
+                    <p>
+                      Use a gateway to discover certificates on private networks that are not
+                      directly accessible from the internet. The gateway acts as a proxy, routing
+                      scan traffic through your infrastructure.
+                    </p>
+                    {!isInfisicalCloud() && (
+                      <p>
+                        Alternatively, you can set the{" "}
+                        <span className="font-medium text-bunker-200">
+                          ALLOW_INTERNAL_IP_CONNECTIONS
+                        </span>{" "}
+                        environment variable to <span className="font-medium">true</span> on your
+                        instance to scan private networks directly without a gateway.
+                      </p>
+                    )}
+                  </div>
+                }
               >
                 <Select
                   value={field.value}


### PR DESCRIPTION
## Context

Self-hosted users didn't know they could skip the gateway for internal IP scans by setting ALLOW_INTERNAL_IP_CONNECTIONS=true. Added a tooltip in the discovery modal, mentioned it in the docs, and tweaked the "gateway required" error to point at it.

## Screenshots


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)