### PR TITLE
feat: updated secret sharing delete to have 7 day grace

### DIFF
--- a/backend/src/services/secret-sharing/secret-sharing-dal.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-dal.ts
@@ -90,9 +90,11 @@ export const secretSharingDALFactory = (db: TDbClient) => {
   const pruneExpiredSharedSecrets = async (tx?: Knex) => {
     logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret started`);
     try {
-      const today = new Date();
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
       const docs = await (tx || db)(TableName.SecretSharing)
-        .where("expiresAt", "<", today)
+        .where("expiresAt", "<", sevenDaysAgo)
         .andWhere("type", SecretSharingType.Share)
         .del();
       logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired shared secret completed`);
@@ -105,11 +107,12 @@ export const secretSharingDALFactory = (db: TDbClient) => {
   const pruneExpiredSecretRequests = async (tx?: Knex) => {
     logger.info(`${QueueName.DailyResourceCleanUp}: pruning expired secret requests started`);
     try {
-      const today = new Date();
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
       const docs = await (tx || db)(TableName.SecretSharing)
         .whereNotNull("expiresAt")
-        .andWhere("expiresAt", "<", today)
+        .andWhere("expiresAt", "<", sevenDaysAgo)
         .andWhere("type", SecretSharingType.Request)
         .delete();
 


### PR DESCRIPTION
## Context

This PR increses secret sharing delete to have 7 day grace

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)