### PR TITLE
fix(db): gate OAuth verified migration on accepted users

### DIFF
--- a/backend/src/db/migrations/20260404140728_username-merge.ts
+++ b/backend/src/db/migrations/20260404140728_username-merge.ts
@@ -40,6 +40,7 @@ export async function up(knex: Knex): Promise<void> {
     UPDATE "${TableName.Users}"
     SET "isGitHubVerified" = TRUE
     WHERE "authMethods" @> ARRAY['github']::text[]
+      AND "isAccepted" = TRUE
       AND ("isGitHubVerified" IS NULL OR "isGitHubVerified" = FALSE)
   `);
 
@@ -47,6 +48,7 @@ export async function up(knex: Knex): Promise<void> {
     UPDATE "${TableName.Users}"
     SET "isGoogleVerified" = TRUE
     WHERE "authMethods" @> ARRAY['google']::text[]
+      AND "isAccepted" = TRUE
       AND ("isGoogleVerified" IS NULL OR "isGoogleVerified" = FALSE)
   `);
 
@@ -54,6 +56,7 @@ export async function up(knex: Knex): Promise<void> {
     UPDATE "${TableName.Users}"
     SET "isGitLabVerified" = TRUE
     WHERE "authMethods" @> ARRAY['gitlab']::text[]
+      AND "isAccepted" = TRUE
       AND ("isGitLabVerified" IS NULL OR "isGitLabVerified" = FALSE)
   `);
     log(`Step 2 done in ${Date.now() - t}ms`);


### PR DESCRIPTION
## Context

Migration: OAuth verified backfill (GitHub/Google/GitLab) now runs only when isAccepted = TRUE, so pending users are not marked verified.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)