### PR TITLE
feat: user controlled ssl rejection option for dynamic secret

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -145,7 +145,7 @@ export const AzureSqlDatabaseProvider = ({
     targetDatabase?: string
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.host }
+      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.originalHost }
       : undefined;
 
     /*

--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -181,7 +181,7 @@ export const AzureSqlDatabaseProvider = ({
         // https://github.com/tediousjs/tedious/blob/ebb023ed90969a7ec0e4b036533ad52739d921f7/test/config.ci.ts#L19
         options: {
           ...(providerInputs.sslEnabled !== undefined ? { encrypt: providerInputs.sslEnabled } : {}),
-          trustServerCertificate: !providerInputs.ca,
+          trustServerCertificate: !providerInputs.sslRejectUnauthorized,
           cryptoCredentialsDetails: providerInputs.ca ? { ca: providerInputs.ca } : {}
         }
       },

--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -145,7 +145,7 @@ export const AzureSqlDatabaseProvider = ({
     targetDatabase?: string
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: false, ca: providerInputs.ca, servername: providerInputs.host }
+      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.host }
       : undefined;
 
     /*

--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -145,7 +145,11 @@ export const AzureSqlDatabaseProvider = ({
     targetDatabase?: string
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.originalHost }
+      ? {
+          rejectUnauthorized: providerInputs.sslRejectUnauthorized,
+          ca: providerInputs.ca,
+          servername: providerInputs.originalHost
+        }
       : undefined;
 
     /*

--- a/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
@@ -43,7 +43,9 @@ export const CassandraProvider = (): TDynamicProviderFns => {
   };
 
   const $getClient = async (providerInputs: z.infer<typeof DynamicSecretCassandraSchema>) => {
-    const sslOptions = providerInputs.ca ? { rejectUnauthorized: true, ca: providerInputs.ca } : undefined;
+    const sslOptions = providerInputs.ca
+      ? { rejectUnauthorized: providerInputs.sslRejectUnauthorized, ca: providerInputs.ca }
+      : undefined;
     const client = new cassandra.Client({
       sslOptions,
       protocolOptions: {

--- a/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
@@ -43,7 +43,7 @@ export const CassandraProvider = (): TDynamicProviderFns => {
   };
 
   const $getClient = async (providerInputs: z.infer<typeof DynamicSecretCassandraSchema>) => {
-    const sslOptions = providerInputs.ca ? { rejectUnauthorized: false, ca: providerInputs.ca } : undefined;
+    const sslOptions = providerInputs.ca ? { rejectedUnauthorized: true, ca: providerInputs.ca } : undefined;
     const client = new cassandra.Client({
       sslOptions,
       protocolOptions: {

--- a/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
@@ -43,7 +43,7 @@ export const CassandraProvider = (): TDynamicProviderFns => {
   };
 
   const $getClient = async (providerInputs: z.infer<typeof DynamicSecretCassandraSchema>) => {
-    const sslOptions = providerInputs.ca ? { rejectedUnauthorized: true, ca: providerInputs.ca } : undefined;
+    const sslOptions = providerInputs.ca ? { rejectUnauthorized: true, ca: providerInputs.ca } : undefined;
     const client = new cassandra.Client({
       sslOptions,
       protocolOptions: {

--- a/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
@@ -30,7 +30,7 @@ export const ElasticSearchProvider = (): TDynamicProviderFns => {
         url: new URL(`${providerInputs.host}:${providerInputs.port}`),
         ...(providerInputs.ca && {
           ssl: {
-            rejectUnauthorized: true,
+            rejectUnauthorized: providerInputs.sslRejectUnauthorized,
             ca: providerInputs.ca
           }
         })

--- a/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
@@ -30,7 +30,7 @@ export const ElasticSearchProvider = (): TDynamicProviderFns => {
         url: new URL(`${providerInputs.host}:${providerInputs.port}`),
         ...(providerInputs.ca && {
           ssl: {
-            rejectUnauthorized: false,
+            rejectUnauthorized: true,
             ca: providerInputs.ca
           }
         })

--- a/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
@@ -341,7 +341,7 @@ export const KubernetesProvider = ({
         providerInputs.ca && providerInputs.sslEnabled
           ? new https.Agent({
               ca: providerInputs.ca,
-              rejectUnauthorized: true
+              rejectUnauthorized: providerInputs.sslRejectUnauthorized
             })
           : undefined;
 
@@ -610,7 +610,7 @@ export const KubernetesProvider = ({
         providerInputs.ca && providerInputs.sslEnabled
           ? new https.Agent({
               ca: providerInputs.ca,
-              rejectUnauthorized: true
+              rejectUnauthorized: providerInputs.sslRejectUnauthorized
             })
           : undefined;
 
@@ -769,7 +769,7 @@ export const KubernetesProvider = ({
           providerInputs.ca && providerInputs.sslEnabled
             ? new https.Agent({
                 ca: providerInputs.ca,
-                rejectUnauthorized: true
+                rejectUnauthorized: providerInputs.sslRejectUnauthorized
               })
             : undefined;
 

--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -56,10 +56,12 @@ export const LdapProvider = (): TDynamicProviderFns => {
     return new Promise((resolve, reject) => {
       const client = ldapjs.createClient({
         url: providerInputs.url,
-        tlsOptions: {
-          ca: providerInputs.ca ? providerInputs.ca : null,
-          rejectUnauthorized: providerInputs.sslRejectUnauthorized
-        },
+        tlsOptions: providerInputs.ca
+          ? {
+              ca: providerInputs.ca ? providerInputs.ca : null,
+              rejectUnauthorized: providerInputs.sslRejectUnauthorized
+            }
+          : undefined,
         reconnect: true,
         bindDN: providerInputs.binddn,
         bindCredentials: providerInputs.bindpass

--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -58,7 +58,7 @@ export const LdapProvider = (): TDynamicProviderFns => {
         url: providerInputs.url,
         tlsOptions: {
           ca: providerInputs.ca ? providerInputs.ca : null,
-          rejectUnauthorized: !!providerInputs.ca
+          rejectUnauthorized: providerInputs.sslRejectUnauthorized
         },
         reconnect: true,
         bindDN: providerInputs.binddn,

--- a/backend/src/ee/services/dynamic-secret/providers/models.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/models.ts
@@ -86,7 +86,8 @@ export const DynamicSecretRedisDBSchema = z.object({
   creationStatement: z.string().trim(),
   revocationStatement: z.string().trim(),
   renewStatement: z.string().trim().optional(),
-  ca: z.string().optional()
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
 });
 
 export const DynamicSecretAwsElastiCacheSchema = z.object({
@@ -96,8 +97,7 @@ export const DynamicSecretAwsElastiCacheSchema = z.object({
 
   region: z.string().trim(),
   creationStatement: z.string().trim(),
-  revocationStatement: z.string().trim(),
-  ca: z.string().optional()
+  revocationStatement: z.string().trim()
 });
 
 export const DynamicSecretElasticSearchSchema = z.object({
@@ -119,7 +119,8 @@ export const DynamicSecretElasticSearchSchema = z.object({
     })
   ]),
 
-  ca: z.string().optional()
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
 });
 
 export const DynamicSecretRabbitMqSchema = z.object({
@@ -131,6 +132,7 @@ export const DynamicSecretRabbitMqSchema = z.object({
   password: z.string().trim().min(1),
 
   ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
 
   virtualHost: z.object({
     name: z.string().trim().min(1),
@@ -176,6 +178,7 @@ export const DynamicSecretSqlDBSchema = z.object({
   renewStatement: z.string().trim().optional(),
   ca: z.string().optional(),
   sslEnabled: z.boolean().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
   gatewayId: z.string().nullable().optional()
 });
 
@@ -224,7 +227,8 @@ export const DynamicSecretCassandraSchema = z.object({
   creationStatement: z.string().trim(),
   revocationStatement: z.string().trim(),
   renewStatement: z.string().trim().optional(),
-  ca: z.string().optional()
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
 });
 
 export const DynamicSecretSapAseSchema = z.object({
@@ -329,6 +333,7 @@ export const DynamicSecretMongoDBSchema = z.object({
   password: z.string().min(1).trim(),
   database: z.string().min(1).trim(),
   ca: z.string().trim().optional().nullable(),
+  sslRejectUnauthorized: z.boolean().default(true),
   roles: z
     .string()
     .array()
@@ -346,7 +351,8 @@ export const DynamicSecretSapHanaSchema = z.object({
   creationStatement: z.string().trim(),
   revocationStatement: z.string().trim(),
   renewStatement: z.string().trim().optional(),
-  ca: z.string().optional()
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
 });
 
 export const DynamicSecretSnowflakeSchema = z.object({
@@ -402,6 +408,7 @@ export const DynamicSecretAzureSqlDBSchema = z.object({
   renewStatement: z.string().trim().optional(),
   ca: z.string().optional(),
   sslEnabled: z.boolean().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
   gatewayId: z.string().nullable().optional()
 });
 
@@ -411,6 +418,7 @@ export const LdapSchema = z.union([
     binddn: z.string().trim().min(1),
     bindpass: z.string().trim().min(1),
     ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true),
     credentialType: z.literal(LdapCredentialType.Dynamic).optional().default(LdapCredentialType.Dynamic),
     creationLdif: z.string().min(1),
     revocationLdif: z.string().min(1),
@@ -421,6 +429,7 @@ export const LdapSchema = z.union([
     binddn: z.string().trim().min(1),
     bindpass: z.string().trim().min(1),
     ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true),
     credentialType: z.literal(LdapCredentialType.Static),
     rotationLdif: z.string().min(1)
   })
@@ -438,6 +447,7 @@ export const DynamicSecretKubernetesSchema = z
       clusterToken: z.string().trim().optional(),
       ca: z.string().optional(),
       sslEnabled: z.boolean().default(false),
+      sslRejectUnauthorized: z.boolean().default(true),
       credentialType: z.literal(KubernetesCredentialType.Static),
       serviceAccountName: z.string().trim().min(1),
       namespace: z
@@ -464,6 +474,7 @@ export const DynamicSecretKubernetesSchema = z
       clusterToken: z.string().trim().optional(),
       ca: z.string().optional(),
       sslEnabled: z.boolean().default(false),
+      sslRejectUnauthorized: z.boolean().default(true),
       credentialType: z.literal(KubernetesCredentialType.Dynamic),
       namespace: z
         .string()

--- a/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
@@ -35,7 +35,8 @@ export const MongoDBProvider = (): TDynamicProviderFns => {
         password: providerInputs.password
       },
       directConnection: !isSrv,
-      ca: providerInputs.ca || undefined
+      ca: providerInputs.ca || undefined,
+      tlsAllowInvalidCertificates: !providerInputs.sslRejectUnauthorized
     });
     return client;
   };

--- a/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
@@ -94,7 +94,7 @@ export const RabbitMqProvider = (): TDynamicProviderFns => {
       },
       maxRedirects: 0,
       ...(providerInputs.ca && {
-        httpsAgent: new https.Agent({ ca: providerInputs.ca, rejectUnauthorized: false })
+        httpsAgent: new https.Agent({ ca: providerInputs.ca, rejectUnauthorized: true })
       })
     });
 

--- a/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
@@ -94,7 +94,7 @@ export const RabbitMqProvider = (): TDynamicProviderFns => {
       },
       maxRedirects: 0,
       ...(providerInputs.ca && {
-        httpsAgent: new https.Agent({ ca: providerInputs.ca, rejectUnauthorized: true })
+        httpsAgent: new https.Agent({ ca: providerInputs.ca, rejectUnauthorized: providerInputs.sslRejectUnauthorized })
       })
     });
 

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -78,7 +78,8 @@ export const RedisDatabaseProvider = (): TDynamicProviderFns => {
         ...(providerInputs.ca && {
           tls: {
             ca: providerInputs.ca,
-            rejectUnauthorized: true
+            rejectUnauthorized: true,
+            servername: providerInputs.host
           }
         })
       });

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -77,7 +77,6 @@ export const RedisDatabaseProvider = (): TDynamicProviderFns => {
         password: providerInputs.password,
         ...(providerInputs.ca && {
           tls: {
-            rejectUnauthorized: false,
             ca: providerInputs.ca
           }
         })

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -78,7 +78,7 @@ export const RedisDatabaseProvider = (): TDynamicProviderFns => {
         ...(providerInputs.ca && {
           tls: {
             ca: providerInputs.ca,
-            rejectUnauthorized: true,
+            rejectUnauthorized: providerInputs.sslRejectUnauthorized,
             servername: providerInputs.host
           }
         })

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -77,7 +77,8 @@ export const RedisDatabaseProvider = (): TDynamicProviderFns => {
         password: providerInputs.password,
         ...(providerInputs.ca && {
           tls: {
-            ca: providerInputs.ca
+            ca: providerInputs.ca,
+            rejectUnauthorized: true
           }
         })
       });

--- a/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
@@ -51,7 +51,8 @@ export const SapHanaProvider = (): TDynamicProviderFns => {
       password: providerInputs.password,
       ...(providerInputs.ca
         ? {
-            ca: providerInputs.ca
+            ca: providerInputs.ca,
+            rejectUnauthorized: providerInputs.sslRejectUnauthorized
           }
         : {})
     });

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -147,7 +147,11 @@ export const SqlDatabaseProvider = ({
     providerInputs: z.infer<typeof DynamicSecretSqlDBSchema> & { hostIp: string; originalHost: string }
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.originalHost }
+      ? {
+          rejectUnauthorized: providerInputs.sslRejectUnauthorized,
+          ca: providerInputs.ca,
+          servername: providerInputs.originalHost
+        }
       : undefined;
 
     const isMsSQLClient = providerInputs.client === SqlProviders.MsSQL;

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -189,7 +189,7 @@ export const SqlDatabaseProvider = ({
         options: isMsSQLClient
           ? {
               ...(providerInputs.sslEnabled !== undefined ? { encrypt: providerInputs.sslEnabled } : {}),
-              trustServerCertificate: !providerInputs.ca,
+              trustServerCertificate: !providerInputs.sslRejectUnauthorized,
               cryptoCredentialsDetails: providerInputs.ca ? { ca: providerInputs.ca } : {}
             }
           : undefined

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -147,7 +147,7 @@ export const SqlDatabaseProvider = ({
     providerInputs: z.infer<typeof DynamicSecretSqlDBSchema> & { hostIp: string; originalHost: string }
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.host }
+      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.originalHost }
       : undefined;
 
     const isMsSQLClient = providerInputs.client === SqlProviders.MsSQL;

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -147,7 +147,7 @@ export const SqlDatabaseProvider = ({
     providerInputs: z.infer<typeof DynamicSecretSqlDBSchema> & { hostIp: string; originalHost: string }
   ) => {
     const ssl = providerInputs.ca
-      ? { rejectUnauthorized: false, ca: providerInputs.ca, servername: providerInputs.host }
+      ? { rejectUnauthorized: true, ca: providerInputs.ca, servername: providerInputs.host }
       : undefined;
 
     const isMsSQLClient = providerInputs.client === SqlProviders.MsSQL;

--- a/docs/documentation/platform/dynamic-secrets/azure-sql-database.mdx
+++ b/docs/documentation/platform/dynamic-secrets/azure-sql-database.mdx
@@ -85,6 +85,10 @@ The user needs:
     	SSL certificate authority certificate. For Azure SQL Database, this is typically not required as Azure manages the certificates.
     </ParamField>
 
+    <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+      If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+    </ParamField>
+
     ![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/azure-sql-database/create-dynamic-secret-form.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/cassandra.mdx
+++ b/docs/documentation/platform/dynamic-secrets/cassandra.mdx
@@ -76,6 +76,10 @@ The above configuration allows user creation and granting permissions.
 		A CA may be required if your cassandra requires it for incoming connections.
   </ParamField>
 
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+	  If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
+
 	![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-setup-modal-cassandra.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/elastic-search.mdx
+++ b/docs/documentation/platform/dynamic-secrets/elastic-search.mdx
@@ -89,6 +89,9 @@ The port that your Elasticsearch instance is running on. _(Example: 9200)_
     <ParamField path="CA(SSL)" type="string">
     	A CA may be required if your DB requires it for incoming connections. This is often the case when connecting to a managed service.
     </ParamField>
+    <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+      If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+    </ParamField>
     <DynamicSecretUsernameTemplateParamField />
 
 ![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-input-modal-elastic-search.png)

--- a/docs/documentation/platform/dynamic-secrets/kubernetes.mdx
+++ b/docs/documentation/platform/dynamic-secrets/kubernetes.mdx
@@ -432,6 +432,9 @@ This feature is ideal for scenarios where you need to:
     <ParamField path="CA" type="string">
       Custom CA certificate for the Kubernetes API server. Leave blank to use the system/public CA. Not required when using Gateway authentication as the Gateway will use its internal TLS configuration.
     </ParamField>
+    <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+      If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+    </ParamField>
     <ParamField path="Auth Method" type="string" required>
       Choose between Token (API) or Gateway authentication. If using Gateway, the Gateway must be deployed in your Kubernetes cluster.
     </ParamField>

--- a/docs/documentation/platform/dynamic-secrets/ldap.mdx
+++ b/docs/documentation/platform/dynamic-secrets/ldap.mdx
@@ -56,6 +56,10 @@ The Infisical LDAP dynamic secret allows you to generate user credentials on dem
           CA certificate to use for TLS in case of a secure connection.
         </ParamField>
 
+        <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+          If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+        </ParamField>
+
         <ParamField path="Credential Type" type="enum">
           The type of LDAP credential - select Dynamic.
         </ParamField>
@@ -195,6 +199,10 @@ The Infisical LDAP dynamic secret allows you to generate user credentials on dem
 
         <ParamField path="CA" type="text">
           CA certificate to use for TLS in case of a secure connection.
+        </ParamField>
+
+        <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+          If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
         </ParamField>
 
         <ParamField path="Credential Type" type="enum">

--- a/docs/documentation/platform/dynamic-secrets/mongo-db.mdx
+++ b/docs/documentation/platform/dynamic-secrets/mongo-db.mdx
@@ -68,6 +68,9 @@ Create a user with the required permission in your MongoDB instance. This user w
 	<ParamField path="CA(SSL)" type="string">
 		A CA may be required if your DB requires it for incoming connections.
 	</ParamField>
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+		If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
 	<DynamicSecretUsernameTemplateParamField />
 
 	![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-mongodb.png)

--- a/docs/documentation/platform/dynamic-secrets/mssql.mdx
+++ b/docs/documentation/platform/dynamic-secrets/mssql.mdx
@@ -68,6 +68,10 @@ Create a user with the required permission in your SQL instance. This user will 
     	A CA may be required if your DB requires it for incoming connections. AWS RDS instances with default settings will requires a CA which can be downloaded [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions).
     </ParamField>
 
+    <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+    	If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+    </ParamField>
+
     ![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-setup-modal-mssql.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/mysql.mdx
+++ b/docs/documentation/platform/dynamic-secrets/mysql.mdx
@@ -68,6 +68,10 @@ Create a user with the required permission in your SQL instance. This user will 
 		A CA may be required if your DB requires it for incoming connections. AWS RDS instances with default settings will requires a CA which can be downloaded [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions).
 	</ParamField>
 
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+		If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
+
   </Step>
   <Step title="(Optional) Modify SQL Statements">
   ![Modify SQL Statements Modal](../../../images/platform/dynamic-secrets/modify-sql-statement-mysql.png)

--- a/docs/documentation/platform/dynamic-secrets/oracle.mdx
+++ b/docs/documentation/platform/dynamic-secrets/oracle.mdx
@@ -68,6 +68,10 @@ Create a user with the required permission in your SQL instance. This user will 
 		A CA may be required if your DB requires it for incoming connections. AWS RDS instances with default settings will requires a CA which can be downloaded [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions).
 	</ParamField>
 
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+		If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
+
 	![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-setup-modal-oracle.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/postgresql.mdx
+++ b/docs/documentation/platform/dynamic-secrets/postgresql.mdx
@@ -69,6 +69,10 @@ Create a user with the required permission in your SQL instance. This user will 
 		A CA may be required if your DB requires it for incoming connections. AWS RDS instances with default settings will requires a CA which can be downloaded [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions).
 	</ParamField>
 
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+		If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
+
 	![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-setup-modal-postgresql.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/rabbit-mq.mdx
+++ b/docs/documentation/platform/dynamic-secrets/rabbit-mq.mdx
@@ -73,6 +73,10 @@ The port that the RabbitMQ management plugin is listening on. This is `15672` by
    	A CA may be required if your DB requires it for incoming connections. This is often the case when connecting to a managed service.
 </ParamField>
 
+<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+  If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+</ParamField>
+
 ![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-input-modal-rabbit-mq.png)
 
   </Step>

--- a/docs/documentation/platform/dynamic-secrets/redis.mdx
+++ b/docs/documentation/platform/dynamic-secrets/redis.mdx
@@ -56,6 +56,10 @@ Create a user with the required permission in your Redis instance. This user wil
 		A CA may be required if your DB requires it for incoming connections. This is often the case when connecting to a managed service.
 	</ParamField>
 
+	<ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+		If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+	</ParamField>
+
   </Step>
   <Step title="(Optional) Modify Redis Statements">
   ![Modify Redis Statements Modal](/images/platform/dynamic-secrets/modify-redis-statement.png)

--- a/docs/documentation/platform/dynamic-secrets/sap-hana.mdx
+++ b/docs/documentation/platform/dynamic-secrets/sap-hana.mdx
@@ -61,6 +61,10 @@ The Infisical SAP HANA dynamic secret allows you to generate SAP HANA database c
 
   </ParamField>
 
+    <ParamField path="SSL Reject Unauthorized" type="boolean" default="true">
+      If enabled, the server certificate will be verified against the list of supplied CAs. Disable this option if you are using a self-signed certificate.
+    </ParamField>
+
     ![Dynamic Secret Setup Modal](../../../images/platform/dynamic-secrets/dynamic-secret-setup-modal-sap-hana.png)
 
   </Step>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AwsElastiCacheInputForm.tsx
@@ -13,7 +13,6 @@ import {
   FilterableSelect,
   FormControl,
   Input,
-  SecretInput,
   TextArea
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
@@ -28,8 +27,7 @@ const formSchema = z.object({
 
     region: z.string().trim(),
     creationStatement: z.string().trim(),
-    revocationStatement: z.string().trim(),
-    ca: z.string().optional()
+    revocationStatement: z.string().trim()
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -246,23 +244,6 @@ export const AwsElastiCacheInputForm = ({
                 />
               </div>
               <div>
-                <Controller
-                  control={control}
-                  name="provider.ca"
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      isOptional
-                      label="CA(SSL)"
-                      isError={Boolean(error?.message)}
-                      errorText={error?.message}
-                    >
-                      <SecretInput
-                        {...field}
-                        containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
-                      />
-                    </FormControl>
-                  )}
-                />
                 <Accordion type="single" collapsible className="mb-2 w-full bg-mineshaft-700">
                   <AccordionItem value="advance-statements">
                     <AccordionTrigger>Modify ElastiCache Statements</AccordionTrigger>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureSqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureSqlDatabaseInputForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
 import ms from "ms";
@@ -68,6 +70,7 @@ const formSchema = z.object({
     renewStatement: z.string().optional(),
     sslEnabled: z.boolean().optional(),
     ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true),
     gatewayId: z.string().optional()
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -138,6 +141,7 @@ export const AzureSqlDatabaseInputForm = ({
       provider: {
         port: 1433,
         ...getDefaultAzureSqlStatements(),
+        sslRejectUnauthorized: true,
         passwordRequirements: {
           length: 48,
           required: {
@@ -401,23 +405,60 @@ export const AzureSqlDatabaseInputForm = ({
                   />
                 </div>
                 {sslEnabled && (
-                  <Controller
-                    control={control}
-                    name="provider.ca"
-                    render={({ field, fieldState: { error } }) => (
-                      <FormControl
-                        isOptional
-                        label="CA (SSL)"
-                        isError={Boolean(error?.message)}
-                        errorText={error?.message}
-                      >
-                        <SecretInput
-                          {...field}
-                          containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
-                        />
-                      </FormControl>
-                    )}
-                  />
+                  <>
+                    <Controller
+                      control={control}
+                      name="provider.ca"
+                      render={({ field, fieldState: { error } }) => (
+                        <FormControl
+                          isOptional
+                          label="CA (SSL)"
+                          isError={Boolean(error?.message)}
+                          errorText={error?.message}
+                        >
+                          <SecretInput
+                            {...field}
+                            containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
+                          />
+                        </FormControl>
+                      )}
+                    />
+                    <Controller
+                      name="provider.sslRejectUnauthorized"
+                      control={control}
+                      render={({ field: { value, onChange }, fieldState: { error } }) => (
+                        <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                          <Switch
+                            className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                            id="ssl-reject-unauthorized"
+                            thumbClassName="bg-mineshaft-800"
+                            isChecked={value}
+                            onCheckedChange={onChange}
+                          >
+                            <p className="w-full">
+                              SSL Reject Unauthorized
+                              <Tooltip
+                                className="max-w-md"
+                                content={
+                                  <p>
+                                    If enabled, the server certificate will be verified against the
+                                    list of supplied CAs. Disable this option if you are using a
+                                    self-signed certificate.
+                                  </p>
+                                }
+                              >
+                                <FontAwesomeIcon
+                                  icon={faQuestionCircle}
+                                  size="sm"
+                                  className="ml-1"
+                                />
+                              </Tooltip>
+                            </p>
+                          </Switch>
+                        </FormControl>
+                      )}
+                    />
+                  </>
                 )}
                 <Accordion type="multiple" className="mb-2 w-full bg-mineshaft-700">
                   <AccordionItem value="advanced">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -16,7 +18,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -38,7 +42,8 @@ const formSchema = z.object({
     creationStatement: z.string().min(1),
     revocationStatement: z.string().min(1),
     renewStatement: z.string().optional(),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true)
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -100,7 +105,7 @@ export const CassandraInputForm = ({
   } = useForm<TForm>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      provider: getSqlStatements(),
+      provider: { ...getSqlStatements(), sslRejectUnauthorized: true },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
     }
@@ -394,6 +399,37 @@ export const CassandraInputForm = ({
                         {...field}
                         containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                       />
+                    </FormControl>
+                  )}
+                />
+                <Controller
+                  name="provider.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/ElasticSearchInputForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -15,7 +15,9 @@ import {
   Input,
   SecretInput,
   Select,
-  SelectItem
+  SelectItem,
+  Switch,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -53,7 +55,8 @@ const formSchema = z.object({
     ]),
 
     roles: z.array(z.string().trim().min(1)).min(1, "At least one role is required"),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true)
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -110,7 +113,8 @@ export const ElasticSearchInputForm = ({
           type: "user"
         },
         roles: ["superuser"],
-        port: 443
+        port: 443,
+        sslRejectUnauthorized: true
       },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
@@ -415,6 +419,37 @@ export const ElasticSearchInputForm = ({
                   )}
                 />
               </div>
+              <Controller
+                name="provider.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
               <Controller
                 control={control}
                 name="usernameTemplate"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/KubernetesInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/KubernetesInputForm.tsx
@@ -65,6 +65,7 @@ const formSchema = z
         clusterToken: z.string().trim().optional(),
         ca: z.string().optional(),
         sslEnabled: z.boolean().default(false),
+        sslRejectUnauthorized: z.boolean().default(true),
         credentialType: z.literal(KubernetesDynamicSecretCredentialType.Static),
         serviceAccountName: z.string().trim().min(1),
         namespace: z
@@ -84,6 +85,7 @@ const formSchema = z
         clusterToken: z.string().trim().optional(),
         ca: z.string().optional(),
         sslEnabled: z.boolean().default(false),
+        sslRejectUnauthorized: z.boolean().default(true),
         credentialType: z.literal(KubernetesDynamicSecretCredentialType.Dynamic),
         namespace: z
           .string()
@@ -183,6 +185,7 @@ export const KubernetesInputForm = ({
         clusterToken: "",
         ca: "",
         sslEnabled: false,
+        sslRejectUnauthorized: true,
         serviceAccountName: "",
         namespace: "",
         credentialType: KubernetesDynamicSecretCredentialType.Static,
@@ -496,6 +499,41 @@ export const KubernetesInputForm = ({
                             placeholder="-----BEGIN CERTIFICATE----- ..."
                             isDisabled={!sslEnabled}
                           />
+                        </FormControl>
+                      )}
+                    />
+                    <Controller
+                      name="provider.sslRejectUnauthorized"
+                      control={control}
+                      render={({ field: { value, onChange }, fieldState: { error } }) => (
+                        <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                          <Switch
+                            className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                            id="ssl-reject-unauthorized"
+                            thumbClassName="bg-mineshaft-800"
+                            isChecked={value}
+                            onCheckedChange={onChange}
+                          >
+                            <p className="w-full">
+                              SSL Reject Unauthorized
+                              <Tooltip
+                                className="max-w-md"
+                                content={
+                                  <p>
+                                    If enabled, the server certificate will be verified against the
+                                    list of supplied CAs. Disable this option if you are using a
+                                    self-signed certificate.
+                                  </p>
+                                }
+                              >
+                                <FontAwesomeIcon
+                                  icon={faQuestionCircle}
+                                  size="sm"
+                                  className="ml-1"
+                                />
+                              </Tooltip>
+                            </p>
+                          </Switch>
                         </FormControl>
                       )}
                     />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -13,7 +15,9 @@ import {
   Input,
   Select,
   SelectItem,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -47,6 +51,7 @@ const formSchema = z.object({
       binddn: z.string().trim().min(1),
       bindpass: z.string().trim().min(1),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().default(true),
       credentialType: z.literal(CredentialType.Dynamic),
       creationLdif: z.string().min(1),
       revocationLdif: z.string().min(1),
@@ -57,6 +62,7 @@ const formSchema = z.object({
       binddn: z.string().trim().min(1),
       bindpass: z.string().trim().min(1),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().default(true),
       credentialType: z.literal(CredentialType.Static),
       rotationLdif: z.string().min(1)
     })
@@ -120,6 +126,7 @@ export const LdapInputForm = ({
         binddn: "",
         bindpass: "",
         ca: "",
+        sslRejectUnauthorized: true,
         creationLdif: "",
         revocationLdif: "",
         rollbackLdif: "",
@@ -331,6 +338,38 @@ export const LdapInputForm = ({
                       errorText={error?.message}
                     >
                       <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
+                    </FormControl>
+                  )}
+                />
+
+                <Controller
+                  name="provider.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/MongoDBInputForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -13,7 +13,9 @@ import {
   FormLabel,
   IconButton,
   Input,
-  SecretInput
+  SecretInput,
+  Switch,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -28,6 +30,7 @@ const formSchema = z.object({
     username: z.string().min(1),
     password: z.string().min(1),
     ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true),
     roles: z
       .object({
         roleName: z.string().min(1)
@@ -86,7 +89,8 @@ export const MongoDBDatabaseInputForm = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       provider: {
-        roles: [{ roleName: "readWrite" }]
+        roles: [{ roleName: "readWrite" }],
+        sslRejectUnauthorized: true
       },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
@@ -338,6 +342,37 @@ export const MongoDBDatabaseInputForm = ({
                   )}
                 />
               </div>
+              <Controller
+                name="provider.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
               <Controller
                 control={control}
                 name="usernameTemplate"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RabbitMqInputForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -13,7 +13,9 @@ import {
   FormLabel,
   IconButton,
   Input,
-  SecretInput
+  SecretInput,
+  Switch,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -37,7 +39,8 @@ const formSchema = z.object({
         configure: z.string().trim().min(1)
       })
     }),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true)
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -99,7 +102,8 @@ export const RabbitMqInputForm = ({
             configure: ".*"
           }
         },
-        tags: []
+        tags: [],
+        sslRejectUnauthorized: true
       },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
@@ -422,6 +426,37 @@ export const RabbitMqInputForm = ({
                   )}
                 />
               </div>
+              <Controller
+                name="provider.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
               <Controller
                 control={control}
                 name="usernameTemplate"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/RedisInputForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -14,7 +16,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -30,7 +34,8 @@ const formSchema = z.object({
     creationStatement: z.string().min(1),
     renewStatement: z.string().optional(),
     revocationStatement: z.string().min(1),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true)
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -84,7 +89,8 @@ export const RedisInputForm = ({
         username: "default",
         port: 6379,
         creationStatement: "ACL SETUSER {{username}} on >{{password}} ~* &* +@all",
-        revocationStatement: "ACL DELUSER {{username}}"
+        revocationStatement: "ACL DELUSER {{username}}",
+        sslRejectUnauthorized: true
       },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
@@ -255,6 +261,37 @@ export const RedisInputForm = ({
                         {...field}
                         containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                       />
+                    </FormControl>
+                  )}
+                />
+                <Controller
+                  name="provider.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SapHanaInputForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -14,7 +16,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
@@ -30,7 +34,8 @@ const formSchema = z.object({
     creationStatement: z.string().min(1),
     revocationStatement: z.string().min(1),
     renewStatement: z.string().optional(),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true)
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -85,7 +90,8 @@ export const SapHanaInputForm = ({
 GRANT "MONITORING" TO {{username}};`,
         revocationStatement: `REVOKE "MONITORING" FROM {{username}};
 DROP USER {{username}};`,
-        renewStatement: "ALTER USER {{username}} VALID UNTIL '{{expiration}}';"
+        renewStatement: "ALTER USER {{username}} VALID UNTIL '{{expiration}}';",
+        sslRejectUnauthorized: true
       },
       environment: isSingleEnvironmentMode ? environments[0] : undefined,
       usernameTemplate: "{{randomUsername}}"
@@ -253,6 +259,37 @@ DROP USER {{username}};`,
                         {...field}
                         containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                       />
+                    </FormControl>
+                  )}
+                />
+                <Controller
+                  name="provider.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
 import ms from "ms";
@@ -73,6 +75,7 @@ const formSchema = z.object({
     renewStatement: z.string().optional(),
     sslEnabled: z.boolean().optional(),
     ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().default(true),
     gatewayId: z.string().optional()
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -188,6 +191,7 @@ export const SqlDatabaseInputForm = ({
     defaultValues: {
       provider: {
         ...getSqlStatements(SqlProviders.Postgres),
+        sslRejectUnauthorized: true,
         passwordRequirements: {
           length: 48,
           required: {
@@ -624,6 +628,37 @@ export const SqlDatabaseInputForm = ({
                         {...field}
                         containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                       />
+                    </FormControl>
+                  )}
+                />
+                <Controller
+                  name="provider.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAwsElastiCacheProviderForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAwsElastiCacheProviderForm.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   FormControl,
   Input,
-  SecretInput,
   TextArea
 } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
@@ -29,8 +28,7 @@ const formSchema = z.object({
 
       region: z.string().trim(),
       creationStatement: z.string().trim(),
-      revocationStatement: z.string().trim(),
-      ca: z.string().optional()
+      revocationStatement: z.string().trim()
     })
     .partial(),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -239,23 +237,6 @@ export const EditDynamicSecretAwsElastiCacheProviderForm = ({
               />
             </div>
             <div>
-              <Controller
-                control={control}
-                name="inputs.ca"
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isOptional
-                    label="CA(SSL)"
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
-                    <SecretInput
-                      {...field}
-                      containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
-                    />
-                  </FormControl>
-                )}
-              />
               <Accordion type="single" collapsible className="mb-2 w-full bg-mineshaft-700">
                 <AccordionItem value="advance-statements">
                   <AccordionTrigger>Modify ElastiCache Statements</AccordionTrigger>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAzureSqlDatabaseForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretAzureSqlDatabaseForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
 import ms from "ms";
@@ -66,6 +68,7 @@ const formSchema = z.object({
       renewStatement: z.string().optional(),
       ca: z.string().optional(),
       sslEnabled: z.boolean().optional(),
+      sslRejectUnauthorized: z.boolean().optional(),
       gatewayId: z.string().optional()
     })
     .partial(),
@@ -389,23 +392,60 @@ export const EditDynamicSecretAzureSqlDatabaseForm = ({
                   />
                 </div>
                 {sslEnabled && (
-                  <Controller
-                    control={control}
-                    name="inputs.ca"
-                    render={({ field, fieldState: { error } }) => (
-                      <FormControl
-                        isOptional
-                        label="CA (SSL)"
-                        isError={Boolean(error?.message)}
-                        errorText={error?.message}
-                      >
-                        <SecretInput
-                          {...field}
-                          containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
-                        />
-                      </FormControl>
-                    )}
-                  />
+                  <>
+                    <Controller
+                      control={control}
+                      name="inputs.ca"
+                      render={({ field, fieldState: { error } }) => (
+                        <FormControl
+                          isOptional
+                          label="CA (SSL)"
+                          isError={Boolean(error?.message)}
+                          errorText={error?.message}
+                        >
+                          <SecretInput
+                            {...field}
+                            containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
+                          />
+                        </FormControl>
+                      )}
+                    />
+                    <Controller
+                      name="inputs.sslRejectUnauthorized"
+                      control={control}
+                      render={({ field: { value, onChange }, fieldState: { error } }) => (
+                        <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                          <Switch
+                            className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                            id="ssl-reject-unauthorized"
+                            thumbClassName="bg-mineshaft-800"
+                            isChecked={value}
+                            onCheckedChange={onChange}
+                          >
+                            <p className="w-full">
+                              SSL Reject Unauthorized
+                              <Tooltip
+                                className="max-w-md"
+                                content={
+                                  <p>
+                                    If enabled, the server certificate will be verified against the
+                                    list of supplied CAs. Disable this option if you are using a
+                                    self-signed certificate.
+                                  </p>
+                                }
+                              >
+                                <FontAwesomeIcon
+                                  icon={faQuestionCircle}
+                                  size="sm"
+                                  className="ml-1"
+                                />
+                              </Tooltip>
+                            </p>
+                          </Switch>
+                        </FormControl>
+                      )}
+                    />
+                  </>
                 )}
                 <Accordion type="multiple" className="mb-2 w-full bg-mineshaft-700">
                   <AccordionItem value="advanced">

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretCassandraForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretCassandraForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -14,7 +16,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
@@ -32,7 +36,8 @@ const formSchema = z.object({
       creationStatement: z.string().min(1),
       revocationStatement: z.string().min(1),
       renewStatement: z.string().optional(),
-      ca: z.string().optional()
+      ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional()
     })
     .partial(),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -284,6 +289,37 @@ export const EditDynamicSecretCassandraForm = ({
                       {...field}
                       containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                     />
+                  </FormControl>
+                )}
+              />
+              <Controller
+                name="inputs.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
                   </FormControl>
                 )}
               />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretElasticSearchForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretElasticSearchForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -15,7 +15,9 @@ import {
   Input,
   SecretInput,
   Select,
-  SelectItem
+  SelectItem,
+  Switch,
+  Tooltip
 } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
@@ -52,7 +54,8 @@ const formSchema = z.object({
     ]),
 
     roles: z.array(z.string().trim().min(1)).min(1, "At least one role is required"),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().optional()
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -408,6 +411,37 @@ export const EditDynamicSecretElasticSearchForm = ({
                   )}
                 />
               </div>
+              <Controller
+                name="inputs.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
               <Controller
                 control={control}
                 name="usernameTemplate"

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretKubernetesForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretKubernetesForm.tsx
@@ -58,6 +58,7 @@ const formSchema = z
         clusterToken: z.string().trim().optional(),
         ca: z.string().optional(),
         sslEnabled: z.boolean().default(false),
+        sslRejectUnauthorized: z.boolean().optional(),
         credentialType: z.literal(KubernetesDynamicSecretCredentialType.Static),
         serviceAccountName: z.string().trim().min(1),
         namespace: z
@@ -77,6 +78,7 @@ const formSchema = z
         clusterToken: z.string().trim().optional(),
         ca: z.string().optional(),
         sslEnabled: z.boolean().default(false),
+        sslRejectUnauthorized: z.boolean().optional(),
         credentialType: z.literal(KubernetesDynamicSecretCredentialType.Dynamic),
         namespace: z
           .string()
@@ -412,6 +414,41 @@ export const EditDynamicSecretKubernetesForm = ({
                               placeholder="-----BEGIN CERTIFICATE----- ..."
                               isDisabled={!sslEnabled}
                             />
+                          </FormControl>
+                        )}
+                      />
+                      <Controller
+                        name="inputs.sslRejectUnauthorized"
+                        control={control}
+                        render={({ field: { value, onChange }, fieldState: { error } }) => (
+                          <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                            <Switch
+                              className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                              id="ssl-reject-unauthorized"
+                              thumbClassName="bg-mineshaft-800"
+                              isChecked={value}
+                              onCheckedChange={onChange}
+                            >
+                              <p className="w-full">
+                                SSL Reject Unauthorized
+                                <Tooltip
+                                  className="max-w-md"
+                                  content={
+                                    <p>
+                                      If enabled, the server certificate will be verified against
+                                      the list of supplied CAs. Disable this option if you are using
+                                      a self-signed certificate.
+                                    </p>
+                                  }
+                                >
+                                  <FontAwesomeIcon
+                                    icon={faQuestionCircle}
+                                    size="sm"
+                                    className="ml-1"
+                                  />
+                                </Tooltip>
+                              </p>
+                            </Switch>
                           </FormControl>
                         )}
                       />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretLdapForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretLdapForm.tsx
@@ -1,11 +1,22 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Select, SelectItem, TextArea } from "@app/components/v2";
+import {
+  Button,
+  FormControl,
+  Input,
+  Select,
+  SelectItem,
+  Switch,
+  TextArea,
+  Tooltip
+} from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 import { slugSchema } from "@app/lib/schemas";
@@ -33,6 +44,7 @@ const formSchema = z.object({
       binddn: z.string().trim().min(1),
       bindpass: z.string().trim().min(1),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional(),
       credentialType: z.literal(CredentialType.Dynamic),
       creationLdif: z.string().min(1),
       revocationLdif: z.string().min(1),
@@ -43,6 +55,7 @@ const formSchema = z.object({
       binddn: z.string().trim().min(1),
       bindpass: z.string().trim().min(1),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional(),
       credentialType: z.literal(CredentialType.Static),
       rotationLdif: z.string().min(1)
     })
@@ -227,6 +240,37 @@ export const EditDynamicSecretLdapForm = ({
             render={({ field, fieldState: { error } }) => (
               <FormControl label="CA" isError={Boolean(error)} errorText={error?.message}>
                 <TextArea {...field} />
+              </FormControl>
+            )}
+          />
+          <Controller
+            name="inputs.sslRejectUnauthorized"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                <Switch
+                  className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                  id="ssl-reject-unauthorized"
+                  thumbClassName="bg-mineshaft-800"
+                  isChecked={value}
+                  onCheckedChange={onChange}
+                >
+                  <p className="w-full">
+                    SSL Reject Unauthorized
+                    <Tooltip
+                      className="max-w-md"
+                      content={
+                        <p>
+                          If enabled, the server certificate will be verified against the list of
+                          supplied CAs. Disable this option if you are using a self-signed
+                          certificate.
+                        </p>
+                      }
+                    >
+                      <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                    </Tooltip>
+                  </p>
+                </Switch>
               </FormControl>
             )}
           />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretMongoDBForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretMongoDBForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -7,7 +7,16 @@ import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, FormLabel, IconButton, Input, SecretInput } from "@app/components/v2";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Input,
+  SecretInput,
+  Switch,
+  Tooltip
+} from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 import { slugSchema } from "@app/lib/schemas";
@@ -21,6 +30,7 @@ const formSchema = z.object({
       username: z.string().min(1),
       password: z.string().min(1),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional(),
       roles: z
         .object({
           roleName: z.string().min(1)
@@ -333,6 +343,37 @@ export const EditDynamicSecretMongoDBForm = ({
                 )}
               />
             </div>
+            <Controller
+              name="inputs.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                  <Switch
+                    className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                    id="ssl-reject-unauthorized"
+                    thumbClassName="bg-mineshaft-800"
+                    isChecked={value}
+                    onCheckedChange={onChange}
+                  >
+                    <p className="w-full">
+                      SSL Reject Unauthorized
+                      <Tooltip
+                        className="max-w-md"
+                        content={
+                          <p>
+                            If enabled, the server certificate will be verified against the list of
+                            supplied CAs. Disable this option if you are using a self-signed
+                            certificate.
+                          </p>
+                        }
+                      >
+                        <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                      </Tooltip>
+                    </p>
+                  </Switch>
+                </FormControl>
+              )}
+            />
             <div>
               <Controller
                 control={control}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretRabbitMqForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretRabbitMqForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -7,7 +7,16 @@ import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, FormLabel, IconButton, Input, SecretInput } from "@app/components/v2";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  IconButton,
+  Input,
+  SecretInput,
+  Switch,
+  Tooltip
+} from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 import { slugSchema } from "@app/lib/schemas";
@@ -29,7 +38,8 @@ const formSchema = z.object({
         configure: z.string().trim().min(1)
       })
     }),
-    ca: z.string().optional()
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().optional()
   }),
   defaultTTL: z.string().superRefine((val, ctx) => {
     const valMs = ms(val);
@@ -408,6 +418,37 @@ export const EditDynamicSecretRabbitMqForm = ({
                   )}
                 />
               </div>
+              <Controller
+                name="inputs.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
               <div>
                 <Controller
                   control={control}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretRedisProviderForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretRedisProviderForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -14,7 +16,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
@@ -31,7 +35,8 @@ const formSchema = z.object({
       creationStatement: z.string().min(1),
       renewStatement: z.string().optional(),
       revocationStatement: z.string().min(1),
-      ca: z.string().optional()
+      ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional()
     })
     .partial(),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -254,6 +259,37 @@ export const EditDynamicSecretRedisProviderForm = ({
                     {...field}
                     containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                   />
+                </FormControl>
+              )}
+            />
+            <Controller
+              name="inputs.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                  <Switch
+                    className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                    id="ssl-reject-unauthorized"
+                    thumbClassName="bg-mineshaft-800"
+                    isChecked={value}
+                    onCheckedChange={onChange}
+                  >
+                    <p className="w-full">
+                      SSL Reject Unauthorized
+                      <Tooltip
+                        className="max-w-md"
+                        content={
+                          <p>
+                            If enabled, the server certificate will be verified against the list of
+                            supplied CAs. Disable this option if you are using a self-signed
+                            certificate.
+                          </p>
+                        }
+                      >
+                        <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                      </Tooltip>
+                    </p>
+                  </Switch>
                 </FormControl>
               )}
             />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretSapHanaForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretSapHanaForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
@@ -14,7 +16,9 @@ import {
   FormControl,
   Input,
   SecretInput,
-  TextArea
+  Switch,
+  TextArea,
+  Tooltip
 } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
@@ -30,7 +34,8 @@ const formSchema = z.object({
       creationStatement: z.string().min(1),
       revocationStatement: z.string().min(1),
       renewStatement: z.string().optional(),
-      ca: z.string().optional()
+      ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional()
     })
     .partial(),
   defaultTTL: z.string().superRefine((val, ctx) => {
@@ -255,6 +260,37 @@ export const EditDynamicSecretSapHanaForm = ({
                         {...field}
                         containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                       />
+                    </FormControl>
+                  )}
+                />
+                <Controller
+                  name="inputs.sslRejectUnauthorized"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="ssl-reject-unauthorized"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={value}
+                        onCheckedChange={onChange}
+                      >
+                        <p className="w-full">
+                          SSL Reject Unauthorized
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <p>
+                                If enabled, the server certificate will be verified against the list
+                                of supplied CAs. Disable this option if you are using a self-signed
+                                certificate.
+                              </p>
+                            }
+                          >
+                            <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                          </Tooltip>
+                        </p>
+                      </Switch>
                     </FormControl>
                   )}
                 />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretSqlProviderForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretSqlProviderForm.tsx
@@ -1,4 +1,6 @@
 import { Controller, useForm } from "react-hook-form";
+import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
 import ms from "ms";
@@ -66,6 +68,7 @@ const formSchema = z.object({
       renewStatement: z.string().optional(),
       sslEnabled: z.boolean().optional(),
       ca: z.string().optional(),
+      sslRejectUnauthorized: z.boolean().optional(),
       gatewayId: z.string().optional().nullable()
     })
     .partial(),
@@ -436,6 +439,37 @@ export const EditDynamicSecretSqlProviderForm = ({
                       {...field}
                       containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-mineshaft-900 px-2 py-1.5"
                     />
+                  </FormControl>
+                )}
+              />
+              <Controller
+                name="inputs.sslRejectUnauthorized"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="ssl-reject-unauthorized"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-full">
+                        SSL Reject Unauthorized
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <p>
+                              If enabled, the server certificate will be verified against the list
+                              of supplied CAs. Disable this option if you are using a self-signed
+                              certificate.
+                            </p>
+                          }
+                        >
+                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
+                        </Tooltip>
+                      </p>
+                    </Switch>
                   </FormControl>
                 )}
               />


### PR DESCRIPTION
## Context

This PR allows user controlled dynamic secret ssl reject unauthorized - providing the configuration for test environment and prod

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)