### PR TITLE
fix(pam): default access duration to policy max

### DIFF
--- a/backend/src/server/routes/v1/approval-policy-routers/approval-policy-endpoints.ts
+++ b/backend/src/server/routes/v1/approval-policy-routers/approval-policy-endpoints.ts
@@ -43,7 +43,8 @@ export const registerApprovalPolicyEndpoints = ({
   createRequestSchema,
   requestResponseSchema,
   grantResponseSchema,
-  inputsSchema
+  inputsSchema,
+  checkPolicyMatchResponseSchema
 }: {
   server: FastifyZodProvider;
   policyType: ApprovalPolicyType;
@@ -54,6 +55,7 @@ export const registerApprovalPolicyEndpoints = ({
   requestResponseSchema: z.ZodObject<z.ZodRawShape>;
   grantResponseSchema: z.ZodObject<z.ZodRawShape>;
   inputsSchema: z.ZodType<TApprovalPolicyInputs>;
+  checkPolicyMatchResponseSchema: z.ZodObject<z.ZodRawShape>;
 }) => {
   // Policies
   server.route({
@@ -683,10 +685,7 @@ export const registerApprovalPolicyEndpoints = ({
         inputs: inputsSchema
       }),
       response: {
-        200: z.object({
-          requiresApproval: z.boolean(),
-          hasActiveGrant: z.boolean()
-        })
+        200: checkPolicyMatchResponseSchema
       }
     },
     onRequest: verifyAuth([AuthMode.JWT]),

--- a/backend/src/server/routes/v1/approval-policy-routers/index.ts
+++ b/backend/src/server/routes/v1/approval-policy-routers/index.ts
@@ -1,6 +1,5 @@
-import { z } from "zod";
-
 import { ApprovalPolicyType } from "@app/services/approval-policy/approval-policy-enums";
+import { BaseCheckPolicyMatchResponseSchema } from "@app/services/approval-policy/approval-policy-schemas";
 import {
   CertRequestPolicyInputsSchema,
   CertRequestPolicySchema,
@@ -22,6 +21,7 @@ import {
 import {
   CreatePamAccessPolicySchema,
   CreatePamAccessRequestSchema,
+  PamAccessCheckPolicyMatchResponseSchema,
   PamAccessPolicyInputsSchema,
   PamAccessPolicySchema,
   PamAccessRequestGrantSchema,
@@ -46,11 +46,7 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       requestResponseSchema: PamAccessRequestSchema,
       grantResponseSchema: PamAccessRequestGrantSchema,
       inputsSchema: PamAccessPolicyInputsSchema,
-      checkPolicyMatchResponseSchema: z.object({
-        requiresApproval: z.boolean(),
-        hasActiveGrant: z.boolean(),
-        constraints: z.object({ accessDuration: z.object({ max: z.string() }) }).optional()
-      })
+      checkPolicyMatchResponseSchema: PamAccessCheckPolicyMatchResponseSchema
     });
   },
   [ApprovalPolicyType.CertRequest]: async (server: FastifyZodProvider) => {
@@ -64,10 +60,7 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       requestResponseSchema: CertRequestRequestSchema,
       grantResponseSchema: CertRequestRequestGrantSchema,
       inputsSchema: CertRequestPolicyInputsSchema,
-      checkPolicyMatchResponseSchema: z.object({
-        requiresApproval: z.boolean(),
-        hasActiveGrant: z.boolean()
-      })
+      checkPolicyMatchResponseSchema: BaseCheckPolicyMatchResponseSchema
     });
   },
   [ApprovalPolicyType.CertCodeSigning]: async (server: FastifyZodProvider) => {
@@ -81,10 +74,7 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       requestResponseSchema: CodeSigningRequestSchema,
       grantResponseSchema: CodeSigningRequestGrantSchema,
       inputsSchema: CodeSigningPolicyInputsSchema,
-      checkPolicyMatchResponseSchema: z.object({
-        requiresApproval: z.boolean(),
-        hasActiveGrant: z.boolean()
-      })
+      checkPolicyMatchResponseSchema: BaseCheckPolicyMatchResponseSchema
     });
   }
 };

--- a/backend/src/server/routes/v1/approval-policy-routers/index.ts
+++ b/backend/src/server/routes/v1/approval-policy-routers/index.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { ApprovalPolicyType } from "@app/services/approval-policy/approval-policy-enums";
 import {
   CertRequestPolicyInputsSchema,
@@ -43,7 +45,12 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       createRequestSchema: CreatePamAccessRequestSchema,
       requestResponseSchema: PamAccessRequestSchema,
       grantResponseSchema: PamAccessRequestGrantSchema,
-      inputsSchema: PamAccessPolicyInputsSchema
+      inputsSchema: PamAccessPolicyInputsSchema,
+      checkPolicyMatchResponseSchema: z.object({
+        requiresApproval: z.boolean(),
+        hasActiveGrant: z.boolean(),
+        constraints: z.object({ accessDuration: z.object({ max: z.string() }) }).optional()
+      })
     });
   },
   [ApprovalPolicyType.CertRequest]: async (server: FastifyZodProvider) => {
@@ -56,7 +63,11 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       createRequestSchema: CreateCertRequestRequestSchema,
       requestResponseSchema: CertRequestRequestSchema,
       grantResponseSchema: CertRequestRequestGrantSchema,
-      inputsSchema: CertRequestPolicyInputsSchema
+      inputsSchema: CertRequestPolicyInputsSchema,
+      checkPolicyMatchResponseSchema: z.object({
+        requiresApproval: z.boolean(),
+        hasActiveGrant: z.boolean()
+      })
     });
   },
   [ApprovalPolicyType.CertCodeSigning]: async (server: FastifyZodProvider) => {
@@ -69,7 +80,11 @@ export const APPROVAL_POLICY_REGISTER_ROUTER_MAP: Record<
       createRequestSchema: CreateCodeSigningRequestSchema,
       requestResponseSchema: CodeSigningRequestSchema,
       grantResponseSchema: CodeSigningRequestGrantSchema,
-      inputsSchema: CodeSigningPolicyInputsSchema
+      inputsSchema: CodeSigningPolicyInputsSchema,
+      checkPolicyMatchResponseSchema: z.object({
+        requiresApproval: z.boolean(),
+        hasActiveGrant: z.boolean()
+      })
     });
   }
 };

--- a/backend/src/services/approval-policy/approval-policy-dal.ts
+++ b/backend/src/services/approval-policy/approval-policy-dal.ts
@@ -64,7 +64,9 @@ export const approvalPolicyDALFactory = (db: TDbClient) => {
   const findByProjectId = async (policyType: ApprovalPolicyType, projectId: string) => {
     try {
       const dbInstance = db.replicaNode();
-      const policies = await dbInstance(TableName.ApprovalPolicies).where({ type: policyType, projectId });
+      const policies = await dbInstance(TableName.ApprovalPolicies)
+        .where({ type: policyType, projectId })
+        .orderBy("id", "asc");
 
       if (!policies.length) {
         return [];

--- a/backend/src/services/approval-policy/approval-policy-schemas.ts
+++ b/backend/src/services/approval-policy/approval-policy-schemas.ts
@@ -95,3 +95,9 @@ export const BaseCreateApprovalRequestSchema = z.object({
 
 // Grants
 export const BaseApprovalRequestGrantSchema = ApprovalRequestGrantsSchema;
+
+// Check Policy Match Response
+export const BaseCheckPolicyMatchResponseSchema = z.object({
+  requiresApproval: z.boolean(),
+  hasActiveGrant: z.boolean()
+});

--- a/backend/src/services/approval-policy/approval-policy-service.ts
+++ b/backend/src/services/approval-policy/approval-policy-service.ts
@@ -942,9 +942,16 @@ export const approvalPolicyServiceFactory = ({
 
     const hasActiveGrant = await fac.canAccess(approvalRequestGrantsDAL, projectId, actor.id, inputs);
 
+    const innerConstraints = policy.constraints?.constraints;
+    const constraints =
+      innerConstraints && "accessDuration" in innerConstraints
+        ? { accessDuration: { max: innerConstraints.accessDuration.max } }
+        : undefined;
+
     return {
       requiresApproval: !hasActiveGrant,
-      hasActiveGrant
+      hasActiveGrant,
+      constraints
     };
   };
 

--- a/backend/src/services/approval-policy/pam-access/pam-access-policy-schemas.ts
+++ b/backend/src/services/approval-policy/pam-access/pam-access-policy-schemas.ts
@@ -7,6 +7,7 @@ import {
   BaseApprovalPolicySchema,
   BaseApprovalRequestGrantSchema,
   BaseApprovalRequestSchema,
+  BaseCheckPolicyMatchResponseSchema,
   BaseCreateApprovalPolicySchema,
   BaseCreateApprovalRequestSchema,
   BaseUpdateApprovalPolicySchema
@@ -149,4 +150,13 @@ export const CreatePamAccessRequestSchema = BaseCreateApprovalRequestSchema.exte
 // Grants
 export const PamAccessRequestGrantSchema = BaseApprovalRequestGrantSchema.extend({
   attributes: PamAccessPolicyRequestDataSchema
+});
+
+// Check Policy Match Response
+export const PamAccessCheckPolicyMatchResponseSchema = BaseCheckPolicyMatchResponseSchema.extend({
+  constraints: z
+    .object({
+      accessDuration: z.object({ max: z.string() })
+    })
+    .optional()
 });

--- a/frontend/src/hooks/api/approvalPolicies/types.ts
+++ b/frontend/src/hooks/api/approvalPolicies/types.ts
@@ -125,4 +125,7 @@ export type TCheckPolicyMatchDTO = {
 export type TCheckPolicyMatchResult = {
   requiresApproval: boolean;
   hasActiveGrant: boolean;
+  constraints?: {
+    accessDuration: { max: string };
+  };
 };

--- a/frontend/src/pages/pam/PamAccountByIDPage/PamAccountByIDPage.tsx
+++ b/frontend/src/pages/pam/PamAccountByIDPage/PamAccountByIDPage.tsx
@@ -149,7 +149,7 @@ const PageContent = () => {
       return;
     }
 
-    const { requiresApproval } = await checkPolicyMatch({
+    const { requiresApproval, constraints } = await checkPolicyMatch({
       policyType: ApprovalPolicyType.PamAccess,
       projectId: projectId!,
       inputs: {
@@ -162,7 +162,8 @@ const PageContent = () => {
       handlePopUpOpen("requestAccount", {
         resourceName: account.resource?.name ?? "",
         accountName: account.name,
-        accountAccessed: true
+        accountAccessed: true,
+        accessDurationMax: constraints?.accessDuration.max
       });
       return;
     }
@@ -353,6 +354,7 @@ const PageContent = () => {
         resourceName={popUp.requestAccount.data?.resourceName}
         accountName={popUp.requestAccount.data?.accountName}
         accountAccessed={popUp.requestAccount.data?.accountAccessed}
+        accessDurationMax={popUp.requestAccount.data?.accessDurationMax}
       />
 
       <PamDeleteAccountModal

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamRequestAccountAccessModal.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamRequestAccountAccessModal.tsx
@@ -56,6 +56,16 @@ const buildFormSchema = (max: string) =>
       .refine(
         (value) => {
           try {
+            return ms(value) >= ms("30s");
+          } catch {
+            return true;
+          }
+        },
+        { message: "Access duration must be at least 30s" }
+      )
+      .refine(
+        (value) => {
+          try {
             return ms(value) <= ms(max);
           } catch {
             return true;

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamRequestAccountAccessModal.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamRequestAccountAccessModal.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { InfoIcon } from "lucide-react";
@@ -24,40 +25,70 @@ type Props = {
   resourceName?: string;
   accountName?: string;
   accountAccessed?: boolean;
+  accessDurationMax?: string;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
 };
 
-const formSchema = z.object({
-  accessDuration: z
-    .string()
-    .min(1, "Access duration is required")
-    .refine(
-      (value) => {
-        try {
-          const duration = ms(value);
-          return duration > 0;
-        } catch {
-          return false;
-        }
-      },
-      { message: "Invalid duration format. Use formats like: 1h, 3d, 30m" }
-    ),
-  justification: z.string().max(512).optional()
-});
+type ContentProps = {
+  resourceName?: string;
+  accountName?: string;
+  accountAccessed?: boolean;
+  accessDurationMax: string;
+  onOpenChange: (isOpen: boolean) => void;
+};
 
-type FormData = z.infer<typeof formSchema>;
+const buildFormSchema = (max: string) =>
+  z.object({
+    accessDuration: z
+      .string()
+      .min(1, "Access duration is required")
+      .refine(
+        (value) => {
+          try {
+            return ms(value) > 0;
+          } catch {
+            return false;
+          }
+        },
+        { message: "Invalid duration format. Use formats like: 1h, 3d, 30m" }
+      )
+      .refine(
+        (value) => {
+          try {
+            return ms(value) <= ms(max);
+          } catch {
+            return true;
+          }
+        },
+        { message: `Access duration cannot exceed ${max}` }
+      ),
+    justification: z.string().max(512).optional()
+  });
 
-const Content = ({ onOpenChange, resourceName, accountName, accountAccessed }: Props) => {
+type FormData = z.infer<ReturnType<typeof buildFormSchema>>;
+
+const Content = ({
+  onOpenChange,
+  resourceName,
+  accountName,
+  accountAccessed,
+  accessDurationMax
+}: ContentProps) => {
   const { projectId } = useProject();
   const { mutateAsync: createApprovalRequest, isPending: isSubmitting } =
     useCreateApprovalRequest();
 
+  const resolver = useMemo(
+    () => zodResolver(buildFormSchema(accessDurationMax)),
+    [accessDurationMax]
+  );
+
   const form = useForm<FormData>({
-    resolver: zodResolver(formSchema),
+    resolver,
     mode: "onChange",
     defaultValues: {
-      accessDuration: "4h",
+      accessDuration: accessDurationMax,
       justification: ""
     }
   });
@@ -130,7 +161,7 @@ const Content = ({ onOpenChange, resourceName, accountName, accountAccessed }: P
             errorText={error?.message}
             isError={Boolean(error?.message)}
           >
-            <Input placeholder="4h" {...field} />
+            <Input placeholder={accessDurationMax} {...field} />
           </FormControl>
         )}
       />
@@ -169,9 +200,14 @@ const Content = ({ onOpenChange, resourceName, accountName, accountAccessed }: P
   );
 };
 
-export const PamRequestAccountAccessModal = (props: Props) => {
-  const { isOpen, onOpenChange } = props;
-
+export const PamRequestAccountAccessModal = ({
+  isOpen,
+  onOpenChange,
+  accessDurationMax,
+  resourceName,
+  accountName,
+  accountAccessed
+}: Props) => {
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
       <ModalContent
@@ -179,7 +215,15 @@ export const PamRequestAccountAccessModal = (props: Props) => {
         title="Request Account Access"
         subTitle="Request access to a protected account"
       >
-        <Content {...props} />
+        {accessDurationMax && (
+          <Content
+            onOpenChange={onOpenChange}
+            resourceName={resourceName}
+            accountName={accountName}
+            accountAccessed={accountAccessed}
+            accessDurationMax={accessDurationMax}
+          />
+        )}
       </ModalContent>
     </Modal>
   );

--- a/frontend/src/pages/pam/PamResourceByIDPage/components/PamResourceAccountsSection.tsx
+++ b/frontend/src/pages/pam/PamResourceByIDPage/components/PamResourceAccountsSection.tsx
@@ -254,7 +254,7 @@ export const PamResourceAccountsSection = ({ resource }: Props) => {
   };
 
   const accessAccount = async (account: TPamAccount) => {
-    const { requiresApproval } = await checkPolicyMatch({
+    const { requiresApproval, constraints } = await checkPolicyMatch({
       policyType: ApprovalPolicyType.PamAccess,
       projectId: projectId!,
       inputs: {
@@ -267,7 +267,8 @@ export const PamResourceAccountsSection = ({ resource }: Props) => {
       handlePopUpOpen("requestAccount", {
         resourceName: resource.name,
         accountName: account.name,
-        accountAccessed: true
+        accountAccessed: true,
+        accessDurationMax: constraints?.accessDuration.max
       });
       return;
     }
@@ -672,6 +673,7 @@ export const PamResourceAccountsSection = ({ resource }: Props) => {
         resourceName={popUp.requestAccount.data?.resourceName}
         accountName={popUp.requestAccount.data?.accountName}
         accountAccessed={popUp.requestAccount.data?.accountAccessed}
+        accessDurationMax={popUp.requestAccount.data?.accessDurationMax}
       />
 
       <PamUpdateAccountModal


### PR DESCRIPTION
## Context

The request modal was hardcoded to 4h and failed when the policy's max was smaller, so now it defaults to the policy's max

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)