### PR TITLE
feat(e2e-tests): fips mode

### DIFF
--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -14,7 +14,7 @@ jobs:
   check-be-pr:
     name: Run integration test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Free up disk space
         run: |
@@ -53,18 +53,32 @@ jobs:
       - name: Run unit test
         run: npm run test:unit
         working-directory: backend
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build FIPS test image
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile.dev.fips
+          load: true
+          tags: infisical-backend-fips:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Run integration test
-        run: npm run test:e2e
-        working-directory: backend
-        env:
-          E2E_TEST_ORACLE_DB_19_HOST: ${{ secrets.E2E_TEST_ORACLE_DB_19_HOST }}
-          E2E_TEST_ORACLE_DB_19_USERNAME: ${{ secrets.E2E_TEST_ORACLE_DB_19_USERNAME }}
-          E2E_TEST_ORACLE_DB_19_PASSWORD: ${{ secrets.E2E_TEST_ORACLE_DB_19_PASSWORD }}
-          E2E_TEST_ORACLE_DB_19_DATABASE: ${{ secrets.E2E_TEST_ORACLE_DB_19_DATABASE }}
-          REDIS_URL: redis://172.17.0.1:6379
-          DB_CONNECTION_URI: postgres://infisical:infisical@172.17.0.1:5432/infisical?sslmode=disable
-          AUTH_SECRET: something-random
-          ENCRYPTION_KEY: 4bnfe4e407b8921c104518903515b218
+        run: |
+          docker run --rm --network host \
+            -e DB_CONNECTION_URI="postgres://infisical:infisical@localhost:5432/infisical?sslmode=disable" \
+            -e REDIS_URL="redis://localhost:6379" \
+            -e AUTH_SECRET="something-random" \
+            -e ENCRYPTION_KEY="p5e5k2j3+HIErjm02dzSrlhXc1xhdgoWvC6pox410rE=" \
+            -e NODE_ENV="test" \
+            -e E2E_TEST_ORACLE_DB_19_HOST="${{ secrets.E2E_TEST_ORACLE_DB_19_HOST }}" \
+            -e E2E_TEST_ORACLE_DB_19_USERNAME="${{ secrets.E2E_TEST_ORACLE_DB_19_USERNAME }}" \
+            -e E2E_TEST_ORACLE_DB_19_PASSWORD="${{ secrets.E2E_TEST_ORACLE_DB_19_PASSWORD }}" \
+            -e E2E_TEST_ORACLE_DB_19_DATABASE="${{ secrets.E2E_TEST_ORACLE_DB_19_DATABASE }}" \
+            -e LICENSE_KEY="${{ secrets.E2E_TEST_LICENSE_KEY }}" \
+            infisical-backend-fips:latest \
+            npm run test:e2e
       - name: cleanup
         run: |
           docker compose -f "docker-compose.dev.yml" down

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -54,9 +54,9 @@ jobs:
         run: npm run test:unit
         working-directory: backend
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build FIPS test image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: backend
           file: backend/Dockerfile.dev.fips

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -72,6 +72,7 @@ jobs:
             -e AUTH_SECRET="something-random" \
             -e ENCRYPTION_KEY="p5e5k2j3+HIErjm02dzSrlhXc1xhdgoWvC6pox410rE=" \
             -e NODE_ENV="test" \
+            -e NODE_OPTIONS="--force-fips" \
             -e E2E_TEST_ORACLE_DB_19_HOST="${{ secrets.E2E_TEST_ORACLE_DB_19_HOST }}" \
             -e E2E_TEST_ORACLE_DB_19_USERNAME="${{ secrets.E2E_TEST_ORACLE_DB_19_USERNAME }}" \
             -e E2E_TEST_ORACLE_DB_19_PASSWORD="${{ secrets.E2E_TEST_ORACLE_DB_19_PASSWORD }}" \

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -77,7 +77,6 @@ jobs:
             -e E2E_TEST_ORACLE_DB_19_USERNAME="${{ secrets.E2E_TEST_ORACLE_DB_19_USERNAME }}" \
             -e E2E_TEST_ORACLE_DB_19_PASSWORD="${{ secrets.E2E_TEST_ORACLE_DB_19_PASSWORD }}" \
             -e E2E_TEST_ORACLE_DB_19_DATABASE="${{ secrets.E2E_TEST_ORACLE_DB_19_DATABASE }}" \
-            -e LICENSE_KEY="${{ secrets.E2E_TEST_LICENSE_KEY }}" \
             infisical-backend-fips:latest \
             npm run test:e2e
       - name: cleanup

--- a/backend/Dockerfile.dev.fips
+++ b/backend/Dockerfile.dev.fips
@@ -77,9 +77,10 @@ WORKDIR /openssl-build
 RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && tar -xf openssl-3.1.2.tar.gz \
     && cd openssl-3.1.2 \
-    && ./Configure enable-fips \
+    && ./Configure enable-fips --libdir=lib \
     && make \
     && make install_fips \
+    && test -f /usr/local/lib/ossl-modules/fips.so \
     && cd / \
     && rm -rf /openssl-build \
     && apt-get clean \

--- a/backend/src/db/seeds/1-user.ts
+++ b/backend/src/db/seeds/1-user.ts
@@ -40,7 +40,12 @@ export async function seed(knex: Knex): Promise<void> {
   await knex(TableName.SuperAdmin).insert([
     // eslint-disable-next-line
     // @ts-ignore
-    { id: "00000000-0000-0000-0000-000000000000", initialized: true, allowSignUp: true }
+    {
+      id: "00000000-0000-0000-0000-000000000000",
+      initialized: true,
+      allowSignUp: true,
+      fipsEnabled: process.env.FIPS_ENABLED === "true"
+    }
   ]);
   // Inserts seed entries
 

--- a/backend/src/db/seeds/1-user.ts
+++ b/backend/src/db/seeds/1-user.ts
@@ -38,9 +38,9 @@ export async function seed(knex: Knex): Promise<void> {
   await initEnvConfig(hsmService, kmsRootConfigDAL, superAdminDAL, logger);
 
   await knex(TableName.SuperAdmin).insert([
-    // eslint-disable-next-line
-    // @ts-ignore
     {
+      // eslint-disable-next-line
+      // @ts-ignore
       id: "00000000-0000-0000-0000-000000000000",
       initialized: true,
       allowSignUp: true,

--- a/backend/src/db/seeds/1-user.ts
+++ b/backend/src/db/seeds/1-user.ts
@@ -70,9 +70,7 @@ export async function seed(knex: Knex): Promise<void> {
     ])
     .returning("*");
 
-  // Hash password for modern login support (POST /api/v3/auth/login)
-  // Uses FIPS-aware hashing: PBKDF2-SHA256 in FIPS mode, bcrypt otherwise
-  const hashedPassword = await crypto.hashing().hash(seedData1.password, 10);
+  const hashedPassword = await crypto.hashing().createHash(seedData1.password, 10);
   await knex(TableName.Users).where({ id: user.id }).update({ hashedPassword });
 
   const encKeys = await generateUserSrpKeys(seedData1.password);

--- a/backend/src/db/seeds/1-user.ts
+++ b/backend/src/db/seeds/1-user.ts
@@ -1,9 +1,9 @@
-import bcrypt from "bcrypt";
 import { Knex } from "knex";
 
 import { initializeHsmModule } from "@app/ee/services/hsm/hsm-fns";
 import { hsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { getHsmConfig, initEnvConfig } from "@app/lib/config/env";
+import { crypto } from "@app/lib/crypto/cryptography";
 import { initLogger, logger } from "@app/lib/logger";
 import { kmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
 import { superAdminDALFactory } from "@app/services/super-admin/super-admin-dal";
@@ -71,7 +71,8 @@ export async function seed(knex: Knex): Promise<void> {
     .returning("*");
 
   // Hash password for modern login support (POST /api/v3/auth/login)
-  const hashedPassword = await bcrypt.hash(seedData1.password, 10);
+  // Uses FIPS-aware hashing: PBKDF2-SHA256 in FIPS mode, bcrypt otherwise
+  const hashedPassword = await crypto.hashing().hash(seedData1.password, 10);
   await knex(TableName.Users).where({ id: user.id }).update({ hashedPassword });
 
   const encKeys = await generateUserSrpKeys(seedData1.password);

--- a/backend/src/db/seeds/3-project.ts
+++ b/backend/src/db/seeds/3-project.ts
@@ -3,7 +3,7 @@ import { Knex } from "knex";
 import { initializeHsmModule } from "@app/ee/services/hsm/hsm-fns";
 import { hsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { getHsmConfig, initEnvConfig } from "@app/lib/config/env";
-import { crypto, SymmetricKeySize } from "@app/lib/crypto/cryptography";
+import { crypto } from "@app/lib/crypto/cryptography";
 import { generateUserSrpKeys } from "@app/lib/crypto/srp";
 import { initLogger, logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
@@ -259,21 +259,15 @@ export async function seed(knex: Knex): Promise<void> {
   await knex(TableName.SecretFolder).insert(envs.map(({ id }) => ({ name: "root", envId: id, parentId: null })));
 
   // save secret secret blind index
-  const encKey = process.env.ENCRYPTION_KEY;
-  if (!encKey) throw new Error("Missing ENCRYPTION_KEY");
   const salt = crypto.randomBytes(16).toString("base64");
-  const secretBlindIndex = crypto.encryption().symmetric().encrypt({
-    plaintext: salt,
-    key: encKey,
-    keySize: SymmetricKeySize.Bits128
-  });
+  const secretBlindIndex = crypto.encryption().symmetric().encryptWithRootEncryptionKey(salt);
   // insert secret blind index for project
   await knex(TableName.SecretBlindIndex).insert({
     projectId: project.id,
     encryptedSaltCipherText: secretBlindIndex.ciphertext,
     saltIV: secretBlindIndex.iv,
     saltTag: secretBlindIndex.tag,
-    algorithm: SecretEncryptionAlgo.AES_256_GCM,
-    keyEncoding: SecretKeyEncoding.UTF8
+    algorithm: secretBlindIndex.algorithm,
+    keyEncoding: secretBlindIndex.encoding
   });
 }

--- a/backend/src/db/seeds/3-project.ts
+++ b/backend/src/db/seeds/3-project.ts
@@ -22,8 +22,6 @@ import {
   OrgMembershipStatus,
   ProjectMembershipRole,
   ProjectType,
-  SecretEncryptionAlgo,
-  SecretKeyEncoding,
   TableName
 } from "../schemas";
 import { seedData1 } from "../seed-data";

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -92,7 +92,7 @@ const generatePassword = (requirements?: PasswordRequirements) => {
           .map(() => chars.symbols[crypto.randomInt(chars.symbols.length)])
       );
     }
-
+    // trigger e2e tests
     const requiredTotal = Object.values(required).reduce<number>((a, b) => a + b, 0);
     const remainingLength = Math.max(length - requiredTotal, 0);
 

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -95,7 +95,7 @@ const generatePassword = (requirements?: PasswordRequirements) => {
 
     const requiredTotal = Object.values(required).reduce<number>((a, b) => a + b, 0);
     const remainingLength = Math.max(length - requiredTotal, 0);
-
+    //
     const allowedChars = Object.entries(chars)
       .filter(([key]) => required[key as keyof typeof required] > 0)
       .map(([, value]) => value)

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -95,7 +95,7 @@ const generatePassword = (requirements?: PasswordRequirements) => {
 
     const requiredTotal = Object.values(required).reduce<number>((a, b) => a + b, 0);
     const remainingLength = Math.max(length - requiredTotal, 0);
-    //
+
     const allowedChars = Object.entries(chars)
       .filter(([key]) => required[key as keyof typeof required] > 0)
       .map(([, value]) => value)

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -92,7 +92,7 @@ const generatePassword = (requirements?: PasswordRequirements) => {
           .map(() => chars.symbols[crypto.randomInt(chars.symbols.length)])
       );
     }
-    // trigger e2e tests
+
     const requiredTotal = Object.values(required).reduce<number>((a, b) => a + b, 0);
     const remainingLength = Math.max(length - requiredTotal, 0);
 

--- a/backend/src/ee/services/license/__mocks__/license-fns.ts
+++ b/backend/src/ee/services/license/__mocks__/license-fns.ts
@@ -37,7 +37,8 @@ export const getDefaultOnPremFeatures = () => {
     machineIdentityAuthTemplates: false,
     pkiLegacyTemplates: false,
     emailDomainVerification: true,
-    gatewayPool: false
+    gatewayPool: false,
+    fips: true
   };
 };
 

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
       E2E_TEST_ORACLE_DB_19_DATABASE: process.env.E2E_TEST_ORACLE_DB_19_DATABASE!
     },
     environment: "./e2e-test/vitest-environment-knex.ts",
-    include: ["./e2e-test/**/*.spec.ts"],
+    include: ["./e2e-test/routes/v3/secret-rotations.spec.ts"],
     pool: "forks",
     poolOptions: {
       forks: {

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -16,6 +16,7 @@ export default defineConfig({
     pool: "forks",
     poolOptions: {
       forks: {
+        singleFork: true,
         minForks: 1,
         maxForks: 1
       }

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
       E2E_TEST_ORACLE_DB_19_DATABASE: process.env.E2E_TEST_ORACLE_DB_19_DATABASE!
     },
     environment: "./e2e-test/vitest-environment-knex.ts",
-    include: ["./e2e-test/routes/v3/secret-rotations.spec.ts"],
+    include: ["./e2e-test/**/*.spec.ts"],
     pool: "forks",
     poolOptions: {
       forks: {

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -13,12 +13,11 @@ export default defineConfig({
     },
     environment: "./e2e-test/vitest-environment-knex.ts",
     include: ["./e2e-test/**/*.spec.ts"],
-    pool: "threads",
+    pool: "forks",
     poolOptions: {
-      threads: {
-        minThreads: 1,
-        maxThreads: 1,
-        singleThread: true
+      forks: {
+        minForks: 1,
+        maxForks: 1
       }
     },
     fileParallelism: false,

--- a/docker-compose.e2e-dbs.yml
+++ b/docker-compose.e2e-dbs.yml
@@ -139,6 +139,7 @@ services:
       - POSTGRES_USER=postgres-test
       - POSTGRES_PASSWORD=postgres-test
       - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+      - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256 --auth-local=scram-sha-256
     volumes:
       - postgres-data-10.12:/var/lib/postgresql/data
     restart: unless-stopped

--- a/docker-compose.e2e-dbs.yml
+++ b/docker-compose.e2e-dbs.yml
@@ -131,12 +131,14 @@ services:
     image: postgres:10.12
     platform: linux/amd64
     container_name: postgres-10.12
+    command: ["postgres", "-c", "password_encryption=scram-sha-256"]
     ports:
       - "5435:5432"
     environment:
       - POSTGRES_DB=postgres-test
       - POSTGRES_USER=postgres-test
       - POSTGRES_PASSWORD=postgres-test
+      - POSTGRES_HOST_AUTH_METHOD=scram-sha-256
     volumes:
       - postgres-data-10.12:/var/lib/postgresql/data
     restart: unless-stopped


### PR DESCRIPTION
## Context


Updated E2E test flow to use FIPS mode in Github CI. The reason we can't run it directly on the bare runner (like before) is that FIPS mode requires OpenSSL compiled with enable-fips. `crypto.setFips(true)` will throw if the FIPS module isn't present in the Node.js runtime.

The backend image build step is cached, so when possible it will use the cached image, greatly reducing build time (such as if only frontend changes are involved)

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)