### PR TITLE
fix: limit ACME requests to 5 minutes for external CAs

### DIFF
--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-errors.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-errors.ts
@@ -1,0 +1,58 @@
+/* eslint-disable max-classes-per-file */
+import RE2 from "re2";
+
+export const ACME_ORDER_TIMEOUT_MS = 5 * 60 * 1000;
+
+export class AcmeOrderTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AcmeOrderTimeoutError";
+  }
+}
+
+export class AcmeRateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AcmeRateLimitError";
+  }
+}
+
+const ACME_ERROR_URN_PREFIX = "urn:ietf:params:acme:error:";
+
+const RATE_LIMIT_URN = `${ACME_ERROR_URN_PREFIX}rateLimited`;
+
+const RATE_LIMITED_WORD_RE = new RE2("\\brateLimited\\b", "i");
+
+export const isAcmeRateLimitError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+  return error.message.includes(RATE_LIMIT_URN) || RATE_LIMITED_WORD_RE.test(error.message);
+};
+
+const formatTimeoutDuration = (timeoutMs: number): string => {
+  const totalSeconds = Math.round(timeoutMs / 1000);
+  if (totalSeconds % 60 === 0) {
+    const minutes = totalSeconds / 60;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${totalSeconds} seconds`;
+};
+
+export const runWithAcmeOrderTimeout = async <T>(operation: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const duration = formatTimeoutDuration(timeoutMs);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(
+        new AcmeOrderTimeoutError(
+          `ACME order did not complete within ${duration}. Possible causes: the CA is rate-limiting requests, the order is blocked at validation, or the CA is slow to respond.`
+        )
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operation, timeoutPromise]);
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+};

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-errors.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-errors.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-classes-per-file */
 import RE2 from "re2";
 
+import { logger } from "@app/lib/logger";
+
 export const ACME_ORDER_TIMEOUT_MS = 5 * 60 * 1000;
 
 export class AcmeOrderTimeoutError extends Error {
@@ -37,11 +39,17 @@ const formatTimeoutDuration = (timeoutMs: number): string => {
   return `${totalSeconds} seconds`;
 };
 
-export const runWithAcmeOrderTimeout = async <T>(operation: Promise<T>, timeoutMs: number): Promise<T> => {
+export const runWithAcmeOrderTimeout = async <T>(
+  operationFactory: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number
+): Promise<T> => {
+  const controller = new AbortController();
   let timeoutHandle: NodeJS.Timeout | undefined;
   const duration = formatTimeoutDuration(timeoutMs);
+
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutHandle = setTimeout(() => {
+      controller.abort();
       reject(
         new AcmeOrderTimeoutError(
           `ACME order did not complete within ${duration}. Possible causes: the CA is rate-limiting requests, the order is blocked at validation, or the CA is slow to respond.`
@@ -50,9 +58,22 @@ export const runWithAcmeOrderTimeout = async <T>(operation: Promise<T>, timeoutM
     }, timeoutMs);
   });
 
+  const operationPromise = operationFactory(controller.signal);
+  operationPromise.catch((err: unknown) => {
+    if (controller.signal.aborted) {
+      logger.debug({ err }, "ACME order operation rejected after timeout");
+    }
+  });
+
   try {
-    return await Promise.race([operation, timeoutPromise]);
+    return await Promise.race([operationPromise, timeoutPromise]);
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+};
+
+export const throwIfAcmeOrderAborted = (signal: AbortSignal | undefined): void => {
+  if (signal?.aborted) {
+    throw new Error("ACME order aborted after timeout");
   }
 };

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -46,6 +46,7 @@ import { keyAlgorithmToAlgCfg } from "../certificate-authority-fns";
 import { route53DeleteRecord, route53UpsertRecord } from "../dns-providers/route53";
 import { TExternalCertificateAuthorityDALFactory } from "../external-certificate-authority-dal";
 import { AcmeDnsProvider } from "./acme-certificate-authority-enums";
+import { throwIfAcmeOrderAborted } from "./acme-certificate-authority-errors";
 import { AcmeCertificateAuthorityCredentialsSchema } from "./acme-certificate-authority-schemas";
 import {
   TAcmeCertificateAuthority,
@@ -295,7 +296,8 @@ export const orderCertificate = async (
     signatureAlgorithm,
     keyAlgorithm,
     isRenewal,
-    originalCertificateId
+    originalCertificateId,
+    abortSignal
   }: {
     caId: string;
     profileId?: string;
@@ -311,6 +313,7 @@ export const orderCertificate = async (
     keyAlgorithm?: string;
     isRenewal?: boolean;
     originalCertificateId?: string;
+    abortSignal?: AbortSignal;
   },
   deps: TOrderCertificateDeps,
   tx?: Knex
@@ -521,6 +524,8 @@ export const orderCertificate = async (
       }
     }
   });
+
+  throwIfAcmeOrderAborted(abortSignal);
 
   const [leafCert, parentCert] = acme.crypto.splitPemChain(pem);
   const certObj = new x509.X509Certificate(leafCert);
@@ -926,7 +931,8 @@ export const AcmeCertificateAuthorityFns = ({
     signatureAlgorithm,
     keyAlgorithm,
     isRenewal,
-    originalCertificateId
+    originalCertificateId,
+    abortSignal
   }: {
     caId: string;
     profileId?: string;
@@ -941,6 +947,7 @@ export const AcmeCertificateAuthorityFns = ({
     keyAlgorithm?: string;
     isRenewal?: boolean;
     originalCertificateId?: string;
+    abortSignal?: AbortSignal;
   }) => {
     return orderCertificate(
       {
@@ -957,7 +964,8 @@ export const AcmeCertificateAuthorityFns = ({
         signatureAlgorithm,
         keyAlgorithm,
         isRenewal,
-        originalCertificateId
+        originalCertificateId,
+        abortSignal
       },
       {
         appConnectionDAL,

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -32,6 +32,13 @@ import { TPkiSyncDALFactory } from "../pki-sync/pki-sync-dal";
 import { TPkiSyncQueueFactory } from "../pki-sync/pki-sync-queue";
 import { TResourceMetadataDALFactory } from "../resource-metadata/resource-metadata-dal";
 import { copyMetadataFromRequestToCertificate } from "../resource-metadata/resource-metadata-fns";
+import {
+  ACME_ORDER_TIMEOUT_MS,
+  AcmeOrderTimeoutError,
+  AcmeRateLimitError,
+  isAcmeRateLimitError,
+  runWithAcmeOrderTimeout
+} from "./acme/acme-certificate-authority-errors";
 import { AcmeCertificateAuthorityFns } from "./acme/acme-certificate-authority-fns";
 import { AcmPendingError } from "./aws-acm-public-ca/aws-acm-public-ca-certificate-authority-errors";
 import { AwsAcmPublicCaCertificateAuthorityFns } from "./aws-acm-public-ca/aws-acm-public-ca-certificate-authority-fns";
@@ -349,21 +356,33 @@ export const certificateIssuanceQueueFactory = ({
           certificateCsr = generatedCsr.toString();
         }
 
-        const acmeResult = await acmeFns.orderCertificateFromProfile({
-          caId,
-          profileId,
-          commonName: commonName || "",
-          altNames: altNames?.map((san) => san.value) || [],
-          csr: Buffer.from(certificateCsr),
-          csrPrivateKey: skLeaf,
-          keyUsages: keyUsages as CertKeyUsage[],
-          extendedKeyUsages: extendedKeyUsages as CertExtendedKeyUsage[],
-          ttl,
-          signatureAlgorithm,
-          keyAlgorithm,
-          isRenewal,
-          originalCertificateId
-        });
+        let acmeResult;
+        try {
+          acmeResult = await runWithAcmeOrderTimeout(
+            acmeFns.orderCertificateFromProfile({
+              caId,
+              profileId,
+              commonName: commonName || "",
+              altNames: altNames?.map((san) => san.value) || [],
+              csr: Buffer.from(certificateCsr),
+              csrPrivateKey: skLeaf,
+              keyUsages: keyUsages as CertKeyUsage[],
+              extendedKeyUsages: extendedKeyUsages as CertExtendedKeyUsage[],
+              ttl,
+              signatureAlgorithm,
+              keyAlgorithm,
+              isRenewal,
+              originalCertificateId
+            }),
+            ACME_ORDER_TIMEOUT_MS
+          );
+        } catch (acmeError) {
+          if (isAcmeRateLimitError(acmeError)) {
+            const message = acmeError instanceof Error ? acmeError.message : String(acmeError);
+            throw new AcmeRateLimitError(`ACME CA rate-limited the order: ${message}`);
+          }
+          throw acmeError;
+        }
 
         if (certificateRequestId && certificateRequestService && acmeResult?.id) {
           try {
@@ -767,12 +786,15 @@ export const certificateIssuanceQueueFactory = ({
 
       logger.error(error, `Certificate issuance job failed for [certificateId=${certificateId}] [caId=${caId}]`);
 
+      const isAcmeTerminal = error instanceof AcmeOrderTimeoutError || error instanceof AcmeRateLimitError;
+
       if (certificateRequestId && certificateRequestService) {
         try {
+          const errorMessage = error instanceof Error ? error.message : String(error);
           await certificateRequestService.updateCertificateRequestStatus({
             certificateRequestId,
             status: CertificateRequestStatus.FAILED,
-            errorMessage: `Certificate issuance failed: ${error instanceof Error ? error.message : String(error)}`
+            errorMessage: isAcmeTerminal ? errorMessage : `Certificate issuance failed: ${errorMessage}`
           });
           logger.info(`Updated certificate request ${certificateRequestId} status to failed due to issuance error`);
         } catch (statusUpdateError) {
@@ -785,7 +807,7 @@ export const certificateIssuanceQueueFactory = ({
 
       // For ACM's 30-attempt queue, wrap non-retryable errors so BullMQ stops retrying immediately.
       // Other CAs keep default retry behavior (3 attempts is short enough that running through them is fine).
-      if (data.caType === CaType.AWS_ACM_PUBLIC_CA) {
+      if (data.caType === CaType.AWS_ACM_PUBLIC_CA || isAcmeTerminal) {
         const message = error instanceof Error ? error.message : String(error);
         const wrapped = new UnrecoverableError(message);
         (wrapped as Error).cause = error;

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -359,21 +359,23 @@ export const certificateIssuanceQueueFactory = ({
         let acmeResult;
         try {
           acmeResult = await runWithAcmeOrderTimeout(
-            acmeFns.orderCertificateFromProfile({
-              caId,
-              profileId,
-              commonName: commonName || "",
-              altNames: altNames?.map((san) => san.value) || [],
-              csr: Buffer.from(certificateCsr),
-              csrPrivateKey: skLeaf,
-              keyUsages: keyUsages as CertKeyUsage[],
-              extendedKeyUsages: extendedKeyUsages as CertExtendedKeyUsage[],
-              ttl,
-              signatureAlgorithm,
-              keyAlgorithm,
-              isRenewal,
-              originalCertificateId
-            }),
+            (signal) =>
+              acmeFns.orderCertificateFromProfile({
+                caId,
+                profileId,
+                commonName: commonName || "",
+                altNames: altNames?.map((san) => san.value) || [],
+                csr: Buffer.from(certificateCsr),
+                csrPrivateKey: skLeaf,
+                keyUsages: keyUsages as CertKeyUsage[],
+                extendedKeyUsages: extendedKeyUsages as CertExtendedKeyUsage[],
+                ttl,
+                signatureAlgorithm,
+                keyAlgorithm,
+                isRenewal,
+                originalCertificateId,
+                abortSignal: signal
+              }),
             ACME_ORDER_TIMEOUT_MS
           );
         } catch (acmeError) {


### PR DESCRIPTION
## Context

ACME certificate orders no longer hang the issuance queue when something goes wrong on the CA side. Each order is now bounded by a 5-minute deadline, if it doesn't complete in time the request is marked as failed with a message pointing at the most likely causes (CA rate-limiting, the order stuck in validation, or a slow CA response). Errors that the CA explicitly flags as rate limits are also surfaced verbatim, and both cases short-circuit BullMQ's retry attempts so we don't repeatedly hit a wall the next attempt would only hit again.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)