### PR TITLE
fix: fail on Schema generation for analytics

### DIFF
--- a/backend/src/auto-start-migrations.ts
+++ b/backend/src/auto-start-migrations.ts
@@ -297,6 +297,7 @@ const withStartupLock = async (db: Knex, logger: Logger, doMigrations: () => Pro
 
 export const runMigrations = async ({ applicationDb, auditLogDb, clickhouseClient, logger }: TArgs) => {
   const generateSanitizedSchema = process.env.GENERATE_SANITIZED_SCHEMA === "true";
+  const failOnSanitizedSchemaError = process.env.FAIL_ON_SANITIZED_SCHEMA_ERROR === "true";
 
   try {
     // akhilmhdh(Feb 10 2025): 2 years  from now remove this
@@ -369,6 +370,9 @@ export const runMigrations = async ({ applicationDb, auditLogDb, clickhouseClien
             { err, errorId: SANITIZED_SCHEMA_ERROR, phase: "recreate" },
             `${SANITIZED_SCHEMA_ERROR}: Failed to recreate sanitized schema`
           );
+          if (failOnSanitizedSchemaError) {
+            throw err;
+          }
         }
       }
       return;
@@ -424,6 +428,9 @@ export const runMigrations = async ({ applicationDb, auditLogDb, clickhouseClien
           { err, errorId: SANITIZED_SCHEMA_ERROR, phase: "create" },
           `${SANITIZED_SCHEMA_ERROR}: Failed to create sanitized schema after migrations`
         );
+        if (failOnSanitizedSchemaError) {
+          throw err;
+        }
       }
     }
   } catch (err) {

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -142,6 +142,9 @@ const envSchema = z
     GENERATE_SANITIZED_SCHEMA: zodStrBool
       .default("false")
       .describe("Generate sanitized schema with views after migrations"),
+    FAIL_ON_SANITIZED_SCHEMA_ERROR: zodStrBool
+      .default("false")
+      .describe("Exit startup when sanitized schema generation fails"),
     SANITIZED_SCHEMA_ROLE: zpStr(
       z.string().describe("PostgreSQL role to grant read access to the sanitized schema").optional()
     ),


### PR DESCRIPTION
Right now, when we fail on schema generation, we end up with no schema at all and no error messages. This leaves hex pretty much down, and we sometimes don't know why it's down. This will help us catch this issue in Gamma; therefore, we should never see it in prod or any of the Dedicated Instances.