### PR TITLE
fix(gateway): add support for gateway v2 on vault migration

### DIFF
--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -4,8 +4,10 @@ import axios, { AxiosInstance, isAxiosError } from "axios";
 import { v4 as uuidv4 } from "uuid";
 
 import { TGatewayServiceFactory } from "@app/ee/services/gateway/gateway-service";
+import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { BadRequestError } from "@app/lib/errors";
 import { GatewayProxyProtocol, withGatewayProxy } from "@app/lib/gateway";
+import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
@@ -18,31 +20,44 @@ type VaultData = {
   secretData: Record<string, string>;
 };
 
-const vaultFactory = (gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">) => {
+const vaultFactory = (
+  gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">
+) => {
   const $gatewayProxyWrapper = async <T>(
     inputs: {
       gatewayId: string;
-      targetHost?: string;
-      targetPort?: number;
+      targetProtocol: string;
+      targetHostname: string;
+      targetPort: number;
     },
     gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent) => Promise<T>
   ): Promise<T> => {
-    const relayDetails = await gatewayService.fnGetGatewayClientTlsByGatewayId(inputs.gatewayId);
+    const { gatewayId, targetProtocol, targetHostname, targetPort } = inputs;
 
-    const callbackResult = await withGatewayProxy(
-      async (port, httpsAgent) => {
-        const res = await gatewayCallback("http://localhost", port, httpsAgent);
-        return res;
-      },
-      {
-        protocol: GatewayProxyProtocol.Http,
-        targetHost: inputs.targetHost,
-        targetPort: inputs.targetPort,
-        relayDetails
-      }
-    );
+    const gatewayV2Details = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+      gatewayId,
+      targetHost: targetHostname,
+      targetPort
+    });
 
-    return callbackResult;
+    if (gatewayV2Details) {
+      return withGatewayV2Proxy(async (port) => gatewayCallback("http://localhost", port), {
+        protocol: GatewayProxyProtocol.Tcp,
+        relayHost: gatewayV2Details.relayHost,
+        gateway: gatewayV2Details.gateway,
+        relay: gatewayV2Details.relay
+      });
+    }
+
+    const relayDetails = await gatewayService.fnGetGatewayClientTlsByGatewayId(gatewayId);
+
+    return withGatewayProxy(async (port, httpsAgent) => gatewayCallback("http://localhost", port, httpsAgent), {
+      protocol: GatewayProxyProtocol.Http,
+      targetHost: `${targetProtocol}://${targetHostname}`,
+      targetPort,
+      relayDetails
+    });
   };
 
   const getMounts = async (request: AxiosInstance) => {
@@ -280,7 +295,8 @@ const vaultFactory = (gatewayService: Pick<TGatewayServiceFactory, "fnGetGateway
       data = await $gatewayProxyWrapper(
         {
           gatewayId,
-          targetHost: `${cleanedProtocol}://${hostname}`,
+          targetProtocol: cleanedProtocol,
+          targetHostname: hostname,
           targetPort: port ? Number(port) : 8200 // 8200, default port for Vault self-hosted/dedicated
         },
         getData
@@ -532,7 +548,13 @@ export const importVaultDataFn = async (
     gatewayId?: string;
     orgId: string;
   },
-  { gatewayService }: { gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId"> }
+  {
+    gatewayService,
+    gatewayV2Service
+  }: {
+    gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">;
+    gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+  }
 ) => {
   await blockLocalAndPrivateIpAddresses(vaultUrl);
 
@@ -561,7 +583,7 @@ export const importVaultDataFn = async (
     `[importVaultDataFn]: Running ${orgId in vaultMigrationTransformMappings ? "custom" : "default"} transform`
   );
 
-  const vaultApi = vaultFactory(gatewayService);
+  const vaultApi = vaultFactory(gatewayService, gatewayV2Service);
 
   const vaultData = await vaultApi.collectVaultData({
     accessToken: vaultAccessToken,

--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -31,7 +31,7 @@ const vaultFactory = (
       targetHostname: string;
       targetPort: number;
     },
-    gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent) => Promise<T>
+    gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent, hostHeader?: string) => Promise<T>
   ): Promise<T> => {
     const { gatewayId, targetProtocol, targetHostname, targetPort } = inputs;
 
@@ -42,12 +42,18 @@ const vaultFactory = (
     });
 
     if (gatewayV2Details) {
-      return withGatewayV2Proxy(async (port) => gatewayCallback("http://localhost", port), {
-        protocol: GatewayProxyProtocol.Tcp,
-        relayHost: gatewayV2Details.relayHost,
-        gateway: gatewayV2Details.gateway,
-        relay: gatewayV2Details.relay
-      });
+      const isHttps = targetProtocol === "https";
+      const httpsAgent = isHttps ? new https.Agent({ servername: targetHostname }) : undefined;
+
+      return withGatewayV2Proxy(
+        async (port) => gatewayCallback(`${targetProtocol}://localhost`, port, httpsAgent, targetHostname),
+        {
+          protocol: GatewayProxyProtocol.Tcp,
+          relayHost: gatewayV2Details.relayHost,
+          gateway: gatewayV2Details.gateway,
+          relay: gatewayV2Details.relay
+        }
+      );
     }
 
     const relayDetails = await gatewayService.fnGetGatewayClientTlsByGatewayId(gatewayId);
@@ -223,14 +229,15 @@ const vaultFactory = (
     accessToken: string;
     gatewayId?: string;
   }): Promise<VaultData[]> {
-    const getData = async (host: string, port?: number, httpsAgent?: https.Agent) => {
+    const getData = async (host: string, port?: number, httpsAgent?: https.Agent, hostHeader?: string) => {
       const allData: VaultData[] = [];
 
       const request = axios.create({
         baseURL: port ? `${host}:${port}` : host,
         headers: {
           "X-Vault-Token": accessToken,
-          ...(namespace ? { "X-Vault-Namespace": namespace } : {})
+          ...(namespace ? { "X-Vault-Namespace": namespace } : {}),
+          ...(hostHeader ? { Host: hostHeader } : {})
         },
         maxRedirects: 0,
         httpsAgent

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -287,7 +287,8 @@ export const externalMigrationServiceFactory = ({
         orgId: actorOrgId
       },
       {
-        gatewayService
+        gatewayService,
+        gatewayV2Service
       }
     );
 

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
@@ -268,7 +268,13 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
             <Field>
               <FieldLabel>Vault Namespace</FieldLabel>
               <FieldContent>
-                <Input type="text" placeholder="" {...field} isError={Boolean(error)} />
+                <Input
+                  type="text"
+                  placeholder="admin"
+                  autoComplete="off"
+                  {...field}
+                  isError={Boolean(error)}
+                />
               </FieldContent>
               <FieldError>{error?.message}</FieldError>
             </Field>
@@ -281,7 +287,13 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
             <Field>
               <FieldLabel>Vault Access Token</FieldLabel>
               <FieldContent>
-                <Input type="password" placeholder="" {...field} isError={Boolean(error)} />
+                <Input
+                  type="password"
+                  placeholder="hvs.XXXXXXXXXXXXXXXX"
+                  autoComplete="new-password"
+                  {...field}
+                  isError={Boolean(error)}
+                />
               </FieldContent>
               <FieldError>{error?.message}</FieldError>
             </Field>

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
@@ -270,7 +270,7 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
               <FieldContent>
                 <Input
                   type="text"
-                  placeholder="admin"
+                  placeholder=""
                   autoComplete="off"
                   {...field}
                   isError={Boolean(error)}

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
@@ -270,7 +270,7 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
               <FieldContent>
                 <Input
                   type="text"
-                  placeholder=""
+                  placeholder="admin"
                   autoComplete="off"
                   {...field}
                   isError={Boolean(error)}


### PR DESCRIPTION
## Context

Add support to gateway v2. The previous implementation only checked gateway v1, so if a new gateway was added and we tried to create a new migration using vault this would fail  

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Start vault locally
- Add a new gateway and a new relay
- Create a new import using vault (at org level)
- This new migration needs to use the gateway defined and point to localhost:8200 (or any other port that vault is running)
- Do not use `host.docker.internal`, since this would not use the gateway. 
- Check the import works. (try with keyvault and namespace)

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)