### PR TITLE
feat(smtp): add SMTP_HELO_HOST to set the EHLO/HELO hostname

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -202,6 +202,14 @@ const envSchema = z
     SMTP_PASSWORD: zpStr(z.string().optional()),
     SMTP_FROM_ADDRESS: zpStr(z.string().optional()),
     SMTP_FROM_NAME: zpStr(z.string().optional().default("Infisical")),
+    SMTP_HELO_HOST: zpStr(
+      z
+        .string()
+        .optional()
+        .describe(
+          "Hostname announced in the SMTP EHLO/HELO greeting. Defaults to the OS hostname, which may not be a valid FQDN inside containers."
+        )
+    ),
     SMTP_CUSTOM_CA_CERT: zpStr(
       z.string().optional().describe("Base64 encoded custom CA certificate PEM(s) for the SMTP server")
     ),
@@ -950,6 +958,7 @@ export const formatSmtpConfig = () => {
   return {
     host: envCfg.SMTP_HOST,
     port: envCfg.SMTP_PORT,
+    name: envCfg.SMTP_HELO_HOST,
     auth:
       envCfg.SMTP_USERNAME && envCfg.SMTP_PASSWORD
         ? { user: envCfg.SMTP_USERNAME, pass: envCfg.SMTP_PASSWORD }

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -355,6 +355,15 @@ Without email configuration, Infisical's core functions like sign-up/login and s
   Name label to be used in From field (e.g. Team)
 </ParamField>
 
+<ParamField query="SMTP_HELO_HOST" type="string" default="none" optional>
+  Hostname that Infisical announces in the SMTP `EHLO`/`HELO` greeting. When
+  unset, the underlying mailer falls back to the operating system hostname.
+  Inside containers (e.g. Cloud Run, Kubernetes) the OS hostname is typically a
+  random container ID, which can be rejected by SMTP relays that validate the
+  sender hostname (such as Gmail SMTP relay with sender-hostname checks). Set
+  this to a valid FQDN that the relay accepts.
+</ParamField>
+
 <ParamField query="SMTP_IGNORE_TLS" type="bool" default="false" optional>
   If this is `true` and `SMTP_PORT` is not 465 then TLS is not used even if the
   server supports STARTTLS extension.


### PR DESCRIPTION
Nodemailer falls back to os.hostname() when no `name` option is provided. Inside containers (Cloud Run, Kubernetes, ECS) that hostname is typically a random container ID, which is rejected by SMTP relays that validate the sender hostname, e.g. Gmail SMTP relay with sender-hostname checks enabled.

Expose SMTP_HELO_HOST so operators can announce a valid FQDN in the EHLO/HELO greeting. The variable is optional; existing deployments keep the previous os.hostname() behavior.

Fixes https://github.com/Infisical/infisical/issues/6228

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)