### PR TITLE
fix: key_algorithm mismatch

### DIFF
--- a/backend/src/server/routes/v1/certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-router.ts
@@ -19,6 +19,7 @@ import {
   validateAltNamesField,
   validateCaDateField
 } from "@app/services/certificate-authority/certificate-authority-validators";
+import { certKeyAlgorithmSchema } from "@app/services/certificate-common/certificate-algorithm-utils";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { InternalCertificateAuthorityResponseSchema } from "../sanitizedSchemas";
@@ -51,8 +52,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
           notBefore: validateCaDateField.optional().describe(CERTIFICATE_AUTHORITIES.CREATE.notBefore),
           notAfter: validateCaDateField.optional().describe(CERTIFICATE_AUTHORITIES.CREATE.notAfter),
           maxPathLength: z.number().min(-1).default(-1).describe(CERTIFICATE_AUTHORITIES.CREATE.maxPathLength),
-          keyAlgorithm: z
-            .nativeEnum(CertKeyAlgorithm)
+          keyAlgorithm: certKeyAlgorithmSchema
             .default(CertKeyAlgorithm.RSA_2048)
             .describe(CERTIFICATE_AUTHORITIES.CREATE.keyAlgorithm),
           requireTemplateForIssuance: z

--- a/backend/src/server/routes/v1/certificate-profiles-router.ts
+++ b/backend/src/server/routes/v1/certificate-profiles-router.ts
@@ -10,6 +10,10 @@ import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { CertStatus } from "@app/services/certificate/certificate-types";
 import {
+  certKeyAlgorithmSchema,
+  certSignatureAlgorithmSchema
+} from "@app/services/certificate-common/certificate-algorithm-utils";
+import {
   CertExtendedKeyUsageType,
   CertKeyAlgorithm,
   CertKeyUsageType,
@@ -101,8 +105,8 @@ export const registerCertificateProfilesRouter = async (
             .object({
               ttlDays: z.number().int().positive().optional(),
               commonName: z.string().optional(),
-              keyAlgorithm: z.nativeEnum(CertKeyAlgorithm).optional(),
-              signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm).optional(),
+              keyAlgorithm: certKeyAlgorithmSchema.optional(),
+              signatureAlgorithm: certSignatureAlgorithmSchema.optional(),
               keyUsages: z.array(z.nativeEnum(CertKeyUsageType)).optional(),
               extendedKeyUsages: z.array(z.nativeEnum(CertExtendedKeyUsageType)).optional(),
               basicConstraints: z
@@ -606,8 +610,8 @@ export const registerCertificateProfilesRouter = async (
             .object({
               ttlDays: z.number().int().positive().optional(),
               commonName: z.string().optional(),
-              keyAlgorithm: z.nativeEnum(CertKeyAlgorithm).optional(),
-              signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm).optional(),
+              keyAlgorithm: certKeyAlgorithmSchema.optional(),
+              signatureAlgorithm: certSignatureAlgorithmSchema.optional(),
               keyUsages: z.array(z.nativeEnum(CertKeyUsageType)).optional(),
               extendedKeyUsages: z.array(z.nativeEnum(CertExtendedKeyUsageType)).optional(),
               basicConstraints: z

--- a/backend/src/server/routes/v1/certificate-router.ts
+++ b/backend/src/server/routes/v1/certificate-router.ts
@@ -11,9 +11,13 @@ import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { addNoCacheHeaders } from "@app/server/lib/caching";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
-import { CertKeyAlgorithm, CertSignatureAlgorithm, CrlReason } from "@app/services/certificate/certificate-types";
+import { CrlReason } from "@app/services/certificate/certificate-types";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
 import { validateCaDateField } from "@app/services/certificate-authority/certificate-authority-validators";
+import {
+  certKeyAlgorithmSchema,
+  certSignatureAlgorithmSchema
+} from "@app/services/certificate-common/certificate-algorithm-utils";
 import {
   CertExtendedKeyUsageType,
   CertKeyUsageType,
@@ -148,8 +152,8 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
                   })
                 )
                 .optional(),
-              signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm).optional(),
-              keyAlgorithm: z.nativeEnum(CertKeyAlgorithm).optional(),
+              signatureAlgorithm: certSignatureAlgorithmSchema.optional(),
+              keyAlgorithm: certKeyAlgorithmSchema.optional(),
               ttl: z
                 .string()
                 .trim()
@@ -779,8 +783,8 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
               })
             )
             .optional(),
-          signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm),
-          keyAlgorithm: z.nativeEnum(CertKeyAlgorithm),
+          signatureAlgorithm: certSignatureAlgorithmSchema,
+          keyAlgorithm: certKeyAlgorithmSchema,
           removeRootsFromChain: booleanSchema.default(false).optional()
         })
         .refine(validateTtlAndDateFields, {
@@ -984,8 +988,8 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
           notBefore: validateCaDateField.optional(),
           notAfter: validateCaDateField.optional(),
           commonName: validateTemplateRegexField.optional(),
-          signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm),
-          keyAlgorithm: z.nativeEnum(CertKeyAlgorithm),
+          signatureAlgorithm: certSignatureAlgorithmSchema,
+          keyAlgorithm: certKeyAlgorithmSchema,
           removeRootsFromChain: booleanSchema.default(false).optional()
         })
         .refine(validateTtlAndDateFields, {

--- a/backend/src/server/routes/v3/deprecated-certificates-router.ts
+++ b/backend/src/server/routes/v3/deprecated-certificates-router.ts
@@ -7,8 +7,11 @@ import { ms } from "@app/lib/ms";
 import { writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
-import { CertKeyAlgorithm, CertSignatureAlgorithm } from "@app/services/certificate/certificate-types";
 import { validateCaDateField } from "@app/services/certificate-authority/certificate-authority-validators";
+import {
+  certKeyAlgorithmSchema,
+  certSignatureAlgorithmSchema
+} from "@app/services/certificate-common/certificate-algorithm-utils";
 import {
   CertExtendedKeyUsageType,
   CertKeyUsageType,
@@ -88,8 +91,8 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
               })
             )
             .optional(),
-          signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm),
-          keyAlgorithm: z.nativeEnum(CertKeyAlgorithm),
+          signatureAlgorithm: certSignatureAlgorithmSchema,
+          keyAlgorithm: certKeyAlgorithmSchema,
           removeRootsFromChain: booleanSchema.default(false).optional()
         })
         .refine(validateTtlAndDateFields, {
@@ -353,8 +356,8 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
           notBefore: validateCaDateField.optional(),
           notAfter: validateCaDateField.optional(),
           commonName: validateTemplateRegexField.optional(),
-          signatureAlgorithm: z.nativeEnum(CertSignatureAlgorithm),
-          keyAlgorithm: z.nativeEnum(CertKeyAlgorithm),
+          signatureAlgorithm: certSignatureAlgorithmSchema,
+          keyAlgorithm: certKeyAlgorithmSchema,
           removeRootsFromChain: booleanSchema.default(false).optional()
         })
         .refine(validateTtlAndDateFields, {

--- a/backend/src/services/certificate-authority/certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.ts
@@ -155,6 +155,12 @@ export const keyAlgorithmToAlgCfg = (keyAlgorithm: CertKeyAlgorithm) => {
         namedCurve: "P-384",
         hash: "SHA-384"
       };
+    case CertKeyAlgorithm.ECDSA_P521:
+      return {
+        name: "ECDSA",
+        namedCurve: "P-521",
+        hash: "SHA-512"
+      };
     // PQC: hash/namedCurve set to satisfy the TypeScript union return type; only `name` is used
     case CertKeyAlgorithm.ML_DSA_44:
       return { name: "ML-DSA-44", hash: "ML-DSA-44", namedCurve: "ML-DSA-44" };

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-schemas.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-schemas.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { CertificateAuthorities } from "@app/lib/api-docs/constants";
 import { CertKeyAlgorithm } from "@app/services/certificate/certificate-types";
+import { certKeyAlgorithmSchema } from "@app/services/certificate-common/certificate-algorithm-utils";
 
 import { CaType, InternalCaType } from "../certificate-authority-enums";
 import {
@@ -43,7 +44,7 @@ export const InternalCertificateAuthorityConfigurationSchema = z
     notBefore: validateCaDateField.optional().describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.notBefore),
     notAfter: validateCaDateField.optional().describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.notAfter),
     maxPathLength: z.number().min(-1).nullish().describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.maxPathLength),
-    keyAlgorithm: z.nativeEnum(CertKeyAlgorithm).describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.keyAlgorithm),
+    keyAlgorithm: certKeyAlgorithmSchema.describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.keyAlgorithm),
     dn: z.string().trim().nullish(),
     parentCaId: z.string().uuid().nullish(),
     serialNumber: z.string().trim().nullish(),

--- a/backend/src/services/certificate-common/certificate-algorithm-utils.ts
+++ b/backend/src/services/certificate-common/certificate-algorithm-utils.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+import { CertKeyAlgorithm, CertSignatureAlgorithm } from "@app/services/certificate/certificate-types";
+
+const KEY_ALGORITHM_ALIAS_MAP: Record<string, CertKeyAlgorithm> = {
+  "RSA-2048": CertKeyAlgorithm.RSA_2048,
+  "RSA-3072": CertKeyAlgorithm.RSA_3072,
+  "RSA-4096": CertKeyAlgorithm.RSA_4096,
+
+  ECDSA_P256: CertKeyAlgorithm.ECDSA_P256,
+  "ECDSA-P256": CertKeyAlgorithm.ECDSA_P256,
+  EC_P256: CertKeyAlgorithm.ECDSA_P256,
+
+  ECDSA_P384: CertKeyAlgorithm.ECDSA_P384,
+  "ECDSA-P384": CertKeyAlgorithm.ECDSA_P384,
+  EC_P384: CertKeyAlgorithm.ECDSA_P384,
+
+  ECDSA_P521: CertKeyAlgorithm.ECDSA_P521,
+  "ECDSA-P521": CertKeyAlgorithm.ECDSA_P521,
+  EC_P521: CertKeyAlgorithm.ECDSA_P521
+};
+
+const SIGNATURE_ALGORITHM_ALIAS_MAP: Record<string, CertSignatureAlgorithm> = {
+  RSA_SHA256: CertSignatureAlgorithm.RSA_SHA256,
+  RSA_SHA384: CertSignatureAlgorithm.RSA_SHA384,
+  RSA_SHA512: CertSignatureAlgorithm.RSA_SHA512,
+  ECDSA_SHA256: CertSignatureAlgorithm.ECDSA_SHA256,
+  ECDSA_SHA384: CertSignatureAlgorithm.ECDSA_SHA384,
+  ECDSA_SHA512: CertSignatureAlgorithm.ECDSA_SHA512,
+
+  "SHA256-RSA": CertSignatureAlgorithm.RSA_SHA256,
+  "SHA384-RSA": CertSignatureAlgorithm.RSA_SHA384,
+  "SHA512-RSA": CertSignatureAlgorithm.RSA_SHA512,
+  "SHA256-ECDSA": CertSignatureAlgorithm.ECDSA_SHA256,
+  "SHA384-ECDSA": CertSignatureAlgorithm.ECDSA_SHA384,
+  "SHA512-ECDSA": CertSignatureAlgorithm.ECDSA_SHA512
+};
+
+export const normalizeKeyAlgorithm = (value: unknown): unknown => {
+  if (typeof value !== "string") return value;
+  return Object.hasOwn(KEY_ALGORITHM_ALIAS_MAP, value) ? KEY_ALGORITHM_ALIAS_MAP[value] : value;
+};
+
+export const normalizeSignatureAlgorithm = (value: unknown): unknown => {
+  if (typeof value !== "string") return value;
+  return Object.hasOwn(SIGNATURE_ALGORITHM_ALIAS_MAP, value) ? SIGNATURE_ALGORITHM_ALIAS_MAP[value] : value;
+};
+
+export const certKeyAlgorithmSchema = z.preprocess(normalizeKeyAlgorithm, z.nativeEnum(CertKeyAlgorithm));
+
+export const certSignatureAlgorithmSchema = z.preprocess(
+  normalizeSignatureAlgorithm,
+  z.nativeEnum(CertSignatureAlgorithm)
+);

--- a/backend/src/services/certificate-common/certificate-constants.ts
+++ b/backend/src/services/certificate-common/certificate-constants.ts
@@ -182,6 +182,7 @@ export enum CertKeyAlgorithm {
   RSA_4096 = "RSA_4096",
   ECDSA_P256 = "EC_prime256v1",
   ECDSA_P384 = "EC_secp384r1",
+  ECDSA_P521 = "EC_secp521r1",
   ML_DSA_44 = "ML-DSA-44",
   ML_DSA_65 = "ML-DSA-65",
   ML_DSA_87 = "ML-DSA-87",


### PR DESCRIPTION
## Context

The cert-manager API previously only accepted OpenSSL curve names (`EC_secp384r1`, `EC_prime256v1`) for `keyAlgorithm`, which mismatched the NIST form (`ECDSA_P384`, `ECDSA-P384`) that's natural for anyone reading the `CertKeyAlgorithm` enum keys or coming from the Terraform provider / frontend policy UI. Adds a `z.preprocess` normalizer (`certKeyAlgorithmSchema` / `certSignatureAlgorithmSchema`) at the request-body validation boundary that maps documented aliases (`ECDSA_P384`, `ECDSA-P384`, `EC_P384`, `RSA-2048`, `RSA_SHA256`, `SHA256-RSA`, …) to the canonical enum value before validation, applied to all cert-manager / CA route entry points. Existing canonical clients are unaffected, unknown values still get a proper Zod enum error, downstream services and audit logs see the canonical value, and the missing `ECDSA_P521` was added to `certificate-common`. 

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)