### PR TITLE
fix(auth): prevent stale replica read during signup after account deletion

### DIFF
--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -51,38 +51,51 @@ export const authSignupServiceFactory = ({
       throw new Error("Provided a disposable email");
     }
 
-    // akhilmhdh: case sensitive email resolution
-    let user = await userDAL.findOne({ username: sanitizedEmail });
-    if (user && user.isAccepted) {
-      // Send informational email for existing accounts instead of throwing error
-      // This prevents user enumeration vulnerability
-      const appCfg = getConfig();
-      await smtpService
-        .sendMail({
-          template: SmtpTemplates.SignupExistingAccount,
-          subjectLine: "Sign-up Request for Your Infisical Account",
-          recipients: [sanitizedEmail],
-          substitutions: {
-            email: sanitizedEmail,
-            loginUrl: `${appCfg.SITE_URL}/login`,
-            resetPasswordUrl: `${appCfg.SITE_URL}/account-recovery`
-          }
-        })
-        .catch((err) =>
-          logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
-        );
-      return;
-    }
+    // Use a transaction to read from the primary database, not a read replica.
+    // After account deletion the replica may still return the stale user record
+    // due to replication lag, which causes re-registration to incorrectly treat
+    // the email as an existing account (see #6034).
+    const user = await userDAL.transaction(async (tx) => {
+      // akhilmhdh: case sensitive email resolution
+      const existingUser = await userDAL.findOne({ username: sanitizedEmail }, tx);
+      if (existingUser && existingUser.isAccepted) {
+        // Send informational email for existing accounts instead of throwing error
+        // This prevents user enumeration vulnerability
+        const appCfg = getConfig();
+        await smtpService
+          .sendMail({
+            template: SmtpTemplates.SignupExistingAccount,
+            subjectLine: "Sign-up Request for Your Infisical Account",
+            recipients: [sanitizedEmail],
+            substitutions: {
+              email: sanitizedEmail,
+              loginUrl: `${appCfg.SITE_URL}/login`,
+              resetPasswordUrl: `${appCfg.SITE_URL}/account-recovery`
+            }
+          })
+          .catch((err) =>
+            logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
+          );
+        return null;
+      }
 
-    if (!user) {
-      user = await userDAL.create({
-        authMethods: [AuthMethod.EMAIL],
-        username: sanitizedEmail,
-        email: sanitizedEmail,
-        isGhost: false
-      });
-    }
-    if (!user) throw new Error("Failed to create user");
+      if (!existingUser) {
+        return userDAL.create(
+          {
+            authMethods: [AuthMethod.EMAIL],
+            username: sanitizedEmail,
+            email: sanitizedEmail,
+            isGhost: false
+          },
+          tx
+        );
+      }
+
+      return existingUser;
+    });
+
+    if (!user) return;
+    if (!user.id) throw new Error("Failed to create user");
 
     const token = await tokenService.createTokenForUser({
       type: TokenType.TOKEN_EMAIL_CONFIRMATION,

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -55,32 +55,18 @@ export const authSignupServiceFactory = ({
     // After account deletion the replica may still return the stale user record
     // due to replication lag, which causes re-registration to incorrectly treat
     // the email as an existing account (see #6034).
-    const user = await userDAL.transaction(async (tx) => {
+    // The transaction is kept short (DB ops only) — side effects like SMTP are
+    // handled after the transaction commits to avoid holding a connection during
+    // network I/O.
+    const { user, isExistingAcceptedUser } = await userDAL.transaction(async (tx) => {
       // akhilmhdh: case sensitive email resolution
       const existingUser = await userDAL.findOne({ username: sanitizedEmail }, tx);
       if (existingUser && existingUser.isAccepted) {
-        // Send informational email for existing accounts instead of throwing error
-        // This prevents user enumeration vulnerability
-        const appCfg = getConfig();
-        await smtpService
-          .sendMail({
-            template: SmtpTemplates.SignupExistingAccount,
-            subjectLine: "Sign-up Request for Your Infisical Account",
-            recipients: [sanitizedEmail],
-            substitutions: {
-              email: sanitizedEmail,
-              loginUrl: `${appCfg.SITE_URL}/login`,
-              resetPasswordUrl: `${appCfg.SITE_URL}/account-recovery`
-            }
-          })
-          .catch((err) =>
-            logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
-          );
-        return null;
+        return { user: null, isExistingAcceptedUser: true };
       }
 
       if (!existingUser) {
-        return userDAL.create(
+        const created = await userDAL.create(
           {
             authMethods: [AuthMethod.EMAIL],
             username: sanitizedEmail,
@@ -89,13 +75,34 @@ export const authSignupServiceFactory = ({
           },
           tx
         );
+        return { user: created, isExistingAcceptedUser: false };
       }
 
-      return existingUser;
+      return { user: existingUser, isExistingAcceptedUser: false };
     });
 
-    if (!user) return;
-    if (!user.id) throw new Error("Failed to create user");
+    if (isExistingAcceptedUser) {
+      // Send informational email for existing accounts instead of throwing error
+      // This prevents user enumeration vulnerability
+      const appCfg = getConfig();
+      await smtpService
+        .sendMail({
+          template: SmtpTemplates.SignupExistingAccount,
+          subjectLine: "Sign-up Request for Your Infisical Account",
+          recipients: [sanitizedEmail],
+          substitutions: {
+            email: sanitizedEmail,
+            loginUrl: `${appCfg.SITE_URL}/login`,
+            resetPasswordUrl: `${appCfg.SITE_URL}/account-recovery`
+          }
+        })
+        .catch((err) =>
+          logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
+        );
+      return;
+    }
+
+    if (!user) throw new Error("Failed to create user");
 
     const token = await tokenService.createTokenForUser({
       type: TokenType.TOKEN_EMAIL_CONFIRMATION,


### PR DESCRIPTION
## Problem

When a user deletes their account and immediately re-registers with the same email, the previous account data appears to persist — they can't log in, can't reset their password, and re-registration doesn't help (#6034, ENG-4856).

## Root Cause

The signup flow in `beginEmailSignupProcess` calls `userDAL.findOne()` without a transaction:

```
beginEmailSignupProcess (auth-signup-service.ts:55)
  → userDAL.findOne({ username: sanitizedEmail })
    → ormify.findOne (lib/knex/index.ts:277)
      → (tx || db.replicaNode())(tableName)  ← hits read replica
```

Account deletion writes to the **primary** via `userDAL.deleteById()` (hard delete, CASCADE cleans up `user_encryption_keys`, auth tokens, org memberships). But the signup user lookup hits `db.replicaNode()` by default. With any replication lag, the replica still returns the stale record with `isAccepted: true`, so the flow sends the "already exists" email instead of creating a fresh account.

Even after the replica catches up, the user already received the wrong email. Password recovery also fails because the record is gone from the primary.

## Fix

Wrap the user lookup and creation in `userDAL.transaction()`. The ormify layer uses `(tx || db.replicaNode())` — with `tx` present, it reads from the primary, ensuring a consistent view right after deletion.

```diff
-    let user = await userDAL.findOne({ username: sanitizedEmail });
+    const user = await userDAL.transaction(async (tx) => {
+      const existingUser = await userDAL.findOne({ username: sanitizedEmail }, tx);
       ...
+    });
```

## Scope

Single file change: `backend/src/services/auth/auth-signup-service.ts`. All existing logic is preserved — the anti-enumeration email, the `isAccepted` check, the token creation flow. The only behavioral change is that the user lookup reads from the primary instead of the replica.

## Test plan

- [ ] Delete account → re-register with same email → verify fresh signup flow (verification email, not "already exists")
- [ ] Normal signup with new email still works
- [ ] Signup with existing accepted email still sends the anti-enumeration email (no user enumeration leak)