### PR TITLE
fix(secret-sync): strip database components from DO app spec before sync update

### DIFF
--- a/backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts
+++ b/backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts
@@ -63,11 +63,19 @@ class DigitalOceanAppPlatformPublicClient {
   async putVariables(connection: TDigitalOceanConnectionConfig, appId: string, ...input: TDigitalOceanVariable[]) {
     const response = await this.getApp(connection, appId);
 
+    // Strip credential-bearing components from the spec before sending the update.
+    // The DO API re-validates ALL components in a PUT /apps/{id} request, not just
+    // the changed fields. When the app has an attached managed database, the GET
+    // response redacts the database password, but the PUT validation requires it —
+    // causing a "password is not accessible" error even though we're only updating
+    // environment variables. Removing `databases` from the spec avoids this (#6210).
+    const { databases: _databases, ...specWithoutDatabases } = response.spec as Record<string, unknown>;
+
     return this.client.put(
       `/apps/${appId}`,
       {
         spec: {
-          ...response.spec,
+          ...specWithoutDatabases,
           envs: input
         }
       },
@@ -85,11 +93,13 @@ class DigitalOceanAppPlatformPublicClient {
 
     const variables = existing.filter((v) => input.find((i) => i.key === v.key));
 
+    const { databases: _databases, ...specWithoutDatabases } = response.spec as Record<string, unknown>;
+
     return this.client.put(
       `/apps/${appId}`,
       {
         spec: {
-          ...response.spec,
+          ...specWithoutDatabases,
           envs: variables
         }
       },


### PR DESCRIPTION
## Problem

DigitalOcean App Platform Secret Sync fails when the target app has an attached managed database (#6210, ENG-4946). Two errors occur:

1. `read:database` scope missing → `GET /apps/{id}` fails to enumerate databases (docs fix needed separately)
2. After adding the scope, `PUT /apps/{id}` still fails with `"database user password is not accessible"`

## Root Cause

`putVariables` in `digital-ocean-connection-public-client.ts` spreads the entire app spec into the PUT request:

```ts
spec: {
  ...response.spec,  // includes databases with redacted credentials
  envs: input
}
```

The DO API `GET /apps/{id}` returns attached database components but **redacts credential fields** (e.g. the managed database password). When the full spec is PUT back, DO re-validates ALL components — including the database. Since the password was redacted in the GET response, validation fails.

## Fix

Destructure out `databases` from the spec before sending PUT requests:

```ts
const { databases: _databases, ...specWithoutDatabases } = response.spec as Record<string, unknown>;
```

Applied to both `putVariables` and `deleteVariables` (same spec-spread pattern). The DO API treats omitted components as unchanged, so the existing database attachment is preserved — only `envs` is actually updated.

## Why stripping only `databases` is safe

- The DO App Platform API treats missing top-level spec fields as "keep existing" — omitting `databases` doesn't detach the database
- `envs` (environment variables) are a separate top-level field from `databases` — stripping databases doesn't affect env var operations
- If the app has no database, destructuring produces `_databases = undefined` and the rest of the spec is unchanged — no-op

## Files Changed

- `backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts` — strip `databases` from spec in `putVariables` and `deleteVariables`