### PR TITLE
improvement(navigation): go to role details when click on a row

### DIFF
--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityRoleDetailsSection/IdentityRoleDetailsSection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityRoleDetailsSection/IdentityRoleDetailsSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { subject } from "@casl/ability";
+import { useNavigate } from "@tanstack/react-router";
 import { format, formatDistance } from "date-fns";
 import { ClockAlertIcon, ClockIcon, EllipsisIcon, PencilIcon } from "lucide-react";
 
@@ -41,6 +42,7 @@ import {
   useProject,
   useProjectPermission
 } from "@app/context";
+import { getProjectBaseURL } from "@app/helpers/project";
 import { formatProjectRoleName } from "@app/helpers/roles";
 import { usePopUp } from "@app/hooks";
 import { useUpdateProjectIdentityMembership } from "@app/hooks/api";
@@ -64,6 +66,7 @@ export const IdentityRoleDetailsSection = ({
 }: Props) => {
   const { currentProject } = useProject();
   const { permission } = useProjectPermission();
+  const navigate = useNavigate();
   const { popUp, handlePopUpOpen, handlePopUpToggle, handlePopUpClose } = usePopUp([
     "deleteRole",
     "modifyRole"
@@ -212,7 +215,22 @@ export const IdentityRoleDetailsSection = ({
                     }
 
                     return (
-                      <TableRow key={`user-project-identity-${roleDetails?.id}`}>
+                      <TableRow
+                        key={`user-project-identity-${roleDetails?.id}`}
+                        className="cursor-pointer"
+                        onClick={() =>
+                          navigate({
+                            to: `${getProjectBaseURL(currentProject.type)}/roles/$roleSlug`,
+                            params: {
+                              projectId: currentProject.id,
+                              roleSlug:
+                                roleDetails.role === "custom"
+                                  ? roleDetails.customRoleSlug
+                                  : roleDetails.role
+                            }
+                          })
+                        }
+                      >
                         <TableCell className="max-w-0 truncate">
                           {roleDetails.role === "custom"
                             ? roleDetails.customRoleName
@@ -239,7 +257,11 @@ export const IdentityRoleDetailsSection = ({
                         <TableCell>
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <IconButton size="xs" variant="ghost">
+                              <IconButton
+                                size="xs"
+                                variant="ghost"
+                                onClick={(e) => e.stopPropagation()}
+                              >
                                 <EllipsisIcon />
                               </IconButton>
                             </DropdownMenuTrigger>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { format, formatDistance } from "date-fns";
 import { ClockAlertIcon, ClockIcon, EllipsisIcon, PencilIcon } from "lucide-react";
 import picomatch from "picomatch";
@@ -42,6 +43,7 @@ import {
   useProjectPermission,
   useUser
 } from "@app/context";
+import { getProjectBaseURL } from "@app/helpers/project";
 import { formatProjectRoleName } from "@app/helpers/roles";
 import { usePopUp } from "@app/hooks";
 import { useUpdateUserWorkspaceRole } from "@app/hooks/api";
@@ -64,8 +66,9 @@ export const MemberRoleDetailsSection = ({
 }: Props) => {
   const { user } = useUser();
   const userId = user?.id;
-  const { projectId } = useProject();
+  const { projectId, currentProject } = useProject();
   const { permission } = useProjectPermission();
+  const navigate = useNavigate();
 
   const assignRoleConditions = useMemo(
     () => getMemberAssignRoleConditions(permission),
@@ -217,8 +220,20 @@ export const MemberRoleDetailsSection = ({
 
                     return (
                       <TableRow
-                        className="group h-10"
+                        className="group h-10 cursor-pointer"
                         key={`user-project-identity-${roleDetails?.id}`}
+                        onClick={() =>
+                          navigate({
+                            to: `${getProjectBaseURL(currentProject.type)}/roles/$roleSlug`,
+                            params: {
+                              projectId: currentProject.id,
+                              roleSlug:
+                                roleDetails.role === "custom"
+                                  ? roleDetails.customRoleSlug
+                                  : roleDetails.role
+                            }
+                          })
+                        }
                       >
                         <TableCell className="max-w-0 truncate">
                           {roleDetails.role === "custom"
@@ -247,7 +262,11 @@ export const MemberRoleDetailsSection = ({
                           <TableCell>
                             <DropdownMenu>
                               <DropdownMenuTrigger asChild>
-                                <IconButton size="xs" variant="ghost">
+                                <IconButton
+                                  size="xs"
+                                  variant="ghost"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
                                   <EllipsisIcon />
                                 </IconButton>
                               </DropdownMenuTrigger>


### PR DESCRIPTION
## Context
Navigate to role details when a click to a row happens 

## Screenshots


https://github.com/user-attachments/assets/cda22cc8-0601-4512-a9ef-96eb471c52c7

## Steps to verify the change
- Create a new user -> click on the role and see if you are redirected to the role page
- create a new machine identity with roles -> click on the role and see if you are redirected to the role page

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)