### PR TITLE
fix: enforce TLS verification for identity auth providers

### DIFF
--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -130,7 +130,9 @@ export const identityJwtAuthServiceFactory = ({
             cipherTextBlob: identityJwtAuth.encryptedJwksCaCert
           }).toString();
 
-          const requestAgent = new https.Agent({ ca: decryptedJwksCaCert, rejectUnauthorized: !!decryptedJwksCaCert });
+          const requestAgent = decryptedJwksCaCert
+            ? new https.Agent({ ca: decryptedJwksCaCert, rejectUnauthorized: true })
+            : undefined;
           client = new JwksClient({
             jwksUri: identityJwtAuth.jwksUrl,
             requestAgent

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -148,7 +148,8 @@ export const identityKubernetesAuthServiceFactory = ({
       if (!inputs.reviewTokenThroughGateway) {
         httpsAgent = new https.Agent({
           ca: inputs.caCert || undefined,
-          rejectUnauthorized: true
+          rejectUnauthorized: true,
+          servername: inputs.targetHost
         });
       }
 
@@ -194,7 +195,8 @@ export const identityKubernetesAuthServiceFactory = ({
           ? {
               httpsAgent: new https.Agent({
                 ca: inputs.caCert || undefined,
-                rejectUnauthorized: true
+                rejectUnauthorized: true,
+                servername: inputs.targetHost
               })
             }
           : {})

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -147,8 +147,8 @@ export const identityKubernetesAuthServiceFactory = ({
       let httpsAgent: https.Agent | undefined;
       if (!inputs.reviewTokenThroughGateway) {
         httpsAgent = new https.Agent({
-          ca: inputs.caCert,
-          rejectUnauthorized: Boolean(inputs.caCert)
+          ca: inputs.caCert || undefined,
+          rejectUnauthorized: true
         });
       }
 
@@ -193,8 +193,8 @@ export const identityKubernetesAuthServiceFactory = ({
         ...(!inputs.reviewTokenThroughGateway
           ? {
               httpsAgent: new https.Agent({
-                ca: inputs.caCert,
-                rejectUnauthorized: Boolean(inputs.caCert)
+                ca: inputs.caCert || undefined,
+                rejectUnauthorized: true
               })
             }
           : {})
@@ -355,8 +355,8 @@ export const identityKubernetesAuthServiceFactory = ({
               signal: AbortSignal.timeout(10000),
               timeout: 10000,
               httpsAgent: new https.Agent({
-                ca: caCert,
-                rejectUnauthorized: Boolean(caCert),
+                ca: caCert || undefined,
+                rejectUnauthorized: true,
                 servername
               })
             }

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
@@ -53,7 +53,7 @@ export const validateKubernetesHostConnectivity = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: Boolean(caCert)
+        rejectUnauthorized: true
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);
@@ -156,7 +156,7 @@ export const validateTokenReviewerPermissions = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: Boolean(caCert)
+        rejectUnauthorized: true
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -112,7 +112,7 @@ export const identityOidcAuthServiceFactory = ({
         caCert = decryptor({ cipherTextBlob: identityOidcAuth.encryptedCaCertificate }).toString();
       }
 
-      const requestAgent = new https.Agent({ ca: caCert, rejectUnauthorized: !!caCert });
+      const requestAgent = caCert ? new https.Agent({ ca: caCert, rejectUnauthorized: true }) : undefined;
 
       await blockLocalAndPrivateIpAddresses(identityOidcAuth.oidcDiscoveryUrl);
 


### PR DESCRIPTION
## Context

This PR ensures outbound TLS verification is always enforced for machine identity auth flows that fetch external trust material or call Kubernetes APIs.

Previously, OIDC/JWT/Kubernetes auth used `rejectUnauthorized: false` whenever no custom CA certificate was configured. This could allow connections to endpoints with invalid or untrusted certificates. Now, custom CAs are still supported when provided, but empty CA configuration falls back to the system trust store while keeping certificate verification enabled.

## Steps to verify the change

- Verify OIDC auth with a valid public issuer, such as GitHub Actions OIDC, still succeeds with no custom CA.
- Verify JWT auth with a valid public JWKS URL still succeeds with no custom CA.
- Verify Kubernetes auth succeeds when the Kubernetes API certificate is trusted by either the system trust store or a provided CA certificate.
- Verify invalid/self-signed TLS endpoints without a configured CA are rejected.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)