### PR TITLE
fix(approvals): add request ID to approval request mail

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-fns.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-fns.ts
@@ -37,7 +37,7 @@ export const sendApprovalEmailsFn = async ({
       type: NotificationType.SECRET_CHANGE_REQUEST,
       title: "Secret Change Request",
       body: `You have a new secret change request pending your review for the project **${project.name}** in the organization **${project.organization.name}**.`,
-      link: `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval`
+      link: `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval?requestId=${secretApprovalRequest.id}`
     }))
   );
 
@@ -51,7 +51,7 @@ export const sendApprovalEmailsFn = async ({
         firstName: reviewerUser.firstName,
         projectName: project.name,
         organizationName: project.organization.name,
-        approvalUrl: `${cfg.SITE_URL}/organizations/${project.orgId}/projects/secret-management/${project.id}/approval`
+        approvalUrl: `${cfg.SITE_URL}/organizations/${project.orgId}/projects/secret-management/${project.id}/approval?requestId=${secretApprovalRequest.id}`
       },
       template: SmtpTemplates.SecretApprovalRequestNeedsReview
     });


### PR DESCRIPTION
## Context

Added request ID to the approval request mail, so it opens the selected approval request when clicking the email.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)