### PR TITLE
fix: update textarea styling to prevent modal overflow

### DIFF
--- a/frontend/src/components/v3/generic/TextArea/TextArea.tsx
+++ b/frontend/src/components/v3/generic/TextArea/TextArea.tsx
@@ -10,7 +10,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
         ref={ref}
         data-slot="textarea"
         className={cn(
-          "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         {...props}

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -229,7 +229,7 @@ export const ShareSecretForm = ({
               <TextArea
                 placeholder="Enter sensitive data to share via an encrypted link"
                 {...field}
-                className={twMerge("min-h-[70px] resize-none", isPublic ? "h-40" : "h-14")}
+                className={twMerge("resize-yg min-h-[70px]", isPublic ? "h-40" : "h-14")}
                 disabled={value !== undefined}
                 aria-invalid={Boolean(error)}
               />

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -229,7 +229,7 @@ export const ShareSecretForm = ({
               <TextArea
                 placeholder="Enter sensitive data to share via an encrypted link"
                 {...field}
-                className={twMerge("resize-yg min-h-[70px]", isPublic ? "h-40" : "h-14")}
+                className={twMerge("min-h-[70px] resize-y", isPublic ? "h-40" : "h-14")}
                 disabled={value !== undefined}
                 aria-invalid={Boolean(error)}
               />


### PR DESCRIPTION
## Context

This PR fixes the styling on v3 text area to prevent it from overflowing out of parent containers if single line

## Screenshots

<img width="3422" height="1924" alt="CleanShot 2026-04-29 at 15 58 30@2x" src="https://github.com/user-attachments/assets/9dc9e623-02ee-4ef3-95c0-82bf47133e5a" />


<img width="3422" height="1924" alt="CleanShot 2026-04-29 at 15 49 28@2x" src="https://github.com/user-attachments/assets/d8aeecb8-7e9b-4d59-a9dd-0f157ec7ba69" />
## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)