### PR TITLE
fix(kubernetes-auth): configurable TLS verification for identity Kubernetes auth

### DIFF
--- a/backend/src/db/migrations/20260430141040_add-enable-ssl-to-identity-kubernetes-auth.ts
+++ b/backend/src/db/migrations/20260430141040_add-enable-ssl-to-identity-kubernetes-auth.ts
@@ -1,0 +1,23 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "enableSsl"))) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
+      t.boolean("enableSsl").defaultTo(false).notNullable();
+    });
+
+    await knex(TableName.IdentityKubernetesAuth)
+      .whereNotNull("encryptedKubernetesCaCertificate")
+      .update({ enableSsl: true });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "enableSsl")) {
+    await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
+      t.dropColumn("enableSsl");
+    });
+  }
+}

--- a/backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
+++ b/backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
@@ -3,21 +3,21 @@ import { Knex } from "knex";
 import { TableName } from "../schemas";
 
 export async function up(knex: Knex): Promise<void> {
-  if (!(await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "enableSsl"))) {
+  if (!(await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "verifyTlsCertificate"))) {
     await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
-      t.boolean("enableSsl").defaultTo(false).notNullable();
+      t.boolean("verifyTlsCertificate").defaultTo(false).notNullable();
     });
 
     await knex(TableName.IdentityKubernetesAuth)
       .whereNotNull("encryptedKubernetesCaCertificate")
-      .update({ enableSsl: true });
+      .update({ verifyTlsCertificate: true });
   }
 }
 
 export async function down(knex: Knex): Promise<void> {
-  if (await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "enableSsl")) {
+  if (await knex.schema.hasColumn(TableName.IdentityKubernetesAuth, "verifyTlsCertificate")) {
     await knex.schema.alterTable(TableName.IdentityKubernetesAuth, (t) => {
-      t.dropColumn("enableSsl");
+      t.dropColumn("verifyTlsCertificate");
     });
   }
 }

--- a/backend/src/db/schemas/identity-kubernetes-auths.ts
+++ b/backend/src/db/schemas/identity-kubernetes-auths.ts
@@ -34,7 +34,8 @@ export const IdentityKubernetesAuthsSchema = z.object({
   accessTokenPeriod: z.coerce.number().default(0),
   tokenReviewMode: z.string().default("api"),
   gatewayV2Id: z.string().uuid().nullable().optional(),
-  gatewayPoolId: z.string().uuid().nullable().optional()
+  gatewayPoolId: z.string().uuid().nullable().optional(),
+  enableSsl: z.boolean().default(false)
 });
 
 export type TIdentityKubernetesAuths = z.infer<typeof IdentityKubernetesAuthsSchema>;

--- a/backend/src/db/schemas/identity-kubernetes-auths.ts
+++ b/backend/src/db/schemas/identity-kubernetes-auths.ts
@@ -35,7 +35,7 @@ export const IdentityKubernetesAuthsSchema = z.object({
   tokenReviewMode: z.string().default("api"),
   gatewayV2Id: z.string().uuid().nullable().optional(),
   gatewayPoolId: z.string().uuid().nullable().optional(),
-  enableSsl: z.boolean().default(false)
+  verifyTlsCertificate: z.boolean().default(false)
 });
 
 export type TIdentityKubernetesAuths = z.infer<typeof IdentityKubernetesAuthsSchema>;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -573,9 +573,9 @@ export const KUBERNETES_AUTH = {
     identityId: "The ID of the machine identity to attach the configuration onto.",
     kubernetesHost: "The host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert:
-      "The PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when enableSsl is true.",
-    enableSsl:
-      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, TLS verification is skipped. If omitted, defaults to true when caCert is provided and false otherwise.",
+      "The PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true.",
+    verifyTlsCertificate:
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified. If omitted, defaults to true when caCert is provided and false otherwise.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:
@@ -595,9 +595,9 @@ export const KUBERNETES_AUTH = {
     identityId: "The ID of the machine identity to update the auth method for.",
     kubernetesHost: "The new host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert:
-      "The new PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when enableSsl is true.",
-    enableSsl:
-      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, TLS verification is skipped. If omitted while supplying a non-empty caCert in the same update, the toggle is auto-promoted to true; otherwise the stored value is preserved.",
+      "The new PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true.",
+    verifyTlsCertificate:
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified. If omitted while supplying a non-empty caCert in the same update, the toggle is auto-promoted to true; otherwise the stored value is preserved.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -572,7 +572,10 @@ export const KUBERNETES_AUTH = {
   ATTACH: {
     identityId: "The ID of the machine identity to attach the configuration onto.",
     kubernetesHost: "The host string, host:port pair, or URL to the base of the Kubernetes API server.",
-    caCert: "The PEM-encoded CA cert for the Kubernetes API server.",
+    caCert:
+      "The PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when enableSsl is true.",
+    enableSsl:
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, TLS verification is skipped. If omitted, defaults to true when caCert is provided and false otherwise.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:
@@ -591,7 +594,10 @@ export const KUBERNETES_AUTH = {
   UPDATE: {
     identityId: "The ID of the machine identity to update the auth method for.",
     kubernetesHost: "The new host string, host:port pair, or URL to the base of the Kubernetes API server.",
-    caCert: "The new PEM-encoded CA cert for the Kubernetes API server.",
+    caCert:
+      "The new PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when enableSsl is true.",
+    enableSsl:
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, TLS verification is skipped. If omitted while supplying a non-empty caCert in the same update, the toggle is auto-promoted to true; otherwise the stored value is preserved.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -573,9 +573,9 @@ export const KUBERNETES_AUTH = {
     identityId: "The ID of the machine identity to attach the configuration onto.",
     kubernetesHost: "The host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert:
-      "The PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true.",
+      "The PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true. Supplying a non-empty caCert always implies verifyTlsCertificate=true; explicitly setting the toggle to false in the same request is rejected.",
     verifyTlsCertificate:
-      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified. If omitted, defaults to true when caCert is provided and false otherwise.",
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified, and caCert must be empty. If omitted, defaults to true when caCert is provided and false otherwise.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:
@@ -595,9 +595,9 @@ export const KUBERNETES_AUTH = {
     identityId: "The ID of the machine identity to update the auth method for.",
     kubernetesHost: "The new host string, host:port pair, or URL to the base of the Kubernetes API server.",
     caCert:
-      "The new PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true.",
+      "The new PEM-encoded CA certificate used to validate the Kubernetes API server's TLS certificate. Required when verifyTlsCertificate is true. Supplying a non-empty caCert always implies verifyTlsCertificate=true; the update is rejected if the resulting effective state would store a CA together with verifyTlsCertificate=false.",
     verifyTlsCertificate:
-      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified. If omitted while supplying a non-empty caCert in the same update, the toggle is auto-promoted to true; otherwise the stored value is preserved.",
+      "Whether to verify the Kubernetes API server's TLS certificate against the configured CA certificate. When true, caCert is required. When false, the connection is still over HTTPS but the API server's certificate is not verified, and the resulting effective CA must be empty. If omitted while supplying a non-empty caCert in the same update, the toggle is auto-promoted to true; otherwise the stored value is preserved.",
     tokenReviewerJwt:
       "Optional JWT token for accessing Kubernetes TokenReview API. If provided, this long-lived token will be used to validate service account tokens during authentication. If omitted, the client's own JWT will be used instead, which requires the client to have the system:auth-delegator ClusterRole binding.",
     tokenReviewMode:

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -32,7 +32,7 @@ const IdentityKubernetesAuthResponseSchema = IdentityKubernetesAuthsSchema.pick(
   allowedAudience: true,
   gatewayId: true,
   gatewayPoolId: true,
-  enableSsl: true
+  verifyTlsCertificate: true
 }).extend({
   caCert: z.string(),
   tokenReviewerJwt: z.string().optional().nullable()
@@ -189,7 +189,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               }
             ),
           caCert: z.string().trim().default("").describe(KUBERNETES_AUTH.ATTACH.caCert),
-          enableSsl: z.boolean().optional().describe(KUBERNETES_AUTH.ATTACH.enableSsl),
+          verifyTlsCertificate: z.boolean().optional().describe(KUBERNETES_AUTH.ATTACH.verifyTlsCertificate),
           tokenReviewerJwt: z.string().trim().optional().describe(KUBERNETES_AUTH.ATTACH.tokenReviewerJwt),
           tokenReviewMode: z
             .nativeEnum(IdentityKubernetesAuthTokenReviewMode)
@@ -264,7 +264,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
             });
           }
           if (
-            data.enableSsl &&
+            data.verifyTlsCertificate &&
             data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
             !data.caCert?.length
           ) {
@@ -272,7 +272,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               path: ["caCert"],
               code: z.ZodIssueCode.custom,
               message:
-                "A CA certificate is required when SSL verification is enabled. Either paste the Kubernetes API server's CA certificate or disable SSL verification."
+                "A CA certificate is required when TLS certificate verification is enabled. Either paste the Kubernetes API server's CA certificate or disable verification."
             });
           }
         }),
@@ -378,7 +378,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               }
             ),
           caCert: z.string().trim().optional().describe(KUBERNETES_AUTH.UPDATE.caCert),
-          enableSsl: z.boolean().optional().describe(KUBERNETES_AUTH.UPDATE.enableSsl),
+          verifyTlsCertificate: z.boolean().optional().describe(KUBERNETES_AUTH.UPDATE.verifyTlsCertificate),
           tokenReviewerJwt: z.string().trim().nullable().optional().describe(KUBERNETES_AUTH.UPDATE.tokenReviewerJwt),
           tokenReviewMode: z
             .nativeEnum(IdentityKubernetesAuthTokenReviewMode)

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -31,7 +31,8 @@ const IdentityKubernetesAuthResponseSchema = IdentityKubernetesAuthsSchema.pick(
   allowedNames: true,
   allowedAudience: true,
   gatewayId: true,
-  gatewayPoolId: true
+  gatewayPoolId: true,
+  enableSsl: true
 }).extend({
   caCert: z.string(),
   tokenReviewerJwt: z.string().optional().nullable()
@@ -188,6 +189,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               }
             ),
           caCert: z.string().trim().default("").describe(KUBERNETES_AUTH.ATTACH.caCert),
+          enableSsl: z.boolean().optional().describe(KUBERNETES_AUTH.ATTACH.enableSsl),
           tokenReviewerJwt: z.string().trim().optional().describe(KUBERNETES_AUTH.ATTACH.tokenReviewerJwt),
           tokenReviewMode: z
             .nativeEnum(IdentityKubernetesAuthTokenReviewMode)
@@ -259,6 +261,18 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               path: ["accessTokenTTL"],
               code: z.ZodIssueCode.custom,
               message: "Access Token TTL cannot be greater than Access Token Max TTL."
+            });
+          }
+          if (
+            data.enableSsl &&
+            data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+            !data.caCert?.length
+          ) {
+            ctx.addIssue({
+              path: ["caCert"],
+              code: z.ZodIssueCode.custom,
+              message:
+                "A CA certificate is required when SSL verification is enabled. Either paste the Kubernetes API server's CA certificate or disable SSL verification."
             });
           }
         }),
@@ -364,6 +378,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
               }
             ),
           caCert: z.string().trim().optional().describe(KUBERNETES_AUTH.UPDATE.caCert),
+          enableSsl: z.boolean().optional().describe(KUBERNETES_AUTH.UPDATE.enableSsl),
           tokenReviewerJwt: z.string().trim().nullable().optional().describe(KUBERNETES_AUTH.UPDATE.tokenReviewerJwt),
           tokenReviewMode: z
             .nativeEnum(IdentityKubernetesAuthTokenReviewMode)

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -275,6 +275,18 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
                 "A CA certificate is required when TLS certificate verification is enabled. Either paste the Kubernetes API server's CA certificate or disable verification."
             });
           }
+          if (
+            data.verifyTlsCertificate === false &&
+            data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+            data.caCert?.length
+          ) {
+            ctx.addIssue({
+              path: ["verifyTlsCertificate"],
+              code: z.ZodIssueCode.custom,
+              message:
+                "TLS certificate verification cannot be disabled when a CA certificate is provided. Either remove the CA certificate or enable verification."
+            });
+          }
         }),
       response: {
         200: z.object({

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -837,6 +837,20 @@ export const identityKubernetesAuthServiceFactory = ({
       return extractIPDetails(accessTokenTrustedIp.ipAddress);
     });
 
+    if (
+      caCert &&
+      caCert.length > 0 &&
+      verifyTlsCertificate === false &&
+      tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api
+    ) {
+      throw new BadRequestError({
+        message:
+          "TLS certificate verification cannot be disabled when a CA certificate is provided. Either remove the CA certificate or enable verification."
+      });
+    }
+
+    const resolvedVerifyTlsCertificate = verifyTlsCertificate ?? Boolean(caCert);
+
     let isGatewayV1 = true;
     if (gatewayId) {
       if (!plan.gateway) {
@@ -881,7 +895,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const gatewayExecutor = $createGatewayValidationRequest(gatewayId, {
           kubernetesHost,
           caCert: caCert || undefined,
-          verifyTlsCertificate
+          verifyTlsCertificate: resolvedVerifyTlsCertificate
         });
         logger.info({ gatewayId, kubernetesHost }, "Validating Kubernetes connectivity through gateway");
         await validateKubernetesHostConnectivity({ gatewayExecutor });
@@ -924,7 +938,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const gatewayExecutor = $createGatewayValidationRequest(validationGateway.id, {
           kubernetesHost,
           caCert: caCert || undefined,
-          verifyTlsCertificate
+          verifyTlsCertificate: resolvedVerifyTlsCertificate
         });
         await validateKubernetesHostConnectivity({ gatewayExecutor });
         if (tokenReviewerJwt) {
@@ -936,7 +950,7 @@ export const identityKubernetesAuthServiceFactory = ({
       await validateKubernetesHostConnectivity({
         kubernetesHost,
         caCert: caCert || undefined,
-        verifyTlsCertificate
+        verifyTlsCertificate: resolvedVerifyTlsCertificate
       });
 
       if (tokenReviewerJwt) {
@@ -945,7 +959,7 @@ export const identityKubernetesAuthServiceFactory = ({
           kubernetesHost,
           tokenReviewerJwt,
           caCert: caCert || undefined,
-          verifyTlsCertificate
+          verifyTlsCertificate: resolvedVerifyTlsCertificate
         });
       }
     }
@@ -980,7 +994,7 @@ export const identityKubernetesAuthServiceFactory = ({
           gatewayId: resolvedGatewayId,
           gatewayV2Id: resolvedGatewayV2Id,
           gatewayPoolId: gatewayPoolId ?? null,
-          verifyTlsCertificate: verifyTlsCertificate ?? Boolean(caCert),
+          verifyTlsCertificate: resolvedVerifyTlsCertificate,
           accessTokenTrustedIps: JSON.stringify(reformattedAccessTokenTrustedIps),
           encryptedKubernetesTokenReviewerJwt: tokenReviewerJwt
             ? encryptor({ plainText: Buffer.from(tokenReviewerJwt) }).cipherTextBlob
@@ -1198,8 +1212,9 @@ export const identityKubernetesAuthServiceFactory = ({
       effectiveCaCert = undefined;
     }
 
-    // Auto-promote enableSsl when the caller is supplying a non-empty CA in this
-    // update without explicitly setting the toggle. Required for backwards compatibility
+    // Auto-promote verifyTlsCertificate when the caller is supplying a non-empty
+    // CA in this update without explicitly setting the toggle. Required for
+    // backwards compatibility
     let resolvedVerifyTlsCertificate: boolean | undefined;
     if (verifyTlsCertificate !== undefined) {
       resolvedVerifyTlsCertificate = verifyTlsCertificate;
@@ -1216,6 +1231,18 @@ export const identityKubernetesAuthServiceFactory = ({
       throw new BadRequestError({
         message:
           "A CA certificate is required when TLS certificate verification is enabled. Either paste the Kubernetes API server's CA certificate or disable verification."
+      });
+    }
+
+    if (
+      effectiveVerifyTlsCertificate === false &&
+      effectiveTokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+      effectiveCaCert &&
+      effectiveCaCert.length > 0
+    ) {
+      throw new BadRequestError({
+        message:
+          "TLS certificate verification cannot be disabled when a CA certificate is provided. Either remove the CA certificate or enable verification."
       });
     }
 

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -127,7 +127,7 @@ export const identityKubernetesAuthServiceFactory = ({
       targetHost?: string;
       targetPort?: number;
       caCert?: string;
-      enableSsl?: boolean;
+      verifyTlsCertificate?: boolean;
       reviewTokenThroughGateway: boolean;
     },
     gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent) => Promise<T>
@@ -149,7 +149,7 @@ export const identityKubernetesAuthServiceFactory = ({
       if (!inputs.reviewTokenThroughGateway) {
         httpsAgent = new https.Agent({
           ca: inputs.caCert || undefined,
-          rejectUnauthorized: inputs.enableSsl ?? false,
+          rejectUnauthorized: inputs.verifyTlsCertificate ?? false,
           servername: inputs.targetHost
         });
       }
@@ -196,7 +196,7 @@ export const identityKubernetesAuthServiceFactory = ({
           ? {
               httpsAgent: new https.Agent({
                 ca: inputs.caCert || undefined,
-                rejectUnauthorized: inputs.enableSsl ?? false,
+                rejectUnauthorized: inputs.verifyTlsCertificate ?? false,
                 servername: inputs.targetHost
               })
             }
@@ -214,7 +214,7 @@ export const identityKubernetesAuthServiceFactory = ({
    */
   const $createGatewayValidationRequest = (
     gatewayId: string,
-    options?: { kubernetesHost?: string; caCert?: string; enableSsl?: boolean }
+    options?: { kubernetesHost?: string; caCert?: string; verifyTlsCertificate?: boolean }
   ): GatewayRequestExecutor => {
     const useGatewayServiceAccount = !options?.kubernetesHost;
 
@@ -236,7 +236,7 @@ export const identityKubernetesAuthServiceFactory = ({
           targetHost,
           targetPort,
           caCert: options?.caCert,
-          enableSsl: options?.enableSsl
+          verifyTlsCertificate: options?.verifyTlsCertificate
         },
         async (host: string, port: number, httpsAgent?: https.Agent) => {
           const config: AxiosRequestConfig = {
@@ -360,7 +360,7 @@ export const identityKubernetesAuthServiceFactory = ({
               timeout: 10000,
               httpsAgent: new https.Agent({
                 ca: caCert || undefined,
-                rejectUnauthorized: identityKubernetesAuth.enableSsl ?? false,
+                rejectUnauthorized: identityKubernetesAuth.verifyTlsCertificate ?? false,
                 servername
               })
             }
@@ -479,7 +479,7 @@ export const identityKubernetesAuthServiceFactory = ({
               : ((identityKubernetesAuth.gatewayV2Id ?? identityKubernetesAuth.gatewayId) as string),
             gatewayPoolId: identityKubernetesAuth.gatewayPoolId ?? undefined,
             caCert: caCert || undefined,
-            enableSsl: identityKubernetesAuth.enableSsl,
+            verifyTlsCertificate: identityKubernetesAuth.verifyTlsCertificate,
             reviewTokenThroughGateway: true
           },
           tokenReviewCallbackThroughGateway
@@ -513,7 +513,7 @@ export const identityKubernetesAuthServiceFactory = ({
                 targetHost: k8sHost,
                 targetPort: k8sPort ? Number(k8sPort) : 443,
                 caCert: caCert || undefined,
-                enableSsl: identityKubernetesAuth.enableSsl,
+                verifyTlsCertificate: identityKubernetesAuth.verifyTlsCertificate,
                 reviewTokenThroughGateway: false
               },
               tokenReviewCallbackRaw
@@ -751,7 +751,7 @@ export const identityKubernetesAuthServiceFactory = ({
     gatewayPoolId,
     kubernetesHost,
     caCert,
-    enableSsl,
+    verifyTlsCertificate,
     tokenReviewerJwt,
     tokenReviewMode,
     allowedNamespaces,
@@ -881,7 +881,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const gatewayExecutor = $createGatewayValidationRequest(gatewayId, {
           kubernetesHost,
           caCert: caCert || undefined,
-          enableSsl
+          verifyTlsCertificate
         });
         logger.info({ gatewayId, kubernetesHost }, "Validating Kubernetes connectivity through gateway");
         await validateKubernetesHostConnectivity({ gatewayExecutor });
@@ -924,7 +924,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const gatewayExecutor = $createGatewayValidationRequest(validationGateway.id, {
           kubernetesHost,
           caCert: caCert || undefined,
-          enableSsl
+          verifyTlsCertificate
         });
         await validateKubernetesHostConnectivity({ gatewayExecutor });
         if (tokenReviewerJwt) {
@@ -936,7 +936,7 @@ export const identityKubernetesAuthServiceFactory = ({
       await validateKubernetesHostConnectivity({
         kubernetesHost,
         caCert: caCert || undefined,
-        enableSsl
+        verifyTlsCertificate
       });
 
       if (tokenReviewerJwt) {
@@ -945,7 +945,7 @@ export const identityKubernetesAuthServiceFactory = ({
           kubernetesHost,
           tokenReviewerJwt,
           caCert: caCert || undefined,
-          enableSsl
+          verifyTlsCertificate
         });
       }
     }
@@ -980,7 +980,7 @@ export const identityKubernetesAuthServiceFactory = ({
           gatewayId: resolvedGatewayId,
           gatewayV2Id: resolvedGatewayV2Id,
           gatewayPoolId: gatewayPoolId ?? null,
-          enableSsl: enableSsl ?? Boolean(caCert),
+          verifyTlsCertificate: verifyTlsCertificate ?? Boolean(caCert),
           accessTokenTrustedIps: JSON.stringify(reformattedAccessTokenTrustedIps),
           encryptedKubernetesTokenReviewerJwt: tokenReviewerJwt
             ? encryptor({ plainText: Buffer.from(tokenReviewerJwt) }).cipherTextBlob
@@ -999,7 +999,7 @@ export const identityKubernetesAuthServiceFactory = ({
     identityId,
     kubernetesHost,
     caCert,
-    enableSsl,
+    verifyTlsCertificate,
     tokenReviewerJwt,
     tokenReviewMode,
     allowedNamespaces,
@@ -1200,22 +1200,22 @@ export const identityKubernetesAuthServiceFactory = ({
 
     // Auto-promote enableSsl when the caller is supplying a non-empty CA in this
     // update without explicitly setting the toggle. Required for backwards compatibility
-    let resolvedEnableSsl: boolean | undefined;
-    if (enableSsl !== undefined) {
-      resolvedEnableSsl = enableSsl;
+    let resolvedVerifyTlsCertificate: boolean | undefined;
+    if (verifyTlsCertificate !== undefined) {
+      resolvedVerifyTlsCertificate = verifyTlsCertificate;
     } else if (caCert !== undefined && caCert.length > 0) {
-      resolvedEnableSsl = true;
+      resolvedVerifyTlsCertificate = true;
     }
-    const effectiveEnableSsl = resolvedEnableSsl ?? identityKubernetesAuth.enableSsl;
+    const effectiveVerifyTlsCertificate = resolvedVerifyTlsCertificate ?? identityKubernetesAuth.verifyTlsCertificate;
 
     if (
-      effectiveEnableSsl &&
+      effectiveVerifyTlsCertificate &&
       effectiveTokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
       !effectiveCaCert
     ) {
       throw new BadRequestError({
         message:
-          "A CA certificate is required when SSL verification is enabled. Either paste the Kubernetes API server's CA certificate or disable SSL verification."
+          "A CA certificate is required when TLS certificate verification is enabled. Either paste the Kubernetes API server's CA certificate or disable verification."
       });
     }
 
@@ -1239,7 +1239,7 @@ export const identityKubernetesAuthServiceFactory = ({
         const gatewayExecutor = $createGatewayValidationRequest(validationGatewayId, {
           kubernetesHost: effectiveKubernetesHost,
           caCert: effectiveCaCert,
-          enableSsl: effectiveEnableSsl
+          verifyTlsCertificate: effectiveVerifyTlsCertificate
         });
         logger.info(
           {
@@ -1261,7 +1261,7 @@ export const identityKubernetesAuthServiceFactory = ({
         await validateKubernetesHostConnectivity({
           kubernetesHost,
           caCert: effectiveCaCert,
-          enableSsl: effectiveEnableSsl
+          verifyTlsCertificate: effectiveVerifyTlsCertificate
         });
       }
 
@@ -1274,7 +1274,7 @@ export const identityKubernetesAuthServiceFactory = ({
           kubernetesHost: effectiveKubernetesHost,
           tokenReviewerJwt,
           caCert: effectiveCaCert,
-          enableSsl: effectiveEnableSsl
+          verifyTlsCertificate: effectiveVerifyTlsCertificate
         });
       }
     }
@@ -1288,7 +1288,7 @@ export const identityKubernetesAuthServiceFactory = ({
       gatewayId: shouldUpdateGatewayId ? gatewayIdValue : undefined,
       gatewayV2Id: shouldUpdateGatewayId ? gatewayV2IdValue : undefined,
       gatewayPoolId: gatewayPoolIdValue,
-      enableSsl: resolvedEnableSsl,
+      verifyTlsCertificate: resolvedVerifyTlsCertificate,
       accessTokenMaxTTL,
       accessTokenTTL,
       accessTokenNumUsesLimit,

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -127,6 +127,7 @@ export const identityKubernetesAuthServiceFactory = ({
       targetHost?: string;
       targetPort?: number;
       caCert?: string;
+      enableSsl?: boolean;
       reviewTokenThroughGateway: boolean;
     },
     gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent) => Promise<T>
@@ -148,7 +149,7 @@ export const identityKubernetesAuthServiceFactory = ({
       if (!inputs.reviewTokenThroughGateway) {
         httpsAgent = new https.Agent({
           ca: inputs.caCert || undefined,
-          rejectUnauthorized: true,
+          rejectUnauthorized: inputs.enableSsl ?? false,
           servername: inputs.targetHost
         });
       }
@@ -195,7 +196,7 @@ export const identityKubernetesAuthServiceFactory = ({
           ? {
               httpsAgent: new https.Agent({
                 ca: inputs.caCert || undefined,
-                rejectUnauthorized: true,
+                rejectUnauthorized: inputs.enableSsl ?? false,
                 servername: inputs.targetHost
               })
             }
@@ -213,7 +214,7 @@ export const identityKubernetesAuthServiceFactory = ({
    */
   const $createGatewayValidationRequest = (
     gatewayId: string,
-    options?: { kubernetesHost?: string; caCert?: string }
+    options?: { kubernetesHost?: string; caCert?: string; enableSsl?: boolean }
   ): GatewayRequestExecutor => {
     const useGatewayServiceAccount = !options?.kubernetesHost;
 
@@ -234,7 +235,8 @@ export const identityKubernetesAuthServiceFactory = ({
           reviewTokenThroughGateway: useGatewayServiceAccount,
           targetHost,
           targetPort,
-          caCert: options?.caCert
+          caCert: options?.caCert,
+          enableSsl: options?.enableSsl
         },
         async (host: string, port: number, httpsAgent?: https.Agent) => {
           const config: AxiosRequestConfig = {
@@ -358,7 +360,7 @@ export const identityKubernetesAuthServiceFactory = ({
               timeout: 10000,
               httpsAgent: new https.Agent({
                 ca: caCert || undefined,
-                rejectUnauthorized: true,
+                rejectUnauthorized: identityKubernetesAuth.enableSsl ?? false,
                 servername
               })
             }
@@ -476,6 +478,8 @@ export const identityKubernetesAuthServiceFactory = ({
               ? undefined
               : ((identityKubernetesAuth.gatewayV2Id ?? identityKubernetesAuth.gatewayId) as string),
             gatewayPoolId: identityKubernetesAuth.gatewayPoolId ?? undefined,
+            caCert: caCert || undefined,
+            enableSsl: identityKubernetesAuth.enableSsl,
             reviewTokenThroughGateway: true
           },
           tokenReviewCallbackThroughGateway
@@ -508,6 +512,8 @@ export const identityKubernetesAuthServiceFactory = ({
                 gatewayPoolId: identityKubernetesAuth.gatewayPoolId ?? undefined,
                 targetHost: k8sHost,
                 targetPort: k8sPort ? Number(k8sPort) : 443,
+                caCert: caCert || undefined,
+                enableSsl: identityKubernetesAuth.enableSsl,
                 reviewTokenThroughGateway: false
               },
               tokenReviewCallbackRaw
@@ -745,6 +751,7 @@ export const identityKubernetesAuthServiceFactory = ({
     gatewayPoolId,
     kubernetesHost,
     caCert,
+    enableSsl,
     tokenReviewerJwt,
     tokenReviewMode,
     allowedNamespaces,
@@ -873,7 +880,8 @@ export const identityKubernetesAuthServiceFactory = ({
         // API mode through gateway: gateway proxies requests with user's JWT
         const gatewayExecutor = $createGatewayValidationRequest(gatewayId, {
           kubernetesHost,
-          caCert: caCert || undefined
+          caCert: caCert || undefined,
+          enableSsl
         });
         logger.info({ gatewayId, kubernetesHost }, "Validating Kubernetes connectivity through gateway");
         await validateKubernetesHostConnectivity({ gatewayExecutor });
@@ -915,7 +923,8 @@ export const identityKubernetesAuthServiceFactory = ({
       } else if (tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && kubernetesHost) {
         const gatewayExecutor = $createGatewayValidationRequest(validationGateway.id, {
           kubernetesHost,
-          caCert: caCert || undefined
+          caCert: caCert || undefined,
+          enableSsl
         });
         await validateKubernetesHostConnectivity({ gatewayExecutor });
         if (tokenReviewerJwt) {
@@ -926,7 +935,8 @@ export const identityKubernetesAuthServiceFactory = ({
       logger.info({ kubernetesHost }, "Validating Kubernetes host connectivity for new auth method");
       await validateKubernetesHostConnectivity({
         kubernetesHost,
-        caCert: caCert || undefined
+        caCert: caCert || undefined,
+        enableSsl
       });
 
       if (tokenReviewerJwt) {
@@ -934,7 +944,8 @@ export const identityKubernetesAuthServiceFactory = ({
         await validateTokenReviewerPermissions({
           kubernetesHost,
           tokenReviewerJwt,
-          caCert: caCert || undefined
+          caCert: caCert || undefined,
+          enableSsl
         });
       }
     }
@@ -969,6 +980,7 @@ export const identityKubernetesAuthServiceFactory = ({
           gatewayId: resolvedGatewayId,
           gatewayV2Id: resolvedGatewayV2Id,
           gatewayPoolId: gatewayPoolId ?? null,
+          enableSsl: enableSsl ?? Boolean(caCert),
           accessTokenTrustedIps: JSON.stringify(reformattedAccessTokenTrustedIps),
           encryptedKubernetesTokenReviewerJwt: tokenReviewerJwt
             ? encryptor({ plainText: Buffer.from(tokenReviewerJwt) }).cipherTextBlob
@@ -987,6 +999,7 @@ export const identityKubernetesAuthServiceFactory = ({
     identityId,
     kubernetesHost,
     caCert,
+    enableSsl,
     tokenReviewerJwt,
     tokenReviewMode,
     allowedNamespaces,
@@ -1185,6 +1198,27 @@ export const identityKubernetesAuthServiceFactory = ({
       effectiveCaCert = undefined;
     }
 
+    // Auto-promote enableSsl when the caller is supplying a non-empty CA in this
+    // update without explicitly setting the toggle. Required for backwards compatibility
+    let resolvedEnableSsl: boolean | undefined;
+    if (enableSsl !== undefined) {
+      resolvedEnableSsl = enableSsl;
+    } else if (caCert !== undefined && caCert.length > 0) {
+      resolvedEnableSsl = true;
+    }
+    const effectiveEnableSsl = resolvedEnableSsl ?? identityKubernetesAuth.enableSsl;
+
+    if (
+      effectiveEnableSsl &&
+      effectiveTokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+      !effectiveCaCert
+    ) {
+      throw new BadRequestError({
+        message:
+          "A CA certificate is required when SSL verification is enabled. Either paste the Kubernetes API server's CA certificate or disable SSL verification."
+      });
+    }
+
     let validationGatewayId: string | null = effectiveGatewayId ?? null;
     if (!validationGatewayId && effectiveGatewayPoolId) {
       const picked = await gatewayPoolService.pickRandomHealthyGateway(effectiveGatewayPoolId);
@@ -1204,7 +1238,8 @@ export const identityKubernetesAuthServiceFactory = ({
       } else if (effectiveTokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && effectiveKubernetesHost) {
         const gatewayExecutor = $createGatewayValidationRequest(validationGatewayId, {
           kubernetesHost: effectiveKubernetesHost,
-          caCert: effectiveCaCert
+          caCert: effectiveCaCert,
+          enableSsl: effectiveEnableSsl
         });
         logger.info(
           {
@@ -1225,7 +1260,8 @@ export const identityKubernetesAuthServiceFactory = ({
         logger.info({ kubernetesHost }, "Validating Kubernetes host connectivity for auth method update");
         await validateKubernetesHostConnectivity({
           kubernetesHost,
-          caCert: effectiveCaCert
+          caCert: effectiveCaCert,
+          enableSsl: effectiveEnableSsl
         });
       }
 
@@ -1237,7 +1273,8 @@ export const identityKubernetesAuthServiceFactory = ({
         await validateTokenReviewerPermissions({
           kubernetesHost: effectiveKubernetesHost,
           tokenReviewerJwt,
-          caCert: effectiveCaCert
+          caCert: effectiveCaCert,
+          enableSsl: effectiveEnableSsl
         });
       }
     }
@@ -1251,6 +1288,7 @@ export const identityKubernetesAuthServiceFactory = ({
       gatewayId: shouldUpdateGatewayId ? gatewayIdValue : undefined,
       gatewayV2Id: shouldUpdateGatewayId ? gatewayV2IdValue : undefined,
       gatewayPoolId: gatewayPoolIdValue,
+      enableSsl: resolvedEnableSsl,
       accessTokenMaxTTL,
       accessTokenTTL,
       accessTokenNumUsesLimit,

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
@@ -15,6 +15,7 @@ export type TAttachKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost: string | null;
   caCert: string;
+  enableSsl?: boolean;
   tokenReviewerJwt?: string;
   tokenReviewMode: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces: string;
@@ -33,6 +34,7 @@ export type TUpdateKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost?: string | null;
   caCert?: string;
+  enableSsl?: boolean;
   tokenReviewerJwt?: string | null;
   tokenReviewMode?: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces?: string;

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
@@ -15,7 +15,7 @@ export type TAttachKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost: string | null;
   caCert: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   tokenReviewerJwt?: string;
   tokenReviewMode: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces: string;
@@ -34,7 +34,7 @@ export type TUpdateKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost?: string | null;
   caCert?: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   tokenReviewerJwt?: string | null;
   tokenReviewMode?: IdentityKubernetesAuthTokenReviewMode;
   allowedNamespaces?: string;

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
@@ -55,7 +55,7 @@ export const validateKubernetesHostConnectivity = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: verifyTlsCertificate ?? true
+        rejectUnauthorized: verifyTlsCertificate ?? false
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
@@ -26,10 +26,12 @@ export type GatewayRequestExecutor = <T>(
 export const validateKubernetesHostConnectivity = async ({
   kubernetesHost,
   caCert,
+  enableSsl,
   gatewayExecutor
 }: {
   kubernetesHost?: string;
   caCert?: string;
+  enableSsl?: boolean;
   gatewayExecutor?: GatewayRequestExecutor;
 }): Promise<void> => {
   const isGatewayMode = Boolean(gatewayExecutor);
@@ -53,7 +55,7 @@ export const validateKubernetesHostConnectivity = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: true
+        rejectUnauthorized: enableSsl ?? false
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);
@@ -110,11 +112,13 @@ export const validateTokenReviewerPermissions = async ({
   kubernetesHost,
   tokenReviewerJwt,
   caCert,
+  enableSsl,
   gatewayExecutor
 }: {
   kubernetesHost?: string;
   tokenReviewerJwt?: string;
   caCert?: string;
+  enableSsl?: boolean;
   gatewayExecutor?: GatewayRequestExecutor;
 }): Promise<void> => {
   const isGatewayMode = Boolean(gatewayExecutor);
@@ -156,7 +160,7 @@ export const validateTokenReviewerPermissions = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: true
+        rejectUnauthorized: enableSsl ?? false
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
@@ -26,12 +26,12 @@ export type GatewayRequestExecutor = <T>(
 export const validateKubernetesHostConnectivity = async ({
   kubernetesHost,
   caCert,
-  enableSsl,
+  verifyTlsCertificate,
   gatewayExecutor
 }: {
   kubernetesHost?: string;
   caCert?: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   gatewayExecutor?: GatewayRequestExecutor;
 }): Promise<void> => {
   const isGatewayMode = Boolean(gatewayExecutor);
@@ -55,7 +55,7 @@ export const validateKubernetesHostConnectivity = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: enableSsl ?? false
+        rejectUnauthorized: verifyTlsCertificate ?? true
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);
@@ -112,13 +112,13 @@ export const validateTokenReviewerPermissions = async ({
   kubernetesHost,
   tokenReviewerJwt,
   caCert,
-  enableSsl,
+  verifyTlsCertificate,
   gatewayExecutor
 }: {
   kubernetesHost?: string;
   tokenReviewerJwt?: string;
   caCert?: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   gatewayExecutor?: GatewayRequestExecutor;
 }): Promise<void> => {
   const isGatewayMode = Boolean(gatewayExecutor);
@@ -160,7 +160,7 @@ export const validateTokenReviewerPermissions = async ({
 
       const httpsAgent = new https.Agent({
         ca: caCert || undefined,
-        rejectUnauthorized: enableSsl ?? false
+        rejectUnauthorized: verifyTlsCertificate ?? false
       });
 
       await blockLocalAndPrivateIpAddresses(kubernetesHost);

--- a/docs/documentation/platform/identities/kubernetes-auth.mdx
+++ b/docs/documentation/platform/identities/kubernetes-auth.mdx
@@ -248,7 +248,8 @@ In the following steps, we explore how to create and use identities for your app
     - Allowed Service Account Names: A comma-separated list of trusted service account names that are allowed to authenticate with Infisical.
     - Allowed Namespaces: A comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.
     - Allowed Audience: An optional audience claim that the service account JWT token must have to authenticate with Infisical.
-    - CA Certificate: The PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server.
+    - Enable SSL Verification: When enabled, Infisical validates the Kubernetes API server's TLS certificate against the CA certificate provided below. Strongly recommended. Pasting a CA certificate below auto-enables this.
+    - CA Certificate: The PEM-encoded CA cert that issued the Kubernetes API server's TLS certificate. Required when SSL verification is enabled.
     - Access Token TTL (default is `2592000` equivalent to 30 days): The lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max TTL (default is `2592000`  equivalent to 30 days): The maximum lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max Number of Uses (default is `0`): The maximum number of times that an access token can be used; a value of `0` implies infinite number of uses.

--- a/docs/documentation/platform/identities/kubernetes-auth.mdx
+++ b/docs/documentation/platform/identities/kubernetes-auth.mdx
@@ -248,8 +248,8 @@ In the following steps, we explore how to create and use identities for your app
     - Allowed Service Account Names: A comma-separated list of trusted service account names that are allowed to authenticate with Infisical.
     - Allowed Namespaces: A comma-separated list of trusted namespaces that service accounts must belong to authenticate with Infisical.
     - Allowed Audience: An optional audience claim that the service account JWT token must have to authenticate with Infisical.
-    - Enable SSL Verification: When enabled, Infisical validates the Kubernetes API server's TLS certificate against the CA certificate provided below. Strongly recommended. Pasting a CA certificate below auto-enables this.
-    - CA Certificate: The PEM-encoded CA cert that issued the Kubernetes API server's TLS certificate. Required when SSL verification is enabled.
+    - Verify TLS Certificate: When enabled, Infisical validates the Kubernetes API server's TLS certificate against the CA certificate provided below. Strongly recommended. Pasting a CA certificate below auto-enables this. When disabled, the connection is still over HTTPS but the API server's identity is not verified.
+    - CA Certificate: The PEM-encoded CA cert that issued the Kubernetes API server's TLS certificate. Required when TLS certificate verification is enabled.
     - Access Token TTL (default is `2592000` equivalent to 30 days): The lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max TTL (default is `2592000`  equivalent to 30 days): The maximum lifetime for an acccess token in seconds. This value will be referenced at renewal time.
     - Access Token Max Number of Uses (default is `0`): The maximum number of times that an access token can be used; a value of `0` implies infinite number of uses.

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -511,7 +511,7 @@ export type IdentityKubernetesAuth = {
   allowedNames: string;
   allowedAudience: string;
   caCert: string;
-  enableSsl: boolean;
+  verifyTlsCertificate: boolean;
   accessTokenTTL: number;
   accessTokenMaxTTL: number;
   accessTokenNumUsesLimit: number;
@@ -533,7 +533,7 @@ export type AddIdentityKubernetesAuthDTO = {
   gatewayId?: string | null;
   gatewayPoolId?: string | null;
   caCert: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   accessTokenTTL: number;
   accessTokenMaxTTL: number;
   accessTokenNumUsesLimit: number;
@@ -555,7 +555,7 @@ export type UpdateIdentityKubernetesAuthDTO = {
   gatewayId?: string | null;
   gatewayPoolId?: string | null;
   caCert?: string;
-  enableSsl?: boolean;
+  verifyTlsCertificate?: boolean;
   accessTokenTTL?: number;
   accessTokenMaxTTL?: number;
   accessTokenNumUsesLimit?: number;

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -511,6 +511,7 @@ export type IdentityKubernetesAuth = {
   allowedNames: string;
   allowedAudience: string;
   caCert: string;
+  enableSsl: boolean;
   accessTokenTTL: number;
   accessTokenMaxTTL: number;
   accessTokenNumUsesLimit: number;
@@ -532,6 +533,7 @@ export type AddIdentityKubernetesAuthDTO = {
   gatewayId?: string | null;
   gatewayPoolId?: string | null;
   caCert: string;
+  enableSsl?: boolean;
   accessTokenTTL: number;
   accessTokenMaxTTL: number;
   accessTokenNumUsesLimit: number;
@@ -553,6 +555,7 @@ export type UpdateIdentityKubernetesAuthDTO = {
   gatewayId?: string | null;
   gatewayPoolId?: string | null;
   caCert?: string;
+  enableSsl?: boolean;
   accessTokenTTL?: number;
   accessTokenMaxTTL?: number;
   accessTokenNumUsesLimit?: number;

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -62,7 +62,7 @@ const schema = z
     allowedNamespaces: z.string(),
     allowedAudience: z.string(),
     caCert: z.string().optional(),
-    enableSsl: z.boolean().default(true),
+    verifyTlsCertificate: z.boolean().default(true),
     accessTokenTTL: z.string().refine((val) => Number(val) <= 315360000, {
       message: "Access Token TTL cannot be greater than 315360000"
     }),
@@ -104,14 +104,14 @@ const schema = z
     }
 
     if (
-      data.enableSsl &&
+      data.verifyTlsCertificate &&
       data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
       !data.caCert?.length
     ) {
       ctx.addIssue({
         path: ["caCert"],
         code: z.ZodIssueCode.custom,
-        message: "A CA certificate is required when SSL verification is enabled."
+        message: "A CA certificate is required when TLS certificate verification is enabled."
       });
     }
   });
@@ -180,7 +180,7 @@ export const IdentityKubernetesAuthForm = ({
       gatewayId: "",
       allowedAudience: "",
       caCert: "",
-      enableSsl: true,
+      verifyTlsCertificate: true,
       accessTokenTTL: "2592000",
       accessTokenMaxTTL: "2592000",
       accessTokenNumUsesLimit: "",
@@ -204,7 +204,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces: data.allowedNamespaces,
         allowedAudience: data.allowedAudience,
         caCert: data.caCert,
-        enableSsl: data.enableSsl ?? true,
+        verifyTlsCertificate: data.verifyTlsCertificate ?? true,
         gatewayId: data.gatewayPoolId ? null : data.gatewayId || null,
         gatewayPoolId: data.gatewayPoolId || null,
         accessTokenTTL: String(data.accessTokenTTL),
@@ -229,7 +229,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces: "",
         allowedAudience: "",
         caCert: "",
-        enableSsl: true,
+        verifyTlsCertificate: true,
         accessTokenTTL: "2592000",
         accessTokenMaxTTL: "2592000",
         accessTokenNumUsesLimit: "",
@@ -330,7 +330,7 @@ export const IdentityKubernetesAuthForm = ({
     allowedNamespaces,
     allowedAudience,
     caCert,
-    enableSsl,
+    verifyTlsCertificate,
     accessTokenTTL,
     accessTokenMaxTTL,
     accessTokenNumUsesLimit,
@@ -356,7 +356,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces,
         allowedAudience,
         caCert,
-        enableSsl,
+        verifyTlsCertificate,
         identityId,
         gatewayId: gatewayPoolId ? null : gatewayId || null,
         gatewayPoolId: gatewayPoolId || null,
@@ -384,7 +384,7 @@ export const IdentityKubernetesAuthForm = ({
         gatewayId: gatewayPoolId ? null : gatewayId || null,
         gatewayPoolId: gatewayPoolId || null,
         caCert: caCert || "",
-        enableSsl,
+        verifyTlsCertificate,
         tokenReviewMode,
         accessTokenTTL: Number(accessTokenTTL),
         accessTokenMaxTTL: Number(accessTokenMaxTTL),
@@ -408,7 +408,7 @@ export const IdentityKubernetesAuthForm = ({
 
   useEffect(() => {
     if (watchedCaCert && watchedCaCert.length > 0) {
-      setValue("enableSsl", true, { shouldDirty: true });
+      setValue("verifyTlsCertificate", true, { shouldDirty: true });
     }
   }, [watchedCaCert, setValue]);
 
@@ -722,18 +722,18 @@ export const IdentityKubernetesAuthForm = ({
             <>
               <Controller
                 control={control}
-                name="enableSsl"
+                name="verifyTlsCertificate"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
                   <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
                     <Switch
                       className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="k8s-enable-ssl"
+                      id="k8s-verify-tls-certificate"
                       thumbClassName="bg-mineshaft-800"
                       isChecked={value}
                       onCheckedChange={onChange}
                     >
                       <p className="w-44 text-sm font-normal text-mineshaft-400">
-                        Enable SSL Verification
+                        Verify TLS Certificate
                         <Tooltip
                           className="max-w-md"
                           content={
@@ -744,8 +744,10 @@ export const IdentityKubernetesAuthForm = ({
                               </p>
                               <p>
                                 Leaving this disabled means any host that responds at the configured
-                                Kubernetes URL will be trusted, regardless of its certificate. Only
-                                do this for testing or if you cannot supply a CA certificate.
+                                Kubernetes URL will be trusted, regardless of its certificate. The
+                                connection is still over HTTPS, but the API server&apos;s identity
+                                is not verified. Only do this for testing or if you cannot supply a
+                                CA certificate.
                               </p>
                             </div>
                           }
@@ -765,22 +767,21 @@ export const IdentityKubernetesAuthForm = ({
                 control={control}
                 name="caCert"
                 render={({ field, fieldState: { error } }) => {
-                  const enableSsl = watch("enableSsl");
+                  const verifyTlsCertificate = watch("verifyTlsCertificate");
                   return (
                     <FormControl
                       label="CA Certificate"
                       errorText={error?.message}
                       isError={Boolean(error)}
-                      isRequired={enableSsl}
+                      isRequired={verifyTlsCertificate}
                       tooltipClassName="max-w-md"
                       tooltipText={
                         <div className="flex flex-col gap-2">
                           <p>
-                            An optional PEM-encoded CA certificate that issued the Kubernetes API
-                            server&apos;s TLS certificate. Required when SSL verification is
-                            enabled.
+                            The PEM-encoded CA certificate that issued the Kubernetes API
+                            server&apos;s TLS certificate. Required when TLS certificate
+                            verification is enabled.
                           </p>
-                          <p>This is required when SSL verification is enabled.</p>
                         </div>
                       }
                     >

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -114,6 +114,19 @@ const schema = z
         message: "A CA certificate is required when TLS certificate verification is enabled."
       });
     }
+
+    if (
+      data.verifyTlsCertificate === false &&
+      data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+      data.caCert?.length
+    ) {
+      ctx.addIssue({
+        path: ["verifyTlsCertificate"],
+        code: z.ZodIssueCode.custom,
+        message:
+          "TLS certificate verification cannot be disabled while a CA certificate is provided. Either remove the CA certificate or enable verification."
+      });
+    }
   });
 
 export type FormData = z.infer<typeof schema>;
@@ -404,13 +417,6 @@ export const IdentityKubernetesAuthForm = ({
   };
 
   const tokenReviewMode = watch("tokenReviewMode");
-  const watchedCaCert = watch("caCert");
-
-  useEffect(() => {
-    if (watchedCaCert && watchedCaCert.length > 0) {
-      setValue("verifyTlsCertificate", true, { shouldDirty: true });
-    }
-  }, [watchedCaCert, setValue]);
 
   return (
     <form
@@ -723,45 +729,59 @@ export const IdentityKubernetesAuthForm = ({
               <Controller
                 control={control}
                 name="verifyTlsCertificate"
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="k8s-verify-tls-certificate"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                    >
-                      <p className="w-44 text-sm font-normal text-mineshaft-400">
-                        Verify TLS Certificate
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <div className="flex flex-col gap-2">
-                              <p>
-                                When enabled, Infisical validates the Kubernetes API server&apos;s
-                                TLS certificate against the CA certificate provided below.
-                              </p>
-                              <p>
-                                Leaving this disabled means any host that responds at the configured
-                                Kubernetes URL will be trusted, regardless of its certificate. The
-                                connection is still over HTTPS, but the API server&apos;s identity
-                                is not verified. Only do this for testing or if you cannot supply a
-                                CA certificate.
-                              </p>
-                            </div>
-                          }
-                        >
-                          <FontAwesomeIcon
-                            icon={faQuestionCircle}
-                            size="sm"
-                            className="ml-1 text-mineshaft-400"
-                          />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
-                )}
+                render={({ field: { value, onChange }, fieldState: { error } }) => {
+                  const hasCaCert = Boolean(watch("caCert")?.length);
+                  return (
+                    <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                      <Switch
+                        className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                        id="k8s-verify-tls-certificate"
+                        thumbClassName="bg-mineshaft-800"
+                        isChecked={hasCaCert ? true : value}
+                        onCheckedChange={onChange}
+                        isDisabled={hasCaCert}
+                      >
+                        <p className="w-44 text-sm font-normal text-mineshaft-400">
+                          Verify TLS Certificate
+                          <Tooltip
+                            className="max-w-md"
+                            content={
+                              <div className="flex flex-col gap-2">
+                                {hasCaCert ? (
+                                  <p>
+                                    Verification is always on while a CA certificate is provided. To
+                                    disable verification, clear the CA certificate field below.
+                                  </p>
+                                ) : (
+                                  <>
+                                    <p>
+                                      When enabled, Infisical validates the Kubernetes API
+                                      server&apos;s TLS certificate against the CA certificate
+                                      provided below.
+                                    </p>
+                                    <p>
+                                      Leaving this disabled means any host that responds at the
+                                      configured Kubernetes URL will be trusted, regardless of its
+                                      certificate. The connection is still over HTTPS, but the API
+                                      server&apos;s identity is not verified. Only do this for
+                                      testing or if you cannot supply a CA certificate.
+                                    </p>
+                                  </>
+                                )}
+                              </div>
+                            }
+                          >
+                            <FontAwesomeIcon
+                              icon={faQuestionCircle}
+                              size="sm"
+                              className="ml-1 text-mineshaft-400"
+                            />
+                          </Tooltip>
+                        </p>
+                      </Switch>
+                    </FormControl>
+                  );
+                }}
               />
               <Controller
                 control={control}
@@ -780,12 +800,25 @@ export const IdentityKubernetesAuthForm = ({
                           <p>
                             The PEM-encoded CA certificate that issued the Kubernetes API
                             server&apos;s TLS certificate. Required when TLS certificate
-                            verification is enabled.
+                            verification is enabled. Providing a CA certificate forces TLS
+                            verification on.
                           </p>
                         </div>
                       }
                     >
-                      <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
+                      <TextArea
+                        {...field}
+                        placeholder="-----BEGIN CERTIFICATE----- ..."
+                        onChange={(e) => {
+                          field.onChange(e);
+                          if (e.target.value.length > 0 && !verifyTlsCertificate) {
+                            setValue("verifyTlsCertificate", true, {
+                              shouldDirty: true,
+                              shouldValidate: true
+                            });
+                          }
+                        }}
+                      />
                     </FormControl>
                   );
                 }}

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faInfoCircle, faPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faPlus, faQuestionCircle, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useParams } from "@tanstack/react-router";
@@ -15,6 +15,7 @@ import {
   Input,
   Select,
   SelectItem,
+  Switch,
   Tab,
   TabList,
   TabPanel,
@@ -61,6 +62,7 @@ const schema = z
     allowedNamespaces: z.string(),
     allowedAudience: z.string(),
     caCert: z.string().optional(),
+    enableSsl: z.boolean().default(true),
     accessTokenTTL: z.string().refine((val) => Number(val) <= 315360000, {
       message: "Access Token TTL cannot be greater than 315360000"
     }),
@@ -98,6 +100,18 @@ const schema = z
         code: z.ZodIssueCode.custom,
         message:
           "When token review mode is set to Gateway, a gateway or gateway pool must be selected"
+      });
+    }
+
+    if (
+      data.enableSsl &&
+      data.tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api &&
+      !data.caCert?.length
+    ) {
+      ctx.addIssue({
+        path: ["caCert"],
+        code: z.ZodIssueCode.custom,
+        message: "A CA certificate is required when SSL verification is enabled."
       });
     }
   });
@@ -166,6 +180,7 @@ export const IdentityKubernetesAuthForm = ({
       gatewayId: "",
       allowedAudience: "",
       caCert: "",
+      enableSsl: true,
       accessTokenTTL: "2592000",
       accessTokenMaxTTL: "2592000",
       accessTokenNumUsesLimit: "",
@@ -189,6 +204,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces: data.allowedNamespaces,
         allowedAudience: data.allowedAudience,
         caCert: data.caCert,
+        enableSsl: data.enableSsl ?? true,
         gatewayId: data.gatewayPoolId ? null : data.gatewayId || null,
         gatewayPoolId: data.gatewayPoolId || null,
         accessTokenTTL: String(data.accessTokenTTL),
@@ -213,6 +229,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces: "",
         allowedAudience: "",
         caCert: "",
+        enableSsl: true,
         accessTokenTTL: "2592000",
         accessTokenMaxTTL: "2592000",
         accessTokenNumUsesLimit: "",
@@ -313,6 +330,7 @@ export const IdentityKubernetesAuthForm = ({
     allowedNamespaces,
     allowedAudience,
     caCert,
+    enableSsl,
     accessTokenTTL,
     accessTokenMaxTTL,
     accessTokenNumUsesLimit,
@@ -338,6 +356,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces,
         allowedAudience,
         caCert,
+        enableSsl,
         identityId,
         gatewayId: gatewayPoolId ? null : gatewayId || null,
         gatewayPoolId: gatewayPoolId || null,
@@ -365,6 +384,7 @@ export const IdentityKubernetesAuthForm = ({
         gatewayId: gatewayPoolId ? null : gatewayId || null,
         gatewayPoolId: gatewayPoolId || null,
         caCert: caCert || "",
+        enableSsl,
         tokenReviewMode,
         accessTokenTTL: Number(accessTokenTTL),
         accessTokenMaxTTL: Number(accessTokenMaxTTL),
@@ -384,6 +404,13 @@ export const IdentityKubernetesAuthForm = ({
   };
 
   const tokenReviewMode = watch("tokenReviewMode");
+  const watchedCaCert = watch("caCert");
+
+  useEffect(() => {
+    if (watchedCaCert && watchedCaCert.length > 0) {
+      setValue("enableSsl", true, { shouldDirty: true });
+    }
+  }, [watchedCaCert, setValue]);
 
   return (
     <form
@@ -692,20 +719,77 @@ export const IdentityKubernetesAuthForm = ({
             )}
           />
           {tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Api && (
-            <Controller
-              control={control}
-              name="caCert"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="CA Certificate"
-                  errorText={error?.message}
-                  isError={Boolean(error)}
-                  tooltipText="An optional PEM-encoded CA cert for the Kubernetes API server. This is used by the TLS client for secure communication with the Kubernetes API server."
-                >
-                  <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
-                </FormControl>
-              )}
-            />
+            <>
+              <Controller
+                control={control}
+                name="enableSsl"
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                    <Switch
+                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
+                      id="k8s-enable-ssl"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      <p className="w-44 text-sm font-normal text-mineshaft-400">
+                        Enable SSL Verification
+                        <Tooltip
+                          className="max-w-md"
+                          content={
+                            <div className="flex flex-col gap-2">
+                              <p>
+                                When enabled, Infisical validates the Kubernetes API server&apos;s
+                                TLS certificate against the CA certificate provided below.
+                              </p>
+                              <p>
+                                Leaving this disabled means any host that responds at the configured
+                                Kubernetes URL will be trusted, regardless of its certificate. Only
+                                do this for testing or if you cannot supply a CA certificate.
+                              </p>
+                            </div>
+                          }
+                        >
+                          <FontAwesomeIcon
+                            icon={faQuestionCircle}
+                            size="sm"
+                            className="ml-1 text-mineshaft-400"
+                          />
+                        </Tooltip>
+                      </p>
+                    </Switch>
+                  </FormControl>
+                )}
+              />
+              <Controller
+                control={control}
+                name="caCert"
+                render={({ field, fieldState: { error } }) => {
+                  const enableSsl = watch("enableSsl");
+                  return (
+                    <FormControl
+                      label="CA Certificate"
+                      errorText={error?.message}
+                      isError={Boolean(error)}
+                      isRequired={enableSsl}
+                      tooltipClassName="max-w-md"
+                      tooltipText={
+                        <div className="flex flex-col gap-2">
+                          <p>
+                            An optional PEM-encoded CA certificate that issued the Kubernetes API
+                            server&apos;s TLS certificate. Required when SSL verification is
+                            enabled.
+                          </p>
+                          <p>This is required when SSL verification is enabled.</p>
+                        </div>
+                      }
+                    >
+                      <TextArea {...field} placeholder="-----BEGIN CERTIFICATE----- ..." />
+                    </FormControl>
+                  );
+                }}
+              />
+            </>
           )}
           {accessTokenTrustedIpsFields.map(({ id }, index) => (
             <div className="mb-3 flex items-end space-x-2" key={id}>


### PR DESCRIPTION
## Context

Restores **opt-out TLS certificate verification** for Identity **Kubernetes Auth** in **API** token-review mode, after [PR #6242](https://github.com/Infisical/infisical/pull/6242) enforced verification whenever no custom CA was configured—breaking clusters whose API server certs are not in the platform trust store (e.g. EKS) unless a CA is supplied.

Adds **`verifyTlsCertificate`** on the machine-identity Kubernetes auth config (DB column `verifyTlsCertificate`, API, UI). When **`true`**, Infisical verifies the Kubernetes API server’s cert using the configured **CA certificate** (required in that case). When **`false`**, HTTPS is still used but **`rejectUnauthorized`** is off (legacy / insecure, explicit customer choice). Migration **backfills `true`** for rows that already have `encryptedKubernetesCaCertificate` set; **`false`** otherwise. Attach uses `verifyTlsCertificate ?? Boolean(caCert)`; PATCH auto-promotes to `true` when a non-empty `caCert` is sent without the flag.

Renames the field from **`enableSsl`** to **`verifyTlsCertificate`** (TLS is always on; the flag only controls **verification**).

## Screenshots

<img width="716" height="811" alt="image" src="https://github.com/user-attachments/assets/4e8abf62-f816-45b4-89f3-90c39385269a" />

## Steps to verify the change

- **Attach** Kubernetes Auth (API mode): with **Verify TLS Certificate** on and a valid cluster **CA**, save and **Kubernetes login** succeeds.
- Same identity with verification **off** and **no CA** (only if you accept the risk): save and login against a cluster that would fail public-CA verification.
- **PATCH** update: sending a non-empty `caCert` without `verifyTlsCertificate` promotes verification to **on**; cannot end up with verification **on** and no CA (router + service guard).
- Run migration on a dev DB: column exists; rows with stored CA get `verifyTlsCertificate: true`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)