### PR TITLE
fix(k8s-auth): align TLS verification with CA presence and empty CA storage

### DIFF
--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -272,6 +272,11 @@ export const identityKubernetesAuthServiceFactory = ({
     };
   };
 
+  const $resolveEffectiveVerifyTlsCertificate = (caCert: string, storedVerify: boolean | null | undefined): boolean => {
+    if (!caCert.length) return false;
+    return storedVerify ?? false;
+  };
+
   const login = async ({ identityId, jwt: serviceAccountJwt, organizationSlug }: TLoginKubernetesAuthDTO) => {
     const appCfg = getConfig();
     const identityKubernetesAuth = await identityKubernetesAuthDAL.findOne({ identityId });
@@ -360,7 +365,10 @@ export const identityKubernetesAuthServiceFactory = ({
               timeout: 10000,
               httpsAgent: new https.Agent({
                 ca: caCert || undefined,
-                rejectUnauthorized: identityKubernetesAuth.verifyTlsCertificate ?? false,
+                rejectUnauthorized: $resolveEffectiveVerifyTlsCertificate(
+                  caCert,
+                  identityKubernetesAuth.verifyTlsCertificate
+                ),
                 servername
               })
             }
@@ -479,7 +487,10 @@ export const identityKubernetesAuthServiceFactory = ({
               : ((identityKubernetesAuth.gatewayV2Id ?? identityKubernetesAuth.gatewayId) as string),
             gatewayPoolId: identityKubernetesAuth.gatewayPoolId ?? undefined,
             caCert: caCert || undefined,
-            verifyTlsCertificate: identityKubernetesAuth.verifyTlsCertificate,
+            verifyTlsCertificate: $resolveEffectiveVerifyTlsCertificate(
+              caCert,
+              identityKubernetesAuth.verifyTlsCertificate
+            ),
             reviewTokenThroughGateway: true
           },
           tokenReviewCallbackThroughGateway
@@ -513,7 +524,10 @@ export const identityKubernetesAuthServiceFactory = ({
                 targetHost: k8sHost,
                 targetPort: k8sPort ? Number(k8sPort) : 443,
                 caCert: caCert || undefined,
-                verifyTlsCertificate: identityKubernetesAuth.verifyTlsCertificate,
+                verifyTlsCertificate: $resolveEffectiveVerifyTlsCertificate(
+                  caCert,
+                  identityKubernetesAuth.verifyTlsCertificate
+                ),
                 reviewTokenThroughGateway: false
               },
               tokenReviewCallbackRaw
@@ -999,7 +1013,7 @@ export const identityKubernetesAuthServiceFactory = ({
           encryptedKubernetesTokenReviewerJwt: tokenReviewerJwt
             ? encryptor({ plainText: Buffer.from(tokenReviewerJwt) }).cipherTextBlob
             : null,
-          encryptedKubernetesCaCertificate: encryptor({ plainText: Buffer.from(caCert) }).cipherTextBlob
+          encryptedKubernetesCaCertificate: caCert ? encryptor({ plainText: Buffer.from(caCert) }).cipherTextBlob : null
         },
         tx
       );
@@ -1214,14 +1228,16 @@ export const identityKubernetesAuthServiceFactory = ({
 
     // Auto-promote verifyTlsCertificate when the caller is supplying a non-empty
     // CA in this update without explicitly setting the toggle. Required for
-    // backwards compatibility
+    // backwards compatibility.
     let resolvedVerifyTlsCertificate: boolean | undefined;
     if (verifyTlsCertificate !== undefined) {
       resolvedVerifyTlsCertificate = verifyTlsCertificate;
     } else if (caCert !== undefined && caCert.length > 0) {
       resolvedVerifyTlsCertificate = true;
     }
-    const effectiveVerifyTlsCertificate = resolvedVerifyTlsCertificate ?? identityKubernetesAuth.verifyTlsCertificate;
+    const effectiveVerifyTlsCertificate =
+      resolvedVerifyTlsCertificate ??
+      $resolveEffectiveVerifyTlsCertificate(effectiveCaCert ?? "", identityKubernetesAuth.verifyTlsCertificate);
 
     if (
       effectiveVerifyTlsCertificate &&
@@ -1325,7 +1341,9 @@ export const identityKubernetesAuthServiceFactory = ({
     };
 
     if (caCert !== undefined) {
-      updateQuery.encryptedKubernetesCaCertificate = encryptor({ plainText: Buffer.from(caCert) }).cipherTextBlob;
+      updateQuery.encryptedKubernetesCaCertificate = caCert
+        ? encryptor({ plainText: Buffer.from(caCert) }).cipherTextBlob
+        : null;
     }
 
     if (tokenReviewerJwt) {
@@ -1434,6 +1452,7 @@ export const identityKubernetesAuthServiceFactory = ({
       ...identityKubernetesAuth,
       caCert,
       tokenReviewerJwt,
+      verifyTlsCertificate: $resolveEffectiveVerifyTlsCertificate(caCert, identityKubernetesAuth.verifyTlsCertificate),
       orgId: identityMembershipOrg.scopeOrgId,
       gatewayId: identityKubernetesAuth.gatewayId ?? identityKubernetesAuth.gatewayV2Id
     };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -217,7 +217,7 @@ export const IdentityKubernetesAuthForm = ({
         allowedNamespaces: data.allowedNamespaces,
         allowedAudience: data.allowedAudience,
         caCert: data.caCert,
-        verifyTlsCertificate: data.verifyTlsCertificate ?? true,
+        verifyTlsCertificate: data.verifyTlsCertificate ?? false,
         gatewayId: data.gatewayPoolId ? null : data.gatewayId || null,
         gatewayPoolId: data.gatewayPoolId || null,
         accessTokenTTL: String(data.accessTokenTTL),


### PR DESCRIPTION
## Context

**Kubernetes identity auth – TLS verification and CA handling**

- **Before:** `rejectUnauthorized` could follow the stored `verifyTlsCertificate` flag even when no CA was configured, and empty CA could still be stored as encrypted ciphertext.
- **After:** Verification is only effective when a non-empty CA is present (`$resolveEffectiveVerifyTlsCertificate`); clearing CA stores `encryptedKubernetesCaCertificate` as `null`; update/login paths use the same rule; GET reflects the effective `verifyTlsCertificate`. The org UI form sends `verifyTlsCertificate: false` when unset (aligned with “no CA ⇒ do not verify”).

## Steps to verify the change

1. Create/update a Kubernetes machine identity: no CA → login to cluster API should not require CA-backed TLS verify; with CA + verify on → TLS verify uses the CA.
2. Clear CA in UI/API → stored CA is null and verify behaves as “off” until CA is set again.
3. Regression: gateway vs direct token review still works with CA + verify.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)