### PR TITLE
improvement: dont show clipboard button on auto-copy

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
@@ -87,7 +87,6 @@ export const RequestSecretForm = () => {
     reset();
 
     navigator.clipboard.writeText(link.toString());
-    setCopyTextSecret("secret");
 
     createNotification({
       text: "Shared secret link copied to clipboard.",

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -183,7 +183,6 @@ export const ShareSecretForm = ({
       setSecretLink(link.toString());
 
       navigator.clipboard.writeText(link.toString());
-      setCopyTextSecret("secret");
 
       createNotification({
         text: "Shared secret link copied to clipboard.",


### PR DESCRIPTION
## Context

This PR remove the state showing the clipboard on secret share/request link generation; the clipboard will only show on click

## Screenshots

<img width="3456" height="1926" alt="CleanShot 2026-05-01 at 10 30 16@2x" src="https://github.com/user-attachments/assets/d668e206-2bc7-4369-a4e9-f541c1319805" />

## Steps to verify the change

- share and request a secret; see no clipboard

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)