### PR TITLE
fix: storybook static fix

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -9,6 +9,18 @@ const config: StorybookConfig = {
   framework: {
     name: "@storybook/react-vite",
     options: {}
+  },
+  viteFinal: async (viteConfig) => {
+    // The main app's vite.config.ts uses experimental.renderBuiltUrl to route
+    // asset URLs through window.__toCdnUrl(...), a runtime function injected
+    // by the standalone Docker deployment's serving layer. Storybook's static
+    // deploy (e.g. Render) has no such injection, so strip the override and
+    // let Vite emit plain relative URLs.
+    const { renderBuiltUrl, ...experimental } = viteConfig.experimental ?? {};
+    return {
+      ...viteConfig,
+      experimental
+    };
   }
 };
 export default config;


### PR DESCRIPTION
## Context

This PR fixes the static site generation for deploying to render

## Screenshots

N/A

## Steps to verify the change

go to site I linked you

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)