### PR TITLE
improvement: reduce non-error toast duration

### DIFF
--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -71,7 +71,7 @@ export const createNotification = (
   toast(<NotificationContent {...myProps} />, {
     position: "bottom-right",
     ...toastProps,
-    autoClose: toastProps.autoClose || (myProps?.type === "error" ? 8000 : 5000),
+    autoClose: toastProps.autoClose || (myProps?.type === "error" ? 8000 : 3000),
     theme: "dark",
     type: myProps?.type || "info",
     className: `pointer-events-auto ${toastProps.className}`


### PR DESCRIPTION
## Context

This PR reduces the toast notification duration to 3 seconds for non-error toasts

## Screenshots

N/A

## Steps to verify the change

- create something

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)