### PR TITLE
chore(upgrade-impact): backfill recent release data

### DIFF
--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run generate -- --tag "${{ steps.release.outputs.tag }}"
         working-directory: upgrade-impact
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Validate upgrade impact data

--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,3 +1,33 @@
 schemaVersion: 1
-generatedAt: "2026-04-29T00:00:00.000Z"
-versions: []
+generatedAt: 2026-05-01T18:25:35.192Z
+versions:
+  - version: v0.159.16
+    releasedAt: 2026-04-17T17:49:54-03:00
+    file: releases/v0.159.16.yaml
+  - version: v0.159.17
+    releasedAt: 2026-04-18T12:45:00+02:00
+    file: releases/v0.159.17.yaml
+  - version: v0.159.18
+    releasedAt: 2026-04-19T14:41:52-04:00
+    file: releases/v0.159.18.yaml
+  - version: v0.159.19
+    releasedAt: 2026-04-22T03:30:00+05:30
+    file: releases/v0.159.19.yaml
+  - version: v0.159.20
+    releasedAt: 2026-04-24T12:14:15+05:30
+    file: releases/v0.159.20.yaml
+  - version: v0.159.21
+    releasedAt: 2026-04-24T10:59:55-03:00
+    file: releases/v0.159.21.yaml
+  - version: v0.159.22
+    releasedAt: 2026-04-24T22:04:21+02:00
+    file: releases/v0.159.22.yaml
+  - version: v0.159.23
+    releasedAt: 2026-04-29T11:56:04+05:30
+    file: releases/v0.159.23.yaml
+  - version: v0.159.24
+    releasedAt: 2026-04-29T16:46:24-03:00
+    file: releases/v0.159.24.yaml
+  - version: v0.159.25
+    releasedAt: 2026-04-30T19:46:57-03:00
+    file: releases/v0.159.25.yaml

--- a/upgrade-impact/data/releases/v0.159.16.yaml
+++ b/upgrade-impact/data/releases/v0.159.16.yaml
@@ -18,9 +18,6 @@ dbSchemaChanges:
       - type: file
         ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
         path: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
-      - type: file
-        ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
-        path: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
         description: Creates nullable filteredEvents text[] column
 configChanges: []
 deploymentNotes: []

--- a/upgrade-impact/data/releases/v0.159.16.yaml
+++ b/upgrade-impact/data/releases/v0.159.16.yaml
@@ -3,22 +3,22 @@ releasedAt: 2026-04-17T17:49:54-03:00
 sourceTag: v0.159.16
 previousTag: v0.159.15
 impactLevel: low
-summary: Runs one additive webhook table migration. No self-hosted config or
-  deployment changes need operator updates.
+summary: Adds one startup-run database migration for webhook event filters. No
+  required self-hosted config or deployment changes.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
-  - title: Webhook events column added
-    description: Adds nullable `filteredEvents` text array column to the `Webhook`
-      table. Existing rows remain valid because the column is optional.
-    action: Run database migrations during upgrade. Verify the application user can
-      alter the `Webhook` table.
+  - title: Webhook event filters column
+    description: Infisical adds a nullable text[] column on the webhook table for
+      event-specific webhook delivery settings. Existing rows remain compatible
+      because the column is only added when missing.
+    action: No manual action required; Infisical runs this migration during startup.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
         path: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
-        description: Creates nullable filteredEvents text[] column
+        description: Adds nullable filteredEvents column if missing
 configChanges: []
 deploymentNotes: []
 knownIssues: []
@@ -26,7 +26,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:25:23.058Z
+  generatedAt: 2026-05-08T21:51:21.609Z
   sourceRange:
     from: v0.159.15
     to: v0.159.16

--- a/upgrade-impact/data/releases/v0.159.16.yaml
+++ b/upgrade-impact/data/releases/v0.159.16.yaml
@@ -1,0 +1,35 @@
+version: v0.159.16
+releasedAt: 2026-04-17T17:49:54-03:00
+sourceTag: v0.159.16
+previousTag: v0.159.15
+impactLevel: low
+summary: Runs one additive webhook table migration. No self-hosted config or
+  deployment changes need operator updates.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: Webhook events column added
+    description: Adds nullable `filteredEvents` text array column to the `Webhook`
+      table. Existing rows remain valid because the column is optional.
+    action: Run database migrations during upgrade. Verify the application user can
+      alter the `Webhook` table.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
+        path: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
+      - type: file
+        ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
+        path: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts
+        description: Creates nullable filteredEvents text[] column
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:25:23.058Z
+  sourceRange:
+    from: v0.159.15
+    to: v0.159.16

--- a/upgrade-impact/data/releases/v0.159.17.yaml
+++ b/upgrade-impact/data/releases/v0.159.17.yaml
@@ -13,8 +13,7 @@ dbSchemaChanges:
     description: A new external_migration_configs table is created with provider,
       encryptedConfig, orgId, and optional connectionId. Existing Vault
       migration configs are copied into the new table during migration.
-    action: Apply database migrations during upgrade. Verify the app can access
-      KMS/HSM-backed encryption settings while migrations run.
+    action: Apply database migrations during upgrade. 
     confidence: high
     evidence:
       - type: file
@@ -33,8 +32,8 @@ deploymentNotes:
     description: The migration initializes logger, HSM, super-admin, KMS root
       config, and encryption services before copying existing Vault migration
       rows into encryptedConfig.
-    action: Run migrations in an environment with the same KMS/HSM and super-admin
-      configuration as the application.
+    action: Run migrations in an environment with the same KMS/HSM
+      environment variables as the application.
     confidence: medium
     evidence:
       - type: file

--- a/upgrade-impact/data/releases/v0.159.17.yaml
+++ b/upgrade-impact/data/releases/v0.159.17.yaml
@@ -2,50 +2,38 @@ version: v0.159.17
 releasedAt: 2026-04-18T12:45:00+02:00
 sourceTag: v0.159.17
 previousTag: v0.159.16
-impactLevel: medium
-summary: Run the new database migrations. The migration creates a new
-  external migration config table and copies existing Vault migration settings
-  into it.
+impactLevel: low
+summary: Adds an automatic database migration for external migration configs
+  used by Vault and Doppler imports. No config or deployment changes are
+  required for existing self-hosted installs.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
-  - title: External migration table added
-    description: A new external_migration_configs table is created with provider,
-      encryptedConfig, orgId, and optional connectionId. Existing Vault
-      migration configs are copied into the new table during migration.
-    action: Apply database migrations during upgrade. 
+  - title: External migration configs table
+    description: Startup adds a new external_migration_configs table and copies
+      existing Vault migration config records into it with encrypted
+      provider-specific config data.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
         path: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
+        description: Creates shared migration config table
       - type: file
         ref: backend/src/db/schemas/external-migration-configs.ts
         path: backend/src/db/schemas/external-migration-configs.ts
-      - type: file
-        ref: backend/src/db/schemas/models.ts
-        path: backend/src/db/schemas/models.ts
-        description: Adds ExternalMigrationConfig table name
+        description: Schema includes provider and encryptedConfig
 configChanges: []
-deploymentNotes:
-  - title: Migration needs encryption services
-    description: The migration initializes logger, HSM, super-admin, KMS root
-      config, and encryption services before copying existing Vault migration
-      rows into encryptedConfig.
-    action: Run migrations in an environment with the same KMS/HSM
-      environment variables as the application.
-    confidence: medium
-    evidence:
-      - type: file
-        ref: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
-        path: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
-        description: Builds HSM and KMS services in migration
+deploymentNotes: []
 knownIssues: []
 generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:25:02.583Z
+  generatedAt: 2026-05-08T21:51:02.430Z
   sourceRange:
     from: v0.159.16
     to: v0.159.17

--- a/upgrade-impact/data/releases/v0.159.17.yaml
+++ b/upgrade-impact/data/releases/v0.159.17.yaml
@@ -1,0 +1,52 @@
+version: v0.159.17
+releasedAt: 2026-04-18T12:45:00+02:00
+sourceTag: v0.159.17
+previousTag: v0.159.16
+impactLevel: medium
+summary: Run the new database migration before serving traffic. It creates a new
+  external migration config table and copies existing Vault migration settings
+  into it.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: External migration table added
+    description: A new external_migration_configs table is created with provider,
+      encryptedConfig, orgId, and optional connectionId. Existing Vault
+      migration configs are copied into the new table during migration.
+    action: Apply database migrations during upgrade. Verify the app can access
+      KMS/HSM-backed encryption settings while migrations run.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
+        path: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
+      - type: file
+        ref: backend/src/db/schemas/external-migration-configs.ts
+        path: backend/src/db/schemas/external-migration-configs.ts
+      - type: file
+        ref: backend/src/db/schemas/models.ts
+        path: backend/src/db/schemas/models.ts
+        description: Adds ExternalMigrationConfig table name
+configChanges: []
+deploymentNotes:
+  - title: Migration needs encryption services
+    description: The migration initializes logger, HSM, super-admin, KMS root
+      config, and encryption services before copying existing Vault migration
+      rows into encryptedConfig.
+    action: Run migrations in an environment with the same KMS/HSM and super-admin
+      configuration as the application.
+    confidence: medium
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
+        path: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts
+        description: Builds HSM and KMS services in migration
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:25:02.583Z
+  sourceRange:
+    from: v0.159.16
+    to: v0.159.17

--- a/upgrade-impact/data/releases/v0.159.17.yaml
+++ b/upgrade-impact/data/releases/v0.159.17.yaml
@@ -3,7 +3,7 @@ releasedAt: 2026-04-18T12:45:00+02:00
 sourceTag: v0.159.17
 previousTag: v0.159.16
 impactLevel: medium
-summary: Run the new database migration before serving traffic. It creates a new
+summary: Run the new database migrations. The migration creates a new
   external migration config table and copies existing Vault migration settings
   into it.
 requiresDbMigration: true

--- a/upgrade-impact/data/releases/v0.159.18.yaml
+++ b/upgrade-impact/data/releases/v0.159.18.yaml
@@ -14,7 +14,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:24:36.008Z
+  generatedAt: 2026-05-08T21:50:43.475Z
   sourceRange:
     from: v0.159.17
     to: v0.159.18

--- a/upgrade-impact/data/releases/v0.159.18.yaml
+++ b/upgrade-impact/data/releases/v0.159.18.yaml
@@ -1,0 +1,20 @@
+version: v0.159.18
+releasedAt: 2026-04-19T14:41:52-04:00
+sourceTag: v0.159.18
+previousTag: v0.159.17
+impactLevel: none
+summary: No self-hosted upgrade actions or operator-facing runtime changes.
+requiresDbMigration: false
+breakingChanges: []
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:24:36.008Z
+  sourceRange:
+    from: v0.159.17
+    to: v0.159.18

--- a/upgrade-impact/data/releases/v0.159.19.yaml
+++ b/upgrade-impact/data/releases/v0.159.19.yaml
@@ -1,0 +1,66 @@
+version: v0.159.19
+releasedAt: 2026-04-22T03:30:00+05:30
+sourceTag: v0.159.19
+previousTag: v0.159.18
+impactLevel: medium
+summary: Run database migrations. PAM Active Directory data moves to domains,
+  and the public upgrade-path endpoint is removed.
+requiresDbMigration: true
+breakingChanges:
+  - title: Upgrade-path API removed
+    description: The backend upgrade-path service and route were removed. Any
+      automation or UI that calls the built-in upgrade-path endpoint will stop
+      working after upgrade.
+    action: Remove dependencies on the in-app upgrade-path endpoint before
+      upgrading, or replace them with your own external process.
+    confidence: high
+    evidence:
+      - type: pr
+        ref: "#6085"
+        url: https://github.com/Infisical/infisical/pull/6085
+      - type: file
+        ref: backend/src/server/routes/v1/upgrade-path-router.ts
+        path: backend/src/server/routes/v1/upgrade-path-router.ts
+      - type: file
+        ref: backend/upgrade-path.yaml
+        path: backend/upgrade-path.yaml
+dbSchemaChanges:
+  - title: PAM domains migration
+    description: Adds pam_domains and new domain reference columns, then migrates
+      existing Active Directory PAM resources into domains. It also removes
+      adServerResourceId and enforces pam_accounts to reference either a
+      resource or a domain.
+    action: Back up the database and run migrations during maintenance. Validate PAM
+      Active Directory domains, accounts, and related resources after upgrade.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260408062748_pam-domains.ts
+        path: backend/src/db/migrations/20260408062748_pam-domains.ts
+      - type: pr
+        ref: "#5982"
+        url: https://github.com/Infisical/infisical/pull/5982
+  - title: Certificates metadata column
+    description: Adds a nullable externalMetadata JSONB column to certificates. This
+      requires the normal database migration step but should not need manual
+      data changes.
+    action: Run database migrations before starting updated application nodes.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260416231234_add-external-metadata-to-certificates.ts
+        path: backend/src/db/migrations/20260416231234_add-external-metadata-to-certificates.ts
+      - type: pr
+        ref: "#6069"
+        url: https://github.com/Infisical/infisical/pull/6069
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:24:20.216Z
+  sourceRange:
+    from: v0.159.18
+    to: v0.159.19

--- a/upgrade-impact/data/releases/v0.159.19.yaml
+++ b/upgrade-impact/data/releases/v0.159.19.yaml
@@ -3,56 +3,51 @@ releasedAt: 2026-04-22T03:30:00+05:30
 sourceTag: v0.159.19
 previousTag: v0.159.18
 impactLevel: medium
-summary: Run database migrations. PAM Active Directory data moves to domains,
-  and the public upgrade-path endpoint is removed.
+summary: Startup runs two database migrations. One restructures PAM Active
+  Directory data and removes the built-in upgrade-path API and page.
 requiresDbMigration: true
 breakingChanges:
-  - title: Upgrade-path API removed
-    description: The backend upgrade-path service and route were removed. Any
-      automation or UI that calls the built-in upgrade-path endpoint will stop
+  - title: Upgrade path API removal
+    description: The public upgrade-path backend route and UI page were removed. Any
+      automation or internal tooling that called these endpoints will stop
       working after upgrade.
-    action: Remove dependencies on the in-app upgrade-path endpoint before
-      upgrading, or replace them with your own external process.
+    action: Update or remove any tooling that calls the upgrade-path endpoints
+      before upgrading.
     confidence: high
     evidence:
-      - type: pr
-        ref: "#6085"
-        url: https://github.com/Infisical/infisical/pull/6085
       - type: file
         ref: backend/src/server/routes/v1/upgrade-path-router.ts
         path: backend/src/server/routes/v1/upgrade-path-router.ts
-      - type: file
-        ref: backend/upgrade-path.yaml
-        path: backend/upgrade-path.yaml
+        description: Route existed previously
+      - type: pr
+        ref: "#6085"
+        url: https://github.com/Infisical/infisical/pull/6085
+        description: Removes page and backend service
 dbSchemaChanges:
   - title: PAM domains migration
-    description: Adds pam_domains and new domain reference columns, then migrates
-      existing Active Directory PAM resources into domains. It also removes
-      adServerResourceId and enforces pam_accounts to reference either a
-      resource or a domain.
-    action: Back up the database and run migrations during maintenance. Validate PAM
-      Active Directory domains, accounts, and related resources after upgrade.
+    description: Startup creates pam_domains, adds domain references to PAM tables,
+      migrates existing Active Directory resources into domains, deletes related
+      rotation and discovery-source rows for migrated AD resources, and drops
+      pam_resources.adServerResourceId.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260408062748_pam-domains.ts
         path: backend/src/db/migrations/20260408062748_pam-domains.ts
-      - type: pr
-        ref: "#5982"
-        url: https://github.com/Infisical/infisical/pull/5982
-  - title: Certificates metadata column
-    description: Adds a nullable externalMetadata JSONB column to certificates. This
-      requires the normal database migration step but should not need manual
-      data changes.
-    action: Run database migrations before starting updated application nodes.
+        description: Creates pam_domains and migrates AD resources
+  - title: Certificate external metadata
+    description: Startup adds a nullable externalMetadata JSONB column to
+      certificates for external CA metadata storage.
+    action: No manual action required; Infisical runs this migration during startup.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260416231234_add-external-metadata-to-certificates.ts
         path: backend/src/db/migrations/20260416231234_add-external-metadata-to-certificates.ts
-      - type: pr
-        ref: "#6069"
-        url: https://github.com/Infisical/infisical/pull/6069
+        description: Adds nullable externalMetadata column
 configChanges: []
 deploymentNotes: []
 knownIssues: []
@@ -60,7 +55,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:24:20.216Z
+  generatedAt: 2026-05-08T21:50:35.458Z
   sourceRange:
     from: v0.159.18
     to: v0.159.19

--- a/upgrade-impact/data/releases/v0.159.20.yaml
+++ b/upgrade-impact/data/releases/v0.159.20.yaml
@@ -1,0 +1,61 @@
+version: v0.159.20
+releasedAt: 2026-04-24T12:14:15+05:30
+sourceTag: v0.159.20
+previousTag: v0.159.19
+impactLevel: medium
+summary: Run database migrations. If you use a reverse proxy, set
+  TRUSTED_PROXY_CIDRS to trusted proxy ranges before or during upgrade.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: Two columns added
+    description: Database migrations add a nullable reason column to pam_sessions
+      and a nullable encryptedPrivateKey column to certificate_requests.
+    action: Run the application migrations before serving traffic. Verify your
+      database user can alter existing tables.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260417245211_pam-session-reason.ts
+        path: backend/src/db/migrations/20260417245211_pam-session-reason.ts
+      - type: file
+        ref: backend/src/db/migrations/20260421135044_add-digicert-external-ca-columns.ts
+        path: backend/src/db/migrations/20260421135044_add-digicert-external-ca-columns.ts
+configChanges:
+  - title: Set trusted proxy CIDRs
+    description: A new TRUSTED_PROXY_CIDRS setting controls which proxy source
+      ranges can supply forwarded client IP headers. Leaving it unset keeps
+      prior behavior and trusts all forwarded headers.
+    action: If Infisical sits behind Nginx, ALB, Cloudflare, or another proxy, set
+      TRUSTED_PROXY_CIDRS to those proxy CIDRs.
+    confidence: high
+    evidence:
+      - type: file
+        ref: docs/self-hosting/configuration/envars.mdx
+        path: docs/self-hosting/configuration/envars.mdx
+        description: Documents TRUSTED_PROXY_CIDRS behavior
+deploymentNotes:
+  - title: Update bundled Nginx header
+    description: Bundled Nginx configs now send X-Real-IP instead of the misspelled
+      X-Real-RIP header.
+    action: If you copied the provided Nginx config into your own manifests or
+      images, update the header name there too.
+    confidence: high
+    evidence:
+      - type: file
+        ref: nginx/default.conf
+        path: nginx/default.conf
+        description: Uses X-Real-IP in current config
+      - type: file
+        ref: nginx/default.dev.conf
+        path: nginx/default.dev.conf
+        description: Uses X-Real-IP in dev config
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:23:47.649Z
+  sourceRange:
+    from: v0.159.19
+    to: v0.159.20

--- a/upgrade-impact/data/releases/v0.159.20.yaml
+++ b/upgrade-impact/data/releases/v0.159.20.yaml
@@ -2,60 +2,43 @@ version: v0.159.20
 releasedAt: 2026-04-24T12:14:15+05:30
 sourceTag: v0.159.20
 previousTag: v0.159.19
-impactLevel: medium
-summary: Run database migrations. If you use a reverse proxy, set
-  TRUSTED_PROXY_CIDRS to trusted proxy ranges before or during upgrade.
+impactLevel: low
+summary: Startup runs two additive database migrations. The new proxy trust
+  setting is optional because leaving it unset preserves existing forwarded-IP
+  behavior.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
-  - title: Two columns added
-    description: Database migrations add a nullable reason column to pam_sessions
-      and a nullable encryptedPrivateKey column to certificate_requests.
-    action: Run the application migrations before serving traffic. Verify your
-      database user can alter existing tables.
+  - title: PAM session reason column
+    description: Adds a nullable `reason` column to `pam_sessions`. Existing rows
+      remain valid and startup applies it only if the table exists and the
+      column is missing.
+    action: No manual action required; Infisical runs this migration during startup.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260417245211_pam-session-reason.ts
         path: backend/src/db/migrations/20260417245211_pam-session-reason.ts
+        description: Adds nullable reason column if missing
+  - title: Certificate request private key column
+    description: Adds a nullable `encryptedPrivateKey` column to
+      `certificate_requests`. Existing rows remain valid and startup applies it
+      only if the table exists and the column is missing.
+    action: No manual action required; Infisical runs this migration during startup.
+    confidence: high
+    evidence:
       - type: file
         ref: backend/src/db/migrations/20260421135044_add-digicert-external-ca-columns.ts
         path: backend/src/db/migrations/20260421135044_add-digicert-external-ca-columns.ts
-configChanges:
-  - title: Set trusted proxy CIDRs
-    description: A new TRUSTED_PROXY_CIDRS setting controls which proxy source
-      ranges can supply forwarded client IP headers. Leaving it unset keeps
-      prior behavior and trusts all forwarded headers.
-    action: If Infisical sits behind Nginx, ALB, Cloudflare, or another proxy, set
-      TRUSTED_PROXY_CIDRS to those proxy CIDRs.
-    confidence: high
-    evidence:
-      - type: file
-        ref: docs/self-hosting/configuration/envars.mdx
-        path: docs/self-hosting/configuration/envars.mdx
-        description: Documents TRUSTED_PROXY_CIDRS behavior
-deploymentNotes:
-  - title: Update bundled Nginx header
-    description: Bundled Nginx configs now send X-Real-IP instead of the misspelled
-      X-Real-RIP header.
-    action: If you copied the provided Nginx config into your own manifests or
-      images, update the header name there too.
-    confidence: high
-    evidence:
-      - type: file
-        ref: nginx/default.conf
-        path: nginx/default.conf
-        description: Uses X-Real-IP in current config
-      - type: file
-        ref: nginx/default.dev.conf
-        path: nginx/default.dev.conf
-        description: Uses X-Real-IP in dev config
+        description: Adds nullable encryptedPrivateKey column
+configChanges: []
+deploymentNotes: []
 knownIssues: []
 generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:23:47.649Z
+  generatedAt: 2026-05-08T21:49:59.071Z
   sourceRange:
     from: v0.159.19
     to: v0.159.20

--- a/upgrade-impact/data/releases/v0.159.21.yaml
+++ b/upgrade-impact/data/releases/v0.159.21.yaml
@@ -3,7 +3,8 @@ releasedAt: 2026-04-24T10:59:55-03:00
 sourceTag: v0.159.21
 previousTag: v0.159.20
 impactLevel: none
-summary: No self-hosted upgrade action required.
+summary: No self-hosted upgrade action. Changes are limited to group listing
+  behavior and do not affect deployment, configuration, or database schema.
 requiresDbMigration: false
 breakingChanges: []
 dbSchemaChanges: []
@@ -14,7 +15,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:23:02.899Z
+  generatedAt: 2026-05-08T21:49:16.883Z
   sourceRange:
     from: v0.159.20
     to: v0.159.21

--- a/upgrade-impact/data/releases/v0.159.21.yaml
+++ b/upgrade-impact/data/releases/v0.159.21.yaml
@@ -1,0 +1,20 @@
+version: v0.159.21
+releasedAt: 2026-04-24T10:59:55-03:00
+sourceTag: v0.159.21
+previousTag: v0.159.20
+impactLevel: none
+summary: No self-hosted upgrade action required.
+requiresDbMigration: false
+breakingChanges: []
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:23:02.899Z
+  sourceRange:
+    from: v0.159.20
+    to: v0.159.21

--- a/upgrade-impact/data/releases/v0.159.22.yaml
+++ b/upgrade-impact/data/releases/v0.159.22.yaml
@@ -1,0 +1,20 @@
+version: v0.159.22
+releasedAt: 2026-04-24T22:04:21+02:00
+sourceTag: v0.159.22
+previousTag: v0.159.21
+impactLevel: none
+summary: No self-hosted upgrade actions found.
+requiresDbMigration: false
+breakingChanges: []
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:22:49.367Z
+  sourceRange:
+    from: v0.159.21
+    to: v0.159.22

--- a/upgrade-impact/data/releases/v0.159.22.yaml
+++ b/upgrade-impact/data/releases/v0.159.22.yaml
@@ -3,7 +3,7 @@ releasedAt: 2026-04-24T22:04:21+02:00
 sourceTag: v0.159.22
 previousTag: v0.159.21
 impactLevel: none
-summary: No self-hosted upgrade actions found.
+summary: No self-hosted upgrade actions or risks found.
 requiresDbMigration: false
 breakingChanges: []
 dbSchemaChanges: []
@@ -14,7 +14,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:22:49.367Z
+  generatedAt: 2026-05-08T21:48:59.964Z
   sourceRange:
     from: v0.159.21
     to: v0.159.22

--- a/upgrade-impact/data/releases/v0.159.23.yaml
+++ b/upgrade-impact/data/releases/v0.159.23.yaml
@@ -3,47 +3,48 @@ releasedAt: 2026-04-29T11:56:04+05:30
 sourceTag: v0.159.23
 previousTag: v0.159.22
 impactLevel: low
-summary: Adds one optional SMTP setting and a gateway-pools database migration
-  for operators using those capabilities.
+summary: Adds an automatic database migration for gateway pools and an optional
+  SMTP_HELO_HOST setting for stricter SMTP relays.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
-  - title: Gateway pools tables added
-    description: Database schema adds gateway pool tables. Startup will need the new
-      migration applied before gateway pool features can work.
-    action: Run database migrations during upgrade. Verify migration jobs complete
-      before serving traffic.
+  - title: Gateway pools migration
+    description: Startup adds gateway_pools, gateway_pool_memberships, and a
+      nullable gatewayPoolId on Kubernetes auth records. Existing data remains
+      compatible.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260414000001_add-gateway-pools.ts
         path: backend/src/db/migrations/20260414000001_add-gateway-pools.ts
-      - type: release
-        ref: v0.159.23
-        url: https://github.com/Infisical/infisical/releases/tag/v0.159.23
-        description: Includes gateway pools feature
+        description: Creates gateway pool tables
 configChanges:
-  - title: Optional SMTP_HELO_HOST
-    description: SMTP now supports SMTP_HELO_HOST to set the EHLO/HELO hostname.
-      Only mail setups that require a specific HELO identity need changes.
-    action: Set SMTP_HELO_HOST if your SMTP relay validates the HELO/EHLO hostname
-      or mail delivery currently depends on a custom hostname.
-    confidence: medium
+  - title: SMTP HELO hostname
+    description: You can now set SMTP_HELO_HOST to control the EHLO/HELO hostname.
+      This helps when your SMTP relay rejects container hostnames that are not
+      valid FQDNs.
+    action: Set SMTP_HELO_HOST to a relay-accepted FQDN if outbound email fails
+      after upgrade or your relay validates sender hostnames.
+    confidence: high
     evidence:
-      - type: release
-        ref: v0.159.23
-        url: https://github.com/Infisical/infisical/releases/tag/v0.159.23
-        description: Lists SMTP_HELO_HOST addition
-      - type: commit
-        ref: 4d0b568c07a9756ca05c4324302c61fca1513761
-        description: Adds SMTP_HELO_HOST support
+      - type: file
+        ref: backend/src/lib/config/env.ts
+        path: backend/src/lib/config/env.ts
+        description: Adds SMTP_HELO_HOST env var
+      - type: file
+        ref: docs/self-hosting/configuration/envars.mdx
+        path: docs/self-hosting/configuration/envars.mdx
+        description: Documents container hostname fallback
 deploymentNotes: []
 knownIssues: []
 generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:22:32.767Z
+  generatedAt: 2026-05-08T21:48:47.989Z
   sourceRange:
     from: v0.159.22
     to: v0.159.23

--- a/upgrade-impact/data/releases/v0.159.23.yaml
+++ b/upgrade-impact/data/releases/v0.159.23.yaml
@@ -1,0 +1,49 @@
+version: v0.159.23
+releasedAt: 2026-04-29T11:56:04+05:30
+sourceTag: v0.159.23
+previousTag: v0.159.22
+impactLevel: low
+summary: Adds one optional SMTP setting and a gateway-pools database migration
+  for operators using those capabilities.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: Gateway pools tables added
+    description: Database schema adds gateway pool tables. Startup will need the new
+      migration applied before gateway pool features can work.
+    action: Run database migrations during upgrade. Verify migration jobs complete
+      before serving traffic.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260414000001_add-gateway-pools.ts
+        path: backend/src/db/migrations/20260414000001_add-gateway-pools.ts
+      - type: release
+        ref: v0.159.23
+        url: https://github.com/Infisical/infisical/releases/tag/v0.159.23
+        description: Includes gateway pools feature
+configChanges:
+  - title: Optional SMTP_HELO_HOST
+    description: SMTP now supports SMTP_HELO_HOST to set the EHLO/HELO hostname.
+      Only mail setups that require a specific HELO identity need changes.
+    action: Set SMTP_HELO_HOST if your SMTP relay validates the HELO/EHLO hostname
+      or mail delivery currently depends on a custom hostname.
+    confidence: medium
+    evidence:
+      - type: release
+        ref: v0.159.23
+        url: https://github.com/Infisical/infisical/releases/tag/v0.159.23
+        description: Lists SMTP_HELO_HOST addition
+      - type: commit
+        ref: 4d0b568c07a9756ca05c4324302c61fca1513761
+        description: Adds SMTP_HELO_HOST support
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:22:32.767Z
+  sourceRange:
+    from: v0.159.22
+    to: v0.159.23

--- a/upgrade-impact/data/releases/v0.159.24.yaml
+++ b/upgrade-impact/data/releases/v0.159.24.yaml
@@ -1,0 +1,42 @@
+version: v0.159.24
+releasedAt: 2026-04-29T16:46:24-03:00
+sourceTag: v0.159.24
+previousTag: v0.159.23
+impactLevel: medium
+summary: Identity auth now enforces TLS certificate verification for OIDC, JWT,
+  and Kubernetes auth providers. Fix invalid or incomplete provider TLS settings
+  before upgrading.
+requiresDbMigration: false
+breakingChanges:
+  - title: Identity auth enforces TLS verification
+    description: OIDC, JWT, and Kubernetes identity auth providers now require valid
+      TLS verification. Providers using self-signed, mismatched, or incomplete
+      certificates may fail authentication after upgrade.
+    action: Test each identity auth provider in staging. Install a trusted CA chain
+      or correct the certificate hostname before upgrading.
+    confidence: medium
+    evidence:
+      - type: release
+        ref: v0.159.24
+        url: https://github.com/Infisical/infisical/releases/tag/v0.159.24
+      - type: file
+        ref: backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+        path: backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+      - type: file
+        ref: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+        path: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+      - type: file
+        ref: backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+        path: backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:22:04.070Z
+  sourceRange:
+    from: v0.159.23
+    to: v0.159.24

--- a/upgrade-impact/data/releases/v0.159.24.yaml
+++ b/upgrade-impact/data/releases/v0.159.24.yaml
@@ -3,31 +3,37 @@ releasedAt: 2026-04-29T16:46:24-03:00
 sourceTag: v0.159.24
 previousTag: v0.159.23
 impactLevel: medium
-summary: Identity auth now enforces TLS certificate verification for OIDC, JWT,
-  and Kubernetes auth providers. Fix invalid or incomplete provider TLS settings
-  before upgrading.
+summary: Identity auth now always verifies TLS certificates for OIDC, JWT JWKS,
+  and Kubernetes auth endpoints. Existing setups using self-signed or mismatched
+  certificates may fail until CA trust and hostnames are corrected.
 requiresDbMigration: false
 breakingChanges:
-  - title: Identity auth enforces TLS verification
-    description: OIDC, JWT, and Kubernetes identity auth providers now require valid
-      TLS verification. Providers using self-signed, mismatched, or incomplete
-      certificates may fail authentication after upgrade.
-    action: Test each identity auth provider in staging. Install a trusted CA chain
-      or correct the certificate hostname before upgrading.
-    confidence: medium
+  - title: Identity auth TLS verification
+    description: OIDC, JWT JWKS, and Kubernetes auth now enforce TLS certificate
+      verification. Logins can fail if your identity provider or Kubernetes API
+      uses an untrusted CA or a certificate hostname that does not match the
+      configured host.
+    action: Add the issuing CA certificate to the auth method configuration and
+      ensure the configured host matches the certificate SAN or CN before
+      upgrading.
+    confidence: high
     evidence:
-      - type: release
-        ref: v0.159.24
-        url: https://github.com/Infisical/infisical/releases/tag/v0.159.24
       - type: file
         ref: backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
         path: backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+        description: JWKS HTTPS agent rejects unauthorized certs
       - type: file
         ref: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
         path: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+        description: Kubernetes HTTPS agents set rejectUnauthorized and servername
       - type: file
-        ref: backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
-        path: backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+        ref: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+        path: backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-validators.ts
+        description: Validation requests enforce TLS verification
+      - type: release
+        ref: v0.159.24
+        url: https://github.com/Infisical/infisical/releases/tag/v0.159.24
+        description: TLS verification fix noted
 dbSchemaChanges: []
 configChanges: []
 deploymentNotes: []
@@ -36,7 +42,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:22:04.070Z
+  generatedAt: 2026-05-08T21:48:23.278Z
   sourceRange:
     from: v0.159.23
     to: v0.159.24

--- a/upgrade-impact/data/releases/v0.159.25.yaml
+++ b/upgrade-impact/data/releases/v0.159.25.yaml
@@ -1,0 +1,57 @@
+version: v0.159.25
+releasedAt: 2026-04-30T19:46:57-03:00
+sourceTag: v0.159.25
+previousTag: v0.159.24
+impactLevel: medium
+summary: Run database migrations. Kubernetes Auth adds TLS verification state,
+  and PKI internal CAs add CRL distribution point URLs.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: Kubernetes Auth TLS column
+    description: Adds verifyTlsCertificate to identity Kubernetes auth records.
+      Existing records with a stored CA certificate are backfilled to true;
+      others default to false.
+    action: Run database migrations before starting upgraded services. Review
+      Kubernetes Auth identities if you rely on custom CA or skipped TLS
+      verification.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
+        path: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
+      - type: file
+        ref: backend/src/db/schemas/identity-kubernetes-auths.ts
+        path: backend/src/db/schemas/identity-kubernetes-auths.ts
+      - type: file
+        ref: docs/documentation/platform/identities/kubernetes-auth.mdx
+        path: docs/documentation/platform/identities/kubernetes-auth.mdx
+        description: Docs describe auto-enable with CA cert
+  - title: Internal CA CRL URLs
+    description: Adds crlDistributionPointUrls to internal certificate authorities.
+      This supports custom CRL distribution points for private CAs.
+    action: Run database migrations. If you manage PKI automation or direct database
+      integrations, account for the new nullable text array column.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260428000635_add-internal-ca-distribution-point-urls.ts
+        path: backend/src/db/migrations/20260428000635_add-internal-ca-distribution-point-urls.ts
+      - type: file
+        ref: backend/src/db/schemas/internal-certificate-authorities.ts
+        path: backend/src/db/schemas/internal-certificate-authorities.ts
+      - type: file
+        ref: docs/documentation/platform/pki/ca/private-ca.mdx
+        path: docs/documentation/platform/pki/ca/private-ca.mdx
+        description: Private CA docs changed
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-01T18:21:48.171Z
+  sourceRange:
+    from: v0.159.24
+    to: v0.159.25

--- a/upgrade-impact/data/releases/v0.159.25.yaml
+++ b/upgrade-impact/data/releases/v0.159.25.yaml
@@ -3,47 +3,35 @@ releasedAt: 2026-04-30T19:46:57-03:00
 sourceTag: v0.159.25
 previousTag: v0.159.24
 impactLevel: medium
-summary: Run database migrations. Kubernetes Auth adds TLS verification state,
-  and PKI internal CAs add CRL distribution point URLs.
+summary: Startup runs two additive schema migrations. Kubernetes auth now stores
+  explicit TLS verification behavior while preserving compatibility for records
+  without CA certificates.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
-  - title: Kubernetes Auth TLS column
-    description: Adds verifyTlsCertificate to identity Kubernetes auth records.
-      Existing records with a stored CA certificate are backfilled to true;
-      others default to false.
-    action: Run database migrations before starting upgraded services. Review
-      Kubernetes Auth identities if you rely on custom CA or skipped TLS
-      verification.
-    confidence: high
-    evidence:
-      - type: file
-        ref: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
-        path: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
-      - type: file
-        ref: backend/src/db/schemas/identity-kubernetes-auths.ts
-        path: backend/src/db/schemas/identity-kubernetes-auths.ts
-      - type: file
-        ref: docs/documentation/platform/identities/kubernetes-auth.mdx
-        path: docs/documentation/platform/identities/kubernetes-auth.mdx
-        description: Docs describe auto-enable with CA cert
-  - title: Internal CA CRL URLs
-    description: Adds crlDistributionPointUrls to internal certificate authorities.
-      This supports custom CRL distribution points for private CAs.
-    action: Run database migrations. If you manage PKI automation or direct database
-      integrations, account for the new nullable text array column.
+  - title: PKI CA distribution points
+    description: Adds a nullable text[] column for internal CA CRL distribution
+      point URLs. Existing data remains compatible.
+    action: No manual action required; Infisical runs this migration during startup.
     confidence: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260428000635_add-internal-ca-distribution-point-urls.ts
         path: backend/src/db/migrations/20260428000635_add-internal-ca-distribution-point-urls.ts
+        description: Adds crlDistributionPointUrls column
+  - title: Kubernetes auth TLS flag
+    description: Adds a non-null verifyTlsCertificate column to identity Kubernetes
+      auth records. Existing records with a stored CA certificate are backfilled
+      to true; others default to false.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
+    confidence: high
+    evidence:
       - type: file
-        ref: backend/src/db/schemas/internal-certificate-authorities.ts
-        path: backend/src/db/schemas/internal-certificate-authorities.ts
-      - type: file
-        ref: docs/documentation/platform/pki/ca/private-ca.mdx
-        path: docs/documentation/platform/pki/ca/private-ca.mdx
-        description: Private CA docs changed
+        ref: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
+        path: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts
+        description: Adds and backfills verifyTlsCertificate
 configChanges: []
 deploymentNotes: []
 knownIssues: []
@@ -51,7 +39,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-01T18:21:48.171Z
+  generatedAt: 2026-05-08T21:47:53.295Z
   sourceRange:
     from: v0.159.24
     to: v0.159.25

--- a/upgrade-impact/src/evidence.ts
+++ b/upgrade-impact/src/evidence.ts
@@ -38,8 +38,8 @@ const githubHeaders = () => {
     "X-GitHub-Api-Version": "2022-11-28"
   };
 
-  if (process.env.GITHUB_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  if (process.env.UPGRADE_TOOL_GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.UPGRADE_TOOL_GITHUB_TOKEN}`;
   }
 
   return headers;

--- a/upgrade-impact/src/generate-ai.ts
+++ b/upgrade-impact/src/generate-ai.ts
@@ -119,6 +119,16 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - Do not include the same evidence item twice in one entry.
 - Do not repeat a release note or PR URL across multiple entries when a more specific file diff can support the claim.
 - Before finalizing, audit the JSON for duplicate titles, duplicate descriptions, and duplicate evidence.
+- Every entry title must clearly name the affected product area, for example "PAM domains migration", "PKI certificate metadata", "Kubernetes auth TLS setting", "SMTP HELO hostname", or "Platform startup migration".
+- Only write an action when there is a specific operator task. If there is no manual task, write "No manual action required; Infisical runs this migration during startup."
+- For additive database migrations, prefer "No manual action required; Infisical runs this migration during startup." Do not tell users to run migrations manually unless the diff proves they must.
+- If a migration failure is the only risk, say "If startup fails during migration, keep the previous version running and inspect migration logs before retrying."
+- Do not say "run migrations before serving traffic", "verify migration jobs complete", "account for", or "review X if you rely on Y".
+- Do not tell operators to change proxy, Helm, Docker, or environment configuration unless the diff introduces a required setting or changes a default that existing deployments must respond to.
+- Optional security-hardening settings such as TRUSTED_PROXY_CIDRS are not upgrade actions when unset preserves legacy behavior.
+- Do not tell API automation owners to update payloads when the service layer provides backwards-compatible defaults or auto-promotion.
+- For optional environment variables, nullable columns, or additive feature tables, include an entry only when existing deployments may need a decision; otherwise omit it or state that no manual action is required.
+- Before using breakingChanges, inspect whether existing records or configs are backfilled or compatibility-preserved. If compatibility exists, do not mark it breaking.
 - Use breakingChanges for changes that can make existing auth, API, startup, database, or integrations fail after upgrade.
 - Use deploymentNotes only when deployment files, self-hosting docs, Docker, Helm, Kubernetes manifests, startup/runtime, or rollout behavior changed.
 - Use configChanges only for environment variables, config files, defaults, or settings that operators must update.

--- a/upgrade-impact/src/generate-ai.ts
+++ b/upgrade-impact/src/generate-ai.ts
@@ -335,7 +335,7 @@ export const generateWithOpenAiAgentic = async (bundle: ReleaseEvidenceBundle): 
     name: "list_changed_files",
     description: "List changed files in this release, optionally filtered by category.",
     parameters: z.object({
-      category: z.enum(FILE_CATEGORIES).optional()
+      category: z.enum(FILE_CATEGORIES).nullable()
     }),
     async execute({ category }) {
       const limitError = recordToolCall();
@@ -361,9 +361,9 @@ export const generateWithOpenAiAgentic = async (bundle: ReleaseEvidenceBundle): 
       "Return a capped git diff for a changed file in this release. Use this before making claims about file-level behavior.",
     parameters: z.object({
       file: z.string(),
-      contextLines: z.number().min(0).max(120).optional()
+      contextLines: z.number().min(0).max(120).nullable()
     }),
-    async execute({ file, contextLines = 40 }) {
+    async execute({ file, contextLines }) {
       const limitError = recordToolCall();
       if (limitError) {
         return limitError;
@@ -373,7 +373,13 @@ export const generateWithOpenAiAgentic = async (bundle: ReleaseEvidenceBundle): 
         return { error: `File is not in changed file set: ${file}` };
       }
 
-      const diff = runGit(["diff", `--unified=${contextLines}`, `${bundle.previousTag}..${bundle.tag}`, "--", file]);
+      const diff = runGit([
+        "diff",
+        `--unified=${contextLines ?? 40}`,
+        `${bundle.previousTag}..${bundle.tag}`,
+        "--",
+        file
+      ]);
       const truncated = truncateText(diff, agenticLimits.maxDiffCharsPerFile);
 
       return recordToolResult({

--- a/upgrade-impact/src/generate-ai.ts
+++ b/upgrade-impact/src/generate-ai.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { ReleaseEvidenceBundle } from "./evidence.js";
 import { runGit } from "./git.js";
-import { ImpactEntry, ImpactEntrySchema } from "./schema.js";
+import { Evidence, ImpactEntry, ImpactEntrySchema } from "./schema.js";
 
 export const MODEL = "gpt-5.4";
 
@@ -27,7 +27,8 @@ const agenticLimits = {
   maxDiffCharsPerFile: 20000,
   maxFileChars: 20000,
   maxTotalToolResultChars: 220000,
-  maxCompletionTokens: 5000
+  maxCompletionTokens: 5000,
+  maxTurns: 20
 };
 
 const evidenceForFile = (file: string, description?: string) => ({
@@ -115,6 +116,9 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - Do not say "the release", "this release", "code changes indicate", "evidence bundle", "identified", or "detected".
 - Do not mention that no Docker, Helm, Kubernetes, or database changes exist unless that absence changes the upgrade action.
 - Do not duplicate the same risk across breakingChanges, configChanges, deploymentNotes, and knownIssues. Pick one category.
+- Do not include the same evidence item twice in one entry.
+- Do not repeat a release note or PR URL across multiple entries when a more specific file diff can support the claim.
+- Before finalizing, audit the JSON for duplicate titles, duplicate descriptions, and duplicate evidence.
 - Use breakingChanges for changes that can make existing auth, API, startup, database, or integrations fail after upgrade.
 - Use deploymentNotes only when deployment files, self-hosting docs, Docker, Helm, Kubernetes manifests, startup/runtime, or rollout behavior changed.
 - Use configChanges only for environment variables, config files, defaults, or settings that operators must update.
@@ -167,13 +171,40 @@ Evidence rules:
 `;
 
 const normalizeDraft = (draft: GeneratedDraft): GeneratedDraft => {
+  const evidenceKey = (evidence: Evidence) =>
+    [evidence.type, evidence.ref, evidence.path ?? "", evidence.url ?? ""].join("\u0000");
+
+  const dedupeEvidence = (evidenceItems: Evidence[]) => {
+    const seen = new Set<string>();
+
+    return evidenceItems.filter((evidence) => {
+      const key = evidenceKey(evidence);
+      if (seen.has(key)) {
+        return false;
+      }
+
+      seen.add(key);
+      return true;
+    });
+  };
+
+  const entryKey = (entry: ImpactEntry) =>
+    [entry.title.trim().toLowerCase(), entry.description.trim().toLowerCase()].join("\u0000");
+
   const normalizeEntries = (entries: ImpactEntry[]) =>
-    entries.map((entry) => ({
-      ...entry,
-      evidence: entry.evidence.map((evidence) =>
-        evidence.type === "file" && evidence.path ? { ...evidence, ref: evidence.path } : evidence
-      )
-    }));
+    entries
+      .map((entry) => ({
+        ...entry,
+        evidence: dedupeEvidence(
+          entry.evidence.map((evidence) =>
+            evidence.type === "file" && evidence.path ? { ...evidence, ref: evidence.path } : evidence
+          )
+        )
+      }))
+      .filter((entry, index, normalizedEntries) => {
+        const key = entryKey(entry);
+        return normalizedEntries.findIndex((candidate) => entryKey(candidate) === key) === index;
+      });
 
   return {
     ...draft,
@@ -469,7 +500,7 @@ export const generateWithOpenAiAgentic = async (bundle: ReleaseEvidenceBundle): 
   });
 
   const result = await run(agent, "Generate the self-hosted upgrade impact JSON for this release.", {
-    maxTurns: 20
+    maxTurns: agenticLimits.maxTurns
   });
 
   if (!result.finalOutput) {

--- a/upgrade-impact/src/validate.test.ts
+++ b/upgrade-impact/src/validate.test.ts
@@ -232,6 +232,39 @@ const validationCases: ValidationCase[] = [
       }
     ],
     expectedErrors: [`${validRelease.version}.yaml repeats impact entry title "Database schema migrations are included"`]
+  },
+  {
+    name: "rejects unclear operator actions",
+    index: makeIndex([
+      {
+        version: validRelease.version,
+        releasedAt: validRelease.releasedAt,
+        file: `releases/${validRelease.version}.yaml`
+      }
+    ]),
+    releases: [
+      {
+        fileName: `${validRelease.version}.yaml`,
+        release: makeRelease({
+          dbSchemaChanges: [
+            {
+              title: "Database schema migrations are included",
+              description: "This release includes a database migration.",
+              action: "Set TRUSTED_PROXY_CIDRS to your proxy CIDR ranges and restart.",
+              confidence: "high",
+              evidence: [
+                {
+                  type: "file",
+                  ref: "backend/src/db/migrations/20260429000000_example.ts",
+                  path: "backend/src/db/migrations/20260429000000_example.ts"
+                }
+              ]
+            }
+          ]
+        })
+      }
+    ],
+    expectedErrors: [`${validRelease.version}.yaml uses unclear operator action`]
   }
 ];
 

--- a/upgrade-impact/src/validate.test.ts
+++ b/upgrade-impact/src/validate.test.ts
@@ -161,6 +161,77 @@ const validationCases: ValidationCase[] = [
       }
     ],
     expectedErrors: [`${validRelease.version}.yaml contains invalid YAML`]
+  },
+  {
+    name: "rejects duplicate evidence within an impact entry",
+    index: makeIndex([
+      {
+        version: validRelease.version,
+        releasedAt: validRelease.releasedAt,
+        file: `releases/${validRelease.version}.yaml`
+      }
+    ]),
+    releases: [
+      {
+        fileName: `${validRelease.version}.yaml`,
+        release: makeRelease({
+          dbSchemaChanges: [
+            {
+              title: "Database schema migrations are included",
+              description: "This release includes a database migration.",
+              action: "Back up the database before upgrading.",
+              confidence: "high",
+              evidence: [
+                {
+                  type: "file",
+                  ref: "backend/src/db/migrations/20260429000000_example.ts",
+                  path: "backend/src/db/migrations/20260429000000_example.ts"
+                },
+                {
+                  type: "file",
+                  ref: "backend/src/db/migrations/20260429000000_example.ts",
+                  path: "backend/src/db/migrations/20260429000000_example.ts"
+                }
+              ]
+            }
+          ]
+        })
+      }
+    ],
+    expectedErrors: [`${validRelease.version}.yaml repeats evidence file:backend/src/db/migrations/20260429000000_example.ts`]
+  },
+  {
+    name: "rejects duplicate impact entry titles",
+    index: makeIndex([
+      {
+        version: validRelease.version,
+        releasedAt: validRelease.releasedAt,
+        file: `releases/${validRelease.version}.yaml`
+      }
+    ]),
+    releases: [
+      {
+        fileName: `${validRelease.version}.yaml`,
+        release: makeRelease({
+          breakingChanges: [
+            {
+              title: "Database schema migrations are included",
+              description: "The same impact is reported in another section.",
+              action: "Keep only one entry for this impact.",
+              confidence: "medium",
+              evidence: [
+                {
+                  type: "file",
+                  ref: "backend/src/db/migrations/20260429000000_example.ts",
+                  path: "backend/src/db/migrations/20260429000000_example.ts"
+                }
+              ]
+            }
+          ]
+        })
+      }
+    ],
+    expectedErrors: [`${validRelease.version}.yaml repeats impact entry title "Database schema migrations are included"`]
   }
 ];
 

--- a/upgrade-impact/src/validate.ts
+++ b/upgrade-impact/src/validate.ts
@@ -65,6 +65,47 @@ const validateReleaseAgainstGit = (release: ReleaseImpact, file: string, errors:
   }
 };
 
+const evidenceKey = (evidence: ReleaseImpact["breakingChanges"][number]["evidence"][number]) =>
+  [evidence.type, evidence.ref, evidence.path ?? "", evidence.url ?? ""].join("\u0000");
+
+const normalizeEntryKey = (value: string) => value.trim().toLowerCase().replace(/\s+/g, " ");
+
+const validateDuplicateContent = (release: ReleaseImpact, file: string, errors: string[]) => {
+  const seenEntryTitles = new Map<string, string>();
+  const sections = [
+    ["breakingChanges", release.breakingChanges],
+    ["dbSchemaChanges", release.dbSchemaChanges],
+    ["configChanges", release.configChanges],
+    ["deploymentNotes", release.deploymentNotes],
+    ["knownIssues", release.knownIssues]
+  ] as const;
+
+  for (const [section, entries] of sections) {
+    for (const [entryIndex, entry] of entries.entries()) {
+      const titleKey = normalizeEntryKey(entry.title);
+      const entryRef = `${section}[${entryIndex}] ${entry.title}`;
+      const previousEntryRef = seenEntryTitles.get(titleKey);
+
+      if (previousEntryRef) {
+        errors.push(`${file} repeats impact entry title "${entry.title}" in ${previousEntryRef} and ${entryRef}`);
+      } else {
+        seenEntryTitles.set(titleKey, entryRef);
+      }
+
+      const seenEvidence = new Set<string>();
+      for (const evidence of entry.evidence) {
+        const key = evidenceKey(evidence);
+
+        if (seenEvidence.has(key)) {
+          errors.push(`${file} repeats evidence ${evidence.type}:${evidence.ref} in ${entryRef}`);
+        }
+
+        seenEvidence.add(key);
+      }
+    }
+  }
+};
+
 const validateReleaseFile = async (
   releasesDir: string,
   file: string,
@@ -115,6 +156,7 @@ const validateReleaseFile = async (
     errors.push(`${file} has impactLevel none but contains impact entries`);
   }
 
+  validateDuplicateContent(release, file, errors);
   validateReleaseAgainstGit(release, file, errors, skipGitChecks);
 
   return release;

--- a/upgrade-impact/src/validate.ts
+++ b/upgrade-impact/src/validate.ts
@@ -70,6 +70,15 @@ const evidenceKey = (evidence: ReleaseImpact["breakingChanges"][number]["evidenc
 
 const normalizeEntryKey = (value: string) => value.trim().toLowerCase().replace(/\s+/g, " ");
 
+const unclearActionPatterns = [
+  /run migrations? before serving traffic/i,
+  /verify migration jobs? complete/i,
+  /account for/i,
+  /review .+ if you rely on/i,
+  /set\s+`?TRUSTED_PROXY_CIDRS`?/i,
+  /update any automation/i
+];
+
 const validateDuplicateContent = (release: ReleaseImpact, file: string, errors: string[]) => {
   const seenEntryTitles = new Map<string, string>();
   const sections = [
@@ -90,6 +99,13 @@ const validateDuplicateContent = (release: ReleaseImpact, file: string, errors: 
         errors.push(`${file} repeats impact entry title "${entry.title}" in ${previousEntryRef} and ${entryRef}`);
       } else {
         seenEntryTitles.set(titleKey, entryRef);
+      }
+
+      for (const pattern of unclearActionPatterns) {
+        if (pattern.test(entry.action)) {
+          errors.push(`${file} uses unclear operator action in ${entryRef}: ${entry.action}`);
+          break;
+        }
       }
 
       const seenEvidence = new Set<string>();


### PR DESCRIPTION
## Summary
- Backfill upgrade impact data for v0.159.16 through v0.159.25 using local OpenAI-backed generation
- Update the upgrade impact index to reference the new release files
- Adjust agent tool schemas to satisfy the OpenAI API strict function schema requirements

## Validation
- npm run type:check
- npm test
- npm run validate