### PR TITLE
improvement(frontend): correct react select disabled styling

### DIFF
--- a/frontend/src/components/v3/generic/ReactSelect/styles.ts
+++ b/frontend/src/components/v3/generic/ReactSelect/styles.ts
@@ -3,10 +3,12 @@ import { ClassNamesConfig, GroupBase, StylesConfig } from "react-select";
 import { cn } from "../../utils";
 
 export const selectClassNames: ClassNamesConfig<unknown, boolean, GroupBase<unknown>> = {
-  control: ({ isFocused }) =>
+  control: ({ isFocused, isDisabled }) =>
     cn(
-      "!min-h-9 w-full cursor-pointer overflow-hidden rounded-md border bg-transparent py-1 pr-1 pl-2 text-sm",
-      isFocused ? "border-ring ring-[3px] ring-ring/50" : "border-border hover:border-foreground/20"
+      "!min-h-9 w-full cursor-pointer overflow-hidden rounded-md border border-border bg-transparent py-1 pr-1 pl-2 text-sm",
+      isFocused && "border-ring ring-[3px] ring-ring/50",
+      !isFocused && !isDisabled && "hover:border-foreground/20",
+      isDisabled && "pointer-events-none cursor-not-allowed opacity-50"
     ),
   placeholder: () => "text-muted text-sm",
   input: () => "text-foreground text-sm",
@@ -56,9 +58,9 @@ export const getSelectClassNames = (
   isError?: boolean
 ): ClassNamesConfig<unknown, boolean, GroupBase<unknown>> => ({
   ...selectClassNames,
-  control: ({ isFocused }) =>
+  control: ({ isFocused, isDisabled }) =>
     cn(
-      "!min-h-9 w-full cursor-pointer overflow-hidden rounded-md border bg-transparent py-1 pr-1 pl-2 text-sm",
+      "!min-h-9 w-full cursor-pointer overflow-hidden rounded-md border border-border bg-transparent py-1 pr-1 pl-2 text-sm",
       // eslint-disable-next-line no-nested-ternary
       isError
         ? isFocused
@@ -66,6 +68,7 @@ export const getSelectClassNames = (
           : "border-danger"
         : isFocused
           ? "border-ring ring-[3px] ring-ring/50"
-          : "border-border hover:border-foreground/20"
+          : !isDisabled && "hover:border-foreground/20",
+      isDisabled && "pointer-events-none cursor-not-allowed opacity-50"
     )
 });


### PR DESCRIPTION
## Context

This PR fixes the react select (CreatableSelect and FilterableSelect) disabled styling to match inputs/select.

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-05-01 at 13 10 02@2x" src="https://github.com/user-attachments/assets/c475f775-29e9-41c0-8857-9c6813c33be7" />

## Steps to verify the change

- verify disabled story doesn't show hover and is semi-transparent

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)