### PR TITLE
fix(identity-membership): honor orderBy/orderDirection on listing endpoints

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -883,7 +883,9 @@ export const ORG_IDENTITY_MEMBERSHIP = {
     offset: "The offset to start from. If you enter 10, it will start from the 10th identity membership.",
     limit: "The number of identity memberships to return.",
     identityName: "",
-    roles: "The role slugs to filter identity memberships by."
+    roles: "The role slugs to filter identity memberships by.",
+    orderBy: "The column to order identity memberships by.",
+    orderDirection: "The direction identity memberships will be sorted in."
   },
   GET_IDENTITY_MEMBERSHIP_BY_ID: {
     identityId: "The ID of the machine identity to get the membership for."
@@ -1160,7 +1162,9 @@ export const PROJECT_IDENTITY_MEMBERSHIP = {
     offset: "The offset to start from. If you enter 10, it will start from the 10th identity membership.",
     limit: "The number of identity memberships to return.",
     identityName: "The text string that identity membership names will be filtered by.",
-    roles: "The role slugs to filter identity memberships by."
+    roles: "The role slugs to filter identity memberships by.",
+    orderBy: "The column to order identity memberships by.",
+    orderDirection: "The direction identity memberships will be sorted in."
   },
   GET_IDENTITY_MEMBERSHIP_BY_ID: {
     projectId: "The ID of the project to get the identity membership for.",

--- a/backend/src/server/routes/v1/identity-org-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-org-membership-router.ts
@@ -4,9 +4,11 @@ import { AccessScope, IdentitiesSchema, MembershipRolesSchema, TemporaryPermissi
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, ORG_IDENTITY_MEMBERSHIP } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
+import { OrderByDirection } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityMembershipOrderBy } from "@app/services/membership-identity/membership-identity-types";
 
 const sanitizedOrgIdentityMembershipSchema = z.object({
   id: z.string().uuid(),
@@ -294,6 +296,16 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
           .string()
           .transform((val) => val.split(",").map((role) => role.trim()))
           .describe(ORG_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.roles)
+          .optional(),
+        orderBy: z
+          .nativeEnum(IdentityMembershipOrderBy)
+          .default(IdentityMembershipOrderBy.Name)
+          .describe(ORG_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.orderBy)
+          .optional(),
+        orderDirection: z
+          .nativeEnum(OrderByDirection)
+          .default(OrderByDirection.ASC)
+          .describe(ORG_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.orderDirection)
           .optional()
       }),
       response: {
@@ -335,7 +347,9 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
           offset: req.query.offset,
           limit: req.query.limit,
           identityName: req.query.identityName,
-          roles: req.query.roles
+          roles: req.query.roles,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/server/routes/v1/identity-project-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-project-membership-router.ts
@@ -11,9 +11,11 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, PROJECT_IDENTITIES, PROJECT_IDENTITY_MEMBERSHIP } from "@app/lib/api-docs";
 import { BadRequestError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
+import { OrderByDirection } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityMembershipOrderBy } from "@app/services/membership-identity/membership-identity-types";
 
 export const registerIdentityProjectMembershipRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -306,6 +308,16 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
           .string()
           .transform((val) => val.split(",").map((role) => role.trim()))
           .describe(PROJECT_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.roles)
+          .optional(),
+        orderBy: z
+          .nativeEnum(IdentityMembershipOrderBy)
+          .default(IdentityMembershipOrderBy.Name)
+          .describe(PROJECT_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.orderBy)
+          .optional(),
+        orderDirection: z
+          .nativeEnum(OrderByDirection)
+          .default(OrderByDirection.ASC)
+          .describe(PROJECT_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.orderDirection)
           .optional()
       }),
       response: {
@@ -349,7 +361,9 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
           offset: req.query.offset,
           limit: req.query.limit,
           identityName: req.query.identityName,
-          roles: req.query.roles
+          roles: req.query.roles,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/services/membership-identity/membership-identity-dal.ts
+++ b/backend/src/services/membership-identity/membership-identity-dal.ts
@@ -6,8 +6,10 @@ import { BadRequestError, DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
 import { buildKnexFilterForSearchResource } from "@app/lib/search-resource/db";
 import { TSearchResourceOperator } from "@app/lib/search-resource/search";
+import { OrderByDirection } from "@app/lib/types";
 
 import { buildAuthMethods } from "../identity/identity-fns";
+import { IdentityMembershipOrderBy } from "./membership-identity-types";
 
 export type TMembershipIdentityDALFactory = ReturnType<typeof membershipIdentityDALFactory>;
 
@@ -20,6 +22,8 @@ type TFindIdentityArg = {
     identityId: string;
     name: Omit<TSearchResourceOperator, "number">;
     role: Omit<TSearchResourceOperator, "number">;
+    orderBy: IdentityMembershipOrderBy;
+    orderDirection: OrderByDirection;
   }>;
 };
 
@@ -232,12 +236,11 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
 
   const findIdentities = async ({ scopeData, tx, filter }: TFindIdentityArg) => {
     try {
-      const paginatedIdentitys = (tx || db.replicaNode())(TableName.Membership)
+      const baseFilterQuery = (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorIdentityId`)
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .distinct(`${TableName.Membership}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, scopeData.orgId)
         .where((qb) => {
           if (filter.identityId) {
@@ -255,7 +258,7 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
 
       if (filter.name || filter.role) {
         buildKnexFilterForSearchResource(
-          paginatedIdentitys,
+          baseFilterQuery,
           {
             ...(filter.name && { name: filter.name }),
             ...(filter.role && { role: filter.role })
@@ -273,10 +276,22 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
         );
       }
 
-      const countQuery = await (tx || db.replicaNode())
-        .count("* as total")
-        .from(paginatedIdentitys.clone().as("distinctMemberships"));
+      const [countResult] = (await baseFilterQuery.clone().countDistinct(`${TableName.Membership}.id as count`)) as [
+        { count: string | number }?
+      ];
+      const totalCount = Number(countResult?.count ?? 0);
 
+      const dir = filter.orderDirection === OrderByDirection.DESC ? "DESC" : "ASC";
+      // identity name is the only sortable column today; fall through to it for any unknown value
+      const orderByRaw = `LOWER("${TableName.Identity}"."name") ${dir}`;
+
+      const paginatedIdentitys = baseFilterQuery
+        .clone()
+        .clearSelect()
+        .select(`${TableName.Membership}.id`)
+        .groupBy(`${TableName.Membership}.id`, `${TableName.Identity}.name`)
+        .orderByRaw(orderByRaw)
+        .orderBy(`${TableName.Membership}.id`, "asc");
       if (filter.limit) void paginatedIdentitys.limit(filter.limit);
       if (filter.offset) void paginatedIdentitys.offset(filter.offset);
 
@@ -285,9 +300,10 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .distinct(`${TableName.Membership}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, scopeData.orgId)
         .whereIn(`${TableName.Membership}.id`, paginatedIdentitys)
+        .orderByRaw(orderByRaw)
+        .orderBy(`${TableName.Membership}.id`, "asc")
         .select(selectAllTableCols(TableName.Membership))
         .select(
           db.ref("name").withSchema(TableName.Identity).as("identityName"),
@@ -367,7 +383,7 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((countQuery?.[0] as unknown as { total: number })?.total ?? 0) };
+      return { data, totalCount };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindIdentity" });
     }

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -335,6 +335,8 @@ export const membershipIdentityServiceFactory = ({
       filter: {
         limit: dto.data.limit,
         offset: dto.data.offset,
+        orderBy: dto.data.orderBy,
+        orderDirection: dto.data.orderDirection,
         name: dto.data.identityName
           ? {
               [SearchResourceOperators.$contains]: dto.data.identityName

--- a/backend/src/services/membership-identity/membership-identity-types.ts
+++ b/backend/src/services/membership-identity/membership-identity-types.ts
@@ -1,5 +1,9 @@
 import { AccessScopeData, TemporaryPermissionMode } from "@app/db/schemas";
-import { OrgServiceActor } from "@app/lib/types";
+import { OrderByDirection, OrgServiceActor } from "@app/lib/types";
+
+export enum IdentityMembershipOrderBy {
+  Name = "name"
+}
 
 export interface TMembershipIdentityScopeFactory {
   onCreateMembershipIdentityGuard: (arg: TCreateMembershipIdentityDTO) => Promise<void>;
@@ -58,6 +62,8 @@ export type TListMembershipIdentityDTO = {
     offset?: number;
     identityName?: string;
     roles?: string[];
+    orderBy?: IdentityMembershipOrderBy;
+    orderDirection?: OrderByDirection;
   };
 };
 


### PR DESCRIPTION
## Context

clicking the name column header on access control → machine identities does nothing. the chevron rotates because frontend state updates, but the row order never changes. closes #6280.

three layers of the gap, all on the server:

1. `identity-project-membership-router.ts` querystring schema for `GET /api/v1/projects/:projectId/memberships/identities` only declared `offset`, `limit`, `identityName`, `roles`. fastify's zod type provider strips unknown query params, so `orderBy` and `orderDirection` were gone before the handler ran. same gap on the org variant `identity-org-membership-router.ts`.
2. `TListMembershipIdentityDTO.data` had no slot for sort fields, so even a forwarded value would have nowhere to land.
3. `membershipIdentityDAL.findIdentities` issued the knex query with no `.orderBy()` at all. postgres returned rows in arbitrary order: stable enough across requests to look like a default sort, but unaffected by anything the ui did.

this pr threads sort through all three layers, mirroring the working `membership-group` pattern (see `membership-group-dal.ts:findGroups`).

## Steps to verify the change

1. open access control → machine identities on a project with 3+ identities of varied names
2. click the name column header. order flips ascending
3. click again. order flips descending; chevron rotates
4. paginate. sort persists across pages
5. ascending sort is case-insensitive (`ORDER BY LOWER(identity.name)`); ties broken by `membership.id` so output is deterministic
6. `GET /api/v1/projects/:projectId/memberships/identities?orderBy=name&orderDirection=desc` returns rows in the requested order. omitting both query params still returns name-asc

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)