### PR TITLE
feat(identities): add sorting to identity listing endpoints

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -193,7 +193,9 @@ export const IDENTITIES = {
     orgId: "The ID of the organization to list identities.",
     search: "The text string that identity names will be filtered by.",
     offset: "The offset to start from. If you enter 10, it will start from the 10th identity.",
-    limit: "The number of identities to return."
+    limit: "The number of identities to return.",
+    orderBy: "The column to order identities by.",
+    orderDirection: "The direction to order identities in."
   },
   SEARCH: {
     search: {

--- a/backend/src/server/routes/v1/identity-org-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-org-membership-router.ts
@@ -4,9 +4,11 @@ import { AccessScope, IdentitiesSchema, MembershipRolesSchema, TemporaryPermissi
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, ORG_IDENTITY_MEMBERSHIP } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
+import { OrderByDirection } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityOrderBy } from "@app/services/membership-identity/membership-identity-types";
 
 const sanitizedOrgIdentityMembershipSchema = z.object({
   id: z.string().uuid(),
@@ -294,7 +296,9 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
           .string()
           .transform((val) => val.split(",").map((role) => role.trim()))
           .describe(ORG_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.roles)
-          .optional()
+          .optional(),
+        orderBy: z.nativeEnum(IdentityOrderBy).default(IdentityOrderBy.Name).optional(),
+        orderDirection: z.nativeEnum(OrderByDirection).default(OrderByDirection.ASC).optional()
       }),
       response: {
         200: z.object({
@@ -335,7 +339,9 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
           offset: req.query.offset,
           limit: req.query.limit,
           identityName: req.query.identityName,
-          roles: req.query.roles
+          roles: req.query.roles,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/server/routes/v1/identity-project-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-project-membership-router.ts
@@ -11,9 +11,11 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, PROJECT_IDENTITIES, PROJECT_IDENTITY_MEMBERSHIP } from "@app/lib/api-docs";
 import { BadRequestError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
+import { OrderByDirection } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityOrderBy } from "@app/services/membership-identity/membership-identity-types";
 
 export const registerIdentityProjectMembershipRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -306,7 +308,9 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
           .string()
           .transform((val) => val.split(",").map((role) => role.trim()))
           .describe(PROJECT_IDENTITY_MEMBERSHIP.LIST_IDENTITY_MEMBERSHIPS.roles)
-          .optional()
+          .optional(),
+        orderBy: z.nativeEnum(IdentityOrderBy).default(IdentityOrderBy.Name).optional(),
+        orderDirection: z.nativeEnum(OrderByDirection).default(OrderByDirection.ASC).optional()
       }),
       response: {
         200: z.object({
@@ -349,7 +353,9 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
           offset: req.query.offset,
           limit: req.query.limit,
           identityName: req.query.identityName,
-          roles: req.query.roles
+          roles: req.query.roles,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/server/routes/v1/org-identity-router.ts
+++ b/backend/src/server/routes/v1/org-identity-router.ts
@@ -6,6 +6,8 @@ import { ApiDocsTags, IDENTITIES } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityOrderBy } from "@app/services/identity-v2/identity-types";
+import { OrderByDirection } from "@app/lib/types";
 
 const metadataSchema = z.object({
   key: z.string().trim().min(1, "Metadata key cannot be empty"),
@@ -262,8 +264,18 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
       querystring: z.object({
         offset: z.coerce.number().min(0).default(0).describe(IDENTITIES.LIST.offset).optional(),
         limit: z.coerce.number().min(1).max(1000).default(20).describe(IDENTITIES.LIST.limit).optional(),
-        search: z.string().trim().describe(IDENTITIES.LIST.search).optional()
-      }),
+        search: z.string().trim().describe(IDENTITIES.LIST.search).optional(),
+        orderBy: z
+          .nativeEnum(IdentityOrderBy)
+          .default(IdentityOrderBy.CreatedAt)
+          .describe(IDENTITIES.LIST.orderBy)
+          .optional(),
+        orderDirection: z
+          .nativeEnum(OrderByDirection)
+          .default(OrderByDirection.Asc)
+          .describe(IDENTITIES.LIST.orderDirection)
+          .optional()
+       }),
       response: {
         200: z.object({
           identities: z.array(sanitizedIdentitySchema),
@@ -281,7 +293,9 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
         data: {
           offset: req.query.offset,
           limit: req.query.limit,
-          search: req.query.search
+          search: req.query.search,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -6,6 +6,8 @@ import { ApiDocsTags, IDENTITIES } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityOrderBy } from "@app/services/identity-v2/identity-types";
+import { OrderByDirection } from "@app/lib/types";
 
 const metadataSchema = z.object({
   key: z.string().trim().min(1, "Metadata key cannot be empty"),
@@ -288,8 +290,18 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
       querystring: z.object({
         offset: z.coerce.number().min(0).default(0).describe(IDENTITIES.LIST.offset).optional(),
         limit: z.coerce.number().min(1).max(1000).default(20).describe(IDENTITIES.LIST.limit).optional(),
-        search: z.string().trim().describe(IDENTITIES.LIST.search).optional()
-      }),
+        search: z.string().trim().describe(IDENTITIES.LIST.search).optional(),
+        orderBy: z
+          .nativeEnum(IdentityOrderBy)
+          .default(IdentityOrderBy.CreatedAt)
+          .describe(IDENTITIES.LIST.orderBy)
+          .optional(),
+        orderDirection: z
+          .nativeEnum(OrderByDirection)
+          .default(OrderByDirection.Asc)
+          .describe(IDENTITIES.LIST.orderDirection)
+          .optional()
+       }),
       response: {
         200: z.object({
           identities: z.array(sanitizedIdentitySchema),
@@ -308,7 +320,9 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
         data: {
           offset: req.query.offset,
           limit: req.query.limit,
-          search: req.query.search
+          search: req.query.search,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/services/identity-v2/identity-dal.ts
+++ b/backend/src/services/identity-v2/identity-dal.ts
@@ -3,7 +3,12 @@ import { AccessScope, AccessScopeData, IdentitiesSchema, TableName } from "@app/
 import { sanitizeSqlLikeString } from "@app/lib/fn";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
 
+import { OrderByDirection } from "@app/lib/types";
+import { TIdentityV2DALFactory } from "@app/services/identity-v2/identity-dal";
+
 import { buildAuthMethods } from "../identity/identity-fns";
+import { IdentityOrderBy } from "./identity-types";
+
 
 export type TIdentityV2DALFactory = ReturnType<typeof identityV2DALFactory>;
 
@@ -132,7 +137,13 @@ export const identityV2DALFactory = (db: TDbClient) => {
 
   const listIdentities = async (
     scopeData: AccessScopeData,
-    filter: { limit?: number; offset?: number; search?: string } = {}
+    filter: {
+      limit?: number;
+      offset?: number;
+      search?: string;
+      orderBy?: IdentityOrderBy;
+      orderDirection?: OrderByDirection;
+    } = {}
   ) => {
     const baseQuery = db
       .replicaNode()(TableName.Identity)
@@ -145,12 +156,32 @@ export const identityV2DALFactory = (db: TDbClient) => {
         }
       });
 
-    if (filter.search)
+    if (filter.search) {
       void baseQuery.whereILike(`${TableName.Identity}.name`, `%${sanitizeSqlLikeString(filter.search)}%`);
+    }
 
-    const countQuery = baseQuery.clone().count(`${TableName.Identity}.id as count`).first<{ count: string }>();
+    const [countResult] = (await baseQuery.clone().count(`${TableName.Identity}.id as count`)) as [
+      { count: string | number }?
+    ];
+    const totalCount = Number(countResult?.count ?? 0);
 
-    const dataQuery = baseQuery
+    const dir = filter.orderDirection === OrderByDirection.DESC ? "DESC" : "ASC";
+    const orderBy = filter.orderBy || IdentityOrderBy.CreatedAt;
+    
+    const paginatedIdentities = await baseQuery
+      .clone()
+      .clearSelect()
+      .select(`${TableName.Identity}.id`)
+      .orderBy(orderBy, dir)
+      .limit(filter.limit || 20)
+      .offset(filter.offset || 0);
+      
+    const dataQuery = db
+      .replicaNode()(TableName.Identity)
+      .whereIn(
+        `${TableName.Identity}.id`,
+        paginatedIdentities.map(({ id }) => id)
+      )
       .leftJoin(TableName.IdentityMetadata, (queryBuilder) => {
         void queryBuilder.on(`${TableName.Identity}.id`, `${TableName.IdentityMetadata}.identityId`);
       })
@@ -159,12 +190,10 @@ export const identityV2DALFactory = (db: TDbClient) => {
         db.ref("id").withSchema(TableName.IdentityMetadata).as("metadataId"),
         db.ref("key").withSchema(TableName.IdentityMetadata).as("metadataKey"),
         db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue")
-      );
+      )
+      .orderBy(orderBy, dir);
 
-    if (filter.limit) void dataQuery.limit(filter.limit);
-    if (filter.offset) void dataQuery.offset(filter.offset || 0);
-
-    const [countResult, docs] = await Promise.all([countQuery, dataQuery]);
+    const docs = await dataQuery;
 
     const formattedDoc = sqlNestRelationships({
       data: docs,
@@ -183,7 +212,7 @@ export const identityV2DALFactory = (db: TDbClient) => {
       ]
     });
 
-    return { docs: formattedDoc, count: Number(countResult?.count ?? 0) };
+    return { docs: formattedDoc, count: totalCount };
   };
 
   return { ...orm, listIdentities, getIdentityById };

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -236,7 +236,9 @@ export const identityV2ServiceFactory = ({
     const identities = await identityDAL.listIdentities(dto.scopeData, {
       search: dto.data.search,
       offset: dto.data.offset,
-      limit: dto.data.limit
+      limit: dto.data.limit,
+      orderBy: dto.data.orderBy,
+      orderDirection: dto.data.orderDirection
     });
 
     return { ...identities, docs: identities.docs.filter((el) => isIdentityAccessible({ identityId: el.id })) };

--- a/backend/src/services/identity-v2/identity-types.ts
+++ b/backend/src/services/identity-v2/identity-types.ts
@@ -10,10 +10,18 @@ export interface TIdentityV2Factory {
   getScopeField: (scope: AccessScopeData) => { key: "orgId" | "projectId"; value: string };
 }
 
+
 export enum IdentityOrderBy {
+  Name = "name",
+  CreatedAt = "createdAt",
+  UpdatedAt = "updatedAt"
+}
+
+export enum OrgIdentityOrderBy {
   Name = "name",
   Role = "role"
 }
+
 
 export type TCreateIdentityV2DTO = {
   permission: OrgServiceActor;

--- a/backend/src/services/membership-identity/membership-identity-dal.ts
+++ b/backend/src/services/membership-identity/membership-identity-dal.ts
@@ -6,8 +6,10 @@ import { BadRequestError, DatabaseError } from "@app/lib/errors";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
 import { buildKnexFilterForSearchResource } from "@app/lib/search-resource/db";
 import { TSearchResourceOperator } from "@app/lib/search-resource/search";
+import { OrderByDirection } from "@app/lib/types";
 
 import { buildAuthMethods } from "../identity/identity-fns";
+import { IdentityOrderBy } from "./membership-identity-types";
 
 export type TMembershipIdentityDALFactory = ReturnType<typeof membershipIdentityDALFactory>;
 
@@ -20,6 +22,8 @@ type TFindIdentityArg = {
     identityId: string;
     name: Omit<TSearchResourceOperator, "number">;
     role: Omit<TSearchResourceOperator, "number">;
+    orderBy: IdentityOrderBy;
+    orderDirection: OrderByDirection;
   }>;
 };
 
@@ -237,7 +241,8 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .distinct(`${TableName.Membership}.id`)
+        .select(`${TableName.Membership}.id`)
+        .groupBy(`${TableName.Membership}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, scopeData.orgId)
         .where((qb) => {
           if (filter.identityId) {
@@ -273,6 +278,11 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
         );
       }
 
+      if (filter.orderBy === IdentityOrderBy.Name) {
+        void paginatedIdentitys.groupBy(`${TableName.Identity}.name`);
+        void paginatedIdentitys.orderBy(`${TableName.Identity}.name`, filter.orderDirection);
+      }
+
       const countQuery = await (tx || db.replicaNode())
         .count("* as total")
         .from(paginatedIdentitys.clone().as("distinctMemberships"));
@@ -280,12 +290,11 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
       if (filter.limit) void paginatedIdentitys.limit(filter.limit);
       if (filter.offset) void paginatedIdentitys.offset(filter.offset);
 
-      const docs = await (tx || db.replicaNode())(TableName.Membership)
+      const query = (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorIdentityId`)
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .distinct(`${TableName.Membership}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, scopeData.orgId)
         .whereIn(`${TableName.Membership}.id`, paginatedIdentitys)
         .select(selectAllTableCols(TableName.Membership))
@@ -313,6 +322,12 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
           db.ref("createdAt").withSchema(TableName.MembershipRole).as("membershipRoleCreatedAt"),
           db.ref("updatedAt").withSchema(TableName.MembershipRole).as("membershipRoleUpdatedAt")
         );
+
+      if (filter.orderBy === IdentityOrderBy.Name) {
+        void query.orderByRaw(`lower(${TableName.Identity}.name) ${filter.orderDirection}`);
+      }
+
+      const docs = await query;
 
       const data = sqlNestRelationships({
         data: docs,

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -335,6 +335,8 @@ export const membershipIdentityServiceFactory = ({
       filter: {
         limit: dto.data.limit,
         offset: dto.data.offset,
+        orderBy: dto.data.orderBy,
+        orderDirection: dto.data.orderDirection,
         name: dto.data.identityName
           ? {
               [SearchResourceOperators.$contains]: dto.data.identityName

--- a/backend/src/services/membership-identity/membership-identity-types.ts
+++ b/backend/src/services/membership-identity/membership-identity-types.ts
@@ -1,5 +1,9 @@
 import { AccessScopeData, TemporaryPermissionMode } from "@app/db/schemas";
-import { OrgServiceActor } from "@app/lib/types";
+import { OrderByDirection, OrgServiceActor } from "@app/lib/types";
+
+export enum IdentityOrderBy {
+  Name = "name"
+}
 
 export interface TMembershipIdentityScopeFactory {
   onCreateMembershipIdentityGuard: (arg: TCreateMembershipIdentityDTO) => Promise<void>;
@@ -58,6 +62,8 @@ export type TListMembershipIdentityDTO = {
     offset?: number;
     identityName?: string;
     roles?: string[];
+    orderBy?: IdentityOrderBy;
+    orderDirection?: OrderByDirection;
   };
 };
 


### PR DESCRIPTION
This PR adds sorting capabilities to the project and organization identity listing endpoints. It also refactors the DAL to use a more efficient two-step pagination strategy.