### PR TITLE
feat(groups): add sorting to group user and identity listing

### DIFF
--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -228,7 +228,9 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
           )
           .optional()
           .describe(GROUPS.LIST_USERS.search),
-        filter: z.nativeEnum(FilterReturnedUsers).optional().describe(GROUPS.LIST_USERS.filterUsers)
+        filter: z.nativeEnum(FilterReturnedUsers).optional().describe(GROUPS.LIST_USERS.filterUsers),
+        orderBy: z.nativeEnum(GroupMembersOrderBy).optional().describe(GROUPS.LIST_USERS.orderBy),
+        orderDirection: z.nativeEnum(OrderByDirection).optional().describe(GROUPS.LIST_USERS.orderDirection)
       }),
       response: {
         200: z.object({
@@ -290,7 +292,9 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         filter: z
           .nativeEnum(FilterReturnedMachineIdentities)
           .optional()
-          .describe(GROUPS.LIST_MACHINE_IDENTITIES.filterMachineIdentities)
+          .describe(GROUPS.LIST_MACHINE_IDENTITIES.filterMachineIdentities),
+        orderBy: z.nativeEnum(GroupMembersOrderBy).optional().describe(GROUPS.LIST_MACHINE_IDENTITIES.orderBy),
+        orderDirection: z.nativeEnum(OrderByDirection).optional().describe(GROUPS.LIST_MACHINE_IDENTITIES.orderDirection)
       }),
       response: {
         200: z.object({

--- a/backend/src/ee/services/group/group-dal.ts
+++ b/backend/src/ee/services/group/group-dal.ts
@@ -121,6 +121,9 @@ export const groupDALFactory = (db: TDbClient) => {
     username?: string;
     search?: string;
     filter?: FilterReturnedUsers;
+    orderBy?: GroupMembersOrderBy;
+    orderDirection?: OrderByDirection;
+
   }) => {
     try {
       const query = db
@@ -148,8 +151,12 @@ export const groupDALFactory = (db: TDbClient) => {
           db.raw(`count(*) OVER() as total_count`)
         )
         .where({ isGhost: false })
-        .offset(offset)
-        .orderBy("firstName", "asc");
+        .offset(offset);
+
+      if (orderBy) {
+        void query.orderBy(orderBy, orderDirection === OrderByDirection.ASC ? "asc" : "desc");
+      }
+
 
       if (limit) {
         void query.limit(limit);
@@ -216,6 +223,9 @@ export const groupDALFactory = (db: TDbClient) => {
     limit?: number;
     search?: string;
     filter?: FilterReturnedMachineIdentities;
+    orderBy?: GroupMembersOrderBy;
+    orderDirection?: OrderByDirection;
+
   }) => {
     try {
       const query = db
@@ -240,8 +250,11 @@ export const groupDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.Identity).as("identityId"),
           db.raw(`count(*) OVER() as total_count`)
         )
-        .offset(offset)
-        .orderBy("name", "asc");
+        .offset(offset);
+
+      if (orderBy) {
+        void query.orderBy(orderBy, orderDirection === OrderByDirection.ASC ? "asc" : "desc");
+      }
 
       if (limit) {
         void query.limit(limit);

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -647,7 +647,9 @@ export const groupServiceFactory = ({
     actorAuthMethod,
     actorOrgId,
     search,
-    filter
+    filter,
+    orderBy,
+    orderDirection
   }: TListGroupUsersDTO) => {
     if (!actorOrgId) throw new UnauthorizedError({ message: "No organization ID provided in request" });
 
@@ -677,7 +679,9 @@ export const groupServiceFactory = ({
       limit,
       username,
       search,
-      filter
+      filter,
+      orderBy,
+      orderDirection
     });
 
     return { users: members, totalCount };
@@ -692,7 +696,9 @@ export const groupServiceFactory = ({
     actorAuthMethod,
     actorOrgId,
     search,
-    filter
+    filter,
+    orderBy,
+    orderDirection
   }: TListGroupMachineIdentitiesDTO) => {
     if (!actorOrgId) throw new UnauthorizedError({ message: "No organization ID provided in request" });
 
@@ -721,7 +727,9 @@ export const groupServiceFactory = ({
       offset,
       limit,
       search,
-      filter
+      filter,
+      orderBy,
+      orderDirection
     });
 
     return { machineIdentities, totalCount };

--- a/backend/src/ee/services/group/group-types.ts
+++ b/backend/src/ee/services/group/group-types.ts
@@ -43,6 +43,9 @@ export type TListGroupUsersDTO = {
   username?: string;
   search?: string;
   filter?: FilterReturnedUsers;
+  orderBy?: GroupMembersOrderBy;
+  orderDirection?: OrderByDirection;
+
 } & TGenericPermission;
 
 export type TListGroupMachineIdentitiesDTO = {
@@ -51,6 +54,9 @@ export type TListGroupMachineIdentitiesDTO = {
   limit: number;
   search?: string;
   filter?: FilterReturnedMachineIdentities;
+  orderBy?: GroupMembersOrderBy;
+  orderDirection?: OrderByDirection;
+
 } & TGenericPermission;
 
 export type TListGroupMembersDTO = {

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -115,7 +115,10 @@ export const GROUPS = {
     search: "The text string that user email or name will be filtered by.",
     projectId: "The ID of the project the group belongs to.",
     filterUsers:
-      "Whether to filter the list of returned users. 'existingMembers' will only return existing users in the group, 'nonMembers' will only return users not in the group, undefined will return all users in the organization."
+      "Whether to filter the list of returned users. 'existingMembers' will only return existing users in the group, 'nonMembers' will only return users not in the group, undefined will return all users in the organization.",
+    orderBy: "The column to order users by.",
+    orderDirection: "The direction to order users in."
+
   },
   LIST_MACHINE_IDENTITIES: {
     id: "The ID of the group to list identities for.",
@@ -123,7 +126,10 @@ export const GROUPS = {
     limit: "The number of identities to return.",
     search: "The text string that machine identity name will be filtered by.",
     filterMachineIdentities:
-      "Whether to filter the list of returned identities. 'assignedMachineIdentities' will only return identities assigned to the group, 'nonAssignedMachineIdentities' will only return identities not assigned to the group, undefined will return all identities in the organization."
+      "Whether to filter the list of returned identities. 'assignedMachineIdentities' will only return identities assigned to the group, 'nonAssignedMachineIdentities' will only return identities not assigned to the group, undefined will return all identities in the organization.",
+    orderBy: "The column to order identities by.",
+    orderDirection: "The direction to order identities in."
+
   },
   LIST_MEMBERS: {
     id: "The ID of the group to list members for.",


### PR DESCRIPTION
This PR adds sorting capabilities to the group user and identity listing endpoints.