### PR TITLE
fix(frontend): handle clipboard copy in non-secure contexts

### DIFF
--- a/frontend/src/components/v2/CopyButton/CopyButton.tsx
+++ b/frontend/src/components/v2/CopyButton/CopyButton.tsx
@@ -2,6 +2,7 @@ import { faCheck, faCopy, IconDefinition } from "@fortawesome/free-solid-svg-ico
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { twMerge } from "tailwind-merge";
 
+import { copyToClipboard } from "@app/helpers/clipboard";
 import { useTimedReset } from "@app/hooks";
 
 import { IconButton } from "../IconButton";
@@ -29,8 +30,8 @@ export const CopyButton = ({
   });
 
   async function handleCopyText() {
-    setCopyText("Copied");
-    navigator.clipboard.writeText(value);
+    const succeeded = await copyToClipboard(value);
+    setCopyText(succeeded ? "Copied" : "Copy failed");
   }
 
   return (

--- a/frontend/src/helpers/clipboard.ts
+++ b/frontend/src/helpers/clipboard.ts
@@ -1,0 +1,75 @@
+/**
+ * Copy text to the clipboard with a fallback for non-secure contexts.
+ *
+ * `navigator.clipboard` is only defined in secure contexts (HTTPS or localhost).
+ * Self-hosted Infisical instances served over plain HTTP — and some embedded
+ * browsers — leave it `undefined`, which would otherwise crash with
+ * `TypeError: Cannot read properties of undefined (reading 'writeText')`
+ * (see #6254).
+ *
+ * Strategy:
+ * 1. Use the modern Async Clipboard API when available.
+ * 2. Fall back to `document.execCommand('copy')` with a transient textarea.
+ *    Although deprecated, it is still supported by every major browser and
+ *    works in non-secure contexts.
+ *
+ * @returns `true` if the copy succeeded, `false` otherwise.
+ */
+export const copyToClipboard = async (value: string): Promise<boolean> => {
+  // Modern path — secure context with the Clipboard API
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch {
+      // Fall through to legacy path (e.g. permission denied in a focused-frame edge case)
+    }
+  }
+
+  // Legacy fallback — execCommand with a hidden textarea.
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  // Position off-screen but keep it visible to the layout so selection works.
+  // `position: fixed` avoids triggering page scroll on focus.
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "none";
+  textarea.style.outline = "none";
+  textarea.style.boxShadow = "none";
+  textarea.style.background = "transparent";
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("aria-hidden", "true");
+
+  document.body.appendChild(textarea);
+
+  try {
+    // Preserve any existing selection so we can restore it afterwards.
+    const previousSelection = document.getSelection();
+    const previousRange =
+      previousSelection && previousSelection.rangeCount > 0
+        ? previousSelection.getRangeAt(0)
+        : null;
+
+    textarea.select();
+    textarea.setSelectionRange(0, value.length);
+
+    const succeeded = document.execCommand("copy");
+
+    if (previousRange && previousSelection) {
+      previousSelection.removeAllRanges();
+      previousSelection.addRange(previousRange);
+    }
+
+    return succeeded;
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx
@@ -24,6 +24,7 @@ import {
   useProjectPermission
 } from "@app/context";
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
+import { copyToClipboard } from "@app/helpers/clipboard";
 import { usePopUp, useToggle } from "@app/hooks";
 import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { ProjectEnv, SecretType, SecretV3RawSanitized } from "@app/hooks/api/types";
@@ -173,7 +174,11 @@ export const SecretEditRow = ({
     try {
       const { data } = await refetchSecretValue();
 
-      await window.navigator.clipboard.writeText(data?.valueOverride ?? data?.value ?? "");
+      const succeeded = await copyToClipboard(data?.valueOverride ?? data?.value ?? "");
+      if (!succeeded) {
+        createNotification({ type: "error", text: "Failed to copy to clipboard" });
+        return;
+      }
       createNotification({ type: "success", text: "Copied secret to clipboard" });
     } catch (e) {
       console.error(e);

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -63,6 +63,7 @@ import {
   useSubscription
 } from "@app/context";
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
+import { copyToClipboard } from "@app/helpers/clipboard";
 import { usePopUp, useTimedReset, useToggle } from "@app/hooks";
 import { useUpdateSecretV3 } from "@app/hooks/api";
 import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
@@ -636,11 +637,17 @@ export const SecretEditTableRow = ({
 
   const handleCopySharedToClipboard = async () => {
     try {
+      let value: string;
       if (isPendingCreate) {
-        await window.navigator.clipboard.writeText((watchedValue as string) ?? "");
+        value = (watchedValue as string) ?? "";
       } else {
         const { data } = await refetchSharedValue();
-        await window.navigator.clipboard.writeText(data?.value ?? "");
+        value = data?.value ?? "";
+      }
+      const succeeded = await copyToClipboard(value);
+      if (!succeeded) {
+        createNotification({ type: "error", text: "Failed to copy to clipboard" });
+        return;
       }
       setIsCopied(true);
       createNotification({ type: "success", text: "Copied secret to clipboard" });

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
@@ -31,6 +31,7 @@ import {
   TooltipTrigger
 } from "@app/components/v3";
 import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import { copyToClipboard } from "@app/helpers/clipboard";
 import { useToggle } from "@app/hooks";
 import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { SecretType } from "@app/hooks/api/types";
@@ -139,7 +140,11 @@ export const SecretOverrideRow = ({
   const handleCopyOverrideToClipboard = async () => {
     try {
       const { data } = await refetchOverrideValue();
-      await window.navigator.clipboard.writeText(data?.valueOverride ?? "");
+      const succeeded = await copyToClipboard(data?.valueOverride ?? "");
+      if (!succeeded) {
+        createNotification({ type: "error", text: "Failed to copy to clipboard" });
+        return;
+      }
       createNotification({ type: "success", text: "Copied override to clipboard" });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Problem

When copying a secret on a self-hosted Infisical instance served over plain HTTP, the browser console throws:

```
TypeError: Cannot read properties of undefined (reading 'writeText')
```

The user sees a misleading "Failed to fetch secret value" toast, even though the fetch succeeded — the clipboard write is what failed.

## Root Cause

`navigator.clipboard` is **only defined in secure contexts** (HTTPS or localhost). On plain HTTP — common for self-hosted deployments behind reverse proxies — and in some embedded browsers, `navigator.clipboard` is `undefined`, so `navigator.clipboard.writeText(...)` throws synchronously.

The bug reporter's stack points at `SecretEditTableRow.tsx:handleCopySharedToClipboard`, but the same vulnerability exists at ~145 call sites across the frontend.

## Fix

Add a `copyToClipboard` helper at `frontend/src/helpers/clipboard.ts` with a two-tier strategy:

1. **Modern path** — use `navigator.clipboard.writeText` when available
2. **Legacy fallback** — use `document.execCommand('copy')` with an off-screen textarea. Deprecated but still supported by every major browser, and works in non-secure contexts.

Returns `boolean` so callers can show an accurate error toast when both paths fail. Preserves any existing user selection across the fallback path. Cleans up the textarea in `finally` so a thrown `execCommand` doesn't leak DOM.

## Wiring

- **`CopyButton`** (`frontend/src/components/v2/CopyButton`) — used in 50+ places for tokens, IDs, slugs, etc. Now shows "Copy failed" tooltip on failure
- **`SecretEditTableRow.handleCopySharedToClipboard`** — the exact site in the bug report
- **`SecretEditRow.handleCopySecretToClipboard`** — sibling row in `SecretOverviewTableRow`
- **`SecretOverrideRow.handleCopyOverrideToClipboard`** — override-value copy

Each updated call-site now shows `"Failed to copy to clipboard"` toast when the copy genuinely fails, instead of the misleading `"Failed to fetch secret value"`.

## Out of scope

There are ~140 other `navigator.clipboard.writeText` call sites across the frontend. They have the same latent bug but most are non-user-facing UUIDs/slugs/paths. Happy to migrate them in a follow-up PR if you'd like — just let me know your preference.

## Files Changed

| File | Change |
|---|---|
| `frontend/src/helpers/clipboard.ts` (new) | `copyToClipboard` utility with execCommand fallback |
| `frontend/src/components/v2/CopyButton/CopyButton.tsx` | Use the helper |
| `frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx` | Use the helper, show "Failed to copy" on failure |
| `frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx` | Use the helper |
| `frontend/src/pages/secret-manager/OverviewPage/components/SecretOverviewTableRow/SecretEditRow.tsx` | Use the helper |

Fixes #6254