### PR TITLE
fix(sync): use atomic Redis INCRBY for connection concurrency counter

### DIFF
--- a/backend/src/services/pki-sync/pki-sync-queue.ts
+++ b/backend/src/services/pki-sync/pki-sync-queue.ts
@@ -56,7 +56,7 @@ type TPkiSyncQueueFactoryDep = {
     "createCipherPairWithDataKey" | "decryptWithKmsKey" | "generateKmsKey" | "encryptWithKmsKey"
   >;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
-  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "getItem" | "incrementBy" | "setExpiry">;
   pkiSyncDAL: Pick<TPkiSyncDALFactory, "findById" | "find" | "updateById" | "deleteById" | "update">;
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
   projectDAL: TProjectDALFactory;
@@ -118,6 +118,12 @@ export const pkiSyncQueueFactory = ({
     unit: "1"
   });
 
+  // The counter expiry acts as a safety net so a stuck counter (e.g. process
+  // killed between increment and decrement) self-heals after the worst-case
+  // job lifetime. Refreshed on every increment to give an active connection a
+  // sliding window.
+  const CONCURRENCY_COUNTER_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000;
+
   const $isConnectionConcurrencyLimitReached = async (connectionId: string) => {
     const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
 
@@ -131,30 +137,29 @@ export const pkiSyncQueueFactory = ({
   };
 
   const $incrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const incrementedCount = Number.isNaN(currentCount) ? 1 : currentCount + 1;
-
-    await keyStore.setItemWithExpiry(
+    // Use the atomic Redis INCRBY to avoid a TOCTOU race between read and
+    // write that previously caused the counter to drift and stay stuck above
+    // the limit under concurrent load (#5563). The expiry must be set
+    // separately because INCRBY does not preserve or set TTL — refreshing it
+    // on every increment also gives long-running active connections a sliding
+    // window so the counter cannot expire mid-flight.
+    await keyStore.incrementBy(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId), 1);
+    await keyStore.setExpiry(
       KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      incrementedCount
+      CONCURRENCY_COUNTER_TTL_SECONDS
     );
   };
 
   const $decrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const decrementedCount = Math.max(0, Number.isNaN(currentCount) ? 0 : currentCount - 1);
-
-    await keyStore.setItemWithExpiry(
+    // Atomic decrement — same rationale as increment. INCRBY -1 may transiently
+    // go below 0 if increments and decrements race; the safety-net TTL ensures
+    // the counter eventually self-corrects. We still refresh the TTL on
+    // decrement so a counter that is non-zero after this call retains its
+    // expiry guarantee.
+    await keyStore.incrementBy(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId), -1);
+    await keyStore.setExpiry(
       KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      decrementedCount
+      CONCURRENCY_COUNTER_TTL_SECONDS
     );
   };
 

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -83,7 +83,7 @@ type TSecretSyncQueueFactoryDep = {
   queueService: Pick<TQueueServiceFactory, "queue" | "start" | "upsertJobScheduler">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
-  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "getItem" | "incrementBy" | "setExpiry">;
   folderDAL: TSecretFolderDALFactory;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
@@ -221,6 +221,12 @@ export const secretSyncQueueFactory = ({
     folderCommitService
   });
 
+  // The counter expiry acts as a safety net so a stuck counter (e.g. process
+  // killed between increment and decrement) self-heals after the worst-case
+  // job lifetime. Refreshed on every increment to give an active connection a
+  // sliding window.
+  const CONCURRENCY_COUNTER_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000;
+
   const $isConnectionConcurrencyLimitReached = async (connectionId: string) => {
     const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
 
@@ -234,30 +240,29 @@ export const secretSyncQueueFactory = ({
   };
 
   const $incrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const incrementedCount = Number.isNaN(currentCount) ? 1 : currentCount + 1;
-
-    await keyStore.setItemWithExpiry(
+    // Use the atomic Redis INCRBY to avoid a TOCTOU race between read and
+    // write that previously caused the counter to drift and stay stuck above
+    // the limit under concurrent load (#5563). The expiry must be set
+    // separately because INCRBY does not preserve or set TTL — refreshing it
+    // on every increment also gives long-running active connections a sliding
+    // window so the counter cannot expire mid-flight.
+    await keyStore.incrementBy(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId), 1);
+    await keyStore.setExpiry(
       KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      incrementedCount
+      CONCURRENCY_COUNTER_TTL_SECONDS
     );
   };
 
   const $decrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const decrementedCount = Math.max(0, Number.isNaN(currentCount) ? 0 : currentCount - 1);
-
-    await keyStore.setItemWithExpiry(
+    // Atomic decrement — same rationale as increment. INCRBY -1 may transiently
+    // go below 0 if increments and decrements race; the safety-net TTL ensures
+    // the counter eventually self-corrects. We still refresh the TTL on
+    // decrement so a counter that is non-zero after this call retains its
+    // expiry guarantee.
+    await keyStore.incrementBy(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId), -1);
+    await keyStore.setExpiry(
       KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      decrementedCount
+      CONCURRENCY_COUNTER_TTL_SECONDS
     );
   };
 


### PR DESCRIPTION
## Problem

The `AppConnectionConcurrentJobs` counter used a non-atomic read-modify-write pattern in both `pki-sync-queue.ts` and `secret-sync-queue.ts`:

```ts
const count = await keyStore.getItem(key);
await keyStore.setItemWithExpiry(key, ttl, count + 1);
```

Two concurrent increments reading the same value before either writes back will both set `N+1` instead of `N+2` — a TOCTOU race. Under sustained concurrent sync load this caused the counter to drift permanently above `CONNECTION_CONCURRENCY_LIMIT`, blocking all subsequent sync jobs with `"concurrency limit reached"` until manual intervention reset the Redis key (#5563).

## Fix

Replace the read-modify-write with Redis `INCRBY` (already exposed via `keyStore.incrementBy`), which executes atomically in Redis. Refresh the TTL with a separate `keyStore.setExpiry` call after each increment/decrement — `INCRBY` does not set or reset TTL on its own.

```ts
await keyStore.incrementBy(key, 1);
await keyStore.setExpiry(key, CONCURRENCY_COUNTER_TTL_SECONDS);
```

Refreshing the TTL on every operation gives long-lived active connections a sliding-window expiry that cannot lapse mid-flight.

## Subtleties considered

- **Below-zero on race**: `INCRBY -1` can transiently take the counter below 0 if a decrement races with an absent increment. This is harmless — the limit check is `count >= LIMIT`, and the safety-net TTL ensures the counter self-corrects within `REQUEUE_MS * REQUEUE_LIMIT` seconds (15 minutes by default).
- **Existing stuck counters self-heal**: After deploy, the next increment for any stuck connection refreshes the TTL, so previously-drifted counters expire and reset as soon as new traffic arrives.
- **Type narrowing**: widened `Pick<TKeyStoreFactory, ...>` to include `incrementBy` and `setExpiry`; dropped the now-unused `setItemWithExpiry` from both pickers.

## Files Changed

| File | Change |
|---|---|
| `backend/src/services/pki-sync/pki-sync-queue.ts` | Atomic increment/decrement + TTL refresh |
| `backend/src/services/secret-sync/secret-sync-queue.ts` | Same pattern (shared key prefix and limit semantics) |

Fixes #5563