### PR TITLE
fix(user): block last super admin from self-deleting

### DIFF
--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -310,6 +310,24 @@ export const userServiceFactory = ({
   };
 
   const deleteUser = async (userId: string) => {
+    // If the deleting user is the only remaining server admin, block self-deletion.
+    // The super_admin table's `initialized` flag is not reset on user delete, so
+    // letting the last super admin self-delete leaves /admin/signup permanently
+    // redirecting to /login — the instance becomes unrecoverable without direct
+    // DB intervention (#6091). The super-admin-service.deleteUser path enforces
+    // the same guard for admin-initiated deletes; this mirrors it for self-delete.
+    const userToDelete = await userDAL.findById(userId);
+
+    if (userToDelete?.superAdmin) {
+      const superAdmins = await userDAL.find({ superAdmin: true });
+      if (superAdmins.length === 1 && superAdmins[0].id === userId) {
+        throw new BadRequestError({
+          message:
+            "Cannot delete the only server admin on this instance. Promote another user to server admin before deleting this account."
+        });
+      }
+    }
+
     const user = await userDAL.deleteById(userId);
 
     try {


### PR DESCRIPTION
## Problem

`userService.deleteUser` is the self-delete entry point used by Personal Settings → "Delete my account". Unlike `superAdminService.deleteUser` (which guards admin-initiated deletes), it never checked whether the caller was the only remaining server admin.

When the last super admin self-deleted, three things broke together:

1. The `users` row was removed
2. The `super_admin.initialized` flag was never reset
3. `/admin/signup` permanently redirected to `/login` — the instance was still "initialized" but had no admin

Result: the self-hosted instance became unrecoverable without direct DB intervention (#6091).

## Why this approach

@akhilmhdh raised in the issue thread that auto-resetting the `initialized` flag would let any unauthenticated visitor claim super admin via `/admin/signup` immediately after the deletion — a privilege-escalation vector. The right answer is to block the destructive action when it would lock the instance.

The same guard already exists in `superAdminService.deleteUser` for admin-initiated deletes:

```ts
if (superAdmins.length === 1 && superAdmins[0].id === userId) {
  throw new BadRequestError({ message: "Cannot delete the only server admin..." });
}
```

This PR mirrors it for the self-delete path.

## Fix

```ts
const userToDelete = await userDAL.findById(userId);

if (userToDelete?.superAdmin) {
  const superAdmins = await userDAL.find({ superAdmin: true });
  if (superAdmins.length === 1 && superAdmins[0].id === userId) {
    throw new BadRequestError({
      message:
        "Cannot delete the only server admin on this instance. Promote another user to server admin before deleting this account."
    });
  }
}
```

The error message tells the user exactly what to do — promote another user first, then retry. Non-super-admin self-delete is unaffected (the guard only fires when `userToDelete.superAdmin === true`).

## Files Changed

- `backend/src/services/user/user-service.ts` — added the guard

Fixes #6091