### PR TITLE
fix(identity-k8s-auth): allow IPv6 bracket syntax in Kubernetes host URLs

### DIFF
--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -21,14 +21,21 @@ export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = f
     throw new BadRequestError({ message: "URLs with user credentials (e.g., user:pass@) are not allowed" });
   }
 
+  // URL.hostname keeps the surrounding brackets for IPv6 literals (RFC 3986 §3.2.2),
+  // e.g. `https://[::1]:6443` → hostname `"[::1]"`. `isIP` doesn't accept the
+  // bracketed form, so strip them before the IP check (#6095).
+  const rawHostname = validUrl.hostname;
+  const hostname =
+    rawHostname.startsWith("[") && rawHostname.endsWith("]") ? rawHostname.slice(1, -1) : rawHostname;
+
   const inputHostIps: string[] = [];
-  if (isIP(validUrl.hostname)) {
-    inputHostIps.push(validUrl.hostname);
+  if (isIP(hostname)) {
+    inputHostIps.push(hostname);
   } else {
-    if (validUrl.hostname === "localhost" || validUrl.hostname === "host.docker.internal") {
+    if (hostname === "localhost" || hostname === "host.docker.internal") {
       throw new BadRequestError({ message: "Local IPs not allowed as URL" });
     }
-    const entries = await dns.lookup(validUrl.hostname, { all: true });
+    const entries = await dns.lookup(hostname, { all: true });
 
     if (!entries || entries.length === 0) {
       throw new BadRequestError({ message: "Could not resolve hostname to any IP address" });

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -179,12 +179,18 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
                   CharacterType.Colon,
                   CharacterType.Period,
                   CharacterType.ForwardSlash,
-                  CharacterType.Hyphen
+                  CharacterType.Hyphen,
+                  // RFC 3986 §3.2.2 — IPv6 addresses in URLs must be wrapped in
+                  // square brackets, e.g. `https://[::1]:6443` or
+                  // `https://[fe80::1]:6443`. Without these, IPv6-only Kubernetes
+                  // clusters cannot be configured (#6095).
+                  CharacterType.OpenBracket,
+                  CharacterType.CloseBracket
                 ])(val);
               },
               {
                 message:
-                  "Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, and forward slashes."
+                  "Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, forward slashes, and square brackets (for IPv6)."
               }
             ),
           caCert: z.string().trim().default("").describe(KUBERNETES_AUTH.ATTACH.caCert),
@@ -355,12 +361,18 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
                   CharacterType.Colon,
                   CharacterType.Period,
                   CharacterType.ForwardSlash,
-                  CharacterType.Hyphen
+                  CharacterType.Hyphen,
+                  // RFC 3986 §3.2.2 — IPv6 addresses in URLs must be wrapped in
+                  // square brackets, e.g. `https://[::1]:6443` or
+                  // `https://[fe80::1]:6443`. Without these, IPv6-only Kubernetes
+                  // clusters cannot be configured (#6095).
+                  CharacterType.OpenBracket,
+                  CharacterType.CloseBracket
                 ])(val);
               },
               {
                 message:
-                  "Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, and forward slashes."
+                  "Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, forward slashes, and square brackets (for IPv6)."
               }
             ),
           caCert: z.string().trim().optional().describe(KUBERNETES_AUTH.UPDATE.caCert),


### PR DESCRIPTION
## Problem

IPv6 Kubernetes host URLs are rejected with:

```
Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, and forward slashes.
```

This blocks all IPv6-only Kubernetes clusters from configuring identity Kubernetes auth (#6095).

## Two layers needed

**Layer 1 — Zod validator rejects bracket syntax**

`identity-kubernetes-auth-router.ts` constrains `kubernetesHost` to a character whitelist that doesn't include `[` or `]`. RFC 3986 §3.2.2 requires IPv6 literals in URLs to be wrapped in square brackets — `https://[::1]:6443`, `https://[fe80::1]:6443` — so any IPv6 URL is rejected before reaching the SSRF check.

**Layer 2 — SSRF check doesn't strip brackets before `isIP()`**

`blockLocalAndPrivateIpAddresses` calls `isIP(validUrl.hostname)`. `URL.hostname` preserves the surrounding brackets for IPv6 literals — `new URL("https://[::1]:6443").hostname === "[::1]"` — but `isIP` rejects the bracketed form, so every IPv6 URL falls through to DNS lookup of `"[::1]"` and fails.

Both updates are required. Without (1) the request never reaches the SSRF check. Without (2) it's silently broken for IPv6.

## Fix

1. Add `OpenBracket` + `CloseBracket` to the kubernetesHost validator (both attach and update routes)
2. Strip the surrounding brackets from `URL.hostname` before passing to `isIP()`. The existing IPv6 private/loopback CIDRs in `lib/ip/ipRange.ts` then correctly classify the address — no further changes needed there.

Verified end-to-end:

| URL | hostname | stripped | isIP |
|---|---|---|---|
| `https://[::1]:6443` | `[::1]` | `::1` | 6 |
| `https://[fe80::1]:6443` | `[fe80::1]` | `fe80::1` | 6 |
| `https://kubernetes.default.svc:6443` | `kubernetes.default.svc` | (unchanged) | 0 (DNS lookup) |
| `https://10.96.0.1:6443` | `10.96.0.1` | (unchanged) | 4 |

## Out of scope

- **`kubernetes.default.svc.cluster.local` → 10.x rejection**: covered by the existing `ALLOW_INTERNAL_IP_CONNECTIONS=true` env flag (per @akhilmhdh's earlier comment). No code change.
- **`queryA ENOTFOUND` for AAAA-only hostnames**: upstream of this code (system getaddrinfo via dns.lookup with `family: 0`). Not addressable here without changing the network stack.

## Files Changed

| File | Change |
|---|---|
| `backend/src/server/routes/v1/identity-kubernetes-auth-router.ts` | Allow `[` and `]` in kubernetesHost validator (attach + update routes) |
| `backend/src/lib/validator/validate-url.ts` | Strip brackets before `isIP()` so IPv6 literals are recognized |

Fixes #6095