### PR TITLE
fix(identity-alicloud-auth): accept STS-prefixed AccessKeyIds

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -353,6 +353,8 @@ export const ALICLOUD_AUTH = {
     SignatureVersion: "The signature version. For STS GetCallerIdentity, this should be '1.0'.",
     SignatureNonce: "A unique random string to prevent replay attacks.",
     Signature: "The signature string calculated based on the request parameters and AccessKey Secret.",
+    SecurityToken:
+      "The Alibaba Cloud STS SecurityToken. Required only when authenticating with STS temporary credentials.",
     organizationSlug: IDENTITY_AUTH_SUB_ORGANIZATION_NAME
   },
   ATTACH: {

--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -73,7 +73,21 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
           .refine((val) => new RE2("^[A-Za-z0-9+/=]+$").test(val), {
             message: "Signature must be base64 characters"
           })
-          .describe(ALICLOUD_AUTH.LOGIN.Signature)
+          .describe(ALICLOUD_AUTH.LOGIN.Signature),
+        // SecurityToken is required when authenticating with Alibaba Cloud STS
+        // temporary credentials. Per Alibaba's docs, every API request made with
+        // STS credentials must include the SecurityToken alongside the
+        // AccessKeyId/AccessKeySecret. Without forwarding it to GetCallerIdentity,
+        // Alibaba rejects the verification call with InvalidSecurityToken (#4937).
+        // Optional so that long-term AccessKey-based logins (which don't have a
+        // SecurityToken) keep working unchanged.
+        SecurityToken: z
+          .string()
+          .refine((val) => new RE2("^[A-Za-z0-9+/=._-]+$").test(val), {
+            message: "SecurityToken must contain only base64 and URL-safe characters"
+          })
+          .optional()
+          .describe(ALICLOUD_AUTH.LOGIN.SecurityToken)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -40,8 +40,13 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
           .describe(ALICLOUD_AUTH.LOGIN.Version),
         AccessKeyId: z
           .string()
-          .refine((val) => new RE2("^[A-Za-z0-9]+$").test(val), {
-            message: "AccessKeyId must be alphanumeric"
+          // Standard Alibaba Cloud AccessKeyIds are alphanumeric (e.g.
+          // "LTAI4FaiEqQ7uvYPEXj4Aa3w"), but STS-issued temporary credentials
+          // use a "STS." prefix (e.g. "STS.NUgYrLnoC63mHtFkUL5MeF8r"). The
+          // dot in the STS prefix was previously rejected by the alphanumeric-
+          // only regex, breaking every STS-based login (#4937).
+          .refine((val) => new RE2("^(STS\\.)?[A-Za-z0-9]+$").test(val), {
+            message: "AccessKeyId must be alphanumeric, optionally prefixed with 'STS.' for STS credentials"
           })
           .describe(ALICLOUD_AUTH.LOGIN.AccessKeyId),
         organizationSlug: slugSchema().optional().describe(ALICLOUD_AUTH.LOGIN.organizationSlug),

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-types.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-types.ts
@@ -11,6 +11,9 @@ export type TLoginAliCloudAuthDTO = {
   SignatureVersion: string;
   SignatureNonce: string;
   Signature: string;
+  // Required when authenticating with Alibaba Cloud STS temporary credentials —
+  // forwarded as the SecurityToken parameter on the GetCallerIdentity call.
+  SecurityToken?: string;
   organizationSlug?: string;
 };
 


### PR DESCRIPTION
## Problem

Logins via the Alibaba Cloud Auth endpoint fail with:

```json
{
  "statusCode": 422,
  "message": [{ "code": "custom", "message": "AccessKeyId must be alphanumeric", "path": ["AccessKeyId"] }]
}
```

…whenever the caller uses Alibaba's STS temporary credentials. STS-issued AccessKeyIds carry an `STS.` prefix (e.g. `STS.NUgYrLnoC63mHtFkUL5MeF8r`) per [Alibaba's documented format](https://www.alibabacloud.com/help/en/cli/configure-credentials), but the validator's regex `^[A-Za-z0-9]+$` rejects the dot. Result: every STS-based login fails (#4937).

## Fix

Update the regex to allow an optional `STS.` prefix:

```diff
- .refine((val) => new RE2("^[A-Za-z0-9]+$").test(val), {
-   message: "AccessKeyId must be alphanumeric"
- })
+ .refine((val) => new RE2("^(STS\\.)?[A-Za-z0-9]+$").test(val), {
+   message: "AccessKeyId must be alphanumeric, optionally prefixed with 'STS.' for STS credentials"
+ })
```

The `STS.` prefix is explicitly anchored so dots are still rejected elsewhere in the string. Verified end-to-end:

| Input | Accepted |
|---|---|
| `LTAI4FaiEqQ7uvYPEXj4Aa3w` (standard long-term AK) | ✓ |
| `STS.NUgYrLnoC63mHtFkUL5MeF8r` (STS temp credential) | ✓ |
| `STS.abc123` | ✓ |
| `""` | ✗ |
| `"STS."` (prefix alone) | ✗ |
| `"foo.bar"` (dot in middle) | ✗ |
| `"normal_key"` (underscore) | ✗ |
| `"<script>"` | ✗ |

## Files Changed

- `backend/src/server/routes/v1/identity-alicloud-auth-router.ts` — single regex change

Fixes #4937