### PR TITLE
fix(identity): add legacy token expiration grace

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -245,6 +245,9 @@ const envSchema = z
         .default("90d")
         .transform((val) => Math.floor(ms(val) / 1000))
     ),
+    LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT: zpStr(
+      z.coerce.date().default(new Date("2026-05-04T00:00:00.000Z"))
+    ),
     // Oauth
     CLIENT_ID_GOOGLE_LOGIN: zpStr(z.string().optional()),
     CLIENT_SECRET_GOOGLE_LOGIN: zpStr(z.string().optional()),

--- a/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import {
-  computeIssuedTtl,
-  hasLegacyTokenWithoutExpExceededMaxAge,
-  LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT
-} from "./identity-access-token-fns";
+import { computeIssuedTtl, hasLegacyTokenWithoutExpExceededMaxAge } from "./identity-access-token-fns";
 
 const MAX_AGE = 7_776_000;
 const NOW = 1_700_000_000;
+const ENFORCED_AT = new Date("2026-05-04T00:00:00.000Z");
 
 vi.mock("@app/lib/config/env", () => ({
   getConfig: () => ({
@@ -122,8 +119,9 @@ describe("hasLegacyTokenWithoutExpExceededMaxAge", () => {
     expect(
       hasLegacyTokenWithoutExpExceededMaxAge({
         exp: NOW,
+        enforcedAt: ENFORCED_AT,
         maxAgeSeconds: MAX_AGE,
-        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
+        nowMs: ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
       })
     ).toBe(false);
   });
@@ -131,8 +129,9 @@ describe("hasLegacyTokenWithoutExpExceededMaxAge", () => {
   test("keeps no-exp legacy JWTs valid until deployment plus max age", () => {
     expect(
       hasLegacyTokenWithoutExpExceededMaxAge({
+        enforcedAt: ENFORCED_AT,
         maxAgeSeconds: MAX_AGE,
-        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000
+        nowMs: ENFORCED_AT.getTime() + MAX_AGE * 1000
       })
     ).toBe(false);
   });
@@ -140,8 +139,9 @@ describe("hasLegacyTokenWithoutExpExceededMaxAge", () => {
   test("expires no-exp legacy JWTs after deployment plus max age", () => {
     expect(
       hasLegacyTokenWithoutExpExceededMaxAge({
+        enforcedAt: ENFORCED_AT,
         maxAgeSeconds: MAX_AGE,
-        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
+        nowMs: ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
       })
     ).toBe(true);
   });

--- a/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { computeIssuedTtl } from "./identity-access-token-fns";
+import {
+  computeIssuedTtl,
+  hasLegacyTokenWithoutExpExceededMaxAge,
+  LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT
+} from "./identity-access-token-fns";
 
 const MAX_AGE = 7_776_000;
 const NOW = 1_700_000_000;
@@ -110,5 +114,35 @@ describe("computeIssuedTtl", () => {
       });
       expect(result).toBe(600);
     });
+  });
+});
+
+describe("hasLegacyTokenWithoutExpExceededMaxAge", () => {
+  test("does not apply to JWTs that already have exp", () => {
+    expect(
+      hasLegacyTokenWithoutExpExceededMaxAge({
+        exp: NOW,
+        maxAgeSeconds: MAX_AGE,
+        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
+      })
+    ).toBe(false);
+  });
+
+  test("keeps no-exp legacy JWTs valid until deployment plus max age", () => {
+    expect(
+      hasLegacyTokenWithoutExpExceededMaxAge({
+        maxAgeSeconds: MAX_AGE,
+        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000
+      })
+    ).toBe(false);
+  });
+
+  test("expires no-exp legacy JWTs after deployment plus max age", () => {
+    expect(
+      hasLegacyTokenWithoutExpExceededMaxAge({
+        maxAgeSeconds: MAX_AGE,
+        nowMs: LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1
+      })
+    ).toBe(true);
   });
 });

--- a/backend/src/services/identity-access-token/identity-access-token-fns.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.ts
@@ -15,6 +15,8 @@ import {
   TSignIdentityAccessTokenOutput
 } from "./identity-access-token-types";
 
+export const LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT = new Date("2026-05-04T00:00:00.000Z");
+
 export const hasNonWildcardTrustedIps = (trustedIps: TIp[] | null | undefined): boolean => {
   if (!trustedIps || trustedIps.length === 0) {
     return false;
@@ -86,6 +88,18 @@ export const hasFullRenewClaims = (decoded: TMinimalRenewClaims): decoded is TRe
 export const assertRevocableClaims = assertMinimalRenewClaims as (
   decoded: TIdentityAccessTokenJwtPayload
 ) => TRevocableClaims;
+
+export const hasLegacyTokenWithoutExpExceededMaxAge = ({
+  exp,
+  maxAgeSeconds,
+  nowMs = Date.now()
+}: {
+  exp?: number;
+  maxAgeSeconds: number;
+  nowMs?: number;
+}) =>
+  typeof exp !== "number" &&
+  nowMs > LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + maxAgeSeconds * 1000;
 
 // Compute the TTL (seconds) to sign the JWT with.
 //

--- a/backend/src/services/identity-access-token/identity-access-token-fns.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.ts
@@ -15,8 +15,6 @@ import {
   TSignIdentityAccessTokenOutput
 } from "./identity-access-token-types";
 
-export const LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT = new Date("2026-05-04T00:00:00.000Z");
-
 export const hasNonWildcardTrustedIps = (trustedIps: TIp[] | null | undefined): boolean => {
   if (!trustedIps || trustedIps.length === 0) {
     return false;
@@ -91,15 +89,15 @@ export const assertRevocableClaims = assertMinimalRenewClaims as (
 
 export const hasLegacyTokenWithoutExpExceededMaxAge = ({
   exp,
+  enforcedAt,
   maxAgeSeconds,
   nowMs = Date.now()
 }: {
   exp?: number;
+  enforcedAt: Date;
   maxAgeSeconds: number;
   nowMs?: number;
-}) =>
-  typeof exp !== "number" &&
-  nowMs > LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + maxAgeSeconds * 1000;
+}) => typeof exp !== "number" && nowMs > enforcedAt.getTime() + maxAgeSeconds * 1000;
 
 // Compute the TTL (seconds) to sign the JWT with.
 //

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -5,7 +5,11 @@ import { crypto } from "@app/lib/crypto";
 import { IPType, TIp } from "@app/lib/ip";
 
 import { AuthTokenType } from "../auth/auth-type";
-import { signIdentityAccessToken, verifyAccessTokenJwt } from "./identity-access-token-fns";
+import {
+  LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT,
+  signIdentityAccessToken,
+  verifyAccessTokenJwt
+} from "./identity-access-token-fns";
 import { identityAccessTokenServiceFactory } from "./identity-access-token-service";
 import { TIdentityAccessTokenJwtPayload } from "./identity-access-token-types";
 
@@ -515,6 +519,33 @@ describe("identityAccessTokenServiceFactory", () => {
     });
   });
 
+  test("renews no-exp legacy tokens with old iat during the deployment grace window", async () => {
+    const { service } = createService({ tokenRow: createLegacyTokenRow() });
+    const legacyToken = signLegacyUniversalAuthAccessToken(
+      { iat: NOW_SECONDS - MAX_AGE - 1 },
+      { expiresIn: undefined }
+    );
+
+    const renewed = await service.renewAccessToken({ accessToken: legacyToken });
+    const renewedClaims = verifyAccessTokenJwt(renewed.accessToken);
+
+    expect(renewedClaims).toMatchObject({
+      jti: "legacy-token-id",
+      identityId: "identity-id",
+      authMethod: IdentityAuthMethod.UNIVERSAL_AUTH
+    });
+  });
+
+  test("rejects no-exp legacy renewal after deployment plus MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
+    const { service } = createService({ tokenRow: createLegacyTokenRow() });
+    const legacyToken = signLegacyUniversalAuthAccessToken({}, { expiresIn: undefined });
+    vi.setSystemTime(
+      new Date(LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1)
+    );
+
+    await expect(service.renewAccessToken({ accessToken: legacyToken })).rejects.toThrow("exceeded max age");
+  });
+
   test("rejects legacy renewal when the PG row is missing", async () => {
     const { service } = createService({ tokenRow: null });
     const legacyToken = signLegacyUniversalAuthAccessToken();
@@ -548,12 +579,26 @@ describe("identityAccessTokenServiceFactory", () => {
     await expect(service.renewAccessToken({ accessToken: legacyToken })).rejects.toThrow("has reached its max TTL");
   });
 
-  test("rejects legacy JWTs without exp after MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
+  test("allows legacy JWTs without exp until deployment plus MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
     const { service } = createService();
 
     await expect(
       service.fnValidateIdentityAccessTokenFast(
         createTokenClaims({ exp: undefined, iat: NOW_SECONDS - MAX_AGE - 1 }),
+        "10.0.0.1"
+      )
+    ).resolves.toMatchObject({ identityId: "identity-id" });
+  });
+
+  test("rejects legacy JWTs without exp after deployment plus MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
+    const { service } = createService();
+    vi.setSystemTime(
+      new Date(LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1)
+    );
+
+    await expect(
+      service.fnValidateIdentityAccessTokenFast(
+        createTokenClaims({ exp: undefined, iat: NOW_SECONDS }),
         "10.0.0.1"
       )
     ).rejects.toThrow("exceeded max age");

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -5,22 +5,20 @@ import { crypto } from "@app/lib/crypto";
 import { IPType, TIp } from "@app/lib/ip";
 
 import { AuthTokenType } from "../auth/auth-type";
-import {
-  LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT,
-  signIdentityAccessToken,
-  verifyAccessTokenJwt
-} from "./identity-access-token-fns";
+import { signIdentityAccessToken, verifyAccessTokenJwt } from "./identity-access-token-fns";
 import { identityAccessTokenServiceFactory } from "./identity-access-token-service";
 import { TIdentityAccessTokenJwtPayload } from "./identity-access-token-types";
 
 const MAX_AGE = 7_776_000;
 const AUTH_SECRET = "test-auth-secret";
 const NOW_SECONDS = 1_700_000_000;
+const ENFORCED_AT = new Date("2026-05-04T00:00:00.000Z");
 
 vi.mock("@app/lib/config/env", () => ({
   getConfig: () => ({
     AUTH_SECRET,
-    MAX_MACHINE_IDENTITY_TOKEN_AGE: MAX_AGE
+    MAX_MACHINE_IDENTITY_TOKEN_AGE: MAX_AGE,
+    LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT: ENFORCED_AT
   })
 }));
 
@@ -539,9 +537,7 @@ describe("identityAccessTokenServiceFactory", () => {
   test("rejects no-exp legacy renewal after deployment plus MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
     const { service } = createService({ tokenRow: createLegacyTokenRow() });
     const legacyToken = signLegacyUniversalAuthAccessToken({}, { expiresIn: undefined });
-    vi.setSystemTime(
-      new Date(LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1)
-    );
+    vi.setSystemTime(new Date(ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1));
 
     await expect(service.renewAccessToken({ accessToken: legacyToken })).rejects.toThrow("exceeded max age");
   });
@@ -592,15 +588,10 @@ describe("identityAccessTokenServiceFactory", () => {
 
   test("rejects legacy JWTs without exp after deployment plus MAX_MACHINE_IDENTITY_TOKEN_AGE", async () => {
     const { service } = createService();
-    vi.setSystemTime(
-      new Date(LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1)
-    );
+    vi.setSystemTime(new Date(ENFORCED_AT.getTime() + MAX_AGE * 1000 + 1));
 
     await expect(
-      service.fnValidateIdentityAccessTokenFast(
-        createTokenClaims({ exp: undefined, iat: NOW_SECONDS }),
-        "10.0.0.1"
-      )
+      service.fnValidateIdentityAccessTokenFast(createTokenClaims({ exp: undefined, iat: NOW_SECONDS }), "10.0.0.1")
     ).rejects.toThrow("exceeded max age");
   });
 

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -16,6 +16,7 @@ import {
   assertRevocableClaims,
   computeIssuedTtl,
   hasFullRenewClaims,
+  hasLegacyTokenWithoutExpExceededMaxAge,
   hasNonWildcardTrustedIps,
   parseUsesRemaining,
   resolveTtlInputs,
@@ -256,11 +257,16 @@ export const identityAccessTokenServiceFactory = ({
         }
       : await loadLegacyTokenSource(token);
 
-    // Legacy tokens (pre-redesign) were signed without `expiresIn` so the JWT
-    // has no `exp`. For those, enforce the `iat + MAX_AGE` ceiling here.
+    // Legacy tokens (pre-redesign) may have no `exp`. Start the max-age clock
+    // at the enforcement deployment date so old tokens get a communication window.
     // New tokens always have `exp`; jwt.verify already rejected expired ones.
     const issuedAtMs = token.iat * 1000;
-    if (typeof token.exp !== "number" && Date.now() > issuedAtMs + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000) {
+    if (
+      hasLegacyTokenWithoutExpExceededMaxAge({
+        exp: token.exp,
+        maxAgeSeconds: appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE
+      })
+    ) {
       throw new UnauthorizedError({ message: "Identity access token exceeded max age, please re-authenticate" });
     }
 
@@ -336,10 +342,14 @@ export const identityAccessTokenServiceFactory = ({
     const appCfg = getConfig();
     const decodedToken = assertMinimalRenewClaims(verifyAccessTokenJwt(accessToken));
 
-    // Single-JWT max age. New-format validation enforces this on the hot path
-    // via the same check; mirror it here so legacy JWTs (which were signed
-    // with arbitrarily long expiresIn) can't renew themselves indefinitely.
-    if (decodedToken.iat * 1000 + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000 < Date.now()) {
+    // Single-JWT max age for legacy tokens without exp. New-format validation
+    // uses JWT exp; no-exp legacy tokens get a deployment-anchored grace window.
+    if (
+      hasLegacyTokenWithoutExpExceededMaxAge({
+        exp: decodedToken.exp,
+        maxAgeSeconds: appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE
+      })
+    ) {
       throw new UnauthorizedError({ message: "Identity access token exceeded max age, please re-authenticate" });
     }
 

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -264,6 +264,7 @@ export const identityAccessTokenServiceFactory = ({
     if (
       hasLegacyTokenWithoutExpExceededMaxAge({
         exp: token.exp,
+        enforcedAt: appCfg.LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT,
         maxAgeSeconds: appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE
       })
     ) {
@@ -347,6 +348,7 @@ export const identityAccessTokenServiceFactory = ({
     if (
       hasLegacyTokenWithoutExpExceededMaxAge({
         exp: decodedToken.exp,
+        enforcedAt: appCfg.LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT,
         maxAgeSeconds: appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE
       })
     ) {


### PR DESCRIPTION
## Context

PLATFOR-290 follow-up to PR #6234.

Legacy identity access tokens may not have an `exp` claim. PR #6234 added a max-age check for no-exp JWTs, but anchoring that check to each token's `iat` would immediately invalidate very old customer tokens when the redesign ships.

This updates no-exp legacy identity token handling to anchor the grace window to a configurable enforcement date instead: `LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT` + `MAX_MACHINE_IDENTITY_TOKEN_AGE`. The default enforcement date is May 4, 2026 for the cloud rollout, and self-hosted/backport deployments can override it to their own communication or upgrade date. Tokens that already have `exp` continue to rely on normal JWT verification.

## Screenshots

Not applicable. Backend-only auth behavior change.

## Steps to verify the change

- `npm run test:unit -- src/services/identity-access-token/identity-access-token-fns.test.ts src/services/identity-access-token/identity-access-token-service.test.ts`
- `npm run type:check`
- `npm run lint -- --quiet`

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g. `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)