### PR TITLE
feat(pam): add export and cell scroll to postgres web access

### DIFF
--- a/docs/documentation/platform/pam/product-reference/web-access/overview.mdx
+++ b/docs/documentation/platform/pam/product-reference/web-access/overview.mdx
@@ -37,7 +37,7 @@ sequenceDiagram
 | Setting | Value |
 |---------|-------|
 | **Max session duration** | 1 hour |
-| **Idle timeout** | 5 minutes (resets on any input) |
+| **Idle timeout** | 10 minutes (resets on any input) |
 | **Concurrent sessions** | 5 per user per project |
 
 Sessions that exceed the idle timeout or max duration are automatically terminated.

--- a/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
+++ b/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
@@ -44,7 +44,7 @@ The interface uses tabs to keep multiple working contexts open at once. Tabs com
 - **Table tabs** — opened by clicking a table in the sidebar. Clicking a table that is already open switches to its existing tab. To open a duplicate tab for the same table, right-click the table and choose **Open in new tab**, or hold <kbd>⌘</kbd> / <kbd>Ctrl</kbd> while clicking.
 - **Query tabs** — opened with the **+ New query** button in the tab bar.
 
-Each tab uses its own database connection, so transactions and uncommitted changes are scoped to the tab they were opened in.
+Each tab uses its own database connection, so transactions are scoped to the tab they were opened in.
 
 ## SQL Queries
 

--- a/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
+++ b/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
@@ -71,8 +71,6 @@ You can export the currently visible data from both table browse tabs and query 
 - **Download as CSV / JSON** — saves a file to your machine.
 - **Copy as CSV / JSON** — copies the data to your clipboard.
 
-Exports include only the rows currently loaded in the browser (the current page for browse tabs, up to 1,000 rows for query results).
-
 ## Limits
 
 In addition to the [common session limits](/documentation/platform/pam/product-reference/web-access/overview#session-limits), the following PostgreSQL-specific limits apply:

--- a/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
+++ b/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
@@ -33,8 +33,18 @@ Once connected, you get a spreadsheet-like interface for your database where you
 - Browse tables and explore their data
 - Filter and sort to quickly find what you need
 - Edit data directly — add, update, or delete rows
+- Export results as CSV or JSON (download or copy to clipboard)
 
 ![PostgreSQL Web Access Interface](/images/pam/product-reference/web-access/pg-data-explorer-overview.png)
+
+## Tabs
+
+The interface uses tabs to keep multiple working contexts open at once. Tabs come in two kinds:
+
+- **Table tabs** — opened by clicking a table in the sidebar. Clicking a table that is already open switches to its existing tab. To open a duplicate tab for the same table, right-click the table and choose **Open in new tab**, or hold <kbd>⌘</kbd> / <kbd>Ctrl</kbd> while clicking.
+- **Query tabs** — opened with the **+ New query** button in the tab bar.
+
+Each tab uses its own database connection, so transactions and uncommitted changes are scoped to the tab they were opened in.
 
 ## SQL Queries
 
@@ -44,11 +54,7 @@ The SQL query runner lets you run arbitrary SQL against your database without le
 
 ### Usage
 
-Click the **+** button in the tab bar to open a new query tab. Each tab has its own SQL editor and results panel.
-
 Write your query in the editor and run it by clicking **Run** or pressing `Cmd+Enter` (Mac) / `Ctrl+Enter` (Windows/Linux). Results are displayed in a table below the editor with column types, primary key, and foreign key indicators.
-
-You can open multiple query tabs at once. Tabs are independent: each has its own SQL content and results.
 
 #### Multi-statement queries
 
@@ -58,6 +64,15 @@ If you run multiple statements at once, the results of the last statement are sh
 
 `INSERT`, `UPDATE`, and `DELETE` statements display the number of affected rows instead of a result table.
 
+## Exporting Data
+
+You can export the currently visible data from both table browse tabs and query result panels. Click the download icon in the toolbar to open the export menu with the following options:
+
+- **Download as CSV / JSON** — saves a file to your machine.
+- **Copy as CSV / JSON** — copies the data to your clipboard.
+
+Exports include only the rows currently loaded in the browser (the current page for browse tabs, up to 1,000 rows for query results).
+
 ## Limits
 
 In addition to the [common session limits](/documentation/platform/pam/product-reference/web-access/overview#session-limits), the following PostgreSQL-specific limits apply:
@@ -66,6 +81,8 @@ In addition to the [common session limits](/documentation/platform/pam/product-r
 |---------|-------|
 | **Statement timeout** | 30 seconds per query |
 
+While the browser tab is in the foreground, sessions are kept alive against the [idle timeout](/documentation/platform/pam/product-reference/web-access/overview#session-limits) (10 minutes); the timeout starts counting once the tab becomes hidden. The max session duration still applies regardless.
+
 ## FAQ
 
 <AccordionGroup>
@@ -73,7 +90,7 @@ In addition to the [common session limits](/documentation/platform/pam/product-r
         Editing is only available for tables that have a primary key defined. Tables without a primary key, as well as views, are displayed in read-only mode.
     </Accordion>
     <Accordion title="Does the SQL query runner support transactions?">
-        Yes. You can use `BEGIN`, `COMMIT`, and `ROLLBACK` to manage transactions. An active transaction is shared across all query tabs — changes made in one tab are visible in others until you commit or roll back. The toolbar will show a **Transaction open** indicator while a transaction is in progress.
+        Yes. You can use `BEGIN`, `COMMIT`, and `ROLLBACK` to manage transactions. The toolbar will show a **Transaction open** indicator while a transaction is in progress.
     </Accordion>
     <Accordion title="Can I run only part of a query?">
         Yes. Select any portion of the SQL in the editor and click **Run Selection** (or press <kbd>⌘ Enter</kbd> / <kbd>Ctrl Enter</kbd>) to execute only the selected text.

--- a/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
+++ b/docs/documentation/platform/pam/product-reference/web-access/postgresql.mdx
@@ -66,7 +66,7 @@ If you run multiple statements at once, the results of the last statement are sh
 
 ## Exporting Data
 
-You can export the currently visible data from both table browse tabs and query result panels. Click the download icon in the toolbar to open the export menu with the following options:
+You can export the currently visible data from both table browse tabs and query result panels. Click the download icon to open the export menu with the following options:
 
 - **Download as CSV / JSON** — saves a file to your machine.
 - **Copy as CSV / JSON** — copies the data to your clipboard.

--- a/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
+++ b/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
@@ -209,8 +209,8 @@ export function ShortTextCell<TData>({
           onInput={onInput}
           suppressContentEditableWarning
           className={cn("size-full outline-none", {
-            "overflow-hidden": !isEditing,
-            "no-scrollbar overflow-x-auto": isEditing,
+            "overflow-hidden": !isEditing && !(isFocused && readOnly),
+            "no-scrollbar overflow-x-auto": isEditing || (isFocused && readOnly),
             "whitespace-nowrap **:inline **:whitespace-nowrap [&_br]:hidden": isEditing
           })}
         >

--- a/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
+++ b/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
@@ -211,7 +211,8 @@ export function ShortTextCell<TData>({
           className={cn("size-full outline-none", {
             "overflow-hidden": !isEditing && !(isFocused && readOnly),
             "no-scrollbar overflow-x-auto": isEditing || (isFocused && readOnly),
-            "whitespace-nowrap **:inline **:whitespace-nowrap [&_br]:hidden": isEditing
+            "whitespace-nowrap **:inline **:whitespace-nowrap [&_br]:hidden":
+              isEditing || (isFocused && readOnly)
           })}
         >
           {displayValue}

--- a/frontend/src/components/v3/generic/DataGrid/data-grid-cell-wrapper.tsx
+++ b/frontend/src/components/v3/generic/DataGrid/data-grid-cell-wrapper.tsx
@@ -165,13 +165,13 @@ export function DataGridCellWrapper<TData>({
           "bg-foreground/[0.07]": isSelected && !isEditing,
           "cursor-default": !isEditing,
           "**:data-[slot=grid-cell-content]:line-clamp-1 **:data-[slot=grid-cell-content]:break-all":
-            !isEditing && rowHeight === "short",
+            !isEditing && !(isFocused && readOnly) && rowHeight === "short",
           "**:data-[slot=grid-cell-content]:line-clamp-2 **:data-[slot=grid-cell-content]:break-all":
-            !isEditing && rowHeight === "medium",
+            !isEditing && !(isFocused && readOnly) && rowHeight === "medium",
           "**:data-[slot=grid-cell-content]:line-clamp-3 **:data-[slot=grid-cell-content]:break-all":
-            !isEditing && rowHeight === "tall",
+            !isEditing && !(isFocused && readOnly) && rowHeight === "tall",
           "**:data-[slot=grid-cell-content]:line-clamp-4 **:data-[slot=grid-cell-content]:break-all":
-            !isEditing && rowHeight === "extra-tall"
+            !isEditing && !(isFocused && readOnly) && rowHeight === "extra-tall"
         },
         className
       )}

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerGrid.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerGrid.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@app/components/v3/generic/Skeleton";
 
 import type { ColumnInfo, FieldInfo, ForeignKeyInfo, TableDetail } from "../data-explorer-types";
 import { getColumnIndicator } from "../data-explorer-utils";
+import { copyData, exportData } from "../data-export";
 import type { FilterCondition, SortCondition } from "../sql-generation";
 import {
   buildCountQuery,
@@ -713,6 +714,21 @@ export const DataExplorerGrid = ({
           await fetchData(offset, pageSize, filters, sorts);
         }}
         isRefreshing={isDataLoading && hasLoaded}
+        onExport={(fmt) =>
+          exportData(
+            currentData,
+            tableColumns.map((c) => c.name),
+            fmt
+          )
+        }
+        onCopy={(fmt) =>
+          copyData(
+            currentData,
+            tableColumns.map((c) => c.name),
+            fmt
+          )
+        }
+        hasData={currentData.length > 0}
       />
 
       {!hasPrimaryKey && (

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerToolbar.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerToolbar.tsx
@@ -14,7 +14,9 @@ import { Button } from "@app/components/v3/generic/Button";
 import { Popover, PopoverContent, PopoverTrigger } from "@app/components/v3/generic/Popover";
 
 import type { ColumnInfo } from "../data-explorer-types";
+import type { ExportFormat } from "../data-export";
 import type { FilterCondition, SortCondition } from "../sql-generation";
+import { ExportPopover } from "./ExportPopover";
 import { FilterPopover } from "./FilterPopover";
 import { SortPopover } from "./SortPopover";
 
@@ -41,6 +43,9 @@ type DataExplorerToolbarProps = {
   isDataLoading?: boolean;
   onRefresh: () => void;
   isRefreshing?: boolean;
+  onExport: (format: ExportFormat) => void;
+  onCopy: (format: ExportFormat) => void;
+  hasData: boolean;
 };
 
 export const DataExplorerToolbar = ({
@@ -65,7 +70,10 @@ export const DataExplorerToolbar = ({
   hasPrimaryKey,
   isDataLoading = false,
   onRefresh,
-  isRefreshing = false
+  isRefreshing = false,
+  onExport,
+  onCopy,
+  hasData
 }: DataExplorerToolbarProps) => {
   const rangeStart = totalCount === 0 ? 0 : offset + 1;
   const rangeEnd = Math.min(offset + pageSize, totalCount);
@@ -161,6 +169,9 @@ export const DataExplorerToolbar = ({
         >
           <ChevronRightIcon className="size-3.5" />
         </Button>
+
+        {/* Export */}
+        <ExportPopover onExport={onExport} onCopy={onCopy} disabled={!hasData} />
 
         {/* Refresh */}
         <Button

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerToolbar.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/DataExplorerToolbar.tsx
@@ -16,7 +16,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@app/components/v3/gene
 import type { ColumnInfo } from "../data-explorer-types";
 import type { ExportFormat } from "../data-export";
 import type { FilterCondition, SortCondition } from "../sql-generation";
-import { ExportPopover } from "./ExportPopover";
+import { ExportDropdown } from "./ExportDropdown";
 import { FilterPopover } from "./FilterPopover";
 import { SortPopover } from "./SortPopover";
 
@@ -171,7 +171,7 @@ export const DataExplorerToolbar = ({
         </Button>
 
         {/* Export */}
-        <ExportPopover onExport={onExport} onCopy={onCopy} disabled={!hasData} />
+        <ExportDropdown onExport={onExport} onCopy={onCopy} disabled={!hasData} />
 
         {/* Refresh */}
         <Button

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
@@ -21,8 +21,8 @@ export function ExportDropdown({ onExport, onCopy, disabled }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="xs" disabled={disabled} className="gap-1" title="Export">
-          <DownloadIcon className="size-3.5" />
+        <Button variant="ghost" size="xs" disabled={disabled} title="Export">
+          <DownloadIcon />
           Export
         </Button>
       </DropdownMenuTrigger>

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
@@ -18,7 +18,7 @@ type Props = {
   showLabel?: boolean;
 };
 
-export function ExportPopover({ onExport, onCopy, disabled, showLabel }: Props) {
+export function ExportDropdown({ onExport, onCopy, disabled, showLabel }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/ExportDropdown.tsx
@@ -15,22 +15,15 @@ type Props = {
   onExport: (format: ExportFormat) => void;
   onCopy: (format: ExportFormat) => void;
   disabled?: boolean;
-  showLabel?: boolean;
 };
 
-export function ExportDropdown({ onExport, onCopy, disabled, showLabel }: Props) {
+export function ExportDropdown({ onExport, onCopy, disabled }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={disabled}
-          className={showLabel ? "gap-1" : "size-7 p-0"}
-          title="Export"
-        >
+        <Button variant="ghost" size="xs" disabled={disabled} className="gap-1" title="Export">
           <DownloadIcon className="size-3.5" />
-          {showLabel && "Export"}
+          Export
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/ExportPopover.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/ExportPopover.tsx
@@ -15,14 +15,22 @@ type Props = {
   onExport: (format: ExportFormat) => void;
   onCopy: (format: ExportFormat) => void;
   disabled?: boolean;
+  showLabel?: boolean;
 };
 
-export function ExportPopover({ onExport, onCopy, disabled }: Props) {
+export function ExportPopover({ onExport, onCopy, disabled, showLabel }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="xs" disabled={disabled} className="size-7 p-0" title="Export">
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={disabled}
+          className={showLabel ? "gap-1" : "size-7 p-0"}
+          title="Export"
+        >
           <DownloadIcon className="size-3.5" />
+          {showLabel && "Export"}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/ExportPopover.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/ExportPopover.tsx
@@ -1,0 +1,49 @@
+import { ClipboardCopyIcon, DownloadIcon } from "lucide-react";
+
+import { Button } from "@app/components/v3/generic/Button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@app/components/v3/generic/Dropdown";
+
+import type { ExportFormat } from "../data-export";
+
+type Props = {
+  onExport: (format: ExportFormat) => void;
+  onCopy: (format: ExportFormat) => void;
+  disabled?: boolean;
+};
+
+export function ExportPopover({ onExport, onCopy, disabled }: Props) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="xs" disabled={disabled} className="size-7 p-0" title="Export">
+          <DownloadIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onExport("csv")}>
+          <DownloadIcon className="size-3.5" />
+          Download as CSV
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onExport("json")}>
+          <DownloadIcon className="size-3.5" />
+          Download as JSON
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => onCopy("csv")}>
+          <ClipboardCopyIcon className="size-3.5" />
+          Copy as CSV
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onCopy("json")}>
+          <ClipboardCopyIcon className="size-3.5" />
+          Copy as JSON
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
@@ -184,6 +184,7 @@ export function QueryPanel({
               </span>
               {result.rows.length > 0 && (
                 <ExportPopover
+                  showLabel
                   onExport={(fmt) =>
                     exportData(
                       result.rows,

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
@@ -184,7 +184,6 @@ export function QueryPanel({
               </span>
               {result.rows.length > 0 && (
                 <ExportDropdown
-                  showLabel
                   onExport={(fmt) =>
                     exportData(
                       result.rows,

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
@@ -6,7 +6,7 @@ import { cn } from "@app/components/v3/utils";
 import type { FieldInfo } from "../data-explorer-types";
 import { copyData, exportData } from "../data-export";
 import type { QueryTab } from "../use-query-tabs";
-import { ExportPopover } from "./ExportPopover";
+import { ExportDropdown } from "./ExportDropdown";
 import { QueryResultsTable } from "./QueryResultsTable";
 import { QueryToolbar } from "./QueryToolbar";
 import { SqlEditor } from "./SqlEditor";
@@ -183,7 +183,7 @@ export function QueryPanel({
                 {result.executionTimeMs}ms
               </span>
               {result.rows.length > 0 && (
-                <ExportPopover
+                <ExportDropdown
                   showLabel
                   onExport={(fmt) =>
                     exportData(

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/QueryPanel.tsx
@@ -4,7 +4,9 @@ import { GripHorizontalIcon } from "lucide-react";
 import { cn } from "@app/components/v3/utils";
 
 import type { FieldInfo } from "../data-explorer-types";
+import { copyData, exportData } from "../data-export";
 import type { QueryTab } from "../use-query-tabs";
+import { ExportPopover } from "./ExportPopover";
 import { QueryResultsTable } from "./QueryResultsTable";
 import { QueryToolbar } from "./QueryToolbar";
 import { SqlEditor } from "./SqlEditor";
@@ -172,7 +174,7 @@ export function QueryPanel({
             <QueryResultsTable result={result} error={error} isRunning={isRunning} />
           </div>
           {!isRunning && result && !error && (
-            <div className="flex shrink-0 items-center border-t border-mineshaft-600 px-3 py-1">
+            <div className="flex shrink-0 items-center justify-between border-t border-mineshaft-600 px-3 py-1">
               <span className="text-xs text-mineshaft-400">
                 {result.rowCount != null
                   ? getRowLabel(result.rowCount, result.isTruncated)
@@ -180,6 +182,24 @@ export function QueryPanel({
                 {" · "}
                 {result.executionTimeMs}ms
               </span>
+              {result.rows.length > 0 && (
+                <ExportPopover
+                  onExport={(fmt) =>
+                    exportData(
+                      result.rows,
+                      result.fields.map((f) => f.name),
+                      fmt
+                    )
+                  }
+                  onCopy={(fmt) =>
+                    copyData(
+                      result.rows,
+                      result.fields.map((f) => f.name),
+                      fmt
+                    )
+                  }
+                />
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/pam/PamDataExplorerPage/data-export.ts
+++ b/frontend/src/pages/pam/PamDataExplorerPage/data-export.ts
@@ -1,8 +1,13 @@
 export type ExportFormat = "csv" | "json";
 
+const FORMULA_PREFIXES = new Set(["=", "+", "-", "@"]);
+
 function escapeCsvField(value: unknown): string {
   if (value === null || value === undefined) return "";
-  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  let str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  if (FORMULA_PREFIXES.has(str.charAt(0))) {
+    str = `'${str}`;
+  }
   if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/frontend/src/pages/pam/PamDataExplorerPage/data-export.ts
+++ b/frontend/src/pages/pam/PamDataExplorerPage/data-export.ts
@@ -1,0 +1,70 @@
+export type ExportFormat = "csv" | "json";
+
+function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "object" ? JSON.stringify(value) : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function buildTimestamp(): string {
+  return new Date()
+    .toISOString()
+    .replace(/[:]/g, "-")
+    .replace(/\.\d+Z$/, "Z");
+}
+
+function buildCsv(rows: Record<string, unknown>[], columns: string[]): string {
+  const header = columns.map(escapeCsvField).join(",");
+  const body = rows
+    .map((row) => columns.map((col) => escapeCsvField(row[col])).join(","))
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+function buildJson(rows: Record<string, unknown>[], columns: string[]): string {
+  const filtered = rows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    columns.forEach((col) => {
+      obj[col] = row[col] ?? null;
+    });
+    return obj;
+  });
+  return JSON.stringify(filtered, null, 2);
+}
+
+function serialize(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  format: ExportFormat
+): string {
+  return format === "json" ? buildJson(rows, columns) : buildCsv(rows, columns);
+}
+
+export function exportData(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  format: ExportFormat
+): void {
+  if (rows.length === 0) return;
+  const content = serialize(rows, columns, format);
+  const mime = format === "json" ? "application/json;charset=utf-8;" : "text/csv;charset=utf-8;";
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `infisical_data_${buildTimestamp()}.${format}`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function copyData(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  format: ExportFormat
+): Promise<void> {
+  if (rows.length === 0) return;
+  await navigator.clipboard.writeText(serialize(rows, columns, format));
+}


### PR DESCRIPTION
## Context

added csv/json export (download + clipboard) to query results and browse toolbar, and made read-only cells scrollable on focus so you can actually see long values

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)