### PR TITLE
fix(frontend): replace &apos; HTML entity with apostrophe in commit sheet description

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
@@ -435,9 +435,9 @@ const ResourceChange: React.FC<ResourceChangeProps> = ({
 
   const referenceCount =
     change.resourceType === "secret" &&
-    change.type === PendingAction.Update &&
-    change.newSecretName &&
-    change.secretKey !== change.newSecretName
+      change.type === PendingAction.Update &&
+      change.newSecretName &&
+      change.secretKey !== change.newSecretName
       ? referenceCountMap[change.secretKey] || 0
       : 0;
 
@@ -623,7 +623,7 @@ export const CommitForm: React.FC<CommitFormProps> = ({
               </Badge>
             </SheetTitle>
             <SheetDescription>
-              Write a commit message and review the changes you&apos;re about to save.
+              Write a commit message and review the changes you're about to save.
             </SheetDescription>
           </SheetHeader>
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
@@ -435,9 +435,9 @@ const ResourceChange: React.FC<ResourceChangeProps> = ({
 
   const referenceCount =
     change.resourceType === "secret" &&
-      change.type === PendingAction.Update &&
-      change.newSecretName &&
-      change.secretKey !== change.newSecretName
+    change.type === PendingAction.Update &&
+    change.newSecretName &&
+    change.secretKey !== change.newSecretName
       ? referenceCountMap[change.secretKey] || 0
       : 0;
 
@@ -623,7 +623,7 @@ export const CommitForm: React.FC<CommitFormProps> = ({
               </Badge>
             </SheetTitle>
             <SheetDescription>
-              Write a commit message and review the changes you're about to save.
+              {" Write a commit message and review the changes you're about to save."}
             </SheetDescription>
           </SheetHeader>
 


### PR DESCRIPTION
## Context
The `SheetDescription` in the `CommitForm` component was using `&apos;` HTML entity inside JSX. Unlike plain HTML, JSX does not decode HTML entities, so it was rendering literally as `&apos;` on screen instead of an apostrophe `'`.

**Before:** `Write a commit message and review the changes you&apos;re about to save.`  
**After:** `Write a commit message and review the changes you're about to save.`

Fixes #6322

## Screenshots
Refer to the screenshots in the linked issue #6322.

## Steps to verify the change
1. Have a secret approval policy enabled on a project
2. Delete or modify an existing secret
3. Click through to the Commit Changes sheet
4. Verify the description now correctly reads:
   `Write a commit message and review the changes you're about to save.`

## Type
- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist
- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated [CLAUDE.md](http://CLAUDE.md) files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)