### PR TITLE
improvement(platfor-315): tolerate newer migration history on startup

### DIFF
--- a/backend/src/auto-start-migrations-fns.ts
+++ b/backend/src/auto-start-migrations-fns.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+
+import { type Knex } from "knex";
+
+type TMigrationConfig = {
+  directory: string;
+  loadExtensions: string[];
+  tableName: string;
+};
+
+type TMigrationBootDirection = {
+  direction: "ahead" | "behind" | "current" | "invalid";
+  unknownAppliedMigrationNames: string[];
+  pendingMigrationNames: string[];
+};
+
+const getMigrationTimestamp = (migrationName: string) => migrationName.match(/^(\d+)/)?.[1] ?? "";
+
+export const getMigrationBootDirection = ({
+  appliedMigrationNames,
+  bundledMigrationNames
+}: {
+  appliedMigrationNames: string[];
+  bundledMigrationNames: string[];
+}): TMigrationBootDirection => {
+  const appliedMigrationNameSet = new Set(appliedMigrationNames);
+  const bundledMigrationNameSet = new Set(bundledMigrationNames);
+
+  const unknownAppliedMigrationNames = appliedMigrationNames.filter(
+    (migrationName) => !bundledMigrationNameSet.has(migrationName)
+  );
+
+  const pendingMigrationNames = bundledMigrationNames.filter(
+    (migrationName) => !appliedMigrationNameSet.has(migrationName)
+  );
+
+  if (unknownAppliedMigrationNames.length && pendingMigrationNames.length) {
+    return {
+      direction: "invalid",
+      unknownAppliedMigrationNames,
+      pendingMigrationNames
+    };
+  }
+
+  const latestBundledMigrationTimestamp = bundledMigrationNames.map(getMigrationTimestamp).sort().at(-1) ?? "";
+  const hasOnlyNewerUnknownMigrations = unknownAppliedMigrationNames.every(
+    (migrationName) => getMigrationTimestamp(migrationName) > latestBundledMigrationTimestamp
+  );
+
+  if (unknownAppliedMigrationNames.length && hasOnlyNewerUnknownMigrations) {
+    return {
+      direction: "ahead",
+      unknownAppliedMigrationNames,
+      pendingMigrationNames: []
+    };
+  }
+
+  if (unknownAppliedMigrationNames.length) {
+    return {
+      direction: "invalid",
+      unknownAppliedMigrationNames,
+      pendingMigrationNames
+    };
+  }
+
+  if (pendingMigrationNames.length) {
+    return {
+      direction: "behind",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames
+    };
+  }
+
+  return {
+    direction: "current",
+    unknownAppliedMigrationNames: [],
+    pendingMigrationNames: []
+  };
+};
+
+export const getBundledMigrationNames = async (migrationConfig: TMigrationConfig) => {
+  const bundledMigrationNames = await fs.readdir(migrationConfig.directory);
+  return bundledMigrationNames
+    .filter((migrationName) => migrationConfig.loadExtensions.some((extension) => migrationName.endsWith(extension)))
+    .sort();
+};
+
+export const getAppliedMigrationNames = async (db: Knex, tableName: string) => {
+  const hasMigrationTable = await db.schema.hasTable(tableName);
+  if (!hasMigrationTable) {
+    return [];
+  }
+
+  const rows = (await db(tableName).select("name").orderBy("id")) as Array<{ name: string }>;
+  return rows.map(({ name }) => name);
+};
+
+export const getMigrationBootState = async ({
+  db,
+  migrationConfig
+}: {
+  db: Knex;
+  migrationConfig: TMigrationConfig;
+}) => {
+  const [appliedMigrationNames, bundledMigrationNames] = await Promise.all([
+    getAppliedMigrationNames(db, migrationConfig.tableName),
+    getBundledMigrationNames(migrationConfig)
+  ]);
+
+  return getMigrationBootDirection({ appliedMigrationNames, bundledMigrationNames });
+};

--- a/backend/src/auto-start-migrations.test.ts
+++ b/backend/src/auto-start-migrations.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { type Knex } from "knex";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getAppliedMigrationNames,
+  getMigrationBootDirection,
+  getMigrationBootState
+} from "./auto-start-migrations-fns";
+
+const migrationTableName = "infisical_migrations";
+const migrationConfig = {
+  directory: "",
+  loadExtensions: [".mjs", ".ts"],
+  tableName: migrationTableName
+};
+
+const testMigrationNames = {
+  first: "20260101000000_first.mjs",
+  second: "20260102000000_second.mjs",
+  renamedSecond: "20260102000000_renamed-second.mjs",
+  future: "20260103000000_future.mjs"
+};
+
+let tempDirs: string[] = [];
+
+const writeBundledMigrations = async (migrationNames: string[]) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "infisical-migrations-"));
+  tempDirs.push(tempDir);
+
+  await Promise.all(migrationNames.map((migrationName) => fs.writeFile(path.join(tempDir, migrationName), "")));
+
+  return {
+    ...migrationConfig,
+    directory: tempDir
+  };
+};
+
+const buildDbWithMissingMigrationTable = () =>
+  ({
+    schema: {
+      hasTable: vi.fn().mockResolvedValue(false)
+    }
+  }) as unknown as Knex;
+
+const buildDbWithAppliedMigrations = (migrationNames: string[]) => {
+  const orderBy = vi.fn().mockResolvedValue(migrationNames.map((name) => ({ name })));
+  const select = vi.fn().mockReturnValue({ orderBy });
+  const db = vi.fn().mockReturnValue({ select });
+
+  return Object.assign(db, {
+    schema: {
+      hasTable: vi.fn().mockResolvedValue(true)
+    }
+  }) as unknown as Knex;
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((tempDir) => fs.rm(tempDir, { force: true, recursive: true })));
+  tempDirs = [];
+  vi.restoreAllMocks();
+});
+
+describe("getMigrationBootDirection", () => {
+  it("returns current when applied migrations match bundled migrations", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.second],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      })
+    ).toEqual({
+      direction: "current",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames: []
+    });
+  });
+
+  it("returns behind when bundled migrations have not been applied yet", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      })
+    ).toEqual({
+      direction: "behind",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames: [testMigrationNames.second]
+    });
+  });
+
+  it("returns ahead when the database has migrations not bundled in this image", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.second, testMigrationNames.future],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      })
+    ).toEqual({
+      direction: "ahead",
+      unknownAppliedMigrationNames: [testMigrationNames.future],
+      pendingMigrationNames: []
+    });
+  });
+
+  it("treats first deployment as behind when no migrations have been applied", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      })
+    ).toEqual({
+      direction: "behind",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+    });
+  });
+
+  it("treats a restored forward image as current after the rollback migration is reapplied", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.second, testMigrationNames.future],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second, testMigrationNames.future]
+      })
+    ).toEqual({
+      direction: "current",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames: []
+    });
+  });
+
+  it("treats a manually applied migration from another image as ahead", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.second, testMigrationNames.future],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      }).direction
+    ).toBe("ahead");
+  });
+
+  it("treats a manually removed migration record as behind", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      }).direction
+    ).toBe("behind");
+  });
+
+  it("treats an unknown historical migration as invalid instead of rollback-safe ahead", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.renamedSecond],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second, testMigrationNames.future]
+      })
+    ).toMatchObject({
+      direction: "invalid",
+      unknownAppliedMigrationNames: [testMigrationNames.renamedSecond],
+      pendingMigrationNames: [testMigrationNames.second, testMigrationNames.future]
+    });
+  });
+
+  it("treats mixed unknown future migrations and missing bundled migrations as invalid", () => {
+    expect(
+      getMigrationBootDirection({
+        appliedMigrationNames: [testMigrationNames.first, testMigrationNames.future],
+        bundledMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+      })
+    ).toMatchObject({
+      direction: "invalid",
+      unknownAppliedMigrationNames: [testMigrationNames.future],
+      pendingMigrationNames: [testMigrationNames.second]
+    });
+  });
+});
+
+describe("getMigrationBootState", () => {
+  it("returns behind on first deployment when the migration table does not exist", async () => {
+    const testMigrationConfig = await writeBundledMigrations([testMigrationNames.first, testMigrationNames.second]);
+
+    await expect(
+      getMigrationBootState({
+        db: buildDbWithMissingMigrationTable(),
+        migrationConfig: testMigrationConfig
+      })
+    ).resolves.toEqual({
+      direction: "behind",
+      unknownAppliedMigrationNames: [],
+      pendingMigrationNames: [testMigrationNames.first, testMigrationNames.second]
+    });
+  });
+
+  it("returns ahead when a newer migration was deployed and the app code was rolled back", async () => {
+    const testMigrationConfig = await writeBundledMigrations([testMigrationNames.first, testMigrationNames.second]);
+
+    await expect(
+      getMigrationBootState({
+        db: buildDbWithAppliedMigrations([
+          testMigrationNames.first,
+          testMigrationNames.second,
+          testMigrationNames.future
+        ]),
+        migrationConfig: testMigrationConfig
+      })
+    ).resolves.toMatchObject({
+      direction: "ahead",
+      unknownAppliedMigrationNames: [testMigrationNames.future]
+    });
+  });
+
+  it("propagates database errors when the database is unavailable", async () => {
+    const testMigrationConfig = await writeBundledMigrations([testMigrationNames.first]);
+    const db = {
+      schema: {
+        hasTable: vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED"))
+      }
+    } as unknown as Knex;
+
+    await expect(
+      getMigrationBootState({
+        db,
+        migrationConfig: testMigrationConfig
+      })
+    ).rejects.toThrow("connect ECONNREFUSED");
+  });
+});
+
+describe("getAppliedMigrationNames", () => {
+  it("returns an empty list when the migration table does not exist", async () => {
+    await expect(getAppliedMigrationNames(buildDbWithMissingMigrationTable(), migrationTableName)).resolves.toEqual([]);
+  });
+});

--- a/backend/src/auto-start-migrations.ts
+++ b/backend/src/auto-start-migrations.ts
@@ -10,6 +10,7 @@ import { Logger } from "pino";
 import { getConfig } from "@app/lib/config/env";
 import { applyJitter, delay } from "@app/lib/delay";
 
+import { getMigrationBootState } from "./auto-start-migrations-fns";
 import { ensureClickHouseSchema } from "./db/clickhouse-migration-runner";
 import {
   acquireSanitizedSchemaLock,
@@ -37,13 +38,41 @@ const migrationConfig = {
   tableName: "infisical_migrations"
 };
 
-const migrationStatusCheckErrorHandler = (err: Error) => {
-  // happens for first time  in which the migration table itself is not created yet
-  //    error: select * from "infisical_migrations" - relation "infisical_migrations" does not exist
-  if (err?.message?.includes("does not exist")) {
-    return true;
-  }
-  throw err;
+const logUnknownAppliedMigrations = ({
+  databaseName,
+  logger,
+  unknownAppliedMigrationNames
+}: {
+  databaseName: string;
+  logger: Logger;
+  unknownAppliedMigrationNames: string[];
+}) => {
+  logger.warn(
+    {
+      databaseName,
+      unknownAppliedMigrationCount: unknownAppliedMigrationNames.length,
+      unknownAppliedMigrationNames: unknownAppliedMigrationNames.slice(-5)
+    },
+    `Database has migrations newer than this image [database=${databaseName}]. Skipping startup migrations.`
+  );
+};
+
+const throwInvalidMigrationHistory = ({
+  databaseName,
+  pendingMigrationNames,
+  unknownAppliedMigrationNames
+}: {
+  databaseName: string;
+  pendingMigrationNames: string[];
+  unknownAppliedMigrationNames: string[];
+}): never => {
+  throw new Error(
+    [
+      `Invalid migration history detected [database=${databaseName}].`,
+      `Unknown applied migrations: ${unknownAppliedMigrationNames.join(", ") || "none"}.`,
+      `Pending bundled migrations: ${pendingMigrationNames.join(", ") || "none"}.`
+    ].join(" ")
+  );
 };
 
 const getLockTableName = (tableName: string): string => {
@@ -345,10 +374,17 @@ export const runMigrations = async ({ applicationDb, auditLogDb, clickhouseClien
       logger.info("No ClickHouse client configured: Skipping ClickHouse audit_logs table creation.");
     }
 
-    const shouldRunMigration = Boolean(
-      await applicationDb.migrate.status(migrationConfig).catch(migrationStatusCheckErrorHandler)
-    ); // db.length - code.length
-    if (!shouldRunMigration) {
+    const applicationMigrationBootState = await getMigrationBootState({ db: applicationDb, migrationConfig });
+    if (applicationMigrationBootState.direction === "ahead") {
+      logUnknownAppliedMigrations({
+        databaseName: "application",
+        logger,
+        unknownAppliedMigrationNames: applicationMigrationBootState.unknownAppliedMigrationNames
+      });
+      return;
+    }
+
+    if (applicationMigrationBootState.direction === "current") {
       logger.info("No migrations pending: Skipping migration process.");
 
       if (generateSanitizedSchema) {
@@ -377,38 +413,89 @@ export const runMigrations = async ({ applicationDb, auditLogDb, clickhouseClien
       }
       return;
     }
+    if (applicationMigrationBootState.direction === "invalid") {
+      throwInvalidMigrationHistory({
+        databaseName: "application",
+        pendingMigrationNames: applicationMigrationBootState.pendingMigrationNames,
+        unknownAppliedMigrationNames: applicationMigrationBootState.unknownAppliedMigrationNames
+      });
+    }
 
     if (auditLogDb) {
-      await ensureMigrationTables(auditLogDb, logger);
-      logger.info("Running audit log migrations.");
-      const didPreviousInstanceRunMigration = !(await auditLogDb.migrate
-        .status(migrationConfig)
-        .catch(migrationStatusCheckErrorHandler));
-      if (didPreviousInstanceRunMigration) {
-        logger.info("No audit log migrations pending: Applied by previous instance. Skipping migration process.");
-        return;
-      }
+      const auditLogMigrationBootState = await getMigrationBootState({ db: auditLogDb, migrationConfig });
+      if (auditLogMigrationBootState.direction === "ahead") {
+        logUnknownAppliedMigrations({
+          databaseName: "audit-log",
+          logger,
+          unknownAppliedMigrationNames: auditLogMigrationBootState.unknownAppliedMigrationNames
+        });
+      } else if (auditLogMigrationBootState.direction === "current") {
+        logger.info("No audit log migrations pending: Skipping migration process.");
+      } else if (auditLogMigrationBootState.direction === "invalid") {
+        throwInvalidMigrationHistory({
+          databaseName: "audit-log",
+          pendingMigrationNames: auditLogMigrationBootState.pendingMigrationNames,
+          unknownAppliedMigrationNames: auditLogMigrationBootState.unknownAppliedMigrationNames
+        });
+      } else {
+        await ensureMigrationTables(auditLogDb, logger);
+        logger.info("Running audit log migrations.");
 
-      // Use startup lock to ensure only one instance runs migrations at a time
-      await withStartupLock(auditLogDb, logger, async () => {
-        await auditLogDb.migrate.latest(migrationConfig);
-      });
-      logger.info("Finished audit log migrations.");
+        // Use startup lock to ensure only one instance runs migrations at a time
+        await withStartupLock(auditLogDb, logger, async () => {
+          const lockedAuditLogMigrationBootState = await getMigrationBootState({ db: auditLogDb, migrationConfig });
+          if (lockedAuditLogMigrationBootState.direction === "ahead") {
+            logUnknownAppliedMigrations({
+              databaseName: "audit-log",
+              logger,
+              unknownAppliedMigrationNames: lockedAuditLogMigrationBootState.unknownAppliedMigrationNames
+            });
+            return;
+          }
+          if (lockedAuditLogMigrationBootState.direction === "current") {
+            logger.info("No audit log migrations pending: Applied by previous instance. Skipping migration process.");
+            return;
+          }
+          if (lockedAuditLogMigrationBootState.direction === "invalid") {
+            throwInvalidMigrationHistory({
+              databaseName: "audit-log",
+              pendingMigrationNames: lockedAuditLogMigrationBootState.pendingMigrationNames,
+              unknownAppliedMigrationNames: lockedAuditLogMigrationBootState.unknownAppliedMigrationNames
+            });
+          }
+
+          await auditLogDb.migrate.latest(migrationConfig);
+        });
+        logger.info("Finished audit log migrations.");
+      }
     }
 
     await ensureMigrationTables(applicationDb, logger);
     logger.info("Running application migrations.");
 
-    const didPreviousInstanceRunMigration = !(await applicationDb.migrate
-      .status(migrationConfig)
-      .catch(migrationStatusCheckErrorHandler));
-    if (didPreviousInstanceRunMigration) {
-      logger.info("No application migrations pending: Applied by previous instance. Skipping migration process.");
-      return;
-    }
-
     // Use startup lock to ensure only one instance runs migrations at a time
     await withStartupLock(applicationDb, logger, async () => {
+      const lockedApplicationMigrationBootState = await getMigrationBootState({ db: applicationDb, migrationConfig });
+      if (lockedApplicationMigrationBootState.direction === "ahead") {
+        logUnknownAppliedMigrations({
+          databaseName: "application",
+          logger,
+          unknownAppliedMigrationNames: lockedApplicationMigrationBootState.unknownAppliedMigrationNames
+        });
+        return;
+      }
+      if (lockedApplicationMigrationBootState.direction === "current") {
+        logger.info("No application migrations pending: Applied by previous instance. Skipping migration process.");
+        return;
+      }
+      if (lockedApplicationMigrationBootState.direction === "invalid") {
+        throwInvalidMigrationHistory({
+          databaseName: "application",
+          pendingMigrationNames: lockedApplicationMigrationBootState.pendingMigrationNames,
+          unknownAppliedMigrationNames: lockedApplicationMigrationBootState.unknownAppliedMigrationNames
+        });
+      }
+
       if (generateSanitizedSchema) await dropSanitizedSchema({ db: applicationDb, logger });
       await applicationDb.migrate.latest(migrationConfig);
     });


### PR DESCRIPTION
## Context

- Ensure that we do not panic when the db has newer migrations than currently running code. This is most common during rollbacks of code. 

## Steps to verify the change

- Run local tests

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)