### PR TITLE
feat: implement preferred entry selection for URL validation

### DIFF
--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -183,11 +183,15 @@ const notFoundError = (hostname: string): NodeJS.ErrnoException => {
   return err;
 };
 
+// v4 by default
+const pickPreferredEntry = (entries: LookupAddress[]): LookupAddress =>
+  entries.find((e) => e.family === 4) ?? entries[0];
+
 const makePinnedLookup = (entries: LookupAddress[]): LookupFunction =>
   ((hostname: string, optionsOrCb: unknown, maybeCb?: unknown) => {
     // Node may invoke `lookup(hostname, callback)` (2-arg) or `lookup(hostname, options, callback)` (3-arg).
     if (typeof optionsOrCb === "function") {
-      const first: LookupAddress = entries[0];
+      const first = pickPreferredEntry(entries);
       (optionsOrCb as TLookupOneCallback)(null, first.address, first.family);
       return;
     }
@@ -216,7 +220,7 @@ const makePinnedLookup = (entries: LookupAddress[]): LookupFunction =>
     if (opts.all) {
       (maybeCb as TLookupAllCallback)(null, entries);
     } else {
-      const first: LookupAddress = entries[0];
+      const first = pickPreferredEntry(entries);
       (maybeCb as TLookupOneCallback)(null, first.address, first.family);
     }
   }) as LookupFunction;


### PR DESCRIPTION
## Context

 For custom lookup used with pinned DNS results, pick an IPv4 LookupAddress when present instead of always using entries[0], so behavior aligns with “v4 by default” when both A and AAAA (or mixed order) exist.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)