### PR TITLE
feature: tab and stepper components

### DIFF
--- a/frontend/src/components/v3/generic/Stepper/Stepper.stories.tsx
+++ b/frontend/src/components/v3/generic/Stepper/Stepper.stories.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../Button";
+import { Stepper, StepperList, StepperStep } from "./Stepper";
+
+/**
+ * Stepper renders an ordered set of steps with per-step status (complete,
+ * current, pending, error) connected by a rail. Use it as the side panel of
+ * a multi-step setup flow (e.g. Secret Sync creation), where the user moves
+ * through a fixed sequence of stages. The stepper is a pure progress
+ * indicator — consumers render their own panel content next to it.
+ *
+ * Pass `onStepChange` to make completed steps clickable for back-navigation;
+ * pending steps stay non-interactive so users can't skip ahead past required
+ * input.
+ */
+const meta = {
+  title: "Generic/Stepper",
+  component: Stepper,
+  parameters: {
+    layout: "centered"
+  },
+  tags: ["autodocs"],
+  args: {
+    activeStep: 0
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} satisfies Meta<typeof Stepper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SETUP_STEPS = [
+  { title: "Provider", description: "Where to sync to" },
+  { title: "Source", description: "Pick env and path" },
+  { title: "Destination", description: "Connect provider" },
+  { title: "Sync Options", description: "Behavior + advanced" },
+  { title: "Details", description: "Name + description" },
+  { title: "Review", description: "Confirm" }
+] as const;
+
+function VerticalRender() {
+  const [step, setStep] = useState(1);
+  return (
+    <div className="flex w-[260px] flex-col gap-4">
+      <p className="text-xs font-semibold tracking-wider text-muted uppercase">Setup steps</p>
+      <Stepper activeStep={step} onStepChange={setStep}>
+        <StepperList>
+          {SETUP_STEPS.map((s, i) => (
+            <StepperStep key={s.title} index={i} title={s.title} description={s.description} />
+          ))}
+        </StepperList>
+      </Stepper>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={() => setStep((s) => Math.max(0, s - 1))}>
+          Back
+        </Button>
+        <Button
+          variant="project"
+          size="sm"
+          onClick={() => setStep((s) => Math.min(SETUP_STEPS.length - 1, s + 1))}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export const Vertical: Story = {
+  name: "Example: Vertical",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Default vertical layout used as a wizard sidebar. Completed steps show a green checkmark, the current step is ringed in warning yellow, pending steps are dimmed. Click Back/Next to advance — completed steps become clickable for back-navigation."
+      }
+    }
+  },
+  render: () => <VerticalRender />
+};
+
+function HorizontalRender() {
+  const [step, setStep] = useState(2);
+  return (
+    <div className="flex w-[640px] flex-col gap-6">
+      <Stepper activeStep={step} orientation="horizontal" onStepChange={setStep}>
+        <StepperList>
+          {SETUP_STEPS.slice(0, 4).map((s, i) => (
+            <StepperStep key={s.title} index={i} title={s.title} description={s.description} />
+          ))}
+        </StepperList>
+      </Stepper>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={() => setStep((s) => Math.max(0, s - 1))}>
+          Back
+        </Button>
+        <Button variant="project" size="sm" onClick={() => setStep((s) => Math.min(3, s + 1))}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export const Horizontal: Story = {
+  name: "Example: Horizontal",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Horizontal orientation for top-of-page wizards or short flows. Indicators sit above the labels and are connected by a horizontal rail."
+      }
+    }
+  },
+  render: () => <HorizontalRender />
+};
+
+function ErrorStateRender() {
+  return (
+    <div className="w-[260px]">
+      <Stepper activeStep={3}>
+        <StepperList>
+          <StepperStep index={0} title="Provider" description="Where to sync to" />
+          <StepperStep index={1} title="Source" description="Pick env and path" />
+          <StepperStep index={2} title="Destination" description="Connect provider" />
+          <StepperStep
+            index={3}
+            title="Sync Options"
+            description="Missing required field"
+            status="error"
+          />
+          <StepperStep index={4} title="Details" description="Name + description" />
+          <StepperStep index={5} title="Review" description="Confirm" />
+        </StepperList>
+      </Stepper>
+    </div>
+  );
+}
+
+export const ErrorState: Story = {
+  name: "Example: Error step",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass `status="error"` on a step that has a validation failure — the indicator switches to the danger color with an alert icon, and the title turns danger-colored. Use this when the user has visited a step but failed to satisfy its requirements before advancing.'
+      }
+    }
+  },
+  render: () => <ErrorStateRender />
+};
+
+function StaticRender() {
+  return (
+    <div className="w-[260px]">
+      <Stepper activeStep={2}>
+        <StepperList>
+          <StepperStep index={0} title="Initialize" description="Create the workspace" />
+          <StepperStep index={1} title="Configure" description="Set defaults" />
+          <StepperStep index={2} title="Deploy" description="Push to environment" />
+          <StepperStep index={3} title="Verify" description="Run smoke tests" />
+        </StepperList>
+      </Stepper>
+    </div>
+  );
+}
+
+export const Static: Story = {
+  name: "Example: Read-only",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Without `onStepChange`, the stepper is purely visual — useful for status displays where the user can't navigate (e.g. a deployment progress card)."
+      }
+    }
+  },
+  render: () => <StaticRender />
+};

--- a/frontend/src/components/v3/generic/Stepper/Stepper.tsx
+++ b/frontend/src/components/v3/generic/Stepper/Stepper.tsx
@@ -1,0 +1,262 @@
+/* eslint-disable react/prop-types */
+
+import * as React from "react";
+import { cva, type VariantProps } from "cva";
+import { AlertCircle, Check } from "lucide-react";
+
+import { cn } from "../../utils";
+
+type Orientation = "vertical" | "horizontal";
+type StepStatus = "complete" | "current" | "pending" | "error";
+
+interface StepperContextValue {
+  activeStep: number;
+  orientation: Orientation;
+  onStepChange?: (index: number) => void;
+}
+
+const StepperContext = React.createContext<StepperContextValue | null>(null);
+
+function useStepperContext() {
+  const ctx = React.useContext(StepperContext);
+  if (!ctx) {
+    throw new Error("Stepper subcomponents must be used within <Stepper />");
+  }
+  return ctx;
+}
+
+interface StepperProps extends React.ComponentProps<"div"> {
+  activeStep: number;
+  orientation?: Orientation;
+  onStepChange?: (index: number) => void;
+}
+
+function Stepper({
+  activeStep,
+  orientation = "vertical",
+  onStepChange,
+  className,
+  ...props
+}: StepperProps) {
+  const value = React.useMemo(
+    () => ({ activeStep, orientation, onStepChange }),
+    [activeStep, orientation, onStepChange]
+  );
+  return (
+    <StepperContext.Provider value={value}>
+      <div
+        data-slot="stepper"
+        data-orientation={orientation}
+        className={cn(
+          "group/stepper flex",
+          orientation === "vertical" ? "flex-col" : "flex-row",
+          className
+        )}
+        {...props}
+      />
+    </StepperContext.Provider>
+  );
+}
+
+interface StepperListProps extends Omit<React.ComponentProps<"ol">, "children"> {
+  children: React.ReactNode;
+}
+
+function StepperList({ children, className, ...props }: StepperListProps) {
+  const { orientation } = useStepperContext();
+  const items = React.Children.toArray(children);
+  return (
+    <ol
+      data-slot="stepper-list"
+      className={cn(
+        "flex",
+        orientation === "vertical" ? "flex-col" : "w-full flex-row items-start",
+        className
+      )}
+      {...props}
+    >
+      {items.map((child, i) => {
+        if (!React.isValidElement<StepperStepInjectedProps>(child)) return child;
+        return React.cloneElement(child, { isLast: i === items.length - 1 });
+      })}
+    </ol>
+  );
+}
+
+const indicatorVariants = cva(
+  "flex size-7 shrink-0 items-center justify-center rounded-full border text-xs font-medium transition-colors [&_svg]:size-3.5 [&_svg]:shrink-0",
+  {
+    variants: {
+      status: {
+        complete: "border-success bg-success/10 text-success",
+        current: "border-warning bg-warning/10 text-warning ring-3 ring-warning/20",
+        pending: "border-border bg-mineshaft-800 text-muted",
+        error: "border-danger bg-danger/10 text-danger"
+      }
+    },
+    defaultVariants: { status: "pending" }
+  }
+);
+
+const titleVariants = cva("text-sm font-semibold leading-tight transition-colors", {
+  variants: {
+    status: {
+      complete: "text-foreground",
+      current: "text-foreground",
+      pending: "text-muted",
+      error: "text-danger"
+    }
+  },
+  defaultVariants: { status: "pending" }
+});
+
+interface StepperStepInjectedProps {
+  isLast?: boolean;
+}
+
+interface StepperStepProps
+  extends Omit<React.ComponentProps<"li">, "title">,
+    StepperStepInjectedProps,
+    VariantProps<typeof indicatorVariants> {
+  index: number;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  status?: "error";
+  disabled?: boolean;
+}
+
+function StepperStep({
+  index,
+  title,
+  description,
+  status: statusOverride,
+  disabled,
+  isLast,
+  className,
+  ...props
+}: StepperStepProps) {
+  const { activeStep, orientation, onStepChange } = useStepperContext();
+
+  let computedStatus: StepStatus;
+  if (statusOverride === "error") computedStatus = "error";
+  else if (index < activeStep) computedStatus = "complete";
+  else if (index === activeStep) computedStatus = "current";
+  else computedStatus = "pending";
+
+  const isClickable =
+    !disabled &&
+    Boolean(onStepChange) &&
+    (computedStatus === "complete" || computedStatus === "error");
+
+  let indicatorContent: React.ReactNode = index + 1;
+  if (computedStatus === "complete") indicatorContent = <Check strokeWidth={3} />;
+  else if (computedStatus === "error") indicatorContent = <AlertCircle />;
+
+  const indicator = (
+    <span
+      aria-hidden="true"
+      data-slot="stepper-indicator"
+      data-status={computedStatus}
+      className={cn(indicatorVariants({ status: computedStatus }))}
+    >
+      {indicatorContent}
+    </span>
+  );
+
+  const labels = (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <span className={cn(titleVariants({ status: computedStatus }))}>{title}</span>
+      {description ? <span className="text-xs leading-snug text-muted">{description}</span> : null}
+    </div>
+  );
+
+  const connectorActive = computedStatus === "complete";
+
+  if (orientation === "vertical") {
+    const handleClick = isClickable ? () => onStepChange?.(index) : undefined;
+    const Tag: "button" | "div" = isClickable ? "button" : "div";
+    const interactiveProps = isClickable
+      ? {
+          type: "button" as const,
+          onClick: handleClick,
+          disabled
+        }
+      : {};
+
+    return (
+      <li
+        data-slot="stepper-step"
+        data-status={computedStatus}
+        aria-current={computedStatus === "current" ? "step" : undefined}
+        className={cn("flex gap-3", className)}
+        {...props}
+      >
+        <div className="flex flex-col items-center">
+          {indicator}
+          {!isLast ? (
+            <span
+              aria-hidden="true"
+              data-slot="stepper-connector"
+              className={cn(
+                "w-px flex-1 transition-colors",
+                connectorActive ? "bg-success/60" : "bg-border"
+              )}
+            />
+          ) : null}
+        </div>
+        <Tag
+          {...interactiveProps}
+          className={cn(
+            "-mt-1 flex flex-1 flex-col text-left",
+            !isLast && "pb-8",
+            isClickable &&
+              "-mx-1 cursor-pointer rounded-md px-1 outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+            !isClickable && "cursor-default"
+          )}
+        >
+          {labels}
+        </Tag>
+      </li>
+    );
+  }
+
+  // horizontal
+  return (
+    <li
+      data-slot="stepper-step"
+      data-status={computedStatus}
+      aria-current={computedStatus === "current" ? "step" : undefined}
+      className={cn("relative flex flex-1 items-start", className)}
+      {...props}
+    >
+      {isClickable ? (
+        <button
+          type="button"
+          onClick={() => onStepChange?.(index)}
+          disabled={disabled}
+          className="flex w-full cursor-pointer flex-col items-center gap-2 rounded-md text-center outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+        >
+          {indicator}
+          {labels}
+        </button>
+      ) : (
+        <div className="flex w-full cursor-default flex-col items-center gap-2 text-center">
+          {indicator}
+          {labels}
+        </div>
+      )}
+      {!isLast ? (
+        <span
+          aria-hidden="true"
+          data-slot="stepper-connector"
+          className={cn(
+            "absolute top-3.5 right-[calc(-50%+14px)] left-[calc(50%+14px)] h-px transition-colors",
+            connectorActive ? "bg-success/60" : "bg-border"
+          )}
+        />
+      ) : null}
+    </li>
+  );
+}
+
+export { Stepper, StepperList, StepperStep };

--- a/frontend/src/components/v3/generic/Stepper/index.ts
+++ b/frontend/src/components/v3/generic/Stepper/index.ts
@@ -1,0 +1,1 @@
+export { Stepper, StepperList, StepperStep } from "./Stepper";

--- a/frontend/src/components/v3/generic/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/v3/generic/Tabs/Tabs.stories.tsx
@@ -1,0 +1,444 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CreditCard, Info, Key, Lock, Plus, ScrollText, Settings, User, Users } from "lucide-react";
+
+import { Button } from "../Button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "../Card";
+import { Field, FieldLabel } from "../Field";
+import { Input } from "../Input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../Select";
+import { Switch } from "../Switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
+
+/**
+ * Tabs render a horizontal or vertical set of triggers that swap a single
+ * region of content. Built on Radix so keyboard navigation and ARIA wiring
+ * come for free. Pick `filled` for primary view switching where the
+ * segmented control reads as a control surface; pick one of the colored
+ * underline variants (`project`, `org`, `sub-org`, `admin`) for in-page
+ * section navigation tied to that identity surface.
+ */
+const meta = {
+  title: "Generic/Tabs",
+  component: Tabs,
+  parameters: {
+    layout: "centered"
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function FilledRender() {
+  const [value, setValue] = useState("account");
+  return (
+    <Tabs value={value} onValueChange={setValue} className="w-[420px]">
+      <TabsList>
+        <TabsTrigger value="account">Account</TabsTrigger>
+        <TabsTrigger value="password">Password</TabsTrigger>
+        <TabsTrigger value="notifications">Notifications</TabsTrigger>
+      </TabsList>
+      <TabsContent value="account" className="rounded-md border border-border p-4">
+        Manage your account details, display name, and contact email.
+      </TabsContent>
+      <TabsContent value="password" className="rounded-md border border-border p-4">
+        Update your password and review recent sign-in activity.
+      </TabsContent>
+      <TabsContent value="notifications" className="rounded-md border border-border p-4">
+        Choose which product and security notifications you want to receive.
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export const Filled: Story = {
+  name: "Example: Filled",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default filled segmented variant — use for primary view switching where the tab strip reads as a discrete control. The list sits in a subtly-tinted bordered pill; the active trigger lifts onto a brighter surface tone with its own thin border."
+      }
+    }
+  },
+  render: () => <FilledRender />
+};
+
+function ColoredVariantRender({ variant }: { variant: "project" | "org" | "sub-org" | "admin" }) {
+  const [value, setValue] = useState("overview");
+  return (
+    <Tabs value={value} onValueChange={setValue} className="w-[420px]">
+      <TabsList variant={variant}>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="activity">Activity</TabsTrigger>
+        <TabsTrigger value="settings">Settings</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview" className="pt-4">
+        High-level summary of the resource and its current state.
+      </TabsContent>
+      <TabsContent value="activity" className="pt-4">
+        Recent events, audit log entries, and lifecycle changes.
+      </TabsContent>
+      <TabsContent value="settings" className="pt-4">
+        Configuration options for this resource.
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export const Project: Story = {
+  name: "Example: Project",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Underline variant for project-scoped pages — the active trigger picks up the project identity color."
+      }
+    }
+  },
+  render: () => <ColoredVariantRender variant="project" />
+};
+
+export const Org: Story = {
+  name: "Example: Org",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Underline variant for organization-scoped pages — the active trigger picks up the org identity color."
+      }
+    }
+  },
+  render: () => <ColoredVariantRender variant="org" />
+};
+
+export const SubOrg: Story = {
+  name: "Example: Sub-org",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Underline variant for sub-organization-scoped pages — the active trigger picks up the sub-org identity color."
+      }
+    }
+  },
+  render: () => <ColoredVariantRender variant="sub-org" />
+};
+
+export const Admin: Story = {
+  name: "Example: Admin",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Underline variant for admin-scoped pages — the active trigger picks up the admin identity color."
+      }
+    }
+  },
+  render: () => <ColoredVariantRender variant="admin" />
+};
+
+function WithIconsRender() {
+  const [value, setValue] = useState("general");
+  return (
+    <Tabs value={value} onValueChange={setValue} className="w-[460px]">
+      <TabsList>
+        <TabsTrigger value="general">
+          <Settings />
+          General
+        </TabsTrigger>
+        <TabsTrigger value="members">
+          <Users />
+          Members
+        </TabsTrigger>
+        <TabsTrigger value="audit">
+          <ScrollText />
+          Audit logs
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="general" className="rounded-md border border-border p-4">
+        Workspace name, default region, and other top-level configuration.
+      </TabsContent>
+      <TabsContent value="members" className="rounded-md border border-border p-4">
+        Invite teammates, manage roles, and review pending invitations.
+      </TabsContent>
+      <TabsContent value="audit" className="rounded-md border border-border p-4">
+        Searchable history of administrative actions across the workspace.
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export const WithIcons: Story = {
+  name: "Example: With icons",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Drop a `lucide-react` icon beside the label inside each `TabsTrigger` — sizing and trigger padding adjust automatically. Use sparingly to anchor frequently-used sections; pure-text triggers usually read cleaner."
+      }
+    }
+  },
+  render: () => <WithIconsRender />
+};
+
+function DisabledRender() {
+  const [value, setValue] = useState("overview");
+  return (
+    <Tabs value={value} onValueChange={setValue} className="w-[460px]">
+      <TabsList variant="project">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="integrations">Integrations</TabsTrigger>
+        <TabsTrigger value="scim" disabled>
+          SCIM
+        </TabsTrigger>
+        <TabsTrigger value="audit">Audit logs</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview" className="pt-4">
+        High-level summary of the resource and its current state.
+      </TabsContent>
+      <TabsContent value="integrations" className="pt-4">
+        Connect this resource to external systems and identity providers.
+      </TabsContent>
+      <TabsContent value="scim" className="pt-4">
+        SCIM directory sync is part of the Enterprise plan.
+      </TabsContent>
+      <TabsContent value="audit" className="pt-4">
+        Recent events, audit log entries, and lifecycle changes.
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export const Disabled: Story = {
+  name: "Example: Disabled tab",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `disabled` to a `TabsTrigger` to gate sections behind a plan, role, or feature flag. The trigger fades, becomes unclickable, and is skipped during keyboard navigation — Radix handles the ARIA state."
+      }
+    }
+  },
+  render: () => <DisabledRender />
+};
+
+function ControlledTabsRender() {
+  const [value, setValue] = useState<"editor" | "preview" | "diff">("editor");
+  return (
+    <div className="flex w-[420px] flex-col gap-3">
+      <Tabs value={value} onValueChange={(next) => setValue(next as typeof value)}>
+        <TabsList>
+          <TabsTrigger value="editor">Editor</TabsTrigger>
+          <TabsTrigger value="preview">Preview</TabsTrigger>
+          <TabsTrigger value="diff">Diff</TabsTrigger>
+        </TabsList>
+        <TabsContent value="editor" className="rounded-md border border-border p-4">
+          Edit the document source directly.
+        </TabsContent>
+        <TabsContent value="preview" className="rounded-md border border-border p-4">
+          Rendered preview of the current draft.
+        </TabsContent>
+        <TabsContent value="diff" className="rounded-md border border-border p-4">
+          Compare the draft against the last published version.
+        </TabsContent>
+      </Tabs>
+      <p className="text-muted-foreground text-xs">
+        Active value: <code>{value}</code>
+      </p>
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  name: "Example: Controlled",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Drive selection from outside by pairing `value` with `onValueChange`. Use this when the active tab needs to round-trip through URL search params, a parent reducer, or an analytics event — `defaultValue` is uncontrolled and won't sync."
+      }
+    }
+  },
+  render: () => <ControlledTabsRender />
+};
+
+function VerticalRender() {
+  const [value, setValue] = useState("profile");
+  return (
+    <Tabs orientation="vertical" value={value} onValueChange={setValue} className="w-[480px]">
+      <TabsList variant="project" className="w-40 shrink-0">
+        <TabsTrigger value="profile">
+          <User />
+          Profile
+        </TabsTrigger>
+        <TabsTrigger value="security">
+          <Lock />
+          Security
+        </TabsTrigger>
+        <TabsTrigger value="billing">
+          <CreditCard />
+          Billing
+        </TabsTrigger>
+        <TabsTrigger value="api-keys">
+          <Key />
+          API keys
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="profile" className="rounded-md border border-border p-4">
+        Personal details, avatar, and locale preferences.
+      </TabsContent>
+      <TabsContent value="security" className="rounded-md border border-border p-4">
+        Two-factor settings, active sessions, and recovery options.
+      </TabsContent>
+      <TabsContent value="billing" className="rounded-md border border-border p-4">
+        Payment method, invoices, and plan changes.
+      </TabsContent>
+      <TabsContent value="api-keys" className="rounded-md border border-border p-4">
+        Issue and revoke personal API keys for scripting.
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export const Vertical: Story = {
+  name: "Example: Vertical",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pair `orientation="vertical"` with one of the underline variants for settings-style layouts where the tab strip becomes a side rail. The colored indicator rides the left edge of the active trigger; icons sit naturally to the left of each label.'
+      }
+    }
+  },
+  render: () => <VerticalRender />
+};
+
+function AddMachineIdentityRender() {
+  const [mode, setMode] = useState<"create" | "assign">("create");
+
+  return (
+    <Card className="w-[36rem]">
+      <CardHeader className="border-b">
+        <CardTitle>Add Machine Identity to Project</CardTitle>
+        <CardDescription>Create a new machine identity or assign an existing one</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs value={mode} onValueChange={(value) => setMode(value as typeof mode)}>
+          <div className="flex items-center justify-center gap-2">
+            <TabsList>
+              <TabsTrigger value="create">Create New</TabsTrigger>
+              <TabsTrigger value="assign">Assign Existing</TabsTrigger>
+            </TabsList>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex cursor-default text-accent">
+                  <Info className="size-4" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                Create a brand-new identity, or attach one already in the org.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <TabsContent value="create" className="flex flex-col gap-4 pt-4">
+            <Field>
+              <FieldLabel htmlFor="machine-name">Name</FieldLabel>
+              <Input id="machine-name" placeholder="Machine 1" />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="machine-role">Role</FieldLabel>
+              <Select defaultValue="no-access">
+                <SelectTrigger id="machine-role" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="no-access">No Access</SelectItem>
+                  <SelectItem value="viewer">Viewer</SelectItem>
+                  <SelectItem value="developer">Developer</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <div className="flex items-center gap-2">
+              <Switch id="delete-protection" />
+              <FieldLabel htmlFor="delete-protection" className="cursor-pointer">
+                Delete Protection Disabled
+              </FieldLabel>
+            </div>
+            <div className="flex flex-col gap-2">
+              <FieldLabel>Metadata</FieldLabel>
+              <div className="flex justify-end">
+                <Button variant="outline" size="sm">
+                  <Plus />
+                  Add Key
+                </Button>
+              </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="assign" className="flex flex-col gap-4 pt-4">
+            <Field>
+              <FieldLabel htmlFor="existing-identity">Identity</FieldLabel>
+              <Select>
+                <SelectTrigger id="existing-identity" className="w-full">
+                  <SelectValue placeholder="Select an existing identity" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ci-runner">ci-runner</SelectItem>
+                  <SelectItem value="terraform">terraform</SelectItem>
+                  <SelectItem value="backups">backups</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="existing-role">Role</FieldLabel>
+              <Select defaultValue="no-access">
+                <SelectTrigger id="existing-role" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="no-access">No Access</SelectItem>
+                  <SelectItem value="viewer">Viewer</SelectItem>
+                  <SelectItem value="developer">Developer</SelectItem>
+                  <SelectItem value="admin">Admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </Field>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+      <div className="flex gap-3">
+        <Button variant="project">Create</Button>
+        <Button variant="ghost">Cancel</Button>
+      </div>
+    </Card>
+  );
+}
+
+export const InCard: Story = {
+  name: "Example: In Card",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Filled tabs inside a Card — switch between create and assign flows on a single section. The list sits centered under the bordered card header with an inline info tooltip on the right. Each `TabsContent` swaps the form body in place, so the footer actions stay anchored at the bottom of the card."
+      }
+    }
+  },
+  render: () => <AddMachineIdentityRender />
+};

--- a/frontend/src/components/v3/generic/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/v3/generic/Tabs/Tabs.stories.tsx
@@ -3,13 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CreditCard, Info, Key, Lock, Plus, ScrollText, Settings, User, Users } from "lucide-react";
 
 import { Button } from "../Button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle
-} from "../Card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../Card";
 import { Field, FieldLabel } from "../Field";
 import { Input } from "../Input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../Select";

--- a/frontend/src/components/v3/generic/Tabs/Tabs.tsx
+++ b/frontend/src/components/v3/generic/Tabs/Tabs.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable react/prop-types */
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cva, type VariantProps } from "cva";
+
+import { cn } from "../../utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-md p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[style=underline]:rounded-none",
+  {
+    variants: {
+      variant: {
+        filled: "border p-1 border-border",
+        project:
+          "bg-transparent group-data-[orientation=horizontal]/tabs:h-11 group-data-[orientation=horizontal]/tabs:border-b group-data-[orientation=horizontal]/tabs:border-border group-data-[orientation=vertical]/tabs:gap-2",
+        org: "bg-transparent group-data-[orientation=horizontal]/tabs:h-11 group-data-[orientation=horizontal]/tabs:border-b group-data-[orientation=horizontal]/tabs:border-border group-data-[orientation=vertical]/tabs:gap-2",
+        "sub-org":
+          "bg-transparent group-data-[orientation=horizontal]/tabs:h-11 group-data-[orientation=horizontal]/tabs:border-b group-data-[orientation=horizontal]/tabs:border-border group-data-[orientation=vertical]/tabs:gap-2",
+        admin:
+          "bg-transparent group-data-[orientation=horizontal]/tabs:h-11 group-data-[orientation=horizontal]/tabs:border-b group-data-[orientation=horizontal]/tabs:border-border group-data-[orientation=vertical]/tabs:gap-2"
+      }
+    },
+    defaultVariants: {
+      variant: "filled"
+    }
+  }
+);
+
+const STYLE_BY_VARIANT = {
+  filled: "filled",
+  project: "underline",
+  org: "underline",
+  "sub-org": "underline",
+  admin: "underline"
+} as const;
+
+function TabsList({
+  className,
+  variant = "filled",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      data-style={STYLE_BY_VARIANT[variant ?? "filled"]}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-sm border border-transparent",
+        "px-1.5 py-0.5 text-sm whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full",
+        "group-data-[orientation=vertical]/tabs:px-2 group-data-[orientation=vertical]/tabs:py-1.5",
+        "group-data-[orientation=horizontal]/tabs:group-data-[style=underline]/tabs-list:px-3",
+        "group-data-[orientation=horizontal]/tabs:group-data-[style=filled]/tabs-list:px-3 group-data-[orientation=horizontal]/tabs:group-data-[style=filled]/tabs-list:py-0.5",
+        "group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px]",
+        "focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50",
+        "has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 [&_svg]:pointer-events-none",
+        "group-data-[style=underline]/tabs-list:bg-transparent [&_svg]:shrink-0",
+        "[&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:text-foreground",
+        "group-data-[style=filled]/tabs-list:data-[state=active]:border-container-hover group-data-[style=filled]/tabs-list:data-[state=active]:bg-container-hover",
+        "after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0",
+        "group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.25",
+        "group-data-[orientation=horizontal]/tabs:group-data-[style=underline]/tabs-list:after:bottom-[-5.6px]",
+        "group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-left-1",
+        "group-data-[orientation=vertical]/tabs:after:w-0.25 group-data-[style=underline]/tabs-list:data-[state=active]:after:opacity-100",
+        "group-data-[variant=project]/tabs-list:after:bg-project",
+        "group-data-[variant=org]/tabs-list:after:bg-org",
+        "group-data-[variant=sub-org]/tabs-list:after:bg-sub-org",
+        "group-data-[variant=admin]/tabs-list:after:bg-admin",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm text-foreground outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, tabsListVariants, TabsTrigger };

--- a/frontend/src/components/v3/generic/Tabs/Tabs.tsx
+++ b/frontend/src/components/v3/generic/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ function Tabs({
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      data-orientation={orientation}
+      orientation={orientation}
       className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
       {...props}
     />

--- a/frontend/src/components/v3/generic/Tabs/index.ts
+++ b/frontend/src/components/v3/generic/Tabs/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tabs";

--- a/frontend/src/components/v3/generic/index.ts
+++ b/frontend/src/components/v3/generic/index.ts
@@ -32,6 +32,7 @@ export * from "./Sidebar";
 export * from "./Skeleton";
 export * from "./Switch";
 export * from "./Table";
+export * from "./Tabs";
 export * from "./TextArea";
 export * from "./Toast";
 export * from "./Tooltip";

--- a/frontend/src/components/v3/generic/index.ts
+++ b/frontend/src/components/v3/generic/index.ts
@@ -30,6 +30,7 @@ export * from "./Separator";
 export * from "./Sheet";
 export * from "./Sidebar";
 export * from "./Skeleton";
+export * from "./Stepper";
 export * from "./Switch";
 export * from "./Table";
 export * from "./Tabs";


### PR DESCRIPTION
## Context

This PR adds v3 versions of our tab and stepper components along with their respective stories

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-05-05 at 13 39 48@2x" src="https://github.com/user-attachments/assets/ff0eb1b7-f9e5-4237-a4e5-ec0f67e9eaa2" />
<img width="3456" height="1920" alt="CleanShot 2026-05-05 at 13 39 42@2x" src="https://github.com/user-attachments/assets/7099966b-c8a6-437a-9054-207fb2ada435" />

## Steps to verify the change

- play around with stories 

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)