### PR TITLE
docs(pki): list supported subject attributes for certificate policies

### DIFF
--- a/docs/documentation/platform/pki/certificates/policies.mdx
+++ b/docs/documentation/platform/pki/certificates/policies.mdx
@@ -21,7 +21,26 @@ Here's some guidance on each field:
 
 - Policy Name: A slug-friendly name for the policy such as `tls-server`.
 - Description: An optional description for the policy.
-- Subject Attributes: A list of common names that can be included in the certificate subject. Each row accepts a fixed value or pattern such as `example.com` or `*.example.com` and whether it is allowed or denied.
+- Subject Attributes: A list of X.509 distinguished name attributes that can be included in the certificate subject. The supported attribute types are:
+
+  | Attribute | Abbreviation |
+  |---|---|
+  | Common Name | CN |
+  | Organization | O |
+  | Organizational Unit | OU |
+  | Country | C |
+  | State/Province | ST |
+  | Locality | L |
+
+  For each attribute, you can configure one or more enforcement modes:
+
+  - **Require**: Values that must be present in the certificate request. The request is rejected if the attribute is missing or does not match the required pattern.
+  - **Allow**: Values that are permitted but not required. Accepts a fixed value or wildcard pattern such as `example.com` or `*.example.com`.
+  - **Deny**: Values that must not appear. The request is rejected if the attribute matches a denied pattern.
+
+  <Note>
+    Any subject attribute included in a certificate request that is not explicitly defined in the policy will be rejected. If no subject attribute rules are defined at all, any request containing subject attributes will be rejected.
+  </Note>
 - Subject Alternative Names (SANs): A list of SANs that can appear in the certificate. Each row accepts a SAN type (e.g. DNS, IP, Email, URI), a fixed value or pattern such as `example.com` or `*.example.com`, and an allow or deny flag.
 - Allowed Signature Algorithms: The set of signature algorithms permitted to sign certificates under this policy such as `SHA256-RSA`, `SHA512-RSA`, etc.
 - Allowed Key Algorithms: The set of public key algorithms permitted for certificate requests such as `RSA-2048`, `RSA-4096`, etc.


### PR DESCRIPTION
## Context

Expand the Subject Attributes field description to list all six supported X.509 DN attributes (CN, O, OU, C, ST, L) and document the Require, Allow, and Deny enforcement modes

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)