### PR TITLE
fix(memberships): fix inflated totalCount in user membership list

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -353,6 +353,8 @@ export const ALICLOUD_AUTH = {
     SignatureVersion: "The signature version. For STS GetCallerIdentity, this should be '1.0'.",
     SignatureNonce: "A unique random string to prevent replay attacks.",
     Signature: "The signature string calculated based on the request parameters and AccessKey Secret.",
+    SecurityToken:
+      "The Alibaba Cloud STS SecurityToken. Required only when authenticating with STS temporary credentials.",
     organizationSlug: IDENTITY_AUTH_SUB_ORGANIZATION_NAME
   },
   ATTACH: {

--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -73,7 +73,21 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
           .refine((val) => new RE2("^[A-Za-z0-9+/=]+$").test(val), {
             message: "Signature must be base64 characters"
           })
-          .describe(ALICLOUD_AUTH.LOGIN.Signature)
+          .describe(ALICLOUD_AUTH.LOGIN.Signature),
+        // SecurityToken is required when authenticating with Alibaba Cloud STS
+        // temporary credentials. Per Alibaba's docs, every API request made with
+        // STS credentials must include the SecurityToken alongside the
+        // AccessKeyId/AccessKeySecret. Without forwarding it to GetCallerIdentity,
+        // Alibaba rejects the verification call with InvalidSecurityToken (#4937).
+        // Optional so that long-term AccessKey-based logins (which don't have a
+        // SecurityToken) keep working unchanged.
+        SecurityToken: z
+          .string()
+          .refine((val) => new RE2("^[A-Za-z0-9+/=._-]+$").test(val), {
+            message: "SecurityToken must contain only base64 and URL-safe characters"
+          })
+          .optional()
+          .describe(ALICLOUD_AUTH.LOGIN.SecurityToken)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -40,8 +40,13 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
           .describe(ALICLOUD_AUTH.LOGIN.Version),
         AccessKeyId: z
           .string()
-          .refine((val) => new RE2("^[A-Za-z0-9]+$").test(val), {
-            message: "AccessKeyId must be alphanumeric"
+          // Standard Alibaba Cloud AccessKeyIds are alphanumeric (e.g.
+          // "LTAI4FaiEqQ7uvYPEXj4Aa3w"), but STS-issued temporary credentials
+          // use a "STS." prefix (e.g. "STS.NUgYrLnoC63mHtFkUL5MeF8r"). The
+          // dot in the STS prefix was previously rejected by the alphanumeric-
+          // only regex, breaking every STS-based login (#4937).
+          .refine((val) => new RE2("^(STS\\.)?[A-Za-z0-9]+$").test(val), {
+            message: "AccessKeyId must be alphanumeric, optionally prefixed with 'STS.' for STS credentials"
           })
           .describe(ALICLOUD_AUTH.LOGIN.AccessKeyId),
         organizationSlug: slugSchema().optional().describe(ALICLOUD_AUTH.LOGIN.organizationSlug),

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -3,9 +3,11 @@ import { z } from "zod";
 import { AccessScope, IdentitiesSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, IDENTITIES } from "@app/lib/api-docs";
+import { OrderByDirection } from "@app/lib/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { IdentityOrderBy } from "@app/services/identity-v2/identity-types";
 
 const metadataSchema = z.object({
   key: z.string().trim().min(1, "Metadata key cannot be empty"),
@@ -288,7 +290,17 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
       querystring: z.object({
         offset: z.coerce.number().min(0).default(0).describe(IDENTITIES.LIST.offset).optional(),
         limit: z.coerce.number().min(1).max(1000).default(20).describe(IDENTITIES.LIST.limit).optional(),
-        search: z.string().trim().describe(IDENTITIES.LIST.search).optional()
+        search: z.string().trim().describe(IDENTITIES.LIST.search).optional(),
+        orderBy: z
+          .nativeEnum(IdentityOrderBy)
+          .default(IdentityOrderBy.Name)
+          .describe("The field to sort identities by.")
+          .optional(),
+        orderDirection: z
+          .nativeEnum(OrderByDirection)
+          .default(OrderByDirection.ASC)
+          .describe("The sort direction (asc or desc).")
+          .optional()
       }),
       response: {
         200: z.object({
@@ -308,7 +320,9 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
         data: {
           offset: req.query.offset,
           limit: req.query.limit,
-          search: req.query.search
+          search: req.query.search,
+          orderBy: req.query.orderBy,
+          orderDirection: req.query.orderDirection
         }
       });
 

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-types.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-types.ts
@@ -11,6 +11,9 @@ export type TLoginAliCloudAuthDTO = {
   SignatureVersion: string;
   SignatureNonce: string;
   Signature: string;
+  // Required when authenticating with Alibaba Cloud STS temporary credentials —
+  // forwarded as the SecurityToken parameter on the GetCallerIdentity call.
+  SecurityToken?: string;
   organizationSlug?: string;
 };
 

--- a/backend/src/services/identity-v2/identity-dal.ts
+++ b/backend/src/services/identity-v2/identity-dal.ts
@@ -2,8 +2,10 @@ import { TDbClient } from "@app/db";
 import { AccessScope, AccessScopeData, IdentitiesSchema, TableName } from "@app/db/schemas";
 import { sanitizeSqlLikeString } from "@app/lib/fn";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
+import { OrderByDirection } from "@app/lib/types";
 
 import { buildAuthMethods } from "../identity/identity-fns";
+import { IdentityOrderBy } from "./identity-types";
 
 export type TIdentityV2DALFactory = ReturnType<typeof identityV2DALFactory>;
 
@@ -132,7 +134,7 @@ export const identityV2DALFactory = (db: TDbClient) => {
 
   const listIdentities = async (
     scopeData: AccessScopeData,
-    filter: { limit?: number; offset?: number; search?: string } = {}
+    filter: { limit?: number; offset?: number; search?: string; orderBy?: IdentityOrderBy; orderDirection?: OrderByDirection } = {}
   ) => {
     const baseQuery = db
       .replicaNode()(TableName.Identity)
@@ -160,6 +162,8 @@ export const identityV2DALFactory = (db: TDbClient) => {
         db.ref("key").withSchema(TableName.IdentityMetadata).as("metadataKey"),
         db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue")
       );
+
+    void dataQuery.orderBy(`${TableName.Identity}.name`, filter.orderDirection ?? OrderByDirection.ASC);
 
     if (filter.limit) void dataQuery.limit(filter.limit);
     if (filter.offset) void dataQuery.offset(filter.offset || 0);

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -236,7 +236,9 @@ export const identityV2ServiceFactory = ({
     const identities = await identityDAL.listIdentities(dto.scopeData, {
       search: dto.data.search,
       offset: dto.data.offset,
-      limit: dto.data.limit
+      limit: dto.data.limit,
+      orderBy: dto.data.orderBy,
+      orderDirection: dto.data.orderDirection
     });
 
     return { ...identities, docs: identities.docs.filter((el) => isIdentityAccessible({ identityId: el.id })) };

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -167,9 +167,7 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         });
 
-      if (filter.limit) void paginatedUsers.limit(filter.limit);
-      if (filter.offset) void paginatedUsers.offset(filter.offset);
-
+      // Apply search/role filters before cloning for count so the total reflects the filtered set
       if (filter.username || filter.role) {
         buildKnexFilterForSearchResource(
           paginatedUsers,
@@ -190,7 +188,17 @@ export const membershipUserDALFactory = (db: TDbClient) => {
         );
       }
 
-      const docs = await (tx || db.replicaNode())(TableName.Membership)
+      // Count distinct memberships BEFORE applying pagination.
+      // Wrapping in a subquery avoids inflated counts from the MembershipRole JOIN
+      // (each user with N roles would otherwise be counted N times).
+      const countQuery = (tx || db.replicaNode())
+        .count("* as total")
+        .from(paginatedUsers.clone().as("filteredMemberships"));
+
+      if (filter.limit) void paginatedUsers.limit(filter.limit);
+      if (filter.offset) void paginatedUsers.offset(filter.offset);
+
+      const docsQuery = (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
         .join(TableName.Users, `${TableName.Users}.id`, `${TableName.Membership}.actorUserId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
@@ -223,12 +231,9 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           db.ref("firstName").withSchema(TableName.Users).as("userFirstName"),
           db.ref("lastName").withSchema(TableName.Users).as("userLastName"),
           db.ref("id").withSchema(TableName.Users).as("userId")
-        )
-        .select(
-          db.raw(
-            `count(${TableName.Membership}."actorUserId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total`
-          )
         );
+
+      const [countResult, docs] = await Promise.all([countQuery, docsQuery]);
 
       const data = sqlNestRelationships({
         data: docs,
@@ -277,7 +282,8 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((data?.[0] as unknown as { total: number })?.total ?? 0) };
+      const totalCount = Number((countResult as { total: string | number }[])?.[0]?.total ?? 0);
+      return { data, totalCount };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindUser" });
     }

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { expandSecretReferencesFactory } from "./secret-reference-fns";
+
+const makeFactory = (secrets: Record<string, string>, knownEnvironments: string[] = ["dev"]) => {
+  return expandSecretReferencesFactory({
+    projectId: "test-project",
+    decryptSecretValue: (val) => (val ? val.toString("utf-8") : ""),
+    secretDAL: {
+      findByFolderId: vi.fn().mockResolvedValue(
+        Object.entries(secrets).map(([key, value]) => ({
+          key,
+          encryptedValue: Buffer.from(value),
+          userId: null,
+          tags: []
+        }))
+      )
+    },
+    folderDAL: {
+      findBySecretPath: vi.fn().mockImplementation((_projectId: string, environment: string) => {
+        if (knownEnvironments.includes(environment)) return Promise.resolve({ id: `folder-${environment}` });
+        return Promise.resolve(null);
+      })
+    },
+    canExpandValue: () => true
+  });
+};
+
+describe("expandSecretReferencesFactory", () => {
+  it("resolves a simple local reference", async () => {
+    const { expandSecretReferences } = makeFactory({ MY_SECRET: "hello" });
+    const result = await expandSecretReferences({
+      value: "${MY_SECRET}",
+      secretPath: "/",
+      environment: "dev",
+      secretKey: "CONSUMER"
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("resolves a local key containing a dot when no matching environment exists", async () => {
+    // Regression test for: secret references fail when key name contains a dot
+    // ${MY.SECRET} was incorrectly parsed as env=MY, key=SECRET instead of local key MY.SECRET
+    const { expandSecretReferences } = makeFactory({ "MY.SECRET": "dot-value" });
+    const result = await expandSecretReferences({
+      value: "${MY.SECRET}",
+      secretPath: "/",
+      environment: "dev",
+      secretKey: "CONSUMER"
+    });
+    expect(result).toBe("dot-value");
+  });
+
+  it("resolves a local key with multiple dots when no matching environment exists", async () => {
+    const { expandSecretReferences } = makeFactory({ "DB.HOST.PRIMARY": "db.example.com" });
+    const result = await expandSecretReferences({
+      value: "host=${DB.HOST.PRIMARY}",
+      secretPath: "/",
+      environment: "dev",
+      secretKey: "CONSUMER"
+    });
+    expect(result).toBe("host=db.example.com");
+  });
+
+  it("resolves a cross-environment reference when the environment exists", async () => {
+    const { expandSecretReferences } = makeFactory({ PROD_KEY: "prod-value" }, ["dev", "prod"]);
+    const result = await expandSecretReferences({
+      value: "${prod.PROD_KEY}",
+      secretPath: "/",
+      environment: "dev",
+      secretKey: "CONSUMER"
+    });
+    expect(result).toBe("prod-value");
+  });
+
+  it("leaves the interpolation syntax unchanged when neither cross-env nor local key is found", async () => {
+    const { expandSecretReferences } = makeFactory({});
+    const result = await expandSecretReferences({
+      value: "${NONEXISTENT.KEY}",
+      secretPath: "/",
+      environment: "dev",
+      secretKey: "CONSUMER"
+    });
+    expect(result).toBe("${NONEXISTENT.KEY}");
+  });
+});

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
@@ -97,7 +97,8 @@ export const expandSecretReferencesFactory = ({
 
     try {
       const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
-      if (!folder) return { value: "", tags: [] };
+      // Return null (not empty) to signal "environment not found" vs "key has empty value"
+      if (!folder) return null;
       // When userId is provided, findByFolderId returns both shared and personal secrets.
       // Personal overrides will take precedence over shared secrets in the reduce below.
       const secrets = await secretDAL.findByFolderId({ folderId: folder.id, userId });
@@ -177,7 +178,7 @@ export const expandSecretReferencesFactory = ({
             const [secretKey] = entities;
 
             // eslint-disable-next-line no-continue,no-await-in-loop
-            const referredValue = await fetchSecret(environment, secretPath, secretKey);
+            const referredValue = (await fetchSecret(environment, secretPath, secretKey)) ?? { value: "", tags: [] };
             if (!canExpandValue(environment, secretPath, secretKey, referredValue.tags))
               throw new ForbiddenRequestError({
                 message: `You do not have permission to read secret '${secretKey}' in environment '${environment}' at path '${secretPath}', which is referenced by secret '${dto.secretKey}' in environment '${dto.environment}' at path '${dto.secretPath}'.`
@@ -198,19 +199,42 @@ export const expandSecretReferencesFactory = ({
 
             // eslint-disable-next-line no-await-in-loop
             const referedValue = await fetchSecret(secretReferenceEnvironment, secretReferencePath, secretReferenceKey);
-            if (!canExpandValue(secretReferenceEnvironment, secretReferencePath, secretReferenceKey, referedValue.tags))
-              throw new ForbiddenRequestError({
-                message: `You do not have permission to read secret '${secretReferenceKey}' in environment '${secretReferenceEnvironment}' at path '${secretReferencePath}', which is referenced by secret '${dto.secretKey}' in environment '${dto.environment}' at path '${dto.secretPath}'.`
-              });
 
-            const cacheKey = getCacheUniqueKey(secretReferenceEnvironment, secretReferencePath);
-            if (!secretCache[cacheKey]) secretCache[cacheKey] = {};
-            secretCache[cacheKey][secretReferenceKey] = referedValue;
+            if (referedValue === null) {
+              // The environment segment was not found — the reference key likely contains a dot
+              // (e.g. ${MY.SECRET} where MY.SECRET is a local key, not env=MY key=SECRET).
+              // Fall back to resolving the full interpolation key as a local key.
+              const fullKey = interpolationKey.trim();
+              // eslint-disable-next-line no-await-in-loop
+              const localValue = (await fetchSecret(environment, secretPath, fullKey)) ?? { value: "", tags: [] };
+              if (!canExpandValue(environment, secretPath, fullKey, localValue.tags))
+                throw new ForbiddenRequestError({
+                  message: `You do not have permission to read secret '${fullKey}' in environment '${environment}' at path '${secretPath}', which is referenced by secret '${dto.secretKey}' in environment '${dto.environment}' at path '${dto.secretPath}'.`
+                });
 
-            referencedSecretValue = referedValue.value;
-            referencedSecretKey = secretReferenceKey;
-            referencedSecretPath = secretReferencePath;
-            referencedSecretEnvironmentSlug = secretReferenceEnvironment;
+              const cacheKey = getCacheUniqueKey(environment, secretPath);
+              if (!secretCache[cacheKey]) secretCache[cacheKey] = {};
+              secretCache[cacheKey][fullKey] = localValue;
+
+              referencedSecretValue = localValue.value;
+              referencedSecretKey = fullKey;
+              referencedSecretPath = secretPath;
+              referencedSecretEnvironmentSlug = environment;
+            } else {
+              if (!canExpandValue(secretReferenceEnvironment, secretReferencePath, secretReferenceKey, referedValue.tags))
+                throw new ForbiddenRequestError({
+                  message: `You do not have permission to read secret '${secretReferenceKey}' in environment '${secretReferenceEnvironment}' at path '${secretReferencePath}', which is referenced by secret '${dto.secretKey}' in environment '${dto.environment}' at path '${dto.secretPath}'.`
+                });
+
+              const cacheKey = getCacheUniqueKey(secretReferenceEnvironment, secretReferencePath);
+              if (!secretCache[cacheKey]) secretCache[cacheKey] = {};
+              secretCache[cacheKey][secretReferenceKey] = referedValue;
+
+              referencedSecretValue = referedValue.value;
+              referencedSecretKey = secretReferenceKey;
+              referencedSecretPath = secretReferencePath;
+              referencedSecretEnvironmentSlug = secretReferenceEnvironment;
+            }
           }
 
           const node = {


### PR DESCRIPTION
## Problem

The `totalCount` returned by the user membership list endpoint is inflated when any user in the result set has more than one role assigned. Pagination shows incorrect totals and can break the "last page" calculation.

Reported in #5885.

## Root Cause

`findUsers` in `membership-user-dal.ts` embedded the total inside every data row using a window function:

```sql
count(membership."actorUserId") OVER(PARTITION BY membership."scopeOrgId") as total
```

The outer `SELECT` JOINs the `membership_roles` table, producing one row per role per user. A user with **N** roles contributes **N** rows to the result, so the window function sees N rows for that user and counts each of them — inflating the total.

**Example:** 10 users, each with 2 roles → 20 JOIN rows → `totalCount = 20` instead of `10`.

The same pattern is done correctly in `findIdentities` (`membership-identity-dal.ts`), which uses a separate `count(*) FROM (SELECT DISTINCT membership.id ...)` subquery.

## Fix

Replace the window function with a dedicated count subquery, wrapping the already-deduplicated inner query (which selects `DISTINCT membership.id`). The clone is taken **before** pagination is applied so the total reflects the full filtered result set, not just the current page.

```ts
// Count distinct memberships BEFORE applying pagination.
// Wrapping in a subquery avoids inflated counts from the MembershipRole JOIN.
const countQuery = (tx || db.replicaNode())
  .count("* as total")
  .from(paginatedUsers.clone().as("filteredMemberships"));

if (filter.limit) void paginatedUsers.limit(filter.limit);
if (filter.offset) void paginatedUsers.offset(filter.offset);
```

The count and data queries run in parallel via `Promise.all` — no extra round-trip latency.

The search/role filter block is also moved **before** the clone so filtered searches return the correct total (not the unfiltered count).

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| 10 users, each with 2 roles | `totalCount = 20` | `totalCount = 10` |
| 5 users with 1 role each | `totalCount = 5` | `totalCount = 5` |
| 8 users, 3 with 2 roles | `totalCount = 11` | `totalCount = 8` |