### PR TITLE
fix(aws-auth): escape regex metacharacters in ARN allowlist matching

### DIFF
--- a/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
+++ b/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
@@ -150,6 +150,7 @@ export const validateAllowlists = ({
       .map((principalArn) => principalArn.trim())
       .filter((principalArn) => principalArn.length > 0)
       .some((principalArn) => {
+        // Convert wildcard to regex; arnRegex in validators ensures safe input.
         const regex = new RE2(`^${principalArn.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`);
         return regex.test(formattedArn) || regex.test(extractPrincipalArn(Arn, true));
       });

--- a/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
+++ b/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
@@ -150,8 +150,7 @@ export const validateAllowlists = ({
       .map((principalArn) => principalArn.trim())
       .filter((principalArn) => principalArn.length > 0)
       .some((principalArn) => {
-        // Convert wildcard to regex; arnRegex in validators ensures safe input.
-        const regex = new RE2(`^${principalArn.replaceAll("*", ".*")}$`);
+        const regex = new RE2(`^${principalArn.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`);
         return regex.test(formattedArn) || regex.test(extractPrincipalArn(Arn, true));
       });
 

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -192,10 +192,7 @@ export const identityAwsAuthServiceFactory = ({
           .split(",")
           .map((principalArn) => principalArn.trim())
           .some((principalArn) => {
-            // convert wildcard ARN to a regular expression: "arn:aws:iam::123456789012:*" -> "^arn:aws:iam::123456789012:.*$"
-            // considers exact matches + wildcard matches
-            // heavily validated in router
-            const regex = new RE2(`^${principalArn.replaceAll("*", ".*")}$`);
+            const regex = new RE2(`^${principalArn.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`);
             return regex.test(formattedArn) || regex.test(extractPrincipalArn(Arn, true));
           });
 

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -192,6 +192,9 @@ export const identityAwsAuthServiceFactory = ({
           .split(",")
           .map((principalArn) => principalArn.trim())
           .some((principalArn) => {
+            // convert wildcard ARN to a regular expression: "arn:aws:iam::123456789012:*" -> "^arn:aws:iam::123456789012:.*$"
+            // considers exact matches + wildcard matches
+            // heavily validated in router
             const regex = new RE2(`^${principalArn.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`);
             return regex.test(formattedArn) || regex.test(extractPrincipalArn(Arn, true));
           });

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-validators.ts
@@ -51,7 +51,11 @@ export const validatePrincipalArns = z
       const arns = data.split(",");
       // Return true only if every item matches one of the allowed ARN formats
       // and checks whether the provided regex is safe
-      return arns.map((el) => el.trim()).every((arn) => safe(`^${arn.replaceAll("*", ".*")}$`) && arnRegex.test(arn));
+      return arns
+        .map((el) => el.trim())
+        .every(
+          (arn) => safe(`^${arn.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*")}$`) && arnRegex.test(arn)
+        );
     },
     {
       message:


### PR DESCRIPTION
## Context

Regex metacharacters like . and + in IAM principal names were not being escaped during wildcard-to-regex conversion, so ARN allowlist entries like role/app.prod would also match role/appXprod.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)