### PR TITLE
fix(docs): fix comment issue for envars ParamField ENCRYPTION_KEY

### DIFF
--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -11,8 +11,8 @@ However, you can configure additional settings to activate more features as need
 Used to configure platform-specific security and operational settings
 
 <ParamField query="ENCRYPTION_KEY" type="string" default="none" required>
-  Must be a random 16 byte hex string. Can be generated with `openssl rand -hex
-  16`
+  Must be a random 32 byte base64 string. Can be generated with `openssl rand
+  -base64 32`
 </ParamField>
 
 <ParamField query="AUTH_SECRET" type="string" default="none" required>


### PR DESCRIPTION
## Context

"In the envars.mdx for the field ENCRYPTION_KEY it said that the user can generate it by using the command openssl rand -hex 16 wich then throws an error "throw new CryptographyError", while building, as FIPS mode is enabled by default. 
`CryptographyError: FIPS mode is enabled, but the ENCRYPTION_KEY environment variable is not a 256-bit key.`
This was changed by simply updating the docs saying the user should use openssl rand -base64 32."

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)