### PR TITLE
fix: resolved sub org id selection in legacy loading

### DIFF
--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -32,11 +32,13 @@ vi.mock("@app/lib/logger", () => ({
 const createService = ({
   trustedIps = [],
   membership = { isActive: true },
+  org = { id: "org-id" },
   activeRevocations = [],
   tokenRow = null
 }: {
   trustedIps?: TIp[] | null;
   membership?: { isActive: boolean } | null;
+  org?: { id: string; rootOrgId?: string; parentOrgId?: string };
   activeRevocations?: Array<{ id: string; identityId: string; revokedAt?: Date | null; createdAt: Date }>;
   tokenRow?: Record<string, unknown> | null;
 } = {}) => {
@@ -54,7 +56,8 @@ const createService = ({
     findById: vi.fn()
   };
   const orgDAL = {
-    findEffectiveOrgMembership: vi.fn().mockResolvedValue(membership)
+    findEffectiveOrgMembership: vi.fn().mockResolvedValue(membership),
+    findOne: vi.fn().mockResolvedValue(org)
   };
   const identityAccessTokenDAL = { findOne: vi.fn().mockResolvedValue(tokenRow) };
 

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -68,7 +68,7 @@ type TIdentityAccessTokenServiceFactoryDep = {
   identityAccessTokenDAL: TIdentityAccessTokenDALFactory;
   identityAccessTokenRevocationDAL: TIdentityAccessTokenRevocationDALFactory;
   identityDAL: Pick<TIdentityDALFactory, "getTrustedIpsByAuthMethod" | "findById">;
-  orgDAL: Pick<TOrgDALFactory, "findEffectiveOrgMembership">;
+  orgDAL: Pick<TOrgDALFactory, "findEffectiveOrgMembership" | "findOne">;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "incrementBy" | "setItemWithExpiry">;
 };
 
@@ -217,7 +217,13 @@ export const identityAccessTokenServiceFactory = ({
     if (!row || row.isAccessTokenRevoked) {
       throw new UnauthorizedError({ message: "Cannot renew revoked or unknown access token" });
     }
-    const fallbackOrgId = decoded.orgId ?? row.identityOrgId ?? "";
+
+    const scopeOrgId = row.subOrganizationId || row.identityOrgId;
+    const identityOrgDetails = await orgDAL.findOne({ id: scopeOrgId });
+    const isSubOrg = Boolean(identityOrgDetails.rootOrgId);
+    const rootOrgId = isSubOrg ? identityOrgDetails.rootOrgId || identityOrgDetails.id : identityOrgDetails.id;
+    const parentOrgId = identityOrgDetails.parentOrgId || rootOrgId;
+
     return {
       authMethod: row.authMethod as IdentityAuthMethod,
       accessTokenTTL: row.accessTokenTTL,
@@ -227,9 +233,9 @@ export const identityAccessTokenServiceFactory = ({
       // legacy lifetime carries over without a free renewal-time extension.
       creationEpoch: Math.floor(row.createdAt.getTime() / 1000),
       identityName: row.identityName ?? decoded.identityName ?? "",
-      orgId: fallbackOrgId,
-      rootOrgId: decoded.rootOrgId ?? fallbackOrgId,
-      parentOrgId: decoded.parentOrgId ?? fallbackOrgId,
+      orgId: decoded?.orgId || scopeOrgId,
+      rootOrgId: decoded.rootOrgId ?? rootOrgId,
+      parentOrgId: decoded.parentOrgId ?? parentOrgId,
       clientSecretId: decoded.clientSecretId ?? "",
       numUsesLimit: row.accessTokenNumUsesLimit,
       identityAuth: decoded.identityAuth


### PR DESCRIPTION
## Context

This fixes a bug in sub org selection in legacy token loading

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)