### PR TITLE
fix(ovh-sync): change request to check SSRF

### DIFF
--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -258,17 +258,6 @@ type TBuildAgentOptions = {
    * addresses or non-DNS subjects (e.g. AD CS web enrollment).
    */
   checkServerIdentity?: https.AgentOptions["checkServerIdentity"];
-  /**
-   * mTLS client private key (PEM). Forwarded to https.Agent. Only applied to
-   * HTTPS. Pair with `cert`. Required for endpoints that authenticate the
-   * client via certificate (e.g. OVH OKMS).
-   */
-  key?: string | Buffer;
-  /**
-   * mTLS client certificate (PEM). Forwarded to https.Agent. Only applied to
-   * HTTPS. Pair with `key`.
-   */
-  cert?: string | Buffer;
 };
 
 const hasAgentCustomization = (opts: TBuildAgentOptions): boolean =>
@@ -277,9 +266,7 @@ const hasAgentCustomization = (opts: TBuildAgentOptions): boolean =>
   opts.ca !== undefined ||
   opts.servername !== undefined ||
   opts.keepAlive !== undefined ||
-  opts.checkServerIdentity !== undefined ||
-  opts.key !== undefined ||
-  opts.cert !== undefined;
+  opts.checkServerIdentity !== undefined;
 
 const buildPinnedAgent = (
   validated: TValidatedHost | undefined,
@@ -304,9 +291,7 @@ const buildPinnedAgent = (
       ...(opts.ca !== undefined && { ca: opts.ca }),
       ...(opts.rejectUnauthorized !== undefined && { rejectUnauthorized: opts.rejectUnauthorized }),
       ...(opts.servername !== undefined && { servername: opts.servername }),
-      ...(opts.checkServerIdentity !== undefined && { checkServerIdentity: opts.checkServerIdentity }),
-      ...(opts.key !== undefined && { key: opts.key }),
-      ...(opts.cert !== undefined && { cert: opts.cert })
+      ...(opts.checkServerIdentity !== undefined && { checkServerIdentity: opts.checkServerIdentity })
     };
     return new https.Agent(httpsOpts);
   }
@@ -349,8 +334,6 @@ type TBuildSsrfSafeAgentOptions = {
   servername?: string;
   keepAlive?: boolean;
   checkServerIdentity?: https.AgentOptions["checkServerIdentity"];
-  key?: string | Buffer;
-  cert?: string | Buffer;
 };
 
 /**
@@ -371,17 +354,8 @@ export const buildSsrfSafeAgent = async (
   url: string,
   options: TBuildSsrfSafeAgentOptions = {}
 ): Promise<http.Agent | https.Agent | undefined> => {
-  const {
-    allowPrivateIps,
-    addressFamily,
-    ca,
-    rejectUnauthorized,
-    servername,
-    keepAlive,
-    checkServerIdentity,
-    key,
-    cert
-  } = options;
+  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, keepAlive, checkServerIdentity } =
+    options;
   const validated = await validateSsrfUrl(url, { allowPrivateIps });
   const { protocol } = new URL(url);
   return buildPinnedAgent(validated, protocol, {
@@ -390,9 +364,7 @@ export const buildSsrfSafeAgent = async (
     rejectUnauthorized,
     servername,
     keepAlive,
-    checkServerIdentity,
-    key,
-    cert
+    checkServerIdentity
   });
 };
 
@@ -421,18 +393,6 @@ type TSafeRequestExtras = {
    * (e.g. Kubernetes API servers). Defaults to the URL hostname if unset.
    */
   servername?: string;
-  /**
-   * mTLS client private key (PEM). Forwarded to the per-request https.Agent
-   * so it composes with the pinned lookup. Only applied to HTTPS URLs. Pair
-   * with `cert`. Required for endpoints that authenticate the client via
-   * certificate (e.g. OVH OKMS).
-   */
-  key?: string | Buffer;
-  /**
-   * mTLS client certificate (PEM). Forwarded to the per-request https.Agent.
-   * Only applied to HTTPS URLs. Pair with `key`.
-   */
-  cert?: string | Buffer;
 };
 
 type TSafeRequestConfig = Omit<AxiosRequestConfig, "httpAgent" | "httpsAgent" | "maxRedirects" | "url" | "method">;
@@ -466,18 +426,11 @@ const dispatch = async <T>(
   data: unknown,
   options: TSafeRequestConfig & TSafeRequestExtras = {}
 ) => {
-  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, key, cert, ...axiosOpts } = options;
+  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, ...axiosOpts } = options;
   const effectiveUrl = resolveBaseUrl(url, axiosOpts.baseURL);
   const validated = await validateSsrfUrl(effectiveUrl, { allowPrivateIps });
   const { protocol } = new URL(effectiveUrl);
-  const agent = buildPinnedAgent(validated, protocol, {
-    addressFamily,
-    ca,
-    rejectUnauthorized,
-    servername,
-    key,
-    cert
-  });
+  const agent = buildPinnedAgent(validated, protocol, { addressFamily, ca, rejectUnauthorized, servername });
 
   return request.request<T>({
     ...axiosOpts,
@@ -491,18 +444,11 @@ const dispatch = async <T>(
 };
 
 const dispatchFull = async <T>(config: TSafeRequestFullConfig) => {
-  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, key, cert, url, ...axiosOpts } = config;
+  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, url, ...axiosOpts } = config;
   const effectiveUrl = resolveBaseUrl(url, axiosOpts.baseURL);
   const validated = await validateSsrfUrl(effectiveUrl, { allowPrivateIps });
   const { protocol } = new URL(effectiveUrl);
-  const agent = buildPinnedAgent(validated, protocol, {
-    addressFamily,
-    ca,
-    rejectUnauthorized,
-    servername,
-    key,
-    cert
-  });
+  const agent = buildPinnedAgent(validated, protocol, { addressFamily, ca, rejectUnauthorized, servername });
 
   return request.request<T>({
     ...axiosOpts,

--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -258,6 +258,17 @@ type TBuildAgentOptions = {
    * addresses or non-DNS subjects (e.g. AD CS web enrollment).
    */
   checkServerIdentity?: https.AgentOptions["checkServerIdentity"];
+  /**
+   * mTLS client private key (PEM). Forwarded to https.Agent. Only applied to
+   * HTTPS. Pair with `cert`. Required for endpoints that authenticate the
+   * client via certificate (e.g. OVH OKMS).
+   */
+  key?: string | Buffer;
+  /**
+   * mTLS client certificate (PEM). Forwarded to https.Agent. Only applied to
+   * HTTPS. Pair with `key`.
+   */
+  cert?: string | Buffer;
 };
 
 const hasAgentCustomization = (opts: TBuildAgentOptions): boolean =>
@@ -266,7 +277,9 @@ const hasAgentCustomization = (opts: TBuildAgentOptions): boolean =>
   opts.ca !== undefined ||
   opts.servername !== undefined ||
   opts.keepAlive !== undefined ||
-  opts.checkServerIdentity !== undefined;
+  opts.checkServerIdentity !== undefined ||
+  opts.key !== undefined ||
+  opts.cert !== undefined;
 
 const buildPinnedAgent = (
   validated: TValidatedHost | undefined,
@@ -291,7 +304,9 @@ const buildPinnedAgent = (
       ...(opts.ca !== undefined && { ca: opts.ca }),
       ...(opts.rejectUnauthorized !== undefined && { rejectUnauthorized: opts.rejectUnauthorized }),
       ...(opts.servername !== undefined && { servername: opts.servername }),
-      ...(opts.checkServerIdentity !== undefined && { checkServerIdentity: opts.checkServerIdentity })
+      ...(opts.checkServerIdentity !== undefined && { checkServerIdentity: opts.checkServerIdentity }),
+      ...(opts.key !== undefined && { key: opts.key }),
+      ...(opts.cert !== undefined && { cert: opts.cert })
     };
     return new https.Agent(httpsOpts);
   }
@@ -334,6 +349,8 @@ type TBuildSsrfSafeAgentOptions = {
   servername?: string;
   keepAlive?: boolean;
   checkServerIdentity?: https.AgentOptions["checkServerIdentity"];
+  key?: string | Buffer;
+  cert?: string | Buffer;
 };
 
 /**
@@ -354,8 +371,17 @@ export const buildSsrfSafeAgent = async (
   url: string,
   options: TBuildSsrfSafeAgentOptions = {}
 ): Promise<http.Agent | https.Agent | undefined> => {
-  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, keepAlive, checkServerIdentity } =
-    options;
+  const {
+    allowPrivateIps,
+    addressFamily,
+    ca,
+    rejectUnauthorized,
+    servername,
+    keepAlive,
+    checkServerIdentity,
+    key,
+    cert
+  } = options;
   const validated = await validateSsrfUrl(url, { allowPrivateIps });
   const { protocol } = new URL(url);
   return buildPinnedAgent(validated, protocol, {
@@ -364,7 +390,9 @@ export const buildSsrfSafeAgent = async (
     rejectUnauthorized,
     servername,
     keepAlive,
-    checkServerIdentity
+    checkServerIdentity,
+    key,
+    cert
   });
 };
 
@@ -393,6 +421,18 @@ type TSafeRequestExtras = {
    * (e.g. Kubernetes API servers). Defaults to the URL hostname if unset.
    */
   servername?: string;
+  /**
+   * mTLS client private key (PEM). Forwarded to the per-request https.Agent
+   * so it composes with the pinned lookup. Only applied to HTTPS URLs. Pair
+   * with `cert`. Required for endpoints that authenticate the client via
+   * certificate (e.g. OVH OKMS).
+   */
+  key?: string | Buffer;
+  /**
+   * mTLS client certificate (PEM). Forwarded to the per-request https.Agent.
+   * Only applied to HTTPS URLs. Pair with `key`.
+   */
+  cert?: string | Buffer;
 };
 
 type TSafeRequestConfig = Omit<AxiosRequestConfig, "httpAgent" | "httpsAgent" | "maxRedirects" | "url" | "method">;
@@ -426,11 +466,18 @@ const dispatch = async <T>(
   data: unknown,
   options: TSafeRequestConfig & TSafeRequestExtras = {}
 ) => {
-  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, ...axiosOpts } = options;
+  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, key, cert, ...axiosOpts } = options;
   const effectiveUrl = resolveBaseUrl(url, axiosOpts.baseURL);
   const validated = await validateSsrfUrl(effectiveUrl, { allowPrivateIps });
   const { protocol } = new URL(effectiveUrl);
-  const agent = buildPinnedAgent(validated, protocol, { addressFamily, ca, rejectUnauthorized, servername });
+  const agent = buildPinnedAgent(validated, protocol, {
+    addressFamily,
+    ca,
+    rejectUnauthorized,
+    servername,
+    key,
+    cert
+  });
 
   return request.request<T>({
     ...axiosOpts,
@@ -444,11 +491,18 @@ const dispatch = async <T>(
 };
 
 const dispatchFull = async <T>(config: TSafeRequestFullConfig) => {
-  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, url, ...axiosOpts } = config;
+  const { allowPrivateIps, addressFamily, ca, rejectUnauthorized, servername, key, cert, url, ...axiosOpts } = config;
   const effectiveUrl = resolveBaseUrl(url, axiosOpts.baseURL);
   const validated = await validateSsrfUrl(effectiveUrl, { allowPrivateIps });
   const { protocol } = new URL(effectiveUrl);
-  const agent = buildPinnedAgent(validated, protocol, { addressFamily, ca, rejectUnauthorized, servername });
+  const agent = buildPinnedAgent(validated, protocol, {
+    addressFamily,
+    ca,
+    rejectUnauthorized,
+    servername,
+    key,
+    cert
+  });
 
   return request.request<T>({
     ...axiosOpts,

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
@@ -1,12 +1,9 @@
-import https from "https";
-
-import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { validateSsrfUrl } from "@app/lib/validator/validate-url";
+import { safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
 import { OVHConnectionMethod } from "./ovh-connection-enums";
-import { TOvhConnection, TOvhConnectionConfig } from "./ovh-connection-types";
+import { TOvhConnectionConfig } from "./ovh-connection-types";
 
 export const getOvhConnectionListItem = () => {
   return {
@@ -16,25 +13,13 @@ export const getOvhConnectionListItem = () => {
   };
 };
 
-export const getOvhHttpsAgent = (connection: Pick<TOvhConnection, "credentials"> | TOvhConnectionConfig) => {
-  const { privateKey, certificate } = connection.credentials;
-
-  return new https.Agent({
-    key: privateKey,
-    cert: certificate
-  });
-};
-
 export const validateOvhConnectionCredentials = async (config: TOvhConnectionConfig) => {
-  const { okmsDomain, okmsId } = config.credentials;
-
-  await validateSsrfUrl(okmsDomain);
-
-  const httpsAgent = getOvhHttpsAgent(config);
+  const { okmsDomain, okmsId, privateKey, certificate } = config.credentials;
 
   try {
-    await request.get(`${okmsDomain}/api/${encodeURIComponent(okmsId)}/v1/servicekey`, {
-      httpsAgent,
+    await safeRequest.get(`${okmsDomain}/api/${encodeURIComponent(okmsId)}/v1/servicekey`, {
+      key: privateKey,
+      cert: certificate,
       timeout: 15000,
       validateStatus: (status) => status === 200
     });

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
@@ -2,6 +2,7 @@ import https from "https";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
+import { removeTrailingSlash } from "@app/lib/fn";
 import { validateSsrfUrl } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
@@ -25,8 +26,28 @@ export const getOvhHttpsAgent = (connection: Pick<TOvhConnection, "credentials">
   });
 };
 
+const normalizeOvhOkmsDomain = (okmsDomain: string) => {
+  const normalized = removeTrailingSlash(okmsDomain.trim());
+
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    throw new BadRequestError({
+      message: "OKMS domain must be a valid URL "
+    });
+  }
+
+  if (url.protocol !== "https:") {
+    throw new BadRequestError({ message: "OKMS domain must use https" });
+  }
+
+  return normalized;
+};
+
 export const validateOvhConnectionCredentials = async (config: TOvhConnectionConfig) => {
-  const { okmsDomain, okmsId } = config.credentials;
+  const okmsDomain = normalizeOvhOkmsDomain(config.credentials.okmsDomain);
+  const { okmsId } = config.credentials;
 
   await validateSsrfUrl(okmsDomain);
 
@@ -44,5 +65,8 @@ export const validateOvhConnectionCredentials = async (config: TOvhConnectionCon
     });
   }
 
-  return config.credentials;
+  return {
+    ...config.credentials,
+    okmsDomain
+  };
 };

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
@@ -1,9 +1,12 @@
+import https from "https";
+
+import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { safeRequest } from "@app/lib/validator";
+import { validateSsrfUrl } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
 import { OVHConnectionMethod } from "./ovh-connection-enums";
-import { TOvhConnectionConfig } from "./ovh-connection-types";
+import { TOvhConnection, TOvhConnectionConfig } from "./ovh-connection-types";
 
 export const getOvhConnectionListItem = () => {
   return {
@@ -13,13 +16,25 @@ export const getOvhConnectionListItem = () => {
   };
 };
 
+export const getOvhHttpsAgent = (connection: Pick<TOvhConnection, "credentials"> | TOvhConnectionConfig) => {
+  const { privateKey, certificate } = connection.credentials;
+
+  return new https.Agent({
+    key: privateKey,
+    cert: certificate
+  });
+};
+
 export const validateOvhConnectionCredentials = async (config: TOvhConnectionConfig) => {
-  const { okmsDomain, okmsId, privateKey, certificate } = config.credentials;
+  const { okmsDomain, okmsId } = config.credentials;
+
+  await validateSsrfUrl(okmsDomain);
+
+  const httpsAgent = getOvhHttpsAgent(config);
 
   try {
-    await safeRequest.get(`${okmsDomain}/api/${encodeURIComponent(okmsId)}/v1/servicekey`, {
-      key: privateKey,
-      cert: certificate,
+    await request.get(`${okmsDomain}/api/${encodeURIComponent(okmsId)}/v1/servicekey`, {
+      httpsAgent,
       timeout: 15000,
       validateStatus: (status) => status === 200
     });

--- a/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
@@ -19,7 +19,6 @@ export const OvhConnectionCertificateCredentialsSchema = z.object({
     .trim()
     .min(1, "OKMS domain required")
     .url("OKMS domain must be a valid URL (e.g. https://example.com)")
-    .refine((val) => new URL(val).protocol === "https:", { message: "OKMS domain must use https" })
     .describe(AppConnections.CREDENTIALS.OVH.okmsDomain),
   okmsId: z.string().trim().min(1, "OKMS ID required").describe(AppConnections.CREDENTIALS.OVH.okmsId)
 });

--- a/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
@@ -14,7 +14,13 @@ import { OVHConnectionMethod } from "./ovh-connection-enums";
 export const OvhConnectionCertificateCredentialsSchema = z.object({
   privateKey: z.string().trim().min(1, "Private key required").describe(AppConnections.CREDENTIALS.OVH.privateKey),
   certificate: z.string().trim().min(1, "Certificate required").describe(AppConnections.CREDENTIALS.OVH.certificate),
-  okmsDomain: z.string().trim().min(1, "OKMS domain required").describe(AppConnections.CREDENTIALS.OVH.okmsDomain),
+  okmsDomain: z
+    .string()
+    .trim()
+    .min(1, "OKMS domain required")
+    .url("OKMS domain must be a valid URL (e.g. https://example.com)")
+    .refine((val) => new URL(val).protocol === "https:", { message: "OKMS domain must use https" })
+    .describe(AppConnections.CREDENTIALS.OVH.okmsDomain),
   okmsId: z.string().trim().min(1, "OKMS ID required").describe(AppConnections.CREDENTIALS.OVH.okmsId)
 });
 

--- a/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
@@ -1,7 +1,10 @@
 import { isAxiosError } from "axios";
+import https from "https";
 
+import { request } from "@app/lib/config/request";
 import { deepEqual } from "@app/lib/fn/object";
-import { safeRequest } from "@app/lib/validator";
+import { validateSsrfUrl } from "@app/lib/validator";
+import { getOvhHttpsAgent } from "@app/services/app-connection/ovh";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
@@ -59,15 +62,14 @@ const readSecret = async (
   okmsDomain: string,
   okmsId: string,
   path: string,
-  privateKey: string,
-  certificate: string
+  httpsAgent: https.Agent
 ): Promise<TOvhSecretRead> => {
   try {
-    const { data } = await safeRequest.get<TOvhGetSecretResponse>(
+    await validateSsrfUrl(okmsDomain);
+    const { data } = await request.get<TOvhGetSecretResponse>(
       `${getSecretUrl(okmsDomain, okmsId, path)}?includeData=true`,
       {
-        key: privateKey,
-        cert: certificate,
+        httpsAgent,
         timeout: REQUEST_TIMEOUT_MS
       }
     );
@@ -89,15 +91,14 @@ const createSecret = async (
   okmsId: string,
   path: string,
   data: Record<string, string>,
-  privateKey: string,
-  certificate: string
-) =>
-  safeRequest.post(
+  httpsAgent: https.Agent
+) => {
+  await validateSsrfUrl(okmsDomain);
+  return request.post(
     `${okmsDomain}/api/${encodeURIComponent(okmsId)}/v2/secret`,
     { path, version: { data } },
     {
-      key: privateKey,
-      cert: certificate,
+      httpsAgent,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
         "Content-Type": "application/json",
@@ -105,6 +106,7 @@ const createSecret = async (
       }
     }
   );
+};
 
 const updateSecret = async (
   okmsDomain: string,
@@ -112,17 +114,16 @@ const updateSecret = async (
   path: string,
   data: Record<string, string>,
   cas: number | null,
-  privateKey: string,
-  certificate: string
+  httpsAgent: https.Agent
 ) => {
+  await validateSsrfUrl(okmsDomain);
   const base = getSecretUrl(okmsDomain, okmsId, path);
   const url = cas !== null ? `${base}?cas=${cas}` : base;
-  return safeRequest.put(
+  return request.put(
     url,
     { version: { data } },
     {
-      key: privateKey,
-      cert: certificate,
+      httpsAgent,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
         "Content-Type": "application/json",
@@ -142,22 +143,19 @@ const writeSecretBundle = async (
 ) => {
   const { connection, destinationConfig } = secretSync;
   const path = String(destinationConfig.path);
-  const { okmsDomain, okmsId, privateKey, certificate } = connection.credentials;
+  const { okmsDomain, okmsId } = connection.credentials;
+  const httpsAgent = getOvhHttpsAgent(connection);
 
   try {
-    const {
-      exists,
-      data: existingData,
-      currentVersion
-    } = await readSecret(okmsDomain, okmsId, path, privateKey, certificate);
+    const { exists, data: existingData, currentVersion } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
     const desiredData = buildDesiredBundle(existingData);
 
     if (deepEqual(existingData, desiredData)) return;
 
     if (exists) {
-      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, privateKey, certificate);
+      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, httpsAgent);
     } else {
-      await createSecret(okmsDomain, okmsId, path, desiredData, privateKey, certificate);
+      await createSecret(okmsDomain, okmsId, path, desiredData, httpsAgent);
     }
   } catch (error) {
     throw new SecretSyncError({ error: sanitizeOvhError(error) });
@@ -193,10 +191,11 @@ export const OvhSyncFns = {
   getSecrets: async (secretSync: TOvhSyncWithCredentials): Promise<TSecretMap> => {
     const { connection, destinationConfig } = secretSync;
     const path = String(destinationConfig.path);
-    const { okmsDomain, okmsId, privateKey, certificate } = connection.credentials;
+    const { okmsDomain, okmsId } = connection.credentials;
+    const httpsAgent = getOvhHttpsAgent(connection);
 
     try {
-      const { data } = await readSecret(okmsDomain, okmsId, path, privateKey, certificate);
+      const { data } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
       return Object.fromEntries(Object.entries(data).map(([key, value]) => [key, { value }]));
     } catch (error) {
       throw new SecretSyncError({ error: sanitizeOvhError(error) });

--- a/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
@@ -1,9 +1,7 @@
 import { isAxiosError } from "axios";
-import https from "https";
 
-import { request } from "@app/lib/config/request";
 import { deepEqual } from "@app/lib/fn/object";
-import { getOvhHttpsAgent } from "@app/services/app-connection/ovh";
+import { safeRequest } from "@app/lib/validator";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
@@ -61,13 +59,15 @@ const readSecret = async (
   okmsDomain: string,
   okmsId: string,
   path: string,
-  httpsAgent: https.Agent
+  privateKey: string,
+  certificate: string
 ): Promise<TOvhSecretRead> => {
   try {
-    const { data } = await request.get<TOvhGetSecretResponse>(
+    const { data } = await safeRequest.get<TOvhGetSecretResponse>(
       `${getSecretUrl(okmsDomain, okmsId, path)}?includeData=true`,
       {
-        httpsAgent,
+        key: privateKey,
+        cert: certificate,
         timeout: REQUEST_TIMEOUT_MS
       }
     );
@@ -89,13 +89,15 @@ const createSecret = async (
   okmsId: string,
   path: string,
   data: Record<string, string>,
-  httpsAgent: https.Agent
+  privateKey: string,
+  certificate: string
 ) =>
-  request.post(
+  safeRequest.post(
     `${okmsDomain}/api/${encodeURIComponent(okmsId)}/v2/secret`,
     { path, version: { data } },
     {
-      httpsAgent,
+      key: privateKey,
+      cert: certificate,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
         "Content-Type": "application/json",
@@ -110,15 +112,17 @@ const updateSecret = async (
   path: string,
   data: Record<string, string>,
   cas: number | null,
-  httpsAgent: https.Agent
+  privateKey: string,
+  certificate: string
 ) => {
   const base = getSecretUrl(okmsDomain, okmsId, path);
   const url = cas !== null ? `${base}?cas=${cas}` : base;
-  return request.put(
+  return safeRequest.put(
     url,
     { version: { data } },
     {
-      httpsAgent,
+      key: privateKey,
+      cert: certificate,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
         "Content-Type": "application/json",
@@ -138,19 +142,22 @@ const writeSecretBundle = async (
 ) => {
   const { connection, destinationConfig } = secretSync;
   const path = String(destinationConfig.path);
-  const { okmsDomain, okmsId } = connection.credentials;
-  const httpsAgent = getOvhHttpsAgent(connection);
+  const { okmsDomain, okmsId, privateKey, certificate } = connection.credentials;
 
   try {
-    const { exists, data: existingData, currentVersion } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
+    const {
+      exists,
+      data: existingData,
+      currentVersion
+    } = await readSecret(okmsDomain, okmsId, path, privateKey, certificate);
     const desiredData = buildDesiredBundle(existingData);
 
     if (deepEqual(existingData, desiredData)) return;
 
     if (exists) {
-      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, httpsAgent);
+      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, privateKey, certificate);
     } else {
-      await createSecret(okmsDomain, okmsId, path, desiredData, httpsAgent);
+      await createSecret(okmsDomain, okmsId, path, desiredData, privateKey, certificate);
     }
   } catch (error) {
     throw new SecretSyncError({ error: sanitizeOvhError(error) });
@@ -186,11 +193,10 @@ export const OvhSyncFns = {
   getSecrets: async (secretSync: TOvhSyncWithCredentials): Promise<TSecretMap> => {
     const { connection, destinationConfig } = secretSync;
     const path = String(destinationConfig.path);
-    const { okmsDomain, okmsId } = connection.credentials;
-    const httpsAgent = getOvhHttpsAgent(connection);
+    const { okmsDomain, okmsId, privateKey, certificate } = connection.credentials;
 
     try {
-      const { data } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
+      const { data } = await readSecret(okmsDomain, okmsId, path, privateKey, certificate);
       return Object.fromEntries(Object.entries(data).map(([key, value]) => [key, { value }]));
     } catch (error) {
       throw new SecretSyncError({ error: sanitizeOvhError(error) });


### PR DESCRIPTION
## Context

Add SSRF validation for all calls to OVH (app connection and sync) to make sure we don't have a SSRF. It also adds a new validation on the schema to only allow URLs.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Create a sync with OVH (or at least an app connection)

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)