### PR TITLE
fix(honey-tokens): validate signing key, stack name and region

### DIFF
--- a/backend/src/ee/services/honey-token/honey-token-types.ts
+++ b/backend/src/ee/services/honey-token/honey-token-types.ts
@@ -39,13 +39,8 @@ export const AwsHoneyTokenConfigSchema = z.object({
     .string()
     .min(1)
     .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
-  stackName: slugSchema({max: 64, field: 'stackName'})
-    .default("infisical-honey-tokens"),
-  awsRegion: z
-    .string()
-    .min(1)
-    .default("us-east-1")
-    .refine(isValidAwsRegion, "Invalid AWS region")
+  stackName: slugSchema({ max: 64, field: "stackName" }).default("infisical-honey-tokens"),
+  awsRegion: z.string().min(1).default("us-east-1").refine(isValidAwsRegion, "Invalid AWS region")
 });
 
 export type TAwsHoneyTokenConfig = z.infer<typeof AwsHoneyTokenConfigSchema>;

--- a/backend/src/ee/services/honey-token/honey-token-types.ts
+++ b/backend/src/ee/services/honey-token/honey-token-types.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { isValidAwsRegion } from "@app/lib/aws/region";
 
 import { HoneyTokenEventType, HoneyTokenType } from "./honey-token-enums";
+import { slugSchema } from "@app/server/lib/schemas";
 
 export const AwsHoneyTokenEventMetadataSchema = z.object({
   accessKeyId: z.string(),
@@ -38,14 +39,7 @@ export const AwsHoneyTokenConfigSchema = z.object({
     .string()
     .min(1)
     .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
-  stackName: z
-    .string()
-    .min(1)
-    .max(128)
-    .regex(
-      /^[a-zA-Z][a-zA-Z0-9-]*$/,
-      "Stack name must start with a letter and contain only letters, numbers, and hyphens"
-    )
+  stackName: slugSchema({max: 64, field: 'stackName'})
     .default("infisical-honey-tokens"),
   awsRegion: z
     .string()

--- a/backend/src/ee/services/honey-token/honey-token-types.ts
+++ b/backend/src/ee/services/honey-token/honey-token-types.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 import { isValidAwsRegion } from "@app/lib/aws/region";
+import { slugSchema } from "@app/server/lib/schemas";
 
 import { HoneyTokenEventType, HoneyTokenType } from "./honey-token-enums";
-import { slugSchema } from "@app/server/lib/schemas";
 
 export const AwsHoneyTokenEventMetadataSchema = z.object({
   accessKeyId: z.string(),

--- a/backend/src/ee/services/honey-token/honey-token-types.ts
+++ b/backend/src/ee/services/honey-token/honey-token-types.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isValidAwsRegion } from "@app/lib/aws/region";
+
 import { HoneyTokenEventType, HoneyTokenType } from "./honey-token-enums";
 
 export const AwsHoneyTokenEventMetadataSchema = z.object({
@@ -32,9 +34,24 @@ export type THoneyTokenEventMetadata = z.infer<typeof HoneyTokenEventMetadataSch
 // --- Config schemas (typed shape for the encrypted config blob per provider) ---
 
 export const AwsHoneyTokenConfigSchema = z.object({
-  webhookSigningKey: z.string().min(1),
-  stackName: z.string().min(1).max(128).default("infisical-honey-tokens"),
-  awsRegion: z.string().min(1).default("us-east-1")
+  webhookSigningKey: z
+    .string()
+    .min(1)
+    .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
+  stackName: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(
+      /^[a-zA-Z][a-zA-Z0-9-]*$/,
+      "Stack name must start with a letter and contain only letters, numbers, and hyphens"
+    )
+    .default("infisical-honey-tokens"),
+  awsRegion: z
+    .string()
+    .min(1)
+    .default("us-east-1")
+    .refine(isValidAwsRegion, "Invalid AWS region")
 });
 
 export type TAwsHoneyTokenConfig = z.infer<typeof AwsHoneyTokenConfigSchema>;

--- a/backend/src/ee/services/honey-token/honey-token-types.ts
+++ b/backend/src/ee/services/honey-token/honey-token-types.ts
@@ -39,7 +39,7 @@ export const AwsHoneyTokenConfigSchema = z.object({
     .string()
     .min(1)
     .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
-  stackName: slugSchema({ max: 64, field: "stackName" }).default("infisical-honey-tokens"),
+  stackName: slugSchema({ max: 128, field: "stackName" }).default("infisical-honey-tokens"),
   awsRegion: z.string().min(1).default("us-east-1").refine(isValidAwsRegion, "Invalid AWS region")
 });
 

--- a/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
+++ b/backend/src/ee/services/resource-auth-method/aws-auth-fns.ts
@@ -1,5 +1,6 @@
 import RE2 from "re2";
 
+import { isValidAwsRegion } from "@app/lib/aws/region";
 import { request } from "@app/lib/config/request";
 import { UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
@@ -25,13 +26,6 @@ const awsRegionFromHeader = (authorizationHeader: string): string | null => {
     return null;
   }
   return null;
-};
-
-const validRegionPattern = new RE2("^[a-z0-9-]+$");
-
-const isValidAwsRegion = (region: string | null): boolean => {
-  if (typeof region !== "string" || region.length === 0 || region.length > 20) return false;
-  return validRegionPattern.test(region);
 };
 
 type TVerifyStsCallerInput = {

--- a/backend/src/lib/aws/region.ts
+++ b/backend/src/lib/aws/region.ts
@@ -1,0 +1,8 @@
+import RE2 from "re2";
+
+const validRegionPattern = new RE2("^[a-z0-9-]+$");
+
+export const isValidAwsRegion = (region: string | null): boolean => {
+  if (typeof region !== "string" || region.length === 0 || region.length > 20) return false;
+  return validRegionPattern.test(region);
+};

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
@@ -55,7 +55,7 @@ const schema = z.object({
     .string()
     .min(1, "Webhook Signing Key is required")
     .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
-  stackName: slugSchema({max: 128, field: 'stackName'}),
+  stackName: slugSchema({ max: 128, field: "stackName" }),
   awsRegion: z
     .string()
     .trim()

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
@@ -26,6 +26,7 @@ import {
   Input
 } from "@app/components/v3";
 import { OrgPermissionHoneyTokenActions, OrgPermissionSubjects } from "@app/context";
+import { AWS_REGIONS } from "@app/helpers/appConnections";
 import { useTimedReset, useToggle } from "@app/hooks";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { useListAppConnections } from "@app/hooks/api/appConnections/queries";
@@ -43,11 +44,30 @@ const DEFAULT_STACK_NAME = "infisical-honey-tokens";
 const DEFAULT_AWS_REGION = "us-east-1";
 const WEBHOOK_SIGNING_KEY_BYTES = 32;
 
+const validAwsRegionSlugs = new Set(AWS_REGIONS.map((r) => r.slug));
+
+const isValidAwsRegion = (region: string) => validAwsRegionSlugs.has(region);
+
 const schema = z.object({
   connectionId: z.string().min(1, "AWS Connection is required"),
-  webhookSigningKey: z.string().min(1, "Webhook Signing Key is required"),
-  stackName: z.string().trim().min(1, "Stack name is required").max(128),
-  awsRegion: z.string().trim().min(1, "AWS region is required")
+  webhookSigningKey: z
+    .string()
+    .min(1, "Webhook Signing Key is required")
+    .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
+  stackName: z
+    .string()
+    .trim()
+    .min(1, "Stack name is required")
+    .max(128)
+    .regex(
+      /^[a-zA-Z][a-zA-Z0-9-]*$/,
+      "Stack name must start with a letter and contain only letters, numbers, and hyphens"
+    ),
+  awsRegion: z
+    .string()
+    .trim()
+    .min(1, "AWS region is required")
+    .refine(isValidAwsRegion, "Invalid AWS region")
 });
 
 type FormData = z.infer<typeof schema>;
@@ -131,13 +151,13 @@ export const HoneyTokenModal = ({ isOpen, onOpenChange }: Props) => {
     () =>
       [
         "aws cloudformation create-stack \\",
-        `  --region ${awsRegion || DEFAULT_AWS_REGION} \\`,
-        `  --stack-name ${stackName || DEFAULT_STACK_NAME} \\`,
-        `  --template-url ${CF_TEMPLATE_URL} \\`,
+        `  --region '${awsRegion || DEFAULT_AWS_REGION}' \\`,
+        `  --stack-name '${stackName || DEFAULT_STACK_NAME}' \\`,
+        `  --template-url '${CF_TEMPLATE_URL}' \\`,
         "  --capabilities CAPABILITY_NAMED_IAM \\",
         "  --parameters \\",
-        `    ParameterKey=WebhookUrl,ParameterValue=${webhookUrl} \\`,
-        `    ParameterKey=WebhookSigningKey,ParameterValue=${webhookSigningKey}`
+        `    ParameterKey=WebhookUrl,ParameterValue='${webhookUrl}' \\`,
+        `    ParameterKey=WebhookSigningKey,ParameterValue='${webhookSigningKey}'`
       ].join("\n"),
     [awsRegion, stackName, webhookSigningKey, webhookUrl]
   );

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
@@ -36,6 +36,7 @@ import {
   useTestHoneyTokenConnection,
   useUpsertHoneyTokenConfig
 } from "@app/hooks/api/honeyToken";
+import { slugSchema } from "@app/lib/schemas";
 
 const CF_TEMPLATE_URL =
   "https://infisical-static-assets.s3.us-east-1.amazonaws.com/honey-tokens/honey-tokens-v1.yaml";
@@ -54,15 +55,7 @@ const schema = z.object({
     .string()
     .min(1, "Webhook Signing Key is required")
     .regex(/^[a-fA-F0-9]+$/, "Signing key must be a hex string"),
-  stackName: z
-    .string()
-    .trim()
-    .min(1, "Stack name is required")
-    .max(128)
-    .regex(
-      /^[a-zA-Z][a-zA-Z0-9-]*$/,
-      "Stack name must start with a letter and contain only letters, numbers, and hyphens"
-    ),
+  stackName: slugSchema({max: 128, field: 'stackName'}),
   awsRegion: z
     .string()
     .trim()


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This prevents command injection into the field values by:

1. Validating the input
2. wrapping the command parameters in quotes

I didn't change the region input to be a `select` because it breaks due to the `accordion`. Will reproduce it in isolation and send to Scott.

## Screenshots

<img width="987" height="1261" alt="image" src="https://github.com/user-attachments/assets/5f16831d-e0e9-4dc0-b0db-40c6b1eb640b" />


<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

* Go to Settings  > Product Settings
* Try to save invalid values, it should fail

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)