### PR TITLE
fix(inc-52): etag expiration

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -101,7 +101,7 @@ export const KeyStorePrefixes = {
   TelemetryIdentifyIdentity: (dedupKey: string) => `telemetry-identify-identity:${dedupKey}` as const,
   TelemetryGroupIdentify: (orgId: string) => `telemetry-group-identify:${orgId}` as const,
   TelemetryIdentify: (distinctId: string) => `telemetry-identify:${distinctId}` as const,
-  SecretEtag: (projectId: string) => `secret-etag:${projectId}` as const,
+  SecretEtag: (projectId: string, dayStamp: string) => `secret-etag:${projectId}:${dayStamp}` as const,
 
   PamAwsIamAccessKeyId: (sessionId: string) => `pam-aws-iam-access-key-id:${sessionId}` as const,
 

--- a/backend/src/lib/dates/index.ts
+++ b/backend/src/lib/dates/index.ts
@@ -6,3 +6,6 @@ export const applyJitter = (delay: number, jitter: number) => {
   const jitterTime = Math.floor(Math.random() * (2 * jitter)) - jitter;
   return delay + jitterTime;
 };
+
+export const utcDayStamp = (d: Date = new Date()) =>
+  `${d.getUTCFullYear()}${String(d.getUTCMonth() + 1).padStart(2, "0")}${String(d.getUTCDate()).padStart(2, "0")}`;

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -6,7 +6,7 @@ import { TDbClient } from "@app/db";
 import { ProjectType, SecretsV2Schema, SecretType, TableName, TSecretsV2, TSecretsV2Update } from "@app/db/schemas";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { generateCacheKeyFromData } from "@app/lib/crypto/cache";
-import { applyJitter } from "@app/lib/dates";
+import { applyJitter, utcDayStamp } from "@app/lib/dates";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import {
   buildFindFilter,
@@ -56,7 +56,7 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
   const invalidateSecretCacheByProjectId = async (projectId: string, tx?: Knex) => {
     const secretDalVersionKey = SecretServiceCacheKeys.getSecretDalVersion(projectId);
     await keyStore.pgIncrementBy(secretDalVersionKey, { incr: 1, tx, expiry: SECRET_DAL_VERSION_TTL });
-    await keyStore.deleteItem(KeyStorePrefixes.SecretEtag(projectId));
+    await keyStore.deleteItem(KeyStorePrefixes.SecretEtag(projectId, utcDayStamp()));
   };
 
   const findOne = async (filter: Partial<TSecretsV2>, tx?: Knex) => {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -35,6 +35,7 @@ import { scanSecretPolicyViolations } from "@app/ee/services/secret-scanning-v2/
 import { TSecretSnapshotServiceFactory } from "@app/ee/services/secret-snapshot/secret-snapshot-service";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { generateCacheKeyFromData } from "@app/lib/crypto/cache";
+import { utcDayStamp } from "@app/lib/dates";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { diff, groupBy } from "@app/lib/fn";
@@ -1177,7 +1178,7 @@ export const secretV2BridgeServiceFactory = ({
       });
     }
 
-    const etagRedisKey = KeyStorePrefixes.SecretEtag(projectId);
+    const etagRedisKey = KeyStorePrefixes.SecretEtag(projectId, utcDayStamp());
     const etagField = `${actorId}:${permissionFingerprint}:${generateCacheKeyFromData({
       environment,
       path,


### PR DESCRIPTION
## Context

- Add date to etag hash to ensure that hashes are expired at least every 24 hours.
- This was a result of the hash expirations being on the hash key rather than the field itself. Which caused all of the keys to permanently ensure that they are in memory and not ever expiring. This fixes that. 

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [X] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)