### PR TITLE
improvement: revamp secret overview secret update and delete confirmation modals

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -32,7 +32,7 @@ import {
   ResolvedSecretValuePopover,
   SecretReferenceTree
 } from "@app/components/secrets/SecretReferenceDetails";
-import { DeleteActionModal, Input, Modal, ModalContent } from "@app/components/v2";
+import { Input, Modal, ModalContent } from "@app/components/v2";
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import {
   AlertDialog,
@@ -310,6 +310,7 @@ export const SecretEditTableRow = ({
   const [isDeleting, setIsDeleting] = useToggle();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
+  const [editConfirmation, setEditConfirmation] = useState("");
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const [isTagOpen, setIsTagOpen] = useState(false);
   const [isMetadataOpen, setIsMetadataOpen] = useState(false);
@@ -326,6 +327,10 @@ export const SecretEditTableRow = ({
   useEffect(() => {
     if (!isModalOpen) setDeleteConfirmation("");
   }, [isModalOpen]);
+
+  useEffect(() => {
+    if (!popUp.editSecret.isOpen) setEditConfirmation("");
+  }, [popUp.editSecret.isOpen]);
 
   const originalCommentRef = useRef(comment ?? "");
   const originalTagsRef = useRef(tags?.map((t) => ({ id: t.id, slug: t.slug })) ?? []);
@@ -1765,26 +1770,60 @@ export const SecretEditTableRow = ({
         text="Secret access insights can be unlocked if you upgrade to Infisical Pro plan."
       />
 
-      <DeleteActionModal
-        isOpen={popUp.editSecret.isOpen}
-        deleteKey="confirm"
-        buttonColorSchema="secondary"
-        buttonText="Save"
-        subTitle=""
-        title="Do you want to edit this secret?"
-        onChange={(isOpen) => handlePopUpToggle("editSecret", isOpen)}
-        onDeleteApproved={() => handleEditSecret(popUp?.editSecret?.data)}
-        formContent={
-          importedBy &&
-          importedBy.length > 0 && (
+      <AlertDialog
+        open={popUp.editSecret.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("editSecret", isOpen)}
+      >
+        <AlertDialogContent className="sm:max-w-4xl!">
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <SaveIcon />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Update this secret?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This secret is referenced by other secrets in your project. Saving these changes will
+              update everywhere it&apos;s referenced.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {importedBy && importedBy.length > 0 && (
             <CollapsibleSecretImports
               importedBy={importedBy}
               secretsToDelete={[secretName]}
               onlyReferences
             />
-          )
-        }
-      />
+          )}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (editConfirmation === "confirm") handleEditSecret(popUp?.editSecret?.data);
+            }}
+          >
+            <Field>
+              <FieldLabel>
+                Type <span className="font-bold">confirm</span> to proceed
+              </FieldLabel>
+              <FieldContent>
+                <V3Input
+                  value={editConfirmation}
+                  onChange={(e) => setEditConfirmation(e.target.value)}
+                  placeholder="Type confirm here"
+                  autoComplete="off"
+                />
+              </FieldContent>
+            </Field>
+          </form>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="project"
+              onClick={() => handleEditSecret(popUp?.editSecret?.data)}
+              disabled={editConfirmation !== "confirm"}
+            >
+              Save Changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <AddShareSecretModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
     </>
   );

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -308,6 +308,7 @@ export const SecretEditTableRow = ({
   const { mutateAsync: updateSecretV3, isPending: isUpdatingMultiline } = useUpdateSecretV3();
 
   const [isDeleting, setIsDeleting] = useToggle();
+  const [isEditing, setIsEditing] = useToggle();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [editConfirmation, setEditConfirmation] = useState("");
@@ -796,23 +797,29 @@ export const SecretEditTableRow = ({
     secretValue: string;
     newKey?: string;
   }) => {
-    await onSecretUpdate({
-      env: environment,
-      key: secretName,
-      value: secretValue,
-      secretValueHidden,
-      type: SecretType.Shared,
-      secretId,
-      newSecretName: newKey
-    });
-    if (!secretValueHidden) {
-      originalValueRef.current = secretValue;
+    if (isEditing) return;
+    setIsEditing.on();
+    try {
+      await onSecretUpdate({
+        env: environment,
+        key: secretName,
+        value: secretValue,
+        secretValueHidden,
+        type: SecretType.Shared,
+        secretId,
+        newSecretName: newKey
+      });
+      if (!secretValueHidden) {
+        originalValueRef.current = secretValue;
+      }
+      reset({
+        value: secretValue,
+        ...(isSingleEnvView ? { key: newKey || secretName } : {})
+      });
+      handlePopUpClose("editSecret");
+    } finally {
+      setIsEditing.off();
     }
-    reset({
-      value: secretValue,
-      ...(isSingleEnvView ? { key: newKey || secretName } : {})
-    });
-    handlePopUpClose("editSecret");
   };
 
   const canReadSecretValue = hasSecretReadValueOrDescribePermission(
@@ -1817,7 +1824,7 @@ export const SecretEditTableRow = ({
             <AlertDialogAction
               variant="project"
               onClick={() => handleEditSecret(popUp?.editSecret?.data)}
-              disabled={editConfirmation !== "confirm"}
+              disabled={editConfirmation !== "confirm" || isEditing}
             >
               Save Changes
             </AlertDialogAction>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -838,16 +838,16 @@ export const SecretEditTableRow = ({
   );
 
   const handleDeleteSecret = useCallback(async () => {
+    if (isDeleting) return;
     setIsDeleting.on();
-    setIsModalOpen(false);
-
     try {
       await onSecretDelete(environment, secretName, secretId);
       reset({ value: null });
+      setIsModalOpen(false);
     } finally {
       setIsDeleting.off();
     }
-  }, [onSecretDelete, environment, secretName, secretId, reset, setIsDeleting]);
+  }, [isDeleting, onSecretDelete, environment, secretName, secretId, reset, setIsDeleting]);
 
   const canReadTags = permission.can(ProjectPermissionActions.Read, ProjectPermissionSub.Tags);
   const canCreate = permission.can(
@@ -960,7 +960,10 @@ export const SecretEditTableRow = ({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               variant="danger"
-              onClick={handleDeleteSecret}
+              onClick={(e) => {
+                e.preventDefault();
+                handleDeleteSecret();
+              }}
               disabled={deleteConfirmation !== secretName || isDeleting}
             >
               Delete Secret
@@ -1823,7 +1826,10 @@ export const SecretEditTableRow = ({
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               variant="project"
-              onClick={() => handleEditSecret(popUp?.editSecret?.data)}
+              onClick={(e) => {
+                e.preventDefault();
+                handleEditSecret(popUp?.editSecret?.data);
+              }}
               disabled={editConfirmation !== "confirm" || isEditing}
             >
               Save Changes

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -35,12 +35,25 @@ import {
 import { DeleteActionModal, Input, Modal, ModalContent } from "@app/components/v2";
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
   Badge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Field,
+  FieldContent,
+  FieldLabel,
   IconButton,
+  Input as V3Input,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -296,6 +309,7 @@ export const SecretEditTableRow = ({
 
   const [isDeleting, setIsDeleting] = useToggle();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const [isTagOpen, setIsTagOpen] = useState(false);
   const [isMetadataOpen, setIsMetadataOpen] = useState(false);
@@ -308,6 +322,10 @@ export const SecretEditTableRow = ({
   const toggleModal = useCallback(() => {
     setIsModalOpen((prev) => !prev);
   }, []);
+
+  useEffect(() => {
+    if (!isModalOpen) setDeleteConfirmation("");
+  }, [isModalOpen]);
 
   const originalCommentRef = useRef(comment ?? "");
   const originalTagsRef = useRef(tags?.map((t) => ({ id: t.id, slug: t.slug })) ?? []);
@@ -894,13 +912,50 @@ export const SecretEditTableRow = ({
 
   const valueContent = (
     <>
-      <DeleteActionModal
-        isOpen={isModalOpen}
-        onClose={toggleModal}
-        title="Do you want to delete the selected secret?"
-        deleteKey={secretName}
-        onDeleteApproved={handleDeleteSecret}
-      />
+      <AlertDialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <TrashIcon />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Are you sure you want to delete {secretName}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove the secret from this environment. This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (deleteConfirmation === secretName) handleDeleteSecret();
+            }}
+          >
+            <Field>
+              <FieldLabel>
+                Type <span className="font-bold">{secretName}</span> to confirm
+              </FieldLabel>
+              <FieldContent>
+                <V3Input
+                  value={deleteConfirmation}
+                  onChange={(e) => setDeleteConfirmation(e.target.value)}
+                  placeholder={`Type ${secretName} here`}
+                  autoComplete="off"
+                />
+              </FieldContent>
+            </Field>
+          </form>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="danger"
+              onClick={handleDeleteSecret}
+              disabled={deleteConfirmation !== secretName || isDeleting}
+            >
+              Delete Secret
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <div className="flex w-full cursor-text items-center space-x-2">
         {secretValueHidden && (


### PR DESCRIPTION
## Context

This PR updates the delete and update secret confirmation modals on the secrets overview page

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-05-06 at 16 58 00@2x" src="https://github.com/user-attachments/assets/46d3a1ac-8371-45a6-96ea-f2c33aabbbd6" />

<img width="3456" height="1924" alt="CleanShot 2026-05-06 at 17 02 21@2x" src="https://github.com/user-attachments/assets/4ca81908-ac94-4e1d-a9b2-313e8e0f2553" />

## Steps to verify the change

- make sure you're not in batch edit mode
- delete a secret, see confirmation modal
- update a secret that is referenced and/or imported by another secret, see modal

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)