### PR TITLE
fix: resolved dashobard not loading when honey token permission was missing

### DIFF
--- a/backend/src/ee/services/honey-token/honey-token-service.ts
+++ b/backend/src/ee/services/honey-token/honey-token-service.ts
@@ -765,10 +765,10 @@ export const honeyTokenServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager,
       projectId
     });
-    ForbiddenError.from(readPermission).throwUnlessCan(
-      ProjectPermissionHoneyTokenActions.Read,
-      ProjectPermissionSub.HoneyTokens
-    );
+
+    if (readPermission.cannot(ProjectPermissionHoneyTokenActions.Read, ProjectPermissionSub.HoneyTokens)) {
+      return 0;
+    }
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environments, secretPath);
     if (!folders.length) return 0;
@@ -817,10 +817,10 @@ export const honeyTokenServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager,
       projectId
     });
-    ForbiddenError.from(readPermission).throwUnlessCan(
-      ProjectPermissionHoneyTokenActions.Read,
-      ProjectPermissionSub.HoneyTokens
-    );
+
+    if (readPermission.cannot(ProjectPermissionHoneyTokenActions.Read, ProjectPermissionSub.HoneyTokens)) {
+      return [];
+    }
 
     const folders = await folderDAL.findBySecretPathMultiEnv(projectId, environments, secretPath);
     if (!folders.length) return [];


### PR DESCRIPTION
## Context

The dashboard was failing to load when the honey token permission was missing for users. The dashboard router should check the permission and do a soft enforcement like other services in dashboard

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)