### PR TITLE
fix(pki-dal): add deterministic id tie-breaker to ORDER BY in PKI list queries

### DIFF
--- a/backend/src/services/pki-alert-v2/pki-alert-history-dal.ts
+++ b/backend/src/services/pki-alert-v2/pki-alert-history-dal.ts
@@ -57,7 +57,8 @@ export const pkiAlertHistoryDALFactory = (db: TDbClient) => {
         .select(selectAllTableCols(TableName.PkiAlertHistory))
         .from(TableName.PkiAlertHistory)
         .where(`${TableName.PkiAlertHistory}.alertId`, alertId)
-        .orderBy(`${TableName.PkiAlertHistory}.triggeredAt`, "desc");
+        .orderBy(`${TableName.PkiAlertHistory}.triggeredAt`, "desc")
+        .orderBy(`${TableName.PkiAlertHistory}.id`, "asc");
 
       if (options?.limit) {
         query = query.limit(options.limit);

--- a/backend/src/services/pki-alert-v2/pki-alert-v2-dal.ts
+++ b/backend/src/services/pki-alert-v2/pki-alert-v2-dal.ts
@@ -192,7 +192,9 @@ export const pkiAlertV2DALFactory = (db: TDbClient) => {
         alertQuery = alertQuery.where(`${TableName.PkiAlertsV2}.enabled`, filters.enabled);
       }
 
-      alertQuery = alertQuery.orderBy(`${TableName.PkiAlertsV2}.createdAt`, "desc");
+      alertQuery = alertQuery
+        .orderBy(`${TableName.PkiAlertsV2}.createdAt`, "desc")
+        .orderBy(`${TableName.PkiAlertsV2}.id`, "asc");
 
       if (filters?.limit) {
         alertQuery = alertQuery.limit(filters.limit);

--- a/backend/src/services/pki-collection/pki-collection-item-dal.ts
+++ b/backend/src/services/pki-collection/pki-collection-item-dal.ts
@@ -63,7 +63,9 @@ export const pkiCollectionItemDALFactory = (db: TDbClient) => {
         void query.limit(limit);
       }
 
-      void query.orderBy(`${TableName.PkiCollectionItem}.createdAt`, "desc");
+      void query
+        .orderBy(`${TableName.PkiCollectionItem}.createdAt`, "desc")
+        .orderBy(`${TableName.PkiCollectionItem}.id`, "asc");
 
       const result = await query;
       return result as (TPkiCollectionItems & { notAfter: Date; notBefore: Date; friendlyName: string })[];

--- a/backend/src/services/signer/signer-dal.ts
+++ b/backend/src/services/signer/signer-dal.ts
@@ -99,6 +99,7 @@ export const signerDALFactory = (db: TDbClient) => {
 
       return (await query
         .orderBy(`${TableName.PkiSigners}.createdAt`, "desc")
+        .orderBy(`${TableName.PkiSigners}.id`, "asc")
         .offset(offset)
         .limit(limit)) as TSignerWithCertificateSummary[];
     } catch (error) {

--- a/backend/src/services/signer/signing-operation-dal.ts
+++ b/backend/src/services/signer/signing-operation-dal.ts
@@ -61,6 +61,7 @@ export const signingOperationDALFactory = (db: TDbClient) => {
 
       const rows = await query
         .orderBy(`${TableName.PkiSigningOperations}.createdAt`, "desc")
+        .orderBy(`${TableName.PkiSigningOperations}.id`, "asc")
         .offset(offset)
         .limit(limit);
 


### PR DESCRIPTION
## Problem

Several paginated PKI list queries order only by `createdAt` (or `triggeredAt`) without a stable secondary sort:

- `signer-dal.findByProjectId`
- `signing-operation-dal.findByProjectId`
- `pki-collection-item-dal.findByCollectionId`
- `pki-alert-history-dal.findByAlertId`
- `pki-alert-v2-dal` (paginated alerts list)

PostgreSQL does not guarantee any ordering for rows that share the primary sort value, so when records are bulk-inserted in the same transaction (or share a millisecond timestamp), pagination becomes non-deterministic — the same `offset`/`limit` combination can return overlapping or skipping pages on consecutive calls.

## Fix

Add the primary key `id` as a secondary `ORDER BY` column in each query. This matches the existing deterministic-pagination pattern used elsewhere in the codebase (e.g. `membership-role-dal`).

```ts
.orderBy(`${TableName.PkiSigners}.createdAt`, "desc")
.orderBy(`${TableName.PkiSigners}.id`, "asc")
```

Five DALs touched, one-line addition each. No behaviour change for the typical case where timestamps are unique; deterministic behaviour for the bulk-insert case.