### PR TITLE
fix(user-notifications): add deterministic id tie-breaker to ORDER BY

### DIFF
--- a/backend/src/services/notification/user-notification-dal.ts
+++ b/backend/src/services/notification/user-notification-dal.ts
@@ -48,6 +48,7 @@ export const userNotificationDALFactory = (db: TDbClient) => {
         .limit(limit)
         .offset(offset)
         .orderBy(`${TableName.UserNotifications}.createdAt`, "desc")
+        .orderBy(`${TableName.UserNotifications}.id`, "asc")
         .timeout(1000 * 120); // 2 minutes timeout
 
       return docs;


### PR DESCRIPTION
## Problem

`findUserNotifications` (in `user-notification-dal.ts`) paginates with `limit`/`offset` and orders only by `createdAt DESC`. PostgreSQL gives no ordering guarantee for rows that share the primary sort value, so notifications inserted in the same transaction — or that happen to share a millisecond timestamp — can shift between pages on consecutive list calls. From the user's perspective: notifications appear to duplicate or skip when scrolling.

## Fix

Add the primary key `id` as a secondary `ORDER BY` column so pagination is deterministic:

```ts
.orderBy(`${TableName.UserNotifications}.createdAt`, "desc")
.orderBy(`${TableName.UserNotifications}.id`, "asc")
```

Same pattern already used by `membership-role-dal` and other paginated list queries in the codebase. One-line addition, no behaviour change for the typical case where timestamps are unique.