### PR TITLE
fix(routes): use writeLimit for mutating endpoints currently capped by readLimit

### DIFF
--- a/backend/src/ee/routes/v1/ldap-router.ts
+++ b/backend/src/ee/routes/v1/ldap-router.ts
@@ -399,7 +399,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     method: "DELETE",
     url: "/config/:configId/group-maps/:groupMapId",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     schema: {

--- a/backend/src/ee/routes/v1/rate-limit-router.ts
+++ b/backend/src/ee/routes/v1/rate-limit-router.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { RateLimitSchema } from "@app/db/schemas";
 import { NotFoundError } from "@app/lib/errors";
-import { readLimit } from "@app/server/config/rateLimiter";
+import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifySuperAdmin } from "@app/server/plugins/auth/superAdmin";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -42,7 +42,7 @@ export const registerRateLimitRouter = async (server: FastifyZodProvider) => {
     method: "PUT",
     url: "/",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     onRequest: (req, res, done) => {
       verifyAuth([AuthMode.JWT])(req, res, () => {

--- a/backend/src/server/routes/v1/certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-router.ts
@@ -203,7 +203,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     method: "PATCH",
     url: "/:caId",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {

--- a/backend/src/server/routes/v1/deprecated-pki-alert-router.ts
+++ b/backend/src/server/routes/v1/deprecated-pki-alert-router.ts
@@ -108,7 +108,7 @@ export const registerDeprecatedPkiAlertRouter = async (server: FastifyZodProvide
     method: "PATCH",
     url: "/:alertId",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -601,7 +601,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
     method: "PUT",
     url: "/:workspaceId/workflow-integration",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       params: z.object({

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -882,7 +882,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
     method: "PUT",
     url: "/:projectId/workflow-integration",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       operationId: "updateProjectWorkflowIntegration",

--- a/backend/src/server/routes/v1/slack-router.ts
+++ b/backend/src/server/routes/v1/slack-router.ts
@@ -277,7 +277,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
     method: "PATCH",
     url: "/:id",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       operationId: "updateSlackIntegration",


### PR DESCRIPTION
## Problem

Several `PUT`/`PATCH`/`DELETE` endpoints across the backend were configured with the `readLimit` preset rate limiter, which is significantly more permissive than the `writeLimit` preset intended for mutating traffic. State-changing requests on these routes were therefore throttled at read-tier thresholds — too lenient for endpoints that mutate persistent state, and inconsistent with sibling routes in the same files.

## Fix

Switch the affected routes to `writeLimit` so each is rate-limited according to its actual write semantics. This matches the convention already used by `POST` creates and other `PATCH` updates in the same files.

| Method | Path | File |
|--------|------|------|
| PATCH  | `/pki/ca/:caId` | `routes/v1/certificate-authority-router.ts` |
| PATCH  | `/pki/alerts/:alertId` | `routes/v1/deprecated-pki-alert-router.ts` |
| PATCH  | `/workflow-integrations/slack/:id` | `routes/v1/slack-router.ts` |
| PUT    | `/workspace/:workspaceId/workflow-integration` | `routes/v1/deprecated-project-router.ts` |
| PUT    | `/workspace/:projectId/workflow-integration` | `routes/v1/project-router.ts` |
| PUT    | `/super-admin/rate-limit` | `ee/routes/v1/rate-limit-router.ts` |
| DELETE | `/sso/ldap/config/:configId/group-maps/:groupMapId` | `ee/routes/v1/ldap-router.ts` |

Each change is a single-line `readLimit` → `writeLimit` swap; `rate-limit-router.ts` also adds `writeLimit` to its existing rateLimiter import.

No API contract change. No behaviour change beyond rate-limit thresholds.