### PR TITLE
docs(honeytokens): fix broken usage links and clarify setup copy

### DIFF
--- a/docs/documentation/platform/honey-tokens/aws/setup.mdx
+++ b/docs/documentation/platform/honey-tokens/aws/setup.mdx
@@ -102,7 +102,7 @@ Use **Manage** any time you need to update:
 - CloudFormation stack name
 - AWS region
 
-In the modal, you can also copy the pre-filled AWS CLI command under **Deploy CloudFormation Stack** and run it to update the stack.
+In the modal, you can also copy the pre-filled AWS CLI command under **Deploy CloudFormation Stack** and run it to deploy the stack.
 
 You can also verify directly in AWS CLI:
 

--- a/docs/documentation/platform/honey-tokens/aws/setup.mdx
+++ b/docs/documentation/platform/honey-tokens/aws/setup.mdx
@@ -7,13 +7,13 @@ description: "One-time organization setup for AWS honey tokens."
 <Info>
   This setup is performed **once per organization** by an admin. After
   completing these steps, any project member can [create honey
-  tokens](/documentation/platform/honey-tokens/usage) without repeating this
+  tokens](/documentation/platform/honey-tokens/aws/usage) without repeating this
   process.
 </Info>
 
 ## Prerequisites
 
-- Create an [AWS App Connection](/integrations/app-connections/aws) with the following IAM permissions:
+- Create an [AWS App Connection](/integrations/app-connections/aws) at the organization level with the following IAM permissions:
 
 ```json
 {
@@ -102,7 +102,7 @@ Use **Manage** any time you need to update:
 - CloudFormation stack name
 - AWS region
 
-In the modal, you can also copy the pre-filled AWS CLI command under **Deploy CloudFormation Stack** and run it to create the stack.
+In the modal, you can also copy the pre-filled AWS CLI command under **Deploy CloudFormation Stack** and run it to update the stack.
 
 You can also verify directly in AWS CLI:
 
@@ -112,4 +112,4 @@ aws cloudformation describe-stacks \
   --query "Stacks[0].StackStatus"
 ```
 
-You can only [create honey tokens](/documentation/platform/honey-tokens/usage) after the stack status is **Verified**.
+You can only [create honey tokens](/documentation/platform/honey-tokens/aws/usage) after the stack status is **Verified**.

--- a/docs/documentation/platform/honey-tokens/aws/usage.mdx
+++ b/docs/documentation/platform/honey-tokens/aws/usage.mdx
@@ -26,7 +26,7 @@ description: "Create, monitor, and manage AWS honey tokens in your projects."
     ![Select Honey Token Type](/images/platform/honey-tokens/honey-token-type.png)
   </Step>
   <Step title="Environment Configuration">
-    Configure where the honey token and it's credentials will be planted within your project:
+    Configure where the honey token and its credentials will be planted within your project:
 
     - **Environment** — choose the target environment.
 
@@ -37,7 +37,7 @@ description: "Create, monitor, and manage AWS honey tokens in your projects."
     ![Honey Token Environment Step](/images/platform/honey-tokens/honey-token-environment.png)
   </Step>
   <Step title="Configure Secret Mappings">
-    Configure the secret mappings. This dictates the secret keys in your selected environment and secret path will be created and contain the honey token credentials.
+    Configure the secret mappings. This dictates which secret keys will be created in your selected environment and secret path to hold the honey token credentials.
 
     - **Access Key ID** — secret name for the AWS access key ID (for example: `AWS_ACCESS_KEY_ID`).
     - **Secret Access Key** — secret name for the AWS secret access key (for example: `AWS_SECRET_ACCESS_KEY`).


### PR DESCRIPTION
## Context

Clarifying some parts of the honey tokens docs

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ x] Docs
- [ ] Chore

## Checklist

- [ x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ x] Tested locally
- [ x] Updated docs (if needed)
- [ x] Updated CLAUDE.md files (if needed)
- [ x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)