### PR TITLE
Add labels support for standalone ingress

### DIFF
--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -44,6 +44,7 @@ A helm chart to deploy Infisical
 | ingress.enabled | bool | `true` | Enable or disable ingress configuration |
 | ingress.hostName | string | `""` | Hostname for ingress access, e.g., app.example.com |
 | ingress.ingressClassName | string | `""` | Specifies the ingress class. Defaults to "infisical-nginx" when bundled ingress-nginx is enabled, or "nginx" otherwise |
+| ingress.labels | object | `{}` | Custom labels for ingress resource |
 | ingress.nginx.enabled | bool | `true` | Enable NGINX-specific settings, if using NGINX ingress controller |
 | ingress.tls | list | `[]` | TLS settings for HTTPS access |
 | nameOverride | string | `""` | Overrides the default release name |

--- a/helm-charts/infisical-standalone-postgres/templates/ingress.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/ingress.yaml
@@ -9,6 +9,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: infisical-ingress
+  {{- with $ingress.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -121,6 +121,8 @@ ingress:
 
   # -- Custom annotations for ingress resource
   annotations: {}
+  # -- Custom labels for ingress resource
+  labels: {}
   # -- TLS settings for HTTPS access
   tls: []
     # -- TLS secret name for HTTPS


### PR DESCRIPTION
## Summary

Adds an `ingress.labels` value to the `infisical-standalone-postgres` Helm chart and renders those labels on the generated `Ingress` resource.

This matches the existing `ingress.annotations` customization point and helps installations where ingress resources must carry labels for policy selectors, inventory, or platform automation.

## Changes

- Adds `ingress.labels: {}` to chart values.
- Renders `ingress.labels` under `metadata.labels` in `templates/ingress.yaml`.
- Updates the chart README values table.

## Testing

- `helm lint helm-charts/infisical-standalone-postgres`
- `helm dependency build helm-charts/infisical-standalone-postgres`
- `helm template infisical helm-charts/infisical-standalone-postgres --set ingress.labels.'example\\.com/policy'=enabled --set ingress.labels.app=infisical` verified labels render on `infisical-ingress`.
- `git diff --check`
