### PR TITLE
fix: see docs to configure github message

### DIFF
--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -221,7 +221,7 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
                   ? `Credentials have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
-                        : `See Docs to configure Github ${methodDetails.name} Connections.`
+                        : `See Docs to configure ${methodDetails.name.startsWith("GitHub") ? methodDetails.name : `GitHub ${methodDetails.name}`} Connections.`
                     }`
                   : error?.message
               }


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The error message says "GitHub GitHub App Connection" (double GitHub)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

**Before**
Notice the **GitHub GitHub App Connection**

<img width="1009" height="332" alt="image" src="https://github.com/user-attachments/assets/d175464e-66a5-4b53-baff-18c24759086a" />


**After**
<img width="1009" height="332" alt="image" src="https://github.com/user-attachments/assets/dfdf4c2a-f77d-4091-9c26-c5871de8c054" />

This has not changed.

<img width="1009" height="332" alt="image" src="https://github.com/user-attachments/assets/2c586dfb-d0f1-4a72-8e7b-78b3606f5237" />


## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)