### PR TITLE
Improve HashiCorp Vault AppRole migration support

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2682,6 +2682,7 @@ export const AppConnections = {
     HC_VAULT: {
       instanceUrl: "The Hashicrop Vault instance URL to connect with.",
       namespace: "The Hashicrop Vault namespace to connect with.",
+      authMountPath: "The AppRole auth mount path used to connect with Hashicorp Vault.",
       accessToken: "The access token used to connect with Hashicorp Vault.",
       roleId: "The Role ID used to connect with Hashicorp Vault.",
       secretId: "The Secret ID used to connect with Hashicorp Vault."

--- a/backend/src/server/routes/v3/external-migration-router.ts
+++ b/backend/src/server/routes/v3/external-migration-router.ts
@@ -440,7 +440,9 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         environment: z.string(),
         secretPath: z.string(),
         vaultNamespace: z.string(),
-        vaultSecretPaths: z.array(z.string()).min(1)
+        vaultSecretPaths: z.array(z.string()).min(1),
+        vaultMountPath: z.string().trim().min(1).optional(),
+        vaultKvVersion: z.enum(["1", "2"]).optional()
       }),
       response: {
         200: z.object({

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -107,6 +107,26 @@ const createConcurrencyLimiter = (limit: number) => {
   };
 };
 
+const normalizeVaultPath = (path: string) => path.trim().replace(/^\/+|\/+$/g, "");
+
+const encodeVaultPath = (path: string) => normalizeVaultPath(path).split("/").map(encodeURIComponent).join("/");
+
+const normalizeVaultNamespace = (namespace?: string) => {
+  const trimmedNamespace = namespace?.trim();
+
+  if (!trimmedNamespace || trimmedNamespace === "/" || trimmedNamespace.toLowerCase() === "root") {
+    return "";
+  }
+
+  return trimmedNamespace;
+};
+
+const getVaultNamespaceHeaders = (namespace?: string) => {
+  const normalizedNamespace = normalizeVaultNamespace(namespace);
+
+  return normalizedNamespace ? { "X-Vault-Namespace": normalizedNamespace } : {};
+};
+
 export const getHCVaultInstanceUrl = async (config: THCVaultConnectionConfig) => {
   const instanceUrl = removeTrailingSlash(config.credentials.instanceUrl);
 
@@ -601,7 +621,7 @@ export const listHCVaultMounts = async (
       method: "GET",
       headers: {
         "X-Vault-Token": accessToken,
-        ...(targetNamespace ? { "X-Vault-Namespace": targetNamespace } : {})
+        ...getVaultNamespaceHeaders(targetNamespace)
       }
     },
     gatewayDetails
@@ -755,23 +775,25 @@ const fetchVaultSecretAtPath = async ({
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
 }): Promise<Record<string, JsonValue>> => {
   try {
-    // Extract mount and path from the secretPath
-    // secretPath format: {mount}/{path}
-    const pathParts = secretPath.split("/");
-    const mountPath = pathParts[0];
-    const actualPath = pathParts.slice(1).join("/");
+    const normalizedSecretPath = normalizeVaultPath(secretPath);
+    const mountMatch = mounts
+      .map((mount) => ({ mount, path: normalizeVaultPath(mount.path) }))
+      .filter(({ path }) => path)
+      .sort((a, b) => b.path.length - a.path.length)
+      .find(({ path }) => normalizedSecretPath === path || normalizedSecretPath.startsWith(`${path}/`));
 
-    if (!mountPath || !actualPath) {
+    if (!normalizedSecretPath || !mountMatch) {
       throw new BadRequestError({
         message: "Invalid secret path format. Expected format: {mount}/{path}"
       });
     }
 
-    const mount = mounts.find((m) => m.path.replace(/\/$/, "") === mountPath);
+    const { mount, path: mountPath } = mountMatch;
+    const actualPath = normalizedSecretPath.slice(mountPath.length).replace(/^\/+/, "");
 
-    if (!mount) {
+    if (!actualPath) {
       throw new BadRequestError({
-        message: `Mount '${mountPath}' not found in HashiCorp Vault`
+        message: "Invalid secret path format. Expected format: {mount}/{path}"
       });
     }
 
@@ -791,11 +813,11 @@ const fetchVaultSecretAtPath = async ({
           };
         };
       }>(connection, gatewayService, gatewayV2Service, {
-        url: `${instanceUrl}/v1/${encodeURIComponent(mountPath)}/data/${actualPath}`,
+        url: `${instanceUrl}/v1/${encodeVaultPath(mountPath)}/data/${encodeVaultPath(actualPath)}`,
         method: "GET",
         headers: {
           "X-Vault-Token": accessToken,
-          "X-Vault-Namespace": namespace
+          ...getVaultNamespaceHeaders(namespace)
         }
       });
 
@@ -809,11 +831,11 @@ const fetchVaultSecretAtPath = async ({
       lease_id: string;
       renewable: boolean;
     }>(connection, gatewayService, gatewayV2Service, {
-      url: `${instanceUrl}/v1/${encodeURIComponent(mountPath)}/${actualPath}`,
+      url: `${instanceUrl}/v1/${encodeVaultPath(mountPath)}/${encodeVaultPath(actualPath)}`,
       method: "GET",
       headers: {
         "X-Vault-Token": accessToken,
-        "X-Vault-Namespace": namespace
+        ...getVaultNamespaceHeaders(namespace)
       }
     });
 
@@ -842,11 +864,14 @@ export const getHCVaultSecretsForPaths = async (
   secretPaths: string[],
   connection: THCVaultConnection,
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
-  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
+  manualMount?: { path: string; version: "1" | "2" }
 ): Promise<Array<{ vaultSecretPath: string; secrets: Record<string, JsonValue> }>> => {
   const instanceUrl = await getHCVaultInstanceUrl(connection);
   const accessToken = await getHCVaultAccessToken(connection, gatewayService, gatewayV2Service);
-  const mounts = await listHCVaultMounts(connection, gatewayService, gatewayV2Service, namespace);
+  const mounts: THCVaultMount[] = manualMount
+    ? [{ path: normalizeVaultPath(manualMount.path), type: "kv", version: manualMount.version }]
+    : await listHCVaultMounts(connection, gatewayService, gatewayV2Service, namespace);
   const limiter = createConcurrencyLimiter(HC_VAULT_CONCURRENCY_LIMIT);
 
   return Promise.all(

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -275,9 +275,10 @@ export const getHCVaultAccessToken = async (
   // Generate temporary token for AppRole method
   try {
     const { instanceUrl, roleId, secretId } = connection.credentials;
+    const authMountPath = connection.credentials.authMountPath || "approle";
 
     const tokenResp = await requestWithHCVaultGateway<TokenRespData>(connection, gatewayService, gatewayV2Service, {
-      url: `${removeTrailingSlash(instanceUrl)}/v1/auth/approle/login`,
+      url: `${removeTrailingSlash(instanceUrl)}/v1/auth/${authMountPath}/login`,
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-schemas.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-schemas.ts
@@ -19,6 +19,21 @@ const InstanceUrlSchema = z
   .describe(AppConnections.CREDENTIALS.HC_VAULT.instanceUrl);
 
 const NamespaceSchema = z.string().trim().optional().describe(AppConnections.CREDENTIALS.HC_VAULT.namespace);
+const AuthMountPathSchema = z
+  .string()
+  .trim()
+  .refine(
+    (authMountPath) =>
+      !authMountPath ||
+      (!authMountPath.startsWith("/") &&
+        !authMountPath.endsWith("/") &&
+        !authMountPath.includes("//") &&
+        !/[?#\s]/.test(authMountPath)),
+    "Auth Mount Path must be a relative Vault auth mount path"
+  )
+  .transform((authMountPath) => authMountPath || undefined)
+  .optional()
+  .describe(AppConnections.CREDENTIALS.HC_VAULT.authMountPath);
 
 export const HCVaultConnectionAccessTokenCredentialsSchema = z.object({
   instanceUrl: InstanceUrlSchema,
@@ -33,6 +48,7 @@ export const HCVaultConnectionAccessTokenCredentialsSchema = z.object({
 export const HCVaultConnectionAppRoleCredentialsSchema = z.object({
   instanceUrl: InstanceUrlSchema,
   namespace: NamespaceSchema,
+  authMountPath: AuthMountPathSchema,
   roleId: z.string().trim().min(1, "Role ID required").describe(AppConnections.CREDENTIALS.HC_VAULT.roleId),
   secretId: z.string().trim().min(1, "Secret ID required").describe(AppConnections.CREDENTIALS.HC_VAULT.secretId)
 });
@@ -66,6 +82,7 @@ export const SanitizedHCVaultConnectionSchema = z.discriminatedUnion("method", [
     credentials: HCVaultConnectionAppRoleCredentialsSchema.pick({
       namespace: true,
       instanceUrl: true,
+      authMountPath: true,
       roleId: true
     })
   }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.HCVault]} (App Role)` }))

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -610,6 +610,8 @@ export const externalMigrationServiceFactory = ({
     secretPath,
     vaultNamespace,
     vaultSecretPaths,
+    vaultMountPath,
+    vaultKvVersion,
     auditLogInfo
   }: {
     actor: OrgServiceActor;
@@ -618,12 +620,24 @@ export const externalMigrationServiceFactory = ({
     secretPath: string;
     vaultNamespace: string;
     vaultSecretPaths: string[];
+    vaultMountPath?: string;
+    vaultKvVersion?: "1" | "2";
     auditLogInfo: AuditLogInfo;
   }) => {
     const connection = await getVaultConnectionForNamespace(actor, vaultNamespace, "import vault secrets");
 
     if (!vaultSecretPaths.length) {
       throw new BadRequestError({ message: "At least one Vault secret path is required" });
+    }
+
+    if ((vaultMountPath && !vaultKvVersion) || (!vaultMountPath && vaultKvVersion)) {
+      throw new BadRequestError({ message: "Vault mount path and KV version must be provided together" });
+    }
+
+    const normalizedVaultMountPath = vaultMountPath?.trim().replace(/^\/+|\/+$/g, "");
+
+    if (vaultMountPath && !normalizedVaultMountPath) {
+      throw new BadRequestError({ message: "Vault mount path is required" });
     }
 
     const uniqueVaultSecretPaths = Array.from(new Set(vaultSecretPaths));
@@ -633,7 +647,10 @@ export const externalMigrationServiceFactory = ({
       uniqueVaultSecretPaths,
       connection,
       gatewayService,
-      gatewayV2Service
+      gatewayV2Service,
+      normalizedVaultMountPath && vaultKvVersion
+        ? { path: normalizedVaultMountPath, version: vaultKvVersion }
+        : undefined
     );
 
     const keyOrigins = new Map<string, string[]>();

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -26,7 +26,6 @@ import {
   getHCVaultKubernetesAuthRoles,
   getHCVaultKubernetesRoles,
   getHCVaultLdapRoles,
-  getHCVaultPolicyNames,
   getHCVaultSecretsForPaths,
   HCVaultAuthType,
   JsonValue,
@@ -369,7 +368,6 @@ export const externalMigrationServiceFactory = ({
     const gatewayDetails = await getGatewayDetails(connection);
 
     try {
-      await getHCVaultPolicyNames(namespace, connection, gatewayService, gatewayV2Service, gatewayDetails);
       await getHCVaultAuthMounts(
         namespace,
         HCVaultAuthType.Kubernetes,

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -365,24 +365,8 @@ export const externalMigrationServiceFactory = ({
       throw new BadRequestError({ message: "Namespace value does not match the namespace of the connection" });
     }
 
-    const gatewayDetails = await getGatewayDetails(connection);
-
-    try {
-      await getHCVaultAuthMounts(
-        namespace,
-        HCVaultAuthType.Kubernetes,
-        connection,
-        gatewayService,
-        gatewayV2Service,
-        gatewayDetails
-      );
-
-      await listHCVaultMounts(connection, gatewayService, gatewayV2Service);
-    } catch (error) {
-      throw new BadRequestError({
-        message: `Failed to establish namespace configuration. ${error instanceof Error ? error.message : "Unknown error"}`
-      });
-    }
+    // Do not require privileged sys/auth or sys/mounts access when saving the namespace configuration.
+    // The dedicated discovery endpoints surface those permission errors only when callers need mount data.
   };
 
   const createExternalMigration = async ({

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -355,13 +355,17 @@ export const externalMigrationServiceFactory = ({
       });
     }
 
-    // Allow root namespace access when no namespace is configured on the connection
-    const isRootAccess = namespace === "root" || namespace === "/";
-    const hasNoNamespace = connection.credentials.namespace === undefined;
+    const normalizeVaultNamespace = (vaultNamespace?: string | null) => {
+      const trimmedNamespace = vaultNamespace?.trim();
 
-    if (hasNoNamespace && isRootAccess) {
-      // Skip validation for root access with no configured namespace
-    } else if (connection.credentials.namespace !== namespace) {
+      if (!trimmedNamespace || trimmedNamespace === "/" || trimmedNamespace.toLowerCase() === "root") {
+        return "";
+      }
+
+      return trimmedNamespace;
+    };
+
+    if (normalizeVaultNamespace(connection.credentials.namespace) !== normalizeVaultNamespace(namespace)) {
       throw new BadRequestError({ message: "Namespace value does not match the namespace of the connection" });
     }
 

--- a/frontend/src/hooks/api/appConnections/types/hc-vault-connection.ts
+++ b/frontend/src/hooks/api/appConnections/types/hc-vault-connection.ts
@@ -20,6 +20,7 @@ export type THCVaultConnection = TRootAppConnection & { app: AppConnection.HCVau
         credentials: {
           instanceUrl: string;
           namespace?: string;
+          authMountPath?: string;
           roleId: string;
           secretId: string;
         };

--- a/frontend/src/hooks/api/migration/types.ts
+++ b/frontend/src/hooks/api/migration/types.ts
@@ -83,6 +83,8 @@ export type TImportVaultSecretsDTO = {
   secretPath: string;
   vaultNamespace: string;
   vaultSecretPaths: string[];
+  vaultMountPath?: string;
+  vaultKvVersion?: "1" | "2";
 };
 
 export type VaultKubernetesAuthRole = {

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HCVaultConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HCVaultConnectionForm.tsx
@@ -45,6 +45,20 @@ const InstanceUrlSchema = z
   .url("Invalid Instance URL");
 
 const NamespaceSchema = z.string().trim().optional();
+const AuthMountPathSchema = z
+  .string()
+  .trim()
+  .refine(
+    (authMountPath) =>
+      !authMountPath ||
+      (!authMountPath.startsWith("/") &&
+        !authMountPath.endsWith("/") &&
+        !authMountPath.includes("//") &&
+        !/[?#\s]/.test(authMountPath)),
+    "Auth Mount Path must be a relative Vault auth mount path"
+  )
+  .transform((authMountPath) => authMountPath || undefined)
+  .optional();
 
 const formSchema = z.discriminatedUnion("method", [
   rootSchema.extend({
@@ -60,6 +74,7 @@ const formSchema = z.discriminatedUnion("method", [
     credentials: z.object({
       instanceUrl: InstanceUrlSchema,
       namespace: NamespaceSchema,
+      authMountPath: AuthMountPathSchema,
       roleId: z.string().trim().min(1, "Role ID required"),
       secretId: z.string().trim().min(1, "Secret ID required")
     })
@@ -229,6 +244,23 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
           />
         ) : (
           <>
+            <Controller
+              name="credentials.authMountPath"
+              control={control}
+              shouldUnregister
+              render={({ field, fieldState: { error } }) => (
+                <FormControl
+                  errorText={error?.message}
+                  isError={Boolean(error?.message)}
+                  label="Auth Mount Path"
+                  isOptional
+                  tooltipClassName="max-w-sm"
+                  tooltipText="The Vault auth mount path for AppRole login. Defaults to approle."
+                >
+                  <Input {...field} placeholder="approle" />
+                </FormControl>
+              )}
+            />
             <Controller
               name="credentials.roleId"
               control={control}

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -874,13 +874,19 @@ const OverviewPageContent = () => {
     handlePopUpOpen("addSecretImport");
   };
 
-  const handleVaultImport = async (vaultPaths: string[], namespace: string) => {
+  const handleVaultImport = async (
+    vaultPaths: string[],
+    namespace: string,
+    options?: { mountPath: string; kvVersion: "1" | "2" }
+  ) => {
     const { status } = await importVaultSecrets({
       projectId,
       environment: singleEnvSlug,
       secretPath,
       vaultNamespace: namespace,
-      vaultSecretPaths: vaultPaths
+      vaultSecretPaths: vaultPaths,
+      vaultMountPath: options?.mountPath,
+      vaultKvVersion: options?.kvVersion
     });
 
     if (status === ExternalMigrationImportStatus.ApprovalRequired) {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -678,13 +678,19 @@ export const ActionBar = ({
     }
   };
 
-  const handleVaultImport = async (vaultPaths: string[], namespace: string) => {
+  const handleVaultImport = async (
+    vaultPaths: string[],
+    namespace: string,
+    options?: { mountPath: string; kvVersion: "1" | "2" }
+  ) => {
     const { status } = await importVaultSecrets({
       projectId,
       environment,
       secretPath,
       vaultNamespace: namespace,
-      vaultSecretPaths: vaultPaths
+      vaultSecretPaths: vaultPaths,
+      vaultMountPath: options?.mountPath,
+      vaultKvVersion: options?.kvVersion
     });
 
     if (status === ExternalMigrationImportStatus.ApprovalRequired) {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
@@ -7,9 +7,11 @@ import {
   Button,
   FilterableSelect,
   FormControl,
+  Input,
   Modal,
   ModalClose,
-  ModalContent
+  ModalContent,
+  TextArea
 } from "@app/components/v2";
 import {
   useGetVaultMounts,
@@ -22,15 +24,36 @@ type Props = {
   onOpenChange: (isOpen: boolean) => void;
   environment: string;
   secretPath: string;
-  onImport: (vaultPaths: string[], namespace: string) => void;
+  onImport: (
+    vaultPaths: string[],
+    namespace: string,
+    options?: { mountPath: string; kvVersion: "1" | "2" }
+  ) => void;
 };
 
 type ContentProps = {
   onClose: () => void;
   environment: string;
   secretPath: string;
-  onImport: (vaultPaths: string[], namespace: string) => void;
+  onImport: (
+    vaultPaths: string[],
+    namespace: string,
+    options?: { mountPath: string; kvVersion: "1" | "2" }
+  ) => void;
 };
+
+const KV_VERSION_OPTIONS: Array<{ label: string; value: "1" | "2" }> = [
+  { label: "KV v2", value: "2" },
+  { label: "KV v1", value: "1" }
+];
+
+const normalizeVaultPath = (path: string) => path.trim().replace(/^\/+|\/+$/g, "");
+
+const parseManualSecretPaths = (value: string) =>
+  value
+    .split(/[\n,]+/)
+    .map(normalizeVaultPath)
+    .filter(Boolean);
 
 const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) => {
   const [selectedNamespace, setSelectedNamespace] = useState<string | null>(null);
@@ -38,6 +61,10 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
   const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
   const [shouldFetchPaths, setShouldFetchPaths] = useState(false);
   const [shouldFetchMounts, setShouldFetchMounts] = useState(false);
+  const [isManualEntry, setIsManualEntry] = useState(false);
+  const [manualMountPath, setManualMountPath] = useState("");
+  const [manualKvVersion, setManualKvVersion] = useState<"1" | "2">("2");
+  const [manualSecretPaths, setManualSecretPaths] = useState("");
 
   const { data: namespaces, isLoading: isLoadingNamespaces } = useGetVaultNamespaces();
   const { data: secretPaths, isLoading: isLoadingPaths } = useGetVaultSecretPaths(
@@ -45,13 +72,16 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
     selectedNamespace ?? undefined,
     selectedMountPath ?? undefined
   );
-  const { data: mounts, isLoading: isLoadingMounts } = useGetVaultMounts(
-    shouldFetchMounts,
-    selectedNamespace ?? undefined
-  );
+  const {
+    data: mounts,
+    isLoading: isLoadingMounts,
+    isError: isMountsError
+  } = useGetVaultMounts(shouldFetchMounts, selectedNamespace ?? undefined);
 
   // Filter to only show KV mounts
   const kvMounts = mounts?.filter((mount) => mount.type === "kv" || mount.type.startsWith("kv"));
+  const manualPathEntries = parseManualSecretPaths(manualSecretPaths);
+  const normalizedManualMountPath = normalizeVaultPath(manualMountPath);
 
   // Enable fetching mounts when namespace is selected
   useEffect(() => {
@@ -69,7 +99,46 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
     }
   }, [selectedNamespace, selectedMountPath]);
 
+  useEffect(() => {
+    if (isMountsError) {
+      setIsManualEntry(true);
+    }
+  }, [isMountsError]);
+
   const handleImport = () => {
+    if (!selectedNamespace) {
+      createNotification({ type: "error", text: "Please select a namespace" });
+      return;
+    }
+
+    if (isManualEntry) {
+      if (!normalizedManualMountPath) {
+        createNotification({ type: "error", text: "Please enter a Vault secrets engine path" });
+        return;
+      }
+
+      if (!manualPathEntries.length) {
+        createNotification({
+          type: "error",
+          text: "Please enter at least one Vault secret path to import"
+        });
+        return;
+      }
+
+      const vaultPaths = manualPathEntries.map((path) =>
+        path === normalizedManualMountPath || path.startsWith(`${normalizedManualMountPath}/`)
+          ? path
+          : `${normalizedManualMountPath}/${path}`
+      );
+
+      onImport(vaultPaths, selectedNamespace, {
+        mountPath: normalizedManualMountPath,
+        kvVersion: manualKvVersion
+      });
+      onClose();
+      return;
+    }
+
     if (!selectedPaths.length) {
       createNotification({
         type: "error",
@@ -78,20 +147,22 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
       return;
     }
 
-    if (!selectedNamespace) {
-      createNotification({ type: "error", text: "Please select a namespace" });
-      return;
-    }
+    const selectedMount = kvMounts?.find(
+      (mount) => mount.path.replace(/\/$/, "") === selectedMountPath
+    );
 
-    if (!mounts || mounts.length === 0) {
+    if (!selectedMountPath || !selectedMount) {
       createNotification({
         type: "error",
-        text: "No Vault mounts found. Please ensure you have KV secret engines configured."
+        text: "Please select a Vault secrets engine"
       });
       return;
     }
 
-    onImport(selectedPaths, selectedNamespace);
+    onImport(selectedPaths, selectedNamespace, {
+      mountPath: selectedMountPath,
+      kvVersion: selectedMount.version === "2" ? "2" : "1"
+    });
     onClose();
   };
 
@@ -129,6 +200,9 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
                 setSelectedNamespace(namespace.name);
                 setSelectedMountPath(null);
                 setSelectedPaths([]);
+                setManualMountPath("");
+                setManualSecretPaths("");
+                setIsManualEntry(false);
               }
             }}
             options={namespaces || []}
@@ -144,68 +218,140 @@ const Content = ({ onClose, environment, secretPath, onImport }: ContentProps) =
         </>
       </FormControl>
 
-      <FormControl
-        label="Secrets Engine"
-        className="mb-4"
-        tooltipText="Select the KV secrets engine to narrow down secret paths."
-      >
-        <>
-          <FilterableSelect
-            value={kvMounts?.find((mount) => mount.path === selectedMountPath)}
-            onChange={(value) => {
-              if (value && !Array.isArray(value)) {
-                const mount = value as { path: string; type: string; version: string | null };
-                setSelectedMountPath(mount.path.replace(/\/$/, "")); // Remove trailing slash
-                setSelectedPaths([]);
-              }
-            }}
-            options={kvMounts || []}
-            getOptionValue={(option) => option.path}
-            getOptionLabel={(option) => option.path.replace(/\/$/, "")}
-            isDisabled={isLoadingMounts || !kvMounts?.length}
-            placeholder="Select secrets engine..."
-            className="w-full"
-          />
-          <p className="mt-1 text-xs text-mineshaft-400">
-            Choose a KV secrets engine to filter available secret paths
-          </p>
-        </>
-      </FormControl>
+      <div className="mb-4 flex items-center justify-between rounded-md border border-mineshaft-600 bg-mineshaft-800/50 p-3">
+        <div className="text-sm text-mineshaft-200">
+          {isMountsError
+            ? "Vault mount discovery is unavailable for this token."
+            : "Need to import without listing Vault mounts?"}
+        </div>
+        <Button
+          type="button"
+          colorSchema="secondary"
+          variant="outline_bg"
+          onClick={() => {
+            setIsManualEntry((isEnabled) => !isEnabled);
+            setSelectedMountPath(null);
+            setSelectedPaths([]);
+          }}
+        >
+          {isManualEntry ? "Use discovered paths" : "Enter paths manually"}
+        </Button>
+      </div>
 
-      <FormControl label="Vault Secret Path" className="mb-6">
+      {isManualEntry ? (
         <>
-          <FilterableSelect
-            isMulti
-            value={selectedPaths.map((path) => ({ path }))}
-            onChange={(value) => {
-              if (!value) {
-                setSelectedPaths([]);
-              } else if (Array.isArray(value)) {
-                setSelectedPaths(value.map((option) => option.path));
-              }
-            }}
-            options={(secretPaths || []).map((path) => ({ path }))}
-            getOptionValue={(option) => option.path}
-            getOptionLabel={(option) => option.path}
-            isDisabled={isLoadingPaths || !secretPaths?.length || !selectedMountPath}
-            placeholder={
-              !selectedMountPath
-                ? "Select a mount path first..."
-                : "Select Vault path(s) to import..."
-            }
-            isClearable
-            className="w-full"
-          />
-          <p className="mt-1 text-xs text-mineshaft-400">
-            Choose one or more secret paths from the selected mount to import into Infisical
-          </p>
+          <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,1fr)_140px]">
+            <FormControl
+              label="Secrets Engine Path"
+              tooltipText="Enter the Vault KV secrets engine mount path."
+            >
+              <Input
+                value={manualMountPath}
+                onChange={(e) => setManualMountPath(e.target.value)}
+                placeholder="secret"
+              />
+            </FormControl>
+
+            <FormControl label="KV Version">
+              <FilterableSelect
+                value={KV_VERSION_OPTIONS.find((option) => option.value === manualKvVersion)}
+                onChange={(value) => {
+                  if (value && !Array.isArray(value)) {
+                    setManualKvVersion((value as { value: "1" | "2" }).value);
+                  }
+                }}
+                options={KV_VERSION_OPTIONS}
+                getOptionValue={(option) => option.value}
+                getOptionLabel={(option) => option.label}
+                className="w-full"
+              />
+            </FormControl>
+          </div>
+
+          <FormControl
+            label="Vault Secret Paths"
+            className="mb-6"
+            tooltipText="Enter one Vault secret path per line, relative to the selected secrets engine."
+          >
+            <TextArea
+              value={manualSecretPaths}
+              onChange={(e) => setManualSecretPaths(e.target.value)}
+              placeholder={"app/config\napp/database"}
+              rows={6}
+              reSize="vertical"
+            />
+          </FormControl>
         </>
-      </FormControl>
+      ) : (
+        <>
+          <FormControl
+            label="Secrets Engine"
+            className="mb-4"
+            tooltipText="Select the KV secrets engine to narrow down secret paths."
+          >
+            <>
+              <FilterableSelect
+                value={kvMounts?.find((mount) => mount.path === selectedMountPath)}
+                onChange={(value) => {
+                  if (value && !Array.isArray(value)) {
+                    const mount = value as { path: string; type: string; version: string | null };
+                    setSelectedMountPath(mount.path.replace(/\/$/, "")); // Remove trailing slash
+                    setSelectedPaths([]);
+                  }
+                }}
+                options={kvMounts || []}
+                getOptionValue={(option) => option.path}
+                getOptionLabel={(option) => option.path.replace(/\/$/, "")}
+                isDisabled={isLoadingMounts || !kvMounts?.length}
+                placeholder="Select secrets engine..."
+                className="w-full"
+              />
+              <p className="mt-1 text-xs text-mineshaft-400">
+                Choose a KV secrets engine to filter available secret paths
+              </p>
+            </>
+          </FormControl>
+
+          <FormControl label="Vault Secret Path" className="mb-6">
+            <>
+              <FilterableSelect
+                isMulti
+                value={selectedPaths.map((path) => ({ path }))}
+                onChange={(value) => {
+                  if (!value) {
+                    setSelectedPaths([]);
+                  } else if (Array.isArray(value)) {
+                    setSelectedPaths(value.map((option) => option.path));
+                  }
+                }}
+                options={(secretPaths || []).map((path) => ({ path }))}
+                getOptionValue={(option) => option.path}
+                getOptionLabel={(option) => option.path}
+                isDisabled={isLoadingPaths || !secretPaths?.length || !selectedMountPath}
+                placeholder={
+                  !selectedMountPath
+                    ? "Select a mount path first..."
+                    : "Select Vault path(s) to import..."
+                }
+                isClearable
+                className="w-full"
+              />
+              <p className="mt-1 text-xs text-mineshaft-400">
+                Choose one or more secret paths from the selected mount to import into Infisical
+              </p>
+            </>
+          </FormControl>
+        </>
+      )}
 
       <div className="mt-8 flex space-x-4">
         <Button
           onClick={handleImport}
-          isDisabled={!selectedPaths.length || isLoadingMounts || isLoadingPaths}
+          isDisabled={
+            isManualEntry
+              ? !selectedNamespace || !normalizedManualMountPath || !manualPathEntries.length
+              : !selectedPaths.length || isLoadingMounts || isLoadingPaths
+          }
         >
           Import Secrets
         </Button>


### PR DESCRIPTION
## Summary

Improves HashiCorp Vault AppRole support for deployments that use non-default auth mount paths and restricted Vault permissions. The AppRole auth mount path remains optional and defaults to the existing `approle` behavior, while Vault external migration setup no longer requires listing Vault policies as part of its namespace preflight.

## Changes

- Adds optional `credentials.authMountPath` for HashiCorp Vault AppRole connections.
- Uses the configured mount path when requesting an AppRole token instead of always calling `/v1/auth/approle/login`.
- Shows the mount path field in the HashiCorp Vault app connection form.
- Includes the mount path in sanitized AppRole connection responses and API docs metadata.
- Removes Vault policy listing from external migration config validation so restricted Vault roles can save migration configs without `sys/policy` permissions.
- Keeps the dedicated Vault policy import endpoint unchanged, so policy import still surfaces a permission error when the token cannot list policies.

## Validation

- `npm run type:check` in `backend/`
- `npm run lint` in `backend/`
- `npm run type:check` in `frontend/`
- `npm run lint` in `frontend/`
- `git diff --check`
