### PR TITLE
chore(dev): add Bull Board service to docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
       - BULL_PREFIX=bull
     ports:
       - "3008:3000"
+    profiles: [queue]
 
   db-test:
     profiles: ["test"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,6 +65,20 @@ services:
     ports:
       - "8085:8081"
 
+  bull-board:
+    container_name: infisical-dev-bull-board
+    image: venatum/bull-board:3.3.7
+    restart: always
+    depends_on:
+      - redis
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - BULL_VERSION=BULLMQ
+      - BULL_PREFIX=bull
+    ports:
+      - "3008:3000"
+
   db-test:
     profiles: ["test"]
     image: postgres:14-alpine


### PR DESCRIPTION
## Context

Adds a **Bull Board** service to `docker-compose.dev.yml` so developers can inspect **BullMQ** queues against the dev stack Redis (`venatum/bull-board:3.3.7`, BullMQ + default `bull` prefix, UI on host port **3008**).

## Screenshots

<img width="2519" height="1713" alt="image" src="https://github.com/user-attachments/assets/26878a8c-2644-42a2-9dab-7c550e50eea1" />

## Steps to verify the change

1. `docker compose -f docker-compose.dev.yml up -d redis backend …` (full stack as usual).
2. `docker compose -f docker-compose.dev.yml up -d bull-board`
3. Open `http://localhost:3008` and confirm queues list against Redis.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)