### PR TITLE
fix(platfor-339): index identity_access_tokens.subOrganizationId for cascade delete

### DIFF
--- a/backend/src/db/migrations/20260507232033_add-identity-access-token-sub-organization-id-index.ts
+++ b/backend/src/db/migrations/20260507232033_add-identity-access-token-sub-organization-id-index.ts
@@ -1,0 +1,41 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+const MIGRATION_TIMEOUT = 60 * 60 * 1000; // 60 minutes
+const MIGRATION_LOCK_TIMEOUT = 30 * 1000; // 30 seconds
+
+export async function up(knex: Knex): Promise<void> {
+  const stmtResult = await knex.raw("SHOW statement_timeout");
+  const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
+  const lockResult = await knex.raw("SHOW lock_timeout");
+  const originalLockTimeout = lockResult.rows[0].lock_timeout;
+
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+    await knex.raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+
+    if (
+      (await knex.schema.hasTable(TableName.IdentityAccessToken)) &&
+      (await knex.schema.hasColumn(TableName.IdentityAccessToken, "subOrganizationId"))
+    ) {
+      await knex.raw(`
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_identity_access_tokens_sub_organization_id
+          ON ${TableName.IdentityAccessToken} ("subOrganizationId")
+          WHERE "subOrganizationId" IS NOT NULL
+      `);
+    }
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+    await knex.raw(`SET lock_timeout = '${originalLockTimeout}'`);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+      DROP INDEX IF EXISTS idx_identity_access_tokens_sub_organization_id
+    `);
+}
+
+const config = { transaction: false };
+export { config };


### PR DESCRIPTION
## Summary
- Adds partial index on `identity_access_tokens(subOrganizationId) WHERE subOrganizationId IS NOT NULL` so the FK cascade can resolve without seq-scanning the table.

## Context
- `DELETE /api/v2/organizations/:id` was timing out in us-prod with `57014 canceling statement due to statement timeout`. The Postgres error pinpoints the cascade query: `DELETE FROM ONLY "public"."identity_access_tokens" WHERE $1 = "subOrganizationId"`.
- The FK was added in `20251127192155_adds-sub-organization-id-to-identity-access-tokens.ts` with `ON DELETE CASCADE` but no supporting index.
- The Dec-27 IAT index batch (revoked / num_uses / expiration) didn't cover this column.
- Unrelated to eng-4942 (revocation-only rework) — that change capped growth but doesn't shrink the existing table.
- Linear: PLATFOR-339

## Migration safety
- `CREATE INDEX CONCURRENTLY` — does not block writers (only `SHARE UPDATE EXCLUSIVE`).
- `transaction: false` (required for CONCURRENTLY).
- `statement_timeout = 60min` (vs the 5-min default in surrounding migrations) to cover the ~66M-row build.
- `lock_timeout = 30s` so it fails fast if a long-running tx blocks the snapshot drain phase, instead of hanging.
- Partial predicate (`WHERE subOrganizationId IS NOT NULL`) keeps the resulting index small — pre-2025-11-27 rows aren't included.
- If killed mid-build, leaves an INVALID index that's not used by the planner. Re-run after `DROP INDEX IF EXISTS idx_identity_access_tokens_sub_organization_id`.

## Test plan
- [ ] CI passes
- [ ] Apply migration in staging, confirm `pg_index.indisvalid = true` after build
- [ ] Verify org delete no longer times out (pick the affected US org from the support thread)
- [ ] Monitor build progress via `pg_stat_progress_create_index` during prod apply