### PR TITLE
fix: add doc on multiple `--path` for `infisical run`

### DIFF
--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -168,12 +168,17 @@ $ infisical run -- npm run dev
   </Accordion>
 
   <Accordion title="--path">
-    The `--path` flag indicates which project folder secrets will be injected from.
+    The `--path` flag indicates which project folder secrets will be injected from. You can specify multiple `--path` flags to inject secrets from multiple folders at once.
 
     ```bash
-    # Example
+    # Example - single path
     infisical run --path="/nextjs" -- npm run dev
+
+    # Example - multiple paths
+    infisical run --path="/common" --path="/nextjs" -- npm run dev
     ```
+
+    When using multiple `--path` flags, secrets from all specified folders will be injected into your application process. If the same secret exists in multiple paths, the first path takes precedence.
 
   </Accordion>
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Complement doc on support for multiple `--path` in `infisical run`

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1092" height="676" alt="image" src="https://github.com/user-attachments/assets/7d43c299-01a5-4051-b36a-f9026dd11621" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)