### PR TITLE
fix(certificate): return 404 instead of 500 when certificate not found

### DIFF
--- a/backend/src/services/certificate/certificate-service.ts
+++ b/backend/src/services/certificate/certificate-service.ts
@@ -235,6 +235,9 @@ export const certificateServiceFactory = ({
     actorOrgId
   }: TGetCertPrivateKeyDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,
@@ -277,6 +280,9 @@ export const certificateServiceFactory = ({
    */
   const deleteCert = async ({ id, serialNumber, actorId, actorAuthMethod, actor, actorOrgId }: TDeleteCertDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,
@@ -345,6 +351,9 @@ export const certificateServiceFactory = ({
     actorOrgId
   }: TRevokeCertDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     if (!cert.caId) {
       throw new BadRequestError({
@@ -467,6 +476,9 @@ export const certificateServiceFactory = ({
    */
   const getCertBody = async ({ id, serialNumber, actorId, actorAuthMethod, actor, actorOrgId }: TGetCertBodyDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,
@@ -780,6 +792,9 @@ export const certificateServiceFactory = ({
     actorOrgId
   }: TGetCertBundleDTO) => {
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,
@@ -913,6 +928,9 @@ export const certificateServiceFactory = ({
       throw new BadRequestError({ message: "Alias is required for PKCS12 keystore generation" });
     }
     const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
+    if (!cert) {
+      throw new NotFoundError({ message: "Certificate not found" });
+    }
 
     const { permission } = await permissionService.getProjectPermission({
       actor,


### PR DESCRIPTION
## Problem

Several PKI certificate endpoints return `500 Internal Server Error` when called with a non-existent serial number or id, instead of a proper `404 Not Found`. The error handler logs a `TypeError: Cannot read properties of undefined (reading 'projectId')` because the affected service methods load a certificate, then immediately pass `cert.projectId` into the permission service without checking whether the lookup actually returned anything.

Reported in #4639.

## Affected endpoints

- `GET /api/v1/pki/certificates/{serialNumber}/private-key`
- `DELETE /api/v1/pki/certificates/{serialNumber}`
- `POST /api/v1/pki/certificates/{serialNumber}/revoke`
- `GET /api/v1/pki/certificates/{serialNumber}/body` (and `/certificate`)
- `GET /api/v1/pki/certificates/{serialNumber}/bundle`
- `POST /api/v1/pki/certificates/{serialNumber}/pkcs12`

## Fix

Add the same `NotFoundError` guard that already exists in `getCert` (line 122) right after each `certificateDAL.findById` / `findOne` call:

```ts
const cert = id ? await certificateDAL.findById(id) : await certificateDAL.findOne({ serialNumber });
if (!cert) {
  throw new NotFoundError({ message: "Certificate not found" });
}
```

`NotFoundError` is already imported. Six guards added, one per affected method (`getCertPrivateKey`, `deleteCert`, `revokeCert`, `getCertBody`, `getCertBundle`, `getCertPkcs12`). Single-file change, no API contract change — clients that previously got a `500` now get a `404` with a clear message.

## Note

PR #4951 was an earlier attempt at this fix but had duplicate function declarations that prevented compilation (flagged by Greptile, no maintainer movement since Feb 2026). This PR is a clean re-implementation that keeps the existing function signatures and just adds the guard line.