### PR TITLE
fix(netlify-sync): preserve values for other contexts when updating a variable

### DIFF
--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -181,18 +181,35 @@ class NetlifyPublicClient {
   }
 
   async upsertVariable(connection: TNetlifyConnectionConfig, params: NetlifyParams, variable: TNetlifyVariable) {
-    const res = await this.getVariable(connection, params, variable);
+    // Fetch the existing variable without the context filter so we can see values
+    // from every context. Netlify's PUT replaces the whole resource, so without this
+    // we would silently wipe values that belong to other contexts (e.g. syncing to
+    // `production` would erase the `branch-deploy` value).
+    const { context_name: _contextName, ...paramsWithoutContext } = params;
+    const res = await this.getVariable(connection, paramsWithoutContext, variable);
 
     if (!res) {
       return this.createVariable(connection, params, variable);
     }
 
     if (res.is_secret) {
-      await this.deleteVariable(connection, params, variable);
+      await this.deleteVariable(connection, paramsWithoutContext, variable);
       return this.createVariable(connection, params, variable);
     }
 
-    return this.updateVariable(connection, params, variable);
+    // Merge the incoming values with existing values for OTHER contexts.
+    // For each context the caller is updating, drop the existing entry; everything
+    // else is preserved verbatim.
+    const incomingContexts = new Set(
+      variable.values.map((v) => v.context).filter((c): c is string => Boolean(c))
+    );
+    const preservedValues = res.values.filter((v) => !v.context || !incomingContexts.has(v.context));
+    const mergedVariable: TNetlifyVariable = {
+      ...variable,
+      values: [...preservedValues, ...variable.values]
+    };
+
+    return this.updateVariable(connection, paramsWithoutContext, mergedVariable);
   }
 
   async deleteVariable(


### PR DESCRIPTION
## Problem

Netlify environment variables are scoped per **context** (`production`, `branch-deploy`, `dev`, etc.) and stored as a single resource with a `values[]` array — one entry per context. The Netlify API's `PUT /accounts/{id}/env/{key}` replaces the **entire resource**, so syncing a value to one context with that PUT erases every other context's value on the same variable.

Two Infisical secret syncs targeting the same Netlify site but different contexts (one sync per environment) therefore overwrite each other — running the second sync wipes variables created by the first sync, even though the syncs target separate contexts.

Reported in #4404. Maintainer (`maidul98`) asked to take a closer look on 2025-09-26; reporter confirmed in v0.149.0 (and Cloud) that the issue persists.

## Root cause

`netlify-connection-public-client.ts → upsertVariable` (before this PR):

```ts
const res = await this.getVariable(connection, params, variable);  // params includes context_name
// ...
return this.updateVariable(connection, params, variable);            // PUT replaces the whole resource
```

The `variable` passed to `updateVariable` only carries the new context's value. Because PUT replaces the resource, every other context's value is dropped.

## Fix

Refetch the existing variable **without** the `context_name` filter so all contexts' values are visible, then build the merged variable: replace values for contexts the caller is explicitly updating, preserve every other context's value verbatim, and PUT the merged variable.

```ts
const { context_name: _, ...paramsWithoutContext } = params;
const res = await this.getVariable(connection, paramsWithoutContext, variable);
// …
const incomingContexts = new Set(variable.values.map((v) => v.context).filter(Boolean));
const preservedValues = res.values.filter((v) => !v.context || !incomingContexts.has(v.context));
const mergedVariable = { ...variable, values: [...preservedValues, ...variable.values] };
return this.updateVariable(connection, paramsWithoutContext, mergedVariable);
```

The original implementation already did a `getVariable` round-trip, so no extra latency is introduced — just the params change to drop the context filter.

The `is_secret` → non-secret delete-then-create branch is unchanged; that's a deliberate type change semantically distinct from the upsert path.

## Scope note

This PR fixes the reported scenario (the **PUT/upsert** path during sync). A related but separate concern exists on the **delete** path — `syncSecrets` and `removeSecrets` call `deleteVariable` which deletes the entire variable across all contexts. Happy to follow up with that fix if you'd like; left out here to keep the change focused on the reported regression.