### PR TITLE
fix(netlify-sync): preserve other contexts when deleting a synced variable

### DIFF
--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -225,7 +225,7 @@ class NetlifyPublicClient {
     try {
       const res = await this.send<TNetlifyVariable>(connection, {
         method: "DELETE",
-        url: `/accounts/${account_id}/${variable.key}/value/${value_id}`,
+        url: `/accounts/${account_id}/env/${variable.key}/value/${value_id}`,
         params
       });
 
@@ -237,6 +237,42 @@ class NetlifyPublicClient {
 
       throw error;
     }
+  }
+
+  /**
+   * Delete a variable while preserving values for any context the caller is
+   * not currently targeting. If `params.context_name` is set and the variable
+   * has values for other contexts, only the value for the targeted context is
+   * removed; otherwise the whole variable is deleted.
+   */
+  async deleteVariableForContext(
+    connection: TNetlifyConnectionConfig,
+    params: NetlifyParams,
+    variable: Pick<TNetlifyVariable, "key">
+  ) {
+    const { context_name: contextName, ...paramsWithoutContext } = params;
+
+    if (!contextName) {
+      return this.deleteVariable(connection, paramsWithoutContext, variable);
+    }
+
+    // Fetch without context filter so we see every context's value.
+    const fullVariable = await this.getVariable(connection, paramsWithoutContext, variable);
+    if (!fullVariable) return null;
+
+    const valueForContext = fullVariable.values.find((v) => v.context === contextName);
+    if (!valueForContext) return null; // nothing to delete in this context
+
+    // If our context is the only one with a value, a full delete is cleaner.
+    if (fullVariable.values.length === 1 || !valueForContext.id) {
+      return this.deleteVariable(connection, paramsWithoutContext, variable);
+    }
+
+    return this.deleteVariableValue(
+      connection,
+      { ...paramsWithoutContext, value_id: valueForContext.id },
+      variable
+    );
   }
 
   async getSites(connection: TNetlifyConnectionConfig, accountId: string) {

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -81,7 +81,11 @@ export const NetlifySyncFns = {
         if (!matchesSchema(key, environment?.slug || "", keySchema)) continue;
 
         if (!secretMap[key]) {
-          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, {
+          // Only remove the value for the current sync context — other contexts on
+          // the same variable (set by other syncs or manually in Netlify) must not
+          // be wiped, since Netlify's DELETE on the variable resource removes ALL
+          // contexts at once.
+          await NetlifyPublicAPI.deleteVariableForContext(secretSync.connection, params, {
             key
           });
         }
@@ -110,7 +114,9 @@ export const NetlifySyncFns = {
     for await (const secret of Object.keys(existingSecrets)) {
       try {
         if (secret in secretMap) {
-          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, {
+          // Scope the deletion to the current sync's context so values that
+          // belong to other contexts on the same variable are not wiped.
+          await NetlifyPublicAPI.deleteVariableForContext(secretSync.connection, params, {
             key: secret
           });
         }


### PR DESCRIPTION
## Problem

Companion fix to #6381. The Netlify env-var resource is shared across contexts (production, branch-deploy, dev, etc.). Netlify's `DELETE /accounts/{id}/env/{key}` removes the entire variable, wiping **every** context's value — not just the calling sync's.

The sync delete paths (the cleanup loop in `syncSecrets` and `removeSecrets`) called `deleteVariable` directly, so removing a secret from one Infisical environment also erased any value the same key held for a different Netlify context (set by a sibling sync or manually).

This is the same root cause as #4404 / #6381 — Netlify's variable-level operations replace/remove the whole variable across contexts — but on the DELETE path instead of the PUT path.

## Fix

Add a context-aware `deleteVariableForContext` helper and wire both delete sites in `netlify-sync-fns.ts` through it:

- If `params.context_name` is set and the variable has values for OTHER contexts → delete only the value for the target context (via the existing `deleteVariableValue` endpoint).
- If our context is the sole occupant (or no value `id` is available) → drop the whole variable (existing behaviour for that case).
- If no context is specified → behaviour unchanged (full delete).

Also fix a **latent path bug** in `deleteVariableValue`: the URL was `/accounts/{id}/{key}/value/{value_id}` — missing the `env/` segment that every other variable endpoint uses. Per Netlify's OpenAPI spec the correct path is `/accounts/{id}/env/{key}/value/{value_id}`. The helper had no live callers, so the wrong URL was never observed — but it needed to be fixed before adopting it from the new context-aware helper.

## Companion to #6381

Together these two PRs make Infisical's Netlify sync **context-isolated** end-to-end: writing a value to one context never touches values bound to other contexts, and removing a synced secret from one Infisical environment never affects siblings synced to other contexts. Either PR alone leaves half the cross-context wipe surface intact.