### PR TITLE
fix: add ldap dynamic secret template valdiation

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { TDynamicSecrets } from "@app/db/schemas";
 import { BadRequestError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
+import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { LdapCredentialType, LdapSchema, TDynamicProviderFns } from "./models";
@@ -49,6 +50,25 @@ const generateLDIF = ({
 export const LdapProvider = (): TDynamicProviderFns => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await LdapSchema.parseAsync(inputs);
+
+    if (providerInputs.credentialType === LdapCredentialType.Static) {
+      validateHandlebarTemplate("LDAP rotation", providerInputs.rotationLdif, {
+        allowedExpressions: (val) => ["Username", "Password", "EncodedPassword"].includes(val)
+      });
+    } else {
+      validateHandlebarTemplate("LDAP creation", providerInputs.creationLdif, {
+        allowedExpressions: (val) => ["Username", "Password", "EncodedPassword"].includes(val)
+      });
+      validateHandlebarTemplate("LDAP revocation", providerInputs.revocationLdif, {
+        allowedExpressions: (val) => ["Username"].includes(val)
+      });
+      if (providerInputs.rollbackLdif) {
+        validateHandlebarTemplate("LDAP rollback", providerInputs.rollbackLdif, {
+          allowedExpressions: (val) => ["Username", "Password", "EncodedPassword"].includes(val)
+        });
+      }
+    }
+
     return providerInputs;
   };
 


### PR DESCRIPTION
## Context

This PR adds template variable validation to our LDAP dynamic secret 

## Screenshots

N/A

## Steps to verify the change

- try to create dynamic secret with invalid template variables

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)