### PR TITLE
feat: added audit log to group operation

### DIFF
--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -210,7 +210,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }
     },
     handler: async (req) => {
-      const group = await server.services.group.deleteGroup({
+      const { group, isUnlinked } = await server.services.group.deleteGroup({
         id: req.params.id,
         actor: req.permission.type,
         actorId: req.permission.id,
@@ -222,14 +222,22 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
           orgId: req.permission.orgId,
-          event: {
-            type: EventType.DELETE_GROUP,
-            metadata: {
-              groupId: group.id,
-              name: group.name,
-              slug: group.slug
-            }
-          }
+          event: isUnlinked
+            ? {
+                type: EventType.UNLINK_GROUP_FROM_SUB_ORG,
+                metadata: {
+                  groupId: group.id,
+                  groupName: group.name
+                }
+              }
+            : {
+                type: EventType.DELETE_GROUP,
+                metadata: {
+                  groupId: group.id,
+                  name: group.name,
+                  slug: group.slug
+                }
+              }
         });
       }
 

--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { GroupsSchema, IdentitiesSchema, OrgMembershipRole, ProjectsSchema } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import {
   FilterMemberType,
   FilterReturnedMachineIdentities,
@@ -56,6 +57,20 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId,
         ...req.body
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.CREATE_GROUP,
+          metadata: {
+            groupId: group.id,
+            name: group.name,
+            slug: group.slug,
+            role: req.body.role
+          }
+        }
       });
 
       return group;
@@ -158,6 +173,20 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         ...req.body
       });
 
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.UPDATE_GROUP,
+          metadata: {
+            groupId: group.id,
+            name: req.body.name,
+            slug: req.body.slug,
+            role: req.body.role
+          }
+        }
+      });
+
       return group;
     }
   });
@@ -188,6 +217,21 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId
       });
+
+      if (group) {
+        await server.services.auditLog.createAuditLog({
+          ...req.auditLogInfo,
+          orgId: req.permission.orgId,
+          event: {
+            type: EventType.DELETE_GROUP,
+            metadata: {
+              groupId: group.id,
+              name: group.name,
+              slug: group.slug
+            }
+          }
+        });
+      }
 
       return group;
     }
@@ -499,13 +543,27 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }
     },
     handler: async (req) => {
-      const user = await server.services.group.addUserToGroup({
+      const { user, group } = await server.services.group.addUserToGroup({
         id: req.params.id,
         username: req.params.username,
         actor: req.permission.type,
         actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.ADD_USER_TO_GROUP,
+          metadata: {
+            groupId: group.id,
+            groupName: group.name,
+            userId: user.id,
+            username: user.username
+          }
+        }
       });
 
       return user;
@@ -534,7 +592,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }
     },
     handler: async (req) => {
-      const machineIdentity = await server.services.group.addMachineIdentityToGroup({
+      const { identity, group } = await server.services.group.addMachineIdentityToGroup({
         id: req.params.id,
         identityId: req.params.machineIdentityId,
         actor: req.permission.type,
@@ -543,7 +601,20 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         actorOrgId: req.permission.orgId
       });
 
-      return machineIdentity;
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.ADD_IDENTITY_TO_GROUP,
+          metadata: {
+            groupId: group.id,
+            groupName: group.name,
+            identityId: identity.id
+          }
+        }
+      });
+
+      return identity;
     }
   });
 
@@ -573,13 +644,27 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }
     },
     handler: async (req) => {
-      const user = await server.services.group.removeUserFromGroup({
+      const { user, group } = await server.services.group.removeUserFromGroup({
         id: req.params.id,
         username: req.params.username,
         actor: req.permission.type,
         actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.REMOVE_USER_FROM_GROUP,
+          metadata: {
+            groupId: group.id,
+            groupName: group.name,
+            userId: user.id,
+            username: user.username
+          }
+        }
       });
 
       return user;
@@ -608,7 +693,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }
     },
     handler: async (req) => {
-      const machineIdentity = await server.services.group.removeMachineIdentityFromGroup({
+      const { identity, group } = await server.services.group.removeMachineIdentityFromGroup({
         id: req.params.id,
         identityId: req.params.machineIdentityId,
         actor: req.permission.type,
@@ -617,7 +702,20 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
         actorOrgId: req.permission.orgId
       });
 
-      return machineIdentity;
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.REMOVE_IDENTITY_FROM_GROUP,
+          metadata: {
+            groupId: group.id,
+            groupName: group.name,
+            identityId: identity.id
+          }
+        }
+      });
+
+      return identity;
     }
   });
 };

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -481,6 +481,18 @@ export enum EventType {
 
   UPDATE_EXTERNAL_GROUP_ORG_ROLE_MAPPINGS = "update-external-group-org-role-mapping",
   GET_EXTERNAL_GROUP_ORG_ROLE_MAPPINGS = "get-external-group-org-role-mapping",
+
+  CREATE_GROUP = "create-group",
+  UPDATE_GROUP = "update-group",
+  DELETE_GROUP = "delete-group",
+  ADD_USER_TO_GROUP = "add-user-to-group",
+  REMOVE_USER_FROM_GROUP = "remove-user-from-group",
+  ADD_IDENTITY_TO_GROUP = "add-identity-to-group",
+  REMOVE_IDENTITY_FROM_GROUP = "remove-identity-from-group",
+  ADD_GROUP_TO_PROJECT = "add-group-to-project",
+  UPDATE_GROUP_PROJECT_MEMBERSHIP = "update-group-project-membership",
+  REMOVE_GROUP_FROM_PROJECT = "remove-group-from-project",
+
   GET_PROJECT_TEMPLATES = "get-project-templates",
   GET_PROJECT_TEMPLATE = "get-project-template",
   CREATE_PROJECT_TEMPLATE = "create-project-template",
@@ -2732,6 +2744,111 @@ interface RemoveHostFromSshHostGroupEvent {
     sshHostGroupId: string;
     sshHostId: string;
     hostname: string;
+  };
+}
+
+interface CreateGroupEvent {
+  type: EventType.CREATE_GROUP;
+  metadata: {
+    groupId: string;
+    name: string;
+    slug: string;
+    role: string;
+  };
+}
+
+interface UpdateGroupEvent {
+  type: EventType.UPDATE_GROUP;
+  metadata: {
+    groupId: string;
+    name?: string;
+    slug?: string;
+    role?: string;
+  };
+}
+
+interface DeleteGroupEvent {
+  type: EventType.DELETE_GROUP;
+  metadata: {
+    groupId: string;
+    name: string;
+    slug: string;
+  };
+}
+
+interface AddUserToGroupEvent {
+  type: EventType.ADD_USER_TO_GROUP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    userId: string;
+    username: string;
+  };
+}
+
+interface RemoveUserFromGroupEvent {
+  type: EventType.REMOVE_USER_FROM_GROUP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    userId: string;
+    username: string;
+  };
+}
+
+interface AddIdentityToGroupEvent {
+  type: EventType.ADD_IDENTITY_TO_GROUP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    identityId: string;
+  };
+}
+
+interface RemoveIdentityFromGroupEvent {
+  type: EventType.REMOVE_IDENTITY_FROM_GROUP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    identityId: string;
+  };
+}
+
+interface AddGroupToProjectEvent {
+  type: EventType.ADD_GROUP_TO_PROJECT;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    roles: Array<{
+      role: string;
+      isTemporary: boolean;
+      temporaryMode?: string;
+      temporaryRange?: string;
+      temporaryAccessStartTime?: string;
+    }>;
+  };
+}
+
+interface UpdateGroupProjectMembershipEvent {
+  type: EventType.UPDATE_GROUP_PROJECT_MEMBERSHIP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    roles: Array<{
+      role: string;
+      isTemporary: boolean;
+      temporaryMode?: string;
+      temporaryRange?: string;
+      temporaryAccessStartTime?: string;
+    }>;
+  };
+}
+
+interface RemoveGroupFromProjectEvent {
+  type: EventType.REMOVE_GROUP_FROM_PROJECT;
+  metadata: {
+    groupId: string;
+    groupName: string;
   };
 }
 
@@ -6986,4 +7103,14 @@ export type Event =
   | GatewayPoolRemoveMemberEvent
   | CreateHoneyTokenEvent
   | UpdateHoneyTokenEvent
-  | RevokeHoneyTokenEvent;
+  | RevokeHoneyTokenEvent
+  | CreateGroupEvent
+  | UpdateGroupEvent
+  | DeleteGroupEvent
+  | AddUserToGroupEvent
+  | RemoveUserFromGroupEvent
+  | AddIdentityToGroupEvent
+  | RemoveIdentityFromGroupEvent
+  | AddGroupToProjectEvent
+  | UpdateGroupProjectMembershipEvent
+  | RemoveGroupFromProjectEvent;

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -485,6 +485,9 @@ export enum EventType {
   CREATE_GROUP = "create-group",
   UPDATE_GROUP = "update-group",
   DELETE_GROUP = "delete-group",
+  LINK_GROUP_TO_SUB_ORG = "link-group-to-sub-org",
+  UPDATE_GROUP_ORG_MEMBERSHIP = "update-group-org-membership",
+  UNLINK_GROUP_FROM_SUB_ORG = "unlink-group-from-sub-org",
   ADD_USER_TO_GROUP = "add-user-to-group",
   REMOVE_USER_FROM_GROUP = "remove-user-from-group",
   ADD_IDENTITY_TO_GROUP = "add-identity-to-group",
@@ -2773,6 +2776,44 @@ interface DeleteGroupEvent {
     groupId: string;
     name: string;
     slug: string;
+  };
+}
+
+interface LinkGroupToSubOrgEvent {
+  type: EventType.LINK_GROUP_TO_SUB_ORG;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    roles: Array<{
+      role: string;
+      isTemporary: boolean;
+      temporaryMode?: string;
+      temporaryRange?: string;
+      temporaryAccessStartTime?: string;
+    }>;
+  };
+}
+
+interface UpdateGroupOrgMembershipEvent {
+  type: EventType.UPDATE_GROUP_ORG_MEMBERSHIP;
+  metadata: {
+    groupId: string;
+    groupName: string;
+    roles: Array<{
+      role: string;
+      isTemporary: boolean;
+      temporaryMode?: string;
+      temporaryRange?: string;
+      temporaryAccessStartTime?: string;
+    }>;
+  };
+}
+
+interface UnlinkGroupFromSubOrgEvent {
+  type: EventType.UNLINK_GROUP_FROM_SUB_ORG;
+  metadata: {
+    groupId: string;
+    groupName: string;
   };
 }
 
@@ -7107,6 +7148,9 @@ export type Event =
   | CreateGroupEvent
   | UpdateGroupEvent
   | DeleteGroupEvent
+  | LinkGroupToSubOrgEvent
+  | UpdateGroupOrgMembershipEvent
+  | UnlinkGroupFromSubOrgEvent
   | AddUserToGroupEvent
   | RemoveUserFromGroupEvent
   | AddIdentityToGroupEvent

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -582,7 +582,11 @@ export const groupServiceFactory = ({
     const isLinkedGroup = group.orgId !== actorOrgId;
 
     if (isLinkedGroup) {
-      const unlinkedGroup = await unlinkGroupFromSubOrg({ groupId: id, groupMembershipId: groupMembership.id, actorOrgId });
+      const unlinkedGroup = await unlinkGroupFromSubOrg({
+        groupId: id,
+        groupMembershipId: groupMembership.id,
+        actorOrgId
+      });
       return { group: unlinkedGroup, isUnlinked: true };
     }
 

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -928,7 +928,7 @@ export const groupServiceFactory = ({
       projectBotDAL
     });
 
-    return users[0];
+    return { user: users[0], group: groupMembership.group };
   };
 
   const addMachineIdentityToGroup = async ({
@@ -1009,7 +1009,7 @@ export const groupServiceFactory = ({
       identityGroupMembershipDAL
     });
 
-    return identities[0];
+    return { identity: identities[0], group: groupMembership.group };
   };
 
   const removeUserFromGroup = async ({
@@ -1101,7 +1101,7 @@ export const groupServiceFactory = ({
       identityIds: []
     });
 
-    return users[0];
+    return { user: users[0], group: groupMembership.group };
   };
 
   const removeMachineIdentityFromGroup = async ({
@@ -1187,7 +1187,7 @@ export const groupServiceFactory = ({
       identityIds: [identityId]
     });
 
-    return identities[0];
+    return { identity: identities[0], group: groupMembership.group };
   };
 
   return {

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -582,10 +582,12 @@ export const groupServiceFactory = ({
     const isLinkedGroup = group.orgId !== actorOrgId;
 
     if (isLinkedGroup) {
-      return unlinkGroupFromSubOrg({ groupId: id, groupMembershipId: groupMembership.id, actorOrgId });
+      const unlinkedGroup = await unlinkGroupFromSubOrg({ groupId: id, groupMembershipId: groupMembership.id, actorOrgId });
+      return { group: unlinkedGroup, isUnlinked: true };
     }
 
-    return deleteOwnedGroup({ groupId: id, actorOrgId });
+    const deletedGroup = await deleteOwnedGroup({ groupId: id, actorOrgId });
+    return { group: deletedGroup, isUnlinked: false };
   };
 
   const getGroupById = async ({ id, actor, actorId, actorAuthMethod, actorOrgId }: TGetGroupByIdDTO) => {

--- a/backend/src/server/routes/v1/group-project-router.ts
+++ b/backend/src/server/routes/v1/group-project-router.ts
@@ -8,6 +8,7 @@ import {
   ProjectUserMembershipRolesSchema,
   TemporaryPermissionMode
 } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { FilterReturnedUsers } from "@app/ee/services/group/group-types";
 import { ApiDocsTags, GROUPS, PROJECTS } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
@@ -85,7 +86,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
         (req.body.role
           ? [{ role: req.body.role, isTemporary: false }]
           : [{ role: ProjectMembershipRole.NoAccess, isTemporary: false }]);
-      const { membership: groupMembership } = await server.services.membershipGroup.createMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.createMembership({
         permission: req.permission,
         data: {
           groupId,
@@ -95,6 +96,27 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.ADD_GROUP_TO_PROJECT,
+          metadata: {
+            groupId,
+            groupName: group.name,
+            roles: roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
         }
       });
 
@@ -155,7 +177,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.updateMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.updateMembership({
         permission: req.permission,
         selector: {
           groupId: req.params.groupId
@@ -167,6 +189,27 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.UPDATE_GROUP_PROJECT_MEMBERSHIP,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: req.body.roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
         }
       });
 
@@ -204,7 +247,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.deleteMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.deleteMembership({
         permission: req.permission,
         selector: {
           groupId: req.params.groupId
@@ -213,6 +256,18 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.REMOVE_GROUP_FROM_PROJECT,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name
+          }
         }
       });
 

--- a/backend/src/server/routes/v1/organization-memberships-router.ts
+++ b/backend/src/server/routes/v1/organization-memberships-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { AccessScope, GroupsSchema, TemporaryPermissionMode } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
 import { OrderByDirection } from "@app/lib/types";
@@ -143,7 +144,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
       }
     },
     handler: async (req) => {
-      await server.services.membershipGroup.createMembership({
+      const { group } = await server.services.membershipGroup.createMembership({
         scopeData: {
           scope: AccessScope.Organization,
           orgId: req.permission.orgId
@@ -159,6 +160,28 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
         permission: req.permission,
         scopeData: { scope: AccessScope.Organization, orgId: req.permission.orgId },
         selector: { groupId: req.params.groupId }
+      });
+
+      // this endpoint is only possible in suborg
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.LINK_GROUP_TO_SUB_ORG,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: req.body.roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
+        }
       });
 
       return {
@@ -252,7 +275,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
       }
     },
     handler: async (req) => {
-      await server.services.membershipGroup.updateMembership({
+      const { group } = await server.services.membershipGroup.updateMembership({
         permission: req.permission,
         scopeData: { scope: AccessScope.Organization, orgId: req.permission.orgId },
         selector: { groupId: req.params.groupId },
@@ -263,6 +286,27 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
         permission: req.permission,
         scopeData: { scope: AccessScope.Organization, orgId: req.permission.orgId },
         selector: { groupId: req.params.groupId }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.UPDATE_GROUP_ORG_MEMBERSHIP,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: req.body.roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
+        }
       });
 
       return {
@@ -305,10 +349,23 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
       }
     },
     handler: async (req) => {
-      const { membership } = await server.services.membershipGroup.deleteMembership({
+      const { membership, group } = await server.services.membershipGroup.deleteMembership({
         scopeData: { scope: AccessScope.Organization, orgId: req.permission.orgId },
         permission: req.permission,
         selector: { groupId: req.params.groupId }
+      });
+
+      // this endpoint is only possible in suborg
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.UNLINK_GROUP_FROM_SUB_ORG,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name
+          }
+        }
       });
 
       return {

--- a/backend/src/server/routes/v1/project-group-memberships-router.ts
+++ b/backend/src/server/routes/v1/project-group-memberships-router.ts
@@ -7,6 +7,7 @@ import {
   ProjectUserMembershipRolesSchema,
   TemporaryPermissionMode
 } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, PROJECTS } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -139,7 +140,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
         (req.body.role
           ? [{ role: req.body.role, isTemporary: false }]
           : [{ role: ProjectMembershipRole.NoAccess, isTemporary: false }]);
-      await server.services.membershipGroup.createMembership({
+      const { group } = await server.services.membershipGroup.createMembership({
         permission: req.permission,
         data: { groupId: req.params.groupId, roles },
         scopeData: {
@@ -157,6 +158,27 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
           projectId: req.params.projectId
         },
         selector: { groupId: req.params.groupId }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.ADD_GROUP_TO_PROJECT,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
+        }
       });
 
       return {
@@ -259,7 +281,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.updateMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.updateMembership({
         permission: req.permission,
         selector: { groupId: req.params.groupId },
         data: { roles: req.body.roles },
@@ -267,6 +289,27 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.UPDATE_GROUP_PROJECT_MEMBERSHIP,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: req.body.roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
         }
       });
 
@@ -302,13 +345,25 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.deleteMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.deleteMembership({
         permission: req.permission,
         selector: { groupId: req.params.groupId },
         scopeData: {
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.REMOVE_GROUP_FROM_PROJECT,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name
+          }
         }
       });
 

--- a/backend/src/server/routes/v2/deprecated-group-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-group-project-router.ts
@@ -8,6 +8,7 @@ import {
   ProjectUserMembershipRolesSchema,
   TemporaryPermissionMode
 } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { FilterReturnedUsers } from "@app/ee/services/group/group-types";
 import { ApiDocsTags, GROUPS, PROJECTS } from "@app/lib/api-docs";
 import { ms } from "@app/lib/ms";
@@ -82,7 +83,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
         (req.body.role
           ? [{ role: req.body.role, isTemporary: false }]
           : [{ role: ProjectMembershipRole.NoAccess, isTemporary: false }]);
-      const { membership: groupMembership } = await server.services.membershipGroup.createMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.createMembership({
         permission: req.permission,
         data: {
           groupId,
@@ -92,6 +93,27 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.ADD_GROUP_TO_PROJECT,
+          metadata: {
+            groupId,
+            groupName: group.name,
+            roles: roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
         }
       });
 
@@ -149,7 +171,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.updateMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.updateMembership({
         permission: req.permission,
         selector: {
           groupId: req.params.groupId
@@ -161,6 +183,27 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.UPDATE_GROUP_PROJECT_MEMBERSHIP,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name,
+            roles: req.body.roles.map((r) => ({
+              role: r.role,
+              isTemporary: r.isTemporary,
+              ...(r.isTemporary && {
+                temporaryMode: r.temporaryMode,
+                temporaryRange: r.temporaryRange,
+                temporaryAccessStartTime: r.temporaryAccessStartTime
+              })
+            }))
+          }
         }
       });
 
@@ -195,7 +238,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
       }
     },
     handler: async (req) => {
-      const { membership: groupMembership } = await server.services.membershipGroup.deleteMembership({
+      const { membership: groupMembership, group } = await server.services.membershipGroup.deleteMembership({
         permission: req.permission,
         selector: {
           groupId: req.params.groupId
@@ -204,6 +247,18 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
           scope: AccessScope.Project,
           orgId: req.permission.orgId,
           projectId: req.params.projectId
+        }
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: req.params.projectId,
+        event: {
+          type: EventType.REMOVE_GROUP_FROM_PROJECT,
+          metadata: {
+            groupId: req.params.groupId,
+            groupName: group.name
+          }
         }
       });
 

--- a/backend/src/services/membership-group/membership-group-service.ts
+++ b/backend/src/services/membership-group/membership-group-service.ts
@@ -100,7 +100,7 @@ export const membershipGroupServiceFactory = ({
 
     const scopeDatabaseFields = factory.getScopeDatabaseFields(dto.scopeData);
 
-    await factory.onCreateMembershipGroupGuard(dto);
+    const { group } = await factory.onCreateMembershipGroupGuard(dto);
 
     const customInputRoles = data.roles.filter((el) => factory.isCustomRole(el.role));
     const hasCustomRole = customInputRoles.length > 0;
@@ -182,14 +182,14 @@ export const membershipGroupServiceFactory = ({
       return doc;
     });
 
-    return { membership };
+    return { membership, group };
   };
 
   const updateMembership = async (dto: TUpdateMembershipGroupDTO) => {
     const { scopeData, data } = dto;
     const factory = scopeFactory[scopeData.scope];
 
-    await factory.onUpdateMembershipGroupGuard(dto);
+    const { group } = await factory.onUpdateMembershipGroupGuard(dto);
 
     const customInputRoles = data.roles.filter((el) => factory.isCustomRole(el.role));
     const hasCustomRole = customInputRoles.length > 0;
@@ -297,14 +297,14 @@ export const membershipGroupServiceFactory = ({
       return { ...doc, roles };
     });
 
-    return { membership: membershipDoc };
+    return { membership: membershipDoc, group };
   };
 
   const deleteMembership = async (dto: TDeleteMembershipGroupDTO) => {
     const { scopeData } = dto;
     const factory = scopeFactory[scopeData.scope];
 
-    await factory.onDeleteMembershipGroupGuard(dto);
+    const { group } = await factory.onDeleteMembershipGroupGuard(dto);
 
     const scopeDatabaseFields = factory.getScopeDatabaseFields(dto.scopeData);
     const existingMembership = await membershipGroupDAL.findOne({
@@ -371,7 +371,7 @@ export const membershipGroupServiceFactory = ({
       const doc = await membershipGroupDAL.deleteById(existingMembership.id, tx);
       return doc;
     });
-    return { membership: membershipDoc };
+    return { membership: membershipDoc, group };
   };
 
   const listMemberships = async (dto: TListMembershipGroupDTO) => {

--- a/backend/src/services/membership-group/membership-group-types.ts
+++ b/backend/src/services/membership-group/membership-group-types.ts
@@ -7,11 +7,15 @@ export enum OrgGroupsOrderBy {
   Role = "role"
 }
 
-export interface TMembershipGroupScopeFactory {
-  onCreateMembershipGroupGuard: (arg: TCreateMembershipGroupDTO) => Promise<void>;
+export type TMembershipGroupGuardReturn = {
+  group: { id: string; name: string };
+};
 
-  onUpdateMembershipGroupGuard: (arg: TUpdateMembershipGroupDTO) => Promise<void>;
-  onDeleteMembershipGroupGuard: (arg: TDeleteMembershipGroupDTO) => Promise<void>;
+export interface TMembershipGroupScopeFactory {
+  onCreateMembershipGroupGuard: (arg: TCreateMembershipGroupDTO) => Promise<TMembershipGroupGuardReturn>;
+
+  onUpdateMembershipGroupGuard: (arg: TUpdateMembershipGroupDTO) => Promise<TMembershipGroupGuardReturn>;
+  onDeleteMembershipGroupGuard: (arg: TDeleteMembershipGroupDTO) => Promise<TMembershipGroupGuardReturn>;
   onListMembershipGroupGuard: (arg: TListMembershipGroupDTO) => Promise<void>;
   onGetMembershipGroupByGroupIdGuard: (arg: TGetMembershipGroupByGroupIdDTO) => Promise<void>;
   getScopeField: (scope: AccessScopeData) => { key: "orgId" | "projectId"; value: string };

--- a/backend/src/services/membership-group/org/org-membership-group-factory.ts
+++ b/backend/src/services/membership-group/org/org-membership-group-factory.ts
@@ -113,6 +113,8 @@ export const newOrgMembershipGroupFactory = ({
           });
       }
     }
+
+    return { group: { id: group.id, name: group.name } };
   };
 
   const onUpdateMembershipGroupGuard: TMembershipGroupScopeFactory["onUpdateMembershipGroupGuard"] = async (dto) => {
@@ -125,6 +127,10 @@ export const newOrgMembershipGroupFactory = ({
       scope: OrganizationActionScope.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionGroupActions.Edit, OrgPermissionSubjects.Groups);
+
+    const groupDetails = await groupDAL.findById(dto.selector.groupId);
+    if (!groupDetails) throw new BadRequestError({ message: "Group details not found" });
+
     const permissionRoles = await permissionService.getOrgPermissionByRoles(
       dto.data.roles.map((el) => el.role),
       dto.permission.orgId
@@ -155,6 +161,8 @@ export const newOrgMembershipGroupFactory = ({
           });
       }
     }
+
+    return { group: { id: groupDetails.id, name: groupDetails.name } };
   };
 
   const onDeleteMembershipGroupGuard: TMembershipGroupScopeFactory["onDeleteMembershipGroupGuard"] = async (dto) => {
@@ -189,6 +197,8 @@ export const newOrgMembershipGroupFactory = ({
       scope: OrganizationActionScope.ChildOrganization
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionGroupActions.Delete, OrgPermissionSubjects.Groups);
+
+    return { group: { id: group.id, name: group.name } };
   };
 
   const onListMembershipGroupGuard: TMembershipGroupScopeFactory["onListMembershipGroupGuard"] = async (dto) => {

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -102,6 +102,8 @@ export const newProjectMembershipGroupFactory = ({
           });
       }
     }
+
+    return { group: { id: groupDetails.id, name: groupDetails.name } };
   };
 
   const onUpdateMembershipGroupGuard: TMembershipGroupScopeFactory["onUpdateMembershipGroupGuard"] = async (dto) => {
@@ -158,6 +160,8 @@ export const newProjectMembershipGroupFactory = ({
           });
       }
     }
+
+    return { group: { id: groupDetails.id, name: groupDetails.name } };
   };
 
   const onDeleteMembershipGroupGuard: TMembershipGroupScopeFactory["onDeleteMembershipGroupGuard"] = async (dto) => {
@@ -172,6 +176,11 @@ export const newProjectMembershipGroupFactory = ({
     });
 
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionGroupActions.Delete, ProjectPermissionSub.Groups);
+
+    const groupDetails = await groupDAL.findById(dto.selector.groupId);
+    if (!groupDetails) throw new BadRequestError({ message: "Group details not found" });
+
+    return { group: { id: groupDetails.id, name: groupDetails.name } };
   };
 
   const onListMembershipGroupGuard: TMembershipGroupScopeFactory["onListMembershipGroupGuard"] = async (dto) => {


### PR DESCRIPTION
## Context

This PR adds audit logging to group operations. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Update license-fn for the audit log days and retention
2. Enable groups as well
3. Do some operation in groups

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)