### PR TITLE
docs(bullmq): add BullBoard section to developing documentation for queue management

### DIFF
--- a/docs/contributing/platform/developing.mdx
+++ b/docs/contributing/platform/developing.mdx
@@ -50,6 +50,18 @@ The `.env.dev.example` file already includes the SMTP variables pre-configured f
 
 To view captured emails, open the Mailhog web UI at [http://localhost:8025](http://localhost:8025).
 
+#### Queue Management with BullBoard
+
+The dev Docker Compose includes [BullBoard](https://github.com/felixmosh/bull-board), a web UI for monitoring and managing BullMQ job queues. This is useful for debugging async job processing, viewing queue status, and inspecting failed jobs during development.
+
+To start BullBoard, use the `queue` profile:
+
+```bash
+docker compose -f docker-compose.dev.yml --profile queue up
+```
+
+Once running, access the BullBoard UI at [http://localhost:3008](http://localhost:3008) to view and manage queues in real-time.
+
 #### Shutdown local server
 
 ```bash


### PR DESCRIPTION
## Context

Updated the development docs with a session about Bullboard.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)