### PR TITLE
fix: use UPGRADE_TOOL_GITHUB_TOKEN secret in upgrade impact workflow

### DIFF
--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run generate -- --tag "${{ steps.release.outputs.tag }}"
         working-directory: upgrade-impact
         env:
-          UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.UPGRADE_TOOL_GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Validate upgrade impact data
@@ -69,7 +69,7 @@ jobs:
       - name: Open upgrade impact PR
         if: steps.release.outputs.stable == 'true'
         env:
-          GH_TOKEN: ${{ secrets.UPGRADE_IMPACT_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.UPGRADE_TOOL_GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.release.outputs.tag }}
         run: |
           BRANCH_NAME="chore/upgrade-impact-${TAG_NAME}"


### PR DESCRIPTION
## Context

- Follow-up to #6273 — secret was renamed to `UPGRADE_TOOL_GITHUB_TOKEN` but the workflow still referenced the old `secrets.UPGRADE_IMPACT_PR_TOKEN`, leaving `GH_TOKEN` empty and breaking `gh pr create` ([failed run](https://github.com/Infisical/infisical/actions/runs/25585713120))
- Point both token-bearing steps at `secrets.UPGRADE_TOOL_GITHUB_TOKEN` so the generate step's API calls and the PR-create step both use the renamed PAT

## Steps to verify the change

- Trigger the workflow via `workflow_dispatch` against an existing tag and confirm the "Open upgrade impact PR" step authenticates and creates a PR

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore