### PR TITLE
improvement: always show environment selection when creating secrets

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -3261,11 +3261,7 @@ const OverviewPageContent = () => {
         <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-lg">
           <SheetHeader className="border-b">
             <SheetTitle>Create Secret</SheetTitle>
-            <SheetDescription>
-              {filteredEnvs.length === 1
-                ? `Create a secret in ${filteredEnvs[0].name}`
-                : "Create a secret across multiple environments"}
-            </SheetDescription>
+            <SheetDescription>Create a secret across one or more environments</SheetDescription>
           </SheetHeader>
           <CreateSecretForm
             secretPath={secretPath}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -153,9 +153,7 @@ export const CreateSecretForm = ({
   const [createMore, setCreateMore] = useState(false);
   const secretKeyInputRef = useRef<HTMLInputElement>(null);
   const secretKey = watch("key");
-  const selectedEnvironments = defaultSelectedEnvs?.length
-    ? defaultSelectedEnvs
-    : watch("environments");
+  const selectedEnvironments = watch("environments");
 
   const handleFormSubmit = async ({
     key,
@@ -331,40 +329,38 @@ export const CreateSecretForm = ({
       className="flex flex-1 flex-col gap-4 overflow-hidden"
     >
       <div className="flex thin-scrollbar flex-1 flex-col gap-4 overflow-y-auto p-4">
-        {defaultSelectedEnvs?.length === 1 ? null : (
-          <Controller
-            control={control}
-            name="environments"
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel>Environments</FieldLabel>
-                <FieldContent>
-                  <FilterableSelect
-                    isMulti
-                    isError={Boolean(error)}
-                    options={environments.filter((environment) =>
-                      permission.can(
-                        ProjectPermissionSecretActions.Create,
-                        subject(ProjectPermissionSub.Secrets, {
-                          environment: environment.slug,
-                          secretPath,
-                          secretName: "*",
-                          secretTags: ["*"]
-                        })
-                      )
-                    )}
-                    value={value}
-                    onChange={onChange}
-                    placeholder="Select environments to create secret in..."
-                    getOptionLabel={(option) => option.name}
-                    getOptionValue={(option) => option.slug}
-                  />
-                  <FieldError errors={[error]} />
-                </FieldContent>
-              </Field>
-            )}
-          />
-        )}
+        <Controller
+          control={control}
+          name="environments"
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>Environments</FieldLabel>
+              <FieldContent>
+                <FilterableSelect
+                  isMulti
+                  isError={Boolean(error)}
+                  options={environments.filter((environment) =>
+                    permission.can(
+                      ProjectPermissionSecretActions.Create,
+                      subject(ProjectPermissionSub.Secrets, {
+                        environment: environment.slug,
+                        secretPath,
+                        secretName: "*",
+                        secretTags: ["*"]
+                      })
+                    )
+                  )}
+                  value={value}
+                  onChange={onChange}
+                  placeholder="Select environments to create secret in..."
+                  getOptionLabel={(option) => option.name}
+                  getOptionValue={(option) => option.slug}
+                />
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
+          )}
+        />
 
         <Controller
           control={control}


### PR DESCRIPTION
## Context

This PR updates the create secret form to always display the env selection; even when only one env is selected on the overview page

## Screenshots
 
 
<img width="3456" height="1928" alt="CleanShot 2026-05-08 at 17 32 15@2x" src="https://github.com/user-attachments/assets/eac649a6-caa9-42d7-a3fb-d9fd51f41701" />


## Steps to verify the change

- create secret with single env selected; env should be pre-selected
- create secret with multiple envs selected; should gbe reflected in sheet

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)