### PR TITLE
fix(docs): Refactor oidcLogin to use fetch API

### DIFF
--- a/docs/documentation/platform/identities/oidc-auth/general.mdx
+++ b/docs/documentation/platform/identities/oidc-auth/general.mdx
@@ -126,29 +126,41 @@ In the following steps, we explore how to create and use identities to access th
 
         #### Sample usage
         ```javascript
+        import * as core from "@actions/core";
+        import querystring from "node:querystring";
+        
         export const oidcLogin = async ({ identityId, domain, oidcAudience }) => {
-            const idToken = await core.getIDToken(oidcAudience);
-
-            const loginData = querystring.stringify({
-                identityId,
-                jwt: idToken,
+          const idToken = await core.getIDToken(oidcAudience);
+          const body = querystring.stringify({
+            identityId,
+            jwt: idToken,
+          });
+        
+          const url = `${domain}/api/v1/auth/oidc-auth/login`;
+        
+          let response;
+          try {
+            response = await fetch(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+              },
+              body,
             });
-
-            try {
-                const response = await axios({
-                method: "post",
-                url: `${domain}/api/v1/auth/oidc-auth/login`,
-                headers: {
-                    "Content-Type": "application/x-www-form-urlencoded",
-                },
-                data: loginData,
-                });
-
-                return response.data.accessToken;
-            } catch (err) {
-                core.error("Error:", err.message);
-                throw err;
-            }
+          } catch (err) {
+            core.error(`Network error contacting Infisical: ${err.message}`);
+            throw err;
+          }
+        
+          if (!response.ok) {
+            const errorBody = await response.text().catch(() => "<no body>");
+            const message = `Infisical OIDC login failed: ${response.status} ${response.statusText} — ${errorBody}`;
+            core.error(message);
+            throw new Error(message);
+          }
+        
+          const data = await response.json();
+          return data.accessToken;
         };
         ```
 


### PR DESCRIPTION
Refactor OIDC login function to use fetch instead of axios for network requests.

this is also suggested for https://github.com/Infisical/secrets-action/blob/77ab1f4ccd183a543cb5b42435fbd181189f4995/package.json#L27 which is using a deprecated version (bad look for a security tool!)

## Context

Looking at axios's CVE cadence — 1.6.8 was released Jan 2024; since then there have been CVE-2024-39338, CVE-2025-27152, CVE-2025-58754, CVE-2025-62718, CVE-2026-25639, CVE-2026-40175 — that's roughly bimonthly disclosures requiring an action release each time. Removing axios moves this action to a dependency surface where the same churn doesn't apply.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)