### PR TITLE
fix(pam-oracle): run TLS hostname probe for all SSL Oracle connections

### DIFF
--- a/backend/src/ee/services/pam-resource/oracle/oracle-resource-factory.ts
+++ b/backend/src/ee/services/pam-resource/oracle/oracle-resource-factory.ts
@@ -53,10 +53,10 @@ const makeOracleConnection = (
 
   return {
     validate: async (connectOnly) => {
-      // When a custom CA is provided, probe the cert chain first — node-oracledb
-      // thin mode can't accept an inline CA, so tcps:// only works if the cert
-      // is already trusted by the system store.
-      if (sslEnabled && sslCertificate) {
+      // Probe TLS first to validate hostname + cert chain. The tcps:// connect
+      // string uses ssl_server_dn_match=false (required because we connect via
+      // localhost proxy), so this probe is the hostname validation layer.
+      if (sslEnabled) {
         try {
           await probeOracleTls({
             tcpHost: "localhost",
@@ -80,13 +80,12 @@ const makeOracleConnection = (
         if (error instanceof Error) {
           const msg = error.message || "";
           if (connectOnly && msg.includes("ORA-")) {
-            // Any Oracle response means the host is reachable.
             return;
           }
         }
-        // If CA was provided and probe passed, the cert is valid — the tcps://
-        // failure is likely because the CA isn't in the system trust store.
-        // Save anyway; creds will be checked on first PAM session.
+        // Probe passed so the cert is valid — tcps:// failure is likely because
+        // the custom CA isn't in the system trust store. Save anyway; creds
+        // will be checked on first PAM session.
         if (sslEnabled && sslCertificate) {
           return;
         }


### PR DESCRIPTION
## Context

- Run the TLS hostname validation probe for all SSL-enabled Oracle connections, not just when a custom CA is provided.
- The tcps:// connect string disables Oracle's DN matching (ssl_server_dn_match=false) because we connect via localhost proxy, so the probe is the hostname validation layer.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)