### PR TITLE
Add migration risk to upgrade impact data

### DIFF
--- a/upgrade-impact/data/releases/v0.159.16.yaml
+++ b/upgrade-impact/data/releases/v0.159.16.yaml
@@ -14,6 +14,7 @@ dbSchemaChanges:
       because the column is only added when missing.
     action: No manual action required; Infisical runs this migration during startup.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260409120000_add-webhook-event-toggles.ts

--- a/upgrade-impact/data/releases/v0.159.17.yaml
+++ b/upgrade-impact/data/releases/v0.159.17.yaml
@@ -17,6 +17,7 @@ dbSchemaChanges:
       If startup fails during migration, keep the previous version running and
       inspect migration logs before retrying.
     confidence: high
+    migrationRisk: medium
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260330172252_rename-vault-to-external-migration-config.ts

--- a/upgrade-impact/data/releases/v0.159.19.yaml
+++ b/upgrade-impact/data/releases/v0.159.19.yaml
@@ -33,6 +33,7 @@ dbSchemaChanges:
       If startup fails during migration, keep the previous version running and
       inspect migration logs before retrying.
     confidence: high
+    migrationRisk: high
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260408062748_pam-domains.ts
@@ -43,6 +44,7 @@ dbSchemaChanges:
       certificates for external CA metadata storage.
     action: No manual action required; Infisical runs this migration during startup.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260416231234_add-external-metadata-to-certificates.ts

--- a/upgrade-impact/data/releases/v0.159.20.yaml
+++ b/upgrade-impact/data/releases/v0.159.20.yaml
@@ -15,6 +15,7 @@ dbSchemaChanges:
       column is missing.
     action: No manual action required; Infisical runs this migration during startup.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260417245211_pam-session-reason.ts
@@ -26,6 +27,7 @@ dbSchemaChanges:
       only if the table exists and the column is missing.
     action: No manual action required; Infisical runs this migration during startup.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260421135044_add-digicert-external-ca-columns.ts

--- a/upgrade-impact/data/releases/v0.159.23.yaml
+++ b/upgrade-impact/data/releases/v0.159.23.yaml
@@ -16,6 +16,7 @@ dbSchemaChanges:
       If startup fails during migration, keep the previous version running and
       inspect migration logs before retrying.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260414000001_add-gateway-pools.ts

--- a/upgrade-impact/data/releases/v0.159.25.yaml
+++ b/upgrade-impact/data/releases/v0.159.25.yaml
@@ -14,6 +14,7 @@ dbSchemaChanges:
       point URLs. Existing data remains compatible.
     action: No manual action required; Infisical runs this migration during startup.
     confidence: high
+    migrationRisk: low
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260428000635_add-internal-ca-distribution-point-urls.ts
@@ -27,6 +28,7 @@ dbSchemaChanges:
       If startup fails during migration, keep the previous version running and
       inspect migration logs before retrying.
     confidence: high
+    migrationRisk: medium
     evidence:
       - type: file
         ref: backend/src/db/migrations/20260430141040_add-verify-tls-certificate-to-identity-kubernetes-auth.ts

--- a/upgrade-impact/src/generate-ai.test.ts
+++ b/upgrade-impact/src/generate-ai.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyMigrationRisk } from "./generate-ai.js";
+
+describe("classifyMigrationRisk", () => {
+  it("classifies additive-only up migrations as low risk", () => {
+    expect(
+      classifyMigrationRisk(`
+export async function up(knex) {
+  await knex.schema.alterTable("projects", (t) => {
+    t.string("description").nullable();
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable("projects", (t) => {
+    t.dropColumn("description");
+  });
+}
+`)
+    ).toBe("low");
+  });
+
+  it("classifies data rewrites as medium risk", () => {
+    expect(
+      classifyMigrationRisk(`
+export async function up(knex) {
+  await knex.schema.alterTable("projects", (t) => {
+    t.boolean("enabled").defaultTo(false).notNullable();
+  });
+
+  await knex("projects").whereNotNull("legacyFlag").update({ enabled: true });
+}
+`)
+    ).toBe("medium");
+  });
+
+  it("classifies destructive up migrations as high risk", () => {
+    expect(
+      classifyMigrationRisk(`
+export async function up(knex) {
+  await knex("projects").where("archived", true).delete();
+  await knex.schema.alterTable("projects", (t) => {
+    t.dropColumn("legacyFlag");
+  });
+}
+`)
+    ).toBe("high");
+  });
+});

--- a/upgrade-impact/src/generate-ai.ts
+++ b/upgrade-impact/src/generate-ai.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { ReleaseEvidenceBundle } from "./evidence.js";
 import { runGit } from "./git.js";
-import { Evidence, ImpactEntry, ImpactEntrySchema } from "./schema.js";
+import { DbSchemaChangeSchema, Evidence, ImpactEntry, ImpactEntrySchema, MigrationRisk } from "./schema.js";
 
 export const MODEL = "gpt-5.4";
 
@@ -14,7 +14,7 @@ const GeneratedDraftSchema = z.object({
   summary: z.string().min(1),
   requiresDbMigration: z.boolean(),
   breakingChanges: z.array(ImpactEntrySchema),
-  dbSchemaChanges: z.array(ImpactEntrySchema),
+  dbSchemaChanges: z.array(DbSchemaChangeSchema),
   configChanges: z.array(ImpactEntrySchema),
   deploymentNotes: z.array(ImpactEntrySchema),
   knownIssues: z.array(ImpactEntrySchema)
@@ -38,17 +38,84 @@ const evidenceForFile = (file: string, description?: string) => ({
   description
 });
 
+const migrationRiskRank: Record<MigrationRisk, number> = {
+  low: 0,
+  medium: 1,
+  high: 2
+};
+
+const maxMigrationRisk = (risks: MigrationRisk[]): MigrationRisk =>
+  risks.reduce<MigrationRisk>(
+    (highestRisk, risk) => (migrationRiskRank[risk] > migrationRiskRank[highestRisk] ? risk : highestRisk),
+    "low"
+  );
+
+const extractUpMigrationSource = (source: string) =>
+  source.match(/export\s+async\s+function\s+up[\s\S]*?(?=\nexport\s+async\s+function\s+down|$)/)?.[0] ?? source;
+
+export const classifyMigrationRisk = (source: string): MigrationRisk => {
+  const upSource = extractUpMigrationSource(source);
+
+  if (
+    /\b(dropColumn|dropTable|dropTableIfExists|renameColumn|renameTable)\b/i.test(upSource) ||
+    /\bDELETE\s+FROM\b/i.test(upSource) ||
+    /\bTRUNCATE\b/i.test(upSource) ||
+    /\.(delete|del)\s*\(/i.test(upSource)
+  ) {
+    return "high";
+  }
+
+  if (
+    /\b(dropForeign|dropIndex)\b/i.test(upSource) ||
+    /\bALTER\s+TABLE\b/i.test(upSource) ||
+    /\.(alter|update|insert)\s*\(/i.test(upSource) ||
+    /\bINSERT\s+INTO\b/i.test(upSource) ||
+    /\bUPDATE\s+.+\s+SET\b/i.test(upSource)
+  ) {
+    return "medium";
+  }
+
+  return "low";
+};
+
+const readMigrationSource = (bundle: ReleaseEvidenceBundle, file: string) => {
+  try {
+    return runGit(["show", `${bundle.tag}:${file}`]);
+  } catch {
+    return "";
+  }
+};
+
+const classifyMigrationFilesRisk = (bundle: ReleaseEvidenceBundle): MigrationRisk => {
+  if (bundle.migrationFiles.length === 0) {
+    return "low";
+  }
+
+  return maxMigrationRisk(
+    bundle.migrationFiles.map((file) => {
+      const source = readMigrationSource(bundle, file);
+      return source ? classifyMigrationRisk(source) : "medium";
+    })
+  );
+};
+
 export const deterministicDraft = (bundle: ReleaseEvidenceBundle): GeneratedDraft => {
   const dbSchemaChanges: GeneratedDraft["dbSchemaChanges"] = [];
   const configChanges: GeneratedDraft["configChanges"] = [];
   const deploymentNotes: GeneratedDraft["deploymentNotes"] = [];
 
   if (bundle.migrationFiles.length > 0) {
+    const migrationRisk = classifyMigrationFilesRisk(bundle);
+
     dbSchemaChanges.push({
       title: "Database schema migrations are included",
       description: `This release adds ${bundle.migrationFiles.length} database migration file(s). Self-hosted instances should expect the application to run migrations during startup.`,
-      action: "Back up the database before upgrading and monitor startup logs until migrations complete.",
+      action:
+        migrationRisk === "low"
+          ? "No manual action required; Infisical runs this migration during startup."
+          : "Back up the database before upgrading and monitor startup logs until migrations complete.",
       confidence: "high",
+      migrationRisk,
       evidence: bundle.migrationFiles.map((file) => evidenceForFile(file, "Added migration file"))
     });
   }
@@ -81,8 +148,10 @@ export const deterministicDraft = (bundle: ReleaseEvidenceBundle): GeneratedDraf
     impactLevel = "low";
   }
 
-  if (dbSchemaChanges.length > 0 || configChanges.length > 0) {
+  if (configChanges.length > 0) {
     impactLevel = "medium";
+  } else if (dbSchemaChanges.length > 0) {
+    impactLevel = "low";
   }
 
   let summary = "No self-hosted upgrade impact was detected from deterministic release signals.";
@@ -115,7 +184,7 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - Use active voice and simple verbs.
 - Do not say "the release", "this release", "code changes indicate", "evidence bundle", "identified", or "detected".
 - Do not mention that no Docker, Helm, Kubernetes, or database changes exist unless that absence changes the upgrade action.
-- Do not duplicate the same risk across breakingChanges, configChanges, deploymentNotes, and knownIssues. Pick one category.
+- Do not duplicate the same risk across breakingChanges, dbSchemaChanges, configChanges, deploymentNotes, and knownIssues. Pick one category.
 - Do not include the same evidence item twice in one entry.
 - Do not repeat a release note or PR URL across multiple entries when a more specific file diff can support the claim.
 - Before finalizing, audit the JSON for duplicate titles, duplicate descriptions, and duplicate evidence.
@@ -123,6 +192,11 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - Only write an action when there is a specific operator task. If there is no manual task, write "No manual action required; Infisical runs this migration during startup."
 - For additive database migrations, prefer "No manual action required; Infisical runs this migration during startup." Do not tell users to run migrations manually unless the diff proves they must.
 - If a migration failure is the only risk, say "If startup fails during migration, keep the previous version running and inspect migration logs before retrying."
+- Every dbSchemaChanges entry must include migrationRisk.
+- Set migrationRisk to "low" for additive-only migrations such as new tables, nullable columns, compatible defaults, indexes, or foreign keys that preserve existing rows.
+- Set migrationRisk to "medium" when the up migration alters existing column types or constraints, backfills or rewrites data, copies data between tables, adds non-null columns to existing tables, or may take longer locks.
+- Set migrationRisk to "high" when the up migration drops columns or tables, deletes existing rows, renames schema that existing data depends on, or otherwise removes data or rollback paths.
+- Classify migrationRisk from the up migration only; ignore destructive operations that appear only in the down rollback.
 - Do not say "run migrations before serving traffic", "verify migration jobs complete", "account for", or "review X if you rely on Y".
 - Do not tell operators to change proxy, Helm, Docker, or environment configuration unless the diff introduces a required setting or changes a default that existing deployments must respond to.
 - Optional security-hardening settings such as TRUSTED_PROXY_CIDRS are not upgrade actions when unset preserves legacy behavior.
@@ -148,7 +222,7 @@ Return only JSON matching this TypeScript shape:
   "summary": "string",
   "requiresDbMigration": boolean,
   "breakingChanges": ImpactEntry[],
-  "dbSchemaChanges": ImpactEntry[],
+  "dbSchemaChanges": DbSchemaChange[],
   "configChanges": ImpactEntry[],
   "deploymentNotes": ImpactEntry[],
   "knownIssues": ImpactEntry[]
@@ -161,6 +235,11 @@ ImpactEntry:
   "action": "string",
   "confidence": "low" | "medium" | "high",
   "evidence": Evidence[]
+}
+
+DbSchemaChange extends ImpactEntry:
+{
+  "migrationRisk": "low" | "medium" | "high"
 }
 
 Evidence:
@@ -201,16 +280,19 @@ const normalizeDraft = (draft: GeneratedDraft): GeneratedDraft => {
   const entryKey = (entry: ImpactEntry) =>
     [entry.title.trim().toLowerCase(), entry.description.trim().toLowerCase()].join("\u0000");
 
-  const normalizeEntries = (entries: ImpactEntry[]) =>
+  const normalizeEntries = <TEntry extends ImpactEntry>(entries: TEntry[]): TEntry[] =>
     entries
-      .map((entry) => ({
-        ...entry,
-        evidence: dedupeEvidence(
-          entry.evidence.map((evidence) =>
-            evidence.type === "file" && evidence.path ? { ...evidence, ref: evidence.path } : evidence
-          )
-        )
-      }))
+      .map(
+        (entry) =>
+          ({
+            ...entry,
+            evidence: dedupeEvidence(
+              entry.evidence.map((evidence) =>
+                evidence.type === "file" && evidence.path ? { ...evidence, ref: evidence.path } : evidence
+              )
+            )
+          }) as TEntry
+      )
       .filter((entry, index, normalizedEntries) => {
         const key = entryKey(entry);
         return normalizedEntries.findIndex((candidate) => entryKey(candidate) === key) === index;

--- a/upgrade-impact/src/schema.ts
+++ b/upgrade-impact/src/schema.ts
@@ -4,6 +4,7 @@ export const StableVersionSchema = z.string().regex(/^v\d+\.\d+\.\d+$/, "Expecte
 
 export const ImpactLevelSchema = z.enum(["none", "low", "medium", "high"]);
 export const ConfidenceSchema = z.enum(["low", "medium", "high"]);
+export const MigrationRiskSchema = z.enum(["low", "medium", "high"]);
 
 export const EvidenceSchema = z
   .object({
@@ -39,6 +40,10 @@ export const ImpactEntrySchema = z.object({
   evidence: z.array(EvidenceSchema).min(1)
 });
 
+export const DbSchemaChangeSchema = ImpactEntrySchema.extend({
+  migrationRisk: MigrationRiskSchema
+});
+
 export const ReleaseImpactSchema = z.object({
   version: StableVersionSchema,
   releasedAt: z.string().datetime({ offset: true }),
@@ -48,7 +53,7 @@ export const ReleaseImpactSchema = z.object({
   summary: z.string().min(1),
   requiresDbMigration: z.boolean(),
   breakingChanges: z.array(ImpactEntrySchema),
-  dbSchemaChanges: z.array(ImpactEntrySchema),
+  dbSchemaChanges: z.array(DbSchemaChangeSchema),
   configChanges: z.array(ImpactEntrySchema),
   deploymentNotes: z.array(ImpactEntrySchema),
   knownIssues: z.array(ImpactEntrySchema),
@@ -78,5 +83,7 @@ export const ReleaseIndexSchema = z.object({
 
 export type Evidence = z.infer<typeof EvidenceSchema>;
 export type ImpactEntry = z.infer<typeof ImpactEntrySchema>;
+export type DbSchemaChange = z.infer<typeof DbSchemaChangeSchema>;
+export type MigrationRisk = z.infer<typeof MigrationRiskSchema>;
 export type ReleaseImpact = z.infer<typeof ReleaseImpactSchema>;
 export type ReleaseIndex = z.infer<typeof ReleaseIndexSchema>;

--- a/upgrade-impact/src/validate.test.ts
+++ b/upgrade-impact/src/validate.test.ts
@@ -27,6 +27,7 @@ const makeRelease = (overrides: Partial<ReleaseImpact> = {}): ReleaseImpact => {
         description: "This release includes a database migration.",
         action: "Back up the database before upgrading.",
         confidence: "high",
+        migrationRisk: "medium",
         evidence: [
           {
             type: "file",
@@ -136,9 +137,43 @@ const validationCases: ValidationCase[] = [
               description: "This release includes a database migration.",
               action: "Back up the database before upgrading.",
               confidence: "high",
+              migrationRisk: "medium",
               evidence: []
             }
           ]
+        })
+      }
+    ],
+    expectedErrors: [`${validRelease.version}.yaml failed schema validation`]
+  },
+  {
+    name: "rejects a database schema change without migration risk",
+    index: makeIndex([
+      {
+        version: validRelease.version,
+        releasedAt: validRelease.releasedAt,
+        file: `releases/${validRelease.version}.yaml`
+      }
+    ]),
+    releases: [
+      {
+        fileName: `${validRelease.version}.yaml`,
+        release: makeRelease({
+          dbSchemaChanges: [
+            {
+              title: "Database schema migrations are included",
+              description: "This release includes a database migration.",
+              action: "Back up the database before upgrading.",
+              confidence: "high",
+              evidence: [
+                {
+                  type: "file",
+                  ref: "backend/src/db/migrations/20260429000000_example.ts",
+                  path: "backend/src/db/migrations/20260429000000_example.ts"
+                }
+              ]
+            }
+          ] as ReleaseImpact["dbSchemaChanges"]
         })
       }
     ],
@@ -181,6 +216,7 @@ const validationCases: ValidationCase[] = [
               description: "This release includes a database migration.",
               action: "Back up the database before upgrading.",
               confidence: "high",
+              migrationRisk: "medium",
               evidence: [
                 {
                   type: "file",
@@ -252,6 +288,7 @@ const validationCases: ValidationCase[] = [
               description: "This release includes a database migration.",
               action: "Set TRUSTED_PROXY_CIDRS to your proxy CIDR ranges and restart.",
               confidence: "high",
+              migrationRisk: "medium",
               evidence: [
                 {
                   type: "file",


### PR DESCRIPTION
## Summary
- add a required migrationRisk field for dbSchemaChanges
- classify deterministic migration risk separately from overall impact
- update generator guidance, validation tests, and existing release fixtures

## Tests
- npm test
- npm run type:check
- npm run validate -- --skip-git-checks