### PR TITLE
fix(logs): demote idle telemetry/teams-sync chatter to debug

### DIFF
--- a/backend/src/services/microsoft-teams/microsoft-teams-service.ts
+++ b/backend/src/services/microsoft-teams/microsoft-teams-service.ts
@@ -133,7 +133,9 @@ export const microsoftTeamsServiceFactory = ({
       }
 
       if (lastKnownUpdatedAt.getTime() === serverCfg.updatedAt.getTime()) {
-        logger.info("No changes to Microsoft Teams integration configuration, skipping sync");
+        // Demoted from info — this fires every poll cycle while idle and dominates
+        // self-hosted log volume / outbound TX.
+        logger.debug("No changes to Microsoft Teams integration configuration, skipping sync");
         return;
       }
 

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -462,7 +462,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     for (const eventType of POSTHOG_AGGREGATED_EVENTS) {
       let totalProcessed = 0;
 
-      logger.info(`Starting bucket processing for ${eventType}`);
+      logger.debug(`Starting bucket processing for ${eventType}`);
 
       // Process each bucket sequentially to control memory usage
       for (const bucketId of TELEMETRY_BUCKET_NAMES) {
@@ -475,7 +475,13 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
         }
       }
 
-      logger.info(`Completed processing ${totalProcessed} total events for ${eventType}`);
+      // Only emit at info when there was something to report; the no-op case is
+      // every-interval idle chatter that floods self-hosted log shippers.
+      if (totalProcessed > 0) {
+        logger.info(`Completed processing ${totalProcessed} total events for ${eventType}`);
+      } else {
+        logger.debug(`Completed processing ${totalProcessed} total events for ${eventType}`);
+      }
     }
   };
 


### PR DESCRIPTION
## Problem

Two log statements fire on every polling cycle of a healthy, idle instance and dominate the outbound log volume on self-hosted deploys. The reporter on #5074 observed ~5 GB/hr of TX on `docker stats` driven by repeating lines like:

```
{"level":30,...,"msg":"No changes to Microsoft Teams integration configuration, skipping sync"}
{"level":30,...,"msg":"Starting bucket processing for secrets pulled"}
{"level":30,...,"msg":"Completed processing 0 total events for secrets pulled"}
```

These run on a timer and aren't gated by whether any work actually happened, so they generate constant noise that floods shipped logs and inflates network egress for users who pipe container output to a remote sink.

## Fix

Demote the idle-state log lines from `info` to `debug`:

- `telemetry-service.ts` `processAggregatedEvents` — `Starting bucket processing for X` runs once per event type per cycle regardless of work, so it goes to debug. The `Completed processing N total events` line is *split*: still emits at info when `totalProcessed > 0` (real telemetry work to record), but goes to debug when N is 0 (idle chatter).
- `microsoft-teams-service.ts` `$syncMicrosoftTeamsIntegrationConfiguration` — `No changes to Microsoft Teams integration configuration, skipping sync` fires every poll while idle, so it goes to debug.

None of these signal an error or an actionable state when zero work was done; they exist for tracing the cycle. They stay available locally (debug-level) but no longer ship to remote log sinks.

Fixes #5074