### PR TITLE
fix(routes): use readLimit for GET endpoints incorrectly capped by writeLimit

### DIFF
--- a/backend/src/server/routes/v1/pki-collection-router.ts
+++ b/backend/src/server/routes/v1/pki-collection-router.ts
@@ -193,7 +193,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     method: "GET",
     url: "/:collectionId/items",
     config: {
-      rateLimit: writeLimit
+      rateLimit: readLimit
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -114,7 +114,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     method: "GET",
     url: "/:organizationId/memberships/:membershipId",
     config: {
-      rateLimit: writeLimit
+      rateLimit: readLimit
     },
     schema: {
       operationId: "getOrgMembership",
@@ -322,7 +322,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     method: "GET",
     url: "/:organizationId/memberships/:membershipId/project-memberships",
     config: {
-      rateLimit: writeLimit
+      rateLimit: readLimit
     },
     schema: {
       operationId: "listProjectMembershipsByOrgMembership",


### PR DESCRIPTION
## What

Three `GET` routes were configured with `writeLimit` instead of `readLimit`:

| Route | File |
|-------|------|
| `GET /pki-collections/:collectionId/items` | `v1/pki-collection-router.ts:196` |
| `GET /organizations/:orgId/memberships/:id` | `v2/organization-router.ts:117` |
| `GET /organizations/:orgId/memberships/:id/project-memberships` | `v2/organization-router.ts:325` |

## Why

These are idempotent, read-only operations. The `writeLimit` preset applies a tighter ceiling designed to throttle state-changing mutations. Using it on `GET` routes:

- Throttles legitimate read traffic more aggressively than intended (cloud instances with high-frequency polling hit the lower write ceiling)
- Obscures the intent — `writeLimit` on a `GET` endpoint is confusing to anyone auditing rate-limit policy

All other `GET` routes in these files correctly use `readLimit`. These three are copy-paste oversights.

## Changes

3 one-line changes: `writeLimit` → `readLimit` in the `config.rateLimit` block of each affected route.