### PR TITLE
fix(logs): demote idle secret-rotation-v2 queue polling log to debug

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-queue.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-queue.ts
@@ -70,11 +70,15 @@ export const secretRotationV2QueueServiceFactory = async ({
 
         const secretRotations = await secretRotationV2DAL.findSecretRotationsToQueue(rotateBy);
 
-        logger.info(
-          `secretRotationV2Queue: Queue Rotations [currentTime=${currentTime.toISOString()}] [rotateBy=${rotateBy.toISOString()}] [count=${
-            secretRotations.length
-          }]`
-        );
+        if (secretRotations.length > 0) {
+          logger.info(
+            `secretRotationV2Queue: Queue Rotations [currentTime=${currentTime.toISOString()}] [rotateBy=${rotateBy.toISOString()}] [count=${secretRotations.length}]`
+          );
+        } else {
+          logger.debug(
+            `secretRotationV2Queue: Queue Rotations [currentTime=${currentTime.toISOString()}] [rotateBy=${rotateBy.toISOString()}] [count=0]`
+          );
+        }
 
         for await (const rotation of secretRotations) {
           logger.info(


### PR DESCRIPTION
## What

The `SecretRotationV2` queue job (`QueueRotations`) runs on a schedule. On every tick it queries for rotations due and unconditionally logs the result at `info` level — even when `count=0` and no work is done:

```ts
// before — fires on every tick regardless of count
logger.info(
  \`secretRotationV2Queue: Queue Rotations [currentTime=...] [rotateBy=...] [count=0]\`
);
```

## Why it matters

This mirrors the same pattern fixed in #6406 for the telemetry bucket processor and Microsoft Teams sync. On self-hosted instances where log lines are shipped to remote sinks (Datadog, Loki, CloudWatch), a single idle `info` line every minute accumulates to ~500 K lines/day per Infisical instance with no rotations configured. The log line carries no actionable signal when `count=0`.

## Fix

Make the log level conditional on whether there is actual work:

```ts
if (secretRotations.length > 0) {
  logger.info(`... [count=${secretRotations.length}]`);
} else {
  logger.debug(`... [count=0]`);
}
```

- When rotations are found and queued → `info` (actionable, ops-relevant)
- When the poll finds nothing → `debug` (diagnostic only)

The per-rotation log inside the `for` loop is already guarded by the loop body and is unchanged.