### PR TITLE
fix: mark password recovery token as consumed

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -138,7 +138,6 @@ export const KeyStoreTtls = {
   MfaSessionInSeconds: 300, // 5 minutes
   WebAuthnChallengeInSeconds: 300, // 5 minutes
   UsedTotpCodeInSeconds: 120, // covers the full ±30s acceptance window (window:1 → 90s) with margin
-  UsedAccountRecoveryTokenInSeconds: 900, // 15 minutes — matches JWT_SIGNUP_LIFETIME default
   ProjectSSEConnectionTtlSeconds: 180, // Must be > heartbeat interval (60s) * 2
   TelemetryIdentifyIdentityInSeconds: 86400, // 24 hours
   RefreshTokenGraceInSeconds: 10,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -84,6 +84,7 @@ export const KeyStorePrefixes = {
   UserMfaLockoutLock: (userId: string) => `user-mfa-lockout-lock:${userId}` as const,
   UserMfaUnlockEmailSent: (userId: string) => `user-mfa-unlock-email-sent:${userId}` as const,
   UsedTotpCode: (userId: string, code: string) => `used-totp-code:${userId}:${code}` as const,
+  UsedAccountRecoveryToken: (userId: string, jti: string) => `used-account-recovery-token:${userId}:${jti}` as const,
 
   AiMcpServerOAuth: (sessionId: string) => `ai-mcp-server-oauth:${sessionId}` as const,
 
@@ -137,6 +138,7 @@ export const KeyStoreTtls = {
   MfaSessionInSeconds: 300, // 5 minutes
   WebAuthnChallengeInSeconds: 300, // 5 minutes
   UsedTotpCodeInSeconds: 120, // covers the full ±30s acceptance window (window:1 → 90s) with margin
+  UsedAccountRecoveryTokenInSeconds: 900, // 15 minutes — matches JWT_SIGNUP_LIFETIME default
   ProjectSSEConnectionTtlSeconds: 180, // Must be > heartbeat interval (60s) * 2
   TelemetryIdentifyIdentityInSeconds: 86400, // 24 hours
   RefreshTokenGraceInSeconds: 10,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1082,7 +1082,8 @@ export const registerRoutes = async (
     smtpService,
     authDAL,
     userDAL,
-    totpConfigDAL
+    totpConfigDAL,
+    keyStore
   });
 
   const accountRecoveryService = accountRecoveryServiceFactory({

--- a/backend/src/server/routes/v2/password-router.ts
+++ b/backend/src/server/routes/v2/password-router.ts
@@ -25,7 +25,8 @@ export const registerPasswordRouter = async (server: FastifyZodProvider) => {
       await server.services.password.resetPasswordV2({
         type: ResetPasswordV2Type.Recovery,
         newPassword: req.body.newPassword,
-        userId: token.userId
+        userId: token.userId,
+        recoveryTokenJti: token.jti
       });
     }
   });

--- a/backend/src/server/routes/v2/password-router.ts
+++ b/backend/src/server/routes/v2/password-router.ts
@@ -26,7 +26,8 @@ export const registerPasswordRouter = async (server: FastifyZodProvider) => {
         type: ResetPasswordV2Type.Recovery,
         newPassword: req.body.newPassword,
         userId: token.userId,
-        recoveryTokenJti: token.jti
+        recoveryTokenJti: token.jti,
+        recoveryTokenExpiresAt: token.exp
       });
     }
   });

--- a/backend/src/services/account-recovery/account-recovery-service.ts
+++ b/backend/src/services/account-recovery/account-recovery-service.ts
@@ -113,7 +113,8 @@ export const accountRecoveryServiceFactory = ({
     const token = crypto.jwt().sign(
       {
         authTokenType: AuthTokenType.ACCOUNT_RECOVERY_TOKEN,
-        userId: user.id
+        userId: user.id,
+        jti: crypto.randomBytes(16).toString("hex")
       },
       cfg.AUTH_SECRET,
       { expiresIn: cfg.JWT_SIGNUP_LIFETIME }

--- a/backend/src/services/auth/auth-password-service.ts
+++ b/backend/src/services/auth/auth-password-service.ts
@@ -1,4 +1,4 @@
-import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
@@ -30,16 +30,26 @@ export const authPaswordServiceFactory = ({
   smtpService,
   keyStore
 }: TAuthPasswordServiceFactoryDep) => {
-  const resetPasswordV2 = async ({ userId, newPassword, oldPassword, type, recoveryTokenJti }: TResetPasswordV2DTO) => {
+  const resetPasswordV2 = async ({
+    userId,
+    newPassword,
+    oldPassword,
+    type,
+    recoveryTokenJti,
+    recoveryTokenExpiresAt
+  }: TResetPasswordV2DTO) => {
     const cfg = getConfig();
 
     if (type === ResetPasswordV2Type.Recovery) {
-      if (!recoveryTokenJti) {
+      if (!recoveryTokenJti || !recoveryTokenExpiresAt) {
         throw new UnauthorizedError({ message: "Invalid recovery token" });
       }
+      // Marker TTL tracks the token's own remaining lifetime so non-default JWT_SIGNUP_LIFETIME
+      // configs can't outlast the replay marker and reopen the reuse window.
+      const ttlSeconds = Math.max(1, recoveryTokenExpiresAt - Math.floor(Date.now() / 1000));
       const claimed = await keyStore.setItemWithExpiryNX(
         KeyStorePrefixes.UsedAccountRecoveryToken(userId, recoveryTokenJti),
-        KeyStoreTtls.UsedAccountRecoveryTokenInSeconds,
+        ttlSeconds,
         "1"
       );
       if (!claimed) {

--- a/backend/src/services/auth/auth-password-service.ts
+++ b/backend/src/services/auth/auth-password-service.ts
@@ -1,6 +1,7 @@
+import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
-import { BadRequestError } from "@app/lib/errors";
+import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { OrgServiceActor } from "@app/lib/types";
 
@@ -19,12 +20,32 @@ type TAuthPasswordServiceFactoryDep = {
   tokenService: TAuthTokenServiceFactory;
   smtpService: TSmtpService;
   totpConfigDAL: Pick<TTotpConfigDALFactory, "delete">;
+  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiryNX">;
 };
 
 export type TAuthPasswordFactory = ReturnType<typeof authPaswordServiceFactory>;
-export const authPaswordServiceFactory = ({ userDAL, tokenService, smtpService }: TAuthPasswordServiceFactoryDep) => {
-  const resetPasswordV2 = async ({ userId, newPassword, oldPassword, type }: TResetPasswordV2DTO) => {
+export const authPaswordServiceFactory = ({
+  userDAL,
+  tokenService,
+  smtpService,
+  keyStore
+}: TAuthPasswordServiceFactoryDep) => {
+  const resetPasswordV2 = async ({ userId, newPassword, oldPassword, type, recoveryTokenJti }: TResetPasswordV2DTO) => {
     const cfg = getConfig();
+
+    if (type === ResetPasswordV2Type.Recovery) {
+      if (!recoveryTokenJti) {
+        throw new UnauthorizedError({ message: "Invalid recovery token" });
+      }
+      const claimed = await keyStore.setItemWithExpiryNX(
+        KeyStorePrefixes.UsedAccountRecoveryToken(userId, recoveryTokenJti),
+        KeyStoreTtls.UsedAccountRecoveryTokenInSeconds,
+        "1"
+      );
+      if (!claimed) {
+        throw new UnauthorizedError({ message: "Invalid recovery token" });
+      }
+    }
 
     const user = await userDAL.findById(userId);
     if (!user || !user.isAccepted || !user.isEmailVerified) {

--- a/backend/src/services/auth/auth-password-type.ts
+++ b/backend/src/services/auth/auth-password-type.ts
@@ -8,6 +8,7 @@ export type TResetPasswordV2DTO = {
   userId: string;
   newPassword: string;
   oldPassword?: string;
+  recoveryTokenJti?: string;
 };
 
 export type TResetPasswordViaBackupKeyDTO = {

--- a/backend/src/services/auth/auth-password-type.ts
+++ b/backend/src/services/auth/auth-password-type.ts
@@ -9,6 +9,7 @@ export type TResetPasswordV2DTO = {
   newPassword: string;
   oldPassword?: string;
   recoveryTokenJti?: string;
+  recoveryTokenExpiresAt?: number;
 };
 
 export type TResetPasswordViaBackupKeyDTO = {

--- a/backend/src/services/auth/auth-type.ts
+++ b/backend/src/services/auth/auth-type.ts
@@ -122,6 +122,7 @@ export type AuthModeSignUpTokenPayload = {
 export type AuthModeAccountRecoveryTokenPayload = {
   authTokenType: AuthTokenType.ACCOUNT_RECOVERY_TOKEN;
   userId: string;
+  jti: string;
 };
 
 export enum MfaMethod {

--- a/backend/src/services/auth/auth-type.ts
+++ b/backend/src/services/auth/auth-type.ts
@@ -123,6 +123,7 @@ export type AuthModeAccountRecoveryTokenPayload = {
   authTokenType: AuthTokenType.ACCOUNT_RECOVERY_TOKEN;
   userId: string;
   jti: string;
+  exp: number;
 };
 
 export enum MfaMethod {


### PR DESCRIPTION
## Context

This PR marks the password recovery token as consumed when resetting your password

## Screenshots

N/A

## Steps to verify the change

Go through recover account flow; ensure the jwt can not be used twice

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)