### PR TITLE
chore(api): add migration to clean empty strings on k8 auth ca certs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6385,6 +6385,9 @@
         "win32"
       ]
     },
+    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
+      "optional": true
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6385,9 +6385,6 @@
         "win32"
       ]
     },
-    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
-      "optional": true
-    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",

--- a/backend/src/db/migrations/20260511162539_clean-empty-encrypted-kubernetes-ca-certificate.ts
+++ b/backend/src/db/migrations/20260511162539_clean-empty-encrypted-kubernetes-ca-certificate.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex";
 
 import { inMemoryKeyStore } from "@app/keystore/memory";
-import { initLogger } from "@app/lib/logger";
+import { initLogger, logger } from "@app/lib/logger";
 import { kmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { superAdminDALFactory } from "@app/services/super-admin/super-admin-dal";
@@ -52,8 +52,7 @@ export async function up(knex: Knex): Promise<void> {
     try {
       decrypted = orgKms.decryptor({ cipherTextBlob: record.encryptedKubernetesCaCertificate }).toString();
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(`Migration failed to decrypt encryptedKubernetesCaCertificate [id=${record.id}]:`, err);
+      logger.error(err, `Migration failed to decrypt encryptedKubernetesCaCertificate [id=${record.id}]`);
       throw err;
     }
 

--- a/backend/src/db/migrations/20260511162539_clean-empty-encrypted-kubernetes-ca-certificate.ts
+++ b/backend/src/db/migrations/20260511162539_clean-empty-encrypted-kubernetes-ca-certificate.ts
@@ -1,0 +1,79 @@
+import { Knex } from "knex";
+
+import { inMemoryKeyStore } from "@app/keystore/memory";
+import { initLogger } from "@app/lib/logger";
+import { kmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
+import { KmsDataKey } from "@app/services/kms/kms-types";
+import { superAdminDALFactory } from "@app/services/super-admin/super-admin-dal";
+
+import { TableName } from "../schemas";
+import { getMigrationEnvConfig, getMigrationHsmConfig } from "./utils/env-config";
+import { createCircularCache } from "./utils/ring-buffer";
+import { getMigrationEncryptionServices, getMigrationHsmService } from "./utils/services";
+
+const BATCH_SIZE = 500;
+
+export async function up(knex: Knex): Promise<void> {
+  const records = await knex(TableName.IdentityKubernetesAuth)
+    .join(TableName.Identity, `${TableName.IdentityKubernetesAuth}.identityId`, `${TableName.Identity}.id`)
+    .whereNotNull(`${TableName.IdentityKubernetesAuth}.encryptedKubernetesCaCertificate`)
+    .select(
+      `${TableName.IdentityKubernetesAuth}.id`,
+      `${TableName.IdentityKubernetesAuth}.encryptedKubernetesCaCertificate`,
+      `${TableName.Identity}.orgId`
+    );
+
+  if (!records.length) return;
+
+  initLogger();
+
+  const { hsmService } = await getMigrationHsmService({ envConfig: getMigrationHsmConfig() });
+  const superAdminDAL = superAdminDALFactory(knex);
+  const kmsRootConfigDAL = kmsRootConfigDALFactory(knex);
+  const envConfig = await getMigrationEnvConfig(superAdminDAL, hsmService, kmsRootConfigDAL);
+  const keyStore = inMemoryKeyStore();
+  const { kmsService } = await getMigrationEncryptionServices({ envConfig, keyStore, db: knex });
+  const orgKmsCache = createCircularCache<Awaited<ReturnType<(typeof kmsService)["createCipherPairWithDataKey"]>>>(25);
+
+  const toNullify: string[] = [];
+
+  for (const record of records) {
+    let orgKms = orgKmsCache.getItem(record.orgId);
+    if (!orgKms) {
+      // eslint-disable-next-line no-await-in-loop
+      orgKms = await kmsService.createCipherPairWithDataKey(
+        { type: KmsDataKey.Organization, orgId: record.orgId },
+        knex
+      );
+      orgKmsCache.push(record.orgId, orgKms);
+    }
+
+    let decrypted: string;
+    try {
+      decrypted = orgKms.decryptor({ cipherTextBlob: record.encryptedKubernetesCaCertificate }).toString();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`Migration failed to decrypt encryptedKubernetesCaCertificate [id=${record.id}]:`, err);
+      throw err;
+    }
+
+    if (decrypted === "") {
+      toNullify.push(record.id);
+    }
+  }
+
+  if (!toNullify.length) return;
+
+  await knex.transaction(async (trx) => {
+    for (let i = 0; i < toNullify.length; i += BATCH_SIZE) {
+      // eslint-disable-next-line no-await-in-loop
+      await trx(TableName.IdentityKubernetesAuth)
+        .whereIn("id", toNullify.slice(i, i + BATCH_SIZE))
+        .update({ encryptedKubernetesCaCertificate: null, verifyTlsCertificate: false });
+    }
+  });
+}
+
+export async function down(): Promise<void> {
+  // The original encrypted-empty-string values cannot be restored once nulled — down is a no-op.
+}

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -188,7 +188,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
                   "Kubernetes host must only contain alphabets, numbers, colons, periods, hyphen, and forward slashes."
               }
             ),
-          caCert: z.string().trim().default("").describe(KUBERNETES_AUTH.ATTACH.caCert),
+          caCert: z.string().trim().optional().describe(KUBERNETES_AUTH.ATTACH.caCert),
           verifyTlsCertificate: z.boolean().optional().describe(KUBERNETES_AUTH.ATTACH.verifyTlsCertificate),
           tokenReviewerJwt: z.string().trim().optional().describe(KUBERNETES_AUTH.ATTACH.tokenReviewerJwt),
           tokenReviewMode: z

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -1021,7 +1021,12 @@ export const identityKubernetesAuthServiceFactory = ({
       return doc;
     });
 
-    return { ...identityKubernetesAuth, caCert, tokenReviewerJwt, orgId: identityMembershipOrg.scopeOrgId };
+    return {
+      ...identityKubernetesAuth,
+      caCert: caCert ?? "",
+      tokenReviewerJwt,
+      orgId: identityMembershipOrg.scopeOrgId
+    };
   };
 
   const updateKubernetesAuth = async ({

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -276,8 +276,11 @@ export const identityKubernetesAuthServiceFactory = ({
     };
   };
 
-  const $resolveEffectiveVerifyTlsCertificate = (caCert: string, storedVerify: boolean | null | undefined): boolean => {
-    if (!caCert.length) return false;
+  const $resolveEffectiveVerifyTlsCertificate = (
+    caCert: string | null | undefined,
+    storedVerify: boolean | null | undefined
+  ): boolean => {
+    if (!caCert?.length) return false;
     return storedVerify ?? false;
   };
 
@@ -1235,7 +1238,7 @@ export const identityKubernetesAuthServiceFactory = ({
     }
     const effectiveVerifyTlsCertificate =
       resolvedVerifyTlsCertificate ??
-      $resolveEffectiveVerifyTlsCertificate(effectiveCaCert ?? "", identityKubernetesAuth.verifyTlsCertificate);
+      $resolveEffectiveVerifyTlsCertificate(effectiveCaCert, identityKubernetesAuth.verifyTlsCertificate);
 
     if (
       effectiveVerifyTlsCertificate &&

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-types.ts
@@ -14,7 +14,7 @@ export enum IdentityKubernetesAuthTokenReviewMode {
 export type TAttachKubernetesAuthDTO = {
   identityId: string;
   kubernetesHost: string | null;
-  caCert: string;
+  caCert?: string;
   verifyTlsCertificate?: boolean;
   tokenReviewerJwt?: string;
   tokenReviewMode: IdentityKubernetesAuthTokenReviewMode;


### PR DESCRIPTION
## Context

- Sets `encryptedKubernetesCaCertificate` to `null` and `verifyTlsCertificate` to `false` when `encryptedKubernetesCaCertificate` is an encrypted empty string.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)