### PR TITLE
fix: scope identity access token revocation (PLATFOR-358/359)

### DIFF
--- a/backend/src/db/migrations/20260511202224_add-scope-to-identity-access-token-revocations.ts
+++ b/backend/src/db/migrations/20260511202224_add-scope-to-identity-access-token-revocations.ts
@@ -1,0 +1,37 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+const SCOPE_COLUMN = "scope";
+const IDENTITY_EXPIRES_INDEX = "identity_access_token_revocations_identityid_expiresat_index";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasScope = await knex.schema.hasColumn(TableName.IdentityAccessTokenRevocation, SCOPE_COLUMN);
+  if (!hasScope) {
+    await knex.schema.alterTable(TableName.IdentityAccessTokenRevocation, (t) => {
+      // Holds the per-marker scope key: clientSecretId UUID for client-secret revokes,
+      // IdentityAuthMethod enum string for auth-method revokes. Null for legacy markers
+      // (per-token and identity-wide) which key off `id` instead.
+      t.string(SCOPE_COLUMN).nullable();
+    });
+  }
+
+  // Validator changes from `WHERE id IN (?, ?)` to `WHERE identityId = ?`, so this
+  // index covers the new hot path.
+  await knex.schema.alterTable(TableName.IdentityAccessTokenRevocation, (t) => {
+    t.index(["identityId", "expiresAt"], IDENTITY_EXPIRES_INDEX);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(TableName.IdentityAccessTokenRevocation, (t) => {
+    t.dropIndex(["identityId", "expiresAt"], IDENTITY_EXPIRES_INDEX);
+  });
+
+  const hasScope = await knex.schema.hasColumn(TableName.IdentityAccessTokenRevocation, SCOPE_COLUMN);
+  if (hasScope) {
+    await knex.schema.alterTable(TableName.IdentityAccessTokenRevocation, (t) => {
+      t.dropColumn(SCOPE_COLUMN);
+    });
+  }
+}

--- a/backend/src/db/schemas/identity-access-token-revocations.ts
+++ b/backend/src/db/schemas/identity-access-token-revocations.ts
@@ -13,7 +13,8 @@ export const IdentityAccessTokenRevocationsSchema = z.object({
   expiresAt: z.date(),
   revokedAt: z.date().nullable().optional(),
   createdAt: z.date(),
-  updatedAt: z.date()
+  updatedAt: z.date(),
+  scope: z.string().nullable().optional()
 });
 
 export type TIdentityAccessTokenRevocations = z.infer<typeof IdentityAccessTokenRevocationsSchema>;

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -2,18 +2,22 @@ import { TDbClient } from "@app/db";
 import { TableName, TIdentityAccessTokenRevocations } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
 
-type TRevocationRow = Pick<TIdentityAccessTokenRevocations, "id" | "identityId" | "revokedAt" | "createdAt">;
+type TRevocationRow = Pick<TIdentityAccessTokenRevocations, "id" | "identityId" | "revokedAt" | "createdAt" | "scope">;
 
 export type TIdentityAccessTokenRevocationDALFactory = ReturnType<typeof identityAccessTokenRevocationDALFactory>;
 
 // `id` is set explicitly: JWT jti for per-token revocations, identityId for
-// revoke-all sentinels. `revokedAt` is populated only for sentinels so runtime
-// validation can compare the JWT iat against the exact revocation time.
+// revoke-all sentinels, random UUID for scoped markers. `revokedAt` is populated
+// for every marker except per-token revocations so runtime validation can compare
+// the JWT iat against the exact revocation time. `scope` is null for legacy
+// (per-token / identity-wide) markers and holds the scope key (clientSecretId or
+// IdentityAuthMethod string) for scoped markers.
 type TInsertRevocationInput = {
   id: string;
   identityId: string;
   expiresAt: Date;
   revokedAt?: Date | null;
+  scope?: string | null;
 };
 
 export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
@@ -26,6 +30,7 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
           identityId: row.identityId,
           expiresAt: row.expiresAt,
           revokedAt: row.revokedAt ?? null,
+          scope: row.scope ?? null,
           updatedAt: db.fn.now()
         });
     } catch (error) {
@@ -44,11 +49,14 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
       return (
         (await db
           .replicaNode()(TableName.IdentityAccessTokenRevocation)
-          .select("id", "identityId", "revokedAt", "createdAt")
+          .select("id", "identityId", "revokedAt", "createdAt", "scope")
           .where("expiresAt", ">", db.fn.now())
           .where("identityId", identityId)
-          // Revoke-all uses identityId as id
-          .whereIn("id", [tokenId, identityId])) as TRevocationRow[]
+          // Legacy markers key off id (tokenId or identityId); scoped markers always
+          // come along so the in-memory filter can match by clientSecretId / authMethod.
+          .andWhere((qb) => {
+            void qb.whereIn("id", [tokenId, identityId]).orWhereNotNull("scope");
+          })) as TRevocationRow[]
       );
     } catch (error) {
       throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationFindActiveForToken" });

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -39,7 +39,13 @@ const createService = ({
   trustedIps?: TIp[] | null;
   membership?: { isActive: boolean } | null;
   org?: { id: string; rootOrgId?: string; parentOrgId?: string };
-  activeRevocations?: Array<{ id: string; identityId: string; revokedAt?: Date | null; createdAt: Date }>;
+  activeRevocations?: Array<{
+    id: string;
+    identityId: string;
+    revokedAt?: Date | null;
+    createdAt: Date;
+    scope?: string | null;
+  }>;
   tokenRow?: Record<string, unknown> | null;
 } = {}) => {
   const keyStore = {
@@ -69,7 +75,14 @@ const createService = ({
     keyStore: keyStore as never
   });
 
-  return { service, keyStore, identityDAL, orgDAL, identityAccessTokenDAL, identityAccessTokenRevocationDAL };
+  return {
+    service,
+    keyStore,
+    identityDAL,
+    orgDAL,
+    identityAccessTokenDAL,
+    identityAccessTokenRevocationDAL
+  };
 };
 
 const createTokenClaims = (

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -93,11 +93,15 @@ export const identityAccessTokenServiceFactory = ({
     tokenId,
     identityId,
     issuedAtMs,
+    clientSecretId,
+    authMethod,
     messagePrefix = "Failed to authorize"
   }: {
     tokenId: string;
     identityId: string;
     issuedAtMs: number;
+    clientSecretId?: string;
+    authMethod?: string;
     messagePrefix?: "Failed to authorize" | "Cannot renew";
   }) => {
     const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForToken({
@@ -106,14 +110,28 @@ export const identityAccessTokenServiceFactory = ({
     });
 
     for (const revocation of activeRevocations) {
-      if (revocation.id === tokenId) {
-        throw new UnauthorizedError({ message: `${messagePrefix}: token has been revoked` });
-      }
-
-      if (revocation.id === identityId) {
+      // Legacy markers have scope=null and key off polymorphic `id`.
+      if (revocation.scope === null || revocation.scope === undefined) {
+        if (revocation.id === tokenId) {
+          throw new UnauthorizedError({ message: `${messagePrefix}: token has been revoked` });
+        }
+        if (revocation.id === identityId) {
+          const revokedAtMs = (revocation.revokedAt ?? revocation.createdAt).getTime();
+          if (issuedAtMs < revokedAtMs) {
+            throw new UnauthorizedError({ message: `${messagePrefix}: identity tokens have been revoked` });
+          }
+        }
+      } else {
+        // Scoped marker: scope holds the value the JWT must NOT match
+        // (clientSecretId for UA tokens, authMethod for any token).
         const revokedAtMs = (revocation.revokedAt ?? revocation.createdAt).getTime();
         if (issuedAtMs < revokedAtMs) {
-          throw new UnauthorizedError({ message: `${messagePrefix}: identity tokens have been revoked` });
+          if (clientSecretId && revocation.scope === clientSecretId) {
+            throw new UnauthorizedError({ message: `${messagePrefix}: client secret has been revoked` });
+          }
+          if (authMethod && revocation.scope === authMethod) {
+            throw new UnauthorizedError({ message: `${messagePrefix}: auth method has been revoked` });
+          }
         }
       }
     }
@@ -281,7 +299,9 @@ export const identityAccessTokenServiceFactory = ({
       assertTokenIsNotRevoked({
         tokenId,
         identityId: token.identityId,
-        issuedAtMs
+        issuedAtMs,
+        clientSecretId: source.clientSecretId,
+        authMethod: source.authMethod
       }),
       keyStore.getItem(KeyStorePrefixes.IdentityTokenUsesRemaining(token.identityId, tokenId))
     ]);
@@ -385,6 +405,8 @@ export const identityAccessTokenServiceFactory = ({
         tokenId,
         identityId: decodedToken.identityId,
         issuedAtMs: decodedToken.iat * 1000,
+        clientSecretId: source.clientSecretId,
+        authMethod: source.authMethod,
         messagePrefix: "Cannot renew"
       }),
       keyStore.getItem(KeyStorePrefixes.IdentityTokenUsesRemaining(decodedToken.identityId, tokenId))
@@ -524,11 +546,57 @@ export const identityAccessTokenServiceFactory = ({
     });
   };
 
+  // Scoped revoke for Universal Auth client secret deletion: rejects every JWT
+  // carrying this clientSecretId with iat < revokedAt. Stored in the polymorphic
+  // revocation table with a synthetic id and scope = clientSecretId.
+  const revokeAllTokensForClientSecret = async ({
+    identityId,
+    clientSecretId
+  }: {
+    identityId: string;
+    clientSecretId: string;
+  }) => {
+    const appCfg = getConfig();
+    const revokedAt = new Date();
+
+    await identityAccessTokenRevocationDAL.insertRevocation({
+      id: crypto.nativeCrypto.randomUUID(),
+      identityId,
+      scope: clientSecretId,
+      revokedAt,
+      expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
+    });
+  };
+
+  // Scoped revoke for auth-method removal: rejects every JWT issued via the
+  // removed method with iat < revokedAt. Tokens issued via other methods on
+  // the same identity stay valid.
+  const revokeTokensForIdentityAuthMethod = async ({
+    identityId,
+    authMethod
+  }: {
+    identityId: string;
+    authMethod: IdentityAuthMethod;
+  }) => {
+    const appCfg = getConfig();
+    const revokedAt = new Date();
+
+    await identityAccessTokenRevocationDAL.insertRevocation({
+      id: crypto.nativeCrypto.randomUUID(),
+      identityId,
+      scope: authMethod,
+      revokedAt,
+      expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
+    });
+  };
+
   return {
     issueIdentityAccessToken,
     renewAccessToken,
     revokeAccessToken,
     revokeAllTokensForIdentity,
+    revokeAllTokensForClientSecret,
+    revokeTokensForIdentityAuthMethod,
     markPerTokenRevocation,
     fnValidateIdentityAccessTokenFast
   };

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -58,7 +58,7 @@ type TIdentityAliCloudAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -575,7 +575,10 @@ export const identityAliCloudAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.ALICLOUD_AUTH
+    });
 
     return revokedIdentityAliCloudAuth;
   };

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -58,7 +58,7 @@ type TIdentityAwsAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -677,7 +677,10 @@ export const identityAwsAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.AWS_AUTH
+    });
 
     return revokedIdentityAwsAuth;
   };

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -54,7 +54,7 @@ type TIdentityAzureAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -578,7 +578,10 @@ export const identityAzureAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.AZURE_AUTH
+    });
 
     return revokedIdentityAzureAuth;
   };

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -52,7 +52,7 @@ type TIdentityGcpAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -627,7 +627,10 @@ export const identityGcpAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.GCP_AUTH
+    });
 
     return revokedIdentityGcpAuth;
   };

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -67,7 +67,7 @@ type TIdentityJwtAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -826,7 +826,10 @@ export const identityJwtAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.JWT_AUTH
+    });
 
     return revokedIdentityJwtAuth;
   };

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -99,7 +99,7 @@ type TIdentityKubernetesAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -1552,7 +1552,10 @@ export const identityKubernetesAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.KUBERNETES_AUTH
+    });
 
     return revokedIdentityKubernetesAuth;
   };

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -76,7 +76,7 @@ type TIdentityLdapAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -867,7 +867,10 @@ export const identityLdapAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.LDAP_AUTH
+    });
 
     return revokedIdentityLdapAuth;
   };

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -56,7 +56,7 @@ type TIdentityOciAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -591,7 +591,10 @@ export const identityOciAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.OCI_AUTH
+    });
 
     return revokedIdentityOciAuth;
   };

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -68,7 +68,7 @@ type TIdentityOidcAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -969,7 +969,10 @@ export const identityOidcAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.OIDC_AUTH
+    });
 
     return revokedIdentityOidcAuth;
   };

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -73,7 +73,7 @@ type TIdentitySpiffeAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -921,7 +921,10 @@ export const identitySpiffeAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.SPIFFE_AUTH
+    });
 
     const { decryptor: orgDataKeyDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.Organization,

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -52,7 +52,7 @@ type TIdentityTlsCertAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
   >;
 };
 
@@ -654,7 +654,10 @@ export const identityTlsCertAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.TLS_CERT_AUTH
+    });
 
     return revokedIdentityTlsCertAuth;
   };

--- a/backend/src/services/identity-token-auth/identity-token-auth-service.ts
+++ b/backend/src/services/identity-token-auth/identity-token-auth-service.ts
@@ -58,7 +58,7 @@ type TIdentityTokenAuthServiceFactoryDep = {
   >;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity" | "markPerTokenRevocation"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "markPerTokenRevocation"
   >;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getProjectPermission">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
@@ -424,7 +424,10 @@ export const identityTokenAuthServiceFactory = ({
     // Detaching the auth method must invalidate any tokens already issued
     // through it; without this, leaked tokens authenticate up to MAX_AGE
     // even after the admin pulled the auth method.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.TOKEN_AUTH
+    });
 
     return revokedIdentityTokenAuth;
   };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -59,7 +59,7 @@ type TIdentityUaServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity"
+    "issueIdentityAccessToken" | "revokeAllTokensForIdentity" | "revokeAllTokensForClientSecret"
   >;
   keyStore: Pick<
     TKeyStoreFactory,
@@ -1169,6 +1169,14 @@ export const identityUaServiceFactory = ({
         });
       }
     }
+    // Insert the revocation marker BEFORE flipping isClientSecretRevoked. If
+    // the flip fails, tokens are already dead and a retry safely re-flips the
+    // bit; flipping first would leave the secret flagged but tokens authentic.
+    await identityAccessTokenService.revokeAllTokensForClientSecret({
+      identityId,
+      clientSecretId
+    });
+
     const updatedClientSecret = await identityUaClientSecretDAL.updateById(clientSecretId, {
       isClientSecretRevoked: true
     });

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -59,7 +59,7 @@ type TIdentityUaServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeAllTokensForIdentity" | "revokeAllTokensForClientSecret"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "revokeAllTokensForClientSecret"
   >;
   keyStore: Pick<
     TKeyStoreFactory,
@@ -775,13 +775,13 @@ export const identityUaServiceFactory = ({
       return { ...deletedUniversalAuth?.[0], orgId: identityMembershipOrg.scopeOrgId };
     });
 
-    // Revoking the auth method must invalidate any access tokens already
-    // issued via it — without this, leaked tokens keep authenticating up
-    // to MAX_MACHINE_IDENTITY_TOKEN_AGE even after an admin pulled the
-    // method. The marker is identity-wide (matches the existing semantics
-    // of identity deletion) which is acceptable here because detaching an
-    // auth method is a high-trust admin action.
-    await identityAccessTokenService.revokeAllTokensForIdentity(identityId);
+    // Scoped marker so leaked tokens issued via UA stop authenticating once an
+    // admin detaches the method; tokens minted via other still-attached methods
+    // on the same identity stay valid (PLATFOR-359).
+    await identityAccessTokenService.revokeTokensForIdentityAuthMethod({
+      identityId,
+      authMethod: IdentityAuthMethod.UNIVERSAL_AUTH
+    });
 
     return revokedIdentityUniversalAuth;
   };


### PR DESCRIPTION
## Context

Revocation only had `tokenId` and `identityId` scopes — couldn't scope by client secret (PLATFOR-358) or by `(identityId, authMethod)` (PLATFOR-359).

- Add nullable `scope` column + `(identityId, expiresAt)` index to `identity_access_token_revocations` — additive, existing rows untouched.
- Validator: when `scope!=null`, reject tokens whose `iat < revokedAt` and whose JWT `clientSecretId` / `authMethod` matches.
- Wire `revokeAllTokensForClientSecret` into `revokeUniversalAuthClientSecret`.
- Swap `revokeAllTokensForIdentity` → `revokeTokensForIdentityAuthMethod` across 13 per-auth-method revoke services. `identityV2.deleteIdentity` keeps the identity-wide revoke (correct for full deletion).

Linear: [PLATFOR-358](https://linear.app/infisical/issue/PLATFOR-358) · [PLATFOR-359](https://linear.app/infisical/issue/PLATFOR-359)

## Steps to verify the change

- `npm run test:unit -- identity-access-token-service` — 29/29 pass.
- `npm run test:e2e -- identity-access-token-redesign` — 12/12 pass (3 new).
- `make reviewable-api` — clean.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs
- [ ] Updated CLAUDE.md files
- [x] Read the contributing guide