### PR TITLE
improvement: add tooltip to overview environment cols/items and give each more default width

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
@@ -126,7 +126,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
           </TooltipTrigger>
           <TooltipContent>Save or discard pending changes to switch environments</TooltipContent>
         </Tooltip>
-        <PopoverContent align="start" className="w-[180px] p-0">
+        <PopoverContent align="start" className="p-0">
           <Command>
             <CommandInput
               value={inputValue}
@@ -158,7 +158,6 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
                     value={env.id}
                     onSelect={handleSelectEnv}
                     keywords={[env.name, env.slug]}
-                    title={env.name}
                   >
                     <CheckIcon
                       className={cn(
@@ -166,7 +165,14 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
                         selectedEnvs.map((e) => e.id).includes(env.id) ? "opacity-100" : "opacity-0"
                       )}
                     />
-                    <span className="truncate">{env.name}</span>
+                    <Tooltip delayDuration={500}>
+                      <TooltipTrigger asChild>
+                        <span className="truncate">{env.name}</span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="max-w-2xl break-all">
+                        {env.name}
+                      </TooltipContent>
+                    </Tooltip>
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
@@ -58,6 +58,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
       : true;
 
   const handleAddEnvironment = () => {
+    setIsOpen(false);
     if (isMoreEnvironmentsAllowed) {
       handlePopUpOpen("createEnvironment");
     } else {
@@ -165,7 +166,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
                         selectedEnvs.map((e) => e.id).includes(env.id) ? "opacity-100" : "opacity-0"
                       )}
                     />
-                    <Tooltip delayDuration={500}>
+                    <Tooltip delayDuration={500} disableHoverableContent>
                       <TooltipTrigger asChild>
                         <span className="truncate">{env.name}</span>
                       </TooltipTrigger>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -483,7 +483,9 @@ export const SecretTableRow = ({
               <Table containerClassName="border-none rounded-none bg-transparent">
                 <TableHeader className="">
                   <TableRow className="border-none">
-                    <TableHead>Environment</TableHead>
+                    <TableHead isTruncatable className="w-px min-w-40 lg:min-w-64 xl:min-w-80">
+                      Environment
+                    </TableHead>
                     <TableHead className="w-full">Value</TableHead>
                     <div className="absolute top-0 right-0">
                       <Button variant="ghost" size="xs" onClick={() => setIsSecretVisible.toggle()}>
@@ -518,9 +520,17 @@ export const SecretTableRow = ({
                     return (
                       <Fragment key={`secret-expanded-${slug}-${secretKey}`}>
                         <TableRow className="group hover:z-10">
-                          <TableCell className={hasOverride ? "border-b-border/50" : undefined}>
-                            <div title={name} className="flex h-8 w-32 items-center space-x-2">
-                              <span className="truncate">{name}</span>
+                          <TableCell
+                            isTruncatable
+                            className={hasOverride ? "border-b-border/50" : undefined}
+                          >
+                            <div className="flex h-8 items-center space-x-2">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="truncate">{name}</span>
+                                </TooltipTrigger>
+                                <TooltipContent side="right">{name}</TooltipContent>
+                              </Tooltip>
                               {isImportedSecret && (
                                 <Tooltip>
                                   <TooltipTrigger asChild>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -525,11 +525,13 @@ export const SecretTableRow = ({
                             className={hasOverride ? "border-b-border/50" : undefined}
                           >
                             <div className="flex h-8 items-center space-x-2">
-                              <Tooltip>
+                              <Tooltip disableHoverableContent>
                                 <TooltipTrigger asChild>
                                   <span className="truncate">{name}</span>
                                 </TooltipTrigger>
-                                <TooltipContent side="right">{name}</TooltipContent>
+                                <TooltipContent side="right" className="max-w-2xl break-all">
+                                  {name}
+                                </TooltipContent>
                               </Tooltip>
                               {isImportedSecret && (
                                 <Tooltip>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
@@ -4,7 +4,20 @@ import slugify from "@sindresorhus/slugify";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Modal, ModalClose, ModalContent } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import { useCreateWsEnvironment } from "@app/hooks/api";
 import { ProjectEnv } from "@app/hooks/api/projects/types";
@@ -25,11 +38,7 @@ const schema = z.object({
 
 export type FormData = z.infer<typeof schema>;
 
-type ContentProps = {
-  onComplete: (environment: ProjectEnv) => void;
-};
-
-const Content = ({ onComplete }: ContentProps) => {
+export const AddEnvironmentModal = ({ isOpen, onOpenChange, onComplete }: Props) => {
   const { currentProject } = useProject();
   const { mutateAsync, isPending } = useCreateWsEnvironment();
   const {
@@ -37,9 +46,14 @@ const Content = ({ onComplete }: ContentProps) => {
     handleSubmit,
     setValue,
     getValues,
+    reset,
     formState: { dirtyFields }
   } = useForm<FormData>({
-    resolver: zodResolver(schema)
+    resolver: zodResolver(schema),
+    defaultValues: {
+      environmentName: "",
+      environmentSlug: ""
+    }
   });
 
   const onFormSubmit = async ({ environmentName, environmentSlug }: FormData) => {
@@ -56,7 +70,9 @@ const Content = ({ onComplete }: ContentProps) => {
       type: "success"
     });
 
-    onComplete(env);
+    if (onComplete) onComplete(env);
+    onOpenChange(false);
+    reset();
   };
 
   const handleEnvironmentNameChange = () => {
@@ -67,69 +83,63 @@ const Content = ({ onComplete }: ContentProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
-      <Controller
-        control={control}
-        defaultValue=""
-        name="environmentName"
-        render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-          <FormControl label="Environment Name" isError={Boolean(error)} errorText={error?.message}>
-            <Input
-              {...field}
-              onChange={(e) => {
-                onChange(e);
-                handleEnvironmentNameChange();
-              }}
-            />
-          </FormControl>
-        )}
-      />
-      <Controller
-        control={control}
-        defaultValue=""
-        name="environmentSlug"
-        render={({ field, fieldState: { error } }) => (
-          <FormControl
-            label="Environment Slug"
-            helperText="Slugs are shorthands used in cli to access environment"
-            isError={Boolean(error)}
-            errorText={error?.message}
-          >
-            <Input {...field} />
-          </FormControl>
-        )}
-      />
-      <div className="mt-8 flex items-center">
-        <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isPending}
-          isDisabled={isPending}
-        >
-          Create
-        </Button>
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
-      </div>
-    </form>
-  );
-};
-
-export const AddEnvironmentModal = ({ onComplete, ...props }: Props) => {
-  return (
-    <Modal {...props}>
-      <ModalContent title="Create a new environment">
-        <Content
-          onComplete={(env) => {
-            if (onComplete) onComplete(env);
-            props.onOpenChange(false);
-          }}
-        />
-      </ModalContent>
-    </Modal>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        onOpenChange(open);
+        if (!open) reset();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create a new environment</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-6">
+          <Controller
+            control={control}
+            name="environmentName"
+            render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="environmentName">Environment Name</FieldLabel>
+                <Input
+                  id="environmentName"
+                  isError={Boolean(error)}
+                  {...field}
+                  onChange={(e) => {
+                    onChange(e);
+                    handleEnvironmentNameChange();
+                  }}
+                />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <Controller
+            control={control}
+            name="environmentSlug"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="environmentSlug">Environment Slug</FieldLabel>
+                <Input id="environmentSlug" isError={Boolean(error)} {...field} />
+                <FieldError>{error?.message}</FieldError>
+                <FieldDescription>
+                  Slugs are shorthands used in cli to access environment
+                </FieldDescription>
+              </Field>
+            )}
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" variant="project" isPending={isPending} isDisabled={isPending}>
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal.tsx
@@ -123,7 +123,7 @@ export const AddEnvironmentModal = ({ isOpen, onOpenChange, onComplete }: Props)
                 <Input id="environmentSlug" isError={Boolean(error)} {...field} />
                 <FieldError>{error?.message}</FieldError>
                 <FieldDescription>
-                  Slugs are shorthands used in cli to access environment
+                  Slugs are shorthand identifiers used to reference this environment.
                 </FieldDescription>
               </Field>
             )}


### PR DESCRIPTION
## Context

This PR adds tooltip display to both the multi-env environment col display and the env selection dropdown and gives both more room to avoid excessive truncation

also migrates create env modal to v3 components 

## Screenshots

<img width="3456" height="1918" alt="CleanShot 2026-05-11 at 17 39 27@2x" src="https://github.com/user-attachments/assets/a9fe1121-427b-47c6-8c70-94cdef23fe93" />

<img width="3456" height="1918" alt="CleanShot 2026-05-11 at 17 39 37@2x" src="https://github.com/user-attachments/assets/1d8518cb-b49c-442d-996c-7a04851ad685" />


<img width="3456" height="1918" alt="CleanShot 2026-05-11 at 17 40 52@2x" src="https://github.com/user-attachments/assets/e896b388-2ca2-4f37-a9f9-f50177840651" />


## Steps to verify the change

- verify truncation handling and tooltip display at various screen widths for responsive breakpoints
- test v3 create environment modal

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)