### PR TITLE
chore(api): create short lived token in key value store for email sign up

### DIFF
--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -18,6 +18,7 @@ export const mockKeyStore = (): TKeyStoreFactory => {
       return "OK";
     },
     setExpiry: async () => 0,
+    ttl: async () => -1,
     setItemWithExpiry: async (key, value) => {
       store[key] = value;
       return "OK";

--- a/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
@@ -7,13 +7,12 @@ import { TTestSmtpService } from "../../mocks/smtp";
 const smtp = () => (globalThis as unknown as { testSmtp: TTestSmtpService }).testSmtp;
 
 describe("Auth Email Signup V3", () => {
-  const testEmail = "signuptest@localhost.local";
-
   beforeEach(() => {
     smtp().clear();
   });
 
   test("Begin email signup sends verification code", async () => {
+    const testEmail = "signuptest-begin@localhost.local";
     const res = await testServer.inject({
       method: "POST",
       url: "/api/v3/signup/email/signup",
@@ -31,6 +30,8 @@ describe("Auth Email Signup V3", () => {
   });
 
   test("Verify email signup with correct code returns signup token", async () => {
+    const testEmail = "signuptest-verify@localhost.local";
+
     // Step 1: Begin signup
     await testServer.inject({
       method: "POST",
@@ -61,6 +62,8 @@ describe("Auth Email Signup V3", () => {
   });
 
   test("Verify email signup with wrong code fails", async () => {
+    const testEmail = "signuptest-wrongcode@localhost.local";
+
     // Begin signup first
     await testServer.inject({
       method: "POST",

--- a/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
@@ -137,4 +137,68 @@ describe("Auth Email Signup V3", () => {
 
     expect(res.statusCode).toBeGreaterThanOrEqual(400);
   });
+
+  test("Begin signup response includes cooldownSeconds", async () => {
+    const res = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email: "cooldown-check@localhost.local" }
+    });
+
+    expect(res.statusCode).toBe(200);
+    const payload = res.json();
+    expect(typeof payload.cooldownSeconds).toBe("number");
+    expect(payload.cooldownSeconds).toBeGreaterThan(0);
+  });
+
+  test("Second signup request within cooldown period returns 400", async () => {
+    const email = "cooldown-twice@localhost.local";
+
+    const first = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+    expect(first.statusCode).toBe(200);
+
+    const second = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+    expect(second.statusCode).toBe(400);
+  });
+
+  test("Exhausting all OTP tries prevents verification even with the correct code", async () => {
+    const email = "exhausted-tries@localhost.local";
+
+    await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+
+    const lastEmail = smtp().getLastEmail();
+    const correctCode = (lastEmail?.substitutions as Record<string, string>)?.code;
+    expect(correctCode).toBeDefined();
+
+    // Exhaust all 3 tries with a wrong code
+    for (let i = 0; i < 3; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await testServer.inject({
+        method: "POST",
+        url: "/api/v3/signup/email/verify",
+        body: { email, code: "000000" }
+      });
+    }
+
+    // Correct code should now also fail because the record was deleted
+    const res = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/verify",
+      body: { email, code: correctCode }
+    });
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
 });

--- a/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
@@ -172,6 +172,54 @@ describe("Auth Email Signup V3", () => {
     expect(second.statusCode).toBe(400);
   });
 
+  test("Second signup request for accepted account also returns 400 (no enumeration oracle)", async () => {
+    const email = "cooldown-accepted@localhost.local";
+
+    // Step 1: full signup flow to create an accepted user
+    await testServer.inject({ method: "POST", url: "/api/v3/signup/email/signup", body: { email } });
+    const signupEmail = smtp().getLastEmail();
+    const code = (signupEmail?.substitutions as Record<string, string>)?.code;
+
+    const verifyRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/verify",
+      body: { email, code }
+    });
+    const { token: signupToken } = verifyRes.json();
+
+    await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/complete-account",
+      headers: { authorization: `Bearer ${signupToken}` },
+      body: {
+        type: "email",
+        email,
+        firstName: "Cool",
+        lastName: "Down",
+        password: "testPassword123!",
+        organizationName: "Cooldown Org"
+      }
+    });
+
+    smtp().clear();
+
+    // Step 2: first re-signup request for the now-accepted account — should succeed (informational email)
+    const first = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+    expect(first.statusCode).toBe(200);
+
+    // Step 3: second request within cooldown — must return 400 for both paths to be indistinguishable
+    const second = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+    expect(second.statusCode).toBe(400);
+  });
+
   test("Exhausting all OTP tries prevents verification even with the correct code", async () => {
     const email = "exhausted-tries@localhost.local";
 

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -110,7 +110,8 @@ export const KeyStorePrefixes = {
   CertActivityTrend: (projectId: string, range: string) => `cert-activity-trend:${projectId}:${range}` as const,
   CertPqcTrend: (projectId: string, range: string) => `cert-pqc-trend:${projectId}:${range}` as const,
   RefreshTokenGrace: (sessionId: string) => `refresh-token-grace:${sessionId}` as const,
-  EmailSignupOtp: (hash: string) => `email-signup-otp:${hash}` as const,
+  EmailSignupOtp: (hash: string) => `email-signup-otp:${hash}:hash` as const,
+  EmailSignupOtpLock: (hash: string) => `email-signup-otp-lock:${hash}:lock` as const,
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const,
 
   AdminConfig: "infisical-admin-cfg",

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -110,6 +110,7 @@ export const KeyStorePrefixes = {
   CertActivityTrend: (projectId: string, range: string) => `cert-activity-trend:${projectId}:${range}` as const,
   CertPqcTrend: (projectId: string, range: string) => `cert-pqc-trend:${projectId}:${range}` as const,
   RefreshTokenGrace: (sessionId: string) => `refresh-token-grace:${sessionId}` as const,
+  EmailSignupOtp: (hash: string) => `email-signup-otp:${hash}` as const,
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const,
 
   AdminConfig: "infisical-admin-cfg",
@@ -140,6 +141,7 @@ export const KeyStoreTtls = {
   ProjectSSEConnectionTtlSeconds: 180, // Must be > heartbeat interval (60s) * 2
   TelemetryIdentifyIdentityInSeconds: 86400, // 24 hours
   RefreshTokenGraceInSeconds: 10,
+  EmailSignupOtpInSeconds: 300, // 5 minutes
   InsightsCacheInSeconds: 300, // 5 minutes
   AdminConfigInSeconds: 60,
   InvalidatingCacheInSeconds: 1800, // 30 minutes max lock for cache invalidation job

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -110,8 +110,9 @@ export const KeyStorePrefixes = {
   CertActivityTrend: (projectId: string, range: string) => `cert-activity-trend:${projectId}:${range}` as const,
   CertPqcTrend: (projectId: string, range: string) => `cert-pqc-trend:${projectId}:${range}` as const,
   RefreshTokenGrace: (sessionId: string) => `refresh-token-grace:${sessionId}` as const,
-  EmailSignupOtp: (hash: string) => `email-signup-otp:${hash}:hash` as const,
-  EmailSignupOtpLock: (hash: string) => `email-signup-otp-lock:${hash}:lock` as const,
+  EmailSignupOtpHash: (hash: string) => `email-signup-otp:${hash}:hash` as const,
+  EmailSignupOtpLock: (hash: string) => `email-signup-otp:${hash}:lock` as const,
+  EmailSignupResendCooldown: (hash: string) => `email-signup-otp:${hash}:cd` as const,
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const,
 
   AdminConfig: "infisical-admin-cfg",
@@ -143,6 +144,7 @@ export const KeyStoreTtls = {
   TelemetryIdentifyIdentityInSeconds: 86400, // 24 hours
   RefreshTokenGraceInSeconds: 10,
   EmailSignupOtpInSeconds: 300, // 5 minutes
+  EmailSignupResendCooldownInSeconds: 60, // 1 minute
   InsightsCacheInSeconds: 300, // 5 minutes
   AdminConfigInSeconds: 60,
   InvalidatingCacheInSeconds: 1800, // 30 minutes max lock for cache invalidation job
@@ -182,6 +184,7 @@ export type TKeyStoreFactory = {
   getItem: (key: string, prefix?: string) => Promise<string | null>;
   getItems: (keys: string[], prefix?: string) => Promise<(string | null)[]>;
   setExpiry: (key: string, expiryInSeconds: number) => Promise<number>;
+  ttl: (key: string) => Promise<number>;
   setItemWithExpiry: (
     key: string,
     expiryInSeconds: number | string,
@@ -324,6 +327,8 @@ export const keyStoreFactory = (
 
   const setExpiry = async (key: string, expiryInSeconds: number) => primaryRedis.expire(key, expiryInSeconds);
 
+  const ttl = async (key: string) => primaryRedis.ttl(key);
+
   const getKeysByPattern = async (pattern: string, limit?: number) => {
     let cursor = "0";
     const allKeys: string[] = [];
@@ -443,6 +448,7 @@ export const keyStoreFactory = (
     setItem,
     getItem,
     setExpiry,
+    ttl,
     setItemWithExpiry,
     setItemWithExpiryNX,
     deleteItem,

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -19,6 +19,7 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
       return "OK";
     },
     setExpiry: async () => 0,
+    ttl: async () => -1,
     setItemWithExpiry: async (key, value) => {
       store[key] = value;
       return "OK";

--- a/backend/src/server/routes/v3/signup-router.ts
+++ b/backend/src/server/routes/v3/signup-router.ts
@@ -27,7 +27,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
       }),
       response: {
         200: z.object({
-          message: z.string()
+          message: z.string(),
+          cooldownSeconds: z.number()
         })
       }
     },
@@ -50,8 +51,8 @@ export const registerSignupRouter = async (server: FastifyZodProvider) => {
           });
         }
       }
-      await server.services.signup.beginEmailSignupProcess(email);
-      return { message: `Sent an email verification code to ${email}` };
+      const { cooldownSeconds } = await server.services.signup.beginEmailSignupProcess(email);
+      return { message: `Sent an email verification code to ${email}`, cooldownSeconds };
     }
   });
 

--- a/backend/src/services/auth-token/auth-token-service.test.ts
+++ b/backend/src/services/auth-token/auth-token-service.test.ts
@@ -29,7 +29,7 @@ const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
 
 type KeyStoreSlice = Pick<
   TKeyStoreFactory,
-  "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
+  "setItemWithExpiry" | "setItemWithExpiryNX" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
 >;
 
 type MockedKeyStore = Mocked<KeyStoreSlice>;
@@ -37,6 +37,7 @@ type MockedKeyStore = Mocked<KeyStoreSlice>;
 const makeKeyStore = (patch: Partial<MockedKeyStore> = {}): MockedKeyStore =>
   ({
     setItemWithExpiry: vi.fn().mockResolvedValue("OK"),
+    setItemWithExpiryNX: vi.fn().mockResolvedValue("OK"),
     getItem: vi.fn().mockResolvedValue(null),
     deleteItem: vi.fn().mockResolvedValue(1),
     acquireLock: vi.fn().mockResolvedValue({ release: vi.fn().mockResolvedValue(undefined) }),
@@ -78,7 +79,7 @@ const setup = () => {
     },
 
     mockCooldown(ttl: number, present = true) {
-      keyStore.getItem.mockImplementation(async (key: string) => (key === cooldownKey && present ? "1" : null));
+      keyStore.setItemWithExpiryNX.mockResolvedValue(present ? null : "OK");
       keyStore.ttl.mockResolvedValue(ttl);
       return this;
     },
@@ -149,12 +150,12 @@ describe("tokenServiceFactory — email signup OTP", () => {
       expect(payload?.triesLeft).toBe(3);
     });
 
-    test("sets cooldown key", async () => {
+    test("sets cooldown key atomically via NX", async () => {
       const { service, keyStore } = setup();
 
       await service.createEmailSignupToken(TEST_EMAIL);
 
-      expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+      expect(keyStore.setItemWithExpiryNX).toHaveBeenCalledWith(
         cooldownKey,
         KeyStoreTtls.EmailSignupResendCooldownInSeconds,
         "1"

--- a/backend/src/services/auth-token/auth-token-service.test.ts
+++ b/backend/src/services/auth-token/auth-token-service.test.ts
@@ -1,13 +1,13 @@
 import { createHmac } from "node:crypto";
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, type Mocked, test, vi } from "vitest";
 
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
 
-import { TEmailSignupOtpPayload } from "./auth-token-types";
 import { tokenServiceFactory } from "./auth-token-service";
+import { TEmailSignupOtpPayload } from "./auth-token-types";
 
 const AUTH_SECRET = "test-secret-for-otp-unit-tests";
 const NOW_MS = 1_700_000_000_000;
@@ -23,14 +23,18 @@ vi.mock("@app/lib/logger", () => ({
 
 const hmac = (value: string) => createHmac("sha256", AUTH_SECRET).update(value).digest("hex");
 
-// Pre-compute key names so assertions can reference them without re-running production logic.
 const emailHash = hmac(TEST_EMAIL);
 const otpKey = KeyStorePrefixes.EmailSignupOtpHash(emailHash);
 const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
 
-type KeyStoreSlice = Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl">;
+type KeyStoreSlice = Pick<
+  TKeyStoreFactory,
+  "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
+>;
 
-const makeKeyStore = (patch: Partial<KeyStoreSlice> = {}): KeyStoreSlice & { [k: string]: ReturnType<typeof vi.fn> } =>
+type MockedKeyStore = Mocked<KeyStoreSlice>;
+
+const makeKeyStore = (patch: Partial<MockedKeyStore> = {}): MockedKeyStore =>
   ({
     setItemWithExpiry: vi.fn().mockResolvedValue("OK"),
     getItem: vi.fn().mockResolvedValue(null),
@@ -39,10 +43,9 @@ const makeKeyStore = (patch: Partial<KeyStoreSlice> = {}): KeyStoreSlice & { [k:
     deleteItemsByKeyIn: vi.fn().mockResolvedValue(2),
     ttl: vi.fn().mockResolvedValue(-1),
     ...patch
-  }) as KeyStoreSlice & { [k: string]: ReturnType<typeof vi.fn> };
+  }) as MockedKeyStore;
 
-const createService = (patch: Partial<KeyStoreSlice> = {}) => {
-  const keyStore = makeKeyStore(patch);
+const createService = (keyStore: MockedKeyStore) => {
   const service = tokenServiceFactory({
     tokenDAL: {} as never,
     userDAL: {} as never,
@@ -50,16 +53,60 @@ const createService = (patch: Partial<KeyStoreSlice> = {}) => {
     membershipUserDAL: {} as never,
     keyStore: keyStore as never
   });
+
   return { service, keyStore };
 };
 
-const makeStoredPayload = (overrides: Partial<TEmailSignupOtpPayload> = {}): string =>
-  JSON.stringify({
-    tokenHash: hmac("123456"),
-    triesLeft: 3,
-    expiresAt: NOW_MS + 300_000,
-    ...overrides
-  } satisfies TEmailSignupOtpPayload);
+const setup = () => {
+  const keyStore = makeKeyStore();
+  const { service } = createService(keyStore);
+
+  return {
+    service,
+    keyStore,
+
+    mockOtp(payload: Partial<TEmailSignupOtpPayload> = {}) {
+      keyStore.getItem.mockResolvedValue(
+        JSON.stringify({
+          tokenHash: hmac("123456"),
+          triesLeft: 3,
+          expiresAt: NOW_MS + 300_000,
+          ...payload
+        })
+      );
+      return this;
+    },
+
+    mockCooldown(ttl: number, present = true) {
+      keyStore.getItem.mockImplementation(async (key: string) => (key === cooldownKey && present ? "1" : null));
+      keyStore.ttl.mockResolvedValue(ttl);
+      return this;
+    },
+
+    mockNoOtp() {
+      keyStore.getItem.mockResolvedValue(null);
+      return this;
+    }
+  };
+};
+
+const getStoredOtpPayload = (keyStore: MockedKeyStore) => {
+  const stored = keyStore.setItemWithExpiry.mock.calls.find(([k]) => k === otpKey)?.[2];
+  return stored ? (JSON.parse(stored as string) as TEmailSignupOtpPayload) : null;
+};
+
+const expectRejected = async <T, E extends Error>(
+  promise: Promise<T>,
+  ErrorType: new (...args: never[]) => E
+): Promise<E> => {
+  try {
+    await promise;
+    throw new Error("Expected rejection");
+  } catch (e) {
+    expect(e).toBeInstanceOf(ErrorType);
+    return e as E;
+  }
+};
 
 describe("tokenServiceFactory — email signup OTP", () => {
   beforeAll(async () => {
@@ -81,13 +128,9 @@ describe("tokenServiceFactory — email signup OTP", () => {
     vi.clearAllMocks();
   });
 
-  // ---------------------------------------------------------------------------
-  // createEmailSignupToken
-  // ---------------------------------------------------------------------------
-
   describe("createEmailSignupToken", () => {
-    test("returns a 6-digit token string and the configured cooldownSeconds", async () => {
-      const { service } = createService();
+    test("returns token and cooldown", async () => {
+      const { service } = setup();
 
       const result = await service.createEmailSignupToken(TEST_EMAIL);
 
@@ -95,24 +138,19 @@ describe("tokenServiceFactory — email signup OTP", () => {
       expect(result.token).toMatch(/^\d{6}$/);
     });
 
-    test("stores the HMAC of the token (not the plain token) in the keystore", async () => {
-      const { service, keyStore } = createService();
+    test("stores hashed token", async () => {
+      const { service, keyStore } = setup();
 
       const { token } = await service.createEmailSignupToken(TEST_EMAIL);
-      const expectedHash = hmac(token);
 
-      const storedArg: string = (keyStore.setItemWithExpiry as ReturnType<typeof vi.fn>).mock.calls.find(
-        ([k]: string[]) => k === otpKey
-      )?.[2];
+      const payload = getStoredOtpPayload(keyStore);
 
-      expect(storedArg).toBeDefined();
-      const parsed = JSON.parse(storedArg) as TEmailSignupOtpPayload;
-      expect(parsed.tokenHash).toBe(expectedHash);
-      expect(parsed.triesLeft).toBe(3);
+      expect(payload?.tokenHash).toBe(hmac(token));
+      expect(payload?.triesLeft).toBe(3);
     });
 
-    test("sets the cooldown key in keystore", async () => {
-      const { service, keyStore } = createService();
+    test("sets cooldown key", async () => {
+      const { service, keyStore } = setup();
 
       await service.createEmailSignupToken(TEST_EMAIL);
 
@@ -123,113 +161,88 @@ describe("tokenServiceFactory — email signup OTP", () => {
       );
     });
 
-    test("throws BadRequestError when cooldown key is present", async () => {
-      const { service } = createService({
-        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
-        ttl: vi.fn().mockResolvedValue(45)
-      });
+    test("blocks when cooldown active", async () => {
+      const { service } = setup().mockCooldown(45);
 
-      await expect(service.createEmailSignupToken(TEST_EMAIL)).rejects.toThrow(BadRequestError);
+      await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
     });
 
-    test("BadRequestError details.cooldownSeconds reflects the remaining TTL", async () => {
-      const { service } = createService({
-        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
-        ttl: vi.fn().mockResolvedValue(30)
-      });
+    test("returns cooldown seconds from TTL", async () => {
+      const { service } = setup().mockCooldown(30);
 
-      const err = await service.createEmailSignupToken(TEST_EMAIL).catch((e) => e);
+      const err = await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
 
-      expect(err).toBeInstanceOf(BadRequestError);
-      expect((err as BadRequestError).details).toMatchObject({ cooldownSeconds: 30 });
+      expect(err.details).toMatchObject({ cooldownSeconds: 30 });
     });
 
-    test("clamps cooldownSeconds to at least 1 when TTL returns -1", async () => {
-      const { service } = createService({
-        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
-        ttl: vi.fn().mockResolvedValue(-1)
-      });
+    test("clamps cooldown to minimum 1", async () => {
+      const { service } = setup().mockCooldown(-1);
 
-      const err = await service.createEmailSignupToken(TEST_EMAIL).catch((e) => e);
+      const err = await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
 
-      expect((err as BadRequestError).details).toMatchObject({ cooldownSeconds: 1 });
+      expect(err.details).toMatchObject({ cooldownSeconds: 1 });
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // validateEmailSignupToken
-  // ---------------------------------------------------------------------------
-
   describe("validateEmailSignupToken", () => {
-    test("resolves without error when code matches a valid unexpired payload", async () => {
-      const { service } = createService({
-        getItem: vi.fn().mockResolvedValue(makeStoredPayload())
-      });
+    test("valid token succeeds", async () => {
+      const { service } = setup().mockOtp();
 
       await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).resolves.toBeUndefined();
     });
 
-    test("deletes both the OTP key and the cooldown key on success", async () => {
-      const { service, keyStore } = createService({
-        getItem: vi.fn().mockResolvedValue(makeStoredPayload())
-      });
+    test("deletes OTP and cooldown on success", async () => {
+      const { service, keyStore } = setup().mockOtp();
 
       await service.validateEmailSignupToken(TEST_EMAIL, "123456");
 
-      expect(keyStore.deleteItemsByKeyIn).toHaveBeenCalledWith(
-        expect.arrayContaining([otpKey, cooldownKey])
-      );
+      expect(keyStore.deleteItemsByKeyIn).toHaveBeenCalledWith(expect.arrayContaining([otpKey, cooldownKey]));
     });
 
-    test("throws UnauthorizedError when no OTP record exists in keystore", async () => {
-      const { service } = createService({
-        getItem: vi.fn().mockResolvedValue(null)
-      });
+    test("throws when OTP missing", async () => {
+      const { service } = setup().mockNoOtp();
 
-      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
+      await expectRejected(service.validateEmailSignupToken(TEST_EMAIL, "123456"), UnauthorizedError);
     });
 
-    test("throws UnauthorizedError and deletes the key when token is expired", async () => {
-      const { service, keyStore } = createService({
-        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ expiresAt: NOW_MS - 1 }))
+    test("expires OTP deletes key", async () => {
+      const { service, keyStore } = setup().mockOtp({
+        expiresAt: NOW_MS - 1
       });
 
-      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
+      await expectRejected(service.validateEmailSignupToken(TEST_EMAIL, "123456"), UnauthorizedError);
+
       expect(keyStore.deleteItem).toHaveBeenCalledWith(otpKey);
     });
 
-    test("throws UnauthorizedError when code is wrong and decrements tries", async () => {
-      const { service, keyStore } = createService({
-        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ triesLeft: 3 }))
-      });
+    test("wrong code decrements tries", async () => {
+      const { service, keyStore } = setup().mockOtp({ triesLeft: 3 });
 
-      await expect(service.validateEmailSignupToken(TEST_EMAIL, "000000")).rejects.toThrow(UnauthorizedError);
+      await expectRejected(service.validateEmailSignupToken(TEST_EMAIL, "000000"), UnauthorizedError);
 
-      const updatedPayload = JSON.parse(
-        (keyStore.setItemWithExpiry as ReturnType<typeof vi.fn>).mock.calls[0][2]
-      ) as TEmailSignupOtpPayload;
-      expect(updatedPayload.triesLeft).toBe(2);
+      const payload = getStoredOtpPayload(keyStore);
+      expect(payload?.triesLeft).toBe(2);
     });
 
-    test("deletes the OTP key and throws when the last try is exhausted", async () => {
-      const { service, keyStore } = createService({
-        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ triesLeft: 1 }))
-      });
+    test("last try deletes OTP", async () => {
+      const { service, keyStore } = setup().mockOtp({ triesLeft: 1 });
 
-      await expect(service.validateEmailSignupToken(TEST_EMAIL, "000000")).rejects.toThrow(UnauthorizedError);
+      await expectRejected(service.validateEmailSignupToken(TEST_EMAIL, "000000"), UnauthorizedError);
+
       expect(keyStore.deleteItem).toHaveBeenCalledWith(otpKey);
       expect(keyStore.setItemWithExpiry).not.toHaveBeenCalled();
     });
 
-    test("always acquires and releases the lock regardless of outcome", async () => {
-      const releaseFn = vi.fn().mockResolvedValue(undefined);
-      const { service } = createService({
-        getItem: vi.fn().mockResolvedValue(null),
-        acquireLock: vi.fn().mockResolvedValue({ release: releaseFn })
+    test("lock is always released", async () => {
+      const release = vi.fn().mockResolvedValue(undefined);
+      const keyStore = makeKeyStore({
+        acquireLock: vi.fn().mockResolvedValue({ release } as never)
       });
+      const { service } = createService(keyStore);
 
-      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
-      expect(releaseFn).toHaveBeenCalledOnce();
+      await expectRejected(service.validateEmailSignupToken(TEST_EMAIL, "123456"), UnauthorizedError);
+
+      expect(release).toHaveBeenCalledOnce();
     });
   });
 });

--- a/backend/src/services/auth-token/auth-token-service.test.ts
+++ b/backend/src/services/auth-token/auth-token-service.test.ts
@@ -1,0 +1,235 @@
+import { createHmac } from "node:crypto";
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { crypto } from "@app/lib/crypto/cryptography";
+import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
+
+import { TEmailSignupOtpPayload } from "./auth-token-types";
+import { tokenServiceFactory } from "./auth-token-service";
+
+const AUTH_SECRET = "test-secret-for-otp-unit-tests";
+const NOW_MS = 1_700_000_000_000;
+const TEST_EMAIL = "otp-test@example.com";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({ AUTH_SECRET })
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+const hmac = (value: string) => createHmac("sha256", AUTH_SECRET).update(value).digest("hex");
+
+// Pre-compute key names so assertions can reference them without re-running production logic.
+const emailHash = hmac(TEST_EMAIL);
+const otpKey = KeyStorePrefixes.EmailSignupOtpHash(emailHash);
+const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
+
+type KeyStoreSlice = Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl">;
+
+const makeKeyStore = (patch: Partial<KeyStoreSlice> = {}): KeyStoreSlice & { [k: string]: ReturnType<typeof vi.fn> } =>
+  ({
+    setItemWithExpiry: vi.fn().mockResolvedValue("OK"),
+    getItem: vi.fn().mockResolvedValue(null),
+    deleteItem: vi.fn().mockResolvedValue(1),
+    acquireLock: vi.fn().mockResolvedValue({ release: vi.fn().mockResolvedValue(undefined) }),
+    deleteItemsByKeyIn: vi.fn().mockResolvedValue(2),
+    ttl: vi.fn().mockResolvedValue(-1),
+    ...patch
+  }) as KeyStoreSlice & { [k: string]: ReturnType<typeof vi.fn> };
+
+const createService = (patch: Partial<KeyStoreSlice> = {}) => {
+  const keyStore = makeKeyStore(patch);
+  const service = tokenServiceFactory({
+    tokenDAL: {} as never,
+    userDAL: {} as never,
+    orgDAL: {} as never,
+    membershipUserDAL: {} as never,
+    keyStore: keyStore as never
+  });
+  return { service, keyStore };
+};
+
+const makeStoredPayload = (overrides: Partial<TEmailSignupOtpPayload> = {}): string =>
+  JSON.stringify({
+    tokenHash: hmac("123456"),
+    triesLeft: 3,
+    expiresAt: NOW_MS + 300_000,
+    ...overrides
+  } satisfies TEmailSignupOtpPayload);
+
+describe("tokenServiceFactory — email signup OTP", () => {
+  beforeAll(async () => {
+    process.env.FIPS_ENABLED = "false";
+    await crypto.initialize({} as never, {} as never, {} as never);
+  });
+
+  afterAll(() => {
+    delete process.env.FIPS_ENABLED;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_MS));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // createEmailSignupToken
+  // ---------------------------------------------------------------------------
+
+  describe("createEmailSignupToken", () => {
+    test("returns a 6-digit token string and the configured cooldownSeconds", async () => {
+      const { service } = createService();
+
+      const result = await service.createEmailSignupToken(TEST_EMAIL);
+
+      expect(result.cooldownSeconds).toBe(KeyStoreTtls.EmailSignupResendCooldownInSeconds);
+      expect(result.token).toMatch(/^\d{6}$/);
+    });
+
+    test("stores the HMAC of the token (not the plain token) in the keystore", async () => {
+      const { service, keyStore } = createService();
+
+      const { token } = await service.createEmailSignupToken(TEST_EMAIL);
+      const expectedHash = hmac(token);
+
+      const storedArg: string = (keyStore.setItemWithExpiry as ReturnType<typeof vi.fn>).mock.calls.find(
+        ([k]: string[]) => k === otpKey
+      )?.[2];
+
+      expect(storedArg).toBeDefined();
+      const parsed = JSON.parse(storedArg) as TEmailSignupOtpPayload;
+      expect(parsed.tokenHash).toBe(expectedHash);
+      expect(parsed.triesLeft).toBe(3);
+    });
+
+    test("sets the cooldown key in keystore", async () => {
+      const { service, keyStore } = createService();
+
+      await service.createEmailSignupToken(TEST_EMAIL);
+
+      expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+        cooldownKey,
+        KeyStoreTtls.EmailSignupResendCooldownInSeconds,
+        "1"
+      );
+    });
+
+    test("throws BadRequestError when cooldown key is present", async () => {
+      const { service } = createService({
+        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
+        ttl: vi.fn().mockResolvedValue(45)
+      });
+
+      await expect(service.createEmailSignupToken(TEST_EMAIL)).rejects.toThrow(BadRequestError);
+    });
+
+    test("BadRequestError details.cooldownSeconds reflects the remaining TTL", async () => {
+      const { service } = createService({
+        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
+        ttl: vi.fn().mockResolvedValue(30)
+      });
+
+      const err = await service.createEmailSignupToken(TEST_EMAIL).catch((e) => e);
+
+      expect(err).toBeInstanceOf(BadRequestError);
+      expect((err as BadRequestError).details).toMatchObject({ cooldownSeconds: 30 });
+    });
+
+    test("clamps cooldownSeconds to at least 1 when TTL returns -1", async () => {
+      const { service } = createService({
+        getItem: vi.fn().mockImplementation(async (key: string) => (key === cooldownKey ? "1" : null)),
+        ttl: vi.fn().mockResolvedValue(-1)
+      });
+
+      const err = await service.createEmailSignupToken(TEST_EMAIL).catch((e) => e);
+
+      expect((err as BadRequestError).details).toMatchObject({ cooldownSeconds: 1 });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // validateEmailSignupToken
+  // ---------------------------------------------------------------------------
+
+  describe("validateEmailSignupToken", () => {
+    test("resolves without error when code matches a valid unexpired payload", async () => {
+      const { service } = createService({
+        getItem: vi.fn().mockResolvedValue(makeStoredPayload())
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).resolves.toBeUndefined();
+    });
+
+    test("deletes both the OTP key and the cooldown key on success", async () => {
+      const { service, keyStore } = createService({
+        getItem: vi.fn().mockResolvedValue(makeStoredPayload())
+      });
+
+      await service.validateEmailSignupToken(TEST_EMAIL, "123456");
+
+      expect(keyStore.deleteItemsByKeyIn).toHaveBeenCalledWith(
+        expect.arrayContaining([otpKey, cooldownKey])
+      );
+    });
+
+    test("throws UnauthorizedError when no OTP record exists in keystore", async () => {
+      const { service } = createService({
+        getItem: vi.fn().mockResolvedValue(null)
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
+    });
+
+    test("throws UnauthorizedError and deletes the key when token is expired", async () => {
+      const { service, keyStore } = createService({
+        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ expiresAt: NOW_MS - 1 }))
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
+      expect(keyStore.deleteItem).toHaveBeenCalledWith(otpKey);
+    });
+
+    test("throws UnauthorizedError when code is wrong and decrements tries", async () => {
+      const { service, keyStore } = createService({
+        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ triesLeft: 3 }))
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "000000")).rejects.toThrow(UnauthorizedError);
+
+      const updatedPayload = JSON.parse(
+        (keyStore.setItemWithExpiry as ReturnType<typeof vi.fn>).mock.calls[0][2]
+      ) as TEmailSignupOtpPayload;
+      expect(updatedPayload.triesLeft).toBe(2);
+    });
+
+    test("deletes the OTP key and throws when the last try is exhausted", async () => {
+      const { service, keyStore } = createService({
+        getItem: vi.fn().mockResolvedValue(makeStoredPayload({ triesLeft: 1 }))
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "000000")).rejects.toThrow(UnauthorizedError);
+      expect(keyStore.deleteItem).toHaveBeenCalledWith(otpKey);
+      expect(keyStore.setItemWithExpiry).not.toHaveBeenCalled();
+    });
+
+    test("always acquires and releases the lock regardless of outcome", async () => {
+      const releaseFn = vi.fn().mockResolvedValue(undefined);
+      const { service } = createService({
+        getItem: vi.fn().mockResolvedValue(null),
+        acquireLock: vi.fn().mockResolvedValue({ release: releaseFn })
+      });
+
+      await expect(service.validateEmailSignupToken(TEST_EMAIL, "123456")).rejects.toThrow(UnauthorizedError);
+      expect(releaseFn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/backend/src/services/auth-token/auth-token-service.test.ts
+++ b/backend/src/services/auth-token/auth-token-service.test.ts
@@ -129,31 +129,20 @@ describe("tokenServiceFactory — email signup OTP", () => {
     vi.clearAllMocks();
   });
 
-  describe("createEmailSignupToken", () => {
-    test("returns token and cooldown", async () => {
+  describe("acquireEmailSignupCooldown", () => {
+    test("returns emailHash and cooldownSeconds on first call", async () => {
       const { service } = setup();
 
-      const result = await service.createEmailSignupToken(TEST_EMAIL);
+      const result = await service.acquireEmailSignupCooldown(TEST_EMAIL);
 
+      expect(result.emailHash).toBe(emailHash);
       expect(result.cooldownSeconds).toBe(KeyStoreTtls.EmailSignupResendCooldownInSeconds);
-      expect(result.token).toMatch(/^\d{6}$/);
-    });
-
-    test("stores hashed token", async () => {
-      const { service, keyStore } = setup();
-
-      const { token } = await service.createEmailSignupToken(TEST_EMAIL);
-
-      const payload = getStoredOtpPayload(keyStore);
-
-      expect(payload?.tokenHash).toBe(hmac(token));
-      expect(payload?.triesLeft).toBe(3);
     });
 
     test("sets cooldown key atomically via NX", async () => {
       const { service, keyStore } = setup();
 
-      await service.createEmailSignupToken(TEST_EMAIL);
+      await service.acquireEmailSignupCooldown(TEST_EMAIL);
 
       expect(keyStore.setItemWithExpiryNX).toHaveBeenCalledWith(
         cooldownKey,
@@ -162,26 +151,75 @@ describe("tokenServiceFactory — email signup OTP", () => {
       );
     });
 
-    test("blocks when cooldown active", async () => {
+    test("throws when cooldown is active", async () => {
       const { service } = setup().mockCooldown(45);
 
-      await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
+      await expectRejected(service.acquireEmailSignupCooldown(TEST_EMAIL), BadRequestError);
     });
 
-    test("returns cooldown seconds from TTL", async () => {
+    test("reports remaining TTL in error details", async () => {
       const { service } = setup().mockCooldown(30);
 
-      const err = await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
+      const err = await expectRejected(service.acquireEmailSignupCooldown(TEST_EMAIL), BadRequestError);
 
       expect(err.details).toMatchObject({ cooldownSeconds: 30 });
     });
 
-    test("clamps cooldown to minimum 1", async () => {
+    test("clamps remaining TTL to minimum 1", async () => {
       const { service } = setup().mockCooldown(-1);
 
-      const err = await expectRejected(service.createEmailSignupToken(TEST_EMAIL), BadRequestError);
+      const err = await expectRejected(service.acquireEmailSignupCooldown(TEST_EMAIL), BadRequestError);
 
       expect(err.details).toMatchObject({ cooldownSeconds: 1 });
+    });
+  });
+
+  describe("createEmailSignupToken", () => {
+    test("returns a six-digit numeric token", async () => {
+      const { service } = setup();
+
+      const token = await service.createEmailSignupToken(emailHash);
+
+      expect(token).toMatch(/^\d{6}$/);
+    });
+
+    test("stores OTP payload with hashed token and 3 tries", async () => {
+      const { service, keyStore } = setup();
+
+      const token = await service.createEmailSignupToken(emailHash);
+
+      const payload = getStoredOtpPayload(keyStore);
+      expect(payload?.tokenHash).toBe(hmac(token));
+      expect(payload?.triesLeft).toBe(3);
+    });
+
+    test("stores OTP with correct expiry", async () => {
+      const { service, keyStore } = setup();
+
+      await service.createEmailSignupToken(emailHash);
+
+      const payload = getStoredOtpPayload(keyStore);
+      expect(payload?.expiresAt).toBe(NOW_MS + KeyStoreTtls.EmailSignupOtpInSeconds * 1000);
+    });
+
+    test("writes to the OTP key with the correct TTL", async () => {
+      const { service, keyStore } = setup();
+
+      await service.createEmailSignupToken(emailHash);
+
+      expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+        otpKey,
+        KeyStoreTtls.EmailSignupOtpInSeconds,
+        expect.any(String)
+      );
+    });
+
+    test("does not touch the cooldown key", async () => {
+      const { service, keyStore } = setup();
+
+      await service.createEmailSignupToken(emailHash);
+
+      expect(keyStore.setItemWithExpiryNX).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -13,7 +13,13 @@ import { TMembershipUserDALFactory } from "../membership-user/membership-user-da
 import { TOrgDALFactory } from "../org/org-dal";
 import { TUserDALFactory } from "../user/user-dal";
 import { TTokenDALFactory } from "./auth-token-dal";
-import { TCreateTokenForUserDTO, TIssueAuthTokenDTO, TokenType, TValidateTokenForUserDTO } from "./auth-token-types";
+import {
+  TCreateTokenForUserDTO,
+  TEmailSignupOtpPayload,
+  TIssueAuthTokenDTO,
+  TokenType,
+  TValidateTokenForUserDTO
+} from "./auth-token-types";
 
 type TAuthTokenServiceFactoryDep = {
   tokenDAL: TTokenDALFactory;
@@ -358,6 +364,52 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     return { user, tokenVersionId: token.tokenVersionId, orgId, orgName, rootOrgId, parentOrgId };
   };
 
+  const createEmailSignupToken = async (email: string): Promise<string> => {
+    const appCfg = getConfig();
+    const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
+    const tokenHash = await crypto.hashing().createHash(token, appCfg.SALT_ROUNDS);
+    const ttlSeconds = KeyStoreTtls.EmailSignupOtpInSeconds;
+    const payload: TEmailSignupOtpPayload = {
+      tokenHash,
+      triesLeft: 3,
+      expiresAt: Date.now() + ttlSeconds * 1000
+    };
+    const emailHash = crypto.nativeCrypto.createHash("sha256").update(email).digest("hex");
+    await keyStore.setItemWithExpiry(KeyStorePrefixes.EmailSignupOtp(emailHash), ttlSeconds, JSON.stringify(payload));
+    return token;
+  };
+
+  const validateEmailSignupToken = async (email: string, code: string): Promise<void> => {
+    const emailHash = crypto.nativeCrypto.createHash("sha256").update(email).digest("hex");
+    const raw = await keyStore.getItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
+    const parsed = raw ? (JSON.parse(raw) as TEmailSignupOtpPayload) : null;
+
+    // Always run bcrypt comparison for constant-time behaviour regardless of token presence.
+    const hashToCompare = parsed?.tokenHash ?? DUMMY_HASH;
+    const isValidToken = await crypto.hashing().compareHash(code, hashToCompare);
+
+    if (!parsed || parsed.expiresAt < Date.now()) {
+      throw new Error("Invalid token");
+    }
+
+    if (!isValidToken) {
+      if (parsed.triesLeft <= 1) {
+        await keyStore.deleteItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
+      } else {
+        const remainingTtlSec = Math.max(1, Math.floor((parsed.expiresAt - Date.now()) / 1000));
+        const updated: TEmailSignupOtpPayload = { ...parsed, triesLeft: parsed.triesLeft - 1 };
+        await keyStore.setItemWithExpiry(
+          KeyStorePrefixes.EmailSignupOtp(emailHash),
+          remainingTtlSec,
+          JSON.stringify(updated)
+        );
+      }
+      throw new Error("Invalid token");
+    }
+
+    await keyStore.deleteItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
+  };
+
   return {
     createTokenForUser,
     validateTokenForUser,
@@ -369,6 +421,8 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     validateRefreshToken,
     rotateRefreshToken,
     fnValidateJwtIdentity,
-    getUserTokenSessionById
+    getUserTokenSessionById,
+    createEmailSignupToken,
+    validateEmailSignupToken
   };
 };

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -31,23 +31,17 @@ type TAuthTokenServiceFactoryDep = {
 
 export type TAuthTokenServiceFactory = ReturnType<typeof tokenServiceFactory>;
 
-const generateSixDigitToken = (): string => crypto.randomInt(0, 1_000_000).toString().padStart(6, "0");
+const generateSixDigitToken = (): string => String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
 
 const generateRandomHex = (size: number): string => crypto.randomBytes(size).toString("hex");
 
 const computeHash = (key: string, pepper: string): string =>
   crypto.nativeCrypto.createHmac("sha256", pepper).update(key).digest("hex");
 
-const getTokenConfig = (tokenType: TokenType) => {
+export const getTokenConfig = (tokenType: TokenType) => {
   // generate random token based on specified token use-case
   // type [type]
   switch (tokenType) {
-    case TokenType.TOKEN_EMAIL_CONFIRMATION: {
-      const token = generateSixDigitToken();
-      const expiresAt = new Date(new Date().getTime() + 86400000);
-      const triesLeft = 3;
-      return { token, expiresAt, triesLeft };
-    }
     case TokenType.TOKEN_EMAIL_VERIFICATION: {
       const token = generateSixDigitToken();
       const triesLeft = 3;

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -28,7 +28,7 @@ type TAuthTokenServiceFactoryDep = {
   membershipUserDAL: Pick<TMembershipUserDALFactory, "findOne">;
   keyStore: Pick<
     TKeyStoreFactory,
-    "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
+    "setItemWithExpiry" | "setItemWithExpiryNX" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
   >;
 };
 
@@ -366,8 +366,9 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     const emailHash = computeHash(email, appCfg.AUTH_SECRET);
 
     const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
-    const hasCooldown = await keyStore.getItem(cooldownKey);
-    if (hasCooldown) {
+    // SET NX is atomic: only one concurrent request can acquire the cooldown slot.
+    const acquired = await keyStore.setItemWithExpiryNX(cooldownKey, KeyStoreTtls.EmailSignupResendCooldownInSeconds, "1");
+    if (!acquired) {
       const remaining = await keyStore.ttl(cooldownKey);
       throw new BadRequestError({
         message: "Please wait before requesting another code",
@@ -389,7 +390,6 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
       ttlSeconds,
       JSON.stringify(payload)
     );
-    await keyStore.setItemWithExpiry(cooldownKey, KeyStoreTtls.EmailSignupResendCooldownInSeconds, "1");
 
     return { token, cooldownSeconds: KeyStoreTtls.EmailSignupResendCooldownInSeconds };
   };

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -26,7 +26,10 @@ type TAuthTokenServiceFactoryDep = {
   userDAL: Pick<TUserDALFactory, "findById" | "transaction">;
   orgDAL: Pick<TOrgDALFactory, "findOne" | "findEffectiveOrgMembership">;
   membershipUserDAL: Pick<TMembershipUserDALFactory, "findOne">;
-  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock">;
+  keyStore: Pick<
+    TKeyStoreFactory,
+    "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
+  >;
 };
 
 export type TAuthTokenServiceFactory = ReturnType<typeof tokenServiceFactory>;
@@ -358,8 +361,20 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     return { user, tokenVersionId: token.tokenVersionId, orgId, orgName, rootOrgId, parentOrgId };
   };
 
-  const createEmailSignupToken = async (email: string): Promise<string> => {
+  const createEmailSignupToken = async (email: string): Promise<{ token: string; cooldownSeconds: number }> => {
     const appCfg = getConfig();
+    const emailHash = computeHash(email, appCfg.AUTH_SECRET);
+
+    const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
+    const hasCooldown = await keyStore.getItem(cooldownKey);
+    if (hasCooldown) {
+      const remaining = await keyStore.ttl(cooldownKey);
+      throw new BadRequestError({
+        message: "Please wait before requesting another code",
+        details: { cooldownSeconds: Math.max(1, remaining) }
+      });
+    }
+
     const token = generateSixDigitToken();
     const tokenHash = computeHash(token, appCfg.AUTH_SECRET);
     const ttlSeconds = KeyStoreTtls.EmailSignupOtpInSeconds;
@@ -369,16 +384,20 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
       expiresAt: Date.now() + ttlSeconds * 1000
     };
 
-    const emailHash = computeHash(email, appCfg.AUTH_SECRET);
-    await keyStore.setItemWithExpiry(KeyStorePrefixes.EmailSignupOtp(emailHash), ttlSeconds, JSON.stringify(payload));
+    await keyStore.setItemWithExpiry(
+      KeyStorePrefixes.EmailSignupOtpHash(emailHash),
+      ttlSeconds,
+      JSON.stringify(payload)
+    );
+    await keyStore.setItemWithExpiry(cooldownKey, KeyStoreTtls.EmailSignupResendCooldownInSeconds, "1");
 
-    return token;
+    return { token, cooldownSeconds: KeyStoreTtls.EmailSignupResendCooldownInSeconds };
   };
 
   const validateEmailSignupToken = async (email: string, code: string): Promise<void> => {
     const appCfg = getConfig();
     const emailHash = computeHash(email, appCfg.AUTH_SECRET);
-    const key = KeyStorePrefixes.EmailSignupOtp(emailHash);
+    const key = KeyStorePrefixes.EmailSignupOtpHash(emailHash);
 
     // Acquire a short-lived lock to make the tries-decrement / delete atomic.
     const lock = await keyStore.acquireLock([KeyStorePrefixes.EmailSignupOtpLock(emailHash)], 5000);
@@ -395,12 +414,18 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
       );
 
       if (!parsed) {
-        throw new Error("Invalid token");
+        throw new UnauthorizedError({
+          message: "Invalid token",
+          name: "InvalidToken"
+        });
       }
 
       if (Date.now() > parsed.expiresAt) {
         await keyStore.deleteItem(key);
-        throw new Error("Invalid token");
+        throw new UnauthorizedError({
+          message: "Invalid token",
+          name: "InvalidToken"
+        });
       }
 
       if (!isValidToken) {
@@ -415,10 +440,14 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
             JSON.stringify({ ...parsed, triesLeft: remainingTries })
           );
         }
-        throw new Error("Invalid token");
+        throw new UnauthorizedError({
+          message: "Invalid token",
+          name: "InvalidToken"
+        });
       }
 
-      await keyStore.deleteItem(key);
+      const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
+      await keyStore.deleteItemsByKeyIn([key, cooldownKey]);
     } finally {
       await lock.release();
     }

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -28,7 +28,13 @@ type TAuthTokenServiceFactoryDep = {
   membershipUserDAL: Pick<TMembershipUserDALFactory, "findOne">;
   keyStore: Pick<
     TKeyStoreFactory,
-    "setItemWithExpiry" | "setItemWithExpiryNX" | "getItem" | "deleteItem" | "acquireLock" | "deleteItemsByKeyIn" | "ttl"
+    | "setItemWithExpiry"
+    | "setItemWithExpiryNX"
+    | "getItem"
+    | "deleteItem"
+    | "acquireLock"
+    | "deleteItemsByKeyIn"
+    | "ttl"
   >;
 };
 
@@ -361,21 +367,32 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     return { user, tokenVersionId: token.tokenVersionId, orgId, orgName, rootOrgId, parentOrgId };
   };
 
-  const createEmailSignupToken = async (email: string): Promise<{ token: string; cooldownSeconds: number }> => {
+  const acquireEmailSignupCooldown = async (email: string): Promise<{ emailHash: string; cooldownSeconds: number }> => {
     const appCfg = getConfig();
     const emailHash = computeHash(email, appCfg.AUTH_SECRET);
-
     const cooldownKey = KeyStorePrefixes.EmailSignupResendCooldown(emailHash);
+    const cooldownSeconds = KeyStoreTtls.EmailSignupResendCooldownInSeconds;
+
     // SET NX is atomic: only one concurrent request can acquire the cooldown slot.
-    const acquired = await keyStore.setItemWithExpiryNX(cooldownKey, KeyStoreTtls.EmailSignupResendCooldownInSeconds, "1");
+    const acquired = await keyStore.setItemWithExpiryNX(cooldownKey, cooldownSeconds, "1");
     if (!acquired) {
       const remaining = await keyStore.ttl(cooldownKey);
       throw new BadRequestError({
         message: "Please wait before requesting another code",
-        details: { cooldownSeconds: Math.max(1, remaining) }
+        details: {
+          cooldownSeconds: Math.max(1, remaining)
+        }
       });
     }
 
+    return {
+      emailHash,
+      cooldownSeconds
+    };
+  };
+
+  const createEmailSignupToken = async (emailHash: string): Promise<string> => {
+    const appCfg = getConfig();
     const token = generateSixDigitToken();
     const tokenHash = computeHash(token, appCfg.AUTH_SECRET);
     const ttlSeconds = KeyStoreTtls.EmailSignupOtpInSeconds;
@@ -391,7 +408,7 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
       JSON.stringify(payload)
     );
 
-    return { token, cooldownSeconds: KeyStoreTtls.EmailSignupResendCooldownInSeconds };
+    return token;
   };
 
   const validateEmailSignupToken = async (email: string, code: string): Promise<void> => {
@@ -402,23 +419,23 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     // Acquire a short-lived lock to make the tries-decrement / delete atomic.
     const lock = await keyStore.acquireLock([KeyStorePrefixes.EmailSignupOtpLock(emailHash)], 5000);
     try {
-      const raw = await keyStore.getItem(key);
-      const parsed = raw ? (JSON.parse(raw) as TEmailSignupOtpPayload) : null;
-
-      // Always compute the HMAC and compare with timingSafeEqual for constant-time behaviour.
       const computedHash = computeHash(code, appCfg.AUTH_SECRET);
-      const storedHash = parsed?.tokenHash ?? "0".repeat(64);
-      const isValidToken = crypto.nativeCrypto.timingSafeEqual(
-        Buffer.from(computedHash, "hex"),
-        Buffer.from(storedHash, "hex")
-      );
 
-      if (!parsed) {
+      const raw = await keyStore.getItem(key);
+      if (!raw) {
+        // Always compute the HMAC and compare with timingSafeEqual for constant-time behaviour.
+        crypto.nativeCrypto.timingSafeEqual(Buffer.from(computedHash, "hex"), Buffer.from("0".repeat(64), "hex"));
         throw new UnauthorizedError({
           message: "Invalid token",
           name: "InvalidToken"
         });
       }
+
+      const parsed = JSON.parse(raw) as TEmailSignupOtpPayload;
+      const isValidToken = crypto.nativeCrypto.timingSafeEqual(
+        Buffer.from(computedHash, "hex"),
+        Buffer.from(parsed.tokenHash, "hex")
+      );
 
       if (Date.now() > parsed.expiresAt) {
         await keyStore.deleteItem(key);
@@ -465,6 +482,7 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     rotateRefreshToken,
     fnValidateJwtIdentity,
     getUserTokenSessionById,
+    acquireEmailSignupCooldown,
     createEmailSignupToken,
     validateEmailSignupToken
   };

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -381,7 +381,7 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
     const key = KeyStorePrefixes.EmailSignupOtp(emailHash);
 
     // Acquire a short-lived lock to make the tries-decrement / delete atomic.
-    const lock = await keyStore.acquireLock([key], 5000);
+    const lock = await keyStore.acquireLock([KeyStorePrefixes.EmailSignupOtpLock(emailHash)], 5000);
     try {
       const raw = await keyStore.getItem(key);
       const parsed = raw ? (JSON.parse(raw) as TEmailSignupOtpPayload) : null;

--- a/backend/src/services/auth-token/auth-token-service.ts
+++ b/backend/src/services/auth-token/auth-token-service.ts
@@ -26,81 +26,81 @@ type TAuthTokenServiceFactoryDep = {
   userDAL: Pick<TUserDALFactory, "findById" | "transaction">;
   orgDAL: Pick<TOrgDALFactory, "findOne" | "findEffectiveOrgMembership">;
   membershipUserDAL: Pick<TMembershipUserDALFactory, "findOne">;
-  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem">;
+  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem" | "acquireLock">;
 };
 
 export type TAuthTokenServiceFactory = ReturnType<typeof tokenServiceFactory>;
 
-export const getTokenConfig = (tokenType: TokenType) => {
+const generateSixDigitToken = (): string => crypto.randomInt(0, 1_000_000).toString().padStart(6, "0");
+
+const generateRandomHex = (size: number): string => crypto.randomBytes(size).toString("hex");
+
+const computeHash = (key: string, pepper: string): string =>
+  crypto.nativeCrypto.createHmac("sha256", pepper).update(key).digest("hex");
+
+const getTokenConfig = (tokenType: TokenType) => {
   // generate random token based on specified token use-case
   // type [type]
   switch (tokenType) {
     case TokenType.TOKEN_EMAIL_CONFIRMATION: {
-      // generate random 6-digit code
-      const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
+      const token = generateSixDigitToken();
       const expiresAt = new Date(new Date().getTime() + 86400000);
       const triesLeft = 3;
       return { token, expiresAt, triesLeft };
     }
     case TokenType.TOKEN_EMAIL_VERIFICATION: {
-      // generate random 6-digit code
-      const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
+      const token = generateSixDigitToken();
       const triesLeft = 3;
       const expiresAt = new Date(new Date().getTime() + 86400000);
       return { token, triesLeft, expiresAt };
     }
     case TokenType.TOKEN_EMAIL_CHANGE_OTP:
     case TokenType.TOKEN_EMAIL_CHANGE_CURRENT_OTP: {
-      const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
+      const token = generateSixDigitToken();
       const triesLeft = 1;
       const expiresAt = new Date(new Date().getTime() + 600000);
       return { token, triesLeft, expiresAt };
     }
     case TokenType.TOKEN_EMAIL_MFA: {
-      // generate random 6-digit code
-      const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
+      const token = generateSixDigitToken();
       const triesLeft = 3;
       const expiresAt = new Date(new Date().getTime() + 300000);
       return { token, triesLeft, expiresAt };
     }
     case TokenType.TOKEN_EMAIL_ORG_INVITATION: {
-      // generate random hex
-      const token = crypto.randomBytes(16).toString("hex");
+      const token = generateRandomHex(16);
       const expiresAt = new Date(new Date().getTime() + 259200000);
       return { token, expiresAt };
     }
     case TokenType.TOKEN_EMAIL_PASSWORD_RESET: {
-      // generate random hex
-      const token = crypto.randomBytes(32).toString("hex");
+      const token = generateRandomHex(32);
       const expiresAt = new Date(new Date().getTime() + 86400000);
       return { token, expiresAt };
     }
     case TokenType.TOKEN_EMAIL_PASSWORD_SETUP: {
-      // generate random hex
-      const token = crypto.randomBytes(16).toString("hex");
+      const token = generateRandomHex(16);
       const expiresAt = new Date(new Date().getTime() + 86400000);
       return { token, expiresAt };
     }
     case TokenType.TOKEN_USER_UNLOCK: {
-      const token = crypto.randomBytes(16).toString("hex");
+      const token = generateRandomHex(16);
       const expiresAt = new Date(new Date().getTime() + 259200000);
       return { token, expiresAt };
     }
     case TokenType.TOKEN_WEBAUTHN_SESSION: {
-      // generate random hex token for WebAuthn session
-      const token = crypto.randomBytes(32).toString("hex");
+      const token = generateRandomHex(32);
       const triesLeft = 1;
       const expiresAt = new Date(new Date().getTime() + 60000); // 60 seconds
       return { token, triesLeft, expiresAt };
     }
     case TokenType.TOKEN_PAM_WS_TICKET: {
-      const token = crypto.randomBytes(32).toString("hex");
+      const token = generateRandomHex(32);
       const triesLeft = 1;
       const expiresAt = new Date(new Date().getTime() + 30000); // 30 seconds
       return { token, triesLeft, expiresAt };
     }
     default: {
-      const token = crypto.randomBytes(16).toString("hex");
+      const token = generateRandomHex(16);
       const expiresAt = new Date();
       return { token, expiresAt };
     }
@@ -366,48 +366,68 @@ export const tokenServiceFactory = ({ tokenDAL, userDAL, orgDAL, keyStore }: TAu
 
   const createEmailSignupToken = async (email: string): Promise<string> => {
     const appCfg = getConfig();
-    const token = String(crypto.randomInt(10 ** 5, 10 ** 6 - 1));
-    const tokenHash = await crypto.hashing().createHash(token, appCfg.SALT_ROUNDS);
+    const token = generateSixDigitToken();
+    const tokenHash = computeHash(token, appCfg.AUTH_SECRET);
     const ttlSeconds = KeyStoreTtls.EmailSignupOtpInSeconds;
     const payload: TEmailSignupOtpPayload = {
       tokenHash,
       triesLeft: 3,
       expiresAt: Date.now() + ttlSeconds * 1000
     };
-    const emailHash = crypto.nativeCrypto.createHash("sha256").update(email).digest("hex");
+
+    const emailHash = computeHash(email, appCfg.AUTH_SECRET);
     await keyStore.setItemWithExpiry(KeyStorePrefixes.EmailSignupOtp(emailHash), ttlSeconds, JSON.stringify(payload));
+
     return token;
   };
 
   const validateEmailSignupToken = async (email: string, code: string): Promise<void> => {
-    const emailHash = crypto.nativeCrypto.createHash("sha256").update(email).digest("hex");
-    const raw = await keyStore.getItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
-    const parsed = raw ? (JSON.parse(raw) as TEmailSignupOtpPayload) : null;
+    const appCfg = getConfig();
+    const emailHash = computeHash(email, appCfg.AUTH_SECRET);
+    const key = KeyStorePrefixes.EmailSignupOtp(emailHash);
 
-    // Always run bcrypt comparison for constant-time behaviour regardless of token presence.
-    const hashToCompare = parsed?.tokenHash ?? DUMMY_HASH;
-    const isValidToken = await crypto.hashing().compareHash(code, hashToCompare);
+    // Acquire a short-lived lock to make the tries-decrement / delete atomic.
+    const lock = await keyStore.acquireLock([key], 5000);
+    try {
+      const raw = await keyStore.getItem(key);
+      const parsed = raw ? (JSON.parse(raw) as TEmailSignupOtpPayload) : null;
 
-    if (!parsed || parsed.expiresAt < Date.now()) {
-      throw new Error("Invalid token");
-    }
+      // Always compute the HMAC and compare with timingSafeEqual for constant-time behaviour.
+      const computedHash = computeHash(code, appCfg.AUTH_SECRET);
+      const storedHash = parsed?.tokenHash ?? "0".repeat(64);
+      const isValidToken = crypto.nativeCrypto.timingSafeEqual(
+        Buffer.from(computedHash, "hex"),
+        Buffer.from(storedHash, "hex")
+      );
 
-    if (!isValidToken) {
-      if (parsed.triesLeft <= 1) {
-        await keyStore.deleteItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
-      } else {
-        const remainingTtlSec = Math.max(1, Math.floor((parsed.expiresAt - Date.now()) / 1000));
-        const updated: TEmailSignupOtpPayload = { ...parsed, triesLeft: parsed.triesLeft - 1 };
-        await keyStore.setItemWithExpiry(
-          KeyStorePrefixes.EmailSignupOtp(emailHash),
-          remainingTtlSec,
-          JSON.stringify(updated)
-        );
+      if (!parsed) {
+        throw new Error("Invalid token");
       }
-      throw new Error("Invalid token");
-    }
 
-    await keyStore.deleteItem(KeyStorePrefixes.EmailSignupOtp(emailHash));
+      if (Date.now() > parsed.expiresAt) {
+        await keyStore.deleteItem(key);
+        throw new Error("Invalid token");
+      }
+
+      if (!isValidToken) {
+        const remainingTries = parsed.triesLeft - 1;
+        if (remainingTries <= 0) {
+          await keyStore.deleteItem(key);
+        } else {
+          const remainingTtlSec = Math.max(1, Math.ceil((parsed.expiresAt - Date.now()) / 1000));
+          await keyStore.setItemWithExpiry(
+            key,
+            remainingTtlSec,
+            JSON.stringify({ ...parsed, triesLeft: remainingTries })
+          );
+        }
+        throw new Error("Invalid token");
+      }
+
+      await keyStore.deleteItem(key);
+    } finally {
+      await lock.release();
+    }
   };
 
   return {

--- a/backend/src/services/auth-token/auth-token-types.ts
+++ b/backend/src/services/auth-token/auth-token-types.ts
@@ -1,7 +1,6 @@
 import { ProjectMembershipRole } from "@app/db/schemas";
 
 export enum TokenType {
-  TOKEN_EMAIL_CONFIRMATION = "emailConfirmation",
   TOKEN_EMAIL_VERIFICATION = "emailVerification", // unverified -> verified
   TOKEN_EMAIL_CHANGE_OTP = "emailChangeOtp",
   TOKEN_EMAIL_CHANGE_CURRENT_OTP = "emailChangeCurrentOtp",

--- a/backend/src/services/auth-token/auth-token-types.ts
+++ b/backend/src/services/auth-token/auth-token-types.ts
@@ -74,3 +74,9 @@ export type TTokenMetadata = {
   type: TokenMetadataType.InviteToProjects;
   payload: TTokenInviteToProjectsMetadataPayload;
 };
+
+export type TEmailSignupOtpPayload = {
+  tokenHash: string;
+  triesLeft: number;
+  expiresAt: number;
+};

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -1,5 +1,4 @@
 import { AccessScope, OrgMembershipStatus } from "@app/db/schemas";
-import { KeyStoreTtls } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
@@ -52,11 +51,13 @@ export const authSignupServiceFactory = ({
       throw new Error("Provided a disposable email");
     }
 
-    // akhilmhdh: case sensitive email resolution
+    // Acquire cooldown before any operation to avoid reliable enumeration oracle
+    const { emailHash, cooldownSeconds } = await tokenService.acquireEmailSignupCooldown(sanitizedEmail);
+
+    // Case sensitive email resolution
     const existingUser = await userDAL.findOne({ username: sanitizedEmail });
     if (existingUser?.isAccepted) {
-      // Send informational email for existing accounts instead of throwing error
-      // This prevents user enumeration vulnerability
+      // Send informational email for existing accounts instead of throwing error to prevent user enumeration vulnerability
       const appCfg = getConfig();
       await smtpService
         .sendMail({
@@ -72,10 +73,10 @@ export const authSignupServiceFactory = ({
         .catch((err) =>
           logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
         );
-      return { cooldownSeconds: KeyStoreTtls.EmailSignupResendCooldownInSeconds };
+      return { cooldownSeconds };
     }
 
-    const { token, cooldownSeconds } = await tokenService.createEmailSignupToken(sanitizedEmail);
+    const token = await tokenService.createEmailSignupToken(emailHash);
 
     await smtpService
       .sendMail({

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -1,4 +1,5 @@
 import { AccessScope, OrgMembershipStatus } from "@app/db/schemas";
+import { KeyStoreTtls } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
@@ -43,7 +44,7 @@ export const authSignupServiceFactory = ({
   loginService
 }: TAuthSignupDep) => {
   // First step of signup to send OTP email
-  const beginEmailSignupProcess = async (email: string) => {
+  const beginEmailSignupProcess = async (email: string): Promise<{ cooldownSeconds: number }> => {
     const sanitizedEmail = sanitizeEmail(email);
     validateEmail(sanitizedEmail);
     const isEmailInvalid = await isDisposableEmail(sanitizedEmail);
@@ -71,10 +72,10 @@ export const authSignupServiceFactory = ({
         .catch((err) =>
           logger.error(err, "Failed to send existing account email — swallowing to prevent user enumeration")
         );
-      return;
+      return { cooldownSeconds: KeyStoreTtls.EmailSignupResendCooldownInSeconds };
     }
 
-    const token = await tokenService.createEmailSignupToken(sanitizedEmail);
+    const { token, cooldownSeconds } = await tokenService.createEmailSignupToken(sanitizedEmail);
 
     await smtpService
       .sendMail({
@@ -86,6 +87,8 @@ export const authSignupServiceFactory = ({
         }
       })
       .catch((err) => throwIfSmtpError(err, "Failed to send signup verification email"));
+
+    return { cooldownSeconds };
   };
 
   const verifyEmailSignup = async (email: string, code: string) => {

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -42,7 +42,7 @@ export const authSignupServiceFactory = ({
   orgDAL,
   loginService
 }: TAuthSignupDep) => {
-  // first step of signup. create user and send email
+  // First step of signup to send OTP email
   const beginEmailSignupProcess = async (email: string) => {
     const sanitizedEmail = sanitizeEmail(email);
     validateEmail(sanitizedEmail);
@@ -52,8 +52,8 @@ export const authSignupServiceFactory = ({
     }
 
     // akhilmhdh: case sensitive email resolution
-    let user = await userDAL.findOne({ username: sanitizedEmail });
-    if (user && user.isAccepted) {
+    const existingUser = await userDAL.findOne({ username: sanitizedEmail });
+    if (existingUser?.isAccepted) {
       // Send informational email for existing accounts instead of throwing error
       // This prevents user enumeration vulnerability
       const appCfg = getConfig();
@@ -74,20 +74,7 @@ export const authSignupServiceFactory = ({
       return;
     }
 
-    if (!user) {
-      user = await userDAL.create({
-        authMethods: [AuthMethod.EMAIL],
-        username: sanitizedEmail,
-        email: sanitizedEmail,
-        isGhost: false
-      });
-    }
-    if (!user) throw new Error("Failed to create user");
-
-    const token = await tokenService.createTokenForUser({
-      type: TokenType.TOKEN_EMAIL_CONFIRMATION,
-      userId: user.id
-    });
+    const token = await tokenService.createEmailSignupToken(sanitizedEmail);
 
     await smtpService
       .sendMail({
@@ -104,31 +91,29 @@ export const authSignupServiceFactory = ({
   const verifyEmailSignup = async (email: string, code: string) => {
     const sanitizedEmail = sanitizeEmail(email);
     validateEmail(sanitizedEmail);
-    const user = await userDAL.findOne({ username: sanitizedEmail });
 
-    // Always call validateTokenForUser so the response time includes
-    // the bcrypt cost regardless of whether the user exists.
-    // Use a dummy userId when there's no valid user.
-    const shouldReject = !user || user.isAccepted;
+    await tokenService.validateEmailSignupToken(sanitizedEmail, code);
 
-    try {
-      await tokenService.validateTokenForUser({
-        type: TokenType.TOKEN_EMAIL_CONFIRMATION,
-        userId: shouldReject ? DUMMY_USER_ID : user.id,
-        code
+    // Only create (or recover) the user after the OTP has been verified.
+    let user = await userDAL.findOne({ username: sanitizedEmail });
+    if (!user) {
+      user = await userDAL.create({
+        authMethods: [AuthMethod.EMAIL],
+        username: sanitizedEmail,
+        email: sanitizedEmail,
+        isGhost: false,
+        isEmailVerified: true
       });
-    } catch {
-      // If we were going to reject anyway, throw the generic message.
-      // If the user was valid but the token failed, same generic message.
+    } else if (!user.isAccepted) {
+      // Migration path: pre-user created by the old flow before this refactor.
+      await userDAL.updateById(user.id, { isEmailVerified: true });
+      user = { ...user, isEmailVerified: true };
+    } else {
+      // isAccepted guard should have been caught in beginEmailSignupProcess, but defend here too.
       throw new Error("Invalid or expired verification request");
     }
 
-    // Reject *after* the constant-time token validation work.
-    if (shouldReject) {
-      throw new Error("Invalid or expired verification request");
-    }
-
-    await userDAL.updateById(user.id, { isEmailVerified: true });
+    if (!user) throw new Error("Failed to create user");
 
     const appCfg = getConfig();
     const jwtToken = crypto.jwt().sign(

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -113,8 +113,6 @@ export const authSignupServiceFactory = ({
       throw new Error("Invalid or expired verification request");
     }
 
-    if (!user) throw new Error("Failed to create user");
-
     const appCfg = getConfig();
     const jwtToken = crypto.jwt().sign(
       {

--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -69,17 +69,8 @@ export default function CodeInputStep({
 
   const [code, setCode] = useState("");
 
-  // Store absolute expiry time (source of truth)
-  const endTimeRef = useRef<number>(0);
-  // Force UI refresh every second
+  const endTimeRef = useRef<number>(initialCooldown > 0 ? Date.now() + initialCooldown * 1000 : 0);
   const [, forceRender] = useState(0);
-
-  // Initialize cooldown from server
-  useEffect(() => {
-    if (initialCooldown > 0) {
-      endTimeRef.current = Date.now() + initialCooldown * 1000;
-    }
-  }, [initialCooldown]);
 
   // Tick every second
   useEffect(() => {

--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ReactCodeInput from "react-code-input";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
@@ -10,7 +10,6 @@ import { useSendVerificationEmail, useVerifySignupEmailVerificationCode } from "
 
 import SecurityClient from "../utilities/SecurityClient";
 
-// Matches v3 input theme: transparent bg, border (#2b2c30), foreground text (#ebebeb), ring on focus (#2d2f33)
 const codeInputStyle = {
   inputStyle: {
     fontFamily: "monospace",
@@ -65,15 +64,35 @@ export default function CodeInputStep({
     isPending: isVerifying,
     isError: isCodeError
   } = useVerifySignupEmailVerificationCode();
-  const [code, setCode] = useState("");
-  const [cooldown, setCooldown] = useState(initialCooldown);
+
   const { t } = useTranslation();
 
+  const [code, setCode] = useState("");
+
+  // Store absolute expiry time (source of truth)
+  const endTimeRef = useRef<number>(0);
+  // Force UI refresh every second
+  const [, forceRender] = useState(0);
+
+  // Initialize cooldown from server
   useEffect(() => {
-    if (cooldown <= 0) return undefined;
-    const timer = setInterval(() => setCooldown((s) => s - 1), 1000);
+    if (initialCooldown > 0) {
+      endTimeRef.current = Date.now() + initialCooldown * 1000;
+    }
+  }, [initialCooldown]);
+
+  // Tick every second
+  useEffect(() => {
+    const timer = setInterval(() => {
+      forceRender((x) => x + 1);
+    }, 1000);
+
     return () => clearInterval(timer);
-  }, [cooldown]);
+  }, []);
+
+  const remainingCooldown = Math.max(0, Math.ceil((endTimeRef.current - Date.now()) / 1000));
+
+  const isCooldownActive = endTimeRef.current > Date.now();
 
   const handleVerify = async () => {
     const { token } = await verifyCode({ email, code });
@@ -84,20 +103,23 @@ export default function CodeInputStep({
   const handleResend = async () => {
     try {
       const { cooldownSeconds } = await resendEmail({ email });
-      setCooldown(cooldownSeconds);
+      endTimeRef.current = Date.now() + cooldownSeconds * 1000;
     } catch (err) {
       if (axios.isAxiosError(err)) {
         const remaining = err.response?.data?.details?.cooldownSeconds;
         if (typeof remaining === "number") {
-          setCooldown(remaining);
+          endTimeRef.current = Date.now() + remaining * 1000;
         }
       }
     }
   };
 
   let resendLabel = t("signup.step2-resend-submit");
-  if (isResending) resendLabel = t("signup.step2-resend-progress");
-  else if (cooldown > 0) resendLabel = `${t("signup.step2-resend-submit")} (${cooldown}s)`;
+  if (isResending) {
+    resendLabel = t("signup.step2-resend-progress");
+  } else if (remainingCooldown > 0) {
+    resendLabel = `${t("signup.step2-resend-submit")} (${remainingCooldown}s)`;
+  }
 
   return (
     <div className="mx-auto flex w-full flex-col items-center justify-center">
@@ -147,10 +169,14 @@ export default function CodeInputStep({
           </div>
           <div className="mt-6 flex flex-col items-center gap-2 text-xs text-label">
             <div className="flex flex-row items-baseline gap-1">
-              <button disabled={isResending || cooldown > 0} onClick={handleResend} type="button">
+              <button
+                disabled={isResending || isCooldownActive}
+                onClick={handleResend}
+                type="button"
+              >
                 <span
                   className={
-                    cooldown > 0
+                    remainingCooldown > 0
                       ? "text-label/60"
                       : "cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2"
                   }

--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ReactCodeInput from "react-code-input";
 import { useTranslation } from "react-i18next";
 import { Link } from "@tanstack/react-router";
+import axios from "axios";
 
 import { Button, Card, CardContent, CardHeader, CardTitle, FieldError } from "@app/components/v3";
 import { useSendVerificationEmail, useVerifySignupEmailVerificationCode } from "@app/hooks/api";
@@ -50,9 +51,14 @@ const codeInputStylePhone = {
 interface CodeInputStepProps {
   email: string;
   onComplete: () => void;
+  initialCooldown: number;
 }
 
-export default function CodeInputStep({ email, onComplete }: CodeInputStepProps): JSX.Element {
+export default function CodeInputStep({
+  email,
+  onComplete,
+  initialCooldown
+}: CodeInputStepProps): JSX.Element {
   const { mutateAsync: resendEmail, isPending: isResending } = useSendVerificationEmail();
   const {
     mutateAsync: verifyCode,
@@ -60,13 +66,38 @@ export default function CodeInputStep({ email, onComplete }: CodeInputStepProps)
     isError: isCodeError
   } = useVerifySignupEmailVerificationCode();
   const [code, setCode] = useState("");
+  const [cooldown, setCooldown] = useState(initialCooldown);
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (cooldown <= 0) return undefined;
+    const timer = setInterval(() => setCooldown((s) => s - 1), 1000);
+    return () => clearInterval(timer);
+  }, [cooldown]);
 
   const handleVerify = async () => {
     const { token } = await verifyCode({ email, code });
     SecurityClient.setSignupToken(token);
     onComplete();
   };
+
+  const handleResend = async () => {
+    try {
+      const { cooldownSeconds } = await resendEmail({ email });
+      setCooldown(cooldownSeconds);
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const remaining = err.response?.data?.details?.cooldownSeconds;
+        if (typeof remaining === "number") {
+          setCooldown(remaining);
+        }
+      }
+    }
+  };
+
+  let resendLabel = t("signup.step2-resend-submit");
+  if (isResending) resendLabel = t("signup.step2-resend-progress");
+  else if (cooldown > 0) resendLabel = `${t("signup.step2-resend-submit")} (${cooldown}s)`;
 
   return (
     <div className="mx-auto flex w-full flex-col items-center justify-center">
@@ -116,12 +147,15 @@ export default function CodeInputStep({ email, onComplete }: CodeInputStepProps)
           </div>
           <div className="mt-6 flex flex-col items-center gap-2 text-xs text-label">
             <div className="flex flex-row items-baseline gap-1">
-              <button disabled={isResending} onClick={() => resendEmail({ email })} type="button">
-                <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">
-                  {t("signup.step2-resend-alert")}{" "}
-                  {isResending
-                    ? t("signup.step2-resend-progress")
-                    : t("signup.step2-resend-submit")}
+              <button disabled={isResending || cooldown > 0} onClick={handleResend} type="button">
+                <span
+                  className={
+                    cooldown > 0
+                      ? "text-label/60"
+                      : "cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2"
+                  }
+                >
+                  {t("signup.step2-resend-alert")} {resendLabel}
                 </span>
               </button>
             </div>

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -29,7 +29,7 @@ interface InitialSignupStepProps {
   email: string;
   setEmail: (value: string) => void;
 
-  incrementStep: () => void;
+  incrementStep: (cooldownSeconds: number) => void;
 }
 
 export default function InitialSignupStep({
@@ -54,9 +54,9 @@ export default function InitialSignupStep({
     }
 
     setEmailError(false);
-    await mutateAsync({ email: email.toLowerCase() });
+    const { cooldownSeconds } = await mutateAsync({ email: email.toLowerCase() });
     setEmail(email.toLowerCase());
-    incrementStep();
+    incrementStep(cooldownSeconds);
   };
 
   const handleSocialSignup = (method: LoginMethod) => {

--- a/frontend/src/hooks/api/auth/queries.tsx
+++ b/frontend/src/hooks/api/auth/queries.tsx
@@ -202,9 +202,10 @@ export const verifySignupInvite = async (details: VerifySignupInviteDTO) => {
 export const useSendVerificationEmail = () => {
   return useMutation({
     mutationFn: async ({ email }: { email: string }) => {
-      const { data } = await apiRequest.post("/api/v3/signup/email/signup", {
-        email
-      });
+      const { data } = await apiRequest.post<{ message: string; cooldownSeconds: number }>(
+        "/api/v3/signup/email/signup",
+        { email }
+      );
 
       return data;
     }

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -33,6 +33,7 @@ export interface SignUpPageProps {
 export const SignUpPage = ({ invite }: SignUpPageProps) => {
   const isInvite = Boolean(invite);
   const [email, setEmail] = useState(invite?.email ?? "");
+  const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
   const [section, setSection] = useState<SignupSection>(
     isInvite ? SignupSection.UserInfo : SignupSection.Email
   );
@@ -51,7 +52,8 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
     }
   }, [config.allowSignUp]);
 
-  const handleEmailComplete = () => {
+  const handleEmailComplete = (cooldownSeconds: number) => {
+    setResendCooldownSeconds(cooldownSeconds);
     if (serverDetails?.emailConfigured) {
       setSection(SignupSection.VerifyCode);
     } else {
@@ -95,7 +97,13 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
           />
         );
       case SignupSection.VerifyCode:
-        return <CodeInputStep email={email} onComplete={handleCodeVerified} />;
+        return (
+          <CodeInputStep
+            email={email}
+            onComplete={handleCodeVerified}
+            initialCooldown={resendCooldownSeconds}
+          />
+        );
       case SignupSection.UserInfo:
         return (
           <UserInfoStep onComplete={handleUserInfoComplete} email={email} isInvite={isInvite} />


### PR DESCRIPTION
## Context

This PR replaces the database-backed email sign-up token flow with a Redis-based HMAC OTP system. Instead of creating a user record before email verification, the new flow stores only a short-lived HMAC of the OTP in Redis, keyed by an HMAC of the email address. The user record is created only after the OTP has been successfully validated. A Redis lock mutex is used to protect the retry-decrement logic from race conditions.

This also adds a sign-up OTP cooldown when requesting a new token. The backend will not issue a new OTP for 60 seconds, and the frontend now displays a countdown timer to provide feedback to the user.

Follow-up needed: create a migration to remove the unused TokenType.TOKEN_EMAIL_CONFIRMATION records from the database once the new flow is fully rolled out.

## Screenshots

<img width="499" height="394" alt="image" src="https://github.com/user-attachments/assets/88dfb225-b92e-4c0f-a6c8-efb295cdd7d4" />

<img width="648" height="707" alt="image" src="https://github.com/user-attachments/assets/5367bc06-4d3e-4867-9a8b-89845f3ca2c1" />

```
{
    "reqId": "req-rTJOrUeFZQPpSe",
    "statusCode": 400,
    "message": "Please wait before requesting another code",
    "error": "BadRequest",
    "details": {
        "cooldownSeconds": 20
    }
}
```

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)