### PR TITLE
feat(gateway): add enrollment flow support to Helm chart and re-add Kubernetes docs

### DIFF
--- a/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
+++ b/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
@@ -36,30 +36,32 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
 
-      - name: Create namespace (legacy)
-        run: kubectl create namespace infisical-gateway-legacy
+      - name: Create namespace
+        run: kubectl create namespace infisical-gateway
 
-      - name: Create gateway secret (legacy)
-        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token --from-literal=INFISICAL_GATEWAY_NAME=ci-test-gateway -n infisical-gateway-legacy
+      - name: Create gateway secret
+        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token --from-literal=INFISICAL_GATEWAY_NAME=ci-test-gateway -n infisical-gateway
 
-      - name: Run chart-testing install (legacy flow)
+      - name: Run chart-testing (install)
         run: |
           ct install \
             --config ct.yaml \
             --charts helm-charts/infisical-gateway \
             --helm-extra-args="--timeout=300s" \
-            --namespace infisical-gateway-legacy
+            --namespace infisical-gateway
 
-      - name: Create namespace (enrollment)
-        run: kubectl create namespace infisical-gateway-enrollment
-
-      - name: Create enrollment token secret
-        run: kubectl create secret generic gateway-enrollment-token --from-literal=enrollment-token=ci-test-token -n infisical-gateway-enrollment
-
-      - name: Run chart-testing install (enrollment flow)
+      - name: Validate enrollment flow templates (token)
         run: |
-          ct install \
-            --config ct.yaml \
-            --charts helm-charts/infisical-gateway \
-            --helm-extra-args="--timeout=300s --set gateway.name=ci-test-gateway --set gateway.enrollment.method=token --set gateway.enrollment.token.existingSecretRef=gateway-enrollment-token --set gateway.domain=https://app.infisical.com" \
-            --namespace infisical-gateway-enrollment
+          helm template test-token helm-charts/infisical-gateway \
+            --set gateway.name=ci-test-gateway \
+            --set gateway.enrollment.method=token \
+            --set gateway.enrollment.token.value=ci-test-token \
+            --set gateway.domain=https://app.infisical.com
+
+      - name: Validate enrollment flow templates (aws)
+        run: |
+          helm template test-aws helm-charts/infisical-gateway \
+            --set gateway.name=ci-test-gateway \
+            --set gateway.enrollment.method=aws \
+            --set gateway.enrollment.aws.gatewayId=ci-test-id \
+            --set gateway.domain=https://app.infisical.com

--- a/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
+++ b/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
@@ -36,16 +36,30 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.12.0
 
-      - name: Create namespace
-        run: kubectl create namespace infisical-gateway
+      - name: Create namespace (legacy)
+        run: kubectl create namespace infisical-gateway-legacy
 
-      - name: Create gateway secret
-        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token --from-literal=INFISICAL_GATEWAY_NAME=ci-test-gateway -n infisical-gateway
+      - name: Create gateway secret (legacy)
+        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token --from-literal=INFISICAL_GATEWAY_NAME=ci-test-gateway -n infisical-gateway-legacy
 
-      - name: Run chart-testing (install)
+      - name: Run chart-testing install (legacy flow)
         run: |
           ct install \
             --config ct.yaml \
             --charts helm-charts/infisical-gateway \
             --helm-extra-args="--timeout=300s" \
-            --namespace infisical-gateway
+            --namespace infisical-gateway-legacy
+
+      - name: Create namespace (enrollment)
+        run: kubectl create namespace infisical-gateway-enrollment
+
+      - name: Create enrollment token secret
+        run: kubectl create secret generic gateway-enrollment-token --from-literal=enrollment-token=ci-test-token -n infisical-gateway-enrollment
+
+      - name: Run chart-testing install (enrollment flow)
+        run: |
+          ct install \
+            --config ct.yaml \
+            --charts helm-charts/infisical-gateway \
+            --helm-extra-args="--timeout=300s --set gateway.name=ci-test-gateway --set gateway.enrollment.method=token --set gateway.enrollment.token.existingSecretRef=gateway-enrollment-token --set gateway.domain=https://app.infisical.com" \
+            --namespace infisical-gateway-enrollment

--- a/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
+++ b/.github/workflows/run-helm-chart-tests-infisical-gateway.yml
@@ -40,7 +40,7 @@ jobs:
         run: kubectl create namespace infisical-gateway
 
       - name: Create gateway secret
-        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token -n infisical-gateway
+        run: kubectl create secret generic infisical-gateway-environment --from-literal=TOKEN=my-test-token --from-literal=INFISICAL_GATEWAY_NAME=ci-test-gateway -n infisical-gateway
 
       - name: Run chart-testing (install)
         run: |

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -137,7 +137,7 @@ This guide covers everything you need to deploy and configure Infisical Gateways
               --set gateway.enrollment.method=aws \
               --set gateway.enrollment.aws.gatewayId=<gateway-id> \
               --set gateway.domain=<your-infisical-domain> \
-              --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<account-id>:role/<role-name> \
+              --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<account-id>:role/<role-name>
             ```
 
             <Info>

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -82,8 +82,8 @@ This guide covers everything you need to deploy and configure Infisical Gateways
             ```bash
             helm install infisical-gateway infisical/infisical-gateway \
               --set gateway.name=<gateway-name> \
-              --set gateway.enrollMethod=token \
-              --set gateway.token.existingSecret=gateway-enrollment-token \
+              --set gateway.enrollment.method=token \
+              --set gateway.enrollment.token.existingSecret=gateway-enrollment-token \
               --set gateway.domain=<your-infisical-domain>
             ```
 
@@ -95,8 +95,8 @@ This guide covers everything you need to deploy and configure Infisical Gateways
             ```bash
             helm install infisical-gateway infisical/infisical-gateway \
               --set gateway.name=<gateway-name> \
-              --set gateway.enrollMethod=token \
-              --set gateway.token.value=<enrollment-token> \
+              --set gateway.enrollment.method=token \
+              --set gateway.enrollment.token.value=<enrollment-token> \
               --set gateway.domain=<your-infisical-domain>
             ```
           </Tab>
@@ -134,16 +134,11 @@ This guide covers everything you need to deploy and configure Infisical Gateways
             ```bash
             helm install infisical-gateway infisical/infisical-gateway \
               --set gateway.name=<gateway-name> \
-              --set gateway.enrollMethod=aws \
-              --set gateway.aws.gatewayId=<gateway-id> \
+              --set gateway.enrollment.method=aws \
+              --set gateway.enrollment.aws.gatewayId=<gateway-id> \
               --set gateway.domain=<your-infisical-domain> \
               --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<account-id>:role/<role-name> \
-              --set persistence.enabled=false
             ```
-
-            <Info>
-              With AWS auth, persistence is optional since the gateway re-authenticates via STS on every start. You can disable it with `persistence.enabled=false` to avoid provisioning a PersistentVolumeClaim.
-            </Info>
 
             <Info>
               Ensure the IAM role's trust policy allows the Kubernetes service account to assume it, and that the role's ARN or account ID is in the gateway's AWS auth allowlist in the Infisical UI.

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -65,6 +65,41 @@ This guide covers everything you need to deploy and configure Infisical Gateways
               --domain=<your-infisical-domain>
             ```
           </Tab>
+          <Tab title="Kubernetes (Helm)">
+            Install the Infisical Helm chart repository:
+            ```bash
+            helm repo add infisical https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+            helm repo update
+            ```
+
+            Create a Kubernetes Secret with your enrollment token:
+            ```bash
+            kubectl create secret generic gateway-enrollment-token \
+              --from-literal=enrollment-token=<enrollment-token>
+            ```
+
+            Install the gateway:
+            ```bash
+            helm install infisical-gateway infisical/infisical-gateway \
+              --set gateway.name=<gateway-name> \
+              --set gateway.enrollMethod=token \
+              --set gateway.token.existingSecret=gateway-enrollment-token \
+              --set gateway.domain=<your-infisical-domain>
+            ```
+
+            <Info>
+              A PersistentVolumeClaim is created by default to store enrollment credentials across pod restarts. The enrollment token is single-use. Without persistent storage, the gateway cannot restart after the initial enrollment.
+            </Info>
+
+            You can also pass the token inline (the chart creates the Secret for you):
+            ```bash
+            helm install infisical-gateway infisical/infisical-gateway \
+              --set gateway.name=<gateway-name> \
+              --set gateway.enrollMethod=token \
+              --set gateway.token.value=<enrollment-token> \
+              --set gateway.domain=<your-infisical-domain>
+            ```
+          </Tab>
         </Tabs>
       </Accordion>
       <Accordion title="AWS Auth">
@@ -87,6 +122,32 @@ This guide covers everything you need to deploy and configure Infisical Gateways
               --gateway-id=<gateway-id> \
               --domain=<your-infisical-domain>
             ```
+          </Tab>
+          <Tab title="Kubernetes (Helm)">
+            Install the Infisical Helm chart repository:
+            ```bash
+            helm repo add infisical https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/
+            helm repo update
+            ```
+
+            Install the gateway with [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html):
+            ```bash
+            helm install infisical-gateway infisical/infisical-gateway \
+              --set gateway.name=<gateway-name> \
+              --set gateway.enrollMethod=aws \
+              --set gateway.aws.gatewayId=<gateway-id> \
+              --set gateway.domain=<your-infisical-domain> \
+              --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<account-id>:role/<role-name> \
+              --set persistence.enabled=false
+            ```
+
+            <Info>
+              With AWS auth, persistence is optional since the gateway re-authenticates via STS on every start. You can disable it with `persistence.enabled=false` to avoid provisioning a PersistentVolumeClaim.
+            </Info>
+
+            <Info>
+              Ensure the IAM role's trust policy allows the Kubernetes service account to assume it, and that the role's ARN or account ID is in the gateway's AWS auth allowlist in the Infisical UI.
+            </Info>
           </Tab>
         </Tabs>
       </Accordion>

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -83,7 +83,7 @@ This guide covers everything you need to deploy and configure Infisical Gateways
             helm install infisical-gateway infisical/infisical-gateway \
               --set gateway.name=<gateway-name> \
               --set gateway.enrollment.method=token \
-              --set gateway.enrollment.token.existingSecret=gateway-enrollment-token \
+              --set gateway.enrollment.token.existingSecretRef=gateway-enrollment-token \
               --set gateway.domain=<your-infisical-domain>
             ```
 

--- a/docs/documentation/platform/identities/kubernetes-auth.mdx
+++ b/docs/documentation/platform/identities/kubernetes-auth.mdx
@@ -173,7 +173,7 @@ In the following steps, we explore how to create and use identities for your app
 
         <Steps>
           <Step title="Deploying a gateway">
-            To deploy a gateway in your Kubernetes cluster, follow our [Gateway deployment guide using helm](/documentation/platform/gateways/overview).
+            To deploy a gateway in your Kubernetes cluster, follow our [Gateway deployment guide using Helm](/documentation/platform/gateways/gateway-deployment).
           </Step>
 
           <Step title="Grant the gateway the system:auth-delegator ClusterRole binding">

--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added support for the new enrollment-based gateway registration flow (`gateway.enrollMethod: token` or `aws`).
 * Added PersistentVolumeClaim support (`persistence.*`) for credential storage across pod restarts.
 * Added optional Secret template for inline enrollment token values (`gateway.token.value`).
+* Updated default CLI image version from `0.43.39` to `0.43.84`.
 * The legacy machine identity flow (`secret.name` with envFrom) remains fully supported when `gateway.enrollMethod` is unset.
 
 ## 1.0.4 (December 9, 2025)

--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (May 11, 2026)
+* Added support for the new enrollment-based gateway registration flow (`gateway.enrollMethod: token` or `aws`).
+* Added PersistentVolumeClaim support (`persistence.*`) for credential storage across pod restarts.
+* Added optional Secret template for inline enrollment token values (`gateway.token.value`).
+* The legacy machine identity flow (`secret.name` with envFrom) remains fully supported when `gateway.enrollMethod` is unset.
+
 ## 1.0.4 (December 9, 2025)
 * Updated default CLI image version from `0.43.0` to `0.43.39`.
 * Added new `gateway.pamSessionRecordingsDirectory`, allowing users to specify the folder where temporary session recording files for PAM are stored. Defaults to `/var/lib/infisical/session_recordings`

--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 1.1.0 (May 11, 2026)
-* Added support for the new enrollment-based gateway registration flow (`gateway.enrollMethod: token` or `aws`).
+* Added support for the new enrollment-based gateway registration flow (`gateway.enrollment.method: token` or `aws`).
 * Added PersistentVolumeClaim support (`persistence.*`) for credential storage across pod restarts.
-* Added optional Secret template for inline enrollment token values (`gateway.token.value`).
+* Added optional Secret template for inline enrollment token values (`gateway.enrollment.token.value`).
 * Updated default CLI image version from `0.43.39` to `0.43.84`.
-* The legacy machine identity flow (`secret.name` with envFrom) remains fully supported when `gateway.enrollMethod` is unset.
+* The legacy machine identity flow (`secret.name` with envFrom) remains fully supported when `gateway.enrollment.method` is unset.
 
 ## 1.0.4 (December 9, 2025)
 * Updated default CLI image version from `0.43.0` to `0.43.39`.

--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.5"
+appVersion: "1.1.0"

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -1,3 +1,11 @@
+{{- if eq .Values.gateway.enrollMethod "token" }}
+  {{- if not .Values.persistence.enabled }}
+    {{- fail "persistence.enabled must be true when gateway.enrollMethod is 'token'. The enrollment token is single-use and credentials must persist across pod restarts." }}
+  {{- end }}
+  {{- if not (or .Values.gateway.token.value .Values.gateway.token.existingSecret) }}
+    {{- fail "gateway.token.value or gateway.token.existingSecret is required when gateway.enrollMethod is 'token'." }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,6 +13,13 @@ metadata:
   labels:
     {{- include "infisical-gateway.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.gateway.enrollMethod }}
+  replicas: 1
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "infisical-gateway.selectorLabels" . | nindent 6 }}
@@ -30,10 +45,27 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.gateway.enrollMethod }}
+        - name: gateway-credentials
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-credentials" (include "infisical-gateway.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: infisical-cache
+          emptyDir: {}
+        {{- $sessionPath := .Values.gateway.pamSessionRecordingsDirectory | default "/var/lib/infisical/session_recordings" }}
+        {{- if not (hasPrefix "/var/lib/infisical" $sessionPath) }}
+        - name: session-recordings
+          emptyDir: {}
+        {{- end }}
+        {{- else }}
         - name: infisical-gateway-session-recordings-data
           emptyDir: {}
         - name: infisical-gateway-cached-relay-data
           emptyDir: {}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}
@@ -42,6 +74,49 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.gateway.enrollMethod }}
+          {{- if .Values.gateway.credentialsSecretRef }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.gateway.credentialsSecretRef }}
+          {{- end }}
+          env:
+            - name: HOME
+              value: /home/infisical
+            {{- if eq .Values.gateway.enrollMethod "token" }}
+            - name: INFISICAL_ENROLLMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.gateway.token.existingSecret | default (printf "%s-enrollment-token" (include "infisical-gateway.fullname" .)) }}
+                  key: {{ .Values.gateway.token.secretKey | default "enrollment-token" }}
+            {{- end }}
+          args:
+            - gateway
+            - start
+            - {{ required "gateway.name is required when gateway.enrollMethod is set" .Values.gateway.name | quote }}
+            - --enroll-method={{ .Values.gateway.enrollMethod }}
+            - --domain={{ required "gateway.domain is required when gateway.enrollMethod is set" .Values.gateway.domain }}
+            {{- if eq .Values.gateway.enrollMethod "token" }}
+            - --token=$(INFISICAL_ENROLLMENT_TOKEN)
+            {{- end }}
+            {{- if eq .Values.gateway.enrollMethod "aws" }}
+            - --gateway-id={{ required "gateway.aws.gatewayId is required when gateway.enrollMethod is 'aws'" .Values.gateway.aws.gatewayId }}
+            {{- end }}
+            {{- if .Values.gateway.relayName }}
+            - --target-relay-name={{ .Values.gateway.relayName }}
+            {{- end }}
+            - --pam-session-recording-path={{ .Values.gateway.pamSessionRecordingsDirectory | default "/var/lib/infisical/session_recordings" }}
+          volumeMounts:
+            - name: gateway-credentials
+              mountPath: /home/infisical
+            - name: infisical-cache
+              mountPath: /var/lib/infisical
+            {{- $sessionPath := .Values.gateway.pamSessionRecordingsDirectory | default "/var/lib/infisical/session_recordings" }}
+            {{- if not (hasPrefix "/var/lib/infisical" $sessionPath) }}
+            - name: session-recordings
+              mountPath: {{ $sessionPath }}
+            {{- end }}
+          {{- else }}
           args:
             - gateway
             - start
@@ -61,6 +136,7 @@ spec:
             - name: infisical-gateway-session-recordings-data
               mountPath: {{ $sessionPath }}
             {{- end }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -1,9 +1,9 @@
-{{- if eq .Values.gateway.enrollMethod "token" }}
+{{- if eq .Values.gateway.enrollment.method "token" }}
   {{- if not .Values.persistence.enabled }}
-    {{- fail "persistence.enabled must be true when gateway.enrollMethod is 'token'. The enrollment token is single-use and credentials must persist across pod restarts." }}
+    {{- fail "persistence.enabled must be true when gateway.enrollment.method is 'token'. The enrollment token is single-use and credentials must persist across pod restarts." }}
   {{- end }}
-  {{- if not (or .Values.gateway.token.value .Values.gateway.token.existingSecret) }}
-    {{- fail "gateway.token.value or gateway.token.existingSecret is required when gateway.enrollMethod is 'token'." }}
+  {{- if not (or .Values.gateway.enrollment.token.value .Values.gateway.enrollment.token.existingSecret) }}
+    {{- fail "gateway.enrollment.token.value or gateway.enrollment.token.existingSecret is required when gateway.enrollment.method is 'token'." }}
   {{- end }}
 {{- end }}
 apiVersion: apps/v1
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "infisical-gateway.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.gateway.enrollMethod }}
+  {{- if .Values.gateway.enrollment.method }}
   replicas: 1
   {{- if .Values.persistence.enabled }}
   strategy:
@@ -45,7 +45,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if .Values.gateway.enrollMethod }}
+        {{- if .Values.gateway.enrollment.method }}
         - name: gateway-credentials
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -74,33 +74,33 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.gateway.enrollMethod }}
-          {{- if .Values.gateway.credentialsSecretRef }}
+          {{- if .Values.gateway.enrollment.method }}
+          {{- if .Values.gateway.enrollment.credentialsSecretRef }}
           envFrom:
             - secretRef:
-                name: {{ .Values.gateway.credentialsSecretRef }}
+                name: {{ .Values.gateway.enrollment.credentialsSecretRef }}
           {{- end }}
           env:
             - name: HOME
               value: /home/infisical
-            {{- if eq .Values.gateway.enrollMethod "token" }}
+            {{- if eq .Values.gateway.enrollment.method "token" }}
             - name: INFISICAL_ENROLLMENT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.gateway.token.existingSecret | default (printf "%s-enrollment-token" (include "infisical-gateway.fullname" .)) }}
-                  key: {{ .Values.gateway.token.secretKey | default "enrollment-token" }}
+                  name: {{ .Values.gateway.enrollment.token.existingSecret | default (printf "%s-enrollment-token" (include "infisical-gateway.fullname" .)) }}
+                  key: {{ .Values.gateway.enrollment.token.secretKey | default "enrollment-token" }}
             {{- end }}
           args:
             - gateway
             - start
-            - {{ required "gateway.name is required when gateway.enrollMethod is set" .Values.gateway.name | quote }}
-            - --enroll-method={{ .Values.gateway.enrollMethod }}
-            - --domain={{ required "gateway.domain is required when gateway.enrollMethod is set" .Values.gateway.domain }}
-            {{- if eq .Values.gateway.enrollMethod "token" }}
+            - {{ required "gateway.name is required when gateway.enrollment.method is set" .Values.gateway.name | quote }}
+            - --enroll-method={{ .Values.gateway.enrollment.method }}
+            - --domain={{ required "gateway.domain is required when gateway.enrollment.method is set" .Values.gateway.domain }}
+            {{- if eq .Values.gateway.enrollment.method "token" }}
             - --token=$(INFISICAL_ENROLLMENT_TOKEN)
             {{- end }}
-            {{- if eq .Values.gateway.enrollMethod "aws" }}
-            - --gateway-id={{ required "gateway.aws.gatewayId is required when gateway.enrollMethod is 'aws'" .Values.gateway.aws.gatewayId }}
+            {{- if eq .Values.gateway.enrollment.method "aws" }}
+            - --gateway-id={{ required "gateway.enrollment.aws.gatewayId is required when gateway.enrollment.method is 'aws'" .Values.gateway.enrollment.aws.gatewayId }}
             {{- end }}
             {{- if .Values.gateway.relayName }}
             - --target-relay-name={{ .Values.gateway.relayName }}

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -3,7 +3,7 @@
     {{- fail "persistence.enabled must be true when gateway.enrollment.method is 'token'. The enrollment token is single-use and credentials must persist across pod restarts." }}
   {{- end }}
   {{- if not (or .Values.gateway.enrollment.token.value .Values.gateway.enrollment.token.existingSecretRef) }}
-    {{- fail "gateway.enrollment.token.value or gateway.enrollment.token.existingSecret is required when gateway.enrollment.method is 'token'." }}
+    {{- fail "gateway.enrollment.token.value or gateway.enrollment.token.existingSecretRef is required when gateway.enrollment.method is 'token'." }}
   {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -2,7 +2,7 @@
   {{- if not .Values.persistence.enabled }}
     {{- fail "persistence.enabled must be true when gateway.enrollment.method is 'token'. The enrollment token is single-use and credentials must persist across pod restarts." }}
   {{- end }}
-  {{- if not (or .Values.gateway.enrollment.token.value .Values.gateway.enrollment.token.existingSecret) }}
+  {{- if not (or .Values.gateway.enrollment.token.value .Values.gateway.enrollment.token.existingSecretRef) }}
     {{- fail "gateway.enrollment.token.value or gateway.enrollment.token.existingSecret is required when gateway.enrollment.method is 'token'." }}
   {{- end }}
 {{- end }}
@@ -87,7 +87,7 @@ spec:
             - name: INFISICAL_ENROLLMENT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.gateway.enrollment.token.existingSecret | default (printf "%s-enrollment-token" (include "infisical-gateway.fullname" .)) }}
+                  name: {{ .Values.gateway.enrollment.token.existingSecretRef | default (printf "%s-enrollment-token" (include "infisical-gateway.fullname" .)) }}
                   key: {{ .Values.gateway.enrollment.token.secretKey | default "enrollment-token" }}
             {{- end }}
           args:

--- a/helm-charts/infisical-gateway/templates/pvc.yaml
+++ b/helm-charts/infisical-gateway/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enrollMethod .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.gateway.enrollment.method .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm-charts/infisical-gateway/templates/pvc.yaml
+++ b/helm-charts/infisical-gateway/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.gateway.enrollMethod .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "infisical-gateway.fullname" . }}-credentials
+  labels:
+    {{- include "infisical-gateway.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/helm-charts/infisical-gateway/templates/secret.yaml
+++ b/helm-charts/infisical-gateway/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.gateway.enrollMethod "token") .Values.gateway.token.value (not .Values.gateway.token.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "infisical-gateway.fullname" . }}-enrollment-token
+  labels:
+    {{- include "infisical-gateway.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.gateway.token.secretKey | default "enrollment-token" }}: {{ .Values.gateway.token.value | b64enc | quote }}
+{{- end }}

--- a/helm-charts/infisical-gateway/templates/secret.yaml
+++ b/helm-charts/infisical-gateway/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.gateway.enrollMethod "token") .Values.gateway.token.value (not .Values.gateway.token.existingSecret) }}
+{{- if and (eq .Values.gateway.enrollment.method "token") .Values.gateway.enrollment.token.value (not .Values.gateway.enrollment.token.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +7,5 @@ metadata:
     {{- include "infisical-gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.gateway.token.secretKey | default "enrollment-token" }}: {{ .Values.gateway.token.value | b64enc | quote }}
+  {{ .Values.gateway.enrollment.token.secretKey | default "enrollment-token" }}: {{ .Values.gateway.enrollment.token.value | b64enc | quote }}
 {{- end }}

--- a/helm-charts/infisical-gateway/templates/secret.yaml
+++ b/helm-charts/infisical-gateway/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.gateway.enrollment.method "token") .Values.gateway.enrollment.token.value (not .Values.gateway.enrollment.token.existingSecret) }}
+{{- if and (eq .Values.gateway.enrollment.method "token") .Values.gateway.enrollment.token.value (not .Values.gateway.enrollment.token.existingSecretRef) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -1,16 +1,58 @@
 image:
   repository: infisical/cli
-  tag: "0.43.39"
+  tag: "0.43.84"
   pullPolicy: IfNotPresent
 
+# Machine identity flow: name of the K8s Secret containing env vars like INFISICAL_AUTH_METHOD, etc.
+# Only used when gateway.enrollMethod is unset.
 secret:
-  # The secret that contains the environment variables to be used by the gateway, such as INFISICAL_API_URL and TOKEN
   name: "infisical-gateway-environment"
 
 gateway:
-  # Specify where to save PAM session recordings. This directory will always be created when the gateway starts.
-  # Defaults to /var/lib/infisical/session_recordings.
+  # Enrollment method: "token" or "aws".
+  # Leave empty to use the legacy machine identity flow (env vars from secret.name).
+  enrollMethod: ""
+
+  # Required when enrollMethod is set. Name of the gateway created in the Infisical UI.
+  name: ""
+
+  # Required when enrollMethod is set. Infisical instance URL (e.g. https://app.infisical.com).
+  domain: ""
+
+  # Token enrollment settings (enrollMethod=token)
+  token:
+    # Inline enrollment token value. Mutually exclusive with existingSecret.
+    value: ""
+    # Name of an existing K8s Secret containing the enrollment token.
+    existingSecret: ""
+    # Key within the secret that holds the enrollment token.
+    secretKey: "enrollment-token"
+
+  # AWS enrollment settings (enrollMethod=aws)
+  aws:
+    # Required when enrollMethod=aws. Gateway ID from the Infisical UI.
+    gatewayId: ""
+
+  # Name of a K8s Secret whose key-value pairs are injected as env vars.
+  # Use this to provide credentials for the enrollment method (e.g. AWS keys, GCP credentials).
+  # Not needed when credentials are provided via workload identity (IRSA, GCP Workload Identity, etc.).
+  credentialsSecretRef: ""
+
+  # Specific relay to connect to. Leave empty for automatic selection.
+  relayName: ""
+
   pamSessionRecordingsDirectory: /var/lib/infisical/session_recordings
+
+# Persistent storage for gateway credentials (enrollment flow only).
+# Required when enrollMethod=token so credentials survive pod restarts.
+# Optional when enrollMethod=aws since it re-authenticates via STS on every start.
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 100Mi
+  accessModes:
+    - ReadWriteOnce
+  existingClaim: ""
 
 resources:
   limits:
@@ -35,6 +77,7 @@ podAnnotations: {}
 podLabels: {}
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 1000
 
 securityContext:
   runAsNonRoot: true

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -45,8 +45,8 @@ gateway:
   pamSessionRecordingsDirectory: /var/lib/infisical/session_recordings
 
 # Persistent storage for gateway credentials (enrollment flow only).
-# Required when enrollMethod=token so credentials survive pod restarts.
-# Optional when enrollMethod=aws since it re-authenticates via STS on every start.
+# Required when enrollment.method=token so credentials survive pod restarts.
+# Optional when enrollment.method=aws since it re-authenticates via STS on every start.
 persistence:
   enabled: true
   storageClass: ""

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -22,10 +22,10 @@ gateway:
 
     # Token enrollment settings (method=token)
     token:
-      # Inline enrollment token value. Mutually exclusive with existingSecret.
+      # Inline enrollment token value. Mutually exclusive with existingSecretRef.
       value: ""
       # Name of an existing K8s Secret containing the enrollment token.
-      existingSecret: ""
+      existingSecretRef: ""
       # Key within the secret that holds the enrollment token.
       secretKey: "enrollment-token"
 

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -4,39 +4,40 @@ image:
   pullPolicy: IfNotPresent
 
 # Machine identity flow: name of the K8s Secret containing env vars like INFISICAL_AUTH_METHOD, etc.
-# Only used when gateway.enrollMethod is unset.
+# Only used when gateway.enrollment.method is unset.
 secret:
   name: "infisical-gateway-environment"
 
 gateway:
-  # Enrollment method: "token" or "aws".
-  # Leave empty to use the legacy machine identity flow (env vars from secret.name).
-  enrollMethod: ""
-
-  # Required when enrollMethod is set. Name of the gateway created in the Infisical UI.
+  # Name of the gateway created in the Infisical UI. Required when enrollment.method is set.
   name: ""
 
-  # Required when enrollMethod is set. Infisical instance URL (e.g. https://app.infisical.com).
+  # Infisical instance URL (e.g. https://app.infisical.com). Required when enrollment.method is set.
   domain: ""
 
-  # Token enrollment settings (enrollMethod=token)
-  token:
-    # Inline enrollment token value. Mutually exclusive with existingSecret.
-    value: ""
-    # Name of an existing K8s Secret containing the enrollment token.
-    existingSecret: ""
-    # Key within the secret that holds the enrollment token.
-    secretKey: "enrollment-token"
+  enrollment:
+    # Enrollment method: "token" or "aws".
+    # Leave empty to use the legacy machine identity flow (env vars from secret.name).
+    method: ""
 
-  # AWS enrollment settings (enrollMethod=aws)
-  aws:
-    # Required when enrollMethod=aws. Gateway ID from the Infisical UI.
-    gatewayId: ""
+    # Token enrollment settings (method=token)
+    token:
+      # Inline enrollment token value. Mutually exclusive with existingSecret.
+      value: ""
+      # Name of an existing K8s Secret containing the enrollment token.
+      existingSecret: ""
+      # Key within the secret that holds the enrollment token.
+      secretKey: "enrollment-token"
 
-  # Name of a K8s Secret whose key-value pairs are injected as env vars.
-  # Use this to provide credentials for the enrollment method (e.g. AWS keys, GCP credentials).
-  # Not needed when credentials are provided via workload identity (IRSA, GCP Workload Identity, etc.).
-  credentialsSecretRef: ""
+    # AWS enrollment settings (method=aws)
+    aws:
+      # Required when method=aws. Gateway ID from the Infisical UI.
+      gatewayId: ""
+
+    # Name of a K8s Secret whose key-value pairs are injected as env vars.
+    # Use this to provide credentials for the enrollment method (e.g. AWS keys, GCP credentials).
+    # Not needed when credentials are provided via workload identity (IRSA, GCP Workload Identity, etc.).
+    credentialsSecretRef: ""
 
   # Specific relay to connect to. Leave empty for automatic selection.
   relayName: ""


### PR DESCRIPTION
## Context

The gateway Helm deployment docs were removed when the gateway registration flow was revamped to use enrollment tokens. The Helm chart itself still only supported the old machine identity flow. This PR adds enrollment flow support to the chart (token + AWS auth) and re-adds the Kubernetes deployment docs.

The chart auto-detects which flow to use based on `gateway.enrollMethod`: when set, it uses the new enrollment flow with CLI args; when empty, it falls back to the legacy machine identity flow (envFrom). Fully backward compatible.

Tested all three flows (token enrollment, AWS enrollment, machine identity) in a local kind cluster.

## Steps to verify the change

1. `helm template` with no `enrollMethod` renders identically to v1.0.5 (old flow)
2. `helm template` with `gateway.enrollMethod=token` renders CLI args, Secret, PVC
3. `helm template` with `gateway.enrollMethod=aws` renders CLI args, no Secret
4. `helm template` with `enrollMethod=token` and `persistence.enabled=false` fails with validation error
5. `helm template` with `enrollMethod=token` and no token source fails with validation error
6. Kubernetes (Helm) tabs render correctly in the gateway deployment docs

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)