### PR TITLE
docs(honey): add walkthrough video to honey tokens overview

### DIFF
--- a/docs/documentation/platform/honey-tokens/overview.mdx
+++ b/docs/documentation/platform/honey-tokens/overview.mdx
@@ -10,6 +10,23 @@ Each honey token is planted alongside your real secrets so it appears genuine. A
 
 At this time, we only support [AWS IAM](/documentation/platform/honey-tokens/aws/usage) credentials as honey tokens, but we're planning to support more providers in the near future.
 
+The short video below walks through how honey tokens work in Infisical and how to use them to catch unauthorized access to your secrets.
+
+<br />
+
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/ifgwwuQ_C30"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 ## Permissions
 
 Honey tokens use two levels of permissions: **organization-level** permissions for the one-time setup, and **project-level** permissions for day-to-day usage.


### PR DESCRIPTION
## Summary
- Embed YouTube walkthrough video on the honey tokens overview page, using the same responsive-iframe convention as the secrets management overview/project pages.

## Test plan
- [ ] Build/preview the docs site and confirm the video renders correctly on `documentation/platform/honey-tokens/overview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)