### PR TITLE
fix(routes): use writeLimit for state-changing POST endpoints in PIT and MS Teams routers

### DIFF
--- a/backend/src/ee/routes/v1/pit-router.ts
+++ b/backend/src/ee/routes/v1/pit-router.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { isValidFolderName } from "@app/lib/validator";
-import { readLimit, secretsLimit } from "@app/server/config/rateLimiter";
+import { readLimit, secretsLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { SecretNameSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -263,7 +263,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     url: "/commits/:commitId/rollback",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       params: z.object({
@@ -338,7 +338,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     url: "/commits/:commitId/revert",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       params: z.object({

--- a/backend/src/server/routes/v1/microsoft-teams-router.ts
+++ b/backend/src/server/routes/v1/microsoft-teams-router.ts
@@ -55,7 +55,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
     method: "POST",
     url: "/",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       operationId: "completeMicrosoftTeamsIntegration",
@@ -140,7 +140,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
     method: "POST",
     url: "/:id/installation-status",
     config: {
-      rateLimit: readLimit
+      rateLimit: writeLimit
     },
     schema: {
       operationId: "checkMicrosoftTeamsInstallationStatus",


### PR DESCRIPTION
## What

Four `POST` endpoints that modify server state were configured with `readLimit` instead of `writeLimit`:

| Endpoint | File | Mutation |
|----------|------|----------|
| `POST /commits/:commitId/rollback` | `ee/routes/v1/pit-router.ts:263` | Rolls back folder tree to a previous commit — rewrites secret state |
| `POST /commits/:commitId/revert` | `ee/routes/v1/pit-router.ts:338` | Creates a revert commit — writes new commit record |
| `POST /microsoft-teams/` | `server/routes/v1/microsoft-teams-router.ts:55` | Completes OAuth and creates an integration record |
| `POST /microsoft-teams/:id/installation-status` | `server/routes/v1/microsoft-teams-router.ts:140` | Polls Microsoft Graph and conditionally updates the integration status |

## Why it matters

`readLimit` and `writeLimit` are operator-configurable via the admin panel (`PUT /api/v1/rate-limit`). When a self-hosted admin tunes write limits (e.g., to throttle heavy CI pipelines hitting the secrets API), they expect those limits to apply to all mutation endpoints. Any POST/PATCH/DELETE mistakenly using `readLimit` silently bypasses the admin-configured write ceiling — users can trigger significantly more state-changing operations than the admin intended.

The PIT rollback endpoint is especially impactful: a single rollback can rewrite hundreds of secrets across an entire folder tree.

## Changes

- `pit-router.ts`: added `writeLimit` to import; changed rollback and revert to `writeLimit`
- `microsoft-teams-router.ts`: changed POST `/` and POST `/:id/installation-status` to `writeLimit`

All GET endpoints and the already-correct `DELETE` and `PATCH` in these files are unchanged.

Related to the same class of fixes as #6366 (mutating community routes) and #6407 (read routes with write limits), which cover overlapping but separate route files.