### PR TITLE
fix(api): add missing operationIds to dynamic secret router public routes

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -55,7 +55,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "createDynamicSecret",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Create a dynamic secret",
       body: z.object({
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRETS.CREATE.projectSlug),
         provider: DynamicSecretProviderSchema.describe(DYNAMIC_SECRETS.CREATE.provider),
@@ -155,7 +157,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "updateDynamicSecret",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Update a dynamic secret",
       params: z.object({
         name: z.string().toLowerCase().describe(DYNAMIC_SECRETS.UPDATE.name)
       }),
@@ -246,7 +250,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "deleteDynamicSecret",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Delete a dynamic secret",
       params: z.object({
         name: z.string().toLowerCase().describe(DYNAMIC_SECRETS.DELETE.name)
       }),
@@ -316,7 +322,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "getDynamicSecretByName",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Retrieve a dynamic secret by name",
       params: z.object({
         name: z.string().min(1).describe(DYNAMIC_SECRETS.GET_BY_NAME.name)
       }),
@@ -372,7 +380,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "listDynamicSecrets",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "List dynamic secrets",
       querystring: z.object({
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRETS.LIST.projectSlug),
         path: z.string().trim().default("/").transform(removeTrailingSlash).describe(DYNAMIC_SECRETS.LIST.path),
@@ -420,7 +430,9 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "listDynamicSecretLeases",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "List leases for a dynamic secret",
       params: z.object({
         name: z.string().min(1).describe(DYNAMIC_SECRETS.LIST_LEASES_BY_NAME.name)
       }),


### PR DESCRIPTION
## Problem

All six public routes in `backend/src/ee/routes/v1/dynamic-secret-router.ts` had `hide: false` and `ApiDocsTags.DynamicSecrets` set, making them visible in the OpenAPI schema — but none had an `operationId`. Without a stable `operationId`, tooling auto-derives identifiers from the method + path on every schema rebuild, producing names that can shift across runs and break generated SDKs and client bindings.

The two SSH-specific routes in the same file (`getSshDynamicSecretCaSetup`, `getSshDynamicSecretCaPublicKey`) already had `operationId` set, showing the pattern was partially applied but not completed for the core CRUD routes.

## Fix

Added `operationId` and `description` to all six public routes:

| Route | operationId |
|---|---|
| `POST /` | `createDynamicSecret` |
| `PATCH /:name` | `updateDynamicSecret` |
| `DELETE /:name` | `deleteDynamicSecret` |
| `GET /:name` | `getDynamicSecretByName` |
| `GET /` | `listDynamicSecrets` |
| `GET /:name/leases` | `listDynamicSecretLeases` |

Naming follows the conventions used throughout the codebase (e.g. `createCertificate`, `listCertificates` in `pki-certificate-router.ts`).

## Testing

No behaviour changes — purely additive metadata on route schemas. Existing route handlers, auth, rate limits, and Zod validation are untouched.