### PR TITLE
fix(api): add missing operationIds to secret validation rule router

### DIFF
--- a/backend/src/server/routes/v1/secret-validation-rule-router.ts
+++ b/backend/src/server/routes/v1/secret-validation-rule-router.ts
@@ -19,6 +19,8 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
     config: { rateLimit: readLimit },
     schema: {
       hide: false,
+      operationId: "listSecretValidationRules",
+      description: "List secret validation rules for a project",
       params: z.object({
         projectId: z.string().trim()
       }),
@@ -48,6 +50,8 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
     config: { rateLimit: writeLimit },
     schema: {
       hide: false,
+      operationId: "createSecretValidationRule",
+      description: "Create a secret validation rule for a project",
       params: z.object({
         projectId: z.string().trim()
       }),
@@ -106,6 +110,8 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
     config: { rateLimit: writeLimit },
     schema: {
       hide: false,
+      operationId: "updateSecretValidationRule",
+      description: "Update a secret validation rule",
       params: z.object({
         projectId: z.string().trim(),
         ruleId: z.string().uuid()
@@ -164,6 +170,8 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
     config: { rateLimit: writeLimit },
     schema: {
       hide: false,
+      operationId: "deleteSecretValidationRule",
+      description: "Delete a secret validation rule",
       params: z.object({
         projectId: z.string().trim(),
         ruleId: z.string().uuid()


### PR DESCRIPTION
## Problem

All four routes in `backend/src/server/routes/v1/secret-validation-rule-router.ts` have `hide: false`, which means they are included in the public OpenAPI schema — but none had an `operationId`. Without a stable `operationId`, OpenAPI tooling auto-derives identifiers from the HTTP method + path on every schema build. These derived names are unstable: they change when routes are reordered and break generated SDK method names and documentation anchors.

The secret validation rule feature was added in migration `20260319*` and represents a recently shipped feature that simply wasn't wired up with operationIds.

## Fix

Added `operationId` and `description` to all four public routes:

| Route | operationId |
|---|---|
| `GET /:projectId/secret-validation-rules` | `listSecretValidationRules` |
| `POST /:projectId/secret-validation-rules` | `createSecretValidationRule` |
| `PATCH /:projectId/secret-validation-rules/:ruleId` | `updateSecretValidationRule` |
| `DELETE /:projectId/secret-validation-rules/:ruleId` | `deleteSecretValidationRule` |

Naming follows the conventions used throughout the codebase.

## Testing

No behaviour changes — purely additive metadata on route schemas. Existing route handlers, auth, rate limits, and Zod validation are untouched.