### PR TITLE
fix: make saml issuer required on saml form

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/SSOModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/SSOModal.tsx
@@ -87,7 +87,7 @@ const schema = z
   .object({
     authProvider: z.string().min(1, "SSO Type is required"),
     entryPoint: z.string().trim().min(1, "URL required"),
-    issuer: z.string().default(""),
+    issuer: z.string().trim().min(1, "Issuer required"),
     cert: z.string().default("")
   })
   .required();
@@ -385,7 +385,7 @@ export const SSOModal = ({ popUp, handlePopUpClose, handlePopUpToggle, hideDelet
                             htmlFor="sso-issuer"
                             className="inline-flex flex-wrap items-baseline gap-1.5"
                           >
-                            {labels.issuer} (optional)
+                            {labels.issuer}
                           </FieldLabel>
                           <Input
                             id="sso-issuer"


### PR DESCRIPTION
## Context

This PR removes the optional label to the saml issuer field and adds form validation to make it required.

## Screenshots

N/A

## Steps to verify the change

- see optional label is removed and form enforces requirement

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)