### PR TITLE
feat: removed reviewer read permission for approval once approval request has closed

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -337,16 +337,18 @@ export const secretApprovalRequestServiceFactory = ({
     const getHasSecretReadAccess = (environment: string, tags: { slug: string }[], secretPath?: string) => {
       const isReviewer = policy.approvers.some(({ userId }) => userId === actorId);
 
-      if (!isReviewer) {
-        const canRead = hasSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.ReadValue, {
-          environment,
-          secretPath: secretPath || "/",
-          secretTags: tags.map((i) => i.slug)
-        });
-        return canRead;
+      // Reviewers get temporary read access only while the request is open for review
+      if (isReviewer && secretApprovalRequest.status === RequestState.Open) {
+        return true;
       }
 
-      return true;
+      // Otherwise check actual read permissions
+      const canRead = hasSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.ReadValue, {
+        environment,
+        secretPath: secretPath || "/",
+        secretTags: tags.map((i) => i.slug)
+      });
+      return canRead;
     };
 
     let secrets;


### PR DESCRIPTION
## Context

This PR removes the secret approval request reviewer permission to read the approval once the the request has been closed due to merging or literally closing the request. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)