### PR TITLE
improvement: bump project max length and add missing validation / update existing validation

### DIFF
--- a/backend/src/db/migrations/20260512231016_increase-project-description-length.ts
+++ b/backend/src/db/migrations/20260512231016_increase-project-description-length.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.Project, "description");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.Project, (t) => {
+      t.string("description", 1024).alter();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn(TableName.Project, "description");
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.Project, (t) => {
+      t.string("description", 255).alter();
+    });
+  }
+}

--- a/backend/src/db/migrations/20260512231016_increase-project-description-length.ts
+++ b/backend/src/db/migrations/20260512231016_increase-project-description-length.ts
@@ -11,11 +11,6 @@ export async function up(knex: Knex): Promise<void> {
   }
 }
 
-export async function down(knex: Knex): Promise<void> {
-  const hasColumn = await knex.schema.hasColumn(TableName.Project, "description");
-  if (hasColumn) {
-    await knex.schema.alterTable(TableName.Project, (t) => {
-      t.string("description", 255).alter();
-    });
-  }
+export async function down(): Promise<void> {
+  // No down migration or it will error
 }

--- a/backend/src/lib/error-codes/database.ts
+++ b/backend/src/lib/error-codes/database.ts
@@ -1,4 +1,5 @@
 export enum DatabaseErrorCode {
+  StringDataRightTruncation = "22001",
   ForeignKeyViolation = "23503",
   UniqueViolation = "23505"
 }

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -188,7 +188,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         description: z
           .string()
           .trim()
-          .max(256, { message: "Description must be 256 or fewer characters" })
+          .max(1024, { message: "Description must be 1024 or fewer characters" })
           .optional()
           .describe(PROJECTS.UPDATE.projectDescription),
         autoCapitalization: z.boolean().optional().describe(PROJECTS.UPDATE.autoCapitalization),

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -154,7 +154,12 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       ],
       body: z.object({
         projectName: z.string().trim().describe(PROJECTS.CREATE.projectName),
-        projectDescription: z.string().trim().optional().describe(PROJECTS.CREATE.projectDescription),
+        projectDescription: z
+          .string()
+          .trim()
+          .max(1024, { message: "Description must be 1024 or fewer characters" })
+          .optional()
+          .describe(PROJECTS.CREATE.projectDescription),
         slug: slugSchema({ min: 5, max: 36 }).optional().describe(PROJECTS.CREATE.slug),
         kmsKeyId: z.string().optional(),
         template: slugSchema({ field: "Template Name", max: 64 })
@@ -426,7 +431,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         description: z
           .string()
           .trim()
-          .max(256, { message: "Description must be 256 or fewer characters" })
+          .max(1024, { message: "Description must be 1024 or fewer characters" })
           .optional()
           .describe(PROJECTS.UPDATE.projectDescription),
         autoCapitalization: z.boolean().optional().describe(PROJECTS.UPDATE.autoCapitalization),

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -153,7 +153,11 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         }
       ],
       body: z.object({
-        projectName: z.string().trim().describe(PROJECTS.CREATE.projectName),
+        projectName: z
+          .string()
+          .trim()
+          .max(64, { message: "Name must be 64 or fewer characters" })
+          .describe(PROJECTS.CREATE.projectName),
         projectDescription: z
           .string()
           .trim()

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -102,7 +102,12 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       ],
       body: z.object({
         projectName: z.string().trim().describe(PROJECTS.CREATE.projectName),
-        projectDescription: z.string().trim().optional().describe(PROJECTS.CREATE.projectDescription),
+        projectDescription: z
+          .string()
+          .trim()
+          .max(1024, { message: "Description must be 1024 or fewer characters" })
+          .optional()
+          .describe(PROJECTS.CREATE.projectDescription),
         slug: slugSchema({ min: 5, max: 36 }).optional().describe(PROJECTS.CREATE.slug),
         kmsKeyId: z.string().optional(),
         template: slugSchema({ field: "Template Name", max: 64 })
@@ -272,7 +277,12 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       }),
       body: z.object({
         name: z.string().trim().optional().describe(PROJECTS.UPDATE.name),
-        description: z.string().trim().optional().describe(PROJECTS.UPDATE.projectDescription),
+        description: z
+          .string()
+          .trim()
+          .max(1024, { message: "Description must be 1024 or fewer characters" })
+          .optional()
+          .describe(PROJECTS.UPDATE.projectDescription),
         autoCapitalization: z.boolean().optional().describe(PROJECTS.UPDATE.autoCapitalization),
         hasDeleteProtection: z.boolean().optional().describe(PROJECTS.UPDATE.hasDeleteProtection)
       }),

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -101,7 +101,11 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         }
       ],
       body: z.object({
-        projectName: z.string().trim().describe(PROJECTS.CREATE.projectName),
+        projectName: z
+          .string()
+          .trim()
+          .max(64, { message: "Name must be 64 or fewer characters" })
+          .describe(PROJECTS.CREATE.projectName),
         projectDescription: z
           .string()
           .trim()
@@ -276,7 +280,12 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         slug: slugSchema({ min: 5, max: 64 }).describe("The slug of the project to update.")
       }),
       body: z.object({
-        name: z.string().trim().optional().describe(PROJECTS.UPDATE.name),
+        name: z
+          .string()
+          .trim()
+          .max(64, { message: "Name must be 64 or fewer characters" })
+          .optional()
+          .describe(PROJECTS.UPDATE.name),
         description: z
           .string()
           .trim()

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -344,13 +344,18 @@ export const projectServiceFactory = ({
           tx
         );
       } catch (err) {
-        if (
-          err instanceof DatabaseError &&
-          (err.error as { code: string })?.code === DatabaseErrorCode.UniqueViolation
-        ) {
-          throw new BadRequestError({
-            message: `A project with the slug "${slug}" already exists in your organization. Please choose a different name or slug.`
-          });
+        if (err instanceof DatabaseError) {
+          const code = (err.error as { code?: string })?.code;
+          if (code === DatabaseErrorCode.UniqueViolation) {
+            throw new BadRequestError({
+              message: `A project with the slug "${slug}" already exists in your organization. Please choose a different name or slug.`
+            });
+          }
+          if (code === DatabaseErrorCode.StringDataRightTruncation) {
+            throw new BadRequestError({
+              message: "One or more fields exceed the allowed length. Please shorten and try again."
+            });
+          }
         }
         throw err;
       }
@@ -910,10 +915,18 @@ export const projectServiceFactory = ({
 
       return updatedProject;
     } catch (err) {
-      if (err instanceof DatabaseError && (err.error as { code: string })?.code === DatabaseErrorCode.UniqueViolation) {
-        throw new BadRequestError({
-          message: `Failed to update project. A project with the slug "${update.slug}" already exists in your organization. Please choose a different slug.`
-        });
+      if (err instanceof DatabaseError) {
+        const code = (err.error as { code?: string })?.code;
+        if (code === DatabaseErrorCode.UniqueViolation) {
+          throw new BadRequestError({
+            message: `Failed to update project. A project with the slug "${update.slug}" already exists in your organization. Please choose a different slug.`
+          });
+        }
+        if (code === DatabaseErrorCode.StringDataRightTruncation) {
+          throw new BadRequestError({
+            message: "One or more fields exceed the allowed length. Please shorten and try again."
+          });
+        }
       }
       throw err;
     }

--- a/frontend/src/components/project/ProjectOverviewChangeSection.tsx
+++ b/frontend/src/components/project/ProjectOverviewChangeSection.tsx
@@ -14,7 +14,7 @@ const baseFormSchema = z.object({
   description: z
     .string()
     .trim()
-    .max(256, "Description too long, max length is 256 characters")
+    .max(1024, "Description too long, max length is 1024 characters")
     .optional()
 });
 

--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -44,7 +44,7 @@ const formSchema = z.object({
   description: z
     .string()
     .trim()
-    .max(256, "Description too long, max length is 256 characters")
+    .max(1024, "Description too long, max length is 1024 characters")
     .optional(),
   type: z.nativeEnum(ProjectType),
   kmsKeyId: z.string(),


### PR DESCRIPTION
## Context

This PR bumps the max project description length and updates the existing api / form validation limits and adds missing ones.


## Screenshots

N/A

## Steps to verify the change

- verify migration runs successfully up / down
- test limit enforcement

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)