### PR TITLE
fix: make scoped identity access token revocation lookup sargable + partial index

### DIFF
--- a/backend/src/db/migrations/20260513003124_add-scope-index-to-identity-access-token-revocations.ts
+++ b/backend/src/db/migrations/20260513003124_add-scope-index-to-identity-access-token-revocations.ts
@@ -1,0 +1,34 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+const SCOPE_INDEX = "idx_identity_access_token_revocations_identityid_scope";
+const MIGRATION_TIMEOUT = 5 * 60 * 1000;
+
+export async function up(knex: Knex): Promise<void> {
+  const result = await knex.raw("SHOW statement_timeout");
+  const originalTimeout = result.rows[0].statement_timeout;
+
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+
+    // Partial index on the scoped-marker subset so the validator's
+    // `... AND (id IN (...) OR scope IN (...))` lookup gets a real index
+    // path on the scope side instead of relying on the planner's row-count
+    // estimate for the OR. CONCURRENTLY so the build doesn't block writes.
+    await knex.raw(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${SCOPE_INDEX}
+        ON ${TableName.IdentityAccessTokenRevocation} ("identityId", "scope")
+        WHERE "scope" IS NOT NULL
+    `);
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalTimeout}'`);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP INDEX IF EXISTS ${SCOPE_INDEX}`);
+}
+
+const config = { transaction: false };
+export { config };

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -38,34 +38,19 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findActiveRevocationsForToken = async ({
-    tokenId,
-    identityId,
-    scopes
-  }: {
-    tokenId: string;
-    identityId: string;
-    scopes: string[];
-  }): Promise<TRevocationRow[]> => {
+  // Returns every active revocation row for the identity. Per-token / identity-wide /
+  // scoped matching is done in the service so the query stays a single (identityId,
+  // expiresAt) index range — no OR predicates that the planner could decompose into
+  // a sequential scan based on `scope` selectivity stats.
+  const findActiveRevocationsForIdentity = async (identityId: string): Promise<TRevocationRow[]> => {
     try {
-      return (
-        (await db
-          .replicaNode()(TableName.IdentityAccessTokenRevocation)
-          .select("id", "identityId", "revokedAt", "createdAt", "scope")
-          .where("expiresAt", ">", db.fn.now())
-          .where("identityId", identityId)
-          // Both halves of the OR must be equality predicates so the planner can
-          // serve `id IN (...)` from the PK and the `scope IN (...)` filter stays
-          // selective. `scope IS NOT NULL` would force a non-sargable scan.
-          .andWhere((qb) => {
-            void qb.whereIn("id", [tokenId, identityId]);
-            if (scopes.length > 0) {
-              void qb.orWhereIn("scope", scopes);
-            }
-          })) as TRevocationRow[]
-      );
+      return (await db
+        .replicaNode()(TableName.IdentityAccessTokenRevocation)
+        .select("id", "identityId", "revokedAt", "createdAt", "scope")
+        .where("expiresAt", ">", db.fn.now())
+        .where("identityId", identityId)) as TRevocationRow[];
     } catch (error) {
-      throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationFindActiveForToken" });
+      throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationFindActiveForIdentity" });
     }
   };
 
@@ -79,7 +64,7 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
 
   return {
     insertRevocation,
-    findActiveRevocationsForToken,
+    findActiveRevocationsForIdentity,
     removeExpiredRevocations
   };
 };

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -38,19 +38,34 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
     }
   };
 
-  // Returns every active revocation row for the identity. Per-token / identity-wide /
-  // scoped matching is done in the service so the query stays a single (identityId,
-  // expiresAt) index range — no OR predicates that the planner could decompose into
-  // a sequential scan based on `scope` selectivity stats.
-  const findActiveRevocationsForIdentity = async (identityId: string): Promise<TRevocationRow[]> => {
+  const findActiveRevocationsForToken = async ({
+    tokenId,
+    identityId,
+    scopes
+  }: {
+    tokenId: string;
+    identityId: string;
+    scopes: string[];
+  }): Promise<TRevocationRow[]> => {
     try {
-      return (await db
-        .replicaNode()(TableName.IdentityAccessTokenRevocation)
-        .select("id", "identityId", "revokedAt", "createdAt", "scope")
-        .where("expiresAt", ">", db.fn.now())
-        .where("identityId", identityId)) as TRevocationRow[];
+      return (
+        (await db
+          .replicaNode()(TableName.IdentityAccessTokenRevocation)
+          .select("id", "identityId", "revokedAt", "createdAt", "scope")
+          .where("expiresAt", ">", db.fn.now())
+          .where("identityId", identityId)
+          // Both halves of the OR must be equality predicates so the planner can
+          // serve `id IN (...)` from the PK and the `scope IN (...)` filter stays
+          // selective. `scope IS NOT NULL` would force a non-sargable scan.
+          .andWhere((qb) => {
+            void qb.whereIn("id", [tokenId, identityId]);
+            if (scopes.length > 0) {
+              void qb.orWhereIn("scope", scopes);
+            }
+          })) as TRevocationRow[]
+      );
     } catch (error) {
-      throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationFindActiveForIdentity" });
+      throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationFindActiveForToken" });
     }
   };
 
@@ -64,7 +79,7 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
 
   return {
     insertRevocation,
-    findActiveRevocationsForIdentity,
+    findActiveRevocationsForToken,
     removeExpiredRevocations
   };
 };

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -40,10 +40,12 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
 
   const findActiveRevocationsForToken = async ({
     tokenId,
-    identityId
+    identityId,
+    scopes
   }: {
     tokenId: string;
     identityId: string;
+    scopes: string[];
   }): Promise<TRevocationRow[]> => {
     try {
       return (
@@ -52,10 +54,14 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
           .select("id", "identityId", "revokedAt", "createdAt", "scope")
           .where("expiresAt", ">", db.fn.now())
           .where("identityId", identityId)
-          // Legacy markers key off id (tokenId or identityId); scoped markers always
-          // come along so the in-memory filter can match by clientSecretId / authMethod.
+          // Both halves of the OR must be equality predicates so the planner can
+          // serve `id IN (...)` from the PK and the `scope IN (...)` filter stays
+          // selective. `scope IS NOT NULL` would force a non-sargable scan.
           .andWhere((qb) => {
-            void qb.whereIn("id", [tokenId, identityId]).orWhereNotNull("scope");
+            void qb.whereIn("id", [tokenId, identityId]);
+            if (scopes.length > 0) {
+              void qb.orWhereIn("scope", scopes);
+            }
           })) as TRevocationRow[]
       );
     } catch (error) {

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -54,7 +54,7 @@ const createService = ({
     setItemWithExpiry: vi.fn()
   };
   const identityAccessTokenRevocationDAL = {
-    findActiveRevocationsForToken: vi.fn().mockResolvedValue(activeRevocations),
+    findActiveRevocationsForIdentity: vi.fn().mockResolvedValue(activeRevocations),
     insertRevocation: vi.fn()
   };
   const identityDAL = {

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -54,7 +54,7 @@ const createService = ({
     setItemWithExpiry: vi.fn()
   };
   const identityAccessTokenRevocationDAL = {
-    findActiveRevocationsForIdentity: vi.fn().mockResolvedValue(activeRevocations),
+    findActiveRevocationsForToken: vi.fn().mockResolvedValue(activeRevocations),
     insertRevocation: vi.fn()
   };
   const identityDAL = {

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -104,7 +104,15 @@ export const identityAccessTokenServiceFactory = ({
     authMethod?: string;
     messagePrefix?: "Failed to authorize" | "Cannot renew";
   }) => {
-    const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForIdentity(identityId);
+    const scopes: string[] = [];
+    if (clientSecretId) scopes.push(clientSecretId);
+    if (authMethod) scopes.push(authMethod);
+
+    const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForToken({
+      tokenId,
+      identityId,
+      scopes
+    });
 
     for (const revocation of activeRevocations) {
       // Legacy markers have scope=null and key off polymorphic `id`.

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -104,15 +104,7 @@ export const identityAccessTokenServiceFactory = ({
     authMethod?: string;
     messagePrefix?: "Failed to authorize" | "Cannot renew";
   }) => {
-    const scopes: string[] = [];
-    if (clientSecretId) scopes.push(clientSecretId);
-    if (authMethod) scopes.push(authMethod);
-
-    const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForToken({
-      tokenId,
-      identityId,
-      scopes
-    });
+    const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForIdentity(identityId);
 
     for (const revocation of activeRevocations) {
       // Legacy markers have scope=null and key off polymorphic `id`.

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -104,9 +104,14 @@ export const identityAccessTokenServiceFactory = ({
     authMethod?: string;
     messagePrefix?: "Failed to authorize" | "Cannot renew";
   }) => {
+    const scopes: string[] = [];
+    if (clientSecretId) scopes.push(clientSecretId);
+    if (authMethod) scopes.push(authMethod);
+
     const activeRevocations = await identityAccessTokenRevocationDAL.findActiveRevocationsForToken({
       tokenId,
-      identityId
+      identityId,
+      scopes
     });
 
     for (const revocation of activeRevocations) {


### PR DESCRIPTION
## Summary

Follow-up to #6417 (`tre/platfor-358-identity-access-revoke`), which caused a large RDS CPU spike on the production EU cluster. Per-call cost on the revocation lookup (the auth hot path) jumped roughly 45× — from ~4 ms to ~200 ms — making it the dominant load on the database.

### Root cause

The DAL changed from
```sql
WHERE expiresAt > NOW() AND identityId = $1 AND id IN ($2, $3)
```
to
```sql
WHERE expiresAt > NOW() AND identityId = $1 AND (id IN ($2, $3) OR scope IS NOT NULL)
```

`scope IS NOT NULL` skews the planner's row-count estimate via `pg_statistic.null_frac` — it looks like the OR branch returns a large fraction of the table, and with no index on `scope` the planner can fall back to a `BitmapOr` that decomposes the non-null half into a Seq Scan. That's the mechanism behind the 45× regression.

### Fix

Two-part:

1. **Make the predicate sargable.** Pass the JWT's `clientSecretId` and `authMethod` through to the DAL and replace `scope IS NOT NULL` with `scope IN (those values)`. Both halves of the OR are now equality predicates — the PK handles the `id` side, and the scope filter is selective enough to stay cheap. When neither value is present the OR drops and we revert to the pre-PR shape.

2. **Partial index on `(identityId, scope) WHERE scope IS NOT NULL`.** Belt-and-suspenders so the scope side of the OR has a real index path regardless of how the planner estimates `scope IN (...)` selectivity. Built `CONCURRENTLY` so it doesn't block writes on the live revocation table.

Together: the planner can do a clean BitmapOr (PK for the `id` side, partial index for the `scope` side), or stay on the `(identityId, expiresAt)` index with a cheap equality post-filter — both fast.

### Legacy revocations (pre-today's PR)

Both row types from before today's PR are still covered:
- Per-token revocations: `id = tokenId`, `scope = NULL` → matched by `id IN (tokenId, identityId)`.
- Identity-wide sentinels: `id = identityId`, `scope = NULL` → also matched by `id IN (...)`.

The `OR scope IN (...)` branch only adds matching for the new scoped markers. No legacy data is missed.

## Test plan

- [x] `npm run type:check` (backend)
- [x] `npm run test:unit -- src/services/identity-access-token/identity-access-token-service.test.ts` (29/29 passing)
- [x] ESLint clean on changed files
- [ ] Verify in staging / prod that the revocation lookup AAS returns to pre-PR levels
- [ ] Confirm scoped-revoke flows (client secret deletion, auth-method removal) still reject the right tokens
- [ ] Confirm migration runs cleanly against prod table size

## Verifying the plan in psql

Pick an `identityId` that has scoped revocation markers (otherwise the new OR branch doesn't get exercised) and substitute it everywhere.

```sql
-- Set these once. Use an identity you know has scoped markers, ideally a hot one.
\set ident       '''<identity-uuid-here>'''
\set token_id    '''<some-jti-or-:ident-works>'''
\set client_sec  '''<a-real-clientSecretId-or-empty-string>'''
\set auth_method '''universal-auth'''
```

**Current prod query (broken)** — confirms the `IS NOT NULL` plan:
```sql
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
SELECT "id", "identityId", "revokedAt", "createdAt", "scope"
FROM identity_access_token_revocations
WHERE "expiresAt" > NOW()
  AND "identityId" = :ident
  AND ("id" IN (:token_id, :ident) OR "scope" IS NOT NULL);
```

**Fixed query (this PR)**:
```sql
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
SELECT "id", "identityId", "revokedAt", "createdAt", "scope"
FROM identity_access_token_revocations
WHERE "expiresAt" > NOW()
  AND "identityId" = :ident
  AND ("id" IN (:token_id, :ident) OR "scope" IN (:client_sec, :auth_method));
```

**Pre-PR baseline (for reference)** — what we're trying to get back to:
```sql
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
SELECT "id", "identityId", "revokedAt", "createdAt"
FROM identity_access_token_revocations
WHERE "expiresAt" > NOW()
  AND "identityId" = :ident
  AND "id" IN (:token_id, :ident);
```

What to look for:
- **Broken query**: expect a `BitmapOr` node with either a `Seq Scan` or a wide bitmap on the `scope IS NOT NULL` side, or a node with a `Rows Removed by Filter` count blown way past the actual matches. That's the smoking gun.
- **Fixed query**: should collapse to either an `Index Scan using identity_access_token_revocations_identityid_expiresat_index` with a `Filter` that removes very few rows, or a `BitmapOr` of two narrow bitmap index scans. Once the partial index lands, the scope branch should show `Bitmap Index Scan on idx_identity_access_token_revocations_identityid_scope`.
- **Pre-PR**: should be an `Index Scan using <PK>` returning ≤2 rows.

**One gotcha** — the planner uses different stats with prepared statements (custom plan vs. generic plan after ~5 executions). To mimic the Node driver's real behavior:
```sql
PREPARE p (uuid, text, text, text, text) AS
SELECT "id", "identityId", "revokedAt", "createdAt", "scope"
FROM identity_access_token_revocations
WHERE "expiresAt" > NOW()
  AND "identityId" = $1
  AND ("id" IN ($2, $3) OR "scope" IN ($4, $5));

EXPLAIN (ANALYZE, BUFFERS) EXECUTE p (:ident, :token_id, :ident, :client_sec, :auth_method);
-- run 6+ times to flip to a generic plan, then EXPLAIN again
```

https://claude.ai/code/session_015UaQf7ZJsWe2oH19sZAfCn