### PR TITLE
fix(api): prevent service token privilege escalation via action and scope checks

### DIFF
--- a/backend/e2e-test/routes/v2/service-token.spec.ts
+++ b/backend/e2e-test/routes/v2/service-token.spec.ts
@@ -590,4 +590,82 @@ describe("Service token fail cases", async () => {
     expect(fetchSecrets.statusCode).toBe(200);
     await deleteServiceToken();
   });
+
+  test("Admin can still create service tokens with full permissions (happy path regression)", async () => {
+    const projectKeyRes = await testServer.inject({
+      method: "GET",
+      url: `/api/v2/workspace/${seedData1.project.id}/encrypted-key`,
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      }
+    });
+    const projectKeyEnc = JSON.parse(projectKeyRes.payload);
+
+    const userInfoRes = await testServer.inject({
+      method: "GET",
+      url: "/api/v2/users/me",
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      }
+    });
+    const { user: userInfo } = JSON.parse(userInfoRes.payload);
+    const privateKey = await getUserPrivateKey(seedData1.password, userInfo);
+
+    const projectKey = crypto.encryption().asymmetric().decrypt({
+      ciphertext: projectKeyEnc.encryptedKey,
+      nonce: projectKeyEnc.nonce,
+      publicKey: projectKeyEnc.sender.publicKey,
+      privateKey
+    });
+
+    const randomBytes = crypto.randomBytes(16).toString("hex");
+
+    const { ciphertext, iv, tag } = crypto.encryption().symmetric().encrypt({
+      plaintext: projectKey,
+      key: randomBytes,
+      keySize: SymmetricKeySize.Bits128
+    });
+
+    const serviceTokenRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v2/service-token",
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      },
+      body: {
+        name: "test-admin-token",
+        workspaceId: seedData1.project.id,
+        scopes: [{ secretPath: "/**", environment: seedData1.environment.slug }],
+        encryptedKey: ciphertext,
+        iv,
+        tag,
+        permissions: ["read", "write"],
+        expiresIn: null
+      }
+    });
+
+    expect(serviceTokenRes.statusCode).toBe(200);
+    const serviceTokenInfo = serviceTokenRes.json();
+    expect(serviceTokenInfo).toHaveProperty("serviceToken");
+    expect(serviceTokenInfo).toHaveProperty("serviceTokenData");
+
+    const serviceTokenListRes = await testServer.inject({
+      method: "GET",
+      url: `/api/v1/projects/${seedData1.project.id}/service-token-data`,
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      }
+    });
+    const serviceTokens = JSON.parse(serviceTokenListRes.payload).serviceTokenData as { name: string; id: string }[];
+    const createdToken = serviceTokens.find(({ name }) => name === "test-admin-token");
+    expect(createdToken).toBeDefined();
+
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/service-token/${createdToken?.id}`,
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      }
+    });
+  });
 });

--- a/backend/e2e-test/routes/v2/service-token.spec.ts
+++ b/backend/e2e-test/routes/v2/service-token.spec.ts
@@ -660,12 +660,13 @@ describe("Service token fail cases", async () => {
     const createdToken = serviceTokens.find(({ name }) => name === "test-admin-token");
     expect(createdToken).toBeDefined();
 
-    await testServer.inject({
+    const deleteRes = await testServer.inject({
       method: "DELETE",
       url: `/api/v2/service-token/${createdToken?.id}`,
       headers: {
         authorization: `Bearer ${jwtAuthToken}`
       }
     });
+    expect(deleteRes.statusCode).toBe(200);
   });
 });

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -2104,19 +2104,21 @@ export const buildServiceTokenProjectPermission = (
           });
         }
         if (canRead) {
-          if (useLegacyRead) {
-            can(ProjectPermissionActions.Read, subject, {
-              // @ts-expect-error type
+          if (!useLegacyRead && subject === ProjectPermissionSub.Secrets) {
+            // @ts-expect-error CASL's per-action condition schema doesn't expose $glob, but the
+            // conditionsMatcher resolves it at runtime; same pattern is used in the legacy branch.
+            can(ProjectPermissionSecretActions.ReadValue, subject, {
+              secretPath: { $glob: secretPath },
+              environment
+            });
+            // @ts-expect-error CASL's per-action condition schema doesn't expose $glob, but the
+            // conditionsMatcher resolves it at runtime; same pattern is used in the legacy branch.
+            can(ProjectPermissionSecretActions.DescribeSecret, subject, {
               secretPath: { $glob: secretPath },
               environment
             });
           } else {
-            can(ProjectPermissionSecretActions.ReadValue, subject, {
-              // @ts-expect-error type
-              secretPath: { $glob: secretPath },
-              environment
-            });
-            can(ProjectPermissionSecretActions.DescribeSecret, subject, {
+            can(ProjectPermissionActions.Read, subject, {
               // @ts-expect-error type
               secretPath: { $glob: secretPath },
               environment

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -2076,8 +2076,10 @@ export type TProjectPermissionV2Schema = z.infer<typeof ProjectPermissionV2Schem
 
 export const buildServiceTokenProjectPermission = (
   scopes: Array<{ secretPath: string; environment: string }>,
-  permission: string[]
+  permission: string[],
+  options: { useLegacyRead?: boolean } = {}
 ) => {
+  const { useLegacyRead = true } = options;
   const canWrite = permission.includes("write");
   const canRead = permission.includes("read");
   const { can, build } = new AbilityBuilder<MongoAbility<ProjectPermissionSet>>(createMongoAbility);
@@ -2102,11 +2104,24 @@ export const buildServiceTokenProjectPermission = (
           });
         }
         if (canRead) {
-          can(ProjectPermissionActions.Read, subject, {
-            // @ts-expect-error type
-            secretPath: { $glob: secretPath },
-            environment
-          });
+          if (useLegacyRead) {
+            can(ProjectPermissionActions.Read, subject, {
+              // @ts-expect-error type
+              secretPath: { $glob: secretPath },
+              environment
+            });
+          } else {
+            can(ProjectPermissionSecretActions.ReadValue, subject, {
+              // @ts-expect-error type
+              secretPath: { $glob: secretPath },
+              environment
+            });
+            can(ProjectPermissionSecretActions.DescribeSecret, subject, {
+              // @ts-expect-error type
+              secretPath: { $glob: secretPath },
+              environment
+            });
+          }
         }
       }
     );

--- a/backend/src/lib/casl/boundary.test.ts
+++ b/backend/src/lib/casl/boundary.test.ts
@@ -683,7 +683,7 @@ describe("Validate Permission Boundary: Checking Parent $GLOB operator", () => {
         }
       ])
     }
-  ])("Child $operator truthy cases", ({ childPermission }) => {
+  ])("Child $operator (parent /hello/** $GLOB) truthy cases", ({ childPermission }) => {
     const permissionBoundary = validatePermissionBoundary(parentPermission, childPermission);
     expect(permissionBoundary.isValid).toBeTruthy();
   });
@@ -737,8 +737,193 @@ describe("Validate Permission Boundary: Checking Parent $GLOB operator", () => {
         }
       ])
     }
-  ])("Child $operator falsy cases", ({ childPermission }) => {
+  ])("Child $operator (parent /hello/** $GLOB) falsy cases", ({ childPermission }) => {
     const permissionBoundary = validatePermissionBoundary(parentPermission, childPermission);
     expect(permissionBoundary.isValid).toBeFalsy();
+  });
+});
+
+describe("Validate Permission Boundary: glob-subset of glob (positive parent)", () => {
+  // Regression for the literal-string-match flaw: `picomatch.isMatch('/apps/**', '/apps/*')`
+  // returns true because `**` is two literal characters with no `/`, so the previous boundary
+  // logic accepted `/apps/**` as a "subset" of `/apps/*` and let callers widen single-segment
+  // scope to recursive scope. The new check uses set containment over the two glob languages.
+  test("Child $glob broader than parent $glob is rejected ('/apps/*' parent, '/apps/**' child)", () => {
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/*" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/**" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+  });
+
+  test("Child $glob equally narrow than parent $glob is accepted ('/apps/*' parent, '/apps/foo' child)", () => {
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/*" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/foo" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
+
+  test("Disjoint glob siblings ('/apps/*' parent, '/secret/*' child) is rejected", () => {
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/*" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/*" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+  });
+});
+
+describe("Validate Permission Boundary: inverted (deny) rule overlap", () => {
+  // Regression for the inverted-rule bypass: a caller with positive `read` plus a deny rule
+  // scoped to `/secret/**` must not be able to mint a child rule scoped to `/**`, because the
+  // child grants exactly the access the parent's deny region forbids. The previous check only
+  // tested "child fully contained in deny region", missing the "child broader than deny region"
+  // case.
+  test("Child broader than parent's deny region is rejected (deny '/secret/**' + child '/**')", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      {
+        action: "read",
+        subject: "secrets",
+        inverted: true,
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/**" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/**" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+  });
+
+  test("Child without the deny-region's constrained field is rejected (deny path='/secret/**' + child {})", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      {
+        action: "read",
+        subject: "secrets",
+        inverted: true,
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/**" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([{ action: "read", subject: "secrets" }]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+  });
+
+  test("Child fully outside the deny region is accepted (deny '/secret/**' + child '/apps/**')", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      {
+        action: "read",
+        subject: "secrets",
+        inverted: true,
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/**" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/**" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
+
+  test("Child disjoint from deny via a different field is accepted (deny env=dev path='/secret/**' + child env=prod)", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      {
+        action: "read",
+        subject: "secrets",
+        inverted: true,
+        conditions: {
+          environment: { [PermissionConditionOperators.$EQ]: "dev" },
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/**" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secrets",
+        conditions: {
+          environment: { [PermissionConditionOperators.$EQ]: "prod" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
+
+  test("Unconditional inverted rule denies all subsets", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      { action: "read", subject: "secrets", inverted: true }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$EQ]: "/" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
   });
 });

--- a/backend/src/lib/casl/boundary.ts
+++ b/backend/src/lib/casl/boundary.ts
@@ -2,6 +2,7 @@ import { MongoAbility } from "@casl/ability";
 import { MongoQuery } from "@ucast/mongo2js";
 import picomatch from "picomatch";
 
+import { haveDisjointLiteralPrefixes, isGlobSubsetOfGlob } from "./glob-subset";
 import { PermissionConditionOperators } from "./index";
 
 type TMissingPermission = {
@@ -132,9 +133,7 @@ const isOperatorsASubset = (parentSet: TPermissionConditionShape, subset: TPermi
     }
     if (
       parentSet[PermissionConditionOperators.$GLOB] &&
-      !picomatch.isMatch(subsetOperatorValue, parentSet[PermissionConditionOperators.$GLOB], {
-        strictSlashes: false
-      })
+      !isGlobSubsetOfGlob(parentSet[PermissionConditionOperators.$GLOB], subsetOperatorValue)
     ) {
       return false;
     }
@@ -142,13 +141,69 @@ const isOperatorsASubset = (parentSet: TPermissionConditionShape, subset: TPermi
   return true;
 };
 
+/**
+ * Returns true if we can prove the two operator constraints define disjoint match sets (share no
+ * elements). Returns false when uncertain — callers should treat that as "potentially overlapping"
+ * and behave conservatively. Used by the inverted (deny) rule overlap check.
+ */
+const areOperatorsDisjoint = (a: TPermissionConditionShape, b: TPermissionConditionShape): boolean => {
+  const aEq = a[PermissionConditionOperators.$EQ];
+  const aNeq = a[PermissionConditionOperators.$NEQ];
+  const aIn = a[PermissionConditionOperators.$IN];
+  const aGlob = a[PermissionConditionOperators.$GLOB];
+  const bEq = b[PermissionConditionOperators.$EQ];
+  const bNeq = b[PermissionConditionOperators.$NEQ];
+  const bIn = b[PermissionConditionOperators.$IN];
+  const bGlob = b[PermissionConditionOperators.$GLOB];
+
+  if (aEq !== undefined && bEq !== undefined) return aEq !== bEq;
+  if (aEq !== undefined && bNeq !== undefined) return aEq === bNeq;
+  if (bEq !== undefined && aNeq !== undefined) return bEq === aNeq;
+  if (aEq !== undefined && bIn !== undefined) return !bIn.includes(aEq);
+  if (bEq !== undefined && aIn !== undefined) return !aIn.includes(bEq);
+  if (aEq !== undefined && bGlob !== undefined) {
+    return !picomatch.isMatch(aEq, bGlob, { strictSlashes: false });
+  }
+  if (bEq !== undefined && aGlob !== undefined) {
+    return !picomatch.isMatch(bEq, aGlob, { strictSlashes: false });
+  }
+
+  if (aIn !== undefined && bIn !== undefined) {
+    return !aIn.some((v) => bIn.includes(v));
+  }
+  if (aIn !== undefined && bGlob !== undefined) {
+    return !aIn.some((v) => picomatch.isMatch(v, bGlob, { strictSlashes: false }));
+  }
+  if (bIn !== undefined && aGlob !== undefined) {
+    return !bIn.some((v) => picomatch.isMatch(v, aGlob, { strictSlashes: false }));
+  }
+  // $in vs $neq: disjoint if every $in value is excluded by $neq (i.e., equals the $neq value).
+  if (aIn !== undefined && bNeq !== undefined) return aIn.every((v) => v === bNeq);
+  if (bIn !== undefined && aNeq !== undefined) return bIn.every((v) => v === aNeq);
+
+  if (aGlob !== undefined && bGlob !== undefined) {
+    return haveDisjointLiteralPrefixes(aGlob, bGlob);
+  }
+
+  // $glob vs $neq: $glob covers a (typically infinite) set; $neq excludes one value. Probably
+  // disjoint only if the glob is exactly the excluded value as a literal string.
+  if (aGlob !== undefined && bNeq !== undefined) return aGlob === bNeq;
+  if (bGlob !== undefined && aNeq !== undefined) return bGlob === aNeq;
+
+  // Two $neq constraints almost always overlap over an infinite string domain.
+  return false;
+};
+
 const isSubsetForSamePermissionSubjectAction = (
   parentSetRules: ReturnType<MongoAbility["possibleRulesFor"]>,
   subsetRules: ReturnType<MongoAbility["possibleRulesFor"]>,
   appendToMissingPermission: (condition?: MongoQuery) => void
 ) => {
-  const isMissingConditionInParent = parentSetRules.every((el) => !el.conditions);
-  if (isMissingConditionInParent) return true;
+  // Fast path: if every NON-inverted parent rule is unconditional and there are no inverted
+  // rules, the parent grants the action universally
+  const hasOnlyUnconditionalNonInvertedRules =
+    parentSetRules.length > 0 && parentSetRules.every((el) => !el.inverted && !el.conditions);
+  if (hasOnlyUnconditionalNonInvertedRules) return true;
 
   // all subset rules must pass in comparison to parent rul
   return subsetRules.every((subsetRule) => {
@@ -173,27 +228,35 @@ const isSubsetForSamePermissionSubjectAction = (
       });
 
     const invertedParentSetRules = parentSetRules.filter((el) => el.inverted);
-    const isNotSubsetOfInvertedParentSet = invertedParentSetRules.length
+    // A subset is invalid if it overlaps any inverted (deny) parent rule. Since conditions are
+    // AND-of-fields, proving any single field disjoint between the subset and the deny rule is
+    // enough to prove non-overlap.
+    const overlapsWithInvertedParent = (invertedConditions: Record<string, TPermissionConditionShape | string>) => {
+      const fields = Object.keys(invertedConditions);
+      for (const field of fields) {
+        const subsetField = subsetRuleConditions?.[field];
+        // If the subset doesn't constrain this field, it matches every value and inevitably
+        // overlaps the deny region for this field — leave the field unproven and check the next.
+        if (subsetField) {
+          const invertedOps = formatConditionOperator(invertedConditions[field]);
+          const subsetOps = formatConditionOperator(subsetField);
+          if (areOperatorsDisjoint(invertedOps, subsetOps)) return false;
+        }
+      }
+      return true;
+    };
+    const isNotInDeniedRegion = invertedParentSetRules.length
       ? !invertedParentSetRules.some((parentSetRule) => {
-          // get conditions and iterate
           const parentSetRuleConditions = parentSetRule?.conditions as Record<
             string,
             TPermissionConditionShape | string
           >;
+          // Unconditional inverted rule denies everything; any subset overlaps it.
           if (!parentSetRuleConditions) return true;
-          return Object.keys(parentSetRuleConditions).every((parentConditionField) => {
-            // if parent condition is missing then it's never a subset
-            if (!subsetRuleConditions?.[parentConditionField]) return false;
-
-            // standardize the conditions plain string operator => $eq function
-            const parentRuleConditionOperators = formatConditionOperator(parentSetRuleConditions[parentConditionField]);
-            const selectedSubsetRuleCondition = subsetRuleConditions?.[parentConditionField];
-            const subsetRuleConditionOperators = formatConditionOperator(selectedSubsetRuleCondition);
-            return isOperatorsASubset(parentRuleConditionOperators, subsetRuleConditionOperators);
-          });
+          return overlapsWithInvertedParent(parentSetRuleConditions);
         })
       : true;
-    const isSubset = isSubsetOfNonInvertedParentSet && isNotSubsetOfInvertedParentSet;
+    const isSubset = isSubsetOfNonInvertedParentSet && isNotInDeniedRegion;
     if (!isSubset) {
       appendToMissingPermission(subsetRule.conditions);
     }

--- a/backend/src/lib/casl/glob-subset.test.ts
+++ b/backend/src/lib/casl/glob-subset.test.ts
@@ -1,0 +1,78 @@
+import { haveDisjointLiteralPrefixes, isGlobSubsetOfGlob, literalPrefix } from "./glob-subset";
+
+describe("isGlobSubsetOfGlob", () => {
+  describe("identical patterns", () => {
+    test.each([
+      ["/", "/"],
+      ["/apps", "/apps"],
+      ["/apps/**", "/apps/**"],
+      ["**", "**"]
+    ])("%s ⊆ %s is true", (a, b) => expect(isGlobSubsetOfGlob(a, b)).toBe(true));
+  });
+
+  describe("subset narrower than parent", () => {
+    test.each([
+      ["/apps/**", "/apps/foo"],
+      ["/apps/**", "/apps/foo/bar"],
+      ["/apps/**", "/apps/foo/bar/baz"],
+      ["/apps/*", "/apps/foo"],
+      ["/apps/**", "/apps/*"],
+      ["/**", "/apps/**"],
+      ["/**", "/apps/foo"],
+      ["**", "/apps/foo"],
+      ["/apps/**", "/apps/"],
+      ["/apps/**", "/apps"]
+    ])("parent=%s, subset=%s → true", (parent, subset) => expect(isGlobSubsetOfGlob(parent, subset)).toBe(true));
+  });
+
+  describe("subset broader than parent (the bug case)", () => {
+    test.each([
+      ["/apps/*", "/apps/**"],
+      ["/apps/*", "/apps/*/foo"],
+      ["/apps/foo", "/apps/*"],
+      ["/apps/foo", "/apps/**"],
+      ["/apps/**", "/**"],
+      ["/secret/**", "/**"]
+    ])("parent=%s, subset=%s → false", (parent, subset) => expect(isGlobSubsetOfGlob(parent, subset)).toBe(false));
+  });
+
+  describe("disjoint literal segments", () => {
+    test.each([
+      ["/apps/*", "/secret/*"],
+      ["/apps/**", "/secret/**"],
+      ["/foo/bar", "/foo/baz"]
+    ])("parent=%s, subset=%s → false", (parent, subset) => expect(isGlobSubsetOfGlob(parent, subset)).toBe(false));
+  });
+
+  describe("intra-segment wildcards (fall-back path)", () => {
+    test("parent /hello/** does not contain subset /hello** (broader pattern, intra-segment)", () => {
+      expect(isGlobSubsetOfGlob("/hello/**", "/hello**")).toBe(false);
+    });
+
+    test("subset matching exactly with intra-segment wildcards passes via reference equality", () => {
+      expect(isGlobSubsetOfGlob("/hello*", "/hello*")).toBe(true);
+    });
+  });
+});
+
+describe("literalPrefix", () => {
+  test.each([
+    ["/apps/foo", "/apps/foo"],
+    ["/apps/*", "/apps/"],
+    ["/apps/**", "/apps/"],
+    ["/**", "/"],
+    ["**", ""],
+    ["*foo", ""]
+  ])("literalPrefix(%s) === %s", (input, expected) => expect(literalPrefix(input)).toBe(expected));
+});
+
+describe("haveDisjointLiteralPrefixes", () => {
+  test.each([
+    ["/apps/*", "/secret/*", true],
+    ["/apps/**", "/secret/**", true],
+    ["/foo/bar", "/foo/baz", true],
+    ["/foo/bar", "/foo/bar", false],
+    ["/**", "/secret/**", false],
+    ["/apps/*", "/apps/**", false]
+  ])("disjoint(%s, %s) === %s", (a, b, expected) => expect(haveDisjointLiteralPrefixes(a, b)).toBe(expected));
+});

--- a/backend/src/lib/casl/glob-subset.ts
+++ b/backend/src/lib/casl/glob-subset.ts
@@ -1,0 +1,121 @@
+import picomatch from "picomatch";
+
+/**
+ * Glob set-containment for permission boundary checks: answers "is every string matched by
+ * `subsetGlob` also matched by `parentGlob`?".
+ *
+ * `picomatch.isMatch(subsetGlob, parentGlob)` treats the subset as a literal
+ * value, so `/apps/**` appears to be a subset of `/apps/*` (the two chars `**` match `*`). This
+ * module instead compares segment sequences (literal, `*`, `**`) with proper containment semantics.
+ * Patterns with intra-segment wildcards (`foo*`, `?`, `[…]`, `{…}`) fall back to picomatch.
+ */
+
+type Segment = { type: "literal"; value: string } | { type: "star" } | { type: "globstar" };
+
+const SEGMENT_METACHARACTER = /[*?[\]{}!()]/;
+
+const parseSegments = (glob: string): Segment[] | null => {
+  const parts = glob.split("/");
+  const segments: Segment[] = [];
+  for (const part of parts) {
+    if (part === "") {
+      segments.push({ type: "literal", value: "" });
+    } else if (part === "*") {
+      segments.push({ type: "star" });
+    } else if (part === "**") {
+      segments.push({ type: "globstar" });
+    } else if (SEGMENT_METACHARACTER.test(part)) {
+      // Intra-segment wildcards or other glob features (e.g. `foo*`, `*foo`, `[abc]`, `{a,b}`).
+      // Signal the caller to fall back rather than guessing about containment.
+      return null;
+    } else {
+      segments.push({ type: "literal", value: part });
+    }
+  }
+  return segments;
+};
+
+const segmentMatch = (parent: Segment[], subset: Segment[], pi: number, si: number): boolean => {
+  if (pi >= parent.length && si >= subset.length) return true;
+
+  // A globstar in parent can consume zero or more subset segments — try both branches.
+  if (pi < parent.length && parent[pi].type === "globstar") {
+    if (segmentMatch(parent, subset, pi + 1, si)) return true;
+    if (si < subset.length) return segmentMatch(parent, subset, pi, si + 1);
+    return false;
+  }
+
+  // Parent exhausted but subset has more segments — parent cannot match those longer strings.
+  if (pi >= parent.length) return false;
+
+  // Subset exhausted but parent has more — only valid if every remaining parent segment is `**`
+  // (each can consume zero subset segments).
+  if (si >= subset.length) {
+    for (let i = pi; i < parent.length; i += 1) {
+      if (parent[i].type !== "globstar") return false;
+    }
+    return true;
+  }
+
+  const pSeg = parent[pi];
+  const sSeg = subset[si];
+
+  if (pSeg.type === "star") {
+    // `*` matches a single segment of any literal/star content, but not a globstar (which spans
+    // multiple segments and is therefore broader than `*`).
+    if (sSeg.type === "globstar") return false;
+    return segmentMatch(parent, subset, pi + 1, si + 1);
+  }
+
+  if (pSeg.type === "literal") {
+    // A literal segment in parent must be matched by an identical literal segment in subset; any
+    // wildcard in subset would make subset broader than parent.
+    if (sSeg.type !== "literal") return false;
+    if (sSeg.value !== pSeg.value) return false;
+    return segmentMatch(parent, subset, pi + 1, si + 1);
+  }
+
+  return false;
+};
+
+/**
+ * Returns true if every string matched by `subsetGlob` is also matched by `parentGlob`.
+ *
+ * Analyzes globs whose segments are literals, `*`, or `**`. For globs with other features
+ * (intra-segment wildcards, character classes, brace expansion), falls back to
+ * `picomatch.isMatch(subsetGlob, parentGlob)` — preserving the previous
+ * behavior so this change does not affect rules that rely on those patterns.
+ */
+export const isGlobSubsetOfGlob = (parentGlob: string, subsetGlob: string): boolean => {
+  if (parentGlob === subsetGlob) return true;
+  const parentSegs = parseSegments(parentGlob);
+  const subsetSegs = parseSegments(subsetGlob);
+  if (parentSegs && subsetSegs) {
+    return segmentMatch(parentSegs, subsetSegs, 0, 0);
+  }
+  return picomatch.isMatch(subsetGlob, parentGlob, { strictSlashes: false });
+};
+
+/**
+ * Returns the static text of a glob — the prefix up to (but not including) the first glob
+ * metacharacter. Used by callers that need a sound disjointness heuristic for two globs.
+ */
+export const literalPrefix = (glob: string): string => {
+  for (let i = 0; i < glob.length; i += 1) {
+    const c = glob[i];
+    if (c === "*" || c === "?" || c === "[" || c === "{") return glob.slice(0, i);
+  }
+  return glob;
+};
+
+/**
+ * Returns true if the literal prefixes of two globs definitively prove the patterns share no
+ * matches. This is sound but conservative: returns true only when neither prefix is a prefix of
+ * the other (so no string can begin with both), and false otherwise — including cases where the
+ * patterns may or may not actually overlap.
+ */
+export const haveDisjointLiteralPrefixes = (a: string, b: string): boolean => {
+  const pa = literalPrefix(a);
+  const pb = literalPrefix(b);
+  return !pa.startsWith(pb) && !pb.startsWith(pa);
+};

--- a/backend/src/services/service-token/service-token-service.test.ts
+++ b/backend/src/services/service-token/service-token-service.test.ts
@@ -1,0 +1,369 @@
+import { AbilityBuilder, createMongoAbility, MongoAbility } from "@casl/ability";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSet,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
+import { conditionsMatcher } from "@app/lib/casl";
+import { crypto } from "@app/lib/crypto";
+
+import { serviceTokenServiceFactory } from "./service-token-service";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({
+    SALT_ROUNDS: 1
+  })
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn()
+  }
+}));
+
+const PROJECT_ID = "project-id";
+const ACTOR_ID = "actor-id";
+const ACTOR_ORG_ID = "org-id";
+const ENV_SLUG = "dev";
+
+type AbilityFn = (builder: AbilityBuilder<MongoAbility<ProjectPermissionSet>>) => void;
+
+const buildAbility = (configure: AbilityFn) => {
+  const builder = new AbilityBuilder<MongoAbility<ProjectPermissionSet>>(createMongoAbility);
+  configure(builder);
+  return builder.build({ conditionsMatcher });
+};
+
+const grantServiceTokenCreate = (b: AbilityBuilder<MongoAbility<ProjectPermissionSet>>) => {
+  b.can(ProjectPermissionActions.Create, ProjectPermissionSub.ServiceTokens);
+};
+
+// Wrapper that lets us pass partial-shape conditions (e.g., $eq via plain string for secretPath) without
+// fighting CASL's strict per-action condition schema. Mirrors the @ts-expect-error pattern used in
+// `buildServiceTokenProjectPermission`.
+const canWithConditions = (
+  b: AbilityBuilder<MongoAbility<ProjectPermissionSet>>,
+  action: string,
+  subj: string,
+  conditions: Record<string, unknown>
+) => {
+  // @ts-expect-error CASL's per-action condition schema is too narrow for our test inputs.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  b.can(action, subj, conditions);
+};
+
+const createService = (permission: MongoAbility<ProjectPermissionSet>) => {
+  const permissionService = {
+    getProjectPermission: vi.fn().mockResolvedValue({
+      permission,
+      memberships: [],
+      hasRole: () => false,
+      hasProjectEnforcement: () => undefined
+    })
+  };
+
+  const projectEnvDAL = {
+    findBySlugs: vi
+      .fn()
+      .mockImplementation((_projectId: string, slugs: string[]) =>
+        Promise.resolve(slugs.map((slug) => ({ slug, id: `${slug}-id` })))
+      )
+  };
+
+  const serviceTokenDAL = {
+    create: vi
+      .fn()
+      .mockImplementation((row: Record<string, unknown>) => Promise.resolve({ ...row, id: "stub-service-token-id" })),
+    findById: vi.fn(),
+    deleteById: vi.fn(),
+    find: vi.fn(),
+    findExpiringTokens: vi.fn(),
+    update: vi.fn()
+  };
+
+  const orgDAL = { findById: vi.fn() };
+  const projectDAL = { findById: vi.fn() };
+  const userDAL = { findById: vi.fn() };
+  const accessTokenQueue = { updateServiceTokenStatus: vi.fn() };
+  const smtpService = { sendMail: vi.fn() };
+
+  const service = serviceTokenServiceFactory({
+    serviceTokenDAL: serviceTokenDAL as never,
+    userDAL: userDAL as never,
+    permissionService: permissionService as never,
+    projectEnvDAL: projectEnvDAL as never,
+    projectDAL: projectDAL as never,
+    accessTokenQueue: accessTokenQueue as never,
+    smtpService: smtpService as never,
+    orgDAL: orgDAL as never
+  });
+
+  return { service, serviceTokenDAL, permissionService };
+};
+
+const callCreate = ({
+  service,
+  scopes,
+  permissions
+}: {
+  service: ReturnType<typeof createService>["service"];
+  scopes: Array<{ environment: string; secretPath: string }>;
+  permissions: ("read" | "write")[];
+}) =>
+  service.createServiceToken({
+    actor: "user" as never,
+    actorId: ACTOR_ID,
+    actorOrgId: ACTOR_ORG_ID,
+    actorAuthMethod: undefined as never,
+    projectId: PROJECT_ID,
+    name: "test-token",
+    scopes,
+    permissions,
+    encryptedKey: "ek",
+    iv: "iv",
+    tag: "tag",
+    expiresIn: null
+  });
+
+describe("createServiceToken authorization", () => {
+  beforeAll(async () => {
+    process.env.FIPS_ENABLED = "false";
+    await crypto.initialize({} as never, {} as never, {} as never);
+  });
+
+  afterAll(() => {
+    delete process.env.FIPS_ENABLED;
+  });
+
+  describe("read capability — legacy umbrella vs granular halves", () => {
+    test("legacy umbrella role can mint a read token", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        // Legacy: a single rule granting `Read` (= DescribeAndReadValue) on the secret subjects
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionActions.Read, subj);
+            b.can(ProjectPermissionSecretActions.Create, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["read"] })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+
+    test("granular pair (ReadValue + DescribeSecret) can mint a read token", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.ReadValue, subj);
+            b.can(ProjectPermissionSecretActions.DescribeSecret, subj);
+            b.can(ProjectPermissionSecretActions.Create, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["read"] })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+
+    test("only ReadValue (no DescribeSecret) is rejected", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.ReadValue, subj);
+            b.can(ProjectPermissionSecretActions.Create, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["read"] })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+
+    test("only DescribeSecret (no ReadValue) is rejected", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.DescribeSecret, subj);
+            b.can(ProjectPermissionSecretActions.Create, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["read"] })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("write capability", () => {
+    test("caller with Edit + Delete + Create can mint a write token", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.Create, subj);
+            b.can(ProjectPermissionSecretActions.Edit, subj);
+            b.can(ProjectPermissionSecretActions.Delete, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["write"] })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+
+    test("create-only caller cannot mint write or read+write token (action escalation, the original CVE)", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.Create, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/" }],
+          permissions: ["read", "write"]
+        })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+
+    test("caller with Edit but no Delete is rejected for a write token", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionSecretActions.Create, subj);
+            b.can(ProjectPermissionSecretActions.Edit, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({ service, scopes: [{ environment: ENV_SLUG, secretPath: "/" }], permissions: ["write"] })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("scope widening (boundary check)", () => {
+    test("caller with $eq:'/apps/foo' cannot mint token with secretPath='/apps/**' (eq → glob)", async () => {
+      const conditions = { secretPath: "/apps/foo", environment: ENV_SLUG };
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            canWithConditions(b, ProjectPermissionSecretActions.Create, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.Edit, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.Delete, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.ReadValue, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.DescribeSecret, subj, conditions);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/apps/**" }],
+          permissions: ["read", "write"]
+        })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+
+    test("caller with $eq:'/apps/foo' can mint token with the literal secretPath='/apps/foo' (no widening)", async () => {
+      const conditions = { secretPath: "/apps/foo", environment: ENV_SLUG };
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            canWithConditions(b, ProjectPermissionSecretActions.Create, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.Edit, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.Delete, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.ReadValue, subj, conditions);
+            canWithConditions(b, ProjectPermissionSecretActions.DescribeSecret, subj, conditions);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/apps/foo" }],
+          permissions: ["read", "write"]
+        })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("admin-equivalent role (full unconditioned permissions)", () => {
+    test("can mint read+write token with recursive scope (regression for happy path)", async () => {
+      const permission = buildAbility((b) => {
+        grantServiceTokenCreate(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            b.can(ProjectPermissionActions.Read, subj);
+            b.can(ProjectPermissionSecretActions.ReadValue, subj);
+            b.can(ProjectPermissionSecretActions.DescribeSecret, subj);
+            b.can(ProjectPermissionSecretActions.Create, subj);
+            b.can(ProjectPermissionSecretActions.Edit, subj);
+            b.can(ProjectPermissionSecretActions.Delete, subj);
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/**" }],
+          permissions: ["read", "write"]
+        })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/src/services/service-token/service-token-service.test.ts
+++ b/backend/src/services/service-token/service-token-service.test.ts
@@ -160,16 +160,21 @@ describe("createServiceToken authorization", () => {
       expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
     });
 
-    test("granular pair (ReadValue + DescribeSecret) can mint a read token", async () => {
+    // Realistic V2 caller shape: Secrets supports granular actions (ReadValue + DescribeSecret),
+    // while SecretFolders / SecretImports only support ProjectPermissionActions (plain Read). The
+    // granular boundary fallback in createServiceToken must therefore grant ReadValue+DescribeSecret
+    // on Secrets and plain Read on SecretFolders/SecretImports; otherwise it would emit
+    // (readValue|describeSecret, SecretFolders|SecretImports) rules that no V2 caller can satisfy.
+    test("granular pair on Secrets + plain Read on folders/imports can mint a read token", async () => {
       const permission = buildAbility((b) => {
         grantServiceTokenCreate(b);
-        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
-          (subj) => {
-            b.can(ProjectPermissionSecretActions.ReadValue, subj);
-            b.can(ProjectPermissionSecretActions.DescribeSecret, subj);
-            b.can(ProjectPermissionSecretActions.Create, subj);
-          }
-        );
+        b.can(ProjectPermissionSecretActions.ReadValue, ProjectPermissionSub.Secrets);
+        b.can(ProjectPermissionSecretActions.DescribeSecret, ProjectPermissionSub.Secrets);
+        b.can(ProjectPermissionSecretActions.Create, ProjectPermissionSub.Secrets);
+        [ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach((subj) => {
+          b.can(ProjectPermissionActions.Read, subj);
+          b.can(ProjectPermissionActions.Create, subj);
+        });
       });
 
       const { service, serviceTokenDAL } = createService(permission);
@@ -283,20 +288,30 @@ describe("createServiceToken authorization", () => {
   });
 
   describe("scope widening (boundary check)", () => {
+    // Caller permissions mirror the realistic V2 schema: granular actions on Secrets
+    // and ProjectPermissionActions on SecretImports / SecretFolders. Both bound by the
+    // same condition so the only variable under test is the requested token scope.
+    const grantV2ScopedPermissions = (
+      b: AbilityBuilder<MongoAbility<ProjectPermissionSet>>,
+      conditions: Record<string, unknown>
+    ) => {
+      grantServiceTokenCreate(b);
+      canWithConditions(b, ProjectPermissionSecretActions.Create, ProjectPermissionSub.Secrets, conditions);
+      canWithConditions(b, ProjectPermissionSecretActions.Edit, ProjectPermissionSub.Secrets, conditions);
+      canWithConditions(b, ProjectPermissionSecretActions.Delete, ProjectPermissionSub.Secrets, conditions);
+      canWithConditions(b, ProjectPermissionSecretActions.ReadValue, ProjectPermissionSub.Secrets, conditions);
+      canWithConditions(b, ProjectPermissionSecretActions.DescribeSecret, ProjectPermissionSub.Secrets, conditions);
+      [ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach((subj) => {
+        canWithConditions(b, ProjectPermissionActions.Read, subj, conditions);
+        canWithConditions(b, ProjectPermissionActions.Create, subj, conditions);
+        canWithConditions(b, ProjectPermissionActions.Edit, subj, conditions);
+        canWithConditions(b, ProjectPermissionActions.Delete, subj, conditions);
+      });
+    };
+
     test("caller with $eq:'/apps/foo' cannot mint token with secretPath='/apps/**' (eq → glob)", async () => {
       const conditions = { secretPath: "/apps/foo", environment: ENV_SLUG };
-      const permission = buildAbility((b) => {
-        grantServiceTokenCreate(b);
-        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
-          (subj) => {
-            canWithConditions(b, ProjectPermissionSecretActions.Create, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.Edit, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.Delete, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.ReadValue, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.DescribeSecret, subj, conditions);
-          }
-        );
-      });
+      const permission = buildAbility((b) => grantV2ScopedPermissions(b, conditions));
 
       const { service, serviceTokenDAL } = createService(permission);
 
@@ -312,18 +327,7 @@ describe("createServiceToken authorization", () => {
 
     test("caller with $eq:'/apps/foo' can mint token with the literal secretPath='/apps/foo' (no widening)", async () => {
       const conditions = { secretPath: "/apps/foo", environment: ENV_SLUG };
-      const permission = buildAbility((b) => {
-        grantServiceTokenCreate(b);
-        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
-          (subj) => {
-            canWithConditions(b, ProjectPermissionSecretActions.Create, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.Edit, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.Delete, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.ReadValue, subj, conditions);
-            canWithConditions(b, ProjectPermissionSecretActions.DescribeSecret, subj, conditions);
-          }
-        );
-      });
+      const permission = buildAbility((b) => grantV2ScopedPermissions(b, conditions));
 
       const { service, serviceTokenDAL } = createService(permission);
 

--- a/backend/src/services/service-token/service-token-service.test.ts
+++ b/backend/src/services/service-token/service-token-service.test.ts
@@ -7,7 +7,7 @@ import {
   ProjectPermissionSet,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
-import { conditionsMatcher } from "@app/lib/casl";
+import { conditionsMatcher, PermissionConditionOperators } from "@app/lib/casl";
 import { crypto } from "@app/lib/crypto";
 
 import { serviceTokenServiceFactory } from "./service-token-service";
@@ -336,6 +336,119 @@ describe("createServiceToken authorization", () => {
           service,
           scopes: [{ environment: ENV_SLUG, secretPath: "/apps/foo" }],
           permissions: ["read", "write"]
+        })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression: glob → broader-glob widening was previously allowed because the boundary check
+    // used `picomatch.isMatch` to compare a subset glob against a parent glob as if the subset
+    // were a literal value, so `/apps/**` matched `/apps/*` (the literal `**` is two non-`/`
+    // characters and matches `*`). The fix in `boundary.ts` switched to a sound glob-set
+    // containment check.
+    test("caller with $glob:'/apps/*' cannot mint token with secretPath='/apps/**' (glob → broader glob)", async () => {
+      const conditions = {
+        secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/*" },
+        environment: ENV_SLUG
+      };
+      const permission = buildAbility((b) => grantV2ScopedPermissions(b, conditions));
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/apps/**" }],
+          permissions: ["read", "write"]
+        })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+
+    test("caller with $glob:'/apps/**' can mint token with secretPath='/apps/foo' (narrower)", async () => {
+      const conditions = {
+        secretPath: { [PermissionConditionOperators.$GLOB]: "/apps/**" },
+        environment: ENV_SLUG
+      };
+      const permission = buildAbility((b) => grantV2ScopedPermissions(b, conditions));
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/apps/foo" }],
+          permissions: ["read", "write"]
+        })
+      ).resolves.toBeDefined();
+      expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression: a caller with a positive unconditional rule plus an inverted (deny) rule
+    // narrower than the requested token scope was previously allowed to mint, even though the
+    // resulting token grants access inside the deny region. Now overlap with the deny region —
+    // including the case where the subset is broader than the deny — fails the boundary check.
+    // The boundary check for a legacy "read" service token mints a token rule using
+    // `ProjectPermissionActions.Read` ("read") on each secret subject. To exercise the inverted-
+    // overlap path, the caller must have a deny rule on the SAME action — `Read` — at a narrower
+    // scope than the token's requested scope. Then the boundary check sees a positive rule plus
+    // a conditional inverted rule for action="read", and rejects the token because the requested
+    // glob (`/**`) overlaps the deny region (`/secret/**`).
+    const grantUnconditionalSecretActions = (b: AbilityBuilder<MongoAbility<ProjectPermissionSet>>) => {
+      grantServiceTokenCreate(b);
+      [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+        (subj) => {
+          b.can(ProjectPermissionActions.Read, subj);
+          b.can(ProjectPermissionSecretActions.ReadValue, subj);
+          b.can(ProjectPermissionSecretActions.DescribeSecret, subj);
+          b.can(ProjectPermissionSecretActions.Create, subj);
+        }
+      );
+    };
+
+    test("caller with deny Read on '/secret/**' cannot mint token with secretPath='/**' (inverted overlap)", async () => {
+      const permission = buildAbility((b) => {
+        grantUnconditionalSecretActions(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            // @ts-expect-error CASL's per-action condition schema doesn't expose $glob, but the
+            // conditionsMatcher resolves it at runtime; same pattern is used in production rules.
+            b.cannot(ProjectPermissionActions.Read, subj, { secretPath: { $glob: "/secret/**" } });
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/**" }],
+          permissions: ["read"]
+        })
+      ).rejects.toThrow();
+      expect(serviceTokenDAL.create).not.toHaveBeenCalled();
+    });
+
+    test("caller with deny Read on '/secret/**' can mint token with secretPath='/apps/**' (no overlap)", async () => {
+      const permission = buildAbility((b) => {
+        grantUnconditionalSecretActions(b);
+        [ProjectPermissionSub.Secrets, ProjectPermissionSub.SecretImports, ProjectPermissionSub.SecretFolders].forEach(
+          (subj) => {
+            // @ts-expect-error CASL's per-action condition schema doesn't expose $glob, but the
+            // conditionsMatcher resolves it at runtime; same pattern is used in production rules.
+            b.cannot(ProjectPermissionActions.Read, subj, { secretPath: { $glob: "/secret/**" } });
+          }
+        );
+      });
+
+      const { service, serviceTokenDAL } = createService(permission);
+
+      await expect(
+        callCreate({
+          service,
+          scopes: [{ environment: ENV_SLUG, secretPath: "/apps/**" }],
+          permissions: ["read"]
         })
       ).resolves.toBeDefined();
       expect(serviceTokenDAL.create).toHaveBeenCalledTimes(1);

--- a/backend/src/services/service-token/service-token-service.ts
+++ b/backend/src/services/service-token/service-token-service.ts
@@ -110,9 +110,12 @@ export const serviceTokenServiceFactory = ({
         const tokenAbilityGranular = buildServiceTokenProjectPermission(scopes, permissions, { useLegacyRead: false });
         const boundaryGranular = validatePermissionBoundary(permission, tokenAbilityGranular);
         if (!boundaryGranular.isValid) {
+          const legacyMissing = boundaryLegacy.missingPermissions ?? [];
+          const granularMissing = boundaryGranular.missingPermissions ?? [];
+          const decisiveMissing = legacyMissing.length <= granularMissing.length ? legacyMissing : granularMissing;
           throw new PermissionBoundaryError({
             message: "Cannot create service token whose permissions exceed the caller's permissions",
-            details: { missingPermissions: boundaryLegacy.missingPermissions }
+            details: { missingPermissions: decisiveMissing }
           });
         }
       }

--- a/backend/src/services/service-token/service-token-service.ts
+++ b/backend/src/services/service-token/service-token-service.ts
@@ -3,13 +3,15 @@ import { ForbiddenError, subject } from "@casl/ability";
 import { ActionProjectType } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
+  buildServiceTokenProjectPermission,
   ProjectPermissionActions,
   ProjectPermissionSecretActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
+import { validatePermissionBoundary } from "@app/lib/casl/boundary";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
-import { ForbiddenRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
+import { ForbiddenRequestError, NotFoundError, PermissionBoundaryError, UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
@@ -76,12 +78,55 @@ export const serviceTokenServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Create, ProjectPermissionSub.ServiceTokens);
 
+    const canRead = permissions.includes("read");
+    const canWrite = permissions.includes("write");
+
     scopes.forEach(({ environment, secretPath }) => {
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionSecretActions.Create,
-        subject(ProjectPermissionSub.Secrets, { environment, secretPath })
-      );
+      const secretSubject = subject(ProjectPermissionSub.Secrets, { environment, secretPath });
+
+      ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionSecretActions.Create, secretSubject);
+
+      if (canRead) {
+        const hasLegacyReadUmbrella = permission.can(
+          ProjectPermissionSecretActions.DescribeAndReadValue,
+          secretSubject
+        );
+        if (!hasLegacyReadUmbrella) {
+          ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionSecretActions.ReadValue, secretSubject);
+          ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionSecretActions.DescribeSecret, secretSubject);
+        }
+      }
+
+      if (canWrite) {
+        ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionSecretActions.Edit, secretSubject);
+        ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionSecretActions.Delete, secretSubject);
+      }
     });
+
+    if (canRead) {
+      const tokenAbilityLegacy = buildServiceTokenProjectPermission(scopes, permissions);
+      const boundaryLegacy = validatePermissionBoundary(permission, tokenAbilityLegacy);
+      if (!boundaryLegacy.isValid) {
+        const tokenAbilityGranular = buildServiceTokenProjectPermission(scopes, permissions, { useLegacyRead: false });
+        const boundaryGranular = validatePermissionBoundary(permission, tokenAbilityGranular);
+        if (!boundaryGranular.isValid) {
+          throw new PermissionBoundaryError({
+            message: "Cannot create service token whose permissions exceed the caller's permissions",
+            details: { missingPermissions: boundaryLegacy.missingPermissions }
+          });
+        }
+      }
+    } else {
+      // Write-only tokens have no read aliasing concern; a single boundary check suffices.
+      const tokenAbility = buildServiceTokenProjectPermission(scopes, permissions);
+      const boundary = validatePermissionBoundary(permission, tokenAbility);
+      if (!boundary.isValid) {
+        throw new PermissionBoundaryError({
+          message: "Cannot create service token whose permissions exceed the caller's permissions",
+          details: { missingPermissions: boundary.missingPermissions }
+        });
+      }
+    }
 
     const appCfg = getConfig();
 


### PR DESCRIPTION
## Context

Fix https://linear.app/infisical/issue/SEC-3

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)