### PR TITLE
fix(api): add missing operationIds to dynamic secret lease router

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
@@ -21,7 +21,9 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
     },
     schema: {
       hide: false,
+      operationId: "createDynamicSecretLease",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Create a lease for a dynamic secret",
       body: z.object({
         dynamicSecretName: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.CREATE.dynamicSecretName).toLowerCase(),
         projectSlug: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.CREATE.projectSlug),
@@ -108,7 +110,9 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
     },
     schema: {
       hide: false,
+      operationId: "deleteDynamicSecretLease",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Delete (revoke) a dynamic secret lease",
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.DELETE.leaseId)
       }),
@@ -174,7 +178,9 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
     },
     schema: {
       hide: false,
+      operationId: "renewDynamicSecretLease",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Renew a dynamic secret lease",
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.RENEW.leaseId)
       }),
@@ -266,7 +272,9 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
     },
     schema: {
       hide: false,
+      operationId: "getDynamicSecretLease",
       tags: [ApiDocsTags.DynamicSecrets],
+      description: "Retrieve a dynamic secret lease by ID",
       params: z.object({
         leaseId: z.string().min(1).describe(DYNAMIC_SECRET_LEASES.GET_BY_LEASEID.leaseId)
       }),


### PR DESCRIPTION
## Problem

All four public routes in `backend/src/ee/routes/v1/dynamic-secret-lease-router.ts` have `hide: false` and `ApiDocsTags.DynamicSecrets`, making them visible in the OpenAPI schema — but none had an `operationId`. Without a stable `operationId`, OpenAPI tooling auto-derives identifiers from the HTTP method + path on every schema rebuild. These derived names are unstable: they shift when routes are reordered and break generated SDK method names and documentation anchors.

This is the companion issue to #6430 (which fixed the same problem in `dynamic-secret-router.ts`). Both routers are part of the same Dynamic Secrets feature surface and were apparently authored at the same time, both missing operationIds.

## Fix

Added `operationId` and `description` to all four public routes:

| Route | operationId |
|---|---|
| `POST /` | `createDynamicSecretLease` |
| `DELETE /:leaseId` | `deleteDynamicSecretLease` |
| `POST /:leaseId/renew` | `renewDynamicSecretLease` |
| `GET /:leaseId` | `getDynamicSecretLease` |

## Testing

No behaviour changes — purely additive metadata on route schemas. Existing route handlers, auth, rate limits, and Zod validation are untouched.