### PR TITLE
fix(api): add missing operationIds to SSH PKI routers

### DIFF
--- a/backend/src/ee/routes/v1/ssh-certificate-authority-router.ts
+++ b/backend/src/ee/routes/v1/ssh-certificate-authority-router.ts
@@ -21,6 +21,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "createSshCa",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Create SSH CA",
       body: z
@@ -95,6 +96,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "getSshCa",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Get SSH CA",
       params: z.object({
@@ -143,6 +145,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       hide: false,
+      operationId: "getSshCaPublicKey",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Get public key of SSH CA",
       params: z.object({
@@ -170,6 +173,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "updateSshCa",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Update SSH CA",
       params: z.object({
@@ -225,6 +229,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "deleteSshCa",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Delete SSH CA",
       params: z.object({
@@ -272,6 +277,7 @@ export const registerSshCaRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "listSshCaCertificateTemplates",
       tags: [ApiDocsTags.SshCertificateAuthorities],
       description: "Get list of certificate templates for the SSH CA",
       params: z.object({

--- a/backend/src/ee/routes/v1/ssh-certificate-router.ts
+++ b/backend/src/ee/routes/v1/ssh-certificate-router.ts
@@ -21,6 +21,7 @@ export const registerSshCertRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "signSshKey",
       tags: [ApiDocsTags.SshCertificates],
       description: "Sign SSH public key",
       body: z.object({
@@ -104,6 +105,7 @@ export const registerSshCertRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "issueSshCredentials",
       tags: [ApiDocsTags.SshCertificates],
       description: "Issue SSH credentials (certificate + key)",
       body: z.object({

--- a/backend/src/ee/routes/v1/ssh-certificate-template-router.ts
+++ b/backend/src/ee/routes/v1/ssh-certificate-template-router.ts
@@ -23,6 +23,8 @@ export const registerSshCertificateTemplateRouter = async (server: FastifyZodPro
     },
     schema: {
       hide: false,
+      operationId: "getSshCertificateTemplate",
+      description: "Get SSH certificate template",
       tags: [ApiDocsTags.SshCertificateTemplates],
       params: z.object({
         certificateTemplateId: z.string().describe(SSH_CERTIFICATE_TEMPLATES.GET.certificateTemplateId)
@@ -64,6 +66,8 @@ export const registerSshCertificateTemplateRouter = async (server: FastifyZodPro
     },
     schema: {
       hide: false,
+      operationId: "createSshCertificateTemplate",
+      description: "Create SSH certificate template",
       tags: [ApiDocsTags.SshCertificateTemplates],
       body: z
         .object({
@@ -146,6 +150,8 @@ export const registerSshCertificateTemplateRouter = async (server: FastifyZodPro
     },
     schema: {
       hide: false,
+      operationId: "updateSshCertificateTemplate",
+      description: "Update SSH certificate template",
       tags: [ApiDocsTags.SshCertificateTemplates],
       body: z.object({
         status: z.nativeEnum(SshCertTemplateStatus).optional(),
@@ -231,6 +237,8 @@ export const registerSshCertificateTemplateRouter = async (server: FastifyZodPro
     },
     schema: {
       hide: false,
+      operationId: "deleteSshCertificateTemplate",
+      description: "Delete SSH certificate template",
       tags: [ApiDocsTags.SshCertificateTemplates],
       params: z.object({
         certificateTemplateId: z.string().describe(SSH_CERTIFICATE_TEMPLATES.DELETE.certificateTemplateId)


### PR DESCRIPTION
## Problem

Three SSH PKI router files have routes marked `hide: false` (visible in the public OpenAPI schema) with tags assigned, but no `operationId`. Without a stable `operationId`, OpenAPI tooling auto-derives identifiers from the HTTP method + path on every schema rebuild. These derived names are unstable — they change when routes are reordered and break generated SDK method names and documentation anchors.

All three files appear to have been authored together as part of the SSH PKI feature but the operationId step was skipped across the board.

## Fix

Added `operationId` (and `description` where missing) to all 12 affected routes across three files:

**`ssh-certificate-router.ts`** (2 routes)
| Route | operationId |
|---|---|
| `POST /sign` | `signSshKey` |
| `POST /issue` | `issueSshCredentials` |

**`ssh-certificate-authority-router.ts`** (6 routes)
| Route | operationId |
|---|---|
| `POST /` | `createSshCa` |
| `GET /:sshCaId` | `getSshCa` |
| `GET /:sshCaId/public-key` | `getSshCaPublicKey` |
| `PATCH /:sshCaId` | `updateSshCa` |
| `DELETE /:sshCaId` | `deleteSshCa` |
| `GET /:sshCaId/certificate-templates` | `listSshCaCertificateTemplates` |

**`ssh-certificate-template-router.ts`** (4 routes)
| Route | operationId |
|---|---|
| `GET /:certificateTemplateId` | `getSshCertificateTemplate` |
| `POST /` | `createSshCertificateTemplate` |
| `PATCH /:certificateTemplateId` | `updateSshCertificateTemplate` |
| `DELETE /:certificateTemplateId` | `deleteSshCertificateTemplate` |

## Testing

No behaviour changes — purely additive metadata on route schemas. Existing handlers, auth, rate limits, and Zod validation are untouched.