### PR TITLE
fix(api): add missing operationIds to identity additional privilege router

### DIFF
--- a/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
@@ -26,6 +26,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "createIdentityAdditionalPrivilegePermanent",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "Create a permanent or a non expiry specific privilege for identity.",
       security: [
@@ -108,6 +109,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "createIdentityAdditionalPrivilegeTemporary",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "Create a temporary or a expiring specific privilege for identity.",
       security: [
@@ -202,6 +204,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "updateIdentityAdditionalPrivilege",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "Update a specific privilege of an identity.",
       security: [
@@ -314,6 +317,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "deleteIdentityAdditionalPrivilege",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "Delete a specific privilege of an identity.",
       security: [
@@ -378,6 +382,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "getIdentityAdditionalPrivilegeBySlug",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "Retrieve details of a specific privilege by privilege slug.",
       security: [
@@ -444,6 +449,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
     },
     schema: {
       hide: false,
+      operationId: "listIdentityAdditionalPrivileges",
       tags: [ApiDocsTags.IdentitySpecificPrivilegesV1],
       description: "List of a specific privilege of an identity in a project.",
       security: [


### PR DESCRIPTION
## Problem

All six routes in `backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts` have `hide: false` (public OpenAPI schema), `ApiDocsTags.IdentitySpecificPrivilegesV1`, descriptions, and `security` blocks — yet none had an `operationId`. Without a stable `operationId`, OpenAPI tooling auto-derives identifiers from the HTTP method + path on every schema rebuild. These derived names shift when routes are reordered and break generated SDK method names and documentation anchors.

## Fix

Added `operationId` to all six public routes:

| Route | operationId |
|---|---|
| `POST /permanent` | `createIdentityAdditionalPrivilegePermanent` |
| `POST /temporary` | `createIdentityAdditionalPrivilegeTemporary` |
| `PATCH /` | `updateIdentityAdditionalPrivilege` |
| `DELETE /` | `deleteIdentityAdditionalPrivilege` |
| `GET /:privilegeSlug` | `getIdentityAdditionalPrivilegeBySlug` |
| `GET /` | `listIdentityAdditionalPrivileges` |

Naming follows the convention used for similar identity management endpoints throughout the codebase.

## Testing

No behaviour changes — purely additive metadata on route schemas. Existing handlers, auth, rate limits, and Zod validation are untouched.