### PR TITLE
fix: allow spaces in project name and group search filter params

### DIFF
--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -331,14 +331,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       querystring: z.object({
         offset: z.coerce.number().min(0).default(0).describe(GROUPS.LIST_MACHINE_IDENTITIES.offset),
         limit: z.coerce.number().min(1).max(100).default(10).describe(GROUPS.LIST_MACHINE_IDENTITIES.limit),
-        search: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
-          .describe(GROUPS.LIST_MACHINE_IDENTITIES.search),
+        search: z.string().trim().max(256).optional().describe(GROUPS.LIST_MACHINE_IDENTITIES.search),
         filter: z
           .nativeEnum(FilterReturnedMachineIdentities)
           .optional()
@@ -476,14 +469,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       querystring: z.object({
         offset: z.coerce.number().min(0).default(0).describe(GROUPS.LIST_PROJECTS.offset),
         limit: z.coerce.number().min(1).max(100).default(10).describe(GROUPS.LIST_PROJECTS.limit),
-        search: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
-          .describe(GROUPS.LIST_PROJECTS.search),
+        search: z.string().trim().max(256).optional().describe(GROUPS.LIST_PROJECTS.search),
         filter: z.nativeEnum(FilterReturnedProjects).optional().describe(GROUPS.LIST_PROJECTS.filterProjects),
         orderBy: z
           .nativeEnum(GroupProjectsOrderBy)

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -11,7 +11,6 @@ import {
 import { ProjectMicrosoftTeamsConfigsSchema } from "@app/db/schemas/project-microsoft-teams-configs";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, PROJECTS } from "@app/lib/api-docs";
-import { CharacterType, characterValidator } from "@app/lib/validator/validate-string";
 import { re2Validator } from "@app/lib/zod";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -704,13 +703,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         type: z.nativeEnum(ProjectType).optional(),
         orderBy: z.nativeEnum(SearchProjectSortBy).optional().default(SearchProjectSortBy.NAME),
         orderDirection: z.nativeEnum(SortDirection).optional().default(SortDirection.ASC),
-        name: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
+        name: z.string().trim().max(256).optional()
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1015,13 +1015,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         orderBy: z.nativeEnum(SearchProjectSortBy).optional().default(SearchProjectSortBy.NAME),
         orderDirection: z.nativeEnum(SortDirection).optional().default(SortDirection.ASC),
         projectIds: z.string().trim().array().optional(),
-        name: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
+        name: z.string().trim().max(256).optional()
       }),
       response: {
         200: z.object({


### PR DESCRIPTION
## Problem

Closes #5813

Project names can contain spaces — they're created using `GenericResourceNameSchema`, which already allows spaces. But the `name`/`search` filter validators on four search/list endpoints applied a character whitelist built for resource *identifiers* (alphanumeric + hyphen only). This means any search query with a space — e.g. `"My Project"` — was rejected with a `422 ValidationFailure`:

```json
{
  "code": "custom",
  "message": "Invalid pattern: only alphanumeric characters, - are allowed.",
  "path": ["name"]
}
```

This broke:
- **All Projects** search (`POST /api/v1/organization/projects/search`)
- **Group → Machine Identities** search (`GET /ee/groups/:id/machine-identities`)  
- **Group → Projects** search (`GET /ee/groups/:id/projects`)

## Root cause

The `.refine(characterValidator([...AlphaNumeric, ...Hyphen]))` guard is correct for *writing* a resource name to the database, but wrong for a read-only *search filter*. The filter is only used to build a SQL `LIKE` or `ILIKE` clause via Knex, which parameterizes all inputs — there is no injection risk from allowing arbitrary characters.

## Fix

Removed the `.refine()` restriction from all four affected locations across three files and replaced each with `z.string().trim().max(256).optional()`. Also removed the now-unused `CharacterType`/`characterValidator` import from `deprecated-project-router.ts`.

| File | Location |
|---|---|
| `project-router.ts` | `searchProjects` body → `name` |
| `deprecated-project-router.ts` | `searchProjects` body → `name` |
| `group-router.ts` | `listGroupMachineIdentities` querystring → `search` |
| `group-router.ts` | `listGroupProjects` querystring → `search` |

## Testing

Search for a project named `"My Project"` (or any multi-word name) via the All Projects view — it should now return results instead of a 422 error. No schema migrations needed.