### PR TITLE
fix(ui): replace &apos; entity with numeric &#39; in CommitForm description

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
@@ -623,7 +623,7 @@ export const CommitForm: React.FC<CommitFormProps> = ({
               </Badge>
             </SheetTitle>
             <SheetDescription>
-              Write a commit message and review the changes you&apos;re about to save.
+              Write a commit message and review the changes you&#39;re about to save.
             </SheetDescription>
           </SheetHeader>
 


### PR DESCRIPTION
## Summary

- Fixes the Commit Changes panel description rendering `&apos;` as a literal string instead of an apostrophe in some browsers
- `&apos;` is absent from the HTML4 named-entity list (only defined in XHTML/HTML5 and XML), so certain browsers and JSX processors pass it through unprocessed
- Replaced with `&#39;` — the universally supported decimal numeric character reference — which renders correctly across all HTML versions and browsers

Fixes #6322

## Test plan

- [ ] Navigate to any secret environment and delete a secret to trigger the Commit Changes sheet
- [ ] Verify the description now reads: _"Write a commit message and review the changes you're about to save."_ with a visible apostrophe