### PR TITLE
fix(ui): wire Cancel buttons in Tax ID and Revoke Certificate modals

### DIFF
--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateRevocationModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateRevocationModal.tsx
@@ -112,7 +112,7 @@ export const CertificateRevocationModal = ({ popUp, handlePopUpToggle }: Props) 
             >
               Revoke
             </Button>
-            <Button colorSchema="secondary" variant="plain">
+            <Button colorSchema="secondary" variant="plain" onClick={() => handlePopUpToggle("revokeCertificate", false)}>
               Cancel
             </Button>
           </div>

--- a/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/TaxIDModal.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingDetailsTab/TaxIDModal.tsx
@@ -163,7 +163,7 @@ export const TaxIDModal = ({ popUp, handlePopUpClose, handlePopUpToggle }: Props
             >
               Add
             </Button>
-            <Button colorSchema="secondary" variant="plain">
+            <Button colorSchema="secondary" variant="plain" onClick={() => handlePopUpClose("addTaxID")}>
               Cancel
             </Button>
           </div>


### PR DESCRIPTION
## Summary

- Fixes the **Add Tax ID** modal's Cancel button having no effect when clicked
- Fixes the **Revoke Certificate** modal's Cancel button having no effect when clicked
- Both buttons were rendered without `onClick` handlers, so clicking them did nothing
- Added the correct close handler to each button:
  - `TaxIDModal`: `onClick={() => handlePopUpClose("addTaxID")}`
  - `CertificateRevocationModal`: `onClick={() => handlePopUpToggle("revokeCertificate", false)}`

Fixes #5725

## Test plan

- [ ] Go to `/organizations/:orgId/billing` → **Billing details** tab → **Tax ID** section → click **Add method**, then click **Cancel** — modal should close
- [ ] Go to Cert Manager project → Certificates → open a certificate's action menu → click **Revoke Certificate** → click **Cancel** in the revoke modal — modal should close