### PR TITLE
fix(signup): validate organization name characters on the frontend

### DIFF
--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -54,7 +54,14 @@ const createUserInfoFormSchema = (isInvite: boolean) =>
     name: z.string().min(1, "Please, specify your name"),
     organizationName: isInvite
       ? z.string().optional()
-      : z.string().min(1, "Please, specify your organization name").max(64),
+      : z
+          .string()
+          .min(1, "Please, specify your organization name")
+          .max(64, "Name must be 64 or fewer characters")
+          .refine(
+            (val) => /^[a-zA-Z0-9\-_ ]+$/.test(val),
+            "Name can only contain alphanumeric characters, dashes, underscores, and spaces"
+          ),
     password: passwordSchema,
     attributionSource: z.string().optional()
   });


### PR DESCRIPTION
## Summary

- The backend `GenericResourceNameSchema` allows only alphanumeric characters, dashes, underscores, and spaces in organization names
- The frontend Zod schema for the signup step was only validating length (`min(1)`, `max(64)`)
- Characters like `&`, `#`, `@`, etc. passed client-side validation, were sent to the backend, and the request failed silently with no error shown to the user
- Added the same character restriction to the frontend schema so users see an inline validation error immediately, before the request is sent

Fixes #3867

## Test plan

- [ ] Go to the signup page (email-based or Google OAuth)
- [ ] In the organization name field, enter a name with a special character like `&why` or `test&org`
- [ ] Verify an inline error appears: _"Name can only contain alphanumeric characters, dashes, underscores, and spaces"_
- [ ] Verify that a name like `my-org_name 123` is accepted