### PR TITLE
chore(api): memoize userDAL.findById on requests and where no mutation occurs

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -120,7 +120,9 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
-    const requestedByUser = await userDAL.findById(actorId);
+    const requestedByUser = await requestMemoize(requestMemoKeys.userFindById(actorId), () =>
+      userDAL.findById(actorId)
+    );
     if (!requestedByUser) throw new ForbiddenRequestError({ message: "User not found" });
 
     await projectDAL.checkProjectUpgradeStatus(project.id);
@@ -363,7 +365,7 @@ export const accessApprovalRequestServiceFactory = ({
       throw new BadRequestError({ message: "This access request has expired" });
     }
 
-    const editedByUser = await userDAL.findById(actorId);
+    const editedByUser = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
 
     if (!editedByUser) throw new NotFoundError({ message: "Editing user not found" });
 
@@ -871,7 +873,9 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
-    const targetUser = await userDAL.findById(accessApprovalRequest.requestedByUserId);
+    const targetUser = await requestMemoize(requestMemoKeys.userFindById(accessApprovalRequest.requestedByUserId), () =>
+      userDAL.findById(accessApprovalRequest.requestedByUserId)
+    );
     if (!targetUser) throw new NotFoundError({ message: "Target user not found" });
 
     const memberSubject = subject(ProjectPermissionSub.Member, {

--- a/backend/src/ee/services/ai-mcp-endpoint/ai-mcp-endpoint-service.ts
+++ b/backend/src/ee/services/ai-mcp-endpoint/ai-mcp-endpoint-service.ts
@@ -19,6 +19,8 @@ import { setupRelayServer } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
 import { PiiEntityType, redactPiiFromObject } from "@app/lib/pii";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { ActorType, AuthMethod, AuthTokenType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -232,7 +234,7 @@ export const aiMcpEndpointServiceFactory = ({
       subject(ProjectPermissionSub.McpEndpoints, { name: endpoint.name })
     );
 
-    const user = await userDAL.findById(userId);
+    const user = await requestMemoize(requestMemoKeys.userFindById(userId), () => userDAL.findById(userId));
     if (!user) {
       throw new NotFoundError({ message: `User with ID '${userId}' not found` });
     }

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
@@ -146,7 +146,7 @@ export const dynamicSecretLeaseServiceFactory = ({
     try {
       const identity: { name: string } = { name: "" };
       if (actor === ActorType.USER) {
-        const user = await userDAL.findById(actorId);
+        const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
         if (user) {
           identity.name = extractEmailUsername(user.username);
         }

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -867,7 +867,7 @@ export const pamAccountServiceFactory = ({
       }
     }
 
-    const actorUser = await userDAL.findById(actor.id);
+    const actorUser = await requestMemoize(requestMemoKeys.userFindById(actor.id), () => userDAL.findById(actor.id));
     if (!actorUser) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });
 
     // If no mfaSessionId is provided, create a new MFA session
@@ -955,7 +955,7 @@ export const pamAccountServiceFactory = ({
       }
     }
 
-    const user = await userDAL.findById(actor.id);
+    const user = await requestMemoize(requestMemoKeys.userFindById(actor.id), () => userDAL.findById(actor.id));
     if (!user) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });
 
     if (resourceType === PamResource.AwsIam) {
@@ -1861,7 +1861,7 @@ export const pamAccountServiceFactory = ({
     if (!mfaSessionId && accountWithParent.requireMfa) {
       // actorOrgId equals project.orgId: getProjectPermission above guarantees project existence
       // and org membership, so no separate project lookup is needed to resolve the org ID.
-      const actorUser = await userDAL.findById(actorId);
+      const actorUser = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
       if (!actorUser) throw new NotFoundError({ message: `User with ID '${actorId}' not found` });
 
       const org = await requestMemoize(requestMemoKeys.orgFindOrgById(actorOrgId), () =>

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -306,7 +306,7 @@ export const pamSessionServiceFactory = ({
       void (async () => {
         let relayConn: net.Socket | null = null;
         try {
-          const user = await userDAL.findById(actor.id);
+          const user = await requestMemoize(requestMemoKeys.userFindById(actor.id), () => userDAL.findById(actor.id));
           const certs = await gatewayV2Service.getPAMConnectionDetails({
             gatewayId: session.gatewayId,
             sessionId,

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -272,7 +272,7 @@ export const pamWebAccessServiceFactory = ({
       );
       if (!project) throw new NotFoundError({ message: `Project with ID '${account.projectId}' not found` });
 
-      const actorUser = await userDAL.findById(actor.id);
+      const actorUser = await requestMemoize(requestMemoKeys.userFindById(actor.id), () => userDAL.findById(actor.id));
       if (!actorUser) throw new NotFoundError({ message: `User with ID '${actor.id}' not found` });
 
       const org = await requestMemoize(requestMemoKeys.orgFindOrgById(project.orgId), () =>
@@ -497,7 +497,7 @@ export const pamWebAccessServiceFactory = ({
       });
 
       // 3. CREATE SESSION
-      const user = await userDAL.findById(userId);
+      const user = await requestMemoize(requestMemoKeys.userFindById(userId), () => userDAL.findById(userId));
       const expiresAt = new Date(Date.now() + DEFAULT_WEB_SESSION_DURATION_MS);
 
       session = await pamSessionDAL.create({

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -366,7 +366,7 @@ export const permissionServiceFactory = ({
 
     let username = "";
     if (actor === ActorType.USER) {
-      const userDetails = await userDAL.findById(actorId);
+      const userDetails = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
       username = userDetails?.username ?? "";
     } else {
       const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(actorId), () =>

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1640,7 +1640,7 @@ export const secretApprovalRequestServiceFactory = ({
     });
 
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
-    const user = await userDAL.findById(actorId);
+    const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${projectId}`;
     const approvalPath = `${projectPath}/approval`;
@@ -2073,7 +2073,7 @@ export const secretApprovalRequestServiceFactory = ({
       ? await executeApprovalRequestCreation(providedTx)
       : await secretApprovalRequestDAL.transaction(executeApprovalRequestCreation);
 
-    const user = await userDAL.findById(actorId);
+    const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${project.id}`;

--- a/backend/src/ee/services/ssh/ssh-certificate-authority-fns.ts
+++ b/backend/src/ee/services/ssh/ssh-certificate-authority-fns.ts
@@ -11,6 +11,8 @@ import { SshCertKeyAlgorithm } from "@app/ee/services/ssh-certificate/ssh-certif
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { CharacterType, characterValidator } from "@app/lib/validator/validate-string";
 import { ActorType } from "@app/services/auth/auth-type";
 import { KmsDataKey } from "@app/services/kms/kms-types";
@@ -600,7 +602,7 @@ export const convertActorToPrincipals = async ({ userDAL, actor, actorId }: TCon
     });
   }
 
-  const user = await userDAL.findById(actorId);
+  const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
 
   return [user.username];
 };

--- a/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
+++ b/backend/src/services/additional-privilege/project/project-additional-privilege-factory.ts
@@ -427,7 +427,9 @@ export const newProjectAdditionalPrivilegesFactory = ({
       let targetIdentifier: string | undefined;
       if (shouldUseNewPrivilegeSystem) {
         if (actorType === ActorType.USER) {
-          const targetUser = await userDAL.findById(actorId);
+          const targetUser = await requestMemoize(requestMemoKeys.userFindById(actorId), () =>
+            userDAL.findById(actorId)
+          );
           targetIdentifier = targetUser?.email ?? undefined;
         } else {
           targetIdentifier = actorId;
@@ -471,7 +473,9 @@ export const newProjectAdditionalPrivilegesFactory = ({
       let targetIdentifier: string | undefined;
       if (shouldUseNewPrivilegeSystem) {
         if (actorType === ActorType.USER) {
-          const targetUser = await userDAL.findById(actorId);
+          const targetUser = await requestMemoize(requestMemoKeys.userFindById(actorId), () =>
+            userDAL.findById(actorId)
+          );
           targetIdentifier = targetUser?.email ?? undefined;
         } else {
           targetIdentifier = actorId;

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -119,7 +119,9 @@ export const newOrgMembershipUserFactory = ({
 
     const actorDetails =
       dto.permission.type === ActorType.USER
-        ? await userDAL.findById(dto.permission.id)
+        ? await requestMemoize(requestMemoKeys.userFindById(dto.permission.id), () =>
+            userDAL.findById(dto.permission.id)
+          )
         : {
             firstName: "Platform Identity",
             email: "identity"

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -175,7 +175,9 @@ export const newProjectMembershipUserFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Edit, ProjectPermissionSub.Member);
 
-    const targetUser = await userDAL.findById(dto.selector.userId);
+    const targetUser = await requestMemoize(requestMemoKeys.userFindById(dto.selector.userId), () =>
+      userDAL.findById(dto.selector.userId)
+    );
     if (!targetUser) {
       throw new NotFoundError({ message: `User not found for project membership update` });
     }

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -2421,7 +2421,9 @@ export const projectServiceFactory = ({
     }
 
     const org = await orgDAL.findOne({ id: permission.orgId });
-    const userDetails = await userDAL.findById(permission.id);
+    const userDetails = await requestMemoize(requestMemoKeys.userFindById(permission.id), () =>
+      userDAL.findById(permission.id)
+    );
     const appCfg = getConfig();
 
     let projectTypeUrl = project.type;

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -292,7 +292,9 @@ export const roleServiceFactory = ({
           throw new NotFoundError({ message: `Identity with ID ${assumedPrivilegeDetails.actorId} not found` });
         assumedPrivilegeDetails.actorName = identityDetails.name;
       } else if (assumedPrivilegeDetails?.actorType === ActorType.USER) {
-        const userDetails = await userDAL.findById(assumedPrivilegeDetails?.actorId);
+        const userDetails = await requestMemoize(requestMemoKeys.userFindById(assumedPrivilegeDetails.actorId), () =>
+          userDAL.findById(assumedPrivilegeDetails.actorId)
+        );
         if (!userDetails)
           throw new NotFoundError({ message: `User with ID ${assumedPrivilegeDetails.actorId} not found` });
         assumedPrivilegeDetails.actorName = `${userDetails?.firstName} ${userDetails?.lastName || ""}`;

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -229,7 +229,7 @@ export const secretSharingServiceFactory = ({
       let displayUsername: string | undefined;
 
       if (actor === ActorType.USER) {
-        const user = await userDAL.findById(actorId);
+        const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
 
         if (!user) {
           throw new NotFoundError({ message: `User with ID '${actorId}' not found` });
@@ -440,7 +440,7 @@ export const secretSharingServiceFactory = ({
       });
       if (!permission) throw new ForbiddenRequestError({ name: "User is not a part of the specified organization" });
 
-      const user = await userDAL.findById(actorId);
+      const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
 
       if (!user) {
         throw new NotFoundError({ message: `User with ID '${actorId}' not found` });
@@ -577,7 +577,7 @@ export const secretSharingServiceFactory = ({
 
     if (!actorId) return false;
 
-    const user = await userDAL.findById(actorId);
+    const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
     if (!user || !user.email) return false;
 
     return (sharedSecret.authorizedEmails as string[]).includes(user.email);


### PR DESCRIPTION
## Context

- Add request memoization on userDAL.findById where the flow belongs to a request, no mutation occurs and is not part of a transaction.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)