### PR TITLE
fix: update oidc upgrade modal to reference enterprise plan, not pro

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
@@ -135,7 +135,7 @@ export const OrgGeneralAuthSection = ({
 
     if (type === EnforceAuthType.SAML) {
       if (!subscription?.samlSSO) {
-        handlePopUpOpen("upgradePlan");
+        handlePopUpOpen("upgradePlan", { featureName: "enforce SAML SSO" });
         return;
       }
 
@@ -160,7 +160,7 @@ export const OrgGeneralAuthSection = ({
 
     if (type === EnforceAuthType.GOOGLE) {
       if (!subscription?.enforceGoogleSSO) {
-        handlePopUpOpen("upgradePlan");
+        handlePopUpOpen("upgradePlan", { featureName: "enforce Google OAuth" });
         return;
       }
 
@@ -182,7 +182,7 @@ export const OrgGeneralAuthSection = ({
       });
     } else if (type === EnforceAuthType.OIDC) {
       if (!subscription?.oidcSSO) {
-        handlePopUpOpen("upgradePlan");
+        handlePopUpOpen("upgradePlan", { featureName: "OIDC SSO", isEnterpriseFeature: true });
         return;
       }
 
@@ -212,7 +212,7 @@ export const OrgGeneralAuthSection = ({
     try {
       if (!currentOrg?.id) return;
       if (!subscription?.samlSSO) {
-        handlePopUpOpen("upgradePlan");
+        handlePopUpOpen("upgradePlan", { featureName: "Admin SSO Bypass" });
         return;
       }
 
@@ -380,7 +380,8 @@ export const OrgGeneralAuthSection = ({
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-        text="Your current plan does not include access to enforce SAML SSO. To unlock this feature, please upgrade to Infisical Pro plan."
+        text={`Your current plan does not include access to ${popUp.upgradePlan.data?.featureName ?? "enforce SAML SSO"}. To unlock this feature, please upgrade to Infisical ${popUp.upgradePlan.data?.isEnterpriseFeature ? "Enterprise" : "Pro"} plan.`}
+        isEnterpriseFeature={popUp.upgradePlan.data?.isEnterpriseFeature}
       />
 
       <Dialog

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
@@ -242,7 +242,8 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-        text="Your current plan does not include access to OIDC SSO. To unlock this feature, please upgrade to Infisical Pro plan."
+        text="Your current plan does not include access to OIDC SSO. To unlock this feature, please upgrade to Infisical Enterprise plan."
+        isEnterpriseFeature
       />
     </>
   );

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgSsoTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgSsoTab.tsx
@@ -194,7 +194,10 @@ export const OrgSsoTab = withPermission(
 
     const handleConnectOidc = () => {
       if (!subscription?.oidcSSO) {
-        handlePopUpOpen("upgradePlan", { featureName: "OIDC SSO" });
+        handlePopUpOpen("upgradePlan", {
+          featureName: "OIDC SSO",
+          isEnterpriseFeature: true
+        });
         return;
       }
       handlePopUpOpen("addOIDC");


### PR DESCRIPTION
## Context

This PR corrects the oidc upgrade modal to reference enterprise, not pro

## Screenshots

N/A

## Steps to verify the change

- look

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)