### PR TITLE
feat: create audit log for honey token triggers

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -822,7 +822,8 @@ export enum EventType {
   // Honey Tokens
   CREATE_HONEY_TOKEN = "create-honey-token",
   UPDATE_HONEY_TOKEN = "update-honey-token",
-  REVOKE_HONEY_TOKEN = "revoke-honey-token"
+  REVOKE_HONEY_TOKEN = "revoke-honey-token",
+  TRIGGER_HONEY_TOKEN = "trigger-honey-token"
 }
 
 // Maps each actor type to the JSONB key that holds the actor's primary ID in actorMetadata.
@@ -6563,6 +6564,20 @@ interface RevokeHoneyTokenEvent {
   };
 }
 
+interface TriggerHoneyTokenEvent {
+  type: EventType.TRIGGER_HONEY_TOKEN;
+  metadata: {
+    honeyTokenId: string;
+    name: string;
+    type: HoneyTokenType;
+    projectId: string;
+    eventName: string;
+    eventTime: string;
+    sourceIp: string;
+    awsRegion: string;
+  };
+}
+
 export type Event =
   | CreateSubOrganizationEvent
   | UpdateSubOrganizationEvent
@@ -7145,6 +7160,7 @@ export type Event =
   | CreateHoneyTokenEvent
   | UpdateHoneyTokenEvent
   | RevokeHoneyTokenEvent
+  | TriggerHoneyTokenEvent
   | CreateGroupEvent
   | UpdateGroupEvent
   | DeleteGroupEvent

--- a/backend/src/ee/services/honey-token/honey-token-service.ts
+++ b/backend/src/ee/services/honey-token/honey-token-service.ts
@@ -1035,41 +1035,41 @@ export const honeyTokenServiceFactory = ({
       if (updatedToken) {
         void $sendTriggerNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata: parsed.data });
         void telemetryService
-        .sendPostHogEvents({
-          event: PostHogEventTypes.HoneyTokenTriggered,
-          distinctId: `honey-token-${honeyToken.id}`,
-          organizationId: honeyTokenWithOrg.orgId,
-          properties: {
-            honeyTokenId: honeyToken.id,
-            type: honeyToken.type,
-            projectId: honeyToken.projectId
-          }
-        })
-        .catch(() => {});
+          .sendPostHogEvents({
+            event: PostHogEventTypes.HoneyTokenTriggered,
+            distinctId: `honey-token-${honeyToken.id}`,
+            organizationId: honeyTokenWithOrg.orgId,
+            properties: {
+              honeyTokenId: honeyToken.id,
+              type: honeyToken.type,
+              projectId: honeyToken.projectId
+            }
+          })
+          .catch(() => {});
 
         void auditLogService
-        .createAuditLog({
-          actor: {
-            type: ActorType.UNKNOWN_USER,
-            metadata: {}
-          },
-          orgId: honeyTokenWithOrg.orgId,
-          projectId: honeyToken.projectId,
-          event: {
-            type: EventType.TRIGGER_HONEY_TOKEN,
-            metadata: {
-              honeyTokenId: honeyToken.id,
-              name: honeyToken.name,
-              type: honeyToken.type as HoneyTokenType,
-              projectId: honeyToken.projectId,
-              eventName: parsed.data.eventName,
-              eventTime: parsed.data.eventTime,
-              sourceIp: parsed.data.sourceIp ?? "Unknown",
-              awsRegion: parsed.data.awsRegion
+          .createAuditLog({
+            actor: {
+              type: ActorType.UNKNOWN_USER,
+              metadata: {}
+            },
+            orgId: honeyTokenWithOrg.orgId,
+            projectId: honeyToken.projectId,
+            event: {
+              type: EventType.TRIGGER_HONEY_TOKEN,
+              metadata: {
+                honeyTokenId: honeyToken.id,
+                name: honeyToken.name,
+                type: honeyToken.type as HoneyTokenType,
+                projectId: honeyToken.projectId,
+                eventName: parsed.data.eventName,
+                eventTime: parsed.data.eventTime,
+                sourceIp: parsed.data.sourceIp ?? "Unknown",
+                awsRegion: parsed.data.awsRegion
+              }
             }
-          }
-        })
-        .catch(() => {});
+          })
+          .catch(() => {});
       }
     }
     /* eslint-enable no-continue */

--- a/backend/src/ee/services/honey-token/honey-token-service.ts
+++ b/backend/src/ee/services/honey-token/honey-token-service.ts
@@ -1030,22 +1030,23 @@ export const honeyTokenServiceFactory = ({
         TRIGGER_NOTIFICATION_COOLDOWN_MS
       );
 
+      void telemetryService
+        .sendPostHogEvents({
+          event: PostHogEventTypes.HoneyTokenTriggered,
+          distinctId: `honey-token-${honeyToken.id}`,
+          organizationId: honeyTokenWithOrg.orgId,
+          properties: {
+            honeyTokenId: honeyToken.id,
+            type: honeyToken.type,
+            projectId: honeyToken.projectId
+          }
+        })
+        .catch(() => {});
+
       // This block only is executed once per token trigger. So, even if we get 100 events
       // this will run only once.
       if (updatedToken) {
         void $sendTriggerNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata: parsed.data });
-        void telemetryService
-          .sendPostHogEvents({
-            event: PostHogEventTypes.HoneyTokenTriggered,
-            distinctId: `honey-token-${honeyToken.id}`,
-            organizationId: honeyTokenWithOrg.orgId,
-            properties: {
-              honeyTokenId: honeyToken.id,
-              type: honeyToken.type,
-              projectId: honeyToken.projectId
-            }
-          })
-          .catch(() => {});
 
         void auditLogService
           .createAuditLog({

--- a/backend/src/ee/services/honey-token/honey-token-service.ts
+++ b/backend/src/ee/services/honey-token/honey-token-service.ts
@@ -32,6 +32,7 @@ import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
+import { EventType, TAuditLogServiceFactory } from "../audit-log/audit-log-types";
 import { THoneyTokenConfigDALFactory } from "../honey-token-config/honey-token-config-dal";
 import { HoneyTokenConfigStatus } from "../honey-token-config/honey-token-config-enums";
 import { TLicenseServiceFactory } from "../license/license-service";
@@ -109,6 +110,7 @@ export type THoneyTokenServiceFactoryDep = {
   snapshotService: Pick<TSecretSnapshotServiceFactory, "performSnapshot">;
   secretQueueService: Pick<TSecretQueueFactory, "syncSecrets" | "removeSecretReminder">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
 };
 
 type TSendTriggerNotificationInput = {
@@ -150,7 +152,8 @@ export const honeyTokenServiceFactory = ({
   resourceMetadataDAL,
   snapshotService,
   secretQueueService,
-  telemetryService
+  telemetryService,
+  auditLogService
 }: THoneyTokenServiceFactoryDep) => {
   const honeyTokenProviderHooksByType = getHoneyTokenServiceHooksByType({
     honeyTokenDAL,
@@ -174,7 +177,8 @@ export const honeyTokenServiceFactory = ({
     resourceMetadataDAL,
     snapshotService,
     secretQueueService,
-    telemetryService
+    telemetryService,
+    auditLogService
   });
 
   const create = async (
@@ -1020,11 +1024,17 @@ export const honeyTokenServiceFactory = ({
         eventType: HoneyTokenEventType.AWS,
         metadata: parsed.data
       });
+
       const updatedToken = await honeyTokenDAL.tryMarkTriggered(
         parsed.data.accessKeyId,
         TRIGGER_NOTIFICATION_COOLDOWN_MS
       );
-      void telemetryService
+
+      // This block only is executed once per token trigger. So, even if we get 100 events
+      // this will run only once.
+      if (updatedToken) {
+        void $sendTriggerNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata: parsed.data });
+        void telemetryService
         .sendPostHogEvents({
           event: PostHogEventTypes.HoneyTokenTriggered,
           distinctId: `honey-token-${honeyToken.id}`,
@@ -1036,8 +1046,30 @@ export const honeyTokenServiceFactory = ({
           }
         })
         .catch(() => {});
-      if (updatedToken) {
-        void $sendTriggerNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata: parsed.data });
+
+        void auditLogService
+        .createAuditLog({
+          actor: {
+            type: ActorType.UNKNOWN_USER,
+            metadata: {}
+          },
+          orgId: honeyTokenWithOrg.orgId,
+          projectId: honeyToken.projectId,
+          event: {
+            type: EventType.TRIGGER_HONEY_TOKEN,
+            metadata: {
+              honeyTokenId: honeyToken.id,
+              name: honeyToken.name,
+              type: honeyToken.type as HoneyTokenType,
+              projectId: honeyToken.projectId,
+              eventName: parsed.data.eventName,
+              eventTime: parsed.data.eventTime,
+              sourceIp: parsed.data.sourceIp ?? "Unknown",
+              awsRegion: parsed.data.awsRegion
+            }
+          }
+        })
+        .catch(() => {});
       }
     }
     /* eslint-enable no-continue */

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2380,7 +2380,8 @@ export const registerRoutes = async (
     snapshotService,
     secretQueueService,
     appConnectionService,
-    telemetryService
+    telemetryService,
+    auditLogService
   });
 
   const webhookService = webhookServiceFactory({


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We added audit logs for honey tokens, but we never added one when the honey token is triggered.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1989" height="799" alt="image" src="https://github.com/user-attachments/assets/3a9d19db-4b94-4168-85b2-fff805e0a211" />


## Steps to verify the change

* Create honey token
* Trigger it
* See that audit log got created

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)