### PR TITLE
fix: pass whether the vault migration config is using a gateway or not

### DIFF
--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -563,7 +563,7 @@ export const importVaultDataFn = async (
     gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   }
 ) => {
-  await blockLocalAndPrivateIpAddresses(vaultUrl);
+  await blockLocalAndPrivateIpAddresses(vaultUrl, Boolean(gatewayId));
 
   if (mappingType === VaultMappingType.Namespace && !vaultNamespace) {
     throw new BadRequestError({


### PR DESCRIPTION
## Context

This PR updates the ip address check in our vault migration to pass whether it is a gateway or not

## Screenshots

N/A

## Steps to verify the change

- setup up gateway and verify vault migration properly skips check

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)