### PR TITLE
improvement(secret-share): add option to now show the external page and endpoint

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -54,6 +54,7 @@ const envSchema = z
       .enum(["true", "false"])
       .default("false")
       .transform((el) => el === "true"),
+    DISABLE_SECRET_SHARING: zodStrBool.default("false"),
     REDIS_URL: zpStr(z.string().optional()),
     REDIS_USERNAME: zpStr(z.string().optional()),
     REDIS_PASSWORD: zpStr(z.string().optional()),

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -54,7 +54,7 @@ const envSchema = z
       .enum(["true", "false"])
       .default("false")
       .transform((el) => el === "true"),
-    DISABLE_SECRET_SHARING: zodStrBool.default("false"),
+    DISABLE_PUBLIC_SECRET_SHARING: zodStrBool.default("false"),
     REDIS_URL: zpStr(z.string().optional()),
     REDIS_USERNAME: zpStr(z.string().optional()),
     REDIS_PASSWORD: zpStr(z.string().optional()),

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -50,6 +50,7 @@ const SanitizedSuperAdminSchema = z.object({
   fipsEnabled: z.boolean().optional(),
   isMigrationModeOn: z.boolean().optional(),
   isSecretScanningDisabled: z.boolean().optional(),
+  isSecretSharingDisabled: z.boolean().optional(),
   kubernetesAutoFetchServiceAccountToken: z.boolean().optional(),
   paramsFolderSecretDetectionEnabled: z.boolean().optional(),
   isOfflineUsageReportsEnabled: z.boolean().optional(),
@@ -97,7 +98,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
             defaultAuthOrgAuthMethod: config.defaultAuthOrgAuthMethod,
             enabledLoginMethods: config.enabledLoginMethods,
             authConsentContent: config.authConsentContent,
-            pageFrameContent: config.pageFrameContent
+            pageFrameContent: config.pageFrameContent,
+            isSecretSharingDisabled: serverEnvs.DISABLE_SECRET_SHARING
           }
         };
       }
@@ -108,6 +110,7 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
           fipsEnabled: crypto.isFipsModeEnabled(),
           isMigrationModeOn: serverEnvs.MAINTENANCE_MODE,
           isSecretScanningDisabled: serverEnvs.DISABLE_SECRET_SCANNING,
+          isSecretSharingDisabled: serverEnvs.DISABLE_SECRET_SHARING,
           kubernetesAutoFetchServiceAccountToken: serverEnvs.KUBERNETES_AUTO_FETCH_SERVICE_ACCOUNT_TOKEN,
           paramsFolderSecretDetectionEnabled: serverEnvs.PARAMS_FOLDER_SECRET_DETECTION_ENABLED,
           isOfflineUsageReportsEnabled: hasOfflineLicense

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -50,7 +50,7 @@ const SanitizedSuperAdminSchema = z.object({
   fipsEnabled: z.boolean().optional(),
   isMigrationModeOn: z.boolean().optional(),
   isSecretScanningDisabled: z.boolean().optional(),
-  isSecretSharingDisabled: z.boolean().optional(),
+  isPublicSecretSharingDisabled: z.boolean().optional(),
   kubernetesAutoFetchServiceAccountToken: z.boolean().optional(),
   paramsFolderSecretDetectionEnabled: z.boolean().optional(),
   isOfflineUsageReportsEnabled: z.boolean().optional(),
@@ -99,7 +99,7 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
             enabledLoginMethods: config.enabledLoginMethods,
             authConsentContent: config.authConsentContent,
             pageFrameContent: config.pageFrameContent,
-            isSecretSharingDisabled: serverEnvs.DISABLE_SECRET_SHARING
+            isPublicSecretSharingDisabled: serverEnvs.DISABLE_PUBLIC_SECRET_SHARING
           }
         };
       }
@@ -110,7 +110,7 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
           fipsEnabled: crypto.isFipsModeEnabled(),
           isMigrationModeOn: serverEnvs.MAINTENANCE_MODE,
           isSecretScanningDisabled: serverEnvs.DISABLE_SECRET_SCANNING,
-          isSecretSharingDisabled: serverEnvs.DISABLE_SECRET_SHARING,
+          isPublicSecretSharingDisabled: serverEnvs.DISABLE_PUBLIC_SECRET_SHARING,
           kubernetesAutoFetchServiceAccountToken: serverEnvs.KUBERNETES_AUTO_FETCH_SERVICE_ACCOUNT_TOKEN,
           paramsFolderSecretDetectionEnabled: serverEnvs.PARAMS_FOLDER_SECRET_DETECTION_ENABLED,
           isOfflineUsageReportsEnabled: hasOfflineLicense

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, SECRET_SHARING } from "@app/lib/api-docs";
+import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
 import { SecretSharingAccessType } from "@app/lib/types";
@@ -231,6 +232,11 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
       }
     },
     handler: async (req) => {
+      const appCfg = getConfig();
+      if (appCfg.DISABLE_SECRET_SHARING) {
+        throw new BadRequestError({ message: "Secret sharing is disabled" });
+      }
+
       const sharedSecret = await req.server.services.secretSharing.createPublicSharedSecret({
         ...req.body,
         accessType: SecretSharingAccessType.Anyone

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -233,8 +233,8 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
     },
     handler: async (req) => {
       const appCfg = getConfig();
-      if (appCfg.DISABLE_SECRET_SHARING) {
-        throw new BadRequestError({ message: "Secret sharing is disabled" });
+      if (appCfg.DISABLE_PUBLIC_SECRET_SHARING) {
+        throw new BadRequestError({ message: "Public Secret sharing is disabled" });
       }
 
       const sharedSecret = await req.server.services.secretSharing.createPublicSharedSecret({

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -234,7 +234,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
     handler: async (req) => {
       const appCfg = getConfig();
       if (appCfg.DISABLE_PUBLIC_SECRET_SHARING) {
-        throw new BadRequestError({ message: "Public Secret sharing is disabled" });
+        throw new BadRequestError({ message: "Public secret sharing is disabled on this instance" });
       }
 
       const sharedSecret = await req.server.services.secretSharing.createPublicSharedSecret({

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -64,7 +64,7 @@ export type TServerConfig = {
   pageFrameContent?: string;
   invalidatingCache: boolean;
   envOverrides?: Record<string, string>;
-  isSecretSharingDisabled?: boolean;
+  isPublicSecretSharingDisabled?: boolean;
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId?: string;
   trustSamlEmails?: boolean;

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -64,6 +64,7 @@ export type TServerConfig = {
   pageFrameContent?: string;
   invalidatingCache: boolean;
   envOverrides?: Record<string, string>;
+  isSecretSharingDisabled?: boolean;
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId?: string;
   trustSamlEmails?: boolean;

--- a/frontend/src/pages/public/ShareSecretPage/route.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/route.tsx
@@ -1,7 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { useServerConfig } from "@app/context";
+
+import { NotFoundPage } from "../NotFoundPage/NotFoundPage";
 import { ShareSecretPage } from "./ShareSecretPage";
 
+const ShareSecretRoute = () => {
+  const { config } = useServerConfig();
+
+  if (config.isSecretSharingDisabled) {
+    return <NotFoundPage />;
+  }
+
+  return <ShareSecretPage />;
+};
+
 export const Route = createFileRoute("/share-secret")({
-  component: ShareSecretPage
+  component: ShareSecretRoute
 });

--- a/frontend/src/pages/public/ShareSecretPage/route.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/route.tsx
@@ -8,7 +8,7 @@ import { ShareSecretPage } from "./ShareSecretPage";
 const ShareSecretRoute = () => {
   const { config } = useServerConfig();
 
-  if (config.isSecretSharingDisabled) {
+  if (config.isPublicSecretSharingDisabled) {
     return <NotFoundPage />;
   }
 


### PR DESCRIPTION
## Context
Add a parameter to not show the share secret page if the user defines it. Using this, people cannot use the share-secret public page.

## Screenshots

## Steps to verify the change
- Set `DISABLE_SECRET_SHARING=true` on the .env
- Recreate the container of infisical using the current env
- Check that the path `share-secret` shows up 404 not found

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)