### PR TITLE
fix(secret-sync): make per-connection concurrency admission atomic and extend retry budget to 60 min

### DIFF
--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -64,6 +64,12 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     incrementBy: async () => {
       return 1;
     },
+    incrementByAndRefreshExpiryIfUnderLimit: async () => {
+      return 1;
+    },
+    decrementByOrDelete: async () => {
+      return 0;
+    },
     pgGetIntItem: async (key) => {
       const value = store[key];
       if (typeof value === "number") {

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -202,6 +202,8 @@ export type TKeyStoreFactory = {
   deleteItemsByKeyIn: (keys: string[]) => Promise<number>;
   deleteItems: (arg: TDeleteItems) => Promise<number>;
   incrementBy: (key: string, value: number) => Promise<number>;
+  incrementByAndRefreshExpiryIfUnderLimit: (key: string, limit: number, expiryInSeconds: number) => Promise<number>;
+  decrementByOrDelete: (key: string) => Promise<number>;
   getKeysByPattern: (pattern: string, limit?: number) => Promise<string[]>;
   // list operations
   listPush: (key: string, value: string) => Promise<number>;
@@ -325,6 +327,52 @@ export const keyStoreFactory = (
   };
 
   const incrementBy = async (key: string, value: number) => primaryRedis.incrby(key, value);
+
+  // Atomic admit: INCR by 1; if the post-INCR count is over the cap, DECR back and
+  // signal rejection without touching EXPIRE — so failed probes against an orphaned
+  // counter cannot keep refreshing its TTL. Otherwise refresh the TTL alongside the
+  // successful admit. Returns -1 for rejection, otherwise the post-INCR count.
+  const INCREMENT_AND_REFRESH_EXPIRY_IF_UNDER_LIMIT_SCRIPT = `
+    local count = redis.call("INCR", KEYS[1])
+    if count > tonumber(ARGV[1]) then
+      redis.call("DECR", KEYS[1])
+      return -1
+    end
+    redis.call("EXPIRE", KEYS[1], ARGV[2])
+    return count
+  `;
+
+  // Atomic release: DECR but never below 0, and never leave a no-TTL key behind. If
+  // the counter is missing or already ≤ 1, DEL so the next admit creates a fresh
+  // key with a fresh TTL. Does NOT touch EXPIRE — the slot is being released.
+  const DECREMENT_OR_DELETE_SCRIPT = `
+    local current = redis.call("GET", KEYS[1])
+    if not current or tonumber(current) <= 1 then
+      redis.call("DEL", KEYS[1])
+      return 0
+    end
+    return redis.call("DECR", KEYS[1])
+  `;
+
+  const incrementByAndRefreshExpiryIfUnderLimit = async (
+    key: string,
+    limit: number,
+    expiryInSeconds: number
+  ): Promise<number> => {
+    const result = await primaryRedis.eval(
+      INCREMENT_AND_REFRESH_EXPIRY_IF_UNDER_LIMIT_SCRIPT,
+      1,
+      key,
+      limit,
+      expiryInSeconds
+    );
+    return Number(result);
+  };
+
+  const decrementByOrDelete = async (key: string): Promise<number> => {
+    const result = await primaryRedis.eval(DECREMENT_OR_DELETE_SCRIPT, 1, key);
+    return Number(result);
+  };
 
   const setExpiry = async (key: string, expiryInSeconds: number) => primaryRedis.expire(key, expiryInSeconds);
 
@@ -455,6 +503,8 @@ export const keyStoreFactory = (
     deleteItem,
     deleteItems,
     incrementBy,
+    incrementByAndRefreshExpiryIfUnderLimit,
+    decrementByOrDelete,
     acquireLock(resources: string[], duration: number, settings?: Partial<Settings>) {
       return redisLock.acquire(resources, duration, settings);
     },

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -82,6 +82,12 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     incrementBy: async () => {
       return 1;
     },
+    incrementByAndRefreshExpiryIfUnderLimit: async () => {
+      return 1;
+    },
+    decrementByOrDelete: async () => {
+      return 0;
+    },
     acquireLock: () => {
       return Promise.resolve({
         release: () => {}

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -1,4 +1,13 @@
-import { Job, JobSchedulerJson, Queue, QueueOptions, RepeatOptions, Worker, WorkerListener } from "bullmq";
+import {
+  Job,
+  JobSchedulerJson,
+  Queue,
+  QueueOptions,
+  RepeatOptions,
+  Worker,
+  WorkerListener,
+  WorkerOptions
+} from "bullmq";
 
 import { SecretEncryptionAlgo, SecretKeyEncoding } from "@app/db/schemas";
 import { TCreateAuditLogDTO } from "@app/ee/services/audit-log/audit-log-types";
@@ -514,7 +523,7 @@ export type TQueueServiceFactory = {
   start: <T extends QueueName>(
     name: T,
     jobFn: (job: Job<TQueueJobTypes[T]["payload"], void, TQueueJobTypes[T]["name"]>, token?: string) => Promise<void>,
-    queueSettings?: Omit<QueueOptions, "connection">
+    queueSettings?: Omit<QueueOptions, "connection"> & Pick<WorkerOptions, "concurrency">
   ) => void;
   listen: <
     T extends QueueName,

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -86,7 +86,7 @@ type TSecretSyncQueueFactoryDep = {
   cronJob: TCronJobFactory;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
-  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "incrementBy" | "setExpiry">;
   folderDAL: TSecretFolderDALFactory;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
@@ -135,8 +135,9 @@ type SecretSyncActionJob = Job<
 
 const JITTER_MS = 10 * 1000;
 const REQUEUE_MS = 30 * 1000;
-const REQUEUE_LIMIT = 30;
+const REQUEUE_LIMIT = 120;
 const CONNECTION_CONCURRENCY_LIMIT = 3;
+const CONNECTION_CONCURRENCY_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000;
 
 const getRequeueDelay = (failureCount?: number) => {
   const jitter = Math.random() * JITTER_MS;
@@ -227,44 +228,32 @@ export const secretSyncQueueFactory = ({
     folderCommitService
   });
 
-  const $isConnectionConcurrencyLimitReached = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
+  // Atomic admission via INCRBY: only one job per connectionId is admitted per increment,
+  // so concurrent admits cannot exceed CONNECTION_CONCURRENCY_LIMIT.
+  const $tryAdmitConnectionConcurrency = async (connectionId: string) => {
+    const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
+    const count = await keyStore.incrementBy(key, 1);
 
-    if (!concurrencyCount) return false;
+    if (count > CONNECTION_CONCURRENCY_LIMIT) {
+      await keyStore.incrementBy(key, -1);
+      return false;
+    }
 
-    const count = Number.parseInt(concurrencyCount, 10);
-
-    if (Number.isNaN(count)) return false;
-
-    return count >= CONNECTION_CONCURRENCY_LIMIT;
+    await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
+    return true;
   };
 
-  const $incrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
+  const $releaseConnectionConcurrency = async (connectionId: string) => {
+    const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
+    const count = await keyStore.incrementBy(key, -1);
 
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const incrementedCount = Number.isNaN(currentCount) ? 1 : currentCount + 1;
-
-    await keyStore.setItemWithExpiry(
-      KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      incrementedCount
-    );
-  };
-
-  const $decrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const decrementedCount = Math.max(0, Number.isNaN(currentCount) ? 0 : currentCount - 1);
-
-    await keyStore.setItemWithExpiry(
-      KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      decrementedCount
-    );
+    // The counter can briefly go negative if the key TTL expired while a job was running
+    // (a new admit creates the key at 0, then this release decrements to -1). Self-heal.
+    if (count < 0) {
+      await keyStore.setItemWithExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS, 0);
+    } else {
+      await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
+    }
   };
 
   const $getInfisicalSecrets = async (
@@ -1148,84 +1137,89 @@ export const secretSyncQueueFactory = ({
     );
   };
 
-  queueService.start(QueueName.AppConnectionSecretSync, async (job) => {
-    if (job.name === QueueJobs.SecretSyncSendActionFailedNotifications) {
-      await $sendSecretSyncFailedNotifications(job as TSendSecretSyncFailedNotificationsJobDTO);
-      return;
-    }
+  queueService.start(
+    QueueName.AppConnectionSecretSync,
+    async (job) => {
+      if (job.name === QueueJobs.SecretSyncSendActionFailedNotifications) {
+        await $sendSecretSyncFailedNotifications(job as TSendSecretSyncFailedNotificationsJobDTO);
+        return;
+      }
 
-    if (job.name === QueueJobs.DailySecretSyncRetry) {
-      await $handleDailySecretSyncRetry();
-      return;
-    }
+      if (job.name === QueueJobs.DailySecretSyncRetry) {
+        await $handleDailySecretSyncRetry();
+        return;
+      }
 
-    const { syncId } = job.data as
-      | TQueueSecretSyncSyncSecretsByIdDTO
-      | TQueueSecretSyncImportSecretsByIdDTO
-      | TQueueSecretSyncRemoveSecretsByIdDTO;
+      const { syncId } = job.data as
+        | TQueueSecretSyncSyncSecretsByIdDTO
+        | TQueueSecretSyncImportSecretsByIdDTO
+        | TQueueSecretSyncRemoveSecretsByIdDTO;
 
-    const secretSync = await secretSyncDAL.findById(syncId);
+      const secretSync = await secretSyncDAL.findById(syncId);
 
-    if (!secretSync) throw new Error(`Cannot find secret sync with ID ${syncId}`);
+      if (!secretSync) throw new Error(`Cannot find secret sync with ID ${syncId}`);
 
-    const { connectionId } = secretSync;
+      const { connectionId } = secretSync;
 
-    if (job.name === QueueJobs.SecretSyncSyncSecrets) {
-      const isConcurrentLimitReached = await $isConnectionConcurrencyLimitReached(connectionId);
+      let lock: Awaited<ReturnType<typeof keyStore.acquireLock>>;
 
-      if (isConcurrentLimitReached) {
-        logger.info(
-          `SecretSync Concurrency limit reached [syncId=${syncId}] [job=${job.name}] [connectionId=${connectionId}]`
+      try {
+        lock = await keyStore.acquireLock(
+          [KeyStorePrefixes.SecretSyncLock(syncId)],
+          // scott: not sure on this duration; syncs can take excessive amounts of time so we need to keep it locked,
+          // but should always release below...
+          5 * 60 * 1000
         );
+      } catch (e) {
+        logger.info(`SecretSync Failed to acquire lock [syncId=${syncId}] [job=${job.name}]`);
 
         await $handleAcquireLockFailure(job as SecretSyncActionJob);
 
         return;
       }
-    }
 
-    let lock: Awaited<ReturnType<typeof keyStore.acquireLock>>;
+      let admittedConnectionSlot = false;
 
-    try {
-      lock = await keyStore.acquireLock(
-        [KeyStorePrefixes.SecretSyncLock(syncId)],
-        // scott: not sure on this duration; syncs can take excessive amounts of time so we need to keep it locked,
-        // but should always release below...
-        5 * 60 * 1000
-      );
-    } catch (e) {
-      logger.info(`SecretSync Failed to acquire lock [syncId=${syncId}] [job=${job.name}]`);
+      try {
+        if (job.name === QueueJobs.SecretSyncSyncSecrets) {
+          admittedConnectionSlot = await $tryAdmitConnectionConcurrency(connectionId);
 
-      await $handleAcquireLockFailure(job as SecretSyncActionJob);
+          if (!admittedConnectionSlot) {
+            logger.info(
+              `SecretSync Concurrency limit reached [syncId=${syncId}] [job=${job.name}] [connectionId=${connectionId}]`
+            );
 
-      return;
-    }
+            await $handleAcquireLockFailure(job as SecretSyncActionJob);
 
-    try {
-      switch (job.name) {
-        case QueueJobs.SecretSyncSyncSecrets: {
-          await $incrementConnectionConcurrencyCount(connectionId);
-          await $handleSyncSecretsJob(job as TSecretSyncSyncSecretsDTO, secretSync);
-          break;
+            return;
+          }
         }
-        case QueueJobs.SecretSyncImportSecrets:
-          await $handleImportSecretsJob(job as TSecretSyncImportSecretsDTO, secretSync);
-          break;
-        case QueueJobs.SecretSyncRemoveSecrets:
-          await $handleRemoveSecretsJob(job as TSecretSyncRemoveSecretsDTO, secretSync);
-          break;
-        default:
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          throw new Error(`Unhandled Secret Sync Job ${job.name}`);
-      }
-    } finally {
-      if (job.name === QueueJobs.SecretSyncSyncSecrets) {
-        await $decrementConnectionConcurrencyCount(connectionId);
-      }
 
-      await lock.release();
-    }
-  });
+        switch (job.name) {
+          case QueueJobs.SecretSyncSyncSecrets: {
+            await $handleSyncSecretsJob(job as TSecretSyncSyncSecretsDTO, secretSync);
+            break;
+          }
+          case QueueJobs.SecretSyncImportSecrets:
+            await $handleImportSecretsJob(job as TSecretSyncImportSecretsDTO, secretSync);
+            break;
+          case QueueJobs.SecretSyncRemoveSecrets:
+            await $handleRemoveSecretsJob(job as TSecretSyncRemoveSecretsDTO, secretSync);
+            break;
+          default:
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            throw new Error(`Unhandled Secret Sync Job ${job.name}`);
+        }
+      } finally {
+        if (admittedConnectionSlot) {
+          await $releaseConnectionConcurrency(connectionId);
+        }
+
+        await lock.release();
+      }
+    },
+    { concurrency: 5 }
+  );
 
   const startDailySecretSyncRetryJob = () => {
     cronJob.register({

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -136,7 +136,7 @@ type SecretSyncActionJob = Job<
 const JITTER_MS = 10 * 1000;
 const REQUEUE_MS = 30 * 1000;
 const REQUEUE_LIMIT = 120;
-const CONNECTION_CONCURRENCY_LIMIT = 3;
+const CONNECTION_CONCURRENCY_LIMIT = 5;
 const CONNECTION_CONCURRENCY_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000;
 
 const getRequeueDelay = (failureCount?: number) => {

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -1130,89 +1130,85 @@ export const secretSyncQueueFactory = ({
     );
   };
 
-  queueService.start(
-    QueueName.AppConnectionSecretSync,
-    async (job) => {
-      if (job.name === QueueJobs.SecretSyncSendActionFailedNotifications) {
-        await $sendSecretSyncFailedNotifications(job as TSendSecretSyncFailedNotificationsJobDTO);
-        return;
-      }
+  queueService.start(QueueName.AppConnectionSecretSync, async (job) => {
+    if (job.name === QueueJobs.SecretSyncSendActionFailedNotifications) {
+      await $sendSecretSyncFailedNotifications(job as TSendSecretSyncFailedNotificationsJobDTO);
+      return;
+    }
 
-      if (job.name === QueueJobs.DailySecretSyncRetry) {
-        await $handleDailySecretSyncRetry();
-        return;
-      }
+    if (job.name === QueueJobs.DailySecretSyncRetry) {
+      await $handleDailySecretSyncRetry();
+      return;
+    }
 
-      const { syncId } = job.data as
-        | TQueueSecretSyncSyncSecretsByIdDTO
-        | TQueueSecretSyncImportSecretsByIdDTO
-        | TQueueSecretSyncRemoveSecretsByIdDTO;
+    const { syncId } = job.data as
+      | TQueueSecretSyncSyncSecretsByIdDTO
+      | TQueueSecretSyncImportSecretsByIdDTO
+      | TQueueSecretSyncRemoveSecretsByIdDTO;
 
-      const secretSync = await secretSyncDAL.findById(syncId);
+    const secretSync = await secretSyncDAL.findById(syncId);
 
-      if (!secretSync) throw new Error(`Cannot find secret sync with ID ${syncId}`);
+    if (!secretSync) throw new Error(`Cannot find secret sync with ID ${syncId}`);
 
-      const { connectionId } = secretSync;
+    const { connectionId } = secretSync;
 
-      let lock: Awaited<ReturnType<typeof keyStore.acquireLock>>;
+    let lock: Awaited<ReturnType<typeof keyStore.acquireLock>>;
 
-      try {
-        lock = await keyStore.acquireLock(
-          [KeyStorePrefixes.SecretSyncLock(syncId)],
-          // scott: not sure on this duration; syncs can take excessive amounts of time so we need to keep it locked,
-          // but should always release below...
-          5 * 60 * 1000
-        );
-      } catch (e) {
-        logger.info(`SecretSync Failed to acquire lock [syncId=${syncId}] [job=${job.name}]`);
+    try {
+      lock = await keyStore.acquireLock(
+        [KeyStorePrefixes.SecretSyncLock(syncId)],
+        // scott: not sure on this duration; syncs can take excessive amounts of time so we need to keep it locked,
+        // but should always release below...
+        5 * 60 * 1000
+      );
+    } catch (e) {
+      logger.info(`SecretSync Failed to acquire lock [syncId=${syncId}] [job=${job.name}]`);
 
-        await $handleAcquireLockFailure(job as SecretSyncActionJob);
+      await $handleAcquireLockFailure(job as SecretSyncActionJob);
 
-        return;
-      }
+      return;
+    }
 
-      let admittedConnectionSlot = false;
+    let admittedConnectionSlot = false;
 
-      try {
-        if (job.name === QueueJobs.SecretSyncSyncSecrets) {
-          admittedConnectionSlot = await $tryAdmitConnectionConcurrency(connectionId);
+    try {
+      if (job.name === QueueJobs.SecretSyncSyncSecrets) {
+        admittedConnectionSlot = await $tryAdmitConnectionConcurrency(connectionId);
 
-          if (!admittedConnectionSlot) {
-            logger.info(
-              `SecretSync Concurrency limit reached [syncId=${syncId}] [job=${job.name}] [connectionId=${connectionId}]`
-            );
+        if (!admittedConnectionSlot) {
+          logger.info(
+            `SecretSync Concurrency limit reached [syncId=${syncId}] [job=${job.name}] [connectionId=${connectionId}]`
+          );
 
-            await $handleAcquireLockFailure(job as SecretSyncActionJob);
+          await $handleAcquireLockFailure(job as SecretSyncActionJob);
 
-            return;
-          }
+          return;
         }
-
-        switch (job.name) {
-          case QueueJobs.SecretSyncSyncSecrets: {
-            await $handleSyncSecretsJob(job as TSecretSyncSyncSecretsDTO, secretSync);
-            break;
-          }
-          case QueueJobs.SecretSyncImportSecrets:
-            await $handleImportSecretsJob(job as TSecretSyncImportSecretsDTO, secretSync);
-            break;
-          case QueueJobs.SecretSyncRemoveSecrets:
-            await $handleRemoveSecretsJob(job as TSecretSyncRemoveSecretsDTO, secretSync);
-            break;
-          default:
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            throw new Error(`Unhandled Secret Sync Job ${job.name}`);
-        }
-      } finally {
-        if (admittedConnectionSlot) {
-          await $releaseConnectionConcurrency(connectionId);
-        }
-
-        await lock.release();
       }
-    },
-    { concurrency: 15 }
-  );
+
+      switch (job.name) {
+        case QueueJobs.SecretSyncSyncSecrets: {
+          await $handleSyncSecretsJob(job as TSecretSyncSyncSecretsDTO, secretSync);
+          break;
+        }
+        case QueueJobs.SecretSyncImportSecrets:
+          await $handleImportSecretsJob(job as TSecretSyncImportSecretsDTO, secretSync);
+          break;
+        case QueueJobs.SecretSyncRemoveSecrets:
+          await $handleRemoveSecretsJob(job as TSecretSyncRemoveSecretsDTO, secretSync);
+          break;
+        default:
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+          throw new Error(`Unhandled Secret Sync Job ${job.name}`);
+      }
+    } finally {
+      if (admittedConnectionSlot) {
+        await $releaseConnectionConcurrency(connectionId);
+      }
+
+      await lock.release();
+    }
+  });
 
   const startDailySecretSyncRetryJob = () => {
     cronJob.register({

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -228,32 +228,38 @@ export const secretSyncQueueFactory = ({
     folderCommitService
   });
 
-  // Atomic admission via INCRBY: only one job per connectionId is admitted per increment,
-  // so concurrent admits cannot exceed CONNECTION_CONCURRENCY_LIMIT.
+  // Admission via INCRBY: the INCR itself is atomic, so concurrent admits cannot exceed
+  // CONNECTION_CONCURRENCY_LIMIT. setExpiry always runs (success and over-limit paths) so
+  // the key never persists TTL-less, and any post-INCR failure fires a compensating DECR.
   const $tryAdmitConnectionConcurrency = async (connectionId: string) => {
     const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
     const count = await keyStore.incrementBy(key, 1);
 
-    if (count > CONNECTION_CONCURRENCY_LIMIT) {
-      await keyStore.incrementBy(key, -1);
-      return false;
-    }
+    try {
+      // INCR on a missing key creates it without a TTL; EXPIRE is what arms it. Calling
+      // this on every path prevents an unarmed key from permanently locking the connection
+      // if a future admit returns over-limit and skips setExpiry.
+      await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
 
-    await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
-    return true;
+      if (count > CONNECTION_CONCURRENCY_LIMIT) {
+        await keyStore.incrementBy(key, -1);
+        return false;
+      }
+
+      return true;
+    } catch (err) {
+      await keyStore.incrementBy(key, -1).catch(() => {});
+      throw err;
+    }
   };
 
   const $releaseConnectionConcurrency = async (connectionId: string) => {
     const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
-    const count = await keyStore.incrementBy(key, -1);
-
-    // The counter can briefly go negative if the key TTL expired while a job was running
-    // (a new admit creates the key at 0, then this release decrements to -1). Self-heal.
-    if (count < 0) {
-      await keyStore.setItemWithExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS, 0);
-    } else {
-      await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
-    }
+    await keyStore.incrementBy(key, -1);
+    // EXPIRE on a missing key is a no-op; on an existing one it refreshes the TTL. The
+    // counter can briefly go negative if the key TTL expired while a job was running, but
+    // it self-corrects as orphan releases land and future admits' INCRs climb back up.
+    await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
   };
 
   const $getInfisicalSecrets = async (

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -86,7 +86,7 @@ type TSecretSyncQueueFactoryDep = {
   cronJob: TCronJobFactory;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
-  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "incrementBy" | "setExpiry">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "incrementByAndRefreshExpiryIfUnderLimit" | "decrementByOrDelete">;
   folderDAL: TSecretFolderDALFactory;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
@@ -137,7 +137,7 @@ const JITTER_MS = 10 * 1000;
 const REQUEUE_MS = 30 * 1000;
 const REQUEUE_LIMIT = 120;
 const CONNECTION_CONCURRENCY_LIMIT = 5;
-const CONNECTION_CONCURRENCY_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000;
+const CONNECTION_CONCURRENCY_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000 / 2;
 
 const getRequeueDelay = (failureCount?: number) => {
   const jitter = Math.random() * JITTER_MS;
@@ -228,44 +228,25 @@ export const secretSyncQueueFactory = ({
     folderCommitService
   });
 
-  // Admission via INCRBY: the INCR itself is atomic, so concurrent admits cannot exceed
-  // CONNECTION_CONCURRENCY_LIMIT. setExpiry always runs (success and over-limit paths) so
-  // the key never persists TTL-less, and any post-INCR failure fires a compensating DECR.
+  // INCR + cap check + EXPIRE happen atomically inside a Lua script. TTL is refreshed
+  // only when a slot is actually claimed; failed probes (over-limit) and releases
+  // never touch EXPIRE — so an orphaned counter from a worker that died mid-sync
+  // can't have its expiry indefinitely shoved forward by subsequent admit attempts,
+  // and ages out within CONNECTION_CONCURRENCY_TTL_SECONDS of the last successful
+  // admit.
   const $tryAdmitConnectionConcurrency = async (connectionId: string) => {
     const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
-    const count = await keyStore.incrementBy(key, 1);
-
-    if (count <= 0) {
-      logger.warn(
-        `SecretSync connection concurrency counter drifted non-positive after admit [connectionId=${connectionId}] [count=${count}]`
-      );
-    }
-
-    try {
-      // INCR on a missing key creates it without a TTL; EXPIRE is what arms it. Calling
-      // this on every path prevents an unarmed key from permanently locking the connection
-      // if a future admit returns over-limit and skips setExpiry.
-      await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
-
-      if (count > CONNECTION_CONCURRENCY_LIMIT) {
-        await keyStore.incrementBy(key, -1);
-        return false;
-      }
-
-      return true;
-    } catch (err) {
-      await keyStore.incrementBy(key, -1).catch(() => {});
-      throw err;
-    }
+    const count = await keyStore.incrementByAndRefreshExpiryIfUnderLimit(
+      key,
+      CONNECTION_CONCURRENCY_LIMIT,
+      CONNECTION_CONCURRENCY_TTL_SECONDS
+    );
+    return count !== -1;
   };
 
   const $releaseConnectionConcurrency = async (connectionId: string) => {
     const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
-    await keyStore.incrementBy(key, -1);
-    // EXPIRE on a missing key is a no-op; on an existing one it refreshes the TTL. The
-    // counter can briefly go negative if the key TTL expired while a job was running, but
-    // it self-corrects as orphan releases land and future admits' INCRs climb back up.
-    await keyStore.setExpiry(key, CONNECTION_CONCURRENCY_TTL_SECONDS);
+    await keyStore.decrementByOrDelete(key);
   };
 
   const $getInfisicalSecrets = async (
@@ -1230,7 +1211,7 @@ export const secretSyncQueueFactory = ({
         await lock.release();
       }
     },
-    { concurrency: 5 }
+    { concurrency: 15 }
   );
 
   const startDailySecretSyncRetryJob = () => {

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -86,7 +86,7 @@ type TSecretSyncQueueFactoryDep = {
   cronJob: TCronJobFactory;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
-  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "incrementBy" | "setExpiry">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock" | "incrementBy" | "setExpiry">;
   folderDAL: TSecretFolderDALFactory;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
@@ -234,6 +234,12 @@ export const secretSyncQueueFactory = ({
   const $tryAdmitConnectionConcurrency = async (connectionId: string) => {
     const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
     const count = await keyStore.incrementBy(key, 1);
+
+    if (count <= 0) {
+      logger.warn(
+        `SecretSync connection concurrency counter drifted non-positive after admit [connectionId=${connectionId}] [count=${count}]`
+      );
+    }
 
     try {
       // INCR on a missing key creates it without a TTL; EXPIRE is what arms it. Calling


### PR DESCRIPTION
## Context

This PR fixes the secret sync concurrency for app connection atomic and extends the retry budget to 60 minutes. Also bumps concurrency limit to 5.

## Screenshots

N/A

## Steps to verify the change

- create 50 syncs using the same app connection
- add 300 secrets to trigger all simultaneously
- ensure the syncs succeed

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)