### PR TITLE
fix: preselect current role in group details edit modal

### DIFF
--- a/frontend/src/pages/organization/GroupDetailsByIDPage/GroupDetailsByIDPage.tsx
+++ b/frontend/src/pages/organization/GroupDetailsByIDPage/GroupDetailsByIDPage.tsx
@@ -2,7 +2,6 @@ import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { ChevronLeftIcon, EllipsisIcon } from "lucide-react";
-
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import { DeleteActionModal, PageHeader, Spinner } from "@app/components/v2";
@@ -50,6 +49,8 @@ const Page = () => {
     "groupCreateUpdate",
     "deleteGroup"
   ] as const);
+
+
 
   const onDeleteGroupSubmit = async ({ name, id }: { name: string; id: string }) => {
     await deleteMutateAsync({
@@ -133,6 +134,7 @@ const Page = () => {
                             name: data.group.name,
                             slug: data.group.slug,
                             role: data.group.roleId || data.group.role
+                            customRole: data.group.customRole
                           });
                         }}
                       >

--- a/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupDetailsSection.tsx
+++ b/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupDetailsSection.tsx
@@ -59,6 +59,7 @@ export const GroupDetailsSection = ({ groupId, handlePopUpOpen, canEditGroup = t
                       name: data.group.name,
                       slug: data.group.slug,
                       role: data.group.roleId || data.group.role
+                      customRole: data.group.customRole
                     });
                   }}
                   size="xs"


### PR DESCRIPTION
## Context

This fixes an issue where the "Update Group" modal from the Group Details page did not preselect the group's current role when editing a group with a custom role.

The modal already supported `customRole`, but the Group Details page was not passing `customRole` into the popup payload. As a result, the role dropdown appeared empty instead of showing the currently assigned role.

This change adds `customRole` to the popup data in both group edit entry points within the Group Details flow.

## Screenshots

N/A

## Steps to verify the change

1. Open a group with a custom role assigned
2. Navigate to the Group Details page
3. Open the "Update Group" modal
4. Verify the current role is preselected in the role dropdown

## Type

* [x] Fix
* [ ] Feature
* [ ] Improvement
* [ ] Breaking
* [ ] Docs
* [ ] Chore

## Checklist

* [x] Title follows the conventional commit format
* [x] Tested locally
* [ ] Updated docs (if needed)
* [ ] Updated CLAUDE.md files (if needed)
* [x] Read the contributing guide
