### PR TITLE
feat: added lock and made scim endpoint idempotent

### DIFF
--- a/backend/src/ee/services/group/group-fns.ts
+++ b/backend/src/ee/services/group/group-fns.ts
@@ -176,9 +176,14 @@ export const addUsersToGroupByUserIds = async ({
   projectDAL,
   projectBotDAL,
   tx: outerTx,
-  membershipGroupDAL
+  membershipGroupDAL,
+  shouldFailOnMissingMembers = true
 }: TAddUsersToGroupByUserIds) => {
   const processAddition = async (tx: Knex) => {
+    if (userIds.length === 0) {
+      return [];
+    }
+
     const foundMembers = await userDAL.find(
       {
         $in: {
@@ -210,10 +215,26 @@ export const addUsersToGroupByUserIds = async ({
       { tx }
     );
 
+    const existingUserGroupMembershipsUserIdsSet = new Set(existingUserGroupMemberships.map((m) => m.userId));
+
+    // Track which userIds we're actually processing (may be filtered for idempotent operations)
+    let userIdsToProcess = userIds;
+
     if (existingUserGroupMemberships.length) {
-      throw new BadRequestError({
-        message: `User(s) are already part of the group ${group.slug}`
-      });
+      if (shouldFailOnMissingMembers) {
+        throw new BadRequestError({
+          message: `User(s) are already part of the group ${group.slug}`
+        });
+      }
+      // filter out users already in group for idempotent operation
+      const filteredFoundMembers = foundMembers.filter((m) => !existingUserGroupMembershipsUserIdsSet.has(m.id));
+      if (filteredFoundMembers.length === 0) {
+        return [];
+      }
+      // continue with filtered list
+      foundMembers.length = 0;
+      foundMembers.push(...filteredFoundMembers);
+      userIdsToProcess = filteredFoundMembers.map((m) => m.id);
     }
 
     // check if all user(s) are part of the organization
@@ -222,7 +243,7 @@ export const addUsersToGroupByUserIds = async ({
         [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: group.orgId,
         scope: AccessScope.Organization,
         $in: {
-          [`${TableName.Membership}.actorUserId` as "actorUserId"]: userIds
+          [`${TableName.Membership}.actorUserId` as "actorUserId"]: userIdsToProcess
         }
       },
       { tx }
@@ -232,7 +253,7 @@ export const addUsersToGroupByUserIds = async ({
       existingUserOrgMemberships.map((u) => u.actorUserId as string)
     );
 
-    userIds.forEach((userId) => {
+    userIdsToProcess.forEach((userId) => {
       if (!existingUserOrgMembershipsUserIdsSet.has(userId))
         throw new ForbiddenRequestError({
           message: `User with id ${userId} is not part of the organization`
@@ -366,9 +387,14 @@ export const removeUsersFromGroupByUserIds = async ({
   userGroupMembershipDAL,
   projectKeyDAL,
   tx: outerTx,
-  membershipGroupDAL
+  membershipGroupDAL,
+  shouldFailOnMissingMembers = true
 }: TRemoveUsersFromGroupByUserIds) => {
   const processRemoval = async (tx: Knex) => {
+    if (userIds.length === 0) {
+      return [];
+    }
+
     const foundMembers = await userDAL.find(
       {
         $in: {
@@ -402,12 +428,23 @@ export const removeUsersFromGroupByUserIds = async ({
 
     const existingUserGroupMembershipsUserIdsSet = new Set(existingUserGroupMemberships.map((u) => u.userId));
 
-    userIds.forEach((userId) => {
-      if (!existingUserGroupMembershipsUserIdsSet.has(userId))
+    const usersNotInGroup = userIds.filter((userId) => !existingUserGroupMembershipsUserIdsSet.has(userId));
+
+    if (usersNotInGroup.length > 0) {
+      if (shouldFailOnMissingMembers) {
         throw new ForbiddenRequestError({
           message: `User(s) are not part of the group ${group.slug}`
         });
-    });
+      }
+      // filter out users not in group for idempotent operation
+      const filteredFoundMembers = foundMembers.filter((m) => existingUserGroupMembershipsUserIdsSet.has(m.id));
+      if (filteredFoundMembers.length === 0) {
+        return [];
+      }
+      // continue with filtered list
+      foundMembers.length = 0;
+      foundMembers.push(...filteredFoundMembers);
+    }
 
     const membersToRemoveFromGroupNonPending: TUsers[] = [];
     const membersToRemoveFromGroupPending: TUsers[] = [];

--- a/backend/src/ee/services/group/group-types.ts
+++ b/backend/src/ee/services/group/group-types.ts
@@ -122,6 +122,7 @@ export type TAddUsersToGroupByUserIds = {
   projectDAL: Pick<TProjectDALFactory, "findProjectGhostUser" | "findById">;
   projectBotDAL: Pick<TProjectBotDALFactory, "findOne">;
   tx?: Knex;
+  shouldFailOnMissingMembers?: boolean;
 };
 
 export type TAddIdentitiesToGroup = {
@@ -140,6 +141,7 @@ export type TRemoveUsersFromGroupByUserIds = {
   membershipGroupDAL: Pick<TMembershipGroupDALFactory, "find">;
   projectKeyDAL: Pick<TProjectKeyDALFactory, "delete">;
   tx?: Knex;
+  shouldFailOnMissingMembers?: boolean;
 };
 
 export type TRemoveIdentitiesFromGroup = {

--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -184,18 +184,18 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findGroupMembershipsByGroupIdInOrg = async (groupId: string, orgId: string) => {
+  const findGroupMembershipsByGroupIdInOrg = async (groupId: string, orgId: string, tx?: Knex) => {
     try {
+      const queryDb = tx || db.replicaNode();
+
       // Group visible in org = has Membership with scopeOrgId = orgId (native or inherited)
-      const groupIdsVisibleInOrg = db
-        .replicaNode()(TableName.Membership)
+      const groupIdsVisibleInOrg = queryDb(TableName.Membership)
         .where(`${TableName.Membership}.scope`, AccessScope.Organization)
         .where(`${TableName.Membership}.scopeOrgId`, orgId)
         .whereNotNull(`${TableName.Membership}.actorGroupId`)
         .select(`${TableName.Membership}.actorGroupId`);
 
-      const docs = await db
-        .replicaNode()(TableName.UserGroupMembership)
+      const docs = await queryDb(TableName.UserGroupMembership)
         .join(TableName.Groups, `${TableName.UserGroupMembership}.groupId`, `${TableName.Groups}.id`)
         .join(TableName.Membership, `${TableName.UserGroupMembership}.userId`, `${TableName.Membership}.actorUserId`)
         .join(TableName.Users, `${TableName.UserGroupMembership}.userId`, `${TableName.Users}.id`)

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -841,11 +841,10 @@ export const scimServiceFactory = ({
       [`${TableName.Membership}.scope` as "scope"]: AccessScope.Organization
     });
 
-    if (!membership)
-      throw new ScimRequestError({
-        detail: "User not found",
-        status: 404
-      });
+    // Return success even if user not found (idempotent delete per SCIM RFC 7644)
+    if (!membership) {
+      return {};
+    }
 
     if (!membership.scimEnabled) {
       throw new ScimRequestError({
@@ -1342,10 +1341,16 @@ export const scimServiceFactory = ({
         status: 403
       });
 
-    const updatedGroup = await $replaceGroupDAL(groupId, orgId, {
-      displayName,
-      members,
-      shouldFailOnMissingMembers: false
+    const updatedGroup = await groupDAL.transaction(async (tx) => {
+      // Acquire advisory lock to serialize concurrent SCIM PUT requests for the same group
+      await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.ScimGroupUpdate(groupId)]);
+
+      return $replaceGroupDAL(groupId, orgId, {
+        displayName,
+        members,
+        shouldFailOnMissingMembers: false,
+        tx
+      });
     });
 
     await scimEventsDAL.create({
@@ -1476,11 +1481,9 @@ export const scimServiceFactory = ({
       orgId
     });
 
+    // Return success even if group not found (idempotent delete per SCIM RFC 7644)
     if (!group) {
-      throw new ScimRequestError({
-        detail: "Group Not Found",
-        status: 404
-      });
+      return {};
     }
 
     await scimEventsDAL.create({
@@ -1491,7 +1494,7 @@ export const scimServiceFactory = ({
       }
     });
 
-    return {}; // intentionally return empty object upon success
+    return {};
   };
 
   const fnValidateScimToken: TScimServiceFactory["fnValidateScimToken"] = async (token) => {

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 import slugify from "@sindresorhus/slugify";
+import { Knex } from "knex";
 import { scimPatch } from "scim-patch";
 
 import {
@@ -16,6 +17,7 @@ import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import { addUsersToGroupByUserIds, removeUsersFromGroupByUserIds } from "@app/ee/services/group/group-fns";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TScimDALFactory } from "@app/ee/services/scim/scim-dal";
+import { PgSqlLock } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { BadRequestError, NotFoundError, ScimRequestError, UnauthorizedError } from "@app/lib/errors";
@@ -1086,7 +1088,8 @@ export const scimServiceFactory = ({
           projectDAL,
           projectBotDAL,
           membershipGroupDAL,
-          tx
+          tx,
+          shouldFailOnMissingMembers: false
         });
 
         await $syncNewMembersRoles(group, members);
@@ -1186,25 +1189,33 @@ export const scimServiceFactory = ({
   const $replaceGroupDAL = async (
     groupId: string,
     orgId: string,
-    { displayName, members = [] }: { displayName: string; members: { value: string }[] }
+    {
+      displayName,
+      members = [],
+      shouldFailOnMissingMembers = true,
+      tx: outerTx
+    }: { displayName: string; members: { value: string }[]; shouldFailOnMissingMembers?: boolean; tx?: Knex }
   ) => {
-    let group = await groupDAL.findOne({
-      id: groupId,
-      orgId
-    });
+    const processReplacement = async (tx: Knex) => {
+      let group = await groupDAL.findOne(
+        {
+          id: groupId,
+          orgId
+        },
+        tx
+      );
 
-    if (!group) {
-      throw new ScimRequestError({
-        detail: "Group Not Found",
-        status: 404
-      });
-    }
+      if (!group) {
+        throw new ScimRequestError({
+          detail: "Group Not Found",
+          status: 404
+        });
+      }
 
-    const updatedGroup = await groupDAL.transaction(async (tx) => {
-      if (group?.name !== displayName) {
+      if (group.name !== displayName) {
         await externalGroupOrgRoleMappingDAL.update(
           {
-            groupName: group?.name,
+            groupName: group.name,
             orgId
           },
           {
@@ -1272,7 +1283,8 @@ export const scimServiceFactory = ({
           projectDAL,
           projectBotDAL,
           membershipGroupDAL,
-          tx
+          tx,
+          shouldFailOnMissingMembers
         });
       }
 
@@ -1284,14 +1296,22 @@ export const scimServiceFactory = ({
           userGroupMembershipDAL,
           membershipGroupDAL,
           projectKeyDAL,
-          tx
+          tx,
+          shouldFailOnMissingMembers
         });
       }
 
       return group;
-    });
+    };
 
-    await $syncNewMembersRoles(group, members);
+    let updatedGroup: TGroups;
+    if (outerTx) {
+      updatedGroup = await processReplacement(outerTx);
+    } else {
+      updatedGroup = await groupDAL.transaction(processReplacement);
+    }
+
+    await $syncNewMembersRoles(updatedGroup, members);
 
     return updatedGroup;
   };
@@ -1322,7 +1342,11 @@ export const scimServiceFactory = ({
         status: 403
       });
 
-    const updatedGroup = await $replaceGroupDAL(groupId, orgId, { displayName, members });
+    const updatedGroup = await $replaceGroupDAL(groupId, orgId, {
+      displayName,
+      members,
+      shouldFailOnMissingMembers: false
+    });
 
     await scimEventsDAL.create({
       orgId,
@@ -1364,33 +1388,49 @@ export const scimServiceFactory = ({
         status: 403
       });
 
-    const group = await groupDAL.findOne({
-      id: groupId,
-      orgId
-    });
+    const { scimGroup, updatedScimMembers } = await groupDAL.transaction(async (tx) => {
+      // Acquire advisory lock to serialize concurrent SCIM PATCH requests for the same group
+      await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.ScimGroupUpdate(groupId)]);
 
-    if (!group) {
-      throw new ScimRequestError({
-        detail: "Group Not Found",
-        status: 404
+      const group = await groupDAL.findOne(
+        {
+          id: groupId,
+          orgId
+        },
+        tx
+      );
+
+      if (!group) {
+        throw new ScimRequestError({
+          detail: "Group Not Found",
+          status: 404
+        });
+      }
+
+      const members = await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(group.id, orgId, tx);
+      const patchedScimGroup = buildScimGroup({
+        groupId: group.id,
+        name: group.name,
+        members: members.map((member) => ({
+          value: member.orgMembershipId
+        })),
+        createdAt: group.createdAt,
+        updatedAt: group.updatedAt
       });
-    }
+      scimPatch(patchedScimGroup, operations);
 
-    const members = await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(group.id, orgId);
-    const scimGroup = buildScimGroup({
-      groupId: group.id,
-      name: group.name,
-      members: members.map((member) => ({
-        value: member.orgMembershipId
-      })),
-      createdAt: group.createdAt,
-      updatedAt: group.updatedAt
+      // Apply the patched state with idempotent operations
+      await $replaceGroupDAL(groupId, orgId, {
+        displayName: patchedScimGroup.displayName,
+        members: patchedScimGroup.members,
+        shouldFailOnMissingMembers: false,
+        tx
+      });
+
+      const finalMembers = await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(group.id, orgId, tx);
+
+      return { scimGroup: patchedScimGroup, updatedScimMembers: finalMembers };
     });
-    scimPatch(scimGroup, operations);
-    // remove members is a weird case not following scim convention
-    await $replaceGroupDAL(groupId, orgId, { displayName: scimGroup.displayName, members: scimGroup.members });
-
-    const updatedScimMembers = await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(group.id, orgId);
 
     await scimEventsDAL.create({
       orgId,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -36,7 +36,8 @@ export const PgSqlLock = {
   KmsOrgKeyCreation: (orgId: string) => pgAdvisoryLockHashText(`kms-org-key:${orgId}`),
   KmsOrgDataKeyCreation: (orgId: string) => pgAdvisoryLockHashText(`kms-org-data-key:${orgId}`),
   KmsProjectKeyCreation: (projectId: string) => pgAdvisoryLockHashText(`kms-project-key:${projectId}`),
-  KmsProjectDataKeyCreation: (projectId: string) => pgAdvisoryLockHashText(`kms-project-data-key:${projectId}`)
+  KmsProjectDataKeyCreation: (projectId: string) => pgAdvisoryLockHashText(`kms-project-data-key:${projectId}`),
+  ScimGroupUpdate: (groupId: string) => pgAdvisoryLockHashText(`scim-group-update:${groupId}`)
 } as const;
 
 // all the key prefixes used must be set here to avoid conflict


### PR DESCRIPTION
## Context

This PR aims to fix two issues happening in SCIM integration
1. Entra sometimes sends group membership update as individual concurrent request. This would cause the last write to overwrite it. This is because the membership operation mutates over a list of things and thus we would need to load all members to figure out the change
2. Scim endpoints need to be idempotent. Especially the group mutation ones. Azure tries to remove a user from the group but it would throw an error if the group is already removed from Infisical. This would just show the status done

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)