### PR TITLE
improvement: use buildkit for standalone contenful generation

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -65,6 +65,10 @@ jobs:
                       INFISICAL_PLATFORM_VERSION=${{ steps.extract_version.outputs.version }}
                       DD_GIT_REPOSITORY_URL=${{ github.server_url }}/${{ github.repository }}
                       DD_GIT_COMMIT_SHA=${{ github.sha }}
+                  secrets: |
+                      contentful_space_id=${{ secrets.CONTENTFUL_SPACE_ID }}
+                      contentful_delivery_token=${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
+                      contentful_environment=${{ vars.CONTENTFUL_ENVIRONMENT }}
             - name: Snyk to check Docker image for vulnerabilities
               continue-on-error: true 
               uses: snyk/actions/docker@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master @ 2026-05-05
@@ -126,6 +130,10 @@ jobs:
                   build-args: |
                       POSTHOG_API_KEY=${{ secrets.PUBLIC_POSTHOG_API_KEY }}
                       INFISICAL_PLATFORM_VERSION=${{ steps.extract_version.outputs.version }}
+                  secrets: |
+                      contentful_space_id=${{ secrets.CONTENTFUL_SPACE_ID }}
+                      contentful_delivery_token=${{ secrets.CONTENTFUL_DELIVERY_TOKEN }}
+                      contentful_environment=${{ vars.CONTENTFUL_ENVIRONMENT }}
     trigger-binary-release:
       runs-on: ubuntu-latest
       needs: [infisical-tests]

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -109,14 +109,16 @@ RUN npm run build
 
 # Bake in-app announcements + their images at build time so self-hosted / air-gapped
 # instances don't make any outbound calls to Contentful at runtime. No-ops silently
-# if Contentful build args are not supplied (cloud / dev builds).
-ARG CONTENTFUL_SPACE_ID
-ARG CONTENTFUL_DELIVERY_TOKEN
-ARG CONTENTFUL_ENVIRONMENT=master
-ENV CONTENTFUL_SPACE_ID=$CONTENTFUL_SPACE_ID
-ENV CONTENTFUL_DELIVERY_TOKEN=$CONTENTFUL_DELIVERY_TOKEN
-ENV CONTENTFUL_ENVIRONMENT=$CONTENTFUL_ENVIRONMENT
-RUN npm run bake:announcements
+# if Contentful secrets are not supplied (cloud / dev builds). Secrets are passed
+# via BuildKit --mount=type=secret so they never enter any image layer or SLSA
+# provenance attestation.
+RUN --mount=type=secret,id=contentful_space_id,required=false \
+    --mount=type=secret,id=contentful_delivery_token,required=false \
+    --mount=type=secret,id=contentful_environment,required=false \
+    CONTENTFUL_SPACE_ID="$(cat /run/secrets/contentful_space_id 2>/dev/null || true)" \
+    CONTENTFUL_DELIVERY_TOKEN="$(cat /run/secrets/contentful_delivery_token 2>/dev/null || true)" \
+    CONTENTFUL_ENVIRONMENT="$(cat /run/secrets/contentful_environment 2>/dev/null || true)" \
+    npm run bake:announcements
 
 # Production stage
 FROM base AS backend-runner

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -110,14 +110,16 @@ RUN npm run build
 
 # Bake in-app announcements + their images at build time so self-hosted / air-gapped
 # instances don't make any outbound calls to Contentful at runtime. No-ops silently
-# if Contentful build args are not supplied (cloud / dev builds).
-ARG CONTENTFUL_SPACE_ID
-ARG CONTENTFUL_DELIVERY_TOKEN
-ARG CONTENTFUL_ENVIRONMENT=master
-ENV CONTENTFUL_SPACE_ID=$CONTENTFUL_SPACE_ID
-ENV CONTENTFUL_DELIVERY_TOKEN=$CONTENTFUL_DELIVERY_TOKEN
-ENV CONTENTFUL_ENVIRONMENT=$CONTENTFUL_ENVIRONMENT
-RUN npm run bake:announcements
+# if Contentful secrets are not supplied (cloud / dev builds). Secrets are passed
+# via BuildKit --mount=type=secret so they never enter any image layer or SLSA
+# provenance attestation.
+RUN --mount=type=secret,id=contentful_space_id,required=false \
+    --mount=type=secret,id=contentful_delivery_token,required=false \
+    --mount=type=secret,id=contentful_environment,required=false \
+    CONTENTFUL_SPACE_ID="$(cat /run/secrets/contentful_space_id 2>/dev/null || true)" \
+    CONTENTFUL_DELIVERY_TOKEN="$(cat /run/secrets/contentful_delivery_token 2>/dev/null || true)" \
+    CONTENTFUL_ENVIRONMENT="$(cat /run/secrets/contentful_environment 2>/dev/null || true)" \
+    npm run bake:announcements
 
 # Production dependencies (runs in parallel with backend-build)
 FROM base AS backend-prod-deps


### PR DESCRIPTION
## Context

This PR updates our standalone contentful generation to use buildkit 

## Screenshots

N/A

## Steps to verify the change

- build image with env vars set, verify feature still works

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)