### PR TITLE
fix: return privateKey in certificate renewal response

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -27,7 +27,7 @@ import {
 import { ActorAuthMethod, ActorType } from "@app/services/auth/auth-type";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
-import { extractCertificateFields } from "@app/services/certificate/certificate-fns";
+import { extractCertificateFields, getCertificateCredentials } from "@app/services/certificate/certificate-fns";
 import { TCertificateSecretDALFactory } from "@app/services/certificate/certificate-secret-dal";
 import {
   CertExtendedKeyUsage,
@@ -2472,6 +2472,34 @@ export const certificateV3ServiceFactory = ({
       finalCertificateChain = removeRootCaFromChain(finalCertificateChain);
     }
 
+    let privateKeyForResponse: string | undefined;
+    if (!internal) {
+      const { permission } = await permissionService.getProjectPermission({
+        actor,
+        actorId,
+        projectId: renewalResult.originalCert.projectId,
+        actorAuthMethod,
+        actorOrgId,
+        actionProjectType: ActionProjectType.CertificateManager
+      });
+
+      const canReadPrivateKey = permission.can(
+        ProjectPermissionCertificateActions.ReadPrivateKey,
+        ProjectPermissionSub.Certificates
+      );
+
+      if (canReadPrivateKey) {
+        const { certPrivateKey } = await getCertificateCredentials({
+          certId: renewalResult.newCert.id,
+          projectId: renewalResult.originalCert.projectId,
+          certificateSecretDAL,
+          projectDAL,
+          kmsService
+        });
+        privateKeyForResponse = certPrivateKey;
+      }
+    }
+
     try {
       await pkiAlertV2Queue?.queueCertificateEvent({
         certificateId: renewalResult.newCert.id,
@@ -2487,6 +2515,7 @@ export const certificateV3ServiceFactory = ({
       certificate: renewalResult.certificate,
       issuingCaCertificate: renewalResult.issuingCaCertificate,
       certificateChain: finalCertificateChain,
+      privateKey: privateKeyForResponse,
       serialNumber: renewalResult.serialNumber,
       certificateId: renewalResult.newCert.id,
       certificateRequestId,


### PR DESCRIPTION
## Summary

Fixes #6454

- `renewCertificate` service function was not returning the `privateKey` in its response
- The route handler already passed `data.privateKey` to the response, but `data.privateKey` was always `undefined` because the service never populated it
- After the internal-CA renewal transaction completes, fetch and decrypt the new certificate's private key from `certificateSecretDAL` using `getCertificateCredentials`, gated behind the `ReadPrivateKey` permission check
- Internal (auto-renewal queue) calls skip the key fetch since the queue only needs the renewal to succeed, not the key material

## Root cause

`certificate-v3-service.ts` → `renewCertificate`:
- The DB transaction issued a new certificate and stored its private key in `certificateSecretDAL`
- But the code after the transaction never fetched/decrypted that key — the return object had no `privateKey` field
- `issueCertificateFromProfile` already follows the correct pattern (permission check → `getCertificateCredentials` → include in return); `renewCertificate` now does the same

## Test plan

- [ ] Renew a certificate via `POST /:id/renew` — `privateKey` is present in the response for users with `ReadPrivateKey` permission
- [ ] Renew a certificate as a user without `ReadPrivateKey` permission — `privateKey` is absent from the response
- [ ] Auto-renewal queue job still completes without error (internal path skips key fetch)
- [ ] External CA renewal path (returns `PENDING` status) is not affected