### PR TITLE
chore: add upgrade impact for v0.159.30

### DIFF
--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generatedAt: 2026-05-09T01:08:18.824Z
+generatedAt: 2026-05-15T21:32:18.759Z
 versions:
   - version: v0.159.16
     releasedAt: 2026-04-17T17:49:54-03:00
@@ -34,3 +34,6 @@ versions:
   - version: v0.159.28
     releasedAt: 2026-05-08T20:34:08-04:00
     file: releases/v0.159.28.yaml
+  - version: v0.159.30
+    releasedAt: 2026-05-15T22:16:02+05:30
+    file: releases/v0.159.30.yaml

--- a/upgrade-impact/data/releases/v0.159.30.yaml
+++ b/upgrade-impact/data/releases/v0.159.30.yaml
@@ -1,0 +1,20 @@
+version: v0.159.30
+releasedAt: 2026-05-15T22:16:02+05:30
+sourceTag: v0.159.30
+previousTag: v0.159.29
+impactLevel: none
+summary: No self-hosted upgrade actions or operator-impacting changes were found.
+requiresDbMigration: false
+breakingChanges: []
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-15T21:32:18.742Z
+  sourceRange:
+    from: v0.159.29
+    to: v0.159.30


### PR DESCRIPTION
Generated self-hosted upgrade impact data for `v0.159.30`.

Review the generated YAML for self-hosted upgrade accuracy before merging.