### PR TITLE
fix(secret-sync): paginate Bitbucket list variables

### DIFF
--- a/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
+++ b/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
@@ -24,22 +24,32 @@ const buildVariablesUrl = (workspace: string, repository: string, environment?: 
   return `${baseUrl}/pipelines_config/variables/${uuid || ""}`;
 };
 
+const BITBUCKET_VARIABLES_PAGE_SIZE = 100;
+
 const listVariables = async ({
   workspaceSlug,
   repositorySlug,
   environmentId,
   authHeader
 }: TBitbucketListVariables): Promise<TBitbucketVariable[]> => {
-  const url = buildVariablesUrl(workspaceSlug, repositorySlug, environmentId);
+  const firstUrl = `${buildVariablesUrl(workspaceSlug, repositorySlug, environmentId)}?pagelen=${BITBUCKET_VARIABLES_PAGE_SIZE}`;
 
-  const { data } = await request.get<{ values: TBitbucketVariable[] }>(url, {
-    headers: {
-      Authorization: authHeader,
-      Accept: "application/json"
-    }
-  });
+  const variables: TBitbucketVariable[] = [];
+  let nextUrl: string | undefined = firstUrl;
 
-  return data.values;
+  while (nextUrl) {
+    const { data }: { data: { values: TBitbucketVariable[]; next?: string } } = await request.get(nextUrl, {
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json"
+      }
+    });
+
+    if (data.values?.length) variables.push(...data.values);
+    nextUrl = data.next;
+  }
+
+  return variables;
 };
 
 const upsertVariable = async ({

--- a/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
+++ b/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
@@ -25,6 +25,7 @@ const buildVariablesUrl = (workspace: string, repository: string, environment?: 
 };
 
 const BITBUCKET_VARIABLES_PAGE_SIZE = 100;
+const BITBUCKET_VARIABLES_MAX_PAGES = 100;
 
 const listVariables = async ({
   workspaceSlug,
@@ -35,10 +36,23 @@ const listVariables = async ({
   const firstUrl = `${buildVariablesUrl(workspaceSlug, repositorySlug, environmentId)}?pagelen=${BITBUCKET_VARIABLES_PAGE_SIZE}`;
 
   const variables: TBitbucketVariable[] = [];
+  const visited = new Set<string>();
   let nextUrl: string | undefined = firstUrl;
+  let pageCount = 0;
 
   while (nextUrl) {
-    const { data }: { data: { values: TBitbucketVariable[]; next?: string } } = await request.get(nextUrl, {
+    if (visited.has(nextUrl)) {
+      throw new Error(`Bitbucket listVariables encountered a repeated pagination URL (possible loop): ${nextUrl}`);
+    }
+    if (pageCount >= BITBUCKET_VARIABLES_MAX_PAGES) {
+      throw new Error(
+        `Bitbucket listVariables exceeded ${BITBUCKET_VARIABLES_MAX_PAGES} pages (possible runaway pagination)`
+      );
+    }
+    visited.add(nextUrl);
+    pageCount += 1;
+
+    const { data } = await request.get<{ values: TBitbucketVariable[]; next?: string }>(nextUrl, {
       headers: {
         Authorization: authHeader,
         Accept: "application/json"


### PR DESCRIPTION
## Context

The Bitbucket secret sync's `listVariables` makes a single unpaged GET against `/2.0/repositories/.../deployments_config/environments/{id}/variables/`. Bitbucket paginates that endpoint server-side (default page size ~10), so any destination env with more variables than fit on page one had unseen variables silently dropped from the in-memory list.

`upsertVariable` and `deleteVariables` both use that list to decide PUT-vs-POST and to compute `keysToDelete`. A missing key on page two was misclassified as new, the resulting POST returned `409 "A variable with the key provided already exists for account ..., environment ..."`, and the sync failed after partially applying the page-one entries.

This patch appends `?pagelen=100` to the first request and walks `data.next` until exhausted, so every existing variable is visible to upsert/delete.

Fixes #6485

## Screenshots

N/A — backend-only change.

## Steps to verify the change

1. Self-host Infisical with this patch (build the `Dockerfile.standalone-infisical` image).
2. Configure a Bitbucket secret sync against a deployment environment.
3. Populate either the Infisical source path or the destination env with **12+ variables** (more than Bitbucket's default page size).
4. Trigger an initial sync, then edit any one secret in Infisical and trigger another sync.

Before this patch: second sync fails with `ERR_BAD_REQUEST` (HTTP 409, `variable-service.variable.duplicate`).
After this patch: backend logs show `GET .../variables/?pagelen=100` (response contains every variable, regardless of count) followed by `N` PUTs and a `SecretSync Sync Job ... Completed`. No POST is issued and no 409 surfaces.

Verified end-to-end against a real production deployment running `v0.159.29` (hot-patched container, 12-variable BB env).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix(secret-sync): paginate Bitbucket list variables`
- [x] Tested locally (hot-patched container, paginated GET observed, full sync of 12 variables completes cleanly with zero POST attempts)
- [ ] Updated docs (no docs touch — internal sync behaviour, no API surface change)
- [ ] Updated CLAUDE.md files (no architectural shift)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
