### PR TITLE
fix(casl): treat extglob in secretPath globs for permission boundary heuristic

### DIFF
--- a/backend/src/lib/casl/boundary.test.ts
+++ b/backend/src/lib/casl/boundary.test.ts
@@ -845,6 +845,35 @@ describe("Validate Permission Boundary: inverted (deny) rule overlap", () => {
     expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
   });
 
+  // Picomatch supports extglob syntax (e.g. `@(a|b)`, `+(a|b)`, `!(...)`) at runtime and in the
+  // $glob schema, so the disjointness heuristic used by the deny-overlap check must treat extglob
+  // metacharacters as wildcards rather than literal text. Otherwise a deny rule like
+  // `/@(secret|restricted)/**` looks disjoint from `/secret/**` even though both match
+  // `/secret/foo` at runtime.
+  test("Child overlapping extglob deny region is rejected (deny '/@(secret|restricted)/**' + child '/secret/**')", () => {
+    const parentPermission = createMongoAbility([
+      { action: "read", subject: "secrets" },
+      {
+        action: "read",
+        subject: "secrets",
+        inverted: true,
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/@(secret|restricted)/**" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/secret/**" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+  });
+
   test("Child without the deny-region's constrained field is rejected (deny path='/secret/**' + child {})", () => {
     const parentPermission = createMongoAbility([
       { action: "read", subject: "secrets" },

--- a/backend/src/lib/casl/boundary.test.ts
+++ b/backend/src/lib/casl/boundary.test.ts
@@ -813,6 +813,66 @@ describe("Validate Permission Boundary: glob-subset of glob (positive parent)", 
     ]);
     expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
   });
+
+  // Symmetric counterpart to the deny-region extglob test below: in the positive-grant path the
+  // boundary check used `isGlobSubsetOfGlob`, whose picomatch fallback compared the child glob as
+  // a literal string. So a parent `/@(public|shared)/*` wrongly appeared to contain `/public/**`
+  // (the literal chars `**` match the parent's `*`), letting a single-segment grant be widened to
+  // recursive scope. Extglob, brace expansion, character classes and `?` all hit the same flaw.
+  test.each([
+    ["/@(public|shared)/*", "/public/**"],
+    ["/+(foo|bar)/*", "/foo/**"],
+    ["/!(public)/*", "/admin/**"],
+    ["/?(opt)/*", "/opt/**"],
+    ["/{a,b}/*", "/a/**"],
+    ["/[ab]/*", "/a/**"],
+    ["/h?llo/*", "/hello/**"]
+  ])(
+    "Child $glob broader than parent $glob with unsupported metacharacters is rejected (parent=%s, child=%s)",
+    (parentGlob, childGlob) => {
+      const parentPermission = createMongoAbility([
+        {
+          action: ["read"],
+          subject: "secrets",
+          conditions: {
+            secretPath: { [PermissionConditionOperators.$GLOB]: parentGlob }
+          }
+        }
+      ]);
+      const childPermission = createMongoAbility([
+        {
+          action: ["read"],
+          subject: "secrets",
+          conditions: {
+            secretPath: { [PermissionConditionOperators.$GLOB]: childGlob }
+          }
+        }
+      ]);
+      expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeFalsy();
+    }
+  );
+
+  test("Identical extglob $glob on parent and child is accepted (reference equality)", () => {
+    const parentPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/@(public|shared)/*" }
+        }
+      }
+    ]);
+    const childPermission = createMongoAbility([
+      {
+        action: ["read"],
+        subject: "secrets",
+        conditions: {
+          secretPath: { [PermissionConditionOperators.$GLOB]: "/@(public|shared)/*" }
+        }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
 });
 
 describe("Validate Permission Boundary: inverted (deny) rule overlap", () => {

--- a/backend/src/lib/casl/glob-subset.test.ts
+++ b/backend/src/lib/casl/glob-subset.test.ts
@@ -53,6 +53,57 @@ describe("isGlobSubsetOfGlob", () => {
       expect(isGlobSubsetOfGlob("/hello*", "/hello*")).toBe(true);
     });
   });
+
+  // Picomatch supports extglob (`@(a|b)`, `+(a|b)`, `!(...)`, `?(a|b)`, `*(a|b)`), brace expansion
+  // (`{a,b}`), character classes (`[abc]`) and `?` at runtime. The old picomatch fallback compared
+  // the subset pattern as a literal string, so a parent like `/@(public|shared)/*` wrongly
+  // appeared to contain `/public/**` (the literal chars `**` match the parent's `*`). The fix
+  // rejects any subset claim whenever either glob contains an unsupported metacharacter.
+  describe("unsupported metacharacters reject the subset claim (escalation guard)", () => {
+    test.each([
+      // Extglob in parent — child uses `**` to widen scope across segments.
+      ["/@(public|shared)/*", "/public/**"],
+      ["/@(public|shared)/*", "/shared/**"],
+      ["/+(foo|bar)/*", "/foo/**"],
+      ["/+(foo|bar)/*", "/bar/**"],
+      ["/!(public)/*", "/admin/**"],
+      ["/?(opt)/*", "/opt/**"],
+      ["/*(a|b)/*", "/a/**"],
+
+      // Brace expansion in parent (documented feature) is just as unsafe via the old fallback.
+      ["/{a,b}/*", "/a/**"],
+      ["/{a,b,c}/**", "/{a,b}/**"],
+
+      // Character classes and `?` in parent.
+      ["/[ab]/*", "/a/**"],
+      ["/h?llo/*", "/hello/**"],
+
+      // Intra-segment `*` in parent.
+      ["/foo*/*", "/foobar/**"],
+
+      // Extglob / brace / char-class in subset → conservatively rejected even if the subset is
+      // genuinely narrower (sound, not complete).
+      ["/**", "/@(a|b)/**"],
+      ["/**", "/{a,b}/**"],
+      ["/**", "/[ab]/**"],
+      ["/**", "/foo?/**"],
+      ["/public/**", "/public/@(foo|bar)"],
+      ["/public/**", "/public/{foo,bar}"]
+    ])("parent=%s, subset=%s → false", (parent, subset) => expect(isGlobSubsetOfGlob(parent, subset)).toBe(false));
+  });
+
+  describe("identical extglob/brace/charclass patterns short-circuit via reference equality", () => {
+    test.each([
+      ["/@(public|shared)/*", "/@(public|shared)/*"],
+      ["/+(foo|bar)/**", "/+(foo|bar)/**"],
+      ["/!(public)/*", "/!(public)/*"],
+      ["/?(opt)/*", "/?(opt)/*"],
+      ["/{a,b}/**", "/{a,b}/**"],
+      ["/[ab]/**", "/[ab]/**"],
+      ["/h?llo/*", "/h?llo/*"],
+      ["/foo*/*", "/foo*/*"]
+    ])("isGlobSubsetOfGlob(%s, %s) → true", (parent, subset) => expect(isGlobSubsetOfGlob(parent, subset)).toBe(true));
+  });
 });
 
 describe("literalPrefix", () => {

--- a/backend/src/lib/casl/glob-subset.test.ts
+++ b/backend/src/lib/casl/glob-subset.test.ts
@@ -62,7 +62,12 @@ describe("literalPrefix", () => {
     ["/apps/**", "/apps/"],
     ["/**", "/"],
     ["**", ""],
-    ["*foo", ""]
+    ["*foo", ""],
+    ["/@(secret|restricted)/**", "/"],
+    ["/+(foo|bar)/**", "/"],
+    ["/!(public)/**", "/"],
+    ["/?(opt)/**", "/"],
+    ["/foo(bar)/**", "/foo"]
   ])("literalPrefix(%s) === %s", (input, expected) => expect(literalPrefix(input)).toBe(expected));
 });
 
@@ -73,6 +78,10 @@ describe("haveDisjointLiteralPrefixes", () => {
     ["/foo/bar", "/foo/baz", true],
     ["/foo/bar", "/foo/bar", false],
     ["/**", "/secret/**", false],
-    ["/apps/*", "/apps/**", false]
+    ["/apps/*", "/apps/**", false],
+    // Extglob deny region must not be proven disjoint from a literal path it actually matches.
+    ["/@(secret|restricted)/**", "/secret/**", false],
+    ["/+(foo|bar)/**", "/foo/**", false],
+    ["/!(public)/**", "/secret/**", false]
   ])("disjoint(%s, %s) === %s", (a, b, expected) => expect(haveDisjointLiteralPrefixes(a, b)).toBe(expected));
 });

--- a/backend/src/lib/casl/glob-subset.ts
+++ b/backend/src/lib/casl/glob-subset.ts
@@ -1,13 +1,10 @@
-import picomatch from "picomatch";
-
 /**
  * Glob set-containment for permission boundary checks: answers "is every string matched by
  * `subsetGlob` also matched by `parentGlob`?".
  *
- * `picomatch.isMatch(subsetGlob, parentGlob)` treats the subset as a literal
- * value, so `/apps/**` appears to be a subset of `/apps/*` (the two chars `**` match `*`). This
- * module instead compares segment sequences (literal, `*`, `**`) with proper containment semantics.
- * Patterns with intra-segment wildcards (`foo*`, `?`, `[…]`, `{…}`) fall back to picomatch.
+ * This module compares segment sequences (literal, `*`, `**`) with proper containment semantics,
+ * and returns `false` whenever either glob contains any other metacharacter (`?`, `[…]`, `{…}`,
+ * extglob `@( )` / `+( )` / `!( )` / `?( )` / `*( )`, or intra-segment `*`).
  */
 
 type Segment = { type: "literal"; value: string } | { type: "star" } | { type: "globstar" };
@@ -81,19 +78,15 @@ const segmentMatch = (parent: Segment[], subset: Segment[], pi: number, si: numb
 /**
  * Returns true if every string matched by `subsetGlob` is also matched by `parentGlob`.
  *
- * Analyzes globs whose segments are literals, `*`, or `**`. For globs with other features
- * (intra-segment wildcards, character classes, brace expansion), falls back to
- * `picomatch.isMatch(subsetGlob, parentGlob)` — preserving the previous
- * behavior so this change does not affect rules that rely on those patterns.
+ * Only reasons about globs whose segments are literals, `*`, or `**`. For any other feature
+ * (intra-segment wildcards, `?`, character classes, brace expansion, extglob), returns `false`.
  */
 export const isGlobSubsetOfGlob = (parentGlob: string, subsetGlob: string): boolean => {
   if (parentGlob === subsetGlob) return true;
   const parentSegs = parseSegments(parentGlob);
   const subsetSegs = parseSegments(subsetGlob);
-  if (parentSegs && subsetSegs) {
-    return segmentMatch(parentSegs, subsetSegs, 0, 0);
-  }
-  return picomatch.isMatch(subsetGlob, parentGlob, { strictSlashes: false });
+  if (!parentSegs || !subsetSegs) return false;
+  return segmentMatch(parentSegs, subsetSegs, 0, 0);
 };
 
 /**

--- a/backend/src/lib/casl/glob-subset.ts
+++ b/backend/src/lib/casl/glob-subset.ts
@@ -97,13 +97,29 @@ export const isGlobSubsetOfGlob = (parentGlob: string, subsetGlob: string): bool
 };
 
 /**
- * Returns the static text of a glob — the prefix up to (but not including) the first glob
+ * Returns the static text of a glob — the prefix up to (but not including) the first picomatch
  * metacharacter. Used by callers that need a sound disjointness heuristic for two globs.
+ *
+ * Stops at any character that picomatch may interpret specially, including extglob syntax
+ * (`@(...)`, `?(...)`, `+(...)`, `*(...)`, `!(...)`), so the returned prefix is guaranteed to be
+ * literal text.
  */
 export const literalPrefix = (glob: string): string => {
   for (let i = 0; i < glob.length; i += 1) {
     const c = glob[i];
-    if (c === "*" || c === "?" || c === "[" || c === "{") return glob.slice(0, i);
+    if (
+      c === "*" ||
+      c === "?" ||
+      c === "[" ||
+      c === "{" ||
+      c === "(" ||
+      c === ")" ||
+      c === "@" ||
+      c === "+" ||
+      c === "!"
+    ) {
+      return glob.slice(0, i);
+    }
   }
   return glob;
 };


### PR DESCRIPTION
## Context

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)