### PR TITLE
fix(secret-sync): show 'Connection Required' instead of 'Expected object, received null' when cancelling new connection dialog

### DIFF
--- a/frontend/src/components/secret-syncs/forms/schemas/base-secret-sync-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/base-secret-sync-schema.ts
@@ -47,7 +47,10 @@ export const BaseSecretSyncSchema = <T extends AnyZodObject | undefined = undefi
   return z.object({
     name: slugSchema({ field: "Name", max: 256 }),
     description: z.string().trim().max(256, "Cannot exceed 256 characters").optional(),
-    connection: z.object({ name: z.string(), id: z.string().uuid() }),
+    connection: z
+      .object({ name: z.string(), id: z.string().uuid() })
+      .nullable()
+      .refine((val) => val !== null, { message: "Connection Required" }),
     environment: z.object({ slug: z.string(), id: z.string(), name: z.string() }),
     secretPath: z.string().min(1, "Secret path required"),
     syncOptions: syncOptionsSchema,


### PR DESCRIPTION
## Context

When creating a secret sync, clicking "+ Create New Connection" in 
the connection dropdown on the Destination tab and cancelling the 
dialog without creating a connection causes the form to show 
"Expected object, received null" instead of "Connection Required" 
when clicking Next or switching tabs.

Fixes #6495 

## Root Cause & Fix

The Zod schema for the connection field was defined as 
`z.object({ name: z.string(), id: z.string().uuid() })` which 
does not accept `null`. When the user opens the Create New 
Connection dialog and cancels without creating a connection, 
the field value becomes `null`. Zod then throws "Expected object, 
received null" instead of the standard "Connection Required" 
validation message.

**Fix:** Updated the Zod schema to use `.nullable().refine()`:

```ts
connection: z.object({ name: z.string(), id: z.string().uuid() })
  .nullable()
  .refine((val) => val !== null, { message: "Connection Required" })
```

This allows `null` as a valid type but still fails validation 
with the correct "Connection Required" message.

## Screen recording

Before fix

https://github.com/user-attachments/assets/931b7ab0-1233-4d4b-9009-2c5b7afb92d1

After fix

https://github.com/user-attachments/assets/68a2974a-a46c-4462-9a45-6b3140d2b664

## Steps to verify the change

1. Go to Secret Syncs → Add Sync → any integration (e.g. Netlify)
2. Go to Destination tab
3. Click connection dropdown → click "+ Create New Connection"
4. Leave everything empty → click Cancel
5. Click Next without selecting a connection
6. Should now show "Connection Required" instead of "Expected object, received null"


## Additional testing
- [ ] Tested with Netlify real connection — selecting a valid 
      connection and clicking Next works correctly, no regression

**Screen Recording for above test:**

https://github.com/user-attachments/assets/fbc9821c-6438-4a13-ae93-823eb8261df1

- [x] Tested cancel flow on multiple sync types
- [x] Existing connection selection flow unaffected

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide