### PR TITLE
chore: updated depot build to match the sha to v1

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
             - name: 📦 Build backend and export to Docker
-              uses: depot/build-push-action@f78af826a1c272c4b60c485e934974b515094928 # Main / v1, Mar 10, 2026
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # Main / v1, Mar 10, 2026
               with:
                   project: 64mmf0n610
                   token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
             - name: Set up Depot CLI
               uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
             - name: 📦 Build backend and export to Docker
-              uses: depot/build-push-action@f78af826a1c272c4b60c485e934974b515094928 # Main / v1, Mar 10, 2026
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # Main / v1, Mar 10, 2026
               with:
                   project: 64mmf0n610
                   token: ${{ secrets.DEPOT_PROJECT_TOKEN }}


### PR DESCRIPTION
## Context

This PR fixes the depot build action to use the correct commit sha pinned to v1

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)