### PR TITLE
chore(cron): per-job timeout for daily resource cleanup

### DIFF
--- a/backend/e2e-test/cron-job.spec.ts
+++ b/backend/e2e-test/cron-job.spec.ts
@@ -46,7 +46,7 @@ const makeFactory = (overrides?: Partial<Parameters<typeof cronJobFactory>[0]>) 
     slotRefreshMs: 100,
     enqueueIntervalMs: 500,
     processIntervalMs: 200,
-    leaseDurationMs: 2000,
+    leaseDurationMs: 5_000,
     retryBackoffBaseMs: 100,
     retryBackoffMaxMs: 500,
     handlerTimeoutMs: 5_000,
@@ -408,7 +408,7 @@ describe("graceful shutdown", () => {
         })
     );
 
-    const f = factory({ handlerTimeoutMs: 30_000, drainTimeoutMs: 5_000 });
+    const f = factory({ leaseDurationMs: 30_000, handlerTimeoutMs: 30_000, drainTimeoutMs: 5_000 });
     f.register({ name: "drain-job", pattern: FAST_PATTERN, handler, runHashTtlS: 3600 });
     f.start();
 
@@ -447,7 +447,7 @@ describe("graceful shutdown", () => {
   // drain timer expires.
   test("stop() releases the slot even when an in-flight handler hangs past drainTimeoutMs", async () => {
     const handler = vi.fn().mockImplementation(() => new Promise<void>(() => {})); // never resolves
-    const f = factory({ handlerTimeoutMs: 30_000, drainTimeoutMs: 300 });
+    const f = factory({ leaseDurationMs: 30_000, handlerTimeoutMs: 30_000, drainTimeoutMs: 300 });
     f.register({ name: "hang-drain-job", pattern: FAST_PATTERN, handler, runHashTtlS: 3600 });
     f.start();
 

--- a/backend/src/lib/cron/cron-job.test.ts
+++ b/backend/src/lib/cron/cron-job.test.ts
@@ -44,7 +44,8 @@ const makeFactory = (deps?: Partial<FakeDeps>) => {
       enqueueIntervalMs: 100,
       processIntervalMs: 100,
       slotTtlMs: 200,
-      leaseDurationMs: 1000
+      leaseDurationMs: 1000,
+      handlerTimeoutMs: 1000
     }),
     redis,
     redlock
@@ -84,6 +85,134 @@ describe("register", () => {
     start();
     expect(redis.eval).not.toHaveBeenCalled();
     await stop();
+  });
+
+  test("throws when per-entry handlerTimeoutMs exceeds factory leaseDurationMs", () => {
+    const { register } = makeFactory(); // factory leaseDurationMs=1000
+    expect(() =>
+      register({
+        name: "x",
+        pattern: "0 0 * * *",
+        handler: vi.fn(),
+        runHashTtlS: 3600,
+        handlerTimeoutMs: 5_000
+      })
+    ).toThrow(/handlerTimeoutMs.*must be <=.*leaseDurationMs/);
+  });
+
+  test("accepts per-entry handlerTimeoutMs when matched by per-entry leaseDurationMs", () => {
+    const { register } = makeFactory();
+    expect(() =>
+      register({
+        name: "x",
+        pattern: "0 0 * * *",
+        handler: vi.fn(),
+        runHashTtlS: 3600,
+        handlerTimeoutMs: 30 * 60_000,
+        leaseDurationMs: 30 * 60_000
+      })
+    ).not.toThrow();
+  });
+
+  test("throws when factory handlerTimeoutMs default exceeds factory leaseDurationMs", () => {
+    const redis = makeRedis();
+    const redlock = makeRedlock();
+    const { register } = cronJobFactory({
+      redis: redis as never,
+      redlock: redlock as never,
+      slotRefreshMs: 50,
+      enqueueIntervalMs: 100,
+      processIntervalMs: 100,
+      slotTtlMs: 200,
+      // No per-knob overrides — handlerTimeoutMs (default 5min) > leaseDurationMs (1s).
+      leaseDurationMs: 1000
+    });
+    expect(() => register({ name: "x", pattern: "0 0 * * *", handler: vi.fn(), runHashTtlS: 3600 })).toThrow(
+      /handlerTimeoutMs.*must be <=.*leaseDurationMs/
+    );
+  });
+});
+
+describe("per-entry lease duration", () => {
+  test("redlock.using receives per-entry leaseDurationMs when set", async () => {
+    vi.setSystemTime(new Date("2024-01-01T00:00:30Z"));
+    const enqueuedAt = Date.parse("2024-01-01T00:00:00Z");
+
+    const redis = makeRedis();
+    redis.set.mockResolvedValue("OK");
+    redis.eval.mockResolvedValue(1);
+    redis.zrangebyscore.mockResolvedValue([`x:${enqueuedAt}`]);
+    redis.hgetall.mockResolvedValue({
+      name: "x",
+      status: "pending",
+      attempts: "0",
+      enqueued_at_ms: "0"
+    });
+
+    const redlock = makeRedlock();
+    const f = cronJobFactory({
+      redis: redis as never,
+      redlock: redlock as never,
+      slotRefreshMs: 50,
+      enqueueIntervalMs: 100,
+      processIntervalMs: 100,
+      slotTtlMs: 200,
+      leaseDurationMs: 1000,
+      handlerTimeoutMs: 1000
+    });
+    f.register({
+      name: "x",
+      pattern: "* * * * *",
+      handler: vi.fn(),
+      runHashTtlS: 3600,
+      handlerTimeoutMs: 30 * 60_000,
+      leaseDurationMs: 30 * 60_000
+    });
+    f.start();
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(redlock.using).toHaveBeenCalled();
+    const [, durationArg] = redlock.using.mock.calls[0] as [unknown, number, unknown];
+    expect(durationArg).toBe(30 * 60_000);
+
+    await f.stop();
+  });
+
+  test("redlock.using falls back to factory leaseDurationMs when entry omits it", async () => {
+    vi.setSystemTime(new Date("2024-01-01T00:00:30Z"));
+    const enqueuedAt = Date.parse("2024-01-01T00:00:00Z");
+
+    const redis = makeRedis();
+    redis.set.mockResolvedValue("OK");
+    redis.eval.mockResolvedValue(1);
+    redis.zrangebyscore.mockResolvedValue([`x:${enqueuedAt}`]);
+    redis.hgetall.mockResolvedValue({
+      name: "x",
+      status: "pending",
+      attempts: "0",
+      enqueued_at_ms: "0"
+    });
+
+    const redlock = makeRedlock();
+    const f = cronJobFactory({
+      redis: redis as never,
+      redlock: redlock as never,
+      slotRefreshMs: 50,
+      enqueueIntervalMs: 100,
+      processIntervalMs: 100,
+      slotTtlMs: 200,
+      leaseDurationMs: 1234,
+      handlerTimeoutMs: 1000
+    });
+    f.register({ name: "x", pattern: "* * * * *", handler: vi.fn(), runHashTtlS: 3600 });
+    f.start();
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(redlock.using).toHaveBeenCalled();
+    const [, durationArg] = redlock.using.mock.calls[0] as [unknown, number, unknown];
+    expect(durationArg).toBe(1234);
+
+    await f.stop();
   });
 });
 
@@ -379,6 +508,7 @@ describe("min-age gate", () => {
       processIntervalMs: 100,
       slotTtlMs: 200,
       leaseDurationMs: 1000,
+      handlerTimeoutMs: 1000,
       minProcessAgeMs: 500
     });
     f.register({ name: "x", pattern: "* * * * *", handler: vi.fn(), runHashTtlS: 3600 });
@@ -458,7 +588,9 @@ describe("stop", () => {
       enqueueIntervalMs: 100,
       processIntervalMs: 100,
       slotTtlMs: 200,
-      leaseDurationMs: 1000,
+      // Lease must cover handlerTimeoutMs; raised together so the
+      // registration-time invariant accepts the entry.
+      leaseDurationMs: 60_000,
       handlerTimeoutMs: 60_000,
       drainTimeoutMs: 5_000
     });
@@ -509,7 +641,7 @@ describe("stop", () => {
       enqueueIntervalMs: 100,
       processIntervalMs: 100,
       slotTtlMs: 200,
-      leaseDurationMs: 1000,
+      leaseDurationMs: 60_000,
       // Long enough that handlerTimeoutMs doesn't naturally drain inFlight.
       handlerTimeoutMs: 60_000,
       drainTimeoutMs: 200

--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -115,6 +115,7 @@ type CronEntry = {
   handler: Handler;
   runHashTtlS: number;
   handlerTimeoutMs?: number;
+  leaseDurationMs?: number;
 };
 class HandlerTimeoutError extends Error {
   constructor(message: string) {
@@ -262,7 +263,8 @@ export const cronJobFactory = ({
     runHashTtlS,
     maxAttempts = 3,
     enabled = true,
-    handlerTimeoutMs: entryHandlerTimeoutMs
+    handlerTimeoutMs: entryHandlerTimeoutMs,
+    leaseDurationMs: entryLeaseDurationMs
   }: {
     name: string;
     pattern: string;
@@ -271,6 +273,7 @@ export const cronJobFactory = ({
     maxAttempts?: number;
     enabled?: boolean;
     handlerTimeoutMs?: number;
+    leaseDurationMs?: number;
   }) => {
     if (!enabled) {
       logger.info(`cron[${name}]: disabled`);
@@ -278,7 +281,24 @@ export const cronJobFactory = ({
     }
     if (entries.has(name)) throw new Error(`cron[${name}] already registered`);
     CronExpressionParser.parse(pattern, { tz: "UTC" }); // validate at registration
-    entries.set(name, { name, pattern, maxAttempts, handler, runHashTtlS, handlerTimeoutMs: entryHandlerTimeoutMs });
+
+    const effectiveHandlerTimeoutMs = entryHandlerTimeoutMs ?? handlerTimeoutMs;
+    const effectiveLeaseDurationMs = entryLeaseDurationMs ?? leaseDurationMs;
+    if (effectiveHandlerTimeoutMs > effectiveLeaseDurationMs) {
+      throw new Error(
+        `cron[${name}] handlerTimeoutMs (${effectiveHandlerTimeoutMs}) must be <= leaseDurationMs (${effectiveLeaseDurationMs})`
+      );
+    }
+
+    entries.set(name, {
+      name,
+      pattern,
+      maxAttempts,
+      handler,
+      runHashTtlS,
+      handlerTimeoutMs: entryHandlerTimeoutMs,
+      leaseDurationMs: entryLeaseDurationMs
+    });
     logger.info(`cron[${name}]: registered (pattern="${pattern}")`);
   };
 
@@ -448,7 +468,9 @@ export const cronJobFactory = ({
     // Track the in-flight run so stop() can wait for it to settle before
     // tearing down. Lock-contention rejections settle within a tick, so they
     // don't measurably delay shutdown drain.
-    const tracked = redlock.using([LEASE_KEY(id)], leaseDurationMs, () => executeUnderLease(entry, id, attempts + 1));
+    const tracked = redlock.using([LEASE_KEY(id)], entry.leaseDurationMs ?? leaseDurationMs, () =>
+      executeUnderLease(entry, id, attempts + 1)
+    );
     inFlight.add(tracked);
     try {
       await tracked;

--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -108,7 +108,14 @@ const RELEASE_SLOT_IF_MINE_LUA = `if redis.call('get', KEYS[1]) == ARGV[1] then 
 // ── types ─────────────────────────────────────────────────────────────────────
 
 type Handler = () => Promise<void>;
-type CronEntry = { name: string; pattern: string; maxAttempts: number; handler: Handler; runHashTtlS: number };
+type CronEntry = {
+  name: string;
+  pattern: string;
+  maxAttempts: number;
+  handler: Handler;
+  runHashTtlS: number;
+  handlerTimeoutMs?: number;
+};
 class HandlerTimeoutError extends Error {
   constructor(message: string) {
     super(message);
@@ -254,7 +261,8 @@ export const cronJobFactory = ({
     handler,
     runHashTtlS,
     maxAttempts = 3,
-    enabled = true
+    enabled = true,
+    handlerTimeoutMs: entryHandlerTimeoutMs
   }: {
     name: string;
     pattern: string;
@@ -262,6 +270,7 @@ export const cronJobFactory = ({
     runHashTtlS: number;
     maxAttempts?: number;
     enabled?: boolean;
+    handlerTimeoutMs?: number;
   }) => {
     if (!enabled) {
       logger.info(`cron[${name}]: disabled`);
@@ -269,7 +278,7 @@ export const cronJobFactory = ({
     }
     if (entries.has(name)) throw new Error(`cron[${name}] already registered`);
     CronExpressionParser.parse(pattern, { tz: "UTC" }); // validate at registration
-    entries.set(name, { name, pattern, maxAttempts, handler, runHashTtlS });
+    entries.set(name, { name, pattern, maxAttempts, handler, runHashTtlS, handlerTimeoutMs: entryHandlerTimeoutMs });
     logger.info(`cron[${name}]: registered (pattern="${pattern}")`);
   };
 
@@ -361,7 +370,7 @@ export const cronJobFactory = ({
     logger.info(`cron[${entry.name}]: start (attempt ${attempt}/${entry.maxAttempts}) [id=${id}]`);
 
     try {
-      await withTimeout(() => entry.handler(), handlerTimeoutMs);
+      await withTimeout(() => entry.handler(), entry.handlerTimeoutMs ?? handlerTimeoutMs);
       await markCompleted(id);
       logger.info(`cron[${entry.name}]: complete [id=${id}] [duration_ms=${Date.now() - startMs}]`);
     } catch (err) {

--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -79,6 +79,7 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
       name: CronJobName.DailyResourceCleanup,
       pattern: appCfg.isDailyResourceCleanUpDevelopmentMode ? "*/5 * * * *" : "0 0 * * *",
       runHashTtlS: 3 * 24 * 60 * 60,
+      handlerTimeoutMs: 30 * 60_000,
       enabled: !appCfg.isSecondaryInstance,
       handler: async () => {
         logger.info(`cron[${CronJobName.DailyResourceCleanup}]: task started`);

--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -75,11 +75,13 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
   }
 
   const init = () => {
+    const dailyCleanupTimeoutMs = appCfg.isDailyResourceCleanUpDevelopmentMode ? 5 * 60_000 : 30 * 60_000;
     cronJob.register({
       name: CronJobName.DailyResourceCleanup,
       pattern: appCfg.isDailyResourceCleanUpDevelopmentMode ? "*/5 * * * *" : "0 0 * * *",
       runHashTtlS: 3 * 24 * 60 * 60,
-      handlerTimeoutMs: 30 * 60_000,
+      handlerTimeoutMs: dailyCleanupTimeoutMs,
+      leaseDurationMs: dailyCleanupTimeoutMs,
       enabled: !appCfg.isSecondaryInstance,
       handler: async () => {
         logger.info(`cron[${CronJobName.DailyResourceCleanup}]: task started`);


### PR DESCRIPTION
## Context

- **Cron jobs:** Supports an optional **per-job `handlerTimeoutMs`** on cron entries (`cron-job.ts`); the daily resource cleanup job uses **30 minutes** so long cleanup runs are less likely to hit the global handler timeout (`resource-cleanup-queue.ts`).

## Type

- [ ] Fix  
- [ ] Feature  
- [ ] Improvement  
- [ ] Breaking  
- [ ] Docs  
- [x] Chore  

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).  
- [x] Tested locally  
- [ ] Updated docs (if needed)  
- [ ] Updated CLAUDE.md files (if needed)  
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)  