### PR TITLE
docs: make go-sdk cleanup more explicit

### DIFF
--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -109,8 +109,8 @@ client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
 
 # Automatic token refreshing
 
-The Infisical Go SDK supports automatic token refreshing. After using one of the auth methods such as Universal Auth, the SDK will automatically renew and re-authenticate when needed.
-This behavior is enabled by default, but you can opt-out by setting `AutoTokenRefresh` to `false` in the client settings.
+The Infisical Go SDK supports automatic token refreshing, **enabled by default**. After using one of the auth methods such as Universal Auth, the SDK will automatically renew and re-authenticate when needed.
+You can opt-out by setting `AutoTokenRefresh` to `false` in the client settings.
 
 ```go
   client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
@@ -118,7 +118,9 @@ This behavior is enabled by default, but you can opt-out by setting `AutoTokenRe
   })
 ```
 
-When using automatic token refreshing it's important to understand how your application uses the Infiiscal client. If you are instantiating new instances of the client often, it's important to cancel the context when the client is no longer needed to avoid the token refreshing process from running indefinitely.
+### Client Lifecycle
+
+When using automatic token refreshing it's important to understand how your application uses the Infisical client. If you are instantiating new instances of the client often, it's important to cancel the context when the client is no longer needed to avoid the token refreshing process from running indefinitely.
 
 ```go
   ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This makes the client cleanup a bit more explicit by adding a section for it. Also highlights that `Automatic token refreshing` is enabled by default.

## Screenshots

<img width="847" height="1021" alt="image" src="https://github.com/user-attachments/assets/4b30b9ba-3da9-4b4d-a4ea-996574608e5d" />


<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)