### PR TITLE
chore: add upgrade impact for v0.160.0

### DIFF
--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generatedAt: 2026-05-18T13:15:44.995Z
+generatedAt: 2026-05-18T16:03:00.491Z
 versions:
   - version: v0.159.16
     releasedAt: 2026-04-17T17:49:54-03:00
@@ -38,5 +38,5 @@ versions:
     releasedAt: 2026-05-15T22:16:02+05:30
     file: releases/v0.159.30.yaml
   - version: v0.160.0
-    releasedAt: 2026-05-18T18:32:44+05:30
+    releasedAt: 2026-05-18T11:53:20-04:00
     file: releases/v0.160.0.yaml

--- a/upgrade-impact/data/releases/v0.160.0.yaml
+++ b/upgrade-impact/data/releases/v0.160.0.yaml
@@ -1,29 +1,17 @@
 version: v0.160.0
-releasedAt: 2026-05-18T18:32:44+05:30
+releasedAt: 2026-05-18T11:53:20-04:00
 sourceTag: v0.160.0
 previousTag: v0.159.29
 impactLevel: low
-summary: Startup runs a PKI applications schema migration and backfills a
-  default Certificate Manager project for organizations that do not already have
-  one.
+summary: Startup applies a PKI applications schema migration and backfills a
+  default Certificate Manager project for organizations missing one.
 requiresDbMigration: true
 breakingChanges: []
 dbSchemaChanges:
   - title: PKI applications migration
-    description: Startup adds PKI application tables and columns, including new
-      links from certificates, requests, alerts, syncs, enrollment configs, and
-      inventory views to applications.
-    action: No manual action required; Infisical runs this migration during startup.
-    confidence: high
-    evidence:
-      - type: file
-        ref: backend/src/db/migrations/20260504432352_cert-manager-applications.ts
-        path: backend/src/db/migrations/20260504432352_cert-manager-applications.ts
-        description: Creates PKI application tables
-  - title: Certificate Manager project backfill
-    description: Certificate Manager moves from multiple projects to single instance per organizations. Organizations without a cert-manager project get a new default
-      "Certificate Manager" instance during migration. Organizations with exactly
-      one existing cert-manager project get it set as the default Certificate Manager instance.
+    description: Startup adds PKI application tables and columns, and backfills a
+      default Certificate Manager project for organizations that do not already
+      have one.
     action: No manual action required; Infisical runs this migration during startup.
       If startup fails during migration, keep the previous version running and
       inspect migration logs before retrying.
@@ -32,7 +20,7 @@ dbSchemaChanges:
       - type: file
         ref: backend/src/db/migrations/20260504432352_cert-manager-applications.ts
         path: backend/src/db/migrations/20260504432352_cert-manager-applications.ts
-        description: Backfills default cert-manager project
+        description: Creates PKI application tables and columns
 configChanges: []
 deploymentNotes: []
 knownIssues: []
@@ -40,7 +28,7 @@ generatedBy:
   generator: "@infisical/upgrade-impact"
   generatorVersion: "1"
   model: gpt-5.4
-  generatedAt: 2026-05-18T13:15:44.974Z
+  generatedAt: 2026-05-18T16:03:00.473Z
   sourceRange:
     from: v0.159.29
     to: v0.160.0


### PR DESCRIPTION
Generated self-hosted upgrade impact data for `v0.160.0`.

Review the generated YAML for self-hosted upgrade accuracy before merging.