### PR TITLE
fix: harden authorization on PKI sync and certificate flows

### DIFF
--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -401,6 +401,7 @@ export const permissionServiceFactory = ({
     });
     if (!permissionData?.length)
       throw new ForbiddenRequestError({
+        name: "ProjectMembershipNotFound",
         message: `You are not a member of this project with ID ${projectId}. Please assign this ${actor} to the project with the appropriate permissions, then try again.`
       });
 
@@ -629,6 +630,10 @@ export const permissionServiceFactory = ({
       });
     }
 
+    if (!actorOrgId) {
+      throw new BadRequestError({ message: "Organization context is required for resource permission checks" });
+    }
+
     const memoKey = requestMemoKeys.resourcePermission({
       projectId,
       resourceType,
@@ -640,15 +645,8 @@ export const permissionServiceFactory = ({
     });
 
     return requestMemoize(memoKey, async () => {
-      const resourceMemberships = await permissionDAL.getResourceMembership({
-        projectId,
-        resourceType,
-        resourceId,
-        actorId,
-        actorType: actor
-      });
-
       let isProjectAdmin = false;
+      let isProjectMember = false;
       try {
         const projectPerm = await getProjectPermission({
           actor,
@@ -659,9 +657,31 @@ export const permissionServiceFactory = ({
           actionProjectType: ActionProjectType.CertificateManager
         });
         isProjectAdmin = projectPerm.hasRole(ProjectMembershipRole.Admin);
-      } catch {
-        isProjectAdmin = false;
+        isProjectMember = true;
+      } catch (err) {
+        if (!(err instanceof ForbiddenRequestError) || err.name !== "ProjectMembershipNotFound") {
+          throw err;
+        }
       }
+
+      if (!isProjectMember) {
+        await getOrgPermission({
+          actor,
+          actorId,
+          orgId: actorOrgId,
+          actorOrgId,
+          scope: OrganizationActionScope.Any,
+          actorAuthMethod
+        });
+      }
+
+      const resourceMemberships = await permissionDAL.getResourceMembership({
+        projectId,
+        resourceType,
+        resourceId,
+        actorId,
+        actorType: actor
+      });
 
       if (resourceMemberships?.length) {
         const permissionFromRoles = flattenActiveRolesFromMemberships(

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -33,6 +33,7 @@ import { TCertificateBodyDALFactory } from "@app/services/certificate/certificat
 import { CertSubjectAlternativeNameType } from "@app/services/certificate/certificate-types";
 import { TCertificateAuthorityDALFactory } from "@app/services/certificate-authority/certificate-authority-dal";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
+import { assertCaInProfileProject } from "@app/services/certificate-authority/certificate-authority-fns";
 import {
   TCertificateIssuanceQueueFactory,
   TIssueCertificateFromProfileJobData
@@ -1134,6 +1135,8 @@ export const pkiAcmeServiceFactory = ({
         if (!ca) {
           throw new NotFoundError({ message: "Certificate Authority not found" });
         }
+
+        assertCaInProfileProject(ca, profile);
 
         const finalizeAccount = await acmeAccountDAL.findByProjectIdAndAccountId(profile.id, accountId);
         const accountApplicationProfileId = (finalizeAccount as { applicationProfileId?: string | null } | null)

--- a/backend/src/ee/services/pki-scep/pki-scep-service.ts
+++ b/backend/src/ee/services/pki-scep/pki-scep-service.ts
@@ -21,7 +21,7 @@ import { TCertificateDALFactory } from "@app/services/certificate/certificate-da
 import { TCertificateAuthorityCertDALFactory } from "@app/services/certificate-authority/certificate-authority-cert-dal";
 import { TCertificateAuthorityDALFactory } from "@app/services/certificate-authority/certificate-authority-dal";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
-import { getCaCertChain } from "@app/services/certificate-authority/certificate-authority-fns";
+import { assertCaInProfileProject, getCaCertChain } from "@app/services/certificate-authority/certificate-authority-fns";
 import { TCertificateIssuanceQueueFactory } from "@app/services/certificate-authority/certificate-issuance-queue";
 import {
   extractAlgorithmsFromCSR,
@@ -149,6 +149,7 @@ export const pkiScepServiceFactory = ({
     if (!ca) {
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
+    assertCaInProfileProject(ca, profile);
     const caType: CaType = (ca.externalCa?.type as CaType) ?? CaType.INTERNAL;
 
     const scepConfig = await scepEnrollmentConfigDAL.findById(resolvedScepConfigId);

--- a/backend/src/ee/services/pki-scep/pki-scep-service.ts
+++ b/backend/src/ee/services/pki-scep/pki-scep-service.ts
@@ -21,7 +21,10 @@ import { TCertificateDALFactory } from "@app/services/certificate/certificate-da
 import { TCertificateAuthorityCertDALFactory } from "@app/services/certificate-authority/certificate-authority-cert-dal";
 import { TCertificateAuthorityDALFactory } from "@app/services/certificate-authority/certificate-authority-dal";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
-import { assertCaInProfileProject, getCaCertChain } from "@app/services/certificate-authority/certificate-authority-fns";
+import {
+  assertCaInProfileProject,
+  getCaCertChain
+} from "@app/services/certificate-authority/certificate-authority-fns";
 import { TCertificateIssuanceQueueFactory } from "@app/services/certificate-authority/certificate-issuance-queue";
 import {
   extractAlgorithmsFromCSR,

--- a/backend/src/services/certificate-authority/ca-signing-config/ca-signing-config-service.ts
+++ b/backend/src/services/certificate-authority/ca-signing-config/ca-signing-config-service.ts
@@ -464,7 +464,7 @@ export const caSigningConfigServiceFactory = ({
     });
 
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionCertificateAuthorityActions.Edit,
+      ProjectPermissionCertificateAuthorityActions.IssueCACertificate,
       subject(ProjectPermissionSub.CertificateAuthorities, { name: ca.name })
     );
 
@@ -519,7 +519,7 @@ export const caSigningConfigServiceFactory = ({
     });
 
     ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionCertificateAuthorityActions.Edit,
+      ProjectPermissionCertificateAuthorityActions.IssueCACertificate,
       subject(ProjectPermissionSub.CertificateAuthorities, { name: ca.name })
     );
 

--- a/backend/src/services/certificate-authority/certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.ts
@@ -4,7 +4,7 @@ import RE2 from "re2";
 
 import { crypto } from "@app/lib/crypto/cryptography";
 import { derivePublicKeyFromSecret, getPqcCrypto, isPqcAlgorithm, PqcCryptoKey } from "@app/lib/crypto/pqc";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
 
 import { CertKeyAlgorithm, CertStatus } from "../certificate/certificate-types";
@@ -23,6 +23,14 @@ export const createSerialNumber = () => {
   const randomBytes = crypto.randomBytes(20); // 20 bytes = 160 bits
   randomBytes[0] &= 0x7f; // ensure the first bit is 0
   return randomBytes.toString("hex");
+};
+
+export const assertCaInProfileProject = (ca: { projectId: string }, profile: { projectId: string }) => {
+  if (ca.projectId !== profile.projectId) {
+    throw new ForbiddenRequestError({
+      message: "Certificate Authority must belong to the same project as the profile"
+    });
+  }
 };
 
 /**

--- a/backend/src/services/certificate-est-v3/certificate-est-v3-service.test.ts
+++ b/backend/src/services/certificate-est-v3/certificate-est-v3-service.test.ts
@@ -65,7 +65,8 @@ vi.mock("@app/services/certificate-authority/certificate-authority-fns", () => (
         certificateChain: "mock-chain"
       }
     ])
-  )
+  ),
+  assertCaInProfileProject: vi.fn()
 }));
 
 vi.mock("@app/services/project/project-fns", () => ({

--- a/backend/src/services/certificate-est-v3/certificate-est-v3-service.ts
+++ b/backend/src/services/certificate-est-v3/certificate-est-v3-service.ts
@@ -8,7 +8,11 @@ import { isCertChainValid } from "@app/services/certificate/certificate-fns";
 import { CertStatus } from "@app/services/certificate/certificate-types";
 import { TCertificateAuthorityCertDALFactory } from "@app/services/certificate-authority/certificate-authority-cert-dal";
 import { TCertificateAuthorityDALFactory } from "@app/services/certificate-authority/certificate-authority-dal";
-import { getCaCertChain, getCaCertChains } from "@app/services/certificate-authority/certificate-authority-fns";
+import {
+  assertCaInProfileProject,
+  getCaCertChain,
+  getCaCertChains
+} from "@app/services/certificate-authority/certificate-authority-fns";
 import { TCertificateProfileDALFactory } from "@app/services/certificate-profile/certificate-profile-dal";
 import { EnrollmentType } from "@app/services/certificate-profile/certificate-profile-types";
 import { CertificateRequestStatus } from "@app/services/certificate-request/certificate-request-types";
@@ -394,6 +398,8 @@ export const certificateEstV3ServiceFactory = ({
         message: `Internal Certificate Authority with ID '${profile.caId}' not found`
       });
     }
+
+    assertCaInProfileProject(ca, profile);
 
     const { caCert, caCertChain } = await getCaCertChain({
       caCertId: ca.internalCa.activeCaCertId as string,

--- a/backend/src/services/certificate-profile/certificate-profile-service.test.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-service.test.ts
@@ -271,6 +271,11 @@ describe("CertificateProfileService", () => {
       return await fn();
     });
 
+    (mockCertificateAuthorityDAL.findById as any).mockResolvedValue({
+      id: "ca-123",
+      projectId: "project-123"
+    });
+
     service = certificateProfileServiceFactory({
       certificateProfileDAL: mockCertificateProfileDAL,
       certificatePolicyDAL: mockCertificatePolicyDAL,

--- a/backend/src/services/certificate-profile/certificate-profile-service.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-service.ts
@@ -121,6 +121,23 @@ const validateAcmEnrollmentType = async (
   }
 };
 
+const validateCaProjectMatch = async (
+  caId: string | null | undefined,
+  projectId: string,
+  certificateAuthorityDAL: Pick<TCertificateAuthorityDALFactory, "findById">
+) => {
+  if (!caId) return;
+  const ca = await certificateAuthorityDAL.findById(caId);
+  if (!ca) {
+    throw new NotFoundError({ message: "Certificate Authority not found" });
+  }
+  if (ca.projectId !== projectId) {
+    throw new ForbiddenRequestError({
+      message: "Invalid Certificate Authority"
+    });
+  }
+};
+
 const validateExternalConfigs = async (
   externalConfigs: Record<string, unknown> | null | undefined,
   caId: string | null,
@@ -364,6 +381,8 @@ export const certificateProfileServiceFactory = ({
         });
       }
     }
+
+    await validateCaProjectMatch(data.caId, projectId, certificateAuthorityDAL);
 
     // Check for slug uniqueness within project
     const existingSlugProfile = await certificateProfileDAL.findBySlugAndProjectId(data.slug, projectId);
@@ -624,6 +643,10 @@ export const certificateProfileServiceFactory = ({
     const finalIssuerType = data.issuerType || existingProfile.issuerType;
     const finalEnrollmentType = data.enrollmentType || existingProfile.enrollmentType;
     const finalCaId = data.caId !== undefined ? data.caId : existingProfile.caId;
+
+    if (data.caId !== undefined) {
+      await validateCaProjectMatch(data.caId, existingProfile.projectId, certificateAuthorityDAL);
+    }
 
     validateIssuerTypeConstraints(finalIssuerType, finalEnrollmentType, finalCaId ?? null, existingProfile.caId);
 

--- a/backend/src/services/certificate-v3/certificate-approval-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-approval-fns.ts
@@ -17,6 +17,7 @@ import { CertKeyAlgorithm, CertSignatureAlgorithm, CertStatus } from "@app/servi
 import { validateAcmIssuanceInputs } from "@app/services/certificate-authority/aws-acm-public-ca/aws-acm-public-ca-certificate-authority-fns";
 import { TCertificateAuthorityDALFactory } from "@app/services/certificate-authority/certificate-authority-dal";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
+import { assertCaInProfileProject } from "@app/services/certificate-authority/certificate-authority-fns";
 import { TCertificateIssuanceQueueFactory } from "@app/services/certificate-authority/certificate-issuance-queue";
 import { TInternalCertificateAuthorityServiceFactory } from "@app/services/certificate-authority/internal/internal-certificate-authority-service";
 import { TCertificatePolicyServiceFactory } from "@app/services/certificate-policy/certificate-policy-service";
@@ -350,6 +351,8 @@ export const certificateApprovalServiceFactory = (
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
 
+    assertCaInProfileProject(ca, profile);
+
     validateCaSupport(ca, "CSR signing");
 
     const { certificate, certificateChain, issuingCaCertificate, serialNumber, cert } =
@@ -439,6 +442,8 @@ export const certificateApprovalServiceFactory = (
     if (!targetCa) {
       return null;
     }
+
+    assertCaInProfileProject(targetCa, profile);
 
     const caType = (targetCa.externalCa?.type as CaType) ?? CaType.INTERNAL;
 
@@ -637,6 +642,8 @@ export const certificateApprovalServiceFactory = (
     if (!ca) {
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
+
+    assertCaInProfileProject(ca, profile);
 
     validateCaSupport(ca, "direct certificate issuance");
     validateAlgorithmCompatibility(ca, certPolicy);

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -53,7 +53,8 @@ vi.mock("../certificate-authority/certificate-authority-fns", () => ({
   extractDnParts: vi.fn().mockReturnValue({
     commonName: "test.example.com"
   }),
-  createDistinguishedName: vi.fn().mockReturnValue("CN=test.example.com")
+  createDistinguishedName: vi.fn().mockReturnValue("CN=test.example.com"),
+  assertCaInProfileProject: vi.fn()
 }));
 
 describe("CertificateV3Service", () => {

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1237,6 +1237,12 @@ export const certificateV3ServiceFactory = ({
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
 
+    if (ca.projectId !== profile.projectId) {
+      throw new ForbiddenRequestError({
+        message: "Invalid Certificate Authority"
+      });
+    }
+
     validateCaSupport(ca, "direct certificate issuance");
     validateAlgorithmCompatibility(ca, policy);
 
@@ -1485,6 +1491,12 @@ export const certificateV3ServiceFactory = ({
     const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId);
     if (!ca) {
       throw new NotFoundError({ message: "Certificate Authority not found" });
+    }
+
+    if (ca.projectId !== profile.projectId) {
+      throw new ForbiddenRequestError({
+        message: "Invalid Certificate Authority"
+      });
     }
 
     validateCaSupport(ca, "CSR signing");

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -46,7 +46,11 @@ import {
   TCertificateAuthorityWithAssociatedCa
 } from "@app/services/certificate-authority/certificate-authority-dal";
 import { CaStatus, CaType } from "@app/services/certificate-authority/certificate-authority-enums";
-import { createDistinguishedName, extractDnParts } from "@app/services/certificate-authority/certificate-authority-fns";
+import {
+  assertCaInProfileProject,
+  createDistinguishedName,
+  extractDnParts
+} from "@app/services/certificate-authority/certificate-authority-fns";
 import { TInternalCertificateAuthorityServiceFactory } from "@app/services/certificate-authority/internal/internal-certificate-authority-service";
 import { TCertificatePolicyServiceFactory } from "@app/services/certificate-policy/certificate-policy-service";
 import { TCertificateProfileDALFactory } from "@app/services/certificate-profile/certificate-profile-dal";
@@ -1237,11 +1241,7 @@ export const certificateV3ServiceFactory = ({
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
 
-    if (ca.projectId !== profile.projectId) {
-      throw new ForbiddenRequestError({
-        message: "Invalid Certificate Authority"
-      });
-    }
+    assertCaInProfileProject(ca, profile);
 
     validateCaSupport(ca, "direct certificate issuance");
     validateAlgorithmCompatibility(ca, policy);
@@ -1493,11 +1493,7 @@ export const certificateV3ServiceFactory = ({
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
 
-    if (ca.projectId !== profile.projectId) {
-      throw new ForbiddenRequestError({
-        message: "Invalid Certificate Authority"
-      });
-    }
+    assertCaInProfileProject(ca, profile);
 
     validateCaSupport(ca, "CSR signing");
 
@@ -1942,6 +1938,9 @@ export const certificateV3ServiceFactory = ({
     // already approved a request that's guaranteed to fail downstream.
     if (profile.caId) {
       const preflightCa = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId);
+      if (preflightCa) {
+        assertCaInProfileProject(preflightCa, profile);
+      }
       if (preflightCa?.externalCa?.type === CaType.AWS_ACM_PUBLIC_CA) {
         validateAcmIssuanceInputs({
           csr: certificateOrder.csr,
@@ -2097,6 +2096,8 @@ export const certificateV3ServiceFactory = ({
     if (!ca) {
       throw new NotFoundError({ message: "Certificate Authority not found" });
     }
+
+    assertCaInProfileProject(ca, profile);
 
     const caType = (ca.externalCa?.type as CaType) ?? CaType.INTERNAL;
 
@@ -2325,6 +2326,8 @@ export const certificateV3ServiceFactory = ({
         if (!ca) {
           throw new NotFoundError({ message: "Certificate Authority not found" });
         }
+
+        assertCaInProfileProject(ca, profile ?? originalCert);
 
         const eligibilityCheck = validateRenewalEligibility(originalCert, ca);
         if (!eligibilityCheck.isEligible) {

--- a/backend/src/services/pki-application/pki-application-service.ts
+++ b/backend/src/services/pki-application/pki-application-service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from "@casl/ability";
+import { ForbiddenError, subject } from "@casl/ability";
 import { packRules } from "@casl/ability/extra";
 
 import {
@@ -11,6 +11,7 @@ import {
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
   ProjectPermissionApplicationActions,
+  ProjectPermissionCertificateProfileActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import {
@@ -139,6 +140,13 @@ export const pkiApplicationServiceFactory = ({
         throw new BadRequestError({
           message: "One or more profileIds do not belong to this project."
         });
+      }
+
+      for (const profile of profilesInProject) {
+        ForbiddenError.from(permission).throwUnlessCan(
+          ProjectPermissionCertificateProfileActions.ManageApplicationAttachments,
+          subject(ProjectPermissionSub.CertificateProfiles, { slug: profile.slug })
+        );
       }
     }
 
@@ -448,6 +456,19 @@ export const pkiApplicationServiceFactory = ({
       throw new BadRequestError({ message: "One or more profileIds do not belong to this project." });
     }
 
+    const { permission: projectPermission } = await $loadProjectPermission(projectId, {
+      actor,
+      actorId,
+      actorAuthMethod,
+      actorOrgId
+    });
+    for (const profile of profilesInProject) {
+      ForbiddenError.from(projectPermission).throwUnlessCan(
+        ProjectPermissionCertificateProfileActions.ManageApplicationAttachments,
+        subject(ProjectPermissionSub.CertificateProfiles, { slug: profile.slug })
+      );
+    }
+
     return pkiApplicationDAL.transaction(async (tx) => {
       const existing = await pkiApplicationProfileDAL.findByApplicationId(applicationId, tx);
       const existingProfileIds = new Set(existing.map((row) => row.profileId));
@@ -496,6 +517,22 @@ export const pkiApplicationServiceFactory = ({
         message: `Profile '${profileId}' is not attached to application '${applicationId}'.`
       });
     }
+
+    const [profile] = await pkiApplicationProfileDAL.findProfilesInProject([profileId], projectId);
+    if (!profile) {
+      throw new NotFoundError({ message: `Profile '${profileId}' not found in project.` });
+    }
+
+    const { permission: projectPermission } = await $loadProjectPermission(projectId, {
+      actor,
+      actorId,
+      actorAuthMethod,
+      actorOrgId
+    });
+    ForbiddenError.from(projectPermission).throwUnlessCan(
+      ProjectPermissionCertificateProfileActions.ManageApplicationAttachments,
+      subject(ProjectPermissionSub.CertificateProfiles, { slug: profile.slug })
+    );
 
     await pkiApplicationProfileDAL.delete({ applicationId, profileId });
     return { applicationId, profileId };

--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
@@ -301,12 +301,14 @@ const removeNetScalerCertificate = async (
 const escapeRegex = (s: string) => s.replace(new RE2("[\\\\^$.*+?()\\[\\]{}|/]", "g"), "\\$&");
 
 const buildManagedCertNamePattern = (certificateNameSchema: string | undefined): RE2 => {
-  const effectiveSchema = certificateNameSchema || "Infisical-{{certificateId}}";
+  if (!certificateNameSchema) {
+    return new RE2("^Infisical-[0-9a-f]{32}(-[a-zA-Z0-9]*)?$");
+  }
 
   const CERT_ID_TOKEN = "__INFISICAL_CERT_ID_PLACEHOLDER__";
   const ENV_TOKEN = "__INFISICAL_ENV_PLACEHOLDER__";
 
-  const tokenized = effectiveSchema
+  const tokenized = certificateNameSchema
     .replace(new RE2("\\{\\{certificateId\\}\\}", "g"), CERT_ID_TOKEN)
     .replace(new RE2("\\{\\{environment\\}\\}", "g"), ENV_TOKEN);
 

--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
@@ -298,6 +298,25 @@ const removeNetScalerCertificate = async (
   await deleteCertKey(session, certKeyName, true);
 };
 
+const escapeRegex = (s: string) => s.replace(new RE2("[\\\\^$.*+?()\\[\\]{}|/]", "g"), "\\$&");
+
+const buildManagedCertNamePattern = (certificateNameSchema: string | undefined): RE2 => {
+  const effectiveSchema = certificateNameSchema || "Infisical-{{certificateId}}";
+
+  const CERT_ID_TOKEN = "__INFISICAL_CERT_ID_PLACEHOLDER__";
+  const ENV_TOKEN = "__INFISICAL_ENV_PLACEHOLDER__";
+
+  const tokenized = effectiveSchema
+    .replace(new RE2("\\{\\{certificateId\\}\\}", "g"), CERT_ID_TOKEN)
+    .replace(new RE2("\\{\\{environment\\}\\}", "g"), ENV_TOKEN);
+
+  const pattern = escapeRegex(tokenized)
+    .replace(new RE2(CERT_ID_TOKEN, "g"), "[0-9a-f]{32}")
+    .replace(new RE2(ENV_TOKEN, "g"), "global");
+
+  return new RE2(`^${pattern}$`);
+};
+
 export const netScalerPkiSyncFactory = ({
   certificateSyncDAL,
   certificateDAL,
@@ -567,13 +586,11 @@ export const netScalerPkiSyncFactory = ({
               }
             }
 
-            const namingPrefix = certificateNameSchema ? certificateNameSchema.split("{{")[0] : "Infisical-";
+            const managedCertNamePattern = buildManagedCertNamePattern(certificateNameSchema);
 
-            if (namingPrefix) {
-              for (const certKeyName of existingCertKeyNames) {
-                if (certKeyName.startsWith(namingPrefix) && !activeExternalIdentifiers.has(certKeyName)) {
-                  certKeysToRemove.add(certKeyName);
-                }
+            for (const certKeyName of existingCertKeyNames) {
+              if (managedCertNamePattern.test(certKeyName) && !activeExternalIdentifiers.has(certKeyName)) {
+                certKeysToRemove.add(certKeyName);
               }
             }
 

--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-schemas.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-schemas.ts
@@ -23,9 +23,13 @@ export const NetScalerPkiSyncOptionsSchema = z.object({
       (schema) => {
         if (!schema) return true;
 
+        if (!schema.includes("{{certificateId}}")) {
+          return false;
+        }
+
         const testName = schema
-          .replace(new RE2("\\{\\{certificateId\\}\\}", "g"), "")
-          .replace(new RE2("\\{\\{environment\\}\\}", "g"), "");
+          .replace(new RE2("\\{\\{certificateId\\}\\}", "g"), "test-cert-id")
+          .replace(new RE2("\\{\\{environment\\}\\}", "g"), "test-env");
 
         const hasForbiddenChars = NETSCALER_NAMING.FORBIDDEN_CHARACTERS.split("").some((char) =>
           testName.includes(char)
@@ -35,7 +39,7 @@ export const NetScalerPkiSyncOptionsSchema = z.object({
       },
       {
         message:
-          "Certificate name schema must result in names that contain only alphanumeric characters, hyphens (-), underscores (_), and periods (.) and be 1-255 characters long for NetScaler"
+          "Certificate name schema must include the {{certificateId}} placeholder and result in names that contain only alphanumeric characters, hyphens (-), underscores (_), and periods (.) and be 1-255 characters long for NetScaler"
       }
     )
 });


### PR DESCRIPTION
## Context

- **NetScaler PKI sync**
  - `certificateNameSchema` now requires the `{{certificateId}}` placeholder so it can't be set to a constant.
  - The orphaned-cert cleanup loop matches against a regex derived from the user's full schema (literal prefix + `[0-9a-f]{32}` for `{{certificateId}}` + literal suffix) instead of a `startsWith` prefix check.

- **External CA install**
  - `installCertificateVenafi` and `installCertificateAzureAdCs` now require `CertificateAuthority.IssueCACertificate` instead of `Edit`, matching the analogous internal renewal path.

- **Resource permission**
  - `getResourcePermission` now propagates org-mismatch, project-type, and SSO errors from `getProjectPermission` instead of silently swallowing them, and runs an explicit org-membership + SSO check for actors who are resource-only members. Tagged "not a project member" with a sentinel `name` so only that specific error falls through.

- **Certificate profile**
  - `createProfile` and `updateProfile` now validate that the supplied `caId` belongs to the profile's project (mirrors the existing certificate-policy check).
  - Defense-in-depth in `certificate-v3` issuance: rejects requests when `profile.caId`'s CA doesn't live in `profile.projectId`.

- **PKI applications**
  - `createApplication` (when `profileIds` is supplied), `attachProfiles`, and `detachProfile` now check `CertificateProfile.ManageApplicationAttachments` on each profile.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)