### PR TITLE
fix: explicit project id requests throw BadRequestError

### DIFF
--- a/backend/src/server/plugins/inject-cert-manager-project-id.ts
+++ b/backend/src/server/plugins/inject-cert-manager-project-id.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 
+import { BadRequestError } from "@app/lib/errors";
+
 const CERT_MANAGER_PREFIXES = ["/api/v1/cert-manager/", "/api/v1/pki/", "/api/v2/pki/"];
 
 const readProjectIdFromRequest = (req: { query?: unknown; body?: unknown; params?: unknown }): string | null => {
@@ -35,10 +37,10 @@ export const injectCertManagerProjectId: FastifyPluginAsync = fp(async (server) 
 
     try {
       req.internalCertManagerProjectId = await server.services.certManagerProjectResolver.resolve(req.permission.orgId);
-    } catch {
-      // Leave internalCertManagerProjectId empty — endpoints that genuinely need it will surface their own
-      // error at the service layer, and endpoints that infer the project from another entity (profileId,
-      // certId, alertId, etc.) continue to work.
+    } catch (err) {
+      // Swallow only the resolver's expected "no project / no default" errors so endpoints that infer the
+      // project from another entity (profileId, certId, alertId, etc.) keep working.
+      if (!(err instanceof BadRequestError)) throw err;
     }
   });
 });

--- a/backend/src/server/plugins/inject-cert-manager-project-id.ts
+++ b/backend/src/server/plugins/inject-cert-manager-project-id.ts
@@ -1,15 +1,16 @@
 import { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 
-import { BadRequestError } from "@app/lib/errors";
-
 const CERT_MANAGER_PREFIXES = ["/api/v1/cert-manager/", "/api/v1/pki/", "/api/v2/pki/"];
 
-const readProjectIdFromRequest = (req: { query?: unknown; body?: unknown }): string | null => {
+const readProjectIdFromRequest = (req: { query?: unknown; body?: unknown; params?: unknown }): string | null => {
   const fromQuery = (req.query as { projectId?: unknown } | undefined)?.projectId;
   if (typeof fromQuery === "string" && fromQuery.length > 0) return fromQuery;
   const fromBody = (req.body as { projectId?: unknown } | undefined)?.projectId;
   if (typeof fromBody === "string" && fromBody.length > 0) return fromBody;
+  const params = req.params as { projectId?: unknown; workspaceId?: unknown } | undefined;
+  const fromParams = params?.projectId ?? params?.workspaceId;
+  if (typeof fromParams === "string" && fromParams.length > 0) return fromParams;
   return null;
 };
 
@@ -28,19 +29,16 @@ export const injectCertManagerProjectId: FastifyPluginAsync = fp(async (server) 
 
     const explicit = readProjectIdFromRequest(req);
     if (explicit) {
-      const isCertManager = await server.services.certManagerProjectResolver.isCertManagerProject(
-        explicit,
-        req.permission.orgId
-      );
-      if (!isCertManager) {
-        throw new BadRequestError({
-          message: "The supplied projectId does not reference a Certificate Manager project."
-        });
-      }
       req.internalCertManagerProjectId = explicit;
       return;
     }
 
-    req.internalCertManagerProjectId = await server.services.certManagerProjectResolver.resolve(req.permission.orgId);
+    try {
+      req.internalCertManagerProjectId = await server.services.certManagerProjectResolver.resolve(req.permission.orgId);
+    } catch {
+      // Leave internalCertManagerProjectId empty — endpoints that genuinely need it will surface their own
+      // error at the service layer, and endpoints that infer the project from another entity (profileId,
+      // certId, alertId, etc.) continue to work.
+    }
   });
 });


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)