### PR TITLE
fix: remove BadRequestError on multiple cert-manager projects

### DIFF
--- a/backend/src/server/plugins/inject-cert-manager-project-id.ts
+++ b/backend/src/server/plugins/inject-cert-manager-project-id.ts
@@ -35,12 +35,6 @@ export const injectCertManagerProjectId: FastifyPluginAsync = fp(async (server) 
       return;
     }
 
-    try {
-      req.internalCertManagerProjectId = await server.services.certManagerProjectResolver.resolve(req.permission.orgId);
-    } catch (err) {
-      // Swallow only the resolver's expected "no project / no default" errors so endpoints that infer the
-      // project from another entity (profileId, certId, alertId, etc.) keep working.
-      if (!(err instanceof BadRequestError)) throw err;
-    }
+    req.internalCertManagerProjectId = await server.services.certManagerProjectResolver.resolve(req.permission.orgId);
   });
 });

--- a/backend/src/services/cert-manager-instance/cert-manager-project-resolver.ts
+++ b/backend/src/services/cert-manager-instance/cert-manager-project-resolver.ts
@@ -28,10 +28,7 @@ const resolveCertManagerProjectId = async (
   }
   if (org.defaultCertManagerProjectId) return org.defaultCertManagerProjectId;
 
-  throw new BadRequestError({
-    message:
-      "This organization has multiple Certificate Manager projects but no default is set. An org Admin must set the default in the Certificate Manager settings."
-  });
+  return "";
 };
 
 export type TCertManagerProjectResolverFactory = ReturnType<typeof certManagerProjectResolverFactory>;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)