### PR TITLE
docs: add principals flag to dynamic secrets and agent docs

### DIFF
--- a/docs/cli/commands/dynamic-secrets.mdx
+++ b/docs/cli/commands/dynamic-secrets.mdx
@@ -184,6 +184,18 @@ The following flags are specific to certain providers or integrations:
   </Accordion>
 </Accordion>
 
+<Accordion title="SSH">
+  <Accordion title="--principals">
+    Comma-separated list of principals for the SSH certificate. Only used for SSH dynamic secrets. The requested principals must be in the allowed list configured on the dynamic secret.
+
+    ```bash
+    # Example
+    infisical dynamic-secrets lease create <dynamic-secret-name> --principals=root,deploy
+    ```
+
+  </Accordion>
+</Accordion>
+
 </Accordion>
 <Accordion title="infisical dynamic-secrets lease list">
   This command is used to list leases for a dynamic secret.

--- a/docs/documentation/platform/dynamic-secrets/ssh.mdx
+++ b/docs/documentation/platform/dynamic-secrets/ssh.mdx
@@ -134,6 +134,21 @@ When you create an SSH dynamic secret, Infisical generates an internal CA key pa
   </Step>
 </Steps>
 
+## Generate via CLI
+
+You can also create SSH dynamic secret leases using the CLI:
+
+```bash
+infisical dynamic-secrets lease create <secret-name> \
+  --projectId=<project-id> \
+  --env=dev \
+  --principals=root,deploy
+```
+
+The `--principals` flag is required for SSH dynamic secrets and accepts a comma-separated list. The requested principals must be a subset of the allowed principals configured on the dynamic secret.
+
+For more details, see the [CLI dynamic secrets documentation](/cli/commands/dynamic-secrets).
+
 ## Audit or Revoke Leases
 
 Once you have created one or more leases, you will be able to access them by clicking on the respective dynamic secret item on the dashboard.

--- a/docs/integrations/platforms/infisical-agent.mdx
+++ b/docs/integrations/platforms/infisical-agent.mdx
@@ -167,7 +167,7 @@ The secret template functions is what you will use to fetch resources such as st
 
     **Returns**: An object with keys corresponding to the dynamic secret lease credentials.
 
-    The `principals` argument is only used for SSH dynamic secrets, where it is **required**. It is ignored for all other providers. It accepts a comma-separated list of principals for the SSH certificate. The requested principals must be in the allowed list configured on the dynamic secret.
+    The `principals` argument is only applicable to SSH dynamic secrets, where it is **required**. It accepts a comma-separated list of principals for the SSH certificate. The requested principals must be in the allowed list configured on the dynamic secret.
 
     <Tip>
       Note that if you have multiple dynamic secret templates with identical configurations, only one lease will be created in Infisical for those templates, and the same lease will be written to your specified destination paths.

--- a/docs/integrations/platforms/infisical-agent.mdx
+++ b/docs/integrations/platforms/infisical-agent.mdx
@@ -143,7 +143,7 @@ The secret template functions is what you will use to fetch resources such as st
 
   <Accordion title="dynamicSecret">
     ```bash
-    dynamicSecret "<project-slug>" "<environment-slug>" "<secret-path>" "<dynamic-secret-name>" "<lease-ttl>"
+    dynamicSecret "<project-slug>" "<environment-slug>" "<secret-path>" "<dynamic-secret-name>" "<lease-ttl>" "<principals>"
     ```
 
     ```bash example-redis-dynamic-secret
@@ -153,11 +153,21 @@ The secret template functions is what you will use to fetch resources such as st
 
     ```
 
+    ```bash example-ssh-dynamic-secret
+      {{ with dynamicSecret "my-project" "dev" "/" "my-ssh-secret" "1h" "root,deploy" }}
+      {{ .PRIVATE_KEY }}
+      {{ .SIGNED_KEY }}
+      {{- end }}
+
+    ```
+
     **Function Name**: `dynamicSecret`
 
     **Description**: This function can be used to render a dynamic secret lease credentials. The credentials are automatically renewed before they expire, ensuring that the rendered credentials are always up-to-date.
 
     **Returns**: An object with keys corresponding to the dynamic secret lease credentials.
+
+    The `principals` argument is optional and only used for SSH dynamic secrets. It accepts a comma-separated list of principals for the SSH certificate. The requested principals must be in the allowed list configured on the dynamic secret.
 
     <Tip>
       Note that if you have multiple dynamic secret templates with identical configurations, only one lease will be created in Infisical for those templates, and the same lease will be written to your specified destination paths.

--- a/docs/integrations/platforms/infisical-agent.mdx
+++ b/docs/integrations/platforms/infisical-agent.mdx
@@ -143,7 +143,7 @@ The secret template functions is what you will use to fetch resources such as st
 
   <Accordion title="dynamicSecret">
     ```bash
-    dynamicSecret "<project-slug>" "<environment-slug>" "<secret-path>" "<dynamic-secret-name>" "<lease-ttl>" "<principals>"
+    dynamicSecret "<project-slug>" "<environment-slug>" "<secret-path>" "<dynamic-secret-name>" "<lease-ttl>" "<optional-principals>"
     ```
 
     ```bash example-redis-dynamic-secret
@@ -167,7 +167,7 @@ The secret template functions is what you will use to fetch resources such as st
 
     **Returns**: An object with keys corresponding to the dynamic secret lease credentials.
 
-    The `principals` argument is optional and only used for SSH dynamic secrets. It accepts a comma-separated list of principals for the SSH certificate. The requested principals must be in the allowed list configured on the dynamic secret.
+    The `principals` argument is only used for SSH dynamic secrets, where it is **required**. It is ignored for all other providers. It accepts a comma-separated list of principals for the SSH certificate. The requested principals must be in the allowed list configured on the dynamic secret.
 
     <Tip>
       Note that if you have multiple dynamic secret templates with identical configurations, only one lease will be created in Infisical for those templates, and the same lease will be written to your specified destination paths.


### PR DESCRIPTION
## Context

Document the new --principals CLI flag and agent template argument for SSH dynamic secrets. Adds SSH section to provider-specific flags, SSH example to agent template docs, and a CLI section to the SSH dynamic secrets page.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)