### PR TITLE
fix(secret): include deleted secrets in snapshots

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -95,7 +95,7 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
     try {
       const docs = await (tx || db.replicaNode())(TableName.SecretVersionV2)
         .where(`${TableName.SecretVersionV2}.folderId`, folderId)
-        .join(TableName.SecretV2, `${TableName.SecretV2}.id`, `${TableName.SecretVersionV2}.secretId`)
+        .leftJoin(TableName.SecretV2, `${TableName.SecretV2}.id`, `${TableName.SecretVersionV2}.secretId`)
         .join<TSecretVersionsV2, TSecretVersionsV2 & { secretId: string; max: number }>(
           (tx || db.replicaNode())(TableName.SecretVersionV2)
             .where(`${TableName.SecretVersionV2}.folderId`, folderId)

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -60,7 +60,7 @@ export const secretVersionDALFactory = (db: TDbClient) => {
     try {
       const docs = await (tx || db.replicaNode())(TableName.SecretVersion)
         .where(`${TableName.SecretVersion}.folderId`, folderId)
-        .join(TableName.Secret, `${TableName.Secret}.id`, `${TableName.SecretVersion}.secretId`)
+        .leftJoin(TableName.Secret, `${TableName.Secret}.id`, `${TableName.SecretVersion}.secretId`)
         .join<TSecretVersions, TSecretVersions & { secretId: string; max: number }>(
           (tx || db)(TableName.SecretVersion)
             .groupBy("folderId", "secretId")


### PR DESCRIPTION
## Summary
- preserve latest secret-version rows in snapshot queries even after the live secret row has been deleted
- apply the same left-join behavior to both legacy secret versions and the v2 bridge path
- keeps delete-triggered snapshots useful for rollback because deleted secrets can still be reinserted from their latest version rows

Fixes #2752

## Testing
- git diff --check
- npm ci --ignore-scripts --no-audit --no-fund in backend
- attempted eslint on the touched DAL files; in this sparse checkout it reports pre-existing unsafe-any errors around unchanged code because the full backend source/alias context is not present