### PR TITLE
feat: resolved entra scim replace issue

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -475,6 +475,9 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
       params: z.object({
         groupId: z.string().trim()
       }),
+      querystring: z.object({
+        excludedAttributes: z.string().trim().optional()
+      }),
       response: {
         200: ScimGroupSchema
       }
@@ -483,7 +486,8 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     handler: async (req) => {
       const group = await req.server.services.scim.getScimGroup({
         groupId: req.params.groupId,
-        orgId: req.permission.orgId
+        orgId: req.permission.orgId,
+        isMembersExcluded: req.query.excludedAttributes === "members"
       });
 
       return group;

--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -461,7 +461,10 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
         startIndex: req.query.startIndex,
         filter: req.query.filter,
         limit: req.query.count,
-        isMembersExcluded: req.query.excludedAttributes === "members"
+        isMembersExcluded: req.query.excludedAttributes
+          ?.split(",")
+          .map((s) => s.trim())
+          .includes("members")
       });
 
       return groups;

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -1138,7 +1138,7 @@ export const scimServiceFactory = ({
     });
   };
 
-  const getScimGroup: TScimServiceFactory["getScimGroup"] = async ({ groupId, orgId }) => {
+  const getScimGroup: TScimServiceFactory["getScimGroup"] = async ({ groupId, orgId, isMembersExcluded }) => {
     const plan = await licenseService.getPlan(orgId);
     if (!plan.groups)
       throw new BadRequestError({
@@ -1155,6 +1155,27 @@ export const scimServiceFactory = ({
         detail: "Group Not Found",
         status: 404
       });
+    }
+
+    if (isMembersExcluded) {
+      await scimEventsDAL.create({
+        orgId,
+        eventType: ScimEvent.GET_GROUP,
+        event: {
+          groupName: group.name,
+          numberOfMembers: 0
+        }
+      });
+
+      const scimGroup = buildScimGroup({
+        groupId: group.id,
+        name: group.name,
+        members: [],
+        createdAt: group.createdAt,
+        updatedAt: group.updatedAt
+      });
+      const { members, ...scimGroupWithoutMembers } = scimGroup;
+      return scimGroupWithoutMembers as TScimGroup;
     }
 
     const users = await groupDAL

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -1162,8 +1162,7 @@ export const scimServiceFactory = ({
         orgId,
         eventType: ScimEvent.GET_GROUP,
         event: {
-          groupName: group.name,
-          numberOfMembers: 0
+          groupName: group.name
         }
       });
 

--- a/backend/src/ee/services/scim/scim-types.ts
+++ b/backend/src/ee/services/scim/scim-types.ts
@@ -114,6 +114,7 @@ export type TCreateScimGroupDTO = {
 export type TGetScimGroupDTO = {
   groupId: string;
   orgId: string;
+  isMembersExcluded?: boolean;
 };
 
 export type TUpdateScimGroupNamePutDTO = {

--- a/docs/documentation/platform/scim/azure.mdx
+++ b/docs/documentation/platform/scim/azure.mdx
@@ -43,8 +43,7 @@ Prerequisites:
         Next, set the following fields:
         
         - Provisioning Mode: Select **Automatic**.
-        - Tenant URL: Input the **Microsoft Entra ID (Azure) Tenant URL** from Step 1
-          (attach the SCIM URL with the `?aadOptscim062020` query parameter appended).
+        - Tenant URL: Input the SCIM URL from Step 1 with `?aadOptscim062020` appended as a query parameter.
         - Secret Token: Input the **New SCIM Token** from Step 1.
 
         Afterwards, click **Enable SCIM** and press the **Test Connection** button to check that SCIM is configured properly.

--- a/docs/documentation/platform/scim/azure.mdx
+++ b/docs/documentation/platform/scim/azure.mdx
@@ -43,9 +43,10 @@ Prerequisites:
         Next, set the following fields:
         
         - Provisioning Mode: Select **Automatic**.
-        - Tenant URL: Input **SCIM URL** from Step 1.
+        - Tenant URL: Input the **Microsoft Entra ID (Azure) Tenant URL** from Step 1
+          (attach the SCIM URL with the `?aadOptscim062020` query parameter appended).
         - Secret Token: Input the **New SCIM Token** from Step 1.
-        
+
         Afterwards, click **Enable SCIM** and press the **Test Connection** button to check that SCIM is configured properly.
         
         ![SCIM Azure](/images/platform/scim/azure/scim-azure-config.png)


### PR DESCRIPTION
## Context

Entra SCIM was sending replace operator inside patch request for membership update in group patch. This would cause the membership to end up having just one user in auto provision. This PR aims to fix that behaviour. 

After investigating a lot on this behaviour - this comment seems to [resolve](https://learn.microsoft.com/en-us/answers/questions/2118795/unexpected-scim-group-membership-updates-in-azure) it. I was able to reproduce this behaviour and confirmed patch resolved it. When Entra doesn't get the excluded properties members it does send add for some reason.

I have also updated doc about the `aadOptscim062020` so Entra follows the standard SCIM 2.0 convention.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)