### PR TITLE
fix(pam): use auth for non-bucket log chunk fetch

### DIFF
--- a/frontend/src/hooks/api/pam/session-playback/decrypt.ts
+++ b/frontend/src/hooks/api/pam/session-playback/decrypt.ts
@@ -11,6 +11,8 @@
 //
 // Any failure renders a placeholder for that chunk in the player UI
 
+import { apiRequest } from "@app/config/request";
+
 import { TPamPlaybackChunk, TPamRecordingStorageBackend } from "./types";
 
 const PAM_RECORDING_AAD_VERSION = "v1";
@@ -79,24 +81,24 @@ const fetchCiphertext = async (
   chunk: TPamPlaybackChunk,
   fallbackUrlBuilder: (chunkIndex: number) => string
 ): Promise<Uint8Array> => {
-  const isExternal = Boolean(chunk.presignedGetUrl);
-  const url = chunk.presignedGetUrl ?? fallbackUrlBuilder(chunk.chunkIndex);
-  const resp = await fetch(url, { credentials: isExternal ? "omit" : "include" });
-  if (!resp.ok) {
-    if (isExternal && resp.status === 404) {
-      throw new Error("Chunk data was not found in the external storage bucket.");
+  if (chunk.presignedGetUrl) {
+    const resp = await fetch(chunk.presignedGetUrl, { credentials: "omit" });
+    if (!resp.ok) {
+      if (resp.status === 404) {
+        throw new Error("Chunk data was not found in the external storage bucket.");
+      }
+      if (resp.status === 403) {
+        throw new Error("Access denied when fetching chunk from external storage bucket.");
+      }
+      throw new Error(`Failed to fetch chunk from external storage bucket (HTTP ${resp.status})`);
     }
-    if (isExternal && resp.status === 403) {
-      throw new Error("Access denied when fetching chunk from external storage bucket.");
-    }
-    throw new Error(
-      isExternal
-        ? `Failed to fetch chunk from external storage bucket (HTTP ${resp.status})`
-        : `Failed to fetch chunk from server (HTTP ${resp.status})`
-    );
+    const buf = await resp.arrayBuffer();
+    return new Uint8Array(buf);
   }
-  const buf = await resp.arrayBuffer();
-  return new Uint8Array(buf);
+
+  const url = fallbackUrlBuilder(chunk.chunkIndex);
+  const { data } = await apiRequest.get<ArrayBuffer>(url, { responseType: "arraybuffer" });
+  return new Uint8Array(data);
 };
 
 export type DecryptChunkInput = {


### PR DESCRIPTION
## Context

Use auth for non-bucket log chunk fetch

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)