### PR TITLE
fix: show multiple actions in org roles page

### DIFF
--- a/frontend/src/hooks/api/roles/types.ts
+++ b/frontend/src/hooks/api/roles/types.ts
@@ -36,7 +36,7 @@ export type TOrgRole = {
 
 export type TPermission = {
   conditions?: Record<string, any>;
-  action: string;
+  action: string | string[];
   subject: string;
 };
 

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -231,13 +231,15 @@ export const rolePermission2Form = (permissions: TPermission[] = []) => {
   // i would have to write a if loop with both conditions same
   const formVal: Record<string, any> = {};
   permissions.forEach((permission) => {
-    const { action } = permission;
+    const actions = Array.isArray(permission.action) ? permission.action : [permission.action];
     let { subject } = permission;
     if (subject === OrgPermissionSubjects.Workspace) {
       subject = OrgPermissionSubjects.Project;
     }
     if (!formVal?.[subject]) formVal[subject] = {};
-    formVal[subject][action] = true;
+    actions.forEach((action) => {
+      formVal[subject][action] = true;
+    });
   });
 
   return formVal;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This fixes a UI bug that happens when you create a role via Terraform and specify multiple actions in the array.

## Screenshots

<img width="1544" height="180" alt="image" src="https://github.com/user-attachments/assets/0a186c9a-ebf5-48da-886b-9152142ac989" />


## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)