### PR TITLE
chore: add upgrade impact for v0.160.1

### DIFF
--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generatedAt: 2026-05-18T13:15:44.995Z
+generatedAt: 2026-05-19T19:39:10.482Z
 versions:
   - version: v0.159.16
     releasedAt: 2026-04-17T17:49:54-03:00
@@ -40,3 +40,6 @@ versions:
   - version: v0.160.0
     releasedAt: 2026-05-18T18:32:44+05:30
     file: releases/v0.160.0.yaml
+  - version: v0.160.1
+    releasedAt: 2026-05-19T22:41:11+04:00
+    file: releases/v0.160.1.yaml

--- a/upgrade-impact/data/releases/v0.160.1.yaml
+++ b/upgrade-impact/data/releases/v0.160.1.yaml
@@ -1,0 +1,71 @@
+version: v0.160.1
+releasedAt: 2026-05-19T22:41:11+04:00
+sourceTag: v0.160.1
+previousTag: v0.160.0
+impactLevel: low
+summary: Adds two startup database migrations and updates gateway health
+  tracking. Gateway Helm chart now supports persistent session recordings for
+  enrolled gateways.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: PAM approvals schema migration
+    description: Startup adds approval policy enforcement and bypass fields, plus a
+      new approval policy bypassers table for PAM access workflows.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260430120000_pam-access-break-glass.ts
+        path: backend/src/db/migrations/20260430120000_pam-access-break-glass.ts
+        description: Adds enforcementLevel and bypass tables/columns
+  - title: Gateway heartbeat TTL migration
+    description: Startup adds gateway heartbeatTTL, backfills existing heartbeat
+      rows to 1800, and removes lastHealthCheckStatus from the gateway table.
+    action: No manual action required; Infisical runs this migration during startup.
+      If startup fails during migration, keep the previous version running and
+      inspect migration logs before retrying.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260515233927_add-gateway-heartbeat-ttl.ts
+        path: backend/src/db/migrations/20260515233927_add-gateway-heartbeat-ttl.ts
+        description: Adds heartbeatTTL and drops lastHealthCheckStatus
+      - type: pr
+        ref: "#6432"
+        url: https://github.com/Infisical/infisical/pull/6432
+        description: Gateway staleness timeout reduced to 5 minutes
+configChanges: []
+deploymentNotes:
+  - title: Gateway Helm session recording storage
+    description: The gateway Helm chart mounts session recordings on persistent
+      storage when enrollment mode uses persistence. Token enrollment still
+      requires persistence to survive pod restarts.
+    action: If you use the infisical-gateway chart and need PAM session recordings
+      kept across pod restarts, set persistence storage as needed before
+      upgrading.
+    confidence: high
+    evidence:
+      - type: file
+        ref: helm-charts/infisical-gateway/templates/deployment.yaml
+        path: helm-charts/infisical-gateway/templates/deployment.yaml
+        description: Mounts session recordings from PVC or emptyDir
+      - type: file
+        ref: helm-charts/infisical-gateway/templates/pvc.yaml
+        path: helm-charts/infisical-gateway/templates/pvc.yaml
+        description: Creates PVC for enrolled gateway data
+      - type: file
+        ref: helm-charts/infisical-gateway/values.yaml
+        path: helm-charts/infisical-gateway/values.yaml
+        description: Persistence defaults enabled with session recordings directory
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-19T19:39:10.464Z
+  sourceRange:
+    from: v0.160.0
+    to: v0.160.1

--- a/upgrade-impact/data/releases/v0.160.1.yaml
+++ b/upgrade-impact/data/releases/v0.160.1.yaml
@@ -38,28 +38,7 @@ dbSchemaChanges:
         url: https://github.com/Infisical/infisical/pull/6432
         description: Gateway staleness timeout reduced to 5 minutes
 configChanges: []
-deploymentNotes:
-  - title: Gateway Helm session recording storage
-    description: The gateway Helm chart mounts session recordings on persistent
-      storage when enrollment mode uses persistence. Token enrollment still
-      requires persistence to survive pod restarts.
-    action: If you use the infisical-gateway chart and need PAM session recordings
-      kept across pod restarts, set persistence storage as needed before
-      upgrading.
-    confidence: high
-    evidence:
-      - type: file
-        ref: helm-charts/infisical-gateway/templates/deployment.yaml
-        path: helm-charts/infisical-gateway/templates/deployment.yaml
-        description: Mounts session recordings from PVC or emptyDir
-      - type: file
-        ref: helm-charts/infisical-gateway/templates/pvc.yaml
-        path: helm-charts/infisical-gateway/templates/pvc.yaml
-        description: Creates PVC for enrolled gateway data
-      - type: file
-        ref: helm-charts/infisical-gateway/values.yaml
-        path: helm-charts/infisical-gateway/values.yaml
-        description: Persistence defaults enabled with session recordings directory
+deploymentNotes: []
 knownIssues: []
 generatedBy:
   generator: "@infisical/upgrade-impact"


### PR DESCRIPTION
Generated self-hosted upgrade impact data for `v0.160.1`.

Review the generated YAML for self-hosted upgrade accuracy before merging.