### PR TITLE
fix: expand forbid policies to cover legacy actions

### DIFF
--- a/backend/src/ee/services/permission/permission-fns.test.ts
+++ b/backend/src/ee/services/permission/permission-fns.test.ts
@@ -1,0 +1,185 @@
+import { createMongoAbility, MongoAbility, RawRuleOf, subject } from "@casl/ability";
+import { describe, expect, test } from "vitest";
+
+import { conditionsMatcher } from "@app/lib/casl";
+
+import { expandLegacyForbidActions } from "./permission-fns";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionGroupActions,
+  ProjectPermissionIdentityActions,
+  ProjectPermissionMemberActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSet,
+  ProjectPermissionSub
+} from "./project-permission";
+
+type Rule = RawRuleOf<MongoAbility<ProjectPermissionSet>>;
+
+const forbid = (overrides: Partial<Rule>): Rule =>
+  ({
+    inverted: true,
+    action: [],
+    subject: ProjectPermissionSub.Secrets,
+    ...overrides
+  }) as Rule;
+
+const allow = (overrides: Partial<Rule>): Rule =>
+  ({
+    inverted: false,
+    action: [],
+    subject: ProjectPermissionSub.Secrets,
+    ...overrides
+  }) as Rule;
+
+describe("expandLegacyForbidActions", () => {
+  test("forbid on Secrets ReadValue is expanded to also forbid legacy DescribeAndReadValue", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionSecretActions.ReadValue],
+        subject: ProjectPermissionSub.Secrets,
+        conditions: { environment: "dev" }
+      })
+    ];
+    const result = expandLegacyForbidActions(rules);
+    expect(result[0].action).toEqual([
+      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeAndReadValue
+    ]);
+    expect(result[0].conditions).toEqual({ environment: "dev" });
+  });
+
+  test("forbid on Secrets DescribeSecret is expanded to also forbid legacy DescribeAndReadValue", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionSecretActions.DescribeSecret],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionSecretActions.DescribeSecret,
+      ProjectPermissionSecretActions.DescribeAndReadValue
+    ]);
+  });
+
+  test("forbid on Secrets that already includes the legacy action is not modified", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionSecretActions.ReadValue, ProjectPermissionSecretActions.DescribeAndReadValue],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionSecretActions.ReadValue,
+      ProjectPermissionSecretActions.DescribeAndReadValue
+    ]);
+  });
+
+  test("forbid on Secrets that has no new read actions is not modified", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionSecretActions.Create, ProjectPermissionSecretActions.Edit],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionSecretActions.Create,
+      ProjectPermissionSecretActions.Edit
+    ]);
+  });
+
+  test("forbid on Member AssignRole expands to also forbid legacy GrantPrivileges", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionMemberActions.AssignRole],
+        subject: ProjectPermissionSub.Member
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionMemberActions.AssignRole,
+      ProjectPermissionMemberActions.GrantPrivileges
+    ]);
+  });
+
+  test("forbid on Identity AssignAdditionalPrivileges expands to also forbid legacy GrantPrivileges", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionIdentityActions.AssignAdditionalPrivileges],
+        subject: ProjectPermissionSub.Identity
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionIdentityActions.AssignAdditionalPrivileges,
+      ProjectPermissionIdentityActions.GrantPrivileges
+    ]);
+  });
+
+  test("forbid on Groups AssignRole expands to also forbid legacy GrantPrivileges", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionGroupActions.AssignRole],
+        subject: ProjectPermissionSub.Groups
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([
+      ProjectPermissionGroupActions.AssignRole,
+      ProjectPermissionGroupActions.GrantPrivileges
+    ]);
+  });
+
+  test("allow rules are never modified", () => {
+    const rules = [
+      allow({
+        action: [ProjectPermissionSecretActions.ReadValue],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([ProjectPermissionSecretActions.ReadValue]);
+  });
+
+  test("forbid on unrelated subject is not modified", () => {
+    const rules = [
+      forbid({
+        action: [ProjectPermissionActions.Read],
+        subject: ProjectPermissionSub.Webhooks
+      })
+    ];
+    expect(expandLegacyForbidActions(rules)[0].action).toEqual([ProjectPermissionActions.Read]);
+  });
+
+  test("end-to-end: admin allow + custom forbid on ReadValue denies legacy read after expansion", () => {
+    // Mirrors the production bug: admin role grants both legacy and new read actions
+    // with no conditions, custom role forbids only the new actions in env=dev.
+    // After expandLegacyForbidActions, the forbid also covers legacy `read`, so
+    // legacy fallbacks like hasSecretReadValueOrDescribePermission can no longer
+    // be used as a backdoor.
+    const rules: Rule[] = expandLegacyForbidActions([
+      allow({
+        action: [
+          ProjectPermissionSecretActions.DescribeAndReadValue,
+          ProjectPermissionSecretActions.ReadValue,
+          ProjectPermissionSecretActions.DescribeSecret
+        ],
+        subject: ProjectPermissionSub.Secrets
+      }),
+      forbid({
+        action: [ProjectPermissionSecretActions.ReadValue, ProjectPermissionSecretActions.DescribeSecret],
+        subject: ProjectPermissionSub.Secrets,
+        conditions: { environment: "dev" }
+      })
+    ]).sort((a, b) => Number(Boolean(a.inverted)) - Number(Boolean(b.inverted)));
+
+    const ability = createMongoAbility<ProjectPermissionSet>(rules, { conditionsMatcher });
+
+    const devSecret = subject(ProjectPermissionSub.Secrets, { environment: "dev", secretPath: "/" });
+    const prodSecret = subject(ProjectPermissionSub.Secrets, { environment: "prod", secretPath: "/" });
+
+    // In dev: every read-flavored action is denied
+    expect(ability.can(ProjectPermissionSecretActions.ReadValue, devSecret)).toBe(false);
+    expect(ability.can(ProjectPermissionSecretActions.DescribeSecret, devSecret)).toBe(false);
+    expect(ability.can(ProjectPermissionSecretActions.DescribeAndReadValue, devSecret)).toBe(false);
+    // In prod: allow rules still apply
+    expect(ability.can(ProjectPermissionSecretActions.ReadValue, prodSecret)).toBe(true);
+    expect(ability.can(ProjectPermissionSecretActions.DescribeAndReadValue, prodSecret)).toBe(true);
+  });
+});

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import { ForbiddenError, MongoAbility, PureAbility, subject } from "@casl/ability";
+import { ForbiddenError, MongoAbility, PureAbility, RawRuleOf, subject } from "@casl/ability";
 import { z } from "zod";
 
 import { TOrganizations } from "@app/db/schemas";
@@ -319,10 +319,58 @@ const assertPermissionBoundary = (actorPermission: MongoAbility, managedPermissi
   }
 };
 
+// Subjects whose forbid rules on new fine-grained actions must also forbid the
+// legacy umbrella action they replaced. Without this expansion, an admin allow
+// on the legacy action survives a custom-role forbid on the new actions and
+// acts as a backdoor through the helpers/call sites that OR-fallback to it
+// (e.g. hasSecretReadValueOrDescribePermission, validatePrivilegeChangeOperation).
+const LEGACY_FORBID_ACTION_EXPANSIONS: Partial<
+  Record<ProjectPermissionSub, { legacyAction: string; newActions: string[] }>
+> = {
+  [ProjectPermissionSub.Secrets]: {
+    legacyAction: ProjectPermissionSecretActions.DescribeAndReadValue,
+    newActions: [ProjectPermissionSecretActions.ReadValue, ProjectPermissionSecretActions.DescribeSecret]
+  },
+  [ProjectPermissionSub.Member]: {
+    legacyAction: ProjectPermissionMemberActions.GrantPrivileges,
+    newActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.AssignAdditionalPrivileges]
+  },
+  [ProjectPermissionSub.Identity]: {
+    legacyAction: ProjectPermissionIdentityActions.GrantPrivileges,
+    newActions: [
+      ProjectPermissionIdentityActions.AssignRole,
+      ProjectPermissionIdentityActions.AssignAdditionalPrivileges
+    ]
+  },
+  [ProjectPermissionSub.Groups]: {
+    legacyAction: ProjectPermissionGroupActions.GrantPrivileges,
+    newActions: [ProjectPermissionGroupActions.AssignRole]
+  }
+};
+
+const expandLegacyForbidActions = <T extends RawRuleOf<MongoAbility<ProjectPermissionSet>>>(rules: T[]): T[] => {
+  return rules.map((rule) => {
+    if (!rule.inverted) return rule;
+
+    const subjects = Array.isArray(rule.subject) ? rule.subject : [rule.subject];
+    if (subjects.length !== 1) return rule;
+
+    const expansion = LEGACY_FORBID_ACTION_EXPANSIONS[subjects[0] as ProjectPermissionSub];
+    if (!expansion) return rule;
+
+    const actions = Array.isArray(rule.action) ? rule.action : [rule.action];
+    const shouldExpand = actions.some((a) => expansion.newActions.includes(a as string));
+    if (!shouldExpand || actions.includes(expansion.legacyAction as (typeof actions)[number])) return rule;
+
+    return { ...rule, action: [...actions, expansion.legacyAction] as typeof rule.action };
+  });
+};
+
 export {
   assertPermissionBoundary,
   constructPermissionErrorMessage,
   escapeHandlebarsMissingDict,
+  expandLegacyForbidActions,
   isAuthMethodSaml,
   validateOrgSSO,
   validatePrivilegeChangeOperation

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -52,7 +52,7 @@ import {
   OrgPermissionSubjects
 } from "./org-permission";
 import { TPermissionDALFactory } from "./permission-dal";
-import { escapeHandlebarsMissingDict, validateOrgSSO } from "./permission-fns";
+import { escapeHandlebarsMissingDict, expandLegacyForbidActions, validateOrgSSO } from "./permission-fns";
 import {
   TBuildOrgPermissionDTO,
   TBuildProjectPermissionDTO,
@@ -91,35 +91,36 @@ const buildOrgPermissionRules = (orgUserRoles: TBuildOrgPermissionDTO) => {
 };
 
 const buildProjectPermissionRules = (projectUserRoles: TBuildProjectPermissionDTO) => {
-  const rules = projectUserRoles
-    .map(({ role, permissions }) => {
-      switch (role) {
-        case ProjectMembershipRole.Admin:
-          return projectAdminPermissions;
-        case ProjectMembershipRole.Member:
-          return projectMemberPermissions;
-        case ProjectMembershipRole.Viewer:
-          return projectViewerPermission;
-        case ProjectMembershipRole.NoAccess:
-          return projectNoAccessPermissions;
-        case ProjectMembershipRole.SshHostBootstrapper:
-          return sshHostBootstrapPermissions;
-        case ProjectMembershipRole.KmsCryptographicOperator:
-          return cryptographicOperatorPermissions;
-        case ProjectMembershipRole.Custom: {
-          return unpackRules<RawRuleOf<MongoAbility<ProjectPermissionSet>>>(
-            permissions as PackRule<RawRuleOf<MongoAbility<ProjectPermissionSet>>>[]
-          );
+  const rules = expandLegacyForbidActions(
+    projectUserRoles
+      .map(({ role, permissions }) => {
+        switch (role) {
+          case ProjectMembershipRole.Admin:
+            return projectAdminPermissions;
+          case ProjectMembershipRole.Member:
+            return projectMemberPermissions;
+          case ProjectMembershipRole.Viewer:
+            return projectViewerPermission;
+          case ProjectMembershipRole.NoAccess:
+            return projectNoAccessPermissions;
+          case ProjectMembershipRole.SshHostBootstrapper:
+            return sshHostBootstrapPermissions;
+          case ProjectMembershipRole.KmsCryptographicOperator:
+            return cryptographicOperatorPermissions;
+          case ProjectMembershipRole.Custom: {
+            return unpackRules<RawRuleOf<MongoAbility<ProjectPermissionSet>>>(
+              permissions as PackRule<RawRuleOf<MongoAbility<ProjectPermissionSet>>>[]
+            );
+          }
+          default:
+            throw new NotFoundError({
+              name: "ProjectRoleInvalid",
+              message: `Project role '${role}' not found`
+            });
         }
-        default:
-          throw new NotFoundError({
-            name: "ProjectRoleInvalid",
-            message: `Project role '${role}' not found`
-          });
-      }
-    })
-    .reduce((prev, curr) => prev.concat(curr), [])
-    .sort((a, b) => Number(Boolean(a.inverted)) - Number(Boolean(b.inverted)));
+      })
+      .reduce((prev, curr) => prev.concat(curr), [] as RawRuleOf<MongoAbility<ProjectPermissionSet>>[])
+  ).sort((a, b) => Number(Boolean(a.inverted)) - Number(Boolean(b.inverted)));
 
   return rules;
 };


### PR DESCRIPTION
## Context

This PR adds a forbid action expansion on permissions unpacking to cover legacy permissions

## Screenshots

N/A

## Steps to verify the change

- read tests, make sure they track, and run tests
- light testing in browser/api

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)