### PR TITLE
fix(secret-sync): handle duplicate Vercel team shared vars and overlapping scopes

### DIFF
--- a/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
+++ b/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
@@ -396,11 +396,6 @@ const setsEqual = (a: readonly string[] | undefined, b: readonly string[] | unde
   return av.every((v) => bSet.has(v));
 };
 
-const isSubset = (a: readonly string[] | undefined, b: readonly string[] | undefined) => {
-  const bSet = new Set(b ?? []);
-  return (a ?? []).every((v) => bSet.has(v));
-};
-
 // Ownership is by exact (target, projectId, applyToAllCustomEnvironments) scope match.
 const isTeamSharedEnvVarOwnedByThisSync = (envVar: VercelSharedEnvVar, destinationConfig: TeamDestinationConfig) => {
   const effectiveTargets = destinationConfig.sensitive
@@ -414,35 +409,20 @@ const isTeamSharedEnvVarOwnedByThisSync = (envVar: VercelSharedEnvVar, destinati
   );
 };
 
-// True when an existing team shared env var's scope is a strict superset of the sync's scope
-const teamVarStrictlyCoversSyncScope = (envVar: VercelSharedEnvVar, destinationConfig: TeamDestinationConfig) => {
+// True when an existing team shared env var overlaps the sync's scope in Vercel's conflict
+// space: (target, applyToAllCustomEnvironments).
+const teamVarOverlapsSyncScope = (envVar: VercelSharedEnvVar, destinationConfig: TeamDestinationConfig) => {
   const effectiveTargets =
     (destinationConfig.sensitive
       ? destinationConfig.targetEnvironments?.filter((env) => env !== VercelEnvironmentType.Development)
       : destinationConfig.targetEnvironments) ?? [];
+  const effectiveTargetsSet = new Set<string>(effectiveTargets);
 
-  if (!isSubset(effectiveTargets, envVar.target)) return false;
+  const targetOverlap = (envVar.target ?? []).some((t) => effectiveTargetsSet.has(t));
+  const applyAllOverlap =
+    Boolean(envVar.applyToAllCustomEnvironments) && Boolean(destinationConfig.applyToAllCustomEnvironments);
 
-  const ourProjects = destinationConfig.targetProjects ?? [];
-  const varProjects = envVar.projectId ?? [];
-
-  // var.projectId empty means "team-wide / all projects" in Vercel
-  if (varProjects.length > 0) {
-    if (ourProjects.length === 0) return false;
-    if (!isSubset(ourProjects, varProjects)) return false;
-  }
-
-  // If our sync claims all-custom-environments, the existing var must also have it set —
-  // otherwise it doesn't cover the custom-env dimension we need.
-  const ourApplyAll = Boolean(destinationConfig.applyToAllCustomEnvironments);
-  const varApplyAll = Boolean(envVar.applyToAllCustomEnvironments);
-  if (ourApplyAll && !varApplyAll) return false;
-
-  // Scopes must not be exactly equal. If they are, this is the "owned" path.
-  const targetEqual = setsEqual(envVar.target, effectiveTargets);
-  const projectEqual = setsEqual(varProjects, ourProjects);
-  const applyAllEqual = ourApplyAll === varApplyAll;
-  return !(targetEqual && projectEqual && applyAllEqual);
+  return targetOverlap || applyAllOverlap;
 };
 
 const listTeamSharedEnvVarsWithRetries = async (
@@ -863,32 +843,35 @@ export const VercelSyncFns = {
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
       const teamDestinationConfig = secretSync.destinationConfig;
       const allSharedEnvVars = await getTeamSharedEnvVars(secretSync);
-      const sharedEnvVarsMap = new Map(allSharedEnvVars.map((s) => [s.key, s]));
 
-      // Vars whose scope strictly covers ours — Vercel rejects creating an overlapping var,
-      // so we must split (detach our scope from the existing var, then create a dedicated
-      // record)
-      const mergedSharedEnvVarsMap = new Map(
-        allSharedEnvVars
-          .filter((envVar) => teamVarStrictlyCoversSyncScope(envVar, teamDestinationConfig))
-          .map((s) => [s.key, s])
-      );
+      // Vercel allows multiple shared env var records with the same key when their
+      // (target, applyToAllCustomEnvironments) scopes do not overlap. Group by key so we
+      // don't lose siblings — a key-only Map would drop all but one and then any create or
+      // scope-expanding patch would collide with the invisible sibling.
+      const sharedEnvVarsByKey = new Map<string, VercelSharedEnvVar[]>();
+      for (const envVar of allSharedEnvVars) {
+        const arr = sharedEnvVarsByKey.get(envVar.key) ?? [];
+        arr.push(envVar);
+        sharedEnvVarsByKey.set(envVar.key, arr);
+      }
 
-      const { targetEnvironments, targetProjects, sensitive, applyToAllCustomEnvironments } =
-        secretSync.destinationConfig;
+      const { sensitive } = secretSync.destinationConfig;
 
       for await (const key of Object.keys(secretMap)) {
-        const existingVar = sharedEnvVarsMap.get(key);
-        const mergedVar = mergedSharedEnvVarsMap.get(key);
+        const records = sharedEnvVarsByKey.get(key) ?? [];
+        const ownedRecord = records.find((r) => isTeamSharedEnvVarOwnedByThisSync(r, teamDestinationConfig));
+        const conflictingRecords = records.filter(
+          (r) => r.id !== ownedRecord?.id && teamVarOverlapsSyncScope(r, teamDestinationConfig)
+        );
 
-        if (mergedVar) {
-          await detachTeamSharedEnvVar(secretSync, mergedVar);
-          await createTeamSharedEnvVar(secretSync, key, secretMap[key].value);
-          // eslint-disable-next-line no-continue
-          continue;
+        // Detach our scope from any sibling that overlaps ours before any create/recreate —
+        // including ahead of the sensitivity-flip delete+create branch, whose CREATE would
+        // otherwise collide with the sibling.
+        for await (const conflict of conflictingRecords) {
+          await detachTeamSharedEnvVar(secretSync, conflict);
         }
 
-        if (!existingVar) {
+        if (!ownedRecord) {
           await createTeamSharedEnvVar(secretSync, key, secretMap[key].value);
           // eslint-disable-next-line no-continue
           continue;
@@ -896,41 +879,18 @@ export const VercelSyncFns = {
 
         // Vercel does not allow changing a secret's `type` between encrypted and sensitive
         // via PATCH, so we delete and recreate when the desired sensitivity differs.
-        const existingIsSensitive = existingVar.type === "sensitive";
+        const existingIsSensitive = ownedRecord.type === "sensitive";
         const sensitivityChanged = existingIsSensitive !== Boolean(sensitive);
 
         if (sensitivityChanged) {
-          await deleteTeamSharedEnvVar(secretSync, existingVar);
+          await deleteTeamSharedEnvVar(secretSync, ownedRecord);
           await createTeamSharedEnvVar(secretSync, key, secretMap[key].value);
           // eslint-disable-next-line no-continue
           continue;
         }
 
-        const hasValueChanged = existingVar.value !== secretMap[key].value;
-
-        // Sensitive secrets cannot target Development in Vercel — strip before comparing.
-        const isSensitive = sensitive || existingVar.type === "sensitive";
-        const effectiveTargets = targetEnvironments?.filter(
-          (env) => !isSensitive || env !== VercelEnvironmentType.Development
-        );
-
-        const existingTarget = existingVar.target ?? [];
-        const hasTargetChanged =
-          effectiveTargets !== undefined
-            ? existingTarget.length !== effectiveTargets.length ||
-              !effectiveTargets.every((env) => existingTarget.includes(env))
-            : false;
-
-        const hasProjectsChanged = targetProjects
-          ? (existingVar.projectId?.length ?? 0) !== targetProjects.length ||
-            !targetProjects.every((pid) => existingVar.projectId?.includes(pid))
-          : false;
-
-        const hasAllCustomChanged =
-          Boolean(applyToAllCustomEnvironments) !== (existingVar.applyToAllCustomEnvironments ?? false);
-
-        if (hasValueChanged || hasTargetChanged || hasProjectsChanged || hasAllCustomChanged) {
-          await updateTeamSharedEnvVar(secretSync, existingVar, secretMap[key].value);
+        if (ownedRecord.value !== secretMap[key].value) {
+          await updateTeamSharedEnvVar(secretSync, ownedRecord, secretMap[key].value);
         }
       }
 

--- a/docs/integrations/secret-syncs/vercel.mdx
+++ b/docs/integrations/secret-syncs/vercel.mdx
@@ -54,6 +54,13 @@ The short video below walks through configuring a Vercel Sync end-to-end.
             <Note>
                 Vercel does not expose the values of [sensitive environment variables](https://vercel.com/docs/environment-variables/sensitive-environment-variables), so Infisical cannot import them during the initial sync. As a result, these secrets are created in Infisical with empty values. After the first sync, you'll need to manually re-enter their values in Infisical to ensure both platforms stay aligned.
             </Note>
+            <Note>
+                **Team-scoped sync — initial import scope matching**
+
+                On the initial import, Infisical only imports Vercel shared environment variables whose scope exactly matches this sync's configuration (same target environments, target projects, and Apply to all Custom Environments flag). Variables covering a broader set of environments — or split across separate records per environment — will not be imported. The next sync will detach those records and create a new one for the sync's scope using the value from Infisical.
+
+                Example: Vercel has a single shared variable `FOO` scoped to **Production and Preview**, but the sync targets only **Production**. `FOO` is not imported. On the next sync, the existing `FOO` is rescoped to Preview (value preserved) and a new `FOO` record is created for Production with the value from Infisical.
+            </Note>
             - **Key Schema**: Template that determines how secret names are transformed when syncing, using `{{secretKey}}` as a placeholder for the original secret name and `{{environment}}` for the environment.
             <Note>
                 We highly recommend using a Key Schema to ensure that Infisical only manages the specific keys you intend, keeping everything else untouched.

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
@@ -187,6 +187,19 @@ export const SecretSyncOptionsFields = ({ hideInitialSync }: Props) => {
               only Overwrite Destination Secrets is supported.
             </p>
           )}
+          {destination === SecretSync.Vercel &&
+            !vercelSensitive &&
+            currentSyncOption.initialSyncBehavior !==
+              SecretSyncInitialSyncBehavior.OverwriteDestination && (
+              <p className="-mt-2.5 mb-2.5 text-xs text-yellow">
+                <FontAwesomeIcon className="mr-1" size="xs" icon={faTriangleExclamation} />
+                For team-scoped syncs, only Vercel shared environment variables whose scope exactly
+                matches this sync&apos;s configuration (target environments, target projects, and
+                Apply to all Custom Environments) will be imported. Variables covering a broader
+                scope, or split across separate records per environment, will not be imported on the
+                initial sync.
+              </p>
+            )}
           {!vercelSensitive && !syncOption?.canImportSecrets && (
             <p className="-mt-2.5 mb-2.5 text-xs text-yellow">
               <FontAwesomeIcon className="mr-1" size="xs" icon={faTriangleExclamation} />


### PR DESCRIPTION
## Context

Team-scope **Vercel secret sync** now groups shared env vars **by key** (so duplicate rows aren’t dropped), treats conflicts by **overlap** in Vercel’s `(target, applyToAllCustomEnvironments)` space, **detaches overlapping siblings** before create/recreate (including sensitivity flips).

## Steps to verify the change

### Core scenarios (must test)

- **[Team scope] Multiple records, disjoint targets (original bug)**  
  Manually create two shared env vars in the Vercel team UI with the same key:  
  `FOO=A`, target=`[production]`, projectId=`[X]`  
  `FOO=B`, target=`[preview]`, projectId=`[X]`  
  Run sync: scope=team, targetEnvironments=`[production, preview]`, targetProjects=`[X]`, FOO=`NEW`  
  **Verify:** No `existing_key_and_target` error. Final state in Vercel: one record FOO with target=`[production, preview]`, projectId=`[X]`, value=`NEW`. Both prior siblings detached (their target reduced to `[]` → full delete fallback).

- **[Team scope] Multiple records, disjoint applyToAllCustomEnvironments**  
  Manually create:  
  `FOO=A`, target=`[production]`, projectId=`[A]`, applyAll=false  
  `FOO=B`, target=`[]`, projectId=`[A]`, applyAll=true  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, applyAll=true, FOO=`NEW`  
  **Verify:** Both prior records detached (one via target overlap, the other via applyAll overlap). Final state: one record FOO with target=`[production]`, projectId=`[A]`, applyAll=true, value=`NEW`.

- **[Team scope] Strict superset detach (merged path)**  
  Manually create: `FOO=ORIGINAL`, target=`[production, preview]`, projectId=`[A]`  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`NEW`  
  **Verify:** Existing record PATCHed to target=`[preview]`, projectId=`[A]`. New record created with target=`[production]`, projectId=`[A]`, value=`NEW`. After the run, fetch the detached record directly from Vercel and confirm its value is still `ORIGINAL` (load-bearing — `detachTeamSharedEnvVar` must preserve value).

- **[Team scope] Disjoint scope, no overlap (no-touch)**  
  Manually create: `FOO=ORIGINAL`, target=`[preview]`, projectId=`[A]`  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`NEW`  
  **Verify:** Existing record untouched (target=`[preview]`, value=`ORIGINAL`). New record created with target=`[production]`, projectId=`[A]`, value=`NEW`. Two records coexist for the key.

- **[Team scope] Owned record, value change (in-place PATCH)**  
  Existing owned record (exact scope match): `FOO=OLD`, target=`[production]`, projectId=`[A]`  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`NEW`  
  **Verify:** Same record ID, value PATCHed to `NEW`. No detach, no recreate, no new record.

- **[Team scope] Owned record, value unchanged (idempotent)**  
  Existing owned record matches sync exactly: `FOO=SAME`, target=`[production]`, projectId=`[A]`  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`SAME`  
  **Verify:** No PATCH/POST/DELETE issued against FOO. Re-running the sync is a no-op.

- **[Team scope] No existing record (plain create)**  
  No shared env var with key FOO exists in the team.  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`NEW`  
  **Verify:** New record created with target=`[production]`, projectId=`[A]`, value=`NEW`.

- **[Team scope] Multiple records — one owned + sibling, no overlap**  
  Existing:  
  `FOO=OWNED`, target=`[production]`, projectId=`[A]` (matches sync exactly)  
  `FOO=OTHER`, target=`[preview]`, projectId=`[A]` (disjoint target)  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, FOO=`NEW`  
  **Verify:** Owned record PATCHed in place to value=`NEW`. Sibling untouched (target=`[preview]`, value=`OTHER`).

- **[Team scope] Multiple records — one owned + sibling that overlaps**  
  Existing:  
  `FOO=OWNED`, target=`[production]`, projectId=`[A]` (will be owned by next sync run)  
  `FOO=OTHER`, target=`[preview]`, projectId=`[B]`, applyAll=true (sibling — overlaps via applyAll)  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, applyAll=true, FOO=`NEW`  
  **Verify:** Sibling detached (applyAll cleared, then if scope becomes empty → full delete). Owned record PATCHed in place to value=`NEW`.

### applyToAllCustomEnvironments coverage

- **[Team scope] Owned record with applyAll=true (exact-match update)**  
  Existing owned: `FOO=OLD`, target=`[]`, projectId=`[A]`, applyAll=true  
  Run sync: targetEnvironments=`[]`, targetProjects=`[A]`, applyAll=true, FOO=`NEW`  
  **Verify:** Same record ID, value PATCHed to `NEW`. Confirms ownership equality includes the applyAll flag.

- **[Team scope] applyAll differentiator — independent syncs coexist**  
  Sync A: targetProjects=`[A]`, targetEnvironments=`[]`, applyAll=true, FOO=A  
  Sync B: targetProjects=`[A]`, targetEnvironments=`[production]`, applyAll=false, FOO=B  
  Run Sync A → Run Sync B → Run Sync A again  
  **Verify:** Both records persist independently (target disjoint, applyAll not both true → no overlap). Each sync only updates its own record on subsequent runs.

- **[Team scope] Merged via applyAll + target — both claim all-custom**  
  Manually create: `FOO=ORIGINAL`, target=`[production, preview]`, projectId=`[A]`, applyAll=true  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, applyAll=true, FOO=`NEW`  
  **Verify:** Existing PATCHed via detach to target=`[preview]`, applyAll=false (sync claims the all-custom slot). Value still `ORIGINAL` on the detached record. New dedicated record target=`[production]`, projectId=`[A]`, applyAll=true, value=`NEW`.

- **[Team scope] applyAll-only existing record — destructive fallback during detach**  
  Manually create: `FOO=ORIGINAL`, target=`[]`, projectId=`[A, B]`, applyAll=true (overlaps but not owned because projectId differs)  
  Run sync: targetEnvironments=`[]`, targetProjects=`[A]`, applyAll=true, FOO=`NEW`  
  **Verify:** Detach computes newTarget=`[]` and newApplyAll=false → falls back to full delete of the existing record. New record created with target=`[]`, projectId=`[A]`, applyAll=true, value=`NEW`.

### Edge cases

- **[Team scope] Sensitivity type flip on owned record**  
  Existing owned: `FOO=OLD`, type=encrypted, target=`[production]`, projectId=`[A]`  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, sensitive=true, FOO=`OLD`  
  **Verify:** Owned record DELETEed and a new one CREATEd with type=sensitive. (Vercel does not allow PATCHing type.)

- **[Team scope] Sensitivity flip + overlapping sibling (detach before delete+create)**  
  Existing:  
  `FOO=A`, type=encrypted, target=`[production]`, projectId=`[A]` (owned by sync)  
  `FOO=B`, type=encrypted, target=`[production]`, projectId=`[B]` (sibling, target overlaps)  
  *Note:* Vercel may not allow both to coexist if projectId-only differentiation isn’t enough. If the second record can’t be created manually due to Vercel rejecting it, skip this case — Vercel itself is enforcing the constraint at create time.  
  Run sync: targetEnvironments=`[production]`, targetProjects=`[A]`, sensitive=true, FOO=A  
  **Verify:** Sibling detached first, then owned record deleted, then new sensitive record created. No `existing_key_and_target` error during the recreate.

- **[Team scope] sensitive=true strips Development from target everywhere**  
  Run sync: targetEnvironments=`[development, production]`, targetProjects=`[A]`, sensitive=true, FOO=X  
  **Verify:** Resulting Vercel record has target=`[production]` only (development stripped). On re-sync, the owned-match check also strips development from the comparison — no spurious detach/recreate.

- **[Team scope] disableSecretDeletion=true**  
  Existing owned: `OLD_KEY=X`, target=`[production]`, projectId=`[A]`  
  Run sync: same scope, disableSecretDeletion=true, secretMap excludes OLD_KEY  
  **Verify:** OLD_KEY NOT deleted, value preserved.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)