### PR TITLE
fix(import-hashicorp-vault): allow the list of namespaces using gateway

### DIFF
--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -65,6 +65,11 @@ const isVault404Error = (error: unknown): boolean => {
   return false;
 };
 
+// Helper to check if error is 404 from gateway
+const isGateway404Error = (error: unknown): boolean => {
+  return error instanceof BadRequestError && error.message?.includes("Request failed with status code 404");
+};
+
 // Helper to extract error message from Vault API errors
 const getVaultErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof AxiosError) {
@@ -509,7 +514,7 @@ export const listHCVaultNamespaces = async (
 
       return data.data.keys || [];
     } catch (error: unknown) {
-      if (error instanceof AxiosError && error.response?.status === 404) {
+      if ((error instanceof AxiosError && error.response?.status === 404) || isGateway404Error(error)) {
         // No child namespaces at this path
         return null;
       }
@@ -674,7 +679,7 @@ export const listHCVaultSecretPaths = async (
 
       return data.data.keys;
     } catch (error) {
-      if (error instanceof AxiosError && error.response?.status === 404) {
+      if ((error instanceof AxiosError && error.response?.status === 404) || isGateway404Error(error)) {
         return null;
       }
 

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -1091,7 +1091,7 @@ export const getHCVaultKubernetesRoles = async (
       );
       roleNames = roleListResponse.data.keys || [];
     } catch (error) {
-      if (isVault404Error(error)) return [];
+      if (isVault404Error(error) || isGateway404Error(error)) return [];
       throw error;
     }
 
@@ -1178,7 +1178,7 @@ export const getHCVaultDatabaseRoles = async (
       );
       connectionNames = connectionListResponse.data.keys || [];
     } catch (error) {
-      if (isVault404Error(error)) return [];
+      if (isVault404Error(error) || isGateway404Error(error)) return [];
       throw error;
     }
 
@@ -1226,7 +1226,7 @@ export const getHCVaultDatabaseRoles = async (
       );
       roleNames = roleListResponse.data.keys || [];
     } catch (error) {
-      if (isVault404Error(error)) return [];
+      if (isVault404Error(error) || isGateway404Error(error)) return [];
       throw error;
     }
 
@@ -1332,7 +1332,7 @@ export const getHCVaultLdapRoles = async (
       );
       roleNames = roleListResponse.data.keys || [];
     } catch (error) {
-      if (isVault404Error(error)) return [];
+      if (isVault404Error(error) || isGateway404Error(error)) return [];
       throw error;
     }
 


### PR DESCRIPTION
## Context
There is a problem when listing namespaces using a gateway connection on vault app connection. Vault instances that are not premium return 404, so we need to show the default namespace `/` which translates to root

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- create an app connection with gateway 
- check that you can create an import using the gateway 
 
## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)- 