### PR TITLE
fix(bitbucket-sync): paginate listVariables to see all destination variables

### DIFF
--- a/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
+++ b/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
@@ -24,22 +24,34 @@ const buildVariablesUrl = (workspace: string, repository: string, environment?: 
   return `${baseUrl}/pipelines_config/variables/${uuid || ""}`;
 };
 
+const BITBUCKET_VARIABLES_PAGE_LEN = 100;
+
+type TBitbucketVariablesPage = { values: TBitbucketVariable[]; next?: string };
+
 const listVariables = async ({
   workspaceSlug,
   repositorySlug,
   environmentId,
   authHeader
 }: TBitbucketListVariables): Promise<TBitbucketVariable[]> => {
-  const url = buildVariablesUrl(workspaceSlug, repositorySlug, environmentId);
+  const variables: TBitbucketVariable[] = [];
+  const initialUrl = buildVariablesUrl(workspaceSlug, repositorySlug, environmentId);
+  let nextUrl: string | undefined = `${initialUrl}?pagelen=${BITBUCKET_VARIABLES_PAGE_LEN}`;
 
-  const { data } = await request.get<{ values: TBitbucketVariable[] }>(url, {
-    headers: {
-      Authorization: authHeader,
-      Accept: "application/json"
-    }
-  });
+  while (nextUrl) {
+    // eslint-disable-next-line no-await-in-loop
+    const { data } = (await request.get<TBitbucketVariablesPage>(nextUrl, {
+      headers: {
+        Authorization: authHeader,
+        Accept: "application/json"
+      }
+    })) as { data: TBitbucketVariablesPage };
 
-  return data.values;
+    if (data.values?.length) variables.push(...data.values);
+    nextUrl = data.next;
+  }
+
+  return variables;
 };
 
 const upsertVariable = async ({


### PR DESCRIPTION
Fixes #6485.

\`listVariables\` in \`backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts\` fetched a single page from Bitbucket's variables endpoint with no \`pagelen\` parameter and no traversal of the \`next\` link. Bitbucket's default page size for this endpoint is around 10 entries, so any destination deployment environment with more variables had the unseen ones treated as missing by \`upsertVariable\` — it took the POST branch and Bitbucket returned \`409 Conflict\` (\`variable-service.variable.duplicate\`). The same truncation also broke \`deleteVariables\` and the \`keysToDelete\` computation inside \`syncSecrets\`.

Page through with \`?pagelen=100\` and follow \`data.next\` until exhausted so the full existing-variables list is visible to upsert and delete logic. \`pagelen=100\` is Bitbucket's documented maximum for variables endpoints, which keeps the number of round trips down for typical envs while still working correctly for very large ones.