### PR TITLE
fix(docs): point Ruby SDK link to Infisical/ruby-sdk

### DIFF
--- a/docs/sdks/languages/ruby.mdx
+++ b/docs/sdks/languages/ruby.mdx
@@ -7,7 +7,7 @@ icon: "/images/sdks/languages/ruby.svg"
 If you're working with Ruby, the official Infisical Ruby SDK package is the easiest way to fetch and work with secrets for your application.
 
 - [Ruby Package](https://rubygems.org/gems/infisical-sdk)
-- [Github Repository](https://github.com/infisical/sdk)
+- [Github Repository](https://github.com/Infisical/ruby-sdk)
 
 <Warning>
   **Deprecation Notice**


### PR DESCRIPTION
Fixes #6387.

The Ruby SDK docs page (\`docs/sdks/languages/ruby.mdx\`) links the GitHub source as \`github.com/infisical/sdk\`, which now 404s — the SDK monorepo was split per language and the Ruby source lives at \`github.com/Infisical/ruby-sdk\`. The \`rubygems.org/gems/infisical-sdk\` package link is still correct and untouched.