### PR TITLE
fix(api): add missing operationIds to PKI routers

### DIFF
--- a/backend/src/server/routes/v1/certificate-authority-routers/internal-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/internal-certificate-authority-router.ts
@@ -156,6 +156,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "generateCaCertificate",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
       description: "Generate certificate for a Certificate Authority",
       params: z.object({
@@ -375,6 +376,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "getCaCertificateById",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
       description: "Get a specific CA certificate by ID",
       params: z.object({

--- a/backend/src/server/routes/v1/pki-alert-router.ts
+++ b/backend/src/server/routes/v1/pki-alert-router.ts
@@ -386,6 +386,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "listPkiAlertCertificatesV1",
       description: "List certificates that match an alert's filter rules",
       tags: [ApiDocsTags.PkiAlerting],
       params: z.object({

--- a/backend/src/server/routes/v1/pki-collection-router.ts
+++ b/backend/src/server/routes/v1/pki-collection-router.ts
@@ -18,6 +18,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       hide: false,
+      operationId: "createPkiCollection",
       tags: [ApiDocsTags.PkiCertificateCollections],
       description: "Create PKI collection",
       body: z.object({

--- a/backend/src/server/routes/v1/pki-subscriber-router.ts
+++ b/backend/src/server/routes/v1/pki-subscriber-router.ts
@@ -411,6 +411,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     },
     schema: {
       hide: false,
+      operationId: "deletePkiSubscriber",
       tags: [ApiDocsTags.PkiSubscribers],
       description: "Delete PKI Subscriber",
       params: z.object({


### PR DESCRIPTION
Five public PKI endpoints declare \`hide: false\` but don't set an \`operationId\`, so the generated OpenAPI spec gives them anonymous fallback names that shift around when files are reordered or new routes are added above them. SDKs and client generators then regenerate those method names on unrelated changes — same pattern as the earlier batches in #6430, #6431, #6444, #6445, #6446.

Routes covered:
- \`POST /api/v1/pki/ca/:caId/certificate\` → \`generateCaCertificate\`
- \`GET /api/v1/pki/ca/:caId/certificate/:certId\` → \`getCaCertificateById\`
- \`GET /api/v1/pki/alerts/:alertId/certificates\` → \`listPkiAlertCertificatesV1\`
- \`POST /api/v1/pki/collections\` → \`createPkiCollection\`
- \`DELETE /api/v1/pki/subscribers/:subscriberName\` → \`deletePkiSubscriber\`

Pure spec metadata addition. No runtime behavior change.