### PR TITLE
chore: add upgrade impact for v0.160.2

### DIFF
--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generatedAt: 2026-05-18T13:15:44.995Z
+generatedAt: 2026-05-20T11:53:40.761Z
 versions:
   - version: v0.159.16
     releasedAt: 2026-04-17T17:49:54-03:00
@@ -40,3 +40,6 @@ versions:
   - version: v0.160.0
     releasedAt: 2026-05-18T18:32:44+05:30
     file: releases/v0.160.0.yaml
+  - version: v0.160.2
+    releasedAt: 2026-05-20T19:13:07+08:00
+    file: releases/v0.160.2.yaml

--- a/upgrade-impact/data/releases/v0.160.2.yaml
+++ b/upgrade-impact/data/releases/v0.160.2.yaml
@@ -1,0 +1,32 @@
+version: v0.160.2
+releasedAt: 2026-05-20T19:13:07+08:00
+sourceTag: v0.160.2
+previousTag: v0.160.1
+impactLevel: low
+summary: Adds one startup database migration for internal PKI certificate
+  authorities. No operator configuration changes are required.
+requiresDbMigration: true
+breakingChanges: []
+dbSchemaChanges:
+  - title: PKI serial number constraint
+    description: Startup drops the unique constraint on internal certificate
+      authority serialNumber values if the table exists. This is an additive
+      compatibility change for existing databases.
+    action: No manual action required; Infisical runs this migration during startup.
+    confidence: high
+    evidence:
+      - type: file
+        ref: backend/src/db/migrations/20260519162000_drop-internal-ca-serial-number-unique.ts
+        path: backend/src/db/migrations/20260519162000_drop-internal-ca-serial-number-unique.ts
+        description: Drops unique constraint in migration file
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-20T11:53:40.742Z
+  sourceRange:
+    from: v0.160.1
+    to: v0.160.2


### PR DESCRIPTION
Generated self-hosted upgrade impact data for `v0.160.2`.

Review the generated YAML for self-hosted upgrade accuracy before merging.