### PR TITLE
fix(cron-job): increase timeout for beforeEach to 20 seconds

### DIFF
--- a/backend/e2e-test/cron-job.spec.ts
+++ b/backend/e2e-test/cron-job.spec.ts
@@ -91,7 +91,7 @@ beforeEach(async () => {
   allFactories.length = 0;
   lockManager.clear();
   await waitForFreshMinute();
-});
+}, 20_000);
 
 afterEach(async () => {
   await Promise.allSettled(allFactories.map((f) => f.stop()));


### PR DESCRIPTION
## Context

`cron-job.spec.ts` beforeEach calls `waitForFreshMinute()`, which can sleep up to ~10s when the test starts within 10s of a minute boundary (so minute-boundary cron fires don’t flake). Vitest’s default hook timeout is 10s, so setup intermittently timed out under load or near boundaries.

Raise the beforeEach hook timeout to 20s so Redis flush + minute alignment always finish.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)