### PR TITLE
chore: add upgrade impact for v0.160.3

### DIFF
--- a/upgrade-impact/data/index.yaml
+++ b/upgrade-impact/data/index.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-generatedAt: 2026-05-20T11:53:40.761Z
+generatedAt: 2026-05-20T16:47:38.851Z
 versions:
   - version: v0.159.16
     releasedAt: 2026-04-17T17:49:54-03:00
@@ -40,9 +40,12 @@ versions:
   - version: v0.160.0
     releasedAt: 2026-05-18T18:32:44+05:30
     file: releases/v0.160.0.yaml
-  - version: v0.160.2
-    releasedAt: 2026-05-20T19:13:07+08:00
-    file: releases/v0.160.2.yaml
   - version: v0.160.1
     releasedAt: 2026-05-19T22:41:11+04:00
     file: releases/v0.160.1.yaml
+  - version: v0.160.2
+    releasedAt: 2026-05-20T19:13:07+08:00
+    file: releases/v0.160.2.yaml
+  - version: v0.160.3
+    releasedAt: 2026-05-21T00:00:47+08:00
+    file: releases/v0.160.3.yaml

--- a/upgrade-impact/data/releases/v0.160.3.yaml
+++ b/upgrade-impact/data/releases/v0.160.3.yaml
@@ -1,0 +1,20 @@
+version: v0.160.3
+releasedAt: 2026-05-21T00:00:47+08:00
+sourceTag: v0.160.3
+previousTag: v0.160.2
+impactLevel: none
+summary: No self-hosted upgrade actions or operator-impacting changes were found.
+requiresDbMigration: false
+breakingChanges: []
+dbSchemaChanges: []
+configChanges: []
+deploymentNotes: []
+knownIssues: []
+generatedBy:
+  generator: "@infisical/upgrade-impact"
+  generatorVersion: "1"
+  model: gpt-5.4
+  generatedAt: 2026-05-20T16:47:38.832Z
+  sourceRange:
+    from: v0.160.2
+    to: v0.160.3


### PR DESCRIPTION
Generated self-hosted upgrade impact data for `v0.160.3`.

Review the generated YAML for self-hosted upgrade accuracy before merging.