### PR TITLE
chore(upgrade-impact): exclude helm and route review to previous-release author

### DIFF
--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -56,12 +56,22 @@ jobs:
         run: npm ci
         working-directory: upgrade-impact
 
+      - name: Type check
+        if: steps.release.outputs.stable == 'true'
+        run: npm run type:check
+        working-directory: upgrade-impact
+
+      - name: Test upgrade impact tooling
+        if: steps.release.outputs.stable == 'true'
+        run: npm test
+        working-directory: upgrade-impact
+
       - name: Generate upgrade impact data
         if: steps.release.outputs.stable == 'true'
         run: npm run generate -- --tag "${{ steps.release.outputs.tag }}"
         working-directory: upgrade-impact
         env:
-          UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.UPGRADE_TOOL_GITHUB_TOKEN }}
+          UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Validate upgrade impact data
@@ -72,7 +82,7 @@ jobs:
       - name: Open upgrade impact PR
         if: steps.release.outputs.stable == 'true'
         env:
-          GH_TOKEN: ${{ secrets.UPGRADE_TOOL_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.release.outputs.tag }}
         run: |
           BRANCH_NAME="chore/upgrade-impact-${TAG_NAME}"
@@ -92,8 +102,8 @@ jobs:
           git commit -m "$PR_TITLE"
           git push --set-upstream origin "$BRANCH_NAME"
 
-          # Pick the previous release's GitHub author as reviewer so the PAT owner
-          # is not the only person notified about this PR.
+          # Request review from whoever cut the previous GitHub release so a real
+          # human gets pinged rather than only the github-actions bot.
           REVIEWER_FLAG=()
           PREVIOUS_TAG="$(awk '/^previousTag:/ { print $2; exit }' "upgrade-impact/data/releases/${TAG_NAME}.yaml")"
           if [ -n "$PREVIOUS_TAG" ]; then
@@ -103,7 +113,7 @@ jobs:
               REVIEWER_FLAG=(--reviewer "$PREVIOUS_AUTHOR")
               echo "Requesting review from previous release author: $PREVIOUS_AUTHOR"
             else
-              echo "Skipping reviewer assignment (previous author missing or matches PAT owner)."
+              echo "Skipping reviewer assignment (previous author missing or matches PR creator)."
             fi
           fi
 

--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -92,10 +92,26 @@ jobs:
           git commit -m "$PR_TITLE"
           git push --set-upstream origin "$BRANCH_NAME"
 
+          # Pick the previous release's GitHub author as reviewer so the PAT owner
+          # is not the only person notified about this PR.
+          REVIEWER_FLAG=()
+          PREVIOUS_TAG="$(awk '/^previousTag:/ { print $2; exit }' "upgrade-impact/data/releases/${TAG_NAME}.yaml")"
+          if [ -n "$PREVIOUS_TAG" ]; then
+            PREVIOUS_AUTHOR="$(gh release view "$PREVIOUS_TAG" --json author --jq .author.login 2>/dev/null || true)"
+            PR_CREATOR="$(gh api user --jq .login 2>/dev/null || true)"
+            if [ -n "$PREVIOUS_AUTHOR" ] && [ "$PREVIOUS_AUTHOR" != "$PR_CREATOR" ]; then
+              REVIEWER_FLAG=(--reviewer "$PREVIOUS_AUTHOR")
+              echo "Requesting review from previous release author: $PREVIOUS_AUTHOR"
+            else
+              echo "Skipping reviewer assignment (previous author missing or matches PAT owner)."
+            fi
+          fi
+
           gh pr create \
             --base main \
             --head "$BRANCH_NAME" \
             --title "$PR_TITLE" \
+            "${REVIEWER_FLAG[@]}" \
             --body "Generated self-hosted upgrade impact data for \`${TAG_NAME}\`.
 
           Review the generated YAML for self-hosted upgrade accuracy before merging."

--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -108,12 +108,11 @@ jobs:
           PREVIOUS_TAG="$(awk '/^previousTag:/ { print $2; exit }' "upgrade-impact/data/releases/${TAG_NAME}.yaml")"
           if [ -n "$PREVIOUS_TAG" ]; then
             PREVIOUS_AUTHOR="$(gh release view "$PREVIOUS_TAG" --json author --jq .author.login 2>/dev/null || true)"
-            PR_CREATOR="$(gh api user --jq .login 2>/dev/null || true)"
-            if [ -n "$PREVIOUS_AUTHOR" ] && [ "$PREVIOUS_AUTHOR" != "$PR_CREATOR" ]; then
+            if [ -n "$PREVIOUS_AUTHOR" ]; then
               REVIEWER_FLAG=(--reviewer "$PREVIOUS_AUTHOR")
               echo "Requesting review from previous release author: $PREVIOUS_AUTHOR"
             else
-              echo "Skipping reviewer assignment (previous author missing or matches PR creator)."
+              echo "Skipping reviewer assignment (could not resolve previous release author)."
             fi
           fi
 

--- a/upgrade-impact/src/evidence.ts
+++ b/upgrade-impact/src/evidence.ts
@@ -79,13 +79,14 @@ const isDeploymentFile = (file: string) =>
     "standalone-entrypoint.sh",
     "docker-compose",
     "docker-swarm/",
-    "helm-charts/",
     "render.yaml",
     "nginx/",
     ".nvmrc",
     "backend/package.json",
     "frontend/package.json"
   ].some((pattern) => file === pattern || file.startsWith(pattern));
+
+const isExcludedFromAnalysis = (file: string) => file.startsWith("helm-charts/");
 
 const isConfigFile = (file: string) =>
   [
@@ -102,8 +103,8 @@ export const collectEvidence = async (tag: string): Promise<ReleaseEvidenceBundl
   }
 
   const previousTag = getPreviousStableTag(tag);
-  const changedFiles = getChangedFiles(previousTag, tag);
-  const addedFiles = getAddedFiles(previousTag, tag);
+  const changedFiles = getChangedFiles(previousTag, tag).filter((file) => !isExcludedFromAnalysis(file));
+  const addedFiles = getAddedFiles(previousTag, tag).filter((file) => !isExcludedFromAnalysis(file));
   const commits = getCommitSummaries(previousTag, tag);
 
   const release = await fetchJson<{

--- a/upgrade-impact/src/generate-ai.ts
+++ b/upgrade-impact/src/generate-ai.ts
@@ -105,7 +105,9 @@ export const deterministicDraft = (bundle: ReleaseEvidenceBundle): GeneratedDraf
 
 const PROMPT_RULES = `You are generating Infisical self-hosted upgrade impact data.
 
-Only include changes that may affect self-hosted customers upgrading Infisical. Focus on breaking changes, database migrations, environment variables, Docker, Helm, Kubernetes, deployment behavior, startup/runtime requirements, manual actions, and known upgrade issues.
+Only include changes that may affect self-hosted customers upgrading Infisical. Focus on breaking changes, database migrations, environment variables, Docker, deployment behavior, startup/runtime requirements, manual actions, and known upgrade issues.
+
+Helm charts live in a separate release cadence and are intentionally excluded from this analysis — never recommend Helm-related actions, do not infer Helm impact from backend or frontend changes, and do not surface Helm chart updates even if they appear in release notes.
 
 Do not include ordinary product features unless they create a self-hosted upgrade action. Every entry must include evidence. If there is no meaningful self-hosted impact, return empty arrays and impactLevel "none".
 
@@ -114,7 +116,7 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - Lead with what changes for the operator, not how you discovered it.
 - Use active voice and simple verbs.
 - Do not say "the release", "this release", "code changes indicate", "evidence bundle", "identified", or "detected".
-- Do not mention that no Docker, Helm, Kubernetes, or database changes exist unless that absence changes the upgrade action.
+- Do not mention that no Docker or database changes exist unless that absence changes the upgrade action.
 - Do not duplicate the same risk across breakingChanges, configChanges, deploymentNotes, and knownIssues. Pick one category.
 - Do not include the same evidence item twice in one entry.
 - Do not repeat a release note or PR URL across multiple entries when a more specific file diff can support the claim.
@@ -124,13 +126,13 @@ Write for a busy self-hosted operator deciding whether and how to upgrade:
 - For additive database migrations, prefer "No manual action required; Infisical runs this migration during startup." Do not tell users to run migrations manually unless the diff proves they must.
 - If a migration failure is the only risk, say "If startup fails during migration, keep the previous version running and inspect migration logs before retrying."
 - Do not say "run migrations before serving traffic", "verify migration jobs complete", "account for", or "review X if you rely on Y".
-- Do not tell operators to change proxy, Helm, Docker, or environment configuration unless the diff introduces a required setting or changes a default that existing deployments must respond to.
+- Do not tell operators to change proxy, Docker, or environment configuration unless the diff introduces a required setting or changes a default that existing deployments must respond to.
 - Optional security-hardening settings such as TRUSTED_PROXY_CIDRS are not upgrade actions when unset preserves legacy behavior.
 - Do not tell API automation owners to update payloads when the service layer provides backwards-compatible defaults or auto-promotion.
 - For optional environment variables, nullable columns, or additive feature tables, include an entry only when existing deployments may need a decision; otherwise omit it or state that no manual action is required.
 - Before using breakingChanges, inspect whether existing records or configs are backfilled or compatibility-preserved. If compatibility exists, do not mark it breaking.
 - Use breakingChanges for changes that can make existing auth, API, startup, database, or integrations fail after upgrade.
-- Use deploymentNotes only when deployment files, self-hosting docs, Docker, Helm, Kubernetes manifests, startup/runtime, or rollout behavior changed.
+- Use deploymentNotes only when deployment files, self-hosting docs, Docker, Kubernetes manifests, startup/runtime, or rollout behavior changed.
 - Use configChanges only for environment variables, config files, defaults, or settings that operators must update.
 - Use knownIssues only for confirmed bugs or documented upgrade failures, not inferred risks.
 - Prefer one strong entry over several overlapping entries.
@@ -322,12 +324,12 @@ const buildAgenticPrompt = (bundle: ReleaseEvidenceBundle, index: BundleIndex) =
 Tool-use workflow:
 - Start from the release map, then inspect only changed files that may affect self-hosted upgrades.
 - Use list_changed_files to orient yourself.
-- Use get_file_diff before making claims about env vars, migrations, Docker, Helm, Kubernetes, startup/runtime behavior, auth, integrations, queues, workers, or database behavior.
+- Use get_file_diff before making claims about env vars, migrations, Docker, Kubernetes, startup/runtime behavior, auth, integrations, queues, workers, or database behavior.
 - When reading diffs, distinguish added/removed lines from unchanged context. Do not describe unchanged context as new behavior.
 - Use get_file_at_ref only when the diff is too narrow and the surrounding file context matters.
 - Before finalizing, inspect representative diffs from every non-empty high-signal bucket: migrationFiles, configFiles, deploymentFiles, and selfHostingDocs.
-- In deploymentFiles, prioritize Dockerfile*, .nvmrc, backend/package.json, Helm values, and Helm templates.
-- Include runtime/build notes for Node version, base image, package engine, Dockerfile, or Helm default changes when operators with custom images, charts, or manifests may need action.
+- In deploymentFiles, prioritize Dockerfile*, .nvmrc, and backend/package.json.
+- Include runtime/build notes for Node version, base image, package engine, or Dockerfile changes when operators with custom images or manifests may need action.
 - Do not inspect frontend-only files unless PR text or release notes connect them to deployment, auth, or self-hosted operation.
 - Stop inspecting once you have enough evidence for concise operator-facing entries.
 - Return final JSON only after tool use is complete.


### PR DESCRIPTION
## Context

Three improvements to the upgrade-impact release-cycle workflow:

- Filter `helm-charts/**` out of changed/added files in `evidence.ts` so the generator never feeds Helm paths to the AI. Helm charts ship on a separate cadence and were producing noisy upgrade notes for self-hosted users.
- Strip Helm-focused language from the AI prompt and add an explicit instruction not to surface Helm impact, even if release notes mention it.
- Drop `secrets.UPGRADE_TOOL_GITHUB_TOKEN` (a personal PAT) and use `secrets.GITHUB_TOKEN` for both the generate step and the `gh pr create` step. PRs are now opened by `github-actions[bot]` so no individual gets author-level notifications.
- Fold `type:check` and `npm test` into this workflow because PRs opened with `GITHUB_TOKEN` don't trigger `validate-upgrade-impact.yml` on `pull_request` events. The standalone validate workflow still runs for human-opened PRs.
- In `generate-upgrade-impact.yml`, read `previousTag` from the just-written release YAML, look up that release's author via `gh release view`, and pass `--reviewer` to `gh pr create` so a real human reviewer is requested.

Follow-up: `secrets.UPGRADE_TOOL_GITHUB_TOKEN` can be removed from repo settings once this lands.

## Steps to verify the change

- `cd upgrade-impact && npm ci && npm run type:check && npm test` — passes
- Spot-check: `awk '/^previousTag:/ { print $2; exit }' upgrade-impact/data/releases/v0.160.3.yaml` → `v0.160.2`
- Next stable release runs the workflow and produces a PR opened by `github-actions[bot]` with the previous release's author as reviewer and no Helm-related entries

## Type

- [x] Improvement

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)