### PR TITLE
feat(gitlab): replace project dropdown with Miller columns navigator

### DIFF
--- a/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
@@ -7,6 +7,7 @@ import {
   CreateGitLabConnectionSchema,
   SanitizedGitLabConnectionSchema,
   TGitLabGroup,
+  TGitLabGroupTreeItem,
   TGitLabProject,
   UpdateGitLabConnectionSchema
 } from "@app/services/app-connection/gitlab";
@@ -53,6 +54,105 @@ export const registerGitLabConnectionRouter = async (server: FastifyZodProvider)
         req.permission
       );
 
+      return projects;
+    }
+  });
+
+  server.route({
+    method: "GET",
+    url: `/:connectionId/root-groups`,
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: "listGitLabRootGroups",
+      params: z.object({
+        connectionId: z.string().uuid()
+      }),
+      response: {
+        200: z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            fullPath: z.string()
+          })
+          .array()
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { connectionId } = req.params;
+      const groups: TGitLabGroupTreeItem[] = await server.services.appConnection.gitlab.listRootGroups(
+        connectionId,
+        req.permission
+      );
+      return groups;
+    }
+  });
+
+  server.route({
+    method: "GET",
+    url: `/:connectionId/groups/:groupId/subgroups`,
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: "listGitLabGroupSubgroups",
+      params: z.object({
+        connectionId: z.string().uuid(),
+        groupId: z.string().min(1)
+      }),
+      response: {
+        200: z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            fullPath: z.string()
+          })
+          .array()
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { connectionId, groupId } = req.params;
+      const subgroups: TGitLabGroupTreeItem[] = await server.services.appConnection.gitlab.listGroupSubgroups(
+        connectionId,
+        groupId,
+        req.permission
+      );
+      return subgroups;
+    }
+  });
+
+  server.route({
+    method: "GET",
+    url: `/:connectionId/groups/:groupId/projects`,
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: "listGitLabGroupProjects",
+      params: z.object({
+        connectionId: z.string().uuid(),
+        groupId: z.string().min(1)
+      }),
+      response: {
+        200: z
+          .object({
+            id: z.string(),
+            name: z.string()
+          })
+          .array()
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { connectionId, groupId } = req.params;
+      const projects: TGitLabProject[] = await server.services.appConnection.gitlab.listGroupProjects(
+        connectionId,
+        groupId,
+        req.permission
+      );
       return projects;
     }
   });

--- a/backend/src/services/app-connection/gitlab/gitlab-connection-fns.ts
+++ b/backend/src/services/app-connection/gitlab/gitlab-connection-fns.ts
@@ -15,7 +15,13 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 
 import { TAppConnectionDALFactory } from "../app-connection-dal";
 import { GitLabAccessTokenType, GitLabConnectionMethod } from "./gitlab-connection-enums";
-import { TGitLabConnection, TGitLabConnectionConfig, TGitLabGroup, TGitLabProject } from "./gitlab-connection-types";
+import {
+  TGitLabConnection,
+  TGitLabConnectionConfig,
+  TGitLabGroup,
+  TGitLabGroupTreeItem,
+  TGitLabProject
+} from "./gitlab-connection-types";
 
 interface GitLabOAuthTokenResponse {
   access_token: string;
@@ -402,5 +408,116 @@ export const listGitLabGroups = async ({
     throw new InternalServerError({
       message: "Unable to fetch GitLab groups"
     });
+  }
+};
+
+type TNavigationParams = {
+  appConnection: TGitLabConnection;
+  appConnectionDAL: Pick<TAppConnectionDALFactory, "updateById">;
+  kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
+};
+
+const getNavigationClient = async ({ appConnection, appConnectionDAL, kmsService }: TNavigationParams) => {
+  let { accessToken } = appConnection.credentials;
+
+  if (
+    appConnection.method === GitLabConnectionMethod.AccessToken &&
+    appConnection.credentials.accessTokenType === GitLabAccessTokenType.Project
+  ) {
+    return null;
+  }
+
+  if (
+    appConnection.method === GitLabConnectionMethod.OAuth &&
+    appConnection.credentials.refreshToken &&
+    new Date(appConnection.credentials.expiresAt) < new Date()
+  ) {
+    accessToken = await refreshGitLabToken(
+      appConnection.credentials.refreshToken,
+      appConnection.id,
+      appConnection.orgId,
+      appConnection.projectId,
+      appConnectionDAL,
+      kmsService,
+      appConnection.credentials.instanceUrl
+    );
+  }
+
+  return getGitLabClient(accessToken, appConnection.credentials.instanceUrl, appConnection.method === GitLabConnectionMethod.OAuth);
+};
+
+export const listGitLabRootGroups = async (params: TNavigationParams): Promise<TGitLabGroupTreeItem[]> => {
+  const client = await getNavigationClient(params);
+  if (!client) return [];
+
+  try {
+    const groups = await client.Groups.all({
+      topLevelOnly: true,
+      orderBy: "name",
+      sort: "asc",
+      minAccessLevel: 20
+    });
+
+    return groups
+      .filter((g) => !g.parentId)
+      .map((g) => ({ id: g.id.toString(), name: g.name, fullPath: g.fullPath }));
+  } catch (error: unknown) {
+    if (error instanceof GitbeakerRequestError) {
+      throw new BadRequestError({
+        message: `Failed to fetch GitLab groups: ${error.message ?? "Unknown error"}${error.cause?.description && error.message !== "Unauthorized" ? `. Cause: ${error.cause.description}` : ""}`
+      });
+    }
+    if (error instanceof InternalServerError) throw error;
+    throw new InternalServerError({ message: "Unable to fetch GitLab root groups" });
+  }
+};
+
+export const listGitLabGroupSubgroups = async (
+  groupId: string,
+  params: TNavigationParams
+): Promise<TGitLabGroupTreeItem[]> => {
+  const client = await getNavigationClient(params);
+  if (!client) return [];
+
+  try {
+    const subgroups = await client.Groups.allSubgroups(Number(groupId), {
+      orderBy: "name",
+      sort: "asc"
+    });
+
+    return subgroups.map((g) => ({ id: g.id.toString(), name: g.name, fullPath: g.fullPath }));
+  } catch (error: unknown) {
+    if (error instanceof GitbeakerRequestError) {
+      throw new BadRequestError({
+        message: `Failed to fetch GitLab subgroups: ${error.message ?? "Unknown error"}${error.cause?.description && error.message !== "Unauthorized" ? `. Cause: ${error.cause.description}` : ""}`
+      });
+    }
+    if (error instanceof InternalServerError) throw error;
+    throw new InternalServerError({ message: "Unable to fetch GitLab subgroups" });
+  }
+};
+
+export const listGitLabGroupProjects = async (
+  groupId: string,
+  params: TNavigationParams
+): Promise<TGitLabProject[]> => {
+  const client = await getNavigationClient(params);
+  if (!client) return [];
+
+  try {
+    const projects = await client.Groups.allProjects(Number(groupId), {
+      archived: false,
+      includeSubgroups: false
+    });
+
+    return projects.map((p) => ({ id: p.id.toString(), name: p.pathWithNamespace }));
+  } catch (error: unknown) {
+    if (error instanceof GitbeakerRequestError) {
+      throw new BadRequestError({
+        message: `Failed to fetch GitLab group projects: ${error.message ?? "Unknown error"}${error.cause?.description && error.message !== "Unauthorized" ? `. Cause: ${error.cause.description}` : ""}`
+      });
+    }
+    if (error instanceof InternalServerError) throw error;
+    throw new InternalServerError({ message: "Unable to fetch GitLab group projects" });
   }
 };

--- a/backend/src/services/app-connection/gitlab/gitlab-connection-service.ts
+++ b/backend/src/services/app-connection/gitlab/gitlab-connection-service.ts
@@ -4,7 +4,13 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 
 import { TAppConnectionDALFactory } from "../app-connection-dal";
 import { AppConnection } from "../app-connection-enums";
-import { listGitLabGroups, listGitLabProjects } from "./gitlab-connection-fns";
+import {
+  listGitLabGroupProjects,
+  listGitLabGroupSubgroups,
+  listGitLabGroups,
+  listGitLabProjects,
+  listGitLabRootGroups
+} from "./gitlab-connection-fns";
 import { TGitLabConnection } from "./gitlab-connection-types";
 
 type TGetAppConnectionFunc = (
@@ -40,8 +46,41 @@ export const gitlabConnectionService = (
     }
   };
 
+  const listRootGroups = async (connectionId: string, actor: OrgServiceActor) => {
+    try {
+      const appConnection = await getAppConnection(AppConnection.GitLab, connectionId, actor);
+      return await listGitLabRootGroups({ appConnection, appConnectionDAL, kmsService });
+    } catch (error) {
+      logger.error(error, `Failed to list root groups for GitLab connection ${connectionId}`);
+      return [];
+    }
+  };
+
+  const listGroupSubgroups = async (connectionId: string, groupId: string, actor: OrgServiceActor) => {
+    try {
+      const appConnection = await getAppConnection(AppConnection.GitLab, connectionId, actor);
+      return await listGitLabGroupSubgroups(groupId, { appConnection, appConnectionDAL, kmsService });
+    } catch (error) {
+      logger.error(error, `Failed to list subgroups for GitLab group ${groupId}`);
+      return [];
+    }
+  };
+
+  const listGroupProjects = async (connectionId: string, groupId: string, actor: OrgServiceActor) => {
+    try {
+      const appConnection = await getAppConnection(AppConnection.GitLab, connectionId, actor);
+      return await listGitLabGroupProjects(groupId, { appConnection, appConnectionDAL, kmsService });
+    } catch (error) {
+      logger.error(error, `Failed to list projects for GitLab group ${groupId}`);
+      return [];
+    }
+  };
+
   return {
     listProjects,
-    listGroups
+    listGroups,
+    listRootGroups,
+    listGroupSubgroups,
+    listGroupProjects
   };
 };

--- a/backend/src/services/app-connection/gitlab/gitlab-connection-types.ts
+++ b/backend/src/services/app-connection/gitlab/gitlab-connection-types.ts
@@ -26,6 +26,12 @@ export type TGitLabProject = {
   id: string;
 };
 
+export type TGitLabGroupTreeItem = {
+  id: string;
+  name: string;
+  fullPath: string;
+};
+
 export type TGitLabAccessTokenCredentials = {
   accessToken: string;
   instanceUrl: string;

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabProjectNavigator.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabProjectNavigator.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from "react";
+import { faCheck, faChevronRight, faCodeBranch, faFolder } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { Spinner } from "@app/components/v2";
+import {
+  TGitLabGroupTreeItem,
+  TGitLabProject,
+  useGitLabConnectionListGroupProjects,
+  useGitLabConnectionListGroupSubgroups,
+  useGitLabConnectionListRootGroups
+} from "@app/hooks/api/appConnections/gitlab";
+
+type ColumnProps = {
+  connectionId: string;
+  groupId: string | null;
+  selectedGroupId: string | null;
+  selectedProjectId: string;
+  onGroupClick: (group: TGitLabGroupTreeItem) => void;
+  onProjectClick: (id: string, name: string) => void;
+  isLastColumn: boolean;
+};
+
+const GitLabFinderColumn = ({
+  connectionId,
+  groupId,
+  selectedGroupId,
+  selectedProjectId,
+  onGroupClick,
+  onProjectClick,
+  isLastColumn
+}: ColumnProps) => {
+  const isRoot = !groupId;
+
+  const { data: rootGroups, isLoading: isLoadingRoot } = useGitLabConnectionListRootGroups(connectionId, {
+    enabled: isRoot && Boolean(connectionId)
+  });
+
+  const { data: subgroups, isLoading: isLoadingSubgroups } = useGitLabConnectionListGroupSubgroups(
+    connectionId,
+    groupId ?? "",
+    { enabled: !isRoot && Boolean(connectionId) }
+  );
+
+  const { data: groupProjects, isLoading: isLoadingProjects } = useGitLabConnectionListGroupProjects(
+    connectionId,
+    groupId ?? "",
+    { enabled: !isRoot && Boolean(connectionId) }
+  );
+
+  const isLoading = isRoot ? isLoadingRoot : isLoadingSubgroups || isLoadingProjects;
+  const groups: TGitLabGroupTreeItem[] = isRoot ? (rootGroups ?? []) : (subgroups ?? []);
+  const projects: TGitLabProject[] = isRoot ? [] : (groupProjects ?? []);
+
+  return (
+    <div
+      className={`flex w-48 shrink-0 flex-col overflow-y-auto border-r border-mineshaft-700 ${isLastColumn ? "border-r-0" : ""}`}
+    >
+      {isLoading && (
+        <div className="flex items-center justify-center py-6">
+          <Spinner size="sm" />
+        </div>
+      )}
+
+      {!isLoading && (
+        <>
+          {groups.map((group) => {
+            const isSelected = group.id === selectedGroupId;
+            return (
+              <button
+                key={group.id}
+                type="button"
+                onClick={() => onGroupClick(group)}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                  isSelected ? "bg-primary/20 text-primary" : "text-mineshaft-200 hover:bg-mineshaft-800"
+                }`}
+              >
+                <FontAwesomeIcon
+                  icon={faFolder}
+                  size="sm"
+                  className={isSelected ? "shrink-0 text-primary" : "shrink-0 text-yellow-600/70"}
+                />
+                <span className="truncate">{group.name}</span>
+                <FontAwesomeIcon
+                  icon={faChevronRight}
+                  size="xs"
+                  className="ml-auto shrink-0 text-mineshaft-500"
+                />
+              </button>
+            );
+          })}
+
+          {projects.map((project) => {
+            const isSelected = project.id === selectedProjectId;
+            return (
+              <button
+                key={project.id}
+                type="button"
+                onClick={() => onProjectClick(project.id, project.name)}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                  isSelected ? "bg-primary/20 text-primary" : "text-mineshaft-200 hover:bg-mineshaft-800"
+                }`}
+              >
+                <FontAwesomeIcon
+                  icon={faCodeBranch}
+                  size="sm"
+                  className={isSelected ? "shrink-0 text-primary" : "shrink-0 text-mineshaft-400"}
+                />
+                <span className="truncate">{project.name}</span>
+                {isSelected && (
+                  <FontAwesomeIcon icon={faCheck} size="xs" className="ml-auto shrink-0 text-primary" />
+                )}
+              </button>
+            );
+          })}
+
+          {groups.length === 0 && projects.length === 0 && (
+            <p className="px-3 py-4 text-center text-xs text-mineshaft-400">Nothing here</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+type Props = {
+  connectionId: string;
+  value: string;
+  projectName: string;
+  onChange: (projectId: string, projectName: string) => void;
+  isDisabled?: boolean;
+};
+
+export const GitLabProjectNavigator = ({ connectionId, value, projectName, onChange, isDisabled }: Props) => {
+  const [navStack, setNavStack] = useState<TGitLabGroupTreeItem[]>([]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({ left: scrollRef.current.scrollWidth, behavior: "smooth" });
+    }
+  }, [navStack.length]);
+
+  const handleGroupClick = (group: TGitLabGroupTreeItem, columnIndex: number) => {
+    setNavStack((prev) => [...prev.slice(0, columnIndex), group]);
+  };
+
+  // columnGroupIds[0] = null (root), columnGroupIds[1] = navStack[0].id, etc.
+  const columnGroupIds: (string | null)[] = [null, ...navStack.map((g) => g.id)];
+
+  return (
+    <div
+      className={`rounded-md border border-mineshaft-600 bg-mineshaft-900 ${isDisabled ? "pointer-events-none opacity-50" : ""}`}
+    >
+      <div ref={scrollRef} className="flex h-52 overflow-x-auto">
+        {columnGroupIds.map((groupId, i) => (
+          <GitLabFinderColumn
+            key={groupId ?? "root"}
+            connectionId={connectionId}
+            groupId={groupId}
+            selectedGroupId={navStack[i]?.id ?? null}
+            selectedProjectId={value}
+            onGroupClick={(group) => handleGroupClick(group, i)}
+            onProjectClick={onChange}
+            isLastColumn={i === columnGroupIds.length - 1}
+          />
+        ))}
+      </div>
+
+      {value && (
+        <div className="flex items-center gap-2 border-t border-mineshaft-600 px-3 py-2 text-xs text-mineshaft-300">
+          <FontAwesomeIcon icon={faCheck} size="xs" className="text-primary" />
+          <span className="truncate">
+            Selected: <span className="text-bunker-200">{projectName}</span>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GitLabSyncFields.tsx
@@ -13,14 +13,11 @@ import {
   Switch,
   Tooltip
 } from "@app/components/v2";
-import {
-  TGitLabGroup,
-  TGitLabProject,
-  useGitLabConnectionListGroups,
-  useGitLabConnectionListProjects
-} from "@app/hooks/api/appConnections/gitlab";
+import { TGitLabGroup, useGitLabConnectionListGroups } from "@app/hooks/api/appConnections/gitlab";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
 import { GitLabSyncScope } from "@app/hooks/api/secretSyncs/types/gitlab-sync";
+
+import { GitLabProjectNavigator } from "./GitLabProjectNavigator";
 
 import { TSecretSyncForm } from "../schemas";
 
@@ -69,17 +66,12 @@ export const GitLabSyncFields = () => {
   const connectionId = useWatch({ name: "connection.id", control });
   const scope = useWatch({ name: "destinationConfig.scope", control });
   const shouldMaskSecrets = useWatch({ name: "destinationConfig.shouldMaskSecrets", control });
+  const projectId = useWatch({ name: "destinationConfig.projectId", control });
+  const projectName = useWatch({ name: "destinationConfig.projectName", control });
 
   const { data: groups, isLoading: isGroupsLoading } = useGitLabConnectionListGroups(connectionId, {
     enabled: Boolean(connectionId) && scope === GitLabSyncScope.Group
   });
-
-  const { data: projects, isLoading: isProjectsLoading } = useGitLabConnectionListProjects(
-    connectionId,
-    {
-      enabled: Boolean(connectionId)
-    }
-  );
 
   return (
     <div className="h-full overflow-auto">
@@ -170,7 +162,7 @@ export const GitLabSyncFields = () => {
         <Controller
           name="destinationConfig.projectId"
           control={control}
-          render={({ field: { value, onChange }, fieldState: { error } }) => (
+          render={({ fieldState: { error } }) => (
             <FormControl
               isError={Boolean(error)}
               errorText={error?.message}
@@ -178,31 +170,24 @@ export const GitLabSyncFields = () => {
               helperText={
                 <Tooltip
                   className="max-w-md"
-                  content="Ensure the project exists in the connection's GitLab instance URL and the connection has access to it."
+                  content="Navigate through your GitLab groups to find and select a project."
                 >
                   <div>
-                    <span>Don&#39;t see the project you&#39;re looking for?</span>{" "}
+                    <span>Browse groups to find your project</span>{" "}
                     <FontAwesomeIcon icon={faCircleInfo} className="text-mineshaft-400" />
                   </div>
                 </Tooltip>
               }
             >
-              <FilterableSelect
-                menuPlacement="top"
-                isLoading={isProjectsLoading && Boolean(connectionId)}
-                isDisabled={!connectionId}
-                value={projects?.find((project) => project.id === value) ?? null}
-                onChange={(option) => {
-                  onChange((option as SingleValue<TGitLabProject>)?.id ?? "");
-                  setValue(
-                    "destinationConfig.projectName",
-                    (option as SingleValue<TGitLabProject>)?.name ?? ""
-                  );
+              <GitLabProjectNavigator
+                connectionId={connectionId}
+                value={projectId ?? ""}
+                projectName={projectName ?? ""}
+                onChange={(id, name) => {
+                  setValue("destinationConfig.projectId", id);
+                  setValue("destinationConfig.projectName", name);
                 }}
-                options={projects}
-                placeholder="Select a project..."
-                getOptionLabel={(option) => option.name}
-                getOptionValue={(option) => option.id}
+                isDisabled={!connectionId}
               />
             </FormControl>
           )}

--- a/frontend/src/hooks/api/appConnections/gitlab/queries.tsx
+++ b/frontend/src/hooks/api/appConnections/gitlab/queries.tsx
@@ -3,14 +3,20 @@ import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { apiRequest } from "@app/config/request";
 
 import { appConnectionKeys } from "../queries";
-import { TGitLabGroup, TGitLabProject } from "./types";
+import { TGitLabGroup, TGitLabGroupTreeItem, TGitLabProject } from "./types";
 
 const gitlabConnectionKeys = {
   all: [...appConnectionKeys.all, "gitlab"] as const,
   listProjects: (connectionId: string) =>
     [...gitlabConnectionKeys.all, "projects", connectionId] as const,
   listGroups: (connectionId: string) =>
-    [...gitlabConnectionKeys.all, "groups", connectionId] as const
+    [...gitlabConnectionKeys.all, "groups", connectionId] as const,
+  listRootGroups: (connectionId: string) =>
+    [...gitlabConnectionKeys.all, "root-groups", connectionId] as const,
+  listGroupSubgroups: (connectionId: string, groupId: string) =>
+    [...gitlabConnectionKeys.all, "subgroups", connectionId, groupId] as const,
+  listGroupProjects: (connectionId: string, groupId: string) =>
+    [...gitlabConnectionKeys.all, "group-projects", connectionId, groupId] as const
 };
 
 export const useGitLabConnectionListProjects = (
@@ -57,6 +63,80 @@ export const useGitLabConnectionListGroups = (
         `/api/v1/app-connections/gitlab/${connectionId}/groups`
       );
 
+      return data;
+    },
+    ...options
+  });
+};
+
+export const useGitLabConnectionListRootGroups = (
+  connectionId: string,
+  options?: Omit<
+    UseQueryOptions<
+      TGitLabGroupTreeItem[],
+      unknown,
+      TGitLabGroupTreeItem[],
+      ReturnType<typeof gitlabConnectionKeys.listRootGroups>
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: gitlabConnectionKeys.listRootGroups(connectionId),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<TGitLabGroupTreeItem[]>(
+        `/api/v1/app-connections/gitlab/${connectionId}/root-groups`
+      );
+      return data;
+    },
+    ...options
+  });
+};
+
+export const useGitLabConnectionListGroupSubgroups = (
+  connectionId: string,
+  groupId: string,
+  options?: Omit<
+    UseQueryOptions<
+      TGitLabGroupTreeItem[],
+      unknown,
+      TGitLabGroupTreeItem[],
+      ReturnType<typeof gitlabConnectionKeys.listGroupSubgroups>
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: gitlabConnectionKeys.listGroupSubgroups(connectionId, groupId),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<TGitLabGroupTreeItem[]>(
+        `/api/v1/app-connections/gitlab/${connectionId}/groups/${groupId}/subgroups`
+      );
+      return data;
+    },
+    ...options
+  });
+};
+
+export const useGitLabConnectionListGroupProjects = (
+  connectionId: string,
+  groupId: string,
+  options?: Omit<
+    UseQueryOptions<
+      TGitLabProject[],
+      unknown,
+      TGitLabProject[],
+      ReturnType<typeof gitlabConnectionKeys.listGroupProjects>
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: gitlabConnectionKeys.listGroupProjects(connectionId, groupId),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<TGitLabProject[]>(
+        `/api/v1/app-connections/gitlab/${connectionId}/groups/${groupId}/projects`
+      );
       return data;
     },
     ...options

--- a/frontend/src/hooks/api/appConnections/gitlab/types.ts
+++ b/frontend/src/hooks/api/appConnections/gitlab/types.ts
@@ -8,6 +8,12 @@ export type TGitLabGroup = {
   fullName: string;
 };
 
+export type TGitLabGroupTreeItem = {
+  id: string;
+  name: string;
+  fullPath: string;
+};
+
 export enum GitLabAccessTokenType {
   Personal = "personal",
   Project = "project",


### PR DESCRIPTION
Fixes a hang for users with a lot of repos by lazily loading one level at a time instead of fetching all projects upfront.

## Context

#6555 

## Screenshots

https://github.com/user-attachments/assets/46caf957-be44-4973-b369-253cc6d24eee

## Steps to verify the change

Instead of loading all accessible projects at once (which triggers dozens of GitLab API calls before rendering anything), the project selector now uses a **Miller columns (Mac Finder-style) navigator**.

  The user drills down through their group hierarchy one level at a time:

  1. The first column loads only top-level groups
  2. Clicking a group opens a new column to the right showing its subgroups and direct projects
  3. The user continues navigating until they find and select their project

  Each column fetches only the data for that level, so a user with 2000+ repos never triggers a bulk fetch. The UI responds immediately at every step.

  ### Before

  The project dropdown would hang indefinitely (or time out) for users with access to large numbers of repositories, because the backend was calling Gitbeaker's `.all()` method which exhausts all paginated pages before returning.

  ### After

  The navigator loads instantly. Each level is a single scoped GitLab API call (`/groups/:id/subgroups` or `/groups/:id/projects`), and already-visited columns are cached by React Query so navigating back is instant.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)