### PR TITLE
feat(pki): allow disabling the default CRL distribution point URL

### DIFF
--- a/backend/src/db/migrations/20260521002616_add-disable-managed-crl-dp.ts
+++ b/backend/src/db/migrations/20260521002616_add-disable-managed-crl-dp.ts
@@ -1,0 +1,35 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TableName.InternalCertificateAuthority);
+  if (!hasTable) return;
+
+  const hasColumn = await knex.schema.hasColumn(
+    TableName.InternalCertificateAuthority,
+    "disableManagedCrlDistributionPointUrl"
+  );
+
+  if (!hasColumn) {
+    await knex.schema.alterTable(TableName.InternalCertificateAuthority, (t) => {
+      t.boolean("disableManagedCrlDistributionPointUrl").defaultTo(false).notNullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasTable = await knex.schema.hasTable(TableName.InternalCertificateAuthority);
+  if (!hasTable) return;
+
+  const hasColumn = await knex.schema.hasColumn(
+    TableName.InternalCertificateAuthority,
+    "disableManagedCrlDistributionPointUrl"
+  );
+
+  if (hasColumn) {
+    await knex.schema.alterTable(TableName.InternalCertificateAuthority, (t) => {
+      t.dropColumn("disableManagedCrlDistributionPointUrl");
+    });
+  }
+}

--- a/backend/src/db/schemas/internal-certificate-authorities.ts
+++ b/backend/src/db/schemas/internal-certificate-authorities.ts
@@ -31,7 +31,8 @@ export const InternalCertificateAuthoritiesSchema = z.object({
   lastRenewalStatus: z.string().nullable().optional(),
   lastRenewalMessage: z.string().nullable().optional(),
   lastRenewalAt: z.date().nullable().optional(),
-  crlDistributionPointUrls: z.string().array().nullable().optional()
+  crlDistributionPointUrls: z.string().array().nullable().optional(),
+  disableManagedCrlDistributionPointUrl: z.boolean().default(false)
 });
 
 export type TInternalCertificateAuthorities = z.infer<typeof InternalCertificateAuthoritiesSchema>;

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2605,7 +2605,9 @@ export const CertificateAuthorities = {
       keyAlgorithm:
         "The type of public key algorithm and size, in bits, of the key pair for the CA; when you create an intermediate CA, you must use a key algorithm supported by the parent CA.",
       crlDistributionPointUrls:
-        "Additional CRL Distribution Point URLs (HTTP/HTTPS) embedded in every certificate issued by this CA. Up to 4 URLs; the Infisical-managed CRL endpoint is always included as the primary."
+        "Additional CRL Distribution Point URLs (HTTP/HTTPS) embedded in every certificate issued by this CA. Up to 4 URLs; the Infisical-managed CRL endpoint is included by default unless disabled.",
+      disableManagedCrlDistributionPointUrl:
+        "When set to true, the Infisical-managed CRL endpoint URL will not be embedded in certificates issued by this CA. Only custom CRL Distribution Point URLs (if any) will be included."
     }
   }
 };

--- a/backend/src/services/certificate-authority/certificate-authority-dal.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-dal.ts
@@ -54,7 +54,11 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
         db
           .ref("crlDistributionPointUrls")
           .withSchema(TableName.InternalCertificateAuthority)
-          .as("internalCrlDistributionPointUrls")
+          .as("internalCrlDistributionPointUrls"),
+        db
+          .ref("disableManagedCrlDistributionPointUrl")
+          .withSchema(TableName.InternalCertificateAuthority)
+          .as("internalDisableManagedCrlDistributionPointUrl")
       )
       .select(
         db.ref("id").withSchema(TableName.ExternalCertificateAuthority).as("externalCaId"),
@@ -90,7 +94,8 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
             notBefore: result.internalNotBefore?.toISOString(),
             notAfter: result.internalNotAfter?.toISOString(),
             activeCaCertId: result.internalActiveCaCertId,
-            crlDistributionPointUrls: result.internalCrlDistributionPointUrls ?? []
+            crlDistributionPointUrls: result.internalCrlDistributionPointUrls ?? [],
+            disableManagedCrlDistributionPointUrl: result.internalDisableManagedCrlDistributionPointUrl ?? false
           }
         : undefined,
       externalCa: result
@@ -143,7 +148,11 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
         db
           .ref("crlDistributionPointUrls")
           .withSchema(TableName.InternalCertificateAuthority)
-          .as("internalCrlDistributionPointUrls")
+          .as("internalCrlDistributionPointUrls"),
+        db
+          .ref("disableManagedCrlDistributionPointUrl")
+          .withSchema(TableName.InternalCertificateAuthority)
+          .as("internalDisableManagedCrlDistributionPointUrl")
       )
       .select(
         db.ref("id").withSchema(TableName.ExternalCertificateAuthority).as("externalCaId"),
@@ -179,7 +188,8 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
             notBefore: result.internalNotBefore?.toISOString(),
             notAfter: result.internalNotAfter?.toISOString(),
             activeCaCertId: result.internalActiveCaCertId,
-            crlDistributionPointUrls: result.internalCrlDistributionPointUrls ?? []
+            crlDistributionPointUrls: result.internalCrlDistributionPointUrls ?? [],
+            disableManagedCrlDistributionPointUrl: result.internalDisableManagedCrlDistributionPointUrl ?? false
           }
         : undefined,
       externalCa: result
@@ -273,7 +283,11 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
           db
             .ref("crlDistributionPointUrls")
             .withSchema(TableName.InternalCertificateAuthority)
-            .as("internalCrlDistributionPointUrls")
+            .as("internalCrlDistributionPointUrls"),
+          db
+            .ref("disableManagedCrlDistributionPointUrl")
+            .withSchema(TableName.InternalCertificateAuthority)
+            .as("internalDisableManagedCrlDistributionPointUrl")
         )
         .select(
           db.ref("id").withSchema(TableName.ExternalCertificateAuthority).as("externalCaId"),
@@ -328,7 +342,8 @@ export const certificateAuthorityDALFactory = (db: TDbClient) => {
               notBefore: ca.internalNotBefore?.toISOString(),
               notAfter: ca.internalNotAfter?.toISOString(),
               activeCaCertId: ca.internalActiveCaCertId,
-              crlDistributionPointUrls: ca.internalCrlDistributionPointUrls ?? []
+              crlDistributionPointUrls: ca.internalCrlDistributionPointUrls ?? [],
+              disableManagedCrlDistributionPointUrl: ca.internalDisableManagedCrlDistributionPointUrl ?? false
             }
           : undefined,
         externalCa: ca

--- a/backend/src/services/certificate-authority/certificate-authority-fns.test.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { CertKeyAlgorithm } from "@app/services/certificate/certificate-types";
 
-import { signatureAlgorithmToAlgCfg } from "./certificate-authority-fns";
+import { buildCrlDistributionPointUrls, signatureAlgorithmToAlgCfg } from "./certificate-authority-fns";
 
 // Helper to access properties on the union return type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -187,5 +187,53 @@ describe("signatureAlgorithmToAlgCfg", () => {
       const result = signatureAlgorithmToAlgCfg("ML-DSA-87", CertKeyAlgorithm.RSA_2048);
       expect(result.name).toBe("ML-DSA-87");
     });
+  });
+});
+
+describe("buildCrlDistributionPointUrls", () => {
+  const managedUrl = "https://infisical.example.com/api/v1/cert-manager/crl/123/der";
+
+  it("should include managed URL by default", () => {
+    const result = buildCrlDistributionPointUrls(managedUrl, null);
+    expect(result).toEqual([managedUrl]);
+  });
+
+  it("should include managed URL and custom URLs", () => {
+    const customUrls = ["https://crl.example.com/ca.crl", "https://crl2.example.com/ca.crl"];
+    const result = buildCrlDistributionPointUrls(managedUrl, customUrls);
+    expect(result).toEqual([managedUrl, ...customUrls]);
+  });
+
+  it("should deduplicate URLs", () => {
+    const customUrls = [managedUrl];
+    const result = buildCrlDistributionPointUrls(managedUrl, customUrls);
+    expect(result).toEqual([managedUrl]);
+  });
+
+  it("should exclude managed URL when disableManagedUrl is true", () => {
+    const customUrls = ["https://crl.example.com/ca.crl"];
+    const result = buildCrlDistributionPointUrls(managedUrl, customUrls, true);
+    expect(result).toEqual(customUrls);
+    expect(result).not.toContain(managedUrl);
+  });
+
+  it("should return empty array when disableManagedUrl is true and no custom URLs", () => {
+    const result = buildCrlDistributionPointUrls(managedUrl, null, true);
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when disableManagedUrl is true and custom URLs is undefined", () => {
+    const result = buildCrlDistributionPointUrls(managedUrl, undefined, true);
+    expect(result).toEqual([]);
+  });
+
+  it("should include managed URL when disableManagedUrl is false", () => {
+    const result = buildCrlDistributionPointUrls(managedUrl, null, false);
+    expect(result).toEqual([managedUrl]);
+  });
+
+  it("should include managed URL when disableManagedUrl is undefined", () => {
+    const result = buildCrlDistributionPointUrls(managedUrl, null, undefined);
+    expect(result).toEqual([managedUrl]);
   });
 });

--- a/backend/src/services/certificate-authority/certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.ts
@@ -567,10 +567,12 @@ export const normalizeUrlForComparison = (url: string) => {
 
 export const buildCrlDistributionPointUrls = (
   managedUrl: string,
-  customUrls: string[] | null | undefined
+  customUrls: string[] | null | undefined,
+  disableManagedUrl?: boolean
 ): string[] => {
   const seen = new Set<string>();
-  return [managedUrl, ...(customUrls ?? [])].reduce<string[]>((acc, rawUrl) => {
+  const sources = disableManagedUrl ? (customUrls ?? []) : [managedUrl, ...(customUrls ?? [])];
+  return sources.reduce<string[]>((acc, rawUrl) => {
     if (!rawUrl) return acc;
     const trimmed = rawUrl.trim();
     const normalized = normalizeUrlForComparison(trimmed);

--- a/backend/src/services/certificate-authority/certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-service.ts
@@ -598,14 +598,17 @@ export const certificateAuthorityServiceFactory = ({
         });
       }
 
-      const internalConfig = configuration as { crlDistributionPointUrls?: string[] } | undefined;
+      const internalConfig = configuration as
+        | { crlDistributionPointUrls?: string[]; disableManagedCrlDistributionPointUrl?: boolean }
+        | undefined;
 
       const updatedCa = await internalCertificateAuthorityService.updateCaById({
         isInternal: true,
         caId: certificateAuthority.id,
         status,
         name,
-        crlDistributionPointUrls: internalConfig?.crlDistributionPointUrls
+        crlDistributionPointUrls: internalConfig?.crlDistributionPointUrls,
+        disableManagedCrlDistributionPointUrl: internalConfig?.disableManagedCrlDistributionPointUrl
       });
 
       if (!updatedCa.internalCa) {

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-fns.ts
@@ -144,11 +144,15 @@ export const InternalCertificateAuthorityFns = ({
 
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const extensions: x509.Extension[] = [
       new x509.BasicConstraintsExtension(false),
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
       new x509.AuthorityInfoAccessExtension({
@@ -393,11 +397,15 @@ export const InternalCertificateAuthorityFns = ({
 
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const extensions: x509.Extension[] = [
       new x509.BasicConstraintsExtension(false),
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
       new x509.AuthorityInfoAccessExtension({

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-schemas.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-schemas.ts
@@ -29,6 +29,7 @@ type TInternalCertificateAuthorityConfiguration = {
   serialNumber?: string | null;
   activeCaCertId?: string | null;
   crlDistributionPointUrls?: string[];
+  disableManagedCrlDistributionPointUrl?: boolean;
 };
 
 export const InternalCertificateAuthorityConfigurationSchema = z
@@ -51,7 +52,12 @@ export const InternalCertificateAuthorityConfigurationSchema = z
     activeCaCertId: z.string().uuid().nullish(),
     crlDistributionPointUrls: distributionPointUrlsSchema
       .optional()
-      .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.crlDistributionPointUrls)
+      .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.crlDistributionPointUrls),
+    disableManagedCrlDistributionPointUrl: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.disableManagedCrlDistributionPointUrl)
   })
   .refine(
     (data) => {
@@ -81,7 +87,11 @@ export const CreateInternalCertificateAuthoritySchema = GenericCreateCertificate
 export const UpdateInternalCertificateAuthorityConfigurationSchema = z.object({
   crlDistributionPointUrls: distributionPointUrlsSchema
     .optional()
-    .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.crlDistributionPointUrls)
+    .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.crlDistributionPointUrls),
+  disableManagedCrlDistributionPointUrl: z
+    .boolean()
+    .optional()
+    .describe(CertificateAuthorities.CONFIGURATIONS.INTERNAL.disableManagedCrlDistributionPointUrl)
 });
 
 export const UpdateInternalCertificateAuthoritySchema = GenericUpdateCertificateAuthorityFieldsSchema(

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -276,6 +276,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     keyAlgorithm,
     name,
     crlDistributionPointUrls,
+    disableManagedCrlDistributionPointUrl,
     ...dto
   }: TCreateCaDTO) => {
     let projectId: string;
@@ -363,6 +364,7 @@ export const internalCertificateAuthorityServiceFactory = ({
           dn,
           keyAlgorithm,
           crlDistributionPointUrls: crlDistributionPointUrls ?? [],
+          disableManagedCrlDistributionPointUrl: disableManagedCrlDistributionPointUrl ?? false,
           ...(type === InternalCaType.ROOT && {
             maxPathLength,
             ...(notAfter && {
@@ -516,7 +518,14 @@ export const internalCertificateAuthorityServiceFactory = ({
    * Update CA with id [caId].
    * Note: Used to enable/disable CA and edit CRL distribution point URLs
    */
-  const updateCaById = async ({ caId, status, name, crlDistributionPointUrls, ...dto }: TUpdateCaDTO) => {
+  const updateCaById = async ({
+    caId,
+    status,
+    name,
+    crlDistributionPointUrls,
+    disableManagedCrlDistributionPointUrl,
+    ...dto
+  }: TUpdateCaDTO) => {
     const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(caId);
     if (!ca.internalCa) throw new NotFoundError({ message: `CA with ID '${caId}' not found` });
 
@@ -541,8 +550,15 @@ export const internalCertificateAuthorityServiceFactory = ({
         await certificateAuthorityDAL.updateById(ca.id, { status, name }, tx);
       }
 
-      if (crlDistributionPointUrls !== undefined) {
-        await internalCertificateAuthorityDAL.update({ caId: ca.id }, { crlDistributionPointUrls }, tx);
+      if (crlDistributionPointUrls !== undefined || disableManagedCrlDistributionPointUrl !== undefined) {
+        await internalCertificateAuthorityDAL.update(
+          { caId: ca.id },
+          {
+            ...(crlDistributionPointUrls !== undefined && { crlDistributionPointUrls }),
+            ...(disableManagedCrlDistributionPointUrl !== undefined && { disableManagedCrlDistributionPointUrl })
+          },
+          tx
+        );
       }
 
       return certificateAuthorityDAL.findByIdWithAssociatedCa(caId, tx);
@@ -1232,7 +1248,11 @@ export const internalCertificateAuthorityServiceFactory = ({
     const caCrl = await certificateAuthorityCrlDAL.findOne({ caSecretId: caSecret.id });
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const intermediateCert = await x509.X509CertificateGenerator.create({
       serialNumber,
@@ -1251,7 +1271,7 @@ export const internalCertificateAuthorityServiceFactory = ({
         new x509.BasicConstraintsExtension(true, maxPathLength === -1 ? undefined : maxPathLength, true),
         await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
         await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
-        new x509.CRLDistributionPointsExtension(cdpUrls),
+        ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
         new x509.AuthorityInfoAccessExtension({
           caIssuers: new x509.GeneralName("url", caIssuerUrl)
         })
@@ -1822,7 +1842,11 @@ export const internalCertificateAuthorityServiceFactory = ({
 
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const basicConstraintsExtension = $createBasicConstraintsExtension({
       basicConstraints,
@@ -1832,7 +1856,7 @@ export const internalCertificateAuthorityServiceFactory = ({
 
     const extensions: x509.Extension[] = [
       basicConstraintsExtension,
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
       new x509.AuthorityInfoAccessExtension({
@@ -2225,7 +2249,11 @@ export const internalCertificateAuthorityServiceFactory = ({
     const caCrl = await certificateAuthorityCrlDAL.findOne({ caSecretId: caSecret.id });
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const basicConstraintsExtension = $createBasicConstraintsExtension({
       basicConstraints,
@@ -2237,7 +2265,7 @@ export const internalCertificateAuthorityServiceFactory = ({
       basicConstraintsExtension,
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       new x509.AuthorityInfoAccessExtension({
         caIssuers: new x509.GeneralName("url", caIssuerUrl)
       }),

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-types.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-types.ts
@@ -50,6 +50,7 @@ export type TCreateCaDTO =
       maxPathLength?: number | null;
       keyAlgorithm: CertKeyAlgorithm;
       crlDistributionPointUrls?: string[];
+      disableManagedCrlDistributionPointUrl?: boolean;
     }
   | ({
       isInternal: false;
@@ -69,6 +70,7 @@ export type TCreateCaDTO =
       maxPathLength?: number | null;
       keyAlgorithm: CertKeyAlgorithm;
       crlDistributionPointUrls?: string[];
+      disableManagedCrlDistributionPointUrl?: boolean;
     } & Omit<TProjectPermission, "projectId">);
 
 export type TGetCaDTO = {
@@ -82,6 +84,7 @@ export type TUpdateCaDTO =
       name?: string;
       status?: CaStatus;
       crlDistributionPointUrls?: string[];
+      disableManagedCrlDistributionPointUrl?: boolean;
     }
   | ({
       isInternal: false;
@@ -89,6 +92,7 @@ export type TUpdateCaDTO =
       name?: string;
       status?: CaStatus;
       crlDistributionPointUrls?: string[];
+      disableManagedCrlDistributionPointUrl?: boolean;
     } & Omit<TProjectPermission, "projectId">);
 
 export type TDeleteCaDTO = {

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -333,7 +333,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-123",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         },
         name: "Test CA",
         status: "ACTIVE",
@@ -396,7 +397,8 @@ describe("CertificateV3Service", () => {
             notAfter: null,
             activeCaCertId: "cert-123",
             caId: "ca-123",
-            crlDistributionPointUrls: []
+            crlDistributionPointUrls: [],
+            disableManagedCrlDistributionPointUrl: false
           }
         }
       };
@@ -490,7 +492,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-123",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         },
         name: "Test CA",
         status: "ACTIVE",
@@ -601,7 +604,8 @@ describe("CertificateV3Service", () => {
             notAfter: null,
             activeCaCertId: "cert-123",
             caId: "ca-123",
-            crlDistributionPointUrls: []
+            crlDistributionPointUrls: [],
+            disableManagedCrlDistributionPointUrl: false
           }
         }
       };
@@ -766,7 +770,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-123",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         },
         name: "Test CA",
         status: "ACTIVE",
@@ -809,7 +814,8 @@ describe("CertificateV3Service", () => {
             notAfter: null,
             activeCaCertId: "cert-123",
             caId: "ca-123",
-            crlDistributionPointUrls: []
+            crlDistributionPointUrls: [],
+            disableManagedCrlDistributionPointUrl: false
           }
         }
       };
@@ -1040,7 +1046,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-1",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         }
       };
 
@@ -1203,7 +1210,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-1",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         }
       };
 
@@ -1366,7 +1374,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-1",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         }
       };
 
@@ -1529,7 +1538,8 @@ describe("CertificateV3Service", () => {
           notAfter: undefined,
           activeCaCertId: "cert-123",
           caId: "ca-1",
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         }
       };
 
@@ -1757,7 +1767,8 @@ describe("CertificateV3Service", () => {
         activeCaCertId: "cert-123",
         dn: "CN=Test CA,O=Test Org,OU=Test OU,C=US",
         serialNumber: "123456789",
-        crlDistributionPointUrls: []
+        crlDistributionPointUrls: [],
+        disableManagedCrlDistributionPointUrl: false
       }
     };
 

--- a/backend/src/services/pki-subscriber/pki-subscriber-service.ts
+++ b/backend/src/services/pki-subscriber/pki-subscriber-service.ts
@@ -527,13 +527,17 @@ export const pkiSubscriberServiceFactory = ({
     const caCrl = await certificateAuthorityCrlDAL.findOne({ caSecretId: caSecret.id });
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const extensions: x509.Extension[] = [
       new x509.BasicConstraintsExtension(false),
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       new x509.AuthorityInfoAccessExtension({
         caIssuers: new x509.GeneralName("url", caIssuerUrl)
       }),

--- a/backend/src/services/pki-templates/pki-templates-service.ts
+++ b/backend/src/services/pki-templates/pki-templates-service.ts
@@ -469,13 +469,17 @@ export const pkiTemplatesServiceFactory = ({
     const caCrl = await certificateAuthorityCrlDAL.findOne({ caSecretId: caSecret.id });
     const managedCdpUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/crl/${caCrl.id}/der`;
     const caIssuerUrl = `${appCfg.SITE_URL}/api/v1/cert-manager/ca/internal/${ca.id}/certificates/${caCert.id}/der`;
-    const cdpUrls = buildCrlDistributionPointUrls(managedCdpUrl, ca.internalCa.crlDistributionPointUrls);
+    const cdpUrls = buildCrlDistributionPointUrls(
+      managedCdpUrl,
+      ca.internalCa.crlDistributionPointUrls,
+      ca.internalCa.disableManagedCrlDistributionPointUrl
+    );
 
     const extensions: x509.Extension[] = [
       new x509.BasicConstraintsExtension(false),
       await x509.AuthorityKeyIdentifierExtension.create(caCertObj, false),
       await x509.SubjectKeyIdentifierExtension.create(csrObj.publicKey),
-      new x509.CRLDistributionPointsExtension(cdpUrls),
+      ...(cdpUrls.length > 0 ? [new x509.CRLDistributionPointsExtension(cdpUrls)] : []),
       new x509.AuthorityInfoAccessExtension({
         caIssuers: new x509.GeneralName("url", caIssuerUrl)
       }),

--- a/docs/documentation/platform/pki/ca/crl-distribution.mdx
+++ b/docs/documentation/platform/pki/ca/crl-distribution.mdx
@@ -12,7 +12,7 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
 
 ## How It Works
 
-- The **Infisical-managed URL** is included as the primary CDP by default. It can be disabled per CA if you only want custom mirror URLs embedded in certificates.
+- The **Infisical-managed URL** is included as the primary CDP by default. It can be disabled per CA.
 - Up to **4 mirror URLs** can be configured per CA.
 - URLs must use `http://` or `https://`.
 - Changes apply only to certificates issued **after** the update — existing certificates are not affected.
@@ -38,7 +38,7 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
         Add one URL per row, in order of preference (clients try them in the listed order).
       </Step>
       <Step title="Disable managed CRL URL (optional)">
-        Toggle **Disable managed CRL URL** if you do not want the Infisical-managed CRL endpoint embedded in issued certificates. When enabled, only your custom mirror URLs will appear in the CDP extension. This is useful when the Infisical instance is not reachable by certificate consumers.
+        Toggle **Disable managed CRL URL** to exclude the Infisical-managed CRL endpoint from issued certificates. This is useful when the Infisical instance is not reachable by certificate consumers.
       </Step>
     </Steps>
   </Tab>

--- a/docs/documentation/platform/pki/ca/crl-distribution.mdx
+++ b/docs/documentation/platform/pki/ca/crl-distribution.mdx
@@ -12,7 +12,7 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
 
 ## How It Works
 
-- The **Infisical-managed URL** is always included as the primary CDP and cannot be removed.
+- The **Infisical-managed URL** is included as the primary CDP by default. It can be disabled per CA if you only want custom mirror URLs embedded in certificates.
 - Up to **4 mirror URLs** can be configured per CA.
 - URLs must use `http://` or `https://`.
 - Changes apply only to certificates issued **after** the update — existing certificates are not affected.
@@ -37,10 +37,13 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
       <Step title="Add mirror URLs">
         Add one URL per row, in order of preference (clients try them in the listed order).
       </Step>
+      <Step title="Disable managed CRL URL (optional)">
+        Toggle **Disable managed CRL URL** if you do not want the Infisical-managed CRL endpoint embedded in issued certificates. When enabled, only your custom mirror URLs will appear in the CDP extension. This is useful when the Infisical instance is not reachable by certificate consumers.
+      </Step>
     </Steps>
   </Tab>
   <Tab title="API">
-    Pass the `crlDistributionPointUrls` array under `configuration` when creating or updating an internal CA.
+    Pass the `crlDistributionPointUrls` array and optionally `disableManagedCrlDistributionPointUrl` under `configuration` when creating or updating an internal CA.
 
     ### Create CA with CRL mirrors
 
@@ -57,7 +60,8 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
               "crlDistributionPointUrls": [
                   "https://crl.example.com/internal-ca.crl",
                   "https://backup-crl.example.com/internal-ca.crl"
-              ]
+              ],
+              "disableManagedCrlDistributionPointUrl": false
           }
       }'
     ```
@@ -72,10 +76,13 @@ Every certificate issued by an internal CA embeds a CRL Distribution Point (CDP)
           "configuration": {
               "crlDistributionPointUrls": [
                   "https://crl.example.com/internal-ca.crl"
-              ]
+              ],
+              "disableManagedCrlDistributionPointUrl": true
           }
       }'
     ```
+
+    Setting `disableManagedCrlDistributionPointUrl` to `true` removes the Infisical-managed CRL endpoint from the CDP extension of newly issued certificates. The managed CRL endpoint itself remains available — this only controls whether its URL is advertised in certificates.
   </Tab>
 </Tabs>
 

--- a/frontend/src/hooks/api/ca/types.ts
+++ b/frontend/src/hooks/api/ca/types.ts
@@ -116,6 +116,7 @@ export type TInternalCertificateAuthority = {
     serialNumber?: string;
     activeCaCertId?: string;
     crlDistributionPointUrls?: string[];
+    disableManagedCrlDistributionPointUrl?: boolean;
   };
 };
 

--- a/frontend/src/pages/cert-manager/CertAuthDetailsByIDPage/components/CaDistributionPointsSection.tsx
+++ b/frontend/src/pages/cert-manager/CertAuthDetailsByIDPage/components/CaDistributionPointsSection.tsx
@@ -16,6 +16,7 @@ import {
   Modal,
   ModalClose,
   ModalContent,
+  Switch,
   Tooltip
 } from "@app/components/v2";
 import {
@@ -75,7 +76,8 @@ const editSchema = z.object({
         }
         seen.add(normalized);
       });
-    })
+    }),
+  disableManagedCrlDistributionPointUrl: z.boolean().default(false)
 });
 
 type EditFormData = z.infer<typeof editSchema>;
@@ -98,7 +100,9 @@ export const CaDistributionPointsSection = ({ caId }: Props) => {
     values: {
       crlDistributionPointUrls: (ca?.configuration.crlDistributionPointUrls ?? []).map((value) => ({
         value
-      }))
+      })),
+      disableManagedCrlDistributionPointUrl:
+        ca?.configuration.disableManagedCrlDistributionPointUrl ?? false
     }
   });
 
@@ -108,13 +112,17 @@ export const CaDistributionPointsSection = ({ caId }: Props) => {
 
   const mirrorUrls = ca.configuration.crlDistributionPointUrls ?? [];
 
-  const onEditSubmit = async ({ crlDistributionPointUrls }: EditFormData) => {
+  const onEditSubmit = async ({
+    crlDistributionPointUrls,
+    disableManagedCrlDistributionPointUrl
+  }: EditFormData) => {
     try {
       await updateCa({
         id: ca.id,
         type: CaType.INTERNAL,
         configuration: {
-          crlDistributionPointUrls: crlDistributionPointUrls.map(({ value }) => value)
+          crlDistributionPointUrls: crlDistributionPointUrls.map(({ value }) => value),
+          disableManagedCrlDistributionPointUrl
         } as TInternalCertificateAuthority["configuration"]
       });
       createNotification({
@@ -157,6 +165,12 @@ export const CaDistributionPointsSection = ({ caId }: Props) => {
         <CardContent>
           <DetailGroup>
             <Detail>
+              <DetailLabel>Managed CRL URL</DetailLabel>
+              <DetailValue>
+                {ca.configuration.disableManagedCrlDistributionPointUrl ? "Disabled" : "Enabled"}
+              </DetailValue>
+            </Detail>
+            <Detail>
               <DetailLabel>Mirror URLs</DetailLabel>
               <DetailValue>
                 {mirrorUrls.length === 0 ? (
@@ -185,6 +199,23 @@ export const CaDistributionPointsSection = ({ caId }: Props) => {
       >
         <ModalContent title="Edit CRL Distribution Points">
           <form onSubmit={handleSubmit(onEditSubmit)}>
+            <Controller
+              control={control}
+              name="disableManagedCrlDistributionPointUrl"
+              render={({ field: { value, onChange } }) => (
+                <FormControl>
+                  <Switch
+                    id="disableManagedCrlDistributionPointUrl"
+                    className="bg-mineshaft-400/80 shadow-inner data-[state=checked]:bg-green/80"
+                    thumbClassName="bg-mineshaft-800"
+                    isChecked={value}
+                    onCheckedChange={onChange}
+                  >
+                    Disable managed CRL URL
+                  </Switch>
+                </FormControl>
+              )}
+            />
             <FormControl
               label="Mirror URLs"
               helperText={`Up to ${MAX_INTERNAL_CA_DISTRIBUTION_POINT_URLS} URLs.`}

--- a/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
@@ -148,7 +148,8 @@ export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
         notAfter: getDateTenYearsFromToday(),
         maxPathLength: "-1",
         keyAlgorithm: CertKeyAlgorithm.RSA_2048,
-        crlDistributionPointUrls: []
+        crlDistributionPointUrls: [],
+        disableManagedCrlDistributionPointUrl: false
       }
     }
   });
@@ -187,7 +188,9 @@ export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
             : CertKeyAlgorithm.RSA_2048,
           crlDistributionPointUrls: (ca.configuration.crlDistributionPointUrls ?? []).map(
             (value) => ({ value })
-          )
+          ),
+          disableManagedCrlDistributionPointUrl:
+            ca.configuration.disableManagedCrlDistributionPointUrl ?? false
         }
       });
     } else {
@@ -206,7 +209,8 @@ export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
           notAfter: getDateTenYearsFromToday(),
           maxPathLength: "-1",
           keyAlgorithm: CertKeyAlgorithm.RSA_2048,
-          crlDistributionPointUrls: []
+          crlDistributionPointUrls: [],
+          disableManagedCrlDistributionPointUrl: false
         }
       });
     }

--- a/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
@@ -16,6 +16,7 @@ import {
   ModalContent,
   Select,
   SelectItem,
+  Switch,
   Tooltip
   // DatePicker
 } from "@app/components/v2";
@@ -95,7 +96,8 @@ const schema = z
         notAfter: z.string().trim().refine(isValidDate, { message: "Invalid date format" }),
         maxPathLength: z.string(),
         keyAlgorithm: z.nativeEnum(CertKeyAlgorithm),
-        crlDistributionPointUrls: distributionPointUrlsSchema.default([])
+        crlDistributionPointUrls: distributionPointUrlsSchema.default([]),
+        disableManagedCrlDistributionPointUrl: z.boolean().default(false)
       })
       .required()
   })
@@ -481,57 +483,76 @@ export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
             )}
           />
           {!ca && (
-            <FormControl
-              label="CRL Distribution Points"
-              helperText={`Backup CRL URLs embedded in issued certificates. Up to ${MAX_INTERNAL_CA_DISTRIBUTION_POINT_URLS}.`}
-            >
-              <div className="flex flex-col gap-2">
-                {crlUrlsFieldArray.fields.map((field, index) => (
-                  <Controller
-                    key={field.id}
-                    control={control}
-                    name={`configuration.crlDistributionPointUrls.${index}.value`}
-                    render={({ field: inputField, fieldState: { error } }) => (
-                      <div className="flex items-start gap-2">
-                        <FormControl
-                          isError={Boolean(error)}
-                          errorText={error?.message}
-                          className="mb-0 flex-1"
-                        >
-                          <Input
-                            {...inputField}
-                            placeholder="https://crl.example.com/internal-ca.crl"
-                          />
-                        </FormControl>
-                        <Tooltip content="Remove URL" position="right">
-                          <IconButton
-                            ariaLabel="Remove URL"
-                            colorSchema="danger"
-                            variant="plain"
-                            size="sm"
-                            className="mt-1.5"
-                            onClick={() => crlUrlsFieldArray.remove(index)}
+            <>
+              <Controller
+                control={control}
+                name="configuration.disableManagedCrlDistributionPointUrl"
+                render={({ field: { value, onChange } }) => (
+                  <FormControl>
+                    <Switch
+                      id="disableManagedCrlDistributionPointUrl"
+                      className="bg-mineshaft-400/80 shadow-inner data-[state=checked]:bg-green/80"
+                      thumbClassName="bg-mineshaft-800"
+                      isChecked={value}
+                      onCheckedChange={onChange}
+                    >
+                      Disable managed CRL URL
+                    </Switch>
+                  </FormControl>
+                )}
+              />
+              <FormControl
+                label="CRL Distribution Points"
+                helperText={`Backup CRL URLs embedded in issued certificates. Up to ${MAX_INTERNAL_CA_DISTRIBUTION_POINT_URLS}.`}
+              >
+                <div className="flex flex-col gap-2">
+                  {crlUrlsFieldArray.fields.map((field, index) => (
+                    <Controller
+                      key={field.id}
+                      control={control}
+                      name={`configuration.crlDistributionPointUrls.${index}.value`}
+                      render={({ field: inputField, fieldState: { error } }) => (
+                        <div className="flex items-start gap-2">
+                          <FormControl
+                            isError={Boolean(error)}
+                            errorText={error?.message}
+                            className="mb-0 flex-1"
                           >
-                            <FontAwesomeIcon icon={faTrash} />
-                          </IconButton>
-                        </Tooltip>
-                      </div>
-                    )}
-                  />
-                ))}
-                <Button
-                  leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                  size="xs"
-                  variant="outline_bg"
-                  isDisabled={
-                    crlUrlsFieldArray.fields.length >= MAX_INTERNAL_CA_DISTRIBUTION_POINT_URLS
-                  }
-                  onClick={() => crlUrlsFieldArray.append({ value: "" })}
-                >
-                  Add URL
-                </Button>
-              </div>
-            </FormControl>
+                            <Input
+                              {...inputField}
+                              placeholder="https://crl.example.com/internal-ca.crl"
+                            />
+                          </FormControl>
+                          <Tooltip content="Remove URL" position="right">
+                            <IconButton
+                              ariaLabel="Remove URL"
+                              colorSchema="danger"
+                              variant="plain"
+                              size="sm"
+                              className="mt-1.5"
+                              onClick={() => crlUrlsFieldArray.remove(index)}
+                            >
+                              <FontAwesomeIcon icon={faTrash} />
+                            </IconButton>
+                          </Tooltip>
+                        </div>
+                      )}
+                    />
+                  ))}
+                  <Button
+                    leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                    size="xs"
+                    variant="outline_bg"
+                    isDisabled={
+                      crlUrlsFieldArray.fields.length >= MAX_INTERNAL_CA_DISTRIBUTION_POINT_URLS
+                    }
+                    onClick={() => crlUrlsFieldArray.append({ value: "" })}
+                  >
+                    Add URL
+                  </Button>
+                </div>
+              </FormControl>
+            </>
           )}
           <div className="flex items-center">
             <Button


### PR DESCRIPTION
## Context

Add a per-CA toggle (disableManagedCrlDistributionPointUrl) to exclude the Infisical-managed CRL endpoint from the CDP extension of issued certificates. When enabled, only user-configured mirror URLs are embedded. The managed CRL endpoint itself remains functional — the toggle only controls whether its URL is advertised in new certificates.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)