### PR TITLE
feat(pki): move PQC algorithms to enterprise plan

### DIFF
--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -101,6 +101,7 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   pkiEst: false,
   pkiAcme: true,
   pkiScep: false,
+  pkiPqc: false,
   enforceMfa: false,
   projectTemplates: false,
   kmip: false,

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -80,6 +80,7 @@ export type TFeatureSet = {
   pkiEst: boolean;
   pkiAcme: true;
   pkiScep: false;
+  pkiPqc: false;
   enforceMfa: false;
   projectTemplates: false;
   kmip: false;

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2625,6 +2625,7 @@ export const registerRoutes = async (
     internalCertificateAuthorityDAL,
     kmsService,
     permissionService,
+    licenseService,
     caSigningConfigDAL
   });
 
@@ -2709,7 +2710,8 @@ export const registerRoutes = async (
     certificateAuthorityService,
     resourceMetadataDAL,
     pkiAlertV2Queue,
-    pkiApplicationDAL
+    pkiApplicationDAL,
+    licenseService
   });
 
   const digicertCaFns = DigiCertCertificateAuthorityFns({
@@ -2824,7 +2826,8 @@ export const registerRoutes = async (
     approvalPolicyService,
     resourceMetadataDAL,
     pkiAlertV2Queue,
-    pkiApplicationProfileDAL
+    pkiApplicationProfileDAL,
+    licenseService
   });
 
   const certificateV3Queue = certificateV3QueueServiceFactory({

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -1788,7 +1788,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     const effectiveKeyAlgorithm =
       (keyAlgorithm as CertKeyAlgorithm) || (ca.internalCa.keyAlgorithm as CertKeyAlgorithm);
 
-    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(effectiveKeyAlgorithm, ca.projectId);
 
     const keyGenAlg = keyAlgorithmToAlgCfg(effectiveKeyAlgorithm);
     const leafCryptoEngine = isPqcAlgorithm(effectiveKeyAlgorithm) ? getPqcCrypto() : crypto.nativeCrypto;

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -6,6 +6,7 @@ import slugify from "@sindresorhus/slugify";
 import { Knex } from "knex";
 
 import { ActionProjectType, TableName, TCertificateAuthorities, TCertificateTemplates } from "@app/db/schemas";
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
   ProjectPermissionCertificateActions,
@@ -125,6 +126,7 @@ type TInternalCertificateAuthorityServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findOne" | "updateById" | "findById" | "transaction" | "findProjectBySlug">;
   kmsService: Pick<TKmsServiceFactory, "generateKmsKey" | "encryptWithKmsKey" | "decryptWithKmsKey">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   caSigningConfigDAL: Pick<TCaSigningConfigDALFactory, "findByCaId" | "create" | "deleteById" | "transaction">;
 };
 
@@ -145,8 +147,21 @@ export const internalCertificateAuthorityServiceFactory = ({
   projectDAL,
   kmsService,
   permissionService,
+  licenseService,
   caSigningConfigDAL
 }: TInternalCertificateAuthorityServiceFactoryDep) => {
+  const validatePqcLicense = async (keyAlgorithm: string, projectId: string) => {
+    if (!isPqcAlgorithm(keyAlgorithm)) return;
+    const project = await projectDAL.findById(projectId);
+    if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
+    const plan = await licenseService.getPlan(project.orgId);
+    if (!plan.pkiPqc) {
+      throw new BadRequestError({
+        message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
+      });
+    }
+  };
+
   // Root CAs: only keyCertSign + cRLSign (they don't perform end-entity operations)
   const ROOT_CA_KEY_USAGES = x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign;
   // PQC root CAs also need digitalSignature per FIPS 204/205
@@ -305,6 +320,8 @@ export const internalCertificateAuthorityServiceFactory = ({
         subject(ProjectPermissionSub.CertificateAuthorities, { name: commonName })
       );
     }
+
+    await validatePqcLicense(keyAlgorithm, projectId);
 
     if (keyAlgorithm.startsWith("SLH-DSA")) {
       throw new BadRequestError({
@@ -606,6 +623,8 @@ export const internalCertificateAuthorityServiceFactory = ({
     if (ca.internalCa.type === InternalCaType.ROOT)
       throw new BadRequestError({ message: "Root CA cannot generate CSR" });
 
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+
     const { caPrivateKey, caPublicKey } = await getCaCredentials({
       caId,
       certificateAuthorityDAL,
@@ -684,6 +703,8 @@ export const internalCertificateAuthorityServiceFactory = ({
     }
 
     if (ca.status === CaStatus.DISABLED) throw new BadRequestError({ message: "CA is disabled" });
+
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     // get latest CA certificate
     const caCert = await certificateAuthorityCertDAL.findById(ca.internalCa.activeCaCertId);
@@ -1164,6 +1185,8 @@ export const internalCertificateAuthorityServiceFactory = ({
     if (!ca.internalCa.activeCaCertId)
       throw new BadRequestError({ message: "CA does not have a certificate installed" });
 
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+
     const caCert = await certificateAuthorityCertDAL.findById(ca.internalCa.activeCaCertId);
 
     if (ca.internalCa.notAfter && new Date() > new Date(ca.internalCa.notAfter)) {
@@ -1488,6 +1511,9 @@ export const internalCertificateAuthorityServiceFactory = ({
       subject(ProjectPermissionSub.CertificateAuthorities, { name: parentCa.name })
     );
 
+    await validatePqcLicense(intermediateCa.internalCa.keyAlgorithm, intermediateCa.projectId);
+    await validatePqcLicense(parentCa.internalCa.keyAlgorithm, parentCa.projectId);
+
     const caSecret = await certificateAuthoritySecretDAL.findOne(
       {
         caId: intermediateCa.id
@@ -1769,6 +1795,10 @@ export const internalCertificateAuthorityServiceFactory = ({
 
     const effectiveKeyAlgorithm =
       (keyAlgorithm as CertKeyAlgorithm) || (ca.internalCa.keyAlgorithm as CertKeyAlgorithm);
+
+    await validatePqcLicense(effectiveKeyAlgorithm, ca.projectId);
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+
     const keyGenAlg = keyAlgorithmToAlgCfg(effectiveKeyAlgorithm);
     const leafCryptoEngine = isPqcAlgorithm(effectiveKeyAlgorithm) ? getPqcCrypto() : crypto.nativeCrypto;
     const leafKeys = await leafCryptoEngine.subtle.generateKey(keyGenAlg as RsaHashedKeyGenParams, true, [
@@ -2197,6 +2227,8 @@ export const internalCertificateAuthorityServiceFactory = ({
       throw new BadRequestError({ message: "notAfter date is after CA certificate's notAfter date" });
     }
 
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+
     if (signatureAlgorithm && ca.internalCa.keyAlgorithm) {
       $checkSignature(ca.internalCa.keyAlgorithm, $getSignatureKeyFamily(signatureAlgorithm), signatureAlgorithm);
     }
@@ -2573,6 +2605,8 @@ export const internalCertificateAuthorityServiceFactory = ({
       ProjectPermissionCertificateAuthorityActions.IssueCACertificate,
       subject(ProjectPermissionSub.CertificateAuthorities, { name: ca.name })
     );
+
+    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const notBeforeDate = new Date(notBefore);
     const notAfterDate = new Date(notAfter);

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -51,6 +51,7 @@ import {
   TAltNameMapping
 } from "../../certificate/certificate-types";
 import { DEFAULT_CRL_VALIDITY_DAYS } from "../../certificate-common/certificate-constants";
+import { validatePqcLicense } from "../../certificate-common/certificate-utils";
 import { TCertificateTemplateDALFactory } from "../../certificate-template/certificate-template-dal";
 import { validateCertificateDetailsAgainstTemplate } from "../../certificate-template/certificate-template-fns";
 import { TCaSigningConfigDALFactory } from "../ca-signing-config/ca-signing-config-dal";
@@ -150,17 +151,8 @@ export const internalCertificateAuthorityServiceFactory = ({
   licenseService,
   caSigningConfigDAL
 }: TInternalCertificateAuthorityServiceFactoryDep) => {
-  const validatePqcLicense = async (keyAlgorithm: string, projectId: string) => {
-    if (!isPqcAlgorithm(keyAlgorithm)) return;
-    const project = await projectDAL.findById(projectId);
-    if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
-    const plan = await licenseService.getPlan(project.orgId);
-    if (!plan.pkiPqc) {
-      throw new BadRequestError({
-        message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
-      });
-    }
-  };
+  const $validatePqcLicense = (keyAlgorithm: string, projectId: string) =>
+    validatePqcLicense({ keyAlgorithm, projectId, projectDAL, licenseService });
 
   // Root CAs: only keyCertSign + cRLSign (they don't perform end-entity operations)
   const ROOT_CA_KEY_USAGES = x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign;
@@ -327,7 +319,7 @@ export const internalCertificateAuthorityServiceFactory = ({
       });
     }
 
-    await validatePqcLicense(keyAlgorithm, projectId);
+    await $validatePqcLicense(keyAlgorithm, projectId);
 
     const dn = createDistinguishedName({
       commonName,
@@ -623,7 +615,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     if (ca.internalCa.type === InternalCaType.ROOT)
       throw new BadRequestError({ message: "Root CA cannot generate CSR" });
 
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const { caPrivateKey, caPublicKey } = await getCaCredentials({
       caId,
@@ -704,7 +696,7 @@ export const internalCertificateAuthorityServiceFactory = ({
 
     if (ca.status === CaStatus.DISABLED) throw new BadRequestError({ message: "CA is disabled" });
 
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     // get latest CA certificate
     const caCert = await certificateAuthorityCertDAL.findById(ca.internalCa.activeCaCertId);
@@ -1185,7 +1177,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     if (!ca.internalCa.activeCaCertId)
       throw new BadRequestError({ message: "CA does not have a certificate installed" });
 
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const caCert = await certificateAuthorityCertDAL.findById(ca.internalCa.activeCaCertId);
 
@@ -1511,8 +1503,8 @@ export const internalCertificateAuthorityServiceFactory = ({
       subject(ProjectPermissionSub.CertificateAuthorities, { name: parentCa.name })
     );
 
-    await validatePqcLicense(intermediateCa.internalCa.keyAlgorithm, intermediateCa.projectId);
-    await validatePqcLicense(parentCa.internalCa.keyAlgorithm, parentCa.projectId);
+    await $validatePqcLicense(intermediateCa.internalCa.keyAlgorithm, intermediateCa.projectId);
+    await $validatePqcLicense(parentCa.internalCa.keyAlgorithm, parentCa.projectId);
 
     const caSecret = await certificateAuthoritySecretDAL.findOne(
       {
@@ -1796,8 +1788,8 @@ export const internalCertificateAuthorityServiceFactory = ({
     const effectiveKeyAlgorithm =
       (keyAlgorithm as CertKeyAlgorithm) || (ca.internalCa.keyAlgorithm as CertKeyAlgorithm);
 
-    await validatePqcLicense(effectiveKeyAlgorithm, ca.projectId);
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(effectiveKeyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const keyGenAlg = keyAlgorithmToAlgCfg(effectiveKeyAlgorithm);
     const leafCryptoEngine = isPqcAlgorithm(effectiveKeyAlgorithm) ? getPqcCrypto() : crypto.nativeCrypto;
@@ -2227,7 +2219,7 @@ export const internalCertificateAuthorityServiceFactory = ({
       throw new BadRequestError({ message: "notAfter date is after CA certificate's notAfter date" });
     }
 
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     if (signatureAlgorithm && ca.internalCa.keyAlgorithm) {
       $checkSignature(ca.internalCa.keyAlgorithm, $getSignatureKeyFamily(signatureAlgorithm), signatureAlgorithm);
@@ -2606,7 +2598,7 @@ export const internalCertificateAuthorityServiceFactory = ({
       subject(ProjectPermissionSub.CertificateAuthorities, { name: ca.name })
     );
 
-    await validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
+    await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const notBeforeDate = new Date(notBefore);
     const notAfterDate = new Date(notAfter);

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -321,13 +321,13 @@ export const internalCertificateAuthorityServiceFactory = ({
       );
     }
 
-    await validatePqcLicense(keyAlgorithm, projectId);
-
     if (keyAlgorithm.startsWith("SLH-DSA")) {
       throw new BadRequestError({
         message: "SLH-DSA algorithms are not currently supported for CA creation. Use ML-DSA instead."
       });
     }
+
+    await validatePqcLicense(keyAlgorithm, projectId);
 
     const dn = createDistinguishedName({
       commonName,

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -1788,7 +1788,6 @@ export const internalCertificateAuthorityServiceFactory = ({
     const effectiveKeyAlgorithm =
       (keyAlgorithm as CertKeyAlgorithm) || (ca.internalCa.keyAlgorithm as CertKeyAlgorithm);
 
-    await $validatePqcLicense(effectiveKeyAlgorithm, ca.projectId);
     await $validatePqcLicense(ca.internalCa.keyAlgorithm, ca.projectId);
 
     const keyGenAlg = keyAlgorithmToAlgCfg(effectiveKeyAlgorithm);

--- a/backend/src/services/certificate-common/certificate-utils.ts
+++ b/backend/src/services/certificate-common/certificate-utils.ts
@@ -1,5 +1,10 @@
 import RE2 from "re2";
 
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { isPqcAlgorithm } from "@app/lib/crypto/pqc";
+import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
+
 import { CertExtendedKeyUsage, CertKeyUsage } from "../certificate/certificate-types";
 import {
   CertExtendedKeyUsageType,
@@ -9,6 +14,29 @@ import {
   mapLegacyExtendedKeyUsageToStandard,
   mapLegacyKeyUsageToStandard
 } from "./certificate-constants";
+
+export const validatePqcLicense = async ({
+  keyAlgorithm,
+  projectId,
+  projectDAL,
+  licenseService
+}: {
+  keyAlgorithm: string;
+  projectId: string;
+  projectDAL: Pick<TProjectDALFactory, "findById">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+}) => {
+  if (!isPqcAlgorithm(keyAlgorithm)) return;
+  const project = await projectDAL.findById(projectId);
+  if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
+  const plan = await licenseService.getPlan(project.orgId);
+  if (!plan.pkiPqc) {
+    throw new BadRequestError({
+      message:
+        "Your license does not include PQC algorithms. Please upgrade to the Enterprise plan to use a PQC algorithm."
+    });
+  }
+};
 
 interface CertificateRequestInput {
   keyUsages?: string[];

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -275,7 +275,10 @@ describe("CertificateV3Service", () => {
       },
       pkiApplicationProfileDAL: {
         findAllByProfileId: vi.fn().mockResolvedValue([])
-      } as never
+      } as never,
+      licenseService: {
+        getPlan: vi.fn().mockResolvedValue({ pkiPqc: true })
+      }
     });
   });
 

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import RE2 from "re2";
 
 import { ActionProjectType, ResourceType, TCertificates } from "@app/db/schemas";
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
   ProjectPermissionCertificateActions,
@@ -15,6 +16,7 @@ import {
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
 import { TPkiAcmeAccountDALFactory } from "@app/ee/services/pki-acme/pki-acme-account-dal";
+import { isPqcAlgorithm } from "@app/lib/crypto/pqc";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
@@ -161,6 +163,7 @@ type TCertificateV3ServiceFactoryDep = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete" | "find">;
   pkiAlertV2Queue?: Pick<TPkiAlertV2QueueServiceFactory, "queueCertificateEvent">;
   pkiApplicationProfileDAL: Pick<TPkiApplicationProfileDALFactory, "findAllByProfileId">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
 };
 
 export type TCertificateV3ServiceFactory = ReturnType<typeof certificateV3ServiceFactory>;
@@ -679,7 +682,8 @@ export const certificateV3ServiceFactory = ({
   approvalPolicyService,
   resourceMetadataDAL,
   pkiAlertV2Queue,
-  pkiApplicationProfileDAL
+  pkiApplicationProfileDAL,
+  licenseService
 }: TCertificateV3ServiceFactoryDep) => {
   const $resolveApplicationIdForProfile = async (
     profile: {
@@ -841,6 +845,21 @@ export const certificateV3ServiceFactory = ({
       { actor, actorId, actorAuthMethod, actorOrgId },
       EnrollmentType.API
     );
+
+    const hasPqcAlgorithm =
+      (certificateRequest.keyAlgorithm && isPqcAlgorithm(certificateRequest.keyAlgorithm)) ||
+      (certificateRequest.signatureAlgorithm && isPqcAlgorithm(certificateRequest.signatureAlgorithm));
+
+    if (hasPqcAlgorithm) {
+      const project = await projectDAL.findById(profile.projectId);
+      if (!project) throw new NotFoundError({ message: `Project with ID '${profile.projectId}' not found` });
+      const plan = await licenseService.getPlan(project.orgId);
+      if (!plan.pkiPqc) {
+        throw new BadRequestError({
+          message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
+        });
+      }
+    }
 
     const approvalFactory = APPROVAL_POLICY_FACTORY_MAP[ApprovalPolicyType.CertRequest](ApprovalPolicyType.CertRequest);
     const matchedApprovalPolicy = (await approvalFactory.matchPolicy(

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -16,7 +16,6 @@ import {
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
 import { TPkiAcmeAccountDALFactory } from "@app/ee/services/pki-acme/pki-acme-account-dal";
-import { isPqcAlgorithm } from "@app/lib/crypto/pqc";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
@@ -92,7 +91,8 @@ import {
   convertKeyUsageArrayToLegacy,
   mapEnumsForValidation,
   normalizeDateForApi,
-  removeRootCaFromChain
+  removeRootCaFromChain,
+  validatePqcLicense
 } from "../certificate-common/certificate-utils";
 import { TCertificateRequest } from "../certificate-policy/certificate-policy-types";
 import { TCertificateRequestDALFactory } from "../certificate-request/certificate-request-dal";
@@ -846,19 +846,21 @@ export const certificateV3ServiceFactory = ({
       EnrollmentType.API
     );
 
-    const hasPqcAlgorithm =
-      (certificateRequest.keyAlgorithm && isPqcAlgorithm(certificateRequest.keyAlgorithm)) ||
-      (certificateRequest.signatureAlgorithm && isPqcAlgorithm(certificateRequest.signatureAlgorithm));
-
-    if (hasPqcAlgorithm) {
-      const project = await projectDAL.findById(profile.projectId);
-      if (!project) throw new NotFoundError({ message: `Project with ID '${profile.projectId}' not found` });
-      const plan = await licenseService.getPlan(project.orgId);
-      if (!plan.pkiPqc) {
-        throw new BadRequestError({
-          message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
-        });
-      }
+    if (certificateRequest.keyAlgorithm) {
+      await validatePqcLicense({
+        keyAlgorithm: certificateRequest.keyAlgorithm,
+        projectId: profile.projectId,
+        projectDAL,
+        licenseService
+      });
+    }
+    if (certificateRequest.signatureAlgorithm) {
+      await validatePqcLicense({
+        keyAlgorithm: certificateRequest.signatureAlgorithm,
+        projectId: profile.projectId,
+        projectDAL,
+        licenseService
+      });
     }
 
     const approvalFactory = APPROVAL_POLICY_FACTORY_MAP[ApprovalPolicyType.CertRequest](ApprovalPolicyType.CertRequest);

--- a/backend/src/services/certificate/certificate-service.ts
+++ b/backend/src/services/certificate/certificate-service.ts
@@ -15,7 +15,6 @@ import {
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
 import { crypto } from "@app/lib/crypto/cryptography";
-import { isPqcAlgorithm } from "@app/lib/crypto/pqc";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
@@ -41,6 +40,7 @@ import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
 
 import { expandInternalCa, getCaCertChain, rebuildCaCrl } from "../certificate-authority/certificate-authority-fns";
+import { validatePqcLicense } from "../certificate-common/certificate-utils";
 import {
   extractCertificateFields,
   generatePkcs12FromCertificate,
@@ -481,15 +481,13 @@ export const certificateServiceFactory = ({
 
     if (cert.status === CertStatus.REVOKED) throw new Error("Certificate already revoked");
 
-    if (ca.internalCa && isPqcAlgorithm(ca.internalCa.keyAlgorithm)) {
-      const project = await projectDAL.findById(ca.projectId);
-      if (!project) throw new NotFoundError({ message: `Project with ID '${ca.projectId}' not found` });
-      const plan = await licenseService.getPlan(project.orgId);
-      if (!plan.pkiPqc) {
-        throw new BadRequestError({
-          message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
-        });
-      }
+    if (ca.internalCa) {
+      await validatePqcLicense({
+        keyAlgorithm: ca.internalCa.keyAlgorithm,
+        projectId: ca.projectId,
+        projectDAL,
+        licenseService
+      });
     }
 
     // Call the upstream CA first so we don't end up with a cert that's revoked locally but still

--- a/backend/src/services/certificate/certificate-service.ts
+++ b/backend/src/services/certificate/certificate-service.ts
@@ -4,6 +4,7 @@ import * as x509 from "@peculiar/x509";
 
 import { ActionProjectType, ProjectMembershipRole, ResourceType } from "@app/db/schemas";
 import { TCertificateAuthorityCrlDALFactory } from "@app/ee/services/certificate-authority-crl/certificate-authority-crl-dal";
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
   ProjectPermissionCertificateActions,
@@ -14,6 +15,7 @@ import {
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
 import { crypto } from "@app/lib/crypto/cryptography";
+import { isPqcAlgorithm } from "@app/lib/crypto/pqc";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
@@ -98,6 +100,7 @@ type TCertificateServiceFactoryDep = {
   certificateAuthorityService: Pick<TCertificateAuthorityServiceFactory, "revokeCertificate">;
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "find">;
   pkiAlertV2Queue?: Pick<TPkiAlertV2QueueServiceFactory, "queueCertificateEvent">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
 };
 
 export type TCertificateServiceFactory = ReturnType<typeof certificateServiceFactory>;
@@ -121,7 +124,8 @@ export const certificateServiceFactory = ({
   certificateAuthorityService,
   resourceMetadataDAL,
   pkiAlertV2Queue,
-  pkiApplicationDAL
+  pkiApplicationDAL,
+  licenseService
 }: TCertificateServiceFactoryDep) => {
   const $canActOnCertViaApplication = async (
     cert: { applicationId?: string | null; projectId: string },
@@ -476,6 +480,17 @@ export const certificateServiceFactory = ({
     }
 
     if (cert.status === CertStatus.REVOKED) throw new Error("Certificate already revoked");
+
+    if (ca.internalCa && isPqcAlgorithm(ca.internalCa.keyAlgorithm)) {
+      const project = await projectDAL.findById(ca.projectId);
+      if (!project) throw new NotFoundError({ message: `Project with ID '${ca.projectId}' not found` });
+      const plan = await licenseService.getPlan(project.orgId);
+      if (!plan.pkiPqc) {
+        throw new BadRequestError({
+          message: "Failed to use PQC algorithm due to plan restriction. Upgrade to the Enterprise plan."
+        });
+      }
+    }
 
     // Call the upstream CA first so we don't end up with a cert that's revoked locally but still
     // active at the issuer (e.g., when the upstream rejects the chosen revocation reason).

--- a/frontend/src/hooks/api/subscriptions/types.ts
+++ b/frontend/src/hooks/api/subscriptions/types.ts
@@ -62,6 +62,7 @@ export type SubscriptionPlan = {
   pkiEst: boolean;
   pkiAcme: boolean;
   pkiLegacyTemplates: boolean;
+  pkiPqc: boolean;
   enforceMfa: boolean;
   enforceGoogleSSO: boolean;
   projectTemplates: boolean;

--- a/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/CaModal.tsx
@@ -19,7 +19,8 @@ import {
   Tooltip
   // DatePicker
 } from "@app/components/v2";
-import { useProject } from "@app/context";
+import { Badge } from "@app/components/v3";
+import { useProject, useSubscription } from "@app/context";
 import {
   CaStatus,
   CaType,
@@ -30,7 +31,7 @@ import {
   useGetCa,
   useUpdateCa
 } from "@app/hooks/api/ca";
-import { certKeyAlgorithms } from "@app/hooks/api/certificates/constants";
+import { certKeyAlgorithms, isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 import { CertKeyAlgorithm } from "@app/hooks/api/certificates/enums";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { slugSchema } from "@app/lib/schemas";
@@ -115,6 +116,7 @@ const caTypes = [
 
 export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { currentProject } = useProject();
+  const { subscription } = useSubscription();
   const { data: ca } = useGetCa({
     caId: (popUp?.ca?.data as { caId: string })?.caId || "",
     type: CaType.INTERNAL
@@ -373,8 +375,17 @@ export const CaModal = ({ popUp, handlePopUpToggle }: Props) => {
                   isDisabled={Boolean(ca)}
                 >
                   {certKeyAlgorithms.map(({ label, value }) => (
-                    <SelectItem value={String(value || "")} key={label}>
-                      {label}
+                    <SelectItem
+                      value={String(value || "")}
+                      key={label}
+                      isDisabled={isPqcAlgorithm(value) && !subscription?.pkiPqc}
+                    >
+                      <div className="flex items-center gap-2">
+                        {label}
+                        {isPqcAlgorithm(value) && !subscription?.pkiPqc && (
+                          <Badge variant="info">Enterprise</Badge>
+                        )}
+                      </div>
                     </SelectItem>
                   ))}
                 </Select>

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/AlgorithmSelectors.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/AlgorithmSelectors.tsx
@@ -1,6 +1,9 @@
 import { Control, Controller } from "react-hook-form";
 
 import { FormControl, Select, SelectItem } from "@app/components/v2";
+import { Badge } from "@app/components/v3";
+import { useSubscription } from "@app/context";
+import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 
 type AlgorithmOption = {
   value: string;
@@ -34,6 +37,7 @@ export const AlgorithmSelectors = ({
   isRequired = true,
   nonePlaceholder
 }: AlgorithmSelectorsProps) => {
+  const { subscription } = useSubscription();
   return (
     <div className="grid grid-cols-2 gap-4">
       <div>
@@ -63,8 +67,17 @@ export const AlgorithmSelectors = ({
               >
                 {nonePlaceholder && <SelectItem value={NONE_VALUE}>{nonePlaceholder}</SelectItem>}
                 {availableSignatureAlgorithms.map((algorithm) => (
-                  <SelectItem key={algorithm.value} value={algorithm.value}>
-                    {algorithm.label}
+                  <SelectItem
+                    key={algorithm.value}
+                    value={algorithm.value}
+                    isDisabled={isPqcAlgorithm(algorithm.value) && !subscription?.pkiPqc}
+                  >
+                    <div className="flex items-center gap-2">
+                      {algorithm.label}
+                      {isPqcAlgorithm(algorithm.value) && !subscription?.pkiPqc && (
+                        <Badge variant="info">Enterprise</Badge>
+                      )}
+                    </div>
                   </SelectItem>
                 ))}
               </Select>
@@ -100,8 +113,17 @@ export const AlgorithmSelectors = ({
               >
                 {nonePlaceholder && <SelectItem value={NONE_VALUE}>{nonePlaceholder}</SelectItem>}
                 {availableKeyAlgorithms.map((algorithm) => (
-                  <SelectItem key={algorithm.value} value={algorithm.value}>
-                    {algorithm.label}
+                  <SelectItem
+                    key={algorithm.value}
+                    value={algorithm.value}
+                    isDisabled={isPqcAlgorithm(algorithm.value) && !subscription?.pkiPqc}
+                  >
+                    <div className="flex items-center gap-2">
+                      {algorithm.label}
+                      {isPqcAlgorithm(algorithm.value) && !subscription?.pkiPqc && (
+                        <Badge variant="info">Enterprise</Badge>
+                      )}
+                    </div>
                   </SelectItem>
                 ))}
               </Select>

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -24,11 +24,10 @@ import {
   TextArea,
   Tooltip
 } from "@app/components/v2";
-import { useOrganization, useProject, useSubscription } from "@app/context";
+import { useOrganization, useProject } from "@app/context";
 import { useGetCert } from "@app/hooks/api";
 import { useGetCertificatePolicyById } from "@app/hooks/api/certificatePolicies";
 import { EnrollmentType, useListCertificateProfiles } from "@app/hooks/api/certificateProfiles";
-import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 import {
   CertExtendedKeyUsage,
   CertificateRequestStatus,
@@ -148,7 +147,6 @@ export const CertificateIssuanceModal = ({
 }: Props) => {
   const { currentProject } = useProject();
   const { currentOrg } = useOrganization();
-  const { subscription } = useSubscription();
   const navigate = useNavigate();
 
   const inputSerialNumber =
@@ -683,16 +681,8 @@ export const CertificateIssuanceModal = ({
                   <>
                     <AlgorithmSelectors
                       control={control}
-                      availableSignatureAlgorithms={
-                        subscription?.pkiPqc
-                          ? availableSignatureAlgorithms
-                          : availableSignatureAlgorithms.filter((a) => !isPqcAlgorithm(a.value))
-                      }
-                      availableKeyAlgorithms={
-                        subscription?.pkiPqc
-                          ? availableKeyAlgorithms
-                          : availableKeyAlgorithms.filter((a) => !isPqcAlgorithm(a.value))
-                      }
+                      availableSignatureAlgorithms={availableSignatureAlgorithms}
+                      availableKeyAlgorithms={availableKeyAlgorithms}
                       signatureError={
                         (formState.errors as { signatureAlgorithm?: { message?: string } })
                           .signatureAlgorithm?.message

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -24,10 +24,11 @@ import {
   TextArea,
   Tooltip
 } from "@app/components/v2";
-import { useOrganization, useProject } from "@app/context";
+import { useOrganization, useProject, useSubscription } from "@app/context";
 import { useGetCert } from "@app/hooks/api";
 import { useGetCertificatePolicyById } from "@app/hooks/api/certificatePolicies";
 import { EnrollmentType, useListCertificateProfiles } from "@app/hooks/api/certificateProfiles";
+import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 import {
   CertExtendedKeyUsage,
   CertificateRequestStatus,
@@ -147,6 +148,7 @@ export const CertificateIssuanceModal = ({
 }: Props) => {
   const { currentProject } = useProject();
   const { currentOrg } = useOrganization();
+  const { subscription } = useSubscription();
   const navigate = useNavigate();
 
   const inputSerialNumber =
@@ -681,8 +683,16 @@ export const CertificateIssuanceModal = ({
                   <>
                     <AlgorithmSelectors
                       control={control}
-                      availableSignatureAlgorithms={availableSignatureAlgorithms}
-                      availableKeyAlgorithms={availableKeyAlgorithms}
+                      availableSignatureAlgorithms={
+                        subscription?.pkiPqc
+                          ? availableSignatureAlgorithms
+                          : availableSignatureAlgorithms.filter((a) => !isPqcAlgorithm(a.value))
+                      }
+                      availableKeyAlgorithms={
+                        subscription?.pkiPqc
+                          ? availableKeyAlgorithms
+                          : availableKeyAlgorithms.filter((a) => !isPqcAlgorithm(a.value))
+                      }
                       signatureError={
                         (formState.errors as { signatureAlgorithm?: { message?: string } })
                           .signatureAlgorithm?.message

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/CreatePolicyModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/CreatePolicyModal.tsx
@@ -23,13 +23,15 @@ import {
   TextArea,
   Tooltip
 } from "@app/components/v2";
-import { useProject } from "@app/context";
+import { Badge } from "@app/components/v3";
+import { useProject, useSubscription } from "@app/context";
 import {
   TCertificatePolicy,
   TCertificatePolicyRule,
   useCreateCertificatePolicy,
   useUpdateCertificatePolicy
 } from "@app/hooks/api/certificatePolicies";
+import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 
 import {
   CertDurationUnit,
@@ -127,6 +129,7 @@ export const CreatePolicyModal = ({
   onComplete
 }: Props) => {
   const { currentProject } = useProject();
+  const { subscription } = useSubscription();
   const createPolicy = useCreateCertificatePolicy();
   const updatePolicy = useUpdateCertificatePolicy();
 
@@ -970,11 +973,13 @@ export const CreatePolicyModal = ({
                           <div className="grid grid-cols-2 gap-2">
                             {SIGNATURE_ALGORITHMS.map((alg) => {
                               const isSelected = field.value?.includes(alg);
+                              const isPqcGated = isPqcAlgorithm(alg) && !subscription?.pkiPqc;
                               return (
                                 <div key={alg} className="flex items-center space-x-3">
                                   <Checkbox
                                     id={`sig-alg-${alg}`}
                                     isChecked={isSelected}
+                                    isDisabled={isPqcGated}
                                     onCheckedChange={(checked) => {
                                       const current = field.value || [];
                                       let newValue;
@@ -992,7 +997,10 @@ export const CreatePolicyModal = ({
                                     htmlFor={`sig-alg-${alg}`}
                                     className="cursor-pointer text-sm font-medium text-mineshaft-200"
                                   >
-                                    {alg}
+                                    <span className="flex items-center gap-2">
+                                      {alg}
+                                      {isPqcGated && <Badge variant="info">Enterprise</Badge>}
+                                    </span>
                                   </label>
                                 </div>
                               );
@@ -1016,11 +1024,13 @@ export const CreatePolicyModal = ({
                           <div className="grid grid-cols-2 gap-2">
                             {KEY_ALGORITHMS.map((alg) => {
                               const isSelected = field.value?.includes(alg);
+                              const isPqcGated = isPqcAlgorithm(alg) && !subscription?.pkiPqc;
                               return (
                                 <div key={alg} className="flex items-center space-x-3">
                                   <Checkbox
                                     id={`key-alg-${alg}`}
                                     isChecked={isSelected}
+                                    isDisabled={isPqcGated}
                                     onCheckedChange={(checked) => {
                                       const current = field.value || [];
                                       let newValue;
@@ -1038,7 +1048,10 @@ export const CreatePolicyModal = ({
                                     htmlFor={`key-alg-${alg}`}
                                     className="cursor-pointer text-sm font-medium text-mineshaft-200"
                                   >
-                                    {alg}
+                                    <span className="flex items-center gap-2">
+                                      {alg}
+                                      {isPqcGated && <Badge variant="info">Enterprise</Badge>}
+                                    </span>
                                   </label>
                                 </div>
                               );

--- a/frontend/src/pages/kms/KmipPage/components/CreateKmipClientCertificateModal.tsx
+++ b/frontend/src/pages/kms/KmipPage/components/CreateKmipClientCertificateModal.tsx
@@ -13,7 +13,7 @@ import {
   Select,
   SelectItem
 } from "@app/components/v2";
-import { certKeyAlgorithms } from "@app/hooks/api/certificates/constants";
+import { certKeyAlgorithms, isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 import { CertKeyAlgorithm } from "@app/hooks/api/certificates/enums";
 import { useGenerateKmipClientCertificate } from "@app/hooks/api/kmip";
 import { KmipClientCertificate, TKmipClient } from "@app/hooks/api/kmip/types";
@@ -98,11 +98,13 @@ const KmipClientCertificateForm = ({
               onValueChange={(e) => onChange(e)}
               className="w-full"
             >
-              {certKeyAlgorithms.map(({ label, value }) => (
-                <SelectItem value={String(value || "")} key={label}>
-                  {label}
-                </SelectItem>
-              ))}
+              {certKeyAlgorithms
+                .filter(({ value }) => !isPqcAlgorithm(value))
+                .map(({ label, value }) => (
+                  <SelectItem value={String(value || "")} key={label}>
+                    {label}
+                  </SelectItem>
+                ))}
             </Select>
           </FormControl>
         )}


### PR DESCRIPTION
## Context

- Gates all PQC algorithm operations (ML-DSA, SLH-DSA) behind the `pkiPqc` enterprise license flag — every compute point is blocked without it, including CA creation, cert issuance, signing, renewal, revocation, and auto-renewal across all enrollment methods (API, ACME, EST, SCEP). PQC options show as disabled with an "Enterprise" badge in the UI dropdowns.
- Removes non-functional PQC options from the KMIP client cert dropdown since KMIP uses native crypto which doesn't support PQC.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)