### PR TITLE
feat(pki): support wildcard DNS identifiers in ACME

### DIFF
--- a/backend/src/db/migrations/20260519144500_add-wildcard-to-pki-acme-auths.ts
+++ b/backend/src/db/migrations/20260519144500_add-wildcard-to-pki-acme-auths.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.PkiAcmeAuth, "wildcard"))) {
+    await knex.schema.alterTable(TableName.PkiAcmeAuth, (t) => {
+      t.boolean("wildcard").nullable().defaultTo(false);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.PkiAcmeAuth, "wildcard")) {
+    await knex.schema.alterTable(TableName.PkiAcmeAuth, (t) => {
+      t.dropColumn("wildcard");
+    });
+  }
+}

--- a/backend/src/db/migrations/20260519144500_add-wildcard-to-pki-acme-auths.ts
+++ b/backend/src/db/migrations/20260519144500_add-wildcard-to-pki-acme-auths.ts
@@ -5,7 +5,7 @@ import { TableName } from "../schemas";
 export async function up(knex: Knex): Promise<void> {
   if (!(await knex.schema.hasColumn(TableName.PkiAcmeAuth, "wildcard"))) {
     await knex.schema.alterTable(TableName.PkiAcmeAuth, (t) => {
-      t.boolean("wildcard").nullable().defaultTo(false);
+      t.boolean("wildcard").notNullable().defaultTo(false);
     });
   }
 }

--- a/backend/src/db/schemas/pki-acme-auths.ts
+++ b/backend/src/db/schemas/pki-acme-auths.ts
@@ -14,11 +14,11 @@ export const PkiAcmeAuthsSchema = z.object({
   token: z.string().nullable().optional(),
   identifierType: z.string(),
   identifierValue: z.string(),
-  wildcard: z.boolean().nullable().optional(),
   expiresAt: z.date(),
   certificateId: z.string().uuid().nullable().optional(),
   createdAt: z.date(),
-  updatedAt: z.date()
+  updatedAt: z.date(),
+  wildcard: z.boolean().default(false).nullable().optional()
 });
 
 export type TPkiAcmeAuths = z.infer<typeof PkiAcmeAuthsSchema>;

--- a/backend/src/db/schemas/pki-acme-auths.ts
+++ b/backend/src/db/schemas/pki-acme-auths.ts
@@ -14,6 +14,7 @@ export const PkiAcmeAuthsSchema = z.object({
   token: z.string().nullable().optional(),
   identifierType: z.string(),
   identifierValue: z.string(),
+  wildcard: z.boolean().nullable().optional(),
   expiresAt: z.date(),
   certificateId: z.string().uuid().nullable().optional(),
   createdAt: z.date(),

--- a/backend/src/db/schemas/pki-acme-auths.ts
+++ b/backend/src/db/schemas/pki-acme-auths.ts
@@ -18,7 +18,7 @@ export const PkiAcmeAuthsSchema = z.object({
   certificateId: z.string().uuid().nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
-  wildcard: z.boolean().default(false).nullable().optional()
+  wildcard: z.boolean().default(false)
 });
 
 export type TPkiAcmeAuths = z.infer<typeof PkiAcmeAuthsSchema>;

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -6363,6 +6363,7 @@ interface CreateAcmeOrderEvent {
     identifiers: Array<{
       type: AcmeIdentifierType;
       value: string;
+      wildcard?: boolean;
     }>;
   };
 }

--- a/backend/src/ee/services/pki-acme/pki-acme-fns.test.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-fns.test.ts
@@ -1,0 +1,30 @@
+import { validateDnsIdentifier } from "./pki-acme-fns";
+
+describe("validateDnsIdentifier", () => {
+  test("accepts standard domain names", () => {
+    expect(validateDnsIdentifier("example.com")).toBe(true);
+    expect(validateDnsIdentifier("sub.example.com")).toBe(true);
+    expect(validateDnsIdentifier("deep.sub.example.com")).toBe(true);
+    expect(validateDnsIdentifier("a.b")).toBe(true);
+  });
+
+  test("accepts wildcard prefixes", () => {
+    expect(validateDnsIdentifier("*.example.com")).toBe(true);
+    expect(validateDnsIdentifier("*.sub.example.com")).toBe(true);
+  });
+
+  test("rejects invalid wildcard forms", () => {
+    expect(validateDnsIdentifier("**.example.com")).toBe(false);
+    expect(validateDnsIdentifier("a*.example.com")).toBe(false);
+    expect(validateDnsIdentifier("*a.example.com")).toBe(false);
+    expect(validateDnsIdentifier("*")).toBe(false);
+    expect(validateDnsIdentifier("*.")).toBe(false);
+    expect(validateDnsIdentifier("sub.*.example.com")).toBe(false);
+  });
+
+  test("rejects invalid domain labels", () => {
+    expect(validateDnsIdentifier("-example.com")).toBe(false);
+    expect(validateDnsIdentifier("example-.com")).toBe(false);
+    expect(validateDnsIdentifier("")).toBe(false);
+  });
+});

--- a/backend/src/ee/services/pki-acme/pki-acme-fns.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-fns.ts
@@ -28,8 +28,18 @@ export const validateIpIdentifier = (identifier: string): boolean => {
 };
 
 export const validateDnsIdentifier = (identifier: string): boolean => {
-  // DNS label pattern: 1-63 chars, alphanumeric or hyphen, but not starting or ending with hyphen
+  let domain = identifier;
+
+  if (domain.startsWith("*.")) {
+    domain = domain.slice(2);
+    if (domain.length === 0) {
+      return false;
+    }
+  } else if (domain.includes("*")) {
+    return false;
+  }
+
   const labelPattern = new RE2(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/);
-  const labels = identifier.split(".");
+  const labels = domain.split(".");
   return labels.every((label) => label.length >= 1 && label.length <= 63 && labelPattern.test(label));
 };

--- a/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
@@ -89,7 +89,7 @@ export const pkiAcmeOrderDALFactory = (db: TDbClient) => {
               id: authId,
               identifierType,
               identifierValue,
-              wildcard: wildcard as boolean | null,
+              wildcard: wildcard as boolean,
               expiresAt: authExpiresAt
             })
           }

--- a/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
@@ -67,6 +67,7 @@ export const pkiAcmeOrderDALFactory = (db: TDbClient) => {
           db.ref("id").withSchema(TableName.PkiAcmeAuth).as("authId"),
           db.ref("identifierType").withSchema(TableName.PkiAcmeAuth).as("identifierType"),
           db.ref("identifierValue").withSchema(TableName.PkiAcmeAuth).as("identifierValue"),
+          db.ref("wildcard").withSchema(TableName.PkiAcmeAuth).as("wildcard"),
           db.ref("expiresAt").withSchema(TableName.PkiAcmeAuth).as("authExpiresAt")
         )
         .where(`${TableName.PkiAcmeOrder}.id`, orderId)
@@ -84,10 +85,11 @@ export const pkiAcmeOrderDALFactory = (db: TDbClient) => {
           {
             key: "authId",
             label: "authorizations" as const,
-            mapper: ({ authId, identifierType, identifierValue, authExpiresAt }) => ({
+            mapper: ({ authId, identifierType, identifierValue, wildcard, authExpiresAt }) => ({
               id: authId,
               identifierType,
               identifierValue,
+              wildcard: wildcard as boolean | null,
               expiresAt: authExpiresAt
             })
           }

--- a/backend/src/ee/services/pki-acme/pki-acme-schemas.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-schemas.ts
@@ -148,6 +148,7 @@ export const GetAcmeAuthorizationResponseSchema = z.object({
     type: z.string(),
     value: z.string()
   }),
+  wildcard: z.boolean().optional(),
   challenges: z.array(
     z.object({
       type: z.enum(Object.values(AcmeChallengeType) as [string, ...string[]]),

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -366,6 +366,7 @@ export const pkiAcmeServiceFactory = ({
         id: string;
         identifierType: string;
         identifierValue: string;
+        wildcard?: boolean | null;
         expiresAt: Date;
       }[];
     };
@@ -378,7 +379,7 @@ export const pkiAcmeServiceFactory = ({
       notAfter: order.notAfter?.toISOString(),
       identifiers: order.authorizations.map((auth) => ({
         type: auth.identifierType,
-        value: auth.identifierValue
+        value: auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue
       })),
       authorizations: order.authorizations.map((auth) => buildUrl(profileId, `/authorizations/${auth.id}`)),
       finalize: buildUrl(profileId, `/orders/${order.id}/finalize`),
@@ -785,12 +786,16 @@ export const pkiAcmeServiceFactory = ({
           } else {
             throw new AcmeUnsupportedIdentifierError({ message: "Only DNS and IP identifiers are supported" });
           }
+          const isWildcard = identifier.type === AcmeIdentifierType.DNS && identifier.value.startsWith("*.");
+          const identifierValue = isWildcard ? identifier.value.slice(2) : identifier.value;
+
           const auth = await acmeAuthDAL.create(
             {
               accountId: account.id,
               status: skipDnsOwnershipVerification ? AcmeAuthStatus.Valid : AcmeAuthStatus.Pending,
               identifierType: identifier.type,
-              identifierValue: identifier.value,
+              identifierValue,
+              wildcard: isWildcard || undefined,
               // RFC 8555 suggests a token with at least 128 bits of entropy
               // We are using 256 bits of entropy here, should be enough for now
               // ref: https://datatracker.ietf.org/doc/html/rfc8555#section-11.3
@@ -801,11 +806,14 @@ export const pkiAcmeServiceFactory = ({
             tx
           );
           if (!skipDnsOwnershipVerification) {
-            // IP identifiers only support HTTP-01 challenges (DNS-01 doesn't apply per RFC 8738)
-            const challengeTypes =
-              identifier.type === AcmeIdentifierType.IP
-                ? [AcmeChallengeType.HTTP_01]
-                : [AcmeChallengeType.HTTP_01, AcmeChallengeType.DNS_01];
+            let challengeTypes: AcmeChallengeType[];
+            if (identifier.type === AcmeIdentifierType.IP) {
+              challengeTypes = [AcmeChallengeType.HTTP_01];
+            } else if (isWildcard) {
+              challengeTypes = [AcmeChallengeType.DNS_01];
+            } else {
+              challengeTypes = [AcmeChallengeType.HTTP_01, AcmeChallengeType.DNS_01];
+            }
             for (const challengeType of challengeTypes) {
               // eslint-disable-next-line no-await-in-loop
               await acmeChallengeDAL.create(
@@ -845,7 +853,8 @@ export const pkiAcmeServiceFactory = ({
             orderId: createdOrder.id,
             identifiers: authorizations.map((auth) => ({
               type: auth.identifierType as AcmeIdentifierType,
-              value: auth.identifierValue
+              value: auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue,
+              ...(auth.wildcard ? { wildcard: true } : {})
             }))
           }
         }
@@ -1123,9 +1132,10 @@ export const pkiAcmeServiceFactory = ({
         }
         if (
           csrIdentifierPairs.size !== orderWithAuthorizations.authorizations.length ||
-          !orderWithAuthorizations.authorizations.every((auth) =>
-            csrIdentifierPairs.has(`${auth.identifierType}:${auth.identifierValue.toLowerCase()}`)
-          )
+          !orderWithAuthorizations.authorizations.every((auth) => {
+            const value = auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue;
+            return csrIdentifierPairs.has(`${auth.identifierType}:${value.toLowerCase()}`);
+          })
         ) {
           throw new AcmeBadCSRError({ message: "Invalid CSR: Common name + SANs mismatch with order identifiers" });
         }
@@ -1516,6 +1526,7 @@ export const pkiAcmeServiceFactory = ({
           type: auth.identifierType,
           value: auth.identifierValue
         },
+        ...(auth.wildcard ? { wildcard: true } : {}),
         challenges: auth.challenges.map((challenge) => {
           return {
             type: challenge.type,

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -366,7 +366,7 @@ export const pkiAcmeServiceFactory = ({
         id: string;
         identifierType: string;
         identifierValue: string;
-        wildcard?: boolean | null;
+        wildcard?: boolean;
         expiresAt: Date;
       }[];
     };
@@ -799,7 +799,7 @@ export const pkiAcmeServiceFactory = ({
               status: skipDnsOwnershipVerification ? AcmeAuthStatus.Valid : AcmeAuthStatus.Pending,
               identifierType: identifier.type,
               identifierValue,
-              wildcard: isWildcard || undefined,
+              wildcard: isWildcard,
               // RFC 8555 suggests a token with at least 128 bits of entropy
               // We are using 256 bits of entropy here, should be enough for now
               // ref: https://datatracker.ietf.org/doc/html/rfc8555#section-11.3

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -735,10 +735,13 @@ export const pkiAcmeServiceFactory = ({
     // TODO: ideally, we should return an error with subproblems if we have multiple unsupported identifiers
     for (const identifier of payload.identifiers) {
       if (identifier.type === AcmeIdentifierType.DNS) {
+        if (!validateDnsIdentifier(identifier.value)) {
+          throw new AcmeUnsupportedIdentifierError({ message: "Invalid DNS identifier" });
+        }
+        const strippedValue = identifier.value.startsWith("*.") ? identifier.value.slice(2) : identifier.value;
         if (
-          !validateDnsIdentifier(identifier.value) ||
-          isPrivateIp(identifier.value) ||
-          (!getConfig().isDevelopmentMode && identifier.value.toLowerCase() === "localhost")
+          isPrivateIp(strippedValue) ||
+          (!getConfig().isDevelopmentMode && strippedValue.toLowerCase() === "localhost")
         ) {
           throw new AcmeUnsupportedIdentifierError({ message: "Invalid DNS identifier" });
         }
@@ -780,7 +783,8 @@ export const pkiAcmeServiceFactory = ({
               });
             }
           } else if (identifier.type === AcmeIdentifierType.DNS) {
-            if (isPrivateIp(identifier.value)) {
+            const stripped = identifier.value.startsWith("*.") ? identifier.value.slice(2) : identifier.value;
+            if (isPrivateIp(stripped)) {
               throw new AcmeUnsupportedIdentifierError({ message: "Private IP addresses are not allowed" });
             }
           } else {


### PR DESCRIPTION
## Context

The ACME server was rejecting wildcard domains like `*.example.com` because the DNS identifier validator didn't allow `*` characters. Updated it to accept wildcard prefixes per RFC 8555 — the authorization stores the stripped domain with a `wildcard: true` flag, and only DNS-01 challenges are offered for wildcards since HTTP-01 can't prove control over all subdomains.

## Screenshots


## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)