### PR TITLE
feat: added ssh app connection block user capability

### DIFF
--- a/backend/src/db/migrations/20260521164116_add-app-connection-encrypted-configuration.ts
+++ b/backend/src/db/migrations/20260521164116_add-app-connection-encrypted-configuration.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn(TableName.AppConnection, "encryptedConfiguration"))) {
+    await knex.schema.alterTable(TableName.AppConnection, (t) => {
+      t.binary("encryptedConfiguration").nullable();
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn(TableName.AppConnection, "encryptedConfiguration")) {
+    await knex.schema.alterTable(TableName.AppConnection, (t) => {
+      t.dropColumn("encryptedConfiguration");
+    });
+  }
+}

--- a/backend/src/db/schemas/app-connections.ts
+++ b/backend/src/db/schemas/app-connections.ts
@@ -24,7 +24,8 @@ export const AppConnectionsSchema = z.object({
   gatewayId: z.string().uuid().nullable().optional(),
   projectId: z.string().nullable().optional(),
   isAutoRotationEnabled: z.boolean().default(false),
-  gatewayPoolId: z.string().uuid().nullable().optional()
+  gatewayPoolId: z.string().uuid().nullable().optional(),
+  encryptedConfiguration: zodBuffer.nullable().optional()
 });
 
 export type TAppConnections = z.infer<typeof AppConnectionsSchema>;

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -401,6 +401,15 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
     if (username === credentials.username)
       throw new BadRequestError({ message: "Provided username is used in Infisical app connections." });
 
+    if (conn.configuration?.blockedUsers) {
+      const blockedUsersList = conn.configuration.blockedUsers.split(",").map((u) => u.trim().toLowerCase());
+      if (blockedUsersList.includes(username.toLowerCase())) {
+        throw new BadRequestError({
+          message: `Username '${username}' is blocked from rotation by the SSH connection configuration.`
+        });
+      }
+    }
+
     let connectConfig: TSshConnectionConfig;
 
     if (isSelfRotation && currentPassword) {

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2821,7 +2821,9 @@ export const AppConnections = {
       authMethod: "The authentication method to use (password or ssh-key).",
       password: "The password for SSH authentication (required when authMethod is 'password').",
       privateKey: "The private key in PEM format for SSH authentication (required when authMethod is 'ssh-key').",
-      passphrase: "The passphrase for the private key, if encrypted (optional, only for 'ssh-key' authMethod)."
+      passphrase: "The passphrase for the private key, if encrypted (optional, only for 'ssh-key' authMethod).",
+      blockedUsers:
+        "A comma-separated list of usernames that are blocked from being used in operations like secret rotation (e.g., 'root,admin,ubuntu')."
     },
     DBT: {
       apiToken: "The API token used to authenticate with DBT.",

--- a/backend/src/server/routes/v1/app-connection-routers/app-connection-endpoints.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/app-connection-endpoints.ts
@@ -34,6 +34,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
     gatewayPoolId?: string | null;
     projectId?: string;
     rotation?: TCreateAppConnectionCredentialRotationSchema | null;
+    configuration?: Record<string, unknown>;
   }>;
   updateSchema: z.ZodType<{
     name?: string;
@@ -44,6 +45,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
     gatewayPoolId?: string | null;
     isAutoRotationEnabled?: boolean | null;
     rotation?: Partial<TCreateAppConnectionCredentialRotationSchema> | null;
+    configuration?: Record<string, unknown>;
   }>;
   sanitizedResponseSchema: z.ZodTypeAny;
 }) => {
@@ -293,7 +295,8 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         gatewayPoolId,
         projectId,
         isAutoRotationEnabled,
-        rotation
+        rotation,
+        configuration
       } = req.body;
 
       const appConnection = (await server.services.appConnection.createAppConnection(
@@ -308,7 +311,8 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
           gatewayPoolId,
           projectId,
           rotation,
-          isAutoRotationEnabled: isAutoRotationEnabled ?? false
+          isAutoRotationEnabled: isAutoRotationEnabled ?? false,
+          configuration
         },
         req.permission
       )) as T;
@@ -375,7 +379,8 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         gatewayId,
         gatewayPoolId,
         rotation,
-        isAutoRotationEnabled
+        isAutoRotationEnabled,
+        configuration
       } = req.body;
       const { connectionId } = req.params;
 
@@ -389,7 +394,8 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
           gatewayId,
           gatewayPoolId,
           isAutoRotationEnabled: isAutoRotationEnabled ?? undefined,
-          rotation: rotation ?? undefined
+          rotation: rotation ?? undefined,
+          configuration
         },
         req.permission
       )) as T;

--- a/backend/src/services/app-connection/app-connection-fns.ts
+++ b/backend/src/services/app-connection/app-connection-fns.ts
@@ -42,6 +42,7 @@ import { TAppConnectionServiceFactoryDep } from "./app-connection-service";
 import {
   TAppConnection,
   TAppConnectionConfig,
+  TAppConnectionConfiguration,
   TAppConnectionCredentialsValidator,
   TAppConnectionTransitionCredentialsToPlatform
 } from "./app-connection-types";
@@ -414,6 +415,67 @@ export const decryptAppConnectionCredentials = async ({
   return JSON.parse(decryptedPlainTextBlob.toString()) as TAppConnection["credentials"];
 };
 
+export const encryptAppConnectionConfiguration = async ({
+  orgId,
+  configuration,
+  kmsService,
+  projectId
+}: {
+  orgId: string;
+  configuration: TAppConnectionConfiguration;
+  kmsService: TAppConnectionServiceFactoryDep["kmsService"];
+  projectId: string | null | undefined;
+}) => {
+  if (!configuration) return null;
+
+  const { encryptor } = await kmsService.createCipherPairWithDataKey(
+    projectId
+      ? {
+          type: KmsDataKey.SecretManager,
+          projectId
+        }
+      : {
+          type: KmsDataKey.Organization,
+          orgId
+        }
+  );
+
+  const { cipherTextBlob: encryptedConfigurationBlob } = encryptor({
+    plainText: Buffer.from(JSON.stringify(configuration))
+  });
+
+  return encryptedConfigurationBlob;
+};
+
+export const decryptAppConnectionConfiguration = async ({
+  orgId,
+  encryptedConfiguration,
+  kmsService,
+  projectId
+}: {
+  orgId: string;
+  encryptedConfiguration: Buffer | null | undefined;
+  kmsService: TAppConnectionServiceFactoryDep["kmsService"];
+  projectId: string | null | undefined;
+}): Promise<TAppConnectionConfiguration> => {
+  if (!encryptedConfiguration) return undefined;
+
+  const { decryptor } = await kmsService.createCipherPairWithDataKey(
+    projectId
+      ? { type: KmsDataKey.SecretManager, projectId }
+      : {
+          type: KmsDataKey.Organization,
+          orgId
+        }
+  );
+
+  const decryptedPlainTextBlob = decryptor({
+    cipherTextBlob: encryptedConfiguration
+  });
+
+  return JSON.parse(decryptedPlainTextBlob.toString()) as TAppConnectionConfiguration;
+};
+
 export const validateAppConnectionCredentials = async (
   appConnection: TAppConnectionConfig,
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
@@ -620,8 +682,10 @@ export const decryptAppConnection = async (
   },
   kmsService: TAppConnectionServiceFactoryDep["kmsService"]
 ) => {
+  const { encryptedCredentials, encryptedConfiguration, ...connectionWithoutEncrypted } = appConnection;
+
   return {
-    ...appConnection,
+    ...connectionWithoutEncrypted,
     rotation: appConnection.rotation
       ? {
           ...appConnection.rotation,
@@ -636,12 +700,18 @@ export const decryptAppConnection = async (
         }
       : undefined,
     credentials: await decryptAppConnectionCredentials({
-      encryptedCredentials: appConnection.encryptedCredentials,
+      encryptedCredentials,
       orgId: appConnection.orgId,
       projectId: appConnection.projectId,
       kmsService
     }),
-    credentialsHash: crypto.nativeCrypto.createHash("sha256").update(appConnection.encryptedCredentials).digest("hex")
+    configuration: await decryptAppConnectionConfiguration({
+      encryptedConfiguration,
+      orgId: appConnection.orgId,
+      projectId: appConnection.projectId,
+      kmsService
+    }),
+    credentialsHash: crypto.nativeCrypto.createHash("sha256").update(encryptedCredentials).digest("hex")
   } as TAppConnection;
 };
 

--- a/backend/src/services/app-connection/app-connection-schemas.ts
+++ b/backend/src/services/app-connection/app-connection-schemas.ts
@@ -15,6 +15,7 @@ import {
 
 export const BaseAppConnectionSchema = AppConnectionsSchema.omit({
   encryptedCredentials: true,
+  encryptedConfiguration: true,
   app: true,
   method: true
 }).extend({

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -29,6 +29,7 @@ import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import { DiscriminativePick, OrgServiceActor } from "@app/lib/types";
 import {
   decryptAppConnection,
+  encryptAppConnectionConfiguration,
   encryptAppConnectionCredentials,
   enterpriseAppCheck,
   getAppConnectionMethodName,
@@ -426,6 +427,7 @@ export const appConnectionServiceFactory = ({
       method,
       app,
       credentials,
+      configuration,
       gatewayId,
       gatewayPoolId,
       projectId,
@@ -540,10 +542,18 @@ export const appConnectionServiceFactory = ({
             projectId
           });
 
+          const encryptedConfiguration = await encryptAppConnectionConfiguration({
+            configuration,
+            orgId: actor.orgId,
+            kmsService,
+            projectId
+          });
+
           const appConnection = await appConnectionDAL.create(
             {
               orgId: actor.orgId,
               encryptedCredentials,
+              encryptedConfiguration,
               method,
               app,
               gatewayId: gatewayPoolId ? null : gatewayId,
@@ -591,7 +601,8 @@ export const appConnectionServiceFactory = ({
       return {
         ...connection,
         credentialsHash: crypto.nativeCrypto.createHash("sha256").update(connection.encryptedCredentials).digest("hex"),
-        credentials: validatedCredentials
+        credentials: validatedCredentials,
+        configuration
       } as TAppConnection;
     } catch (err) {
       if (err instanceof DatabaseError && (err.error as { code: string })?.code === DatabaseErrorCode.UniqueViolation) {
@@ -606,6 +617,7 @@ export const appConnectionServiceFactory = ({
     {
       connectionId,
       credentials,
+      configuration,
       gatewayId,
       gatewayPoolId,
       isAutoRotationEnabled,
@@ -764,11 +776,22 @@ export const appConnectionServiceFactory = ({
             })
           : undefined;
 
+        const encryptedConfiguration =
+          configuration !== undefined
+            ? await encryptAppConnectionConfiguration({
+                configuration,
+                orgId: actor.orgId,
+                kmsService,
+                projectId: appConnection.projectId
+              })
+            : undefined;
+
         return appConnectionDAL.updateById(
           connectionId,
           {
             orgId: actor.orgId,
             encryptedCredentials,
+            ...(encryptedConfiguration !== undefined && { encryptedConfiguration }),
             ...(gatewayIdValue !== undefined && { gatewayId: gatewayIdValue }),
             ...(gatewayPoolIdValue !== undefined && { gatewayPoolId: gatewayPoolIdValue }),
             ...params

--- a/backend/src/services/app-connection/app-connection-types.ts
+++ b/backend/src/services/app-connection/app-connection-types.ts
@@ -384,7 +384,9 @@ import {
   TZabbixConnectionInput
 } from "./zabbix";
 
-export type TAppConnection = { id: string } & (
+export type TAppConnectionConfiguration = Record<string, unknown> | undefined;
+
+export type TAppConnection = { id: string; configuration?: TAppConnectionConfiguration } & (
   | TAwsConnection
   | TGitHubConnection
   | TGitHubRadarConnection
@@ -547,7 +549,9 @@ export type TCreateAppConnectionDTO = Pick<
   | "projectId"
   | "rotation"
   | "isAutoRotationEnabled"
->;
+> & {
+  configuration?: Record<string, unknown>;
+};
 
 export type TUpdateAppConnectionDTO = Partial<
   Omit<TCreateAppConnectionDTO, "method" | "app" | "projectId" | "rotation">

--- a/backend/src/services/app-connection/ssh/ssh-connection-schemas.ts
+++ b/backend/src/services/app-connection/ssh/ssh-connection-schemas.ts
@@ -28,15 +28,22 @@ export const SshConnectionSshKeyCredentialsSchema = z.object({
   passphrase: z.string().trim().optional().describe(AppConnections.CREDENTIALS.SSH.passphrase)
 });
 
+// Configuration schema for SSH-specific settings
+export const SshConnectionConfigurationSchema = z.object({
+  blockedUsers: z.string().trim().optional().describe(AppConnections.CREDENTIALS.SSH.blockedUsers)
+});
+
 // Validation schema for credentials - top-level method discrimination
 export const ValidateSshConnectionCredentialsSchema = z.discriminatedUnion("method", [
   z.object({
     method: z.literal(SshConnectionMethod.Password).describe(AppConnections.CREATE(AppConnection.SSH).method),
-    credentials: SshConnectionPasswordCredentialsSchema.describe(AppConnections.CREATE(AppConnection.SSH).credentials)
+    credentials: SshConnectionPasswordCredentialsSchema.describe(AppConnections.CREATE(AppConnection.SSH).credentials),
+    configuration: SshConnectionConfigurationSchema.optional()
   }),
   z.object({
     method: z.literal(SshConnectionMethod.SshKey).describe(AppConnections.CREATE(AppConnection.SSH).method),
-    credentials: SshConnectionSshKeyCredentialsSchema.describe(AppConnections.CREATE(AppConnection.SSH).credentials)
+    credentials: SshConnectionSshKeyCredentialsSchema.describe(AppConnections.CREATE(AppConnection.SSH).credentials),
+    configuration: SshConnectionConfigurationSchema.optional()
   })
 ]);
 
@@ -53,7 +60,8 @@ export const UpdateSshConnectionSchema = z
     credentials: z
       .union([SshConnectionPasswordCredentialsSchema, SshConnectionSshKeyCredentialsSchema])
       .optional()
-      .describe(AppConnections.UPDATE(AppConnection.SSH).credentials)
+      .describe(AppConnections.UPDATE(AppConnection.SSH).credentials),
+    configuration: SshConnectionConfigurationSchema.optional()
   })
   .and(
     GenericUpdateAppConnectionFieldsSchema(AppConnection.SSH, {
@@ -72,11 +80,13 @@ export const SshConnectionSchema = z.intersection(
   z.discriminatedUnion("method", [
     z.object({
       method: z.literal(SshConnectionMethod.Password),
-      credentials: SshConnectionPasswordCredentialsSchema
+      credentials: SshConnectionPasswordCredentialsSchema,
+      configuration: SshConnectionConfigurationSchema.optional()
     }),
     z.object({
       method: z.literal(SshConnectionMethod.SshKey),
-      credentials: SshConnectionSshKeyCredentialsSchema
+      credentials: SshConnectionSshKeyCredentialsSchema,
+      configuration: SshConnectionConfigurationSchema.optional()
     })
   ])
 );
@@ -92,11 +102,13 @@ const SanitizedSshConnectionCredentialsSchema = z.object({
 export const SanitizedSshConnectionSchema = z.discriminatedUnion("method", [
   BaseSshConnectionSchema.extend({
     method: z.literal(SshConnectionMethod.Password),
-    credentials: SanitizedSshConnectionCredentialsSchema
+    credentials: SanitizedSshConnectionCredentialsSchema,
+    configuration: SshConnectionConfigurationSchema.optional()
   }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.SSH]} (Password)` })),
   BaseSshConnectionSchema.extend({
     method: z.literal(SshConnectionMethod.SshKey),
-    credentials: SanitizedSshConnectionCredentialsSchema
+    credentials: SanitizedSshConnectionCredentialsSchema,
+    configuration: SshConnectionConfigurationSchema.optional()
   }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.SSH]} (SSH Key)` }))
 ]);
 

--- a/backend/src/services/app-connection/ssh/ssh-connection-types.ts
+++ b/backend/src/services/app-connection/ssh/ssh-connection-types.ts
@@ -5,6 +5,7 @@ import { AppConnection } from "@app/services/app-connection/app-connection-enums
 
 import {
   CreateSshConnectionSchema,
+  SshConnectionConfigurationSchema,
   SshConnectionSchema,
   ValidateSshConnectionCredentialsSchema
 } from "./ssh-connection-schemas";
@@ -14,6 +15,8 @@ export type TSshConnection = z.infer<typeof SshConnectionSchema>;
 export type TSshConnectionInput = z.infer<typeof CreateSshConnectionSchema> & {
   app: AppConnection.SSH;
 };
+
+export type TSshConnectionConfiguration = z.infer<typeof SshConnectionConfigurationSchema>;
 
 export type TValidateSshConnectionCredentialsSchema = typeof ValidateSshConnectionCredentialsSchema;
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3456,7 +3456,7 @@
     "href": "https://infisical.com"
   },
   "api": {
-    "openapi": "https://app.infisical.com/api/docs/json",
+    "openapi": "http://localhost:8080/api/docs/json",
     "mdx": {
       "server": ["https://app.infisical.com"]
     }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3456,7 +3456,7 @@
     "href": "https://infisical.com"
   },
   "api": {
-    "openapi": "http://localhost:8080/api/docs/json",
+    "openapi": "https://app.infisical.com/api/docs/json",
     "mdx": {
       "server": ["https://app.infisical.com"]
     }

--- a/frontend/src/hooks/api/appConnections/types/index.ts
+++ b/frontend/src/hooks/api/appConnections/types/index.ts
@@ -217,7 +217,9 @@ export type TCreateAppConnectionDTO = Pick<
   | "gatewayId"
   | "gatewayPoolId"
   | "projectId"
->;
+> & {
+  configuration?: Record<string, unknown>;
+};
 
 export type TUpdateAppConnectionDTO = Partial<
   Pick<
@@ -237,6 +239,7 @@ export type TUpdateAppConnectionDTO = Partial<
     rotationInterval?: number;
     rotateAtUtc?: { hours: number; minutes: number };
   };
+  configuration?: Record<string, unknown>;
 };
 
 export type TDeleteAppConnectionDTO = {

--- a/frontend/src/hooks/api/appConnections/types/ssh-connection.ts
+++ b/frontend/src/hooks/api/appConnections/types/ssh-connection.ts
@@ -6,7 +6,14 @@ export enum SshConnectionMethod {
   SshKey = "ssh-key"
 }
 
-export type TSshConnection = TRootAppConnection & { app: AppConnection.SSH } & (
+export type TSshConnectionConfiguration = {
+  blockedUsers?: string;
+};
+
+export type TSshConnection = TRootAppConnection & {
+  app: AppConnection.SSH;
+  configuration?: TSshConnectionConfiguration;
+} & (
     | {
         method: SshConnectionMethod.Password;
         credentials: {

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
@@ -93,6 +93,7 @@ type AppConnectionFormData = DiscriminativePick<
     rotationInterval: number;
     rotateAtUtc: { hours: number; minutes: number };
   };
+  configuration?: Record<string, unknown>;
 };
 
 const RotationConfirmation = ({

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SshConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SshConnectionForm.tsx
@@ -30,8 +30,13 @@ type Props = {
   onSubmit: (formData: FormData) => Promise<void>;
 };
 
+const configurationSchema = z.object({
+  blockedUsers: z.string().trim().optional()
+});
+
 const rootSchema = genericAppConnectionFieldsSchema.extend({
-  app: z.literal(AppConnection.SSH)
+  app: z.literal(AppConnection.SSH),
+  configuration: configurationSchema.optional()
 });
 
 const formSchema = z.discriminatedUnion("method", [
@@ -285,6 +290,21 @@ export const SshConnectionForm = ({ appConnection, onSubmit }: Props) => {
             </>
           )}
         </div>
+        <Controller
+          name="configuration.blockedUsers"
+          control={control}
+          render={({ field, fieldState: { error } }) => (
+            <FormControl
+              errorText={error?.message}
+              isError={Boolean(error?.message)}
+              label="Blocked Users"
+              isOptional
+              tooltipText="A comma-separated list of usernames that are blocked from being used in operations like secret rotation (e.g., root,admin,ubuntu)."
+            >
+              <Input {...field} value={field.value ?? ""} placeholder="root,admin,ubuntu" />
+            </FormControl>
+          )}
+        />
         <div className="mt-8 flex items-center">
           <Button
             className="mr-4"


### PR DESCRIPTION
## Context

This PR adds a new option for SSH app connection to allow configuring person to control the consumers username usage.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Create an SSH app connection
2. Add a username as blocked user lit 
3. Try creating secret rotation for that user and it should fail

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)