### PR TITLE
fix: project templates role editor exception

### DIFF
--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ChevronDownIcon, DownloadIcon, LayersIcon, PlusIcon } from "lucide-react";
 
 import {
@@ -29,6 +30,61 @@ type Props = {
   portalContainer?: React.RefObject<HTMLElement | null>;
 };
 
+type VaultImportControlsProps = {
+  projectId: string;
+  isDisabled?: boolean;
+  onCloseOptionsMenu: () => void;
+};
+
+// Mounted only when a projectId is present so the project-permission hook
+// isn't called outside a ProjectPermissionContext (e.g. the org-level
+// project-templates editor).
+const VaultImportControls = ({
+  projectId,
+  isDisabled,
+  onCloseOptionsMenu
+}: VaultImportControlsProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const canUseAppConnectionImport = useCanUseProjectAppConnectionImport(
+    ProjectPermissionSub.Secrets
+  );
+  const { data: vaultAppConnections = [] } = useListAvailableAppConnections(
+    AppConnection.HCVault,
+    projectId,
+    { enabled: canUseAppConnectionImport }
+  );
+
+  if (vaultAppConnections.length === 0) return null;
+
+  return (
+    <>
+      <Tooltip open={!canUseAppConnectionImport ? undefined : false}>
+        <TooltipTrigger className="block w-full">
+          <DropdownMenuItem
+            onClick={() => {
+              setIsModalOpen(true);
+              onCloseOptionsMenu();
+            }}
+            isDisabled={isDisabled}
+          >
+            <DownloadIcon />
+            Add from HashiCorp Vault
+          </DropdownMenuItem>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          Only authorized users can import policies from HashiCorp Vault
+        </TooltipContent>
+      </Tooltip>
+      <VaultPolicyImportModal
+        isOpen={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        appConnections={vaultAppConnections}
+      />
+    </>
+  );
+};
+
 export const AddPoliciesButton = ({
   isDisabled,
   projectType,
@@ -39,20 +95,8 @@ export const AddPoliciesButton = ({
   const { popUp, handlePopUpToggle, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "addPolicy",
     "addPolicyOptions",
-    "applyTemplate",
-    "importFromVault"
+    "applyTemplate"
   ] as const);
-
-  const canUseAppConnectionImport = useCanUseProjectAppConnectionImport(
-    ProjectPermissionSub.Secrets
-  );
-  const { data: vaultAppConnections = [] } = useListAvailableAppConnections(
-    AppConnection.HCVault,
-    projectId ?? "",
-    { enabled: Boolean(projectId) && canUseAppConnectionImport }
-  );
-  const hasVaultConnection = vaultAppConnections.length > 0;
-  const isVaultImportDisabled = isDisabled;
 
   return (
     <div>
@@ -95,24 +139,12 @@ export const AddPoliciesButton = ({
               <LayersIcon />
               Add From Template
             </DropdownMenuItem>
-            {hasVaultConnection && (
-              <Tooltip open={!canUseAppConnectionImport ? undefined : false}>
-                <TooltipTrigger className="block w-full">
-                  <DropdownMenuItem
-                    onClick={() => {
-                      handlePopUpOpen("importFromVault");
-                      handlePopUpClose("addPolicyOptions");
-                    }}
-                    isDisabled={isVaultImportDisabled}
-                  >
-                    <DownloadIcon />
-                    Add from HashiCorp Vault
-                  </DropdownMenuItem>
-                </TooltipTrigger>
-                <TooltipContent side="left">
-                  Only authorized users can import policies from HashiCorp Vault
-                </TooltipContent>
-              </Tooltip>
+            {projectId && (
+              <VaultImportControls
+                projectId={projectId}
+                isDisabled={isDisabled}
+                onCloseOptionsMenu={() => handlePopUpClose("addPolicyOptions")}
+              />
             )}
           </DropdownMenuContent>
         </DropdownMenu>
@@ -121,11 +153,6 @@ export const AddPoliciesButton = ({
         type={projectType}
         isOpen={popUp.applyTemplate.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("applyTemplate", isOpen)}
-      />
-      <VaultPolicyImportModal
-        isOpen={popUp.importFromVault.isOpen}
-        onOpenChange={(isOpen) => handlePopUpToggle("importFromVault", isOpen)}
-        appConnections={vaultAppConnections}
       />
     </div>
   );


### PR DESCRIPTION
## Context

The AddPoliciesButton (rendered inside the project templatete role editor) called `useCanUseProjectAppConnectionImport`, which uses `useProjectPermission`, which requires a project ID from the route. On the org-settings page there is no projectId, so the hook threw. It only fired when the form rendered the button.

## Screenshots

<img width="1364" height="596" alt="CleanShot 2026-05-22 at 03 13 20@2x" src="https://github.com/user-attachments/assets/ce22240d-6ebb-4454-af8b-60f7e18fe115" />

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)