### PR TITLE
improvement(vault-impoter): move limiter to request 

### DIFF
--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -694,27 +694,25 @@ export const listHCVaultSecretPaths = async (
     limiter: ReturnType<typeof createConcurrencyLimiter>,
     currentPath: string = ""
   ): Promise<string[]> => {
-    const paths = await getPaths(mountPath, currentPath, kvVersion);
+    const paths = await limiter(() => getPaths(mountPath, currentPath, kvVersion));
 
     if (paths === null || paths.length === 0) {
       return [];
     }
 
-    // Process paths in parallel with concurrency control
+    // Process paths in parallel; concurrency is enforced on getPaths
     const secretPathsArrays = await Promise.all(
-      paths.map((path) =>
-        limiter(async () => {
-          const cleanPath = path.endsWith("/") ? path.slice(0, -1) : path;
-          const fullItemPath = currentPath ? `${currentPath}/${cleanPath}` : cleanPath;
+      paths.map(async (path) => {
+        const cleanPath = path.endsWith("/") ? path.slice(0, -1) : path;
+        const fullItemPath = currentPath ? `${currentPath}/${cleanPath}` : cleanPath;
 
-          if (path.endsWith("/")) {
-            // it's a folder so we recurse into it
-            return recursivelyGetAllPaths(mountPath, kvVersion, limiter, fullItemPath);
-          }
-          // it's a secret so we return it
-          return [`${mountPath}/${fullItemPath}`];
-        })
-      )
+        if (path.endsWith("/")) {
+          // it's a folder so we recurse into it
+          return recursivelyGetAllPaths(mountPath, kvVersion, limiter, fullItemPath);
+        }
+        // it's a secret so we return it
+        return [`${mountPath}/${fullItemPath}`];
+      })
     );
 
     // Flatten the arrays into a single array


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The previous limiter was not performing operations in parallel. The requests were sequential, so we were not getting much from the limiter. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Createa a vault instance with several paths (let me know if you need help with this) (around 600 folders is file)
- try to import data from there  
- make sure it does not take too long to return  

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)