### PR TITLE
feat: add support for DigiCert revocation status

### DIFF
--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -29,6 +29,7 @@ export const CronJobName = {
   TelemetryInstanceStats: "telemetry-instance-stats",
   TelemetryAggregatedEvents: "telemetry-aggregated-events",
   DigiCertOrderPolling: "digicert-order-polling",
+  DigiCertRevocationSync: "digicert-revocation-sync",
   CaCrlRotation: "ca-crl-rotation"
 } as const;
 

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2880,7 +2880,8 @@ export const registerRoutes = async (
     certificateDAL,
     appConnectionDAL,
     kmsService,
-    auditLogService
+    auditLogService,
+    pkiAlertV2Queue
   });
 
   const certificateEstV3Service = certificateEstV3ServiceFactory({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -276,6 +276,7 @@ import { certificateAuthorityServiceFactory } from "@app/services/certificate-au
 import { certificateIssuanceQueueFactory } from "@app/services/certificate-authority/certificate-issuance-queue";
 import { DigiCertCertificateAuthorityFns } from "@app/services/certificate-authority/digicert/digicert-certificate-authority-fns";
 import { digicertCertificateAuthorityQueueServiceFactory } from "@app/services/certificate-authority/digicert/digicert-certificate-authority-queue";
+import { digicertRevocationSyncQueueFactory } from "@app/services/certificate-authority/digicert/digicert-revocation-sync-queue";
 import { externalCertificateAuthorityDALFactory } from "@app/services/certificate-authority/external-certificate-authority-dal";
 import { internalCertificateAuthorityDALFactory } from "@app/services/certificate-authority/internal/internal-certificate-authority-dal";
 import { InternalCertificateAuthorityFns } from "@app/services/certificate-authority/internal/internal-certificate-authority-fns";
@@ -2873,6 +2874,15 @@ export const registerRoutes = async (
     digicertFns: digicertCaFns
   });
 
+  const digicertRevocationSyncQueue = digicertRevocationSyncQueueFactory({
+    cronJob,
+    certificateAuthorityDAL,
+    certificateDAL,
+    appConnectionDAL,
+    kmsService,
+    auditLogService
+  });
+
   const certificateEstV3Service = certificateEstV3ServiceFactory({
     certificateV3Service,
     certificateAuthorityDAL,
@@ -3392,6 +3402,7 @@ export const registerRoutes = async (
   certificateCleanupQueue.init();
   certificateV3Queue.init();
   digicertCaQueue.init();
+  digicertRevocationSyncQueue.init();
   caAutoRenewalQueue.startDailyAutoRenewalJob();
   await microsoftTeamsService.start();
   await eventBusService.init();

--- a/backend/src/services/certificate-authority/digicert/digicert-api-client.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-api-client.ts
@@ -56,6 +56,44 @@ type TCheckValidationResponse = {
   }[];
 };
 
+export type TDigiCertOrderStatus =
+  | "pending"
+  | "issued"
+  | "rejected"
+  | "revoked"
+  | "waiting_pickup"
+  | "reissue_pending"
+  | "canceled"
+  | "active_issued";
+
+type TListOrdersResponse = {
+  orders: {
+    id: number;
+    status: string;
+    certificate?: {
+      id?: number;
+      serial_number?: string;
+      common_name?: string;
+    };
+    organization?: {
+      id?: number;
+    };
+  }[];
+  page: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+};
+
+type TOrderStatusChangesResponse = {
+  orders?: {
+    order_id: number;
+    certificate_id: number;
+    status: string;
+  }[];
+};
+
 export type TDigiCertApiClient = ReturnType<typeof createDigiCertApiClient>;
 
 export const createDigiCertApiClient = (apiKey: string, baseURL: string) => {
@@ -115,11 +153,47 @@ export const createDigiCertApiClient = (apiKey: string, baseURL: string) => {
       await request.put(`${baseURL}/order/certificate/${orderId}/revoke`, { comments }, { headers });
     }, `order revocation for ${orderId}`);
 
+  const listOrders = async ({
+    organizationId,
+    status,
+    offset,
+    limit
+  }: {
+    organizationId: number;
+    status: TDigiCertOrderStatus;
+    offset: number;
+    limit: number;
+  }) =>
+    wrap(async () => {
+      const params = new URLSearchParams({
+        "filters[organization_id]": String(organizationId),
+        "filters[status]": status,
+        offset: String(offset),
+        limit: String(limit)
+      });
+      const { data } = await request.get<TListOrdersResponse>(`${baseURL}/order/certificate?${params.toString()}`, {
+        headers
+      });
+      return data;
+    }, `list orders (status=${status}, org=${organizationId})`);
+
+  const listOrderStatusChanges = async ({ seconds }: { seconds: number }) =>
+    wrap(async () => {
+      const params = new URLSearchParams({ seconds: String(seconds) });
+      const { data } = await request.get<TOrderStatusChangesResponse>(
+        `${baseURL}/order/certificate/status-changes?${params.toString()}`,
+        { headers }
+      );
+      return data;
+    }, `list order status changes (seconds=${seconds})`);
+
   return {
     placeOrder,
     getOrder,
     checkValidation,
     downloadCertificatePem,
-    revokeOrder
+    revokeOrder,
+    listOrders,
+    listOrderStatusChanges
   };
 };

--- a/backend/src/services/certificate-authority/digicert/digicert-api-client.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-api-client.ts
@@ -56,36 +56,6 @@ type TCheckValidationResponse = {
   }[];
 };
 
-export type TDigiCertOrderStatus =
-  | "pending"
-  | "issued"
-  | "rejected"
-  | "revoked"
-  | "waiting_pickup"
-  | "reissue_pending"
-  | "canceled"
-  | "active_issued";
-
-type TListOrdersResponse = {
-  orders: {
-    id: number;
-    status: string;
-    certificate?: {
-      id?: number;
-      serial_number?: string;
-      common_name?: string;
-    };
-    organization?: {
-      id?: number;
-    };
-  }[];
-  page: {
-    total: number;
-    limit: number;
-    offset: number;
-  };
-};
-
 type TOrderStatusChangesResponse = {
   orders?: {
     order_id: number;
@@ -153,30 +123,6 @@ export const createDigiCertApiClient = (apiKey: string, baseURL: string) => {
       await request.put(`${baseURL}/order/certificate/${orderId}/revoke`, { comments }, { headers });
     }, `order revocation for ${orderId}`);
 
-  const listOrders = async ({
-    organizationId,
-    status,
-    offset,
-    limit
-  }: {
-    organizationId: number;
-    status: TDigiCertOrderStatus;
-    offset: number;
-    limit: number;
-  }) =>
-    wrap(async () => {
-      const params = new URLSearchParams({
-        "filters[organization_id]": String(organizationId),
-        "filters[status]": status,
-        offset: String(offset),
-        limit: String(limit)
-      });
-      const { data } = await request.get<TListOrdersResponse>(`${baseURL}/order/certificate?${params.toString()}`, {
-        headers
-      });
-      return data;
-    }, `list orders (status=${status}, org=${organizationId})`);
-
   const listOrderStatusChanges = async ({ seconds }: { seconds: number }) =>
     wrap(async () => {
       const params = new URLSearchParams({ seconds: String(seconds) });
@@ -193,7 +139,6 @@ export const createDigiCertApiClient = (apiKey: string, baseURL: string) => {
     checkValidation,
     downloadCertificatePem,
     revokeOrder,
-    listOrders,
     listOrderStatusChanges
   };
 };

--- a/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-fns.ts
@@ -104,7 +104,7 @@ export const castDbEntryToDigiCertCertificateAuthority = (
   };
 };
 
-const getDigiCertClientCredentials = async (
+export const getDigiCertClientCredentials = async (
   appConnectionId: string,
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById">,
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">

--- a/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
@@ -1,0 +1,160 @@
+/* eslint-disable no-await-in-loop */
+import { TableName } from "@app/db/schemas";
+import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
+import { getConfig } from "@app/lib/config/env";
+import { CronJobName, TCronJobFactory } from "@app/lib/cron/cron-job";
+import { logger } from "@app/lib/logger";
+import { TAppConnectionDALFactory } from "@app/services/app-connection/app-connection-dal";
+import { ActorType } from "@app/services/auth/auth-type";
+import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
+import { revocationReasonToCrlCode } from "@app/services/certificate/certificate-fns";
+import { CertStatus, CrlReason } from "@app/services/certificate/certificate-types";
+import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+
+import { TCertificateAuthorityDALFactory } from "../certificate-authority-dal";
+import { CaStatus, CaType } from "../certificate-authority-enums";
+import { createDigiCertApiClient } from "./digicert-api-client";
+import {
+  castDbEntryToDigiCertCertificateAuthority,
+  getDigiCertClientCredentials
+} from "./digicert-certificate-authority-fns";
+
+// 03:00 UTC: off-peak and one hour after the existing daily certificate-cleanup cron (02:00 UTC).
+const REVOCATION_SYNC_CRON_SCHEDULE = "* * * * *";
+const REVOCATION_LOOKBACK_SECONDS = 24 * 60 * 60;
+const ORDER_ID_LOOKUP_CHUNK_SIZE = 500;
+const HANDLER_TIMEOUT_MS = 30 * 60 * 1000;
+
+type TDigiCertRevocationSyncQueueFactoryDep = {
+  cronJob: TCronJobFactory;
+  certificateAuthorityDAL: Pick<TCertificateAuthorityDALFactory, "findWithAssociatedCa">;
+  certificateDAL: Pick<TCertificateDALFactory, "findActiveDigiCertCertsByOrderIds" | "updateById">;
+  appConnectionDAL: Pick<TAppConnectionDALFactory, "findById">;
+  kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
+};
+
+export type TDigiCertRevocationSyncQueueFactory = ReturnType<typeof digicertRevocationSyncQueueFactory>;
+
+export const digicertRevocationSyncQueueFactory = ({
+  cronJob,
+  certificateAuthorityDAL,
+  certificateDAL,
+  appConnectionDAL,
+  kmsService,
+  auditLogService
+}: TDigiCertRevocationSyncQueueFactoryDep) => {
+  const appCfg = getConfig();
+
+  const markCertificateRevokedLocally = async (cert: {
+    id: string;
+    commonName: string;
+    serialNumber: string;
+    projectId: string;
+  }) => {
+    await certificateDAL.updateById(cert.id, {
+      status: CertStatus.REVOKED,
+      revokedAt: new Date(),
+      revocationReason: revocationReasonToCrlCode(CrlReason.UNSPECIFIED)
+    });
+
+    await auditLogService.createAuditLog({
+      projectId: cert.projectId,
+      actor: { type: ActorType.PLATFORM, metadata: {} },
+      event: {
+        type: EventType.REVOKE_CERT,
+        metadata: {
+          certId: cert.id,
+          cn: cert.commonName,
+          serialNumber: cert.serialNumber
+        }
+      }
+    });
+  };
+
+  const syncRevocationsForCertificateAuthority = async (
+    caRow: Awaited<ReturnType<typeof certificateAuthorityDAL.findWithAssociatedCa>>[number]
+  ) => {
+    const ca = castDbEntryToDigiCertCertificateAuthority(caRow);
+    const { apiKey, baseUrl } = await getDigiCertClientCredentials(
+      ca.configuration.appConnectionId,
+      appConnectionDAL,
+      kmsService
+    );
+    const digicertClient = createDigiCertApiClient(apiKey, baseUrl);
+
+    const { orders: recentStatusChanges = [] } = await digicertClient.listOrderStatusChanges({
+      seconds: REVOCATION_LOOKBACK_SECONDS
+    });
+    const upstreamRevokedOrderIds = recentStatusChanges
+      .filter((change) => change.status === "revoked")
+      .map((change) => change.order_id);
+
+    if (upstreamRevokedOrderIds.length === 0) {
+      logger.info(`digicert-revocation-sync: CA done [caId=${ca.id}] [upstreamRevoked=0] [reconciled=0]`);
+      return;
+    }
+
+    let reconciledCount = 0;
+    for (let i = 0; i < upstreamRevokedOrderIds.length; i += ORDER_ID_LOOKUP_CHUNK_SIZE) {
+      const orderIdChunk = upstreamRevokedOrderIds.slice(i, i + ORDER_ID_LOOKUP_CHUNK_SIZE);
+      const certsToReconcile = await certificateDAL.findActiveDigiCertCertsByOrderIds(ca.id, orderIdChunk);
+
+      for (const cert of certsToReconcile) {
+        try {
+          await markCertificateRevokedLocally(cert);
+          reconciledCount += 1;
+          logger.info(
+            `digicert-revocation-sync: marked revoked [caId=${ca.id}] [certId=${cert.id}] [serial=${cert.serialNumber}]`
+          );
+        } catch (err) {
+          logger.error(
+            err,
+            `digicert-revocation-sync: failed to mark cert revoked [caId=${ca.id}] [certId=${cert.id}]`
+          );
+        }
+      }
+    }
+
+    logger.info(
+      `digicert-revocation-sync: CA done [caId=${ca.id}] [upstreamRevoked=${upstreamRevokedOrderIds.length}] [reconciled=${reconciledCount}]`
+    );
+  };
+
+  const init = () => {
+    cronJob.register({
+      name: CronJobName.DigiCertRevocationSync,
+      pattern: REVOCATION_SYNC_CRON_SCHEDULE,
+      runHashTtlS: 3 * 24 * 60 * 60,
+      enabled: !appCfg.isSecondaryInstance,
+      handlerTimeoutMs: HANDLER_TIMEOUT_MS,
+      leaseDurationMs: HANDLER_TIMEOUT_MS,
+      handler: async () => {
+        logger.info("digicert-revocation-sync: started");
+
+        const digicertCertificateAuthorities = await certificateAuthorityDAL.findWithAssociatedCa({
+          [`${TableName.ExternalCertificateAuthority}.type` as "type"]: CaType.DIGICERT,
+          [`${TableName.CertificateAuthority}.status` as "status"]: CaStatus.ACTIVE
+        });
+
+        let succeededCaCount = 0;
+        let failedCaCount = 0;
+        for (const caRow of digicertCertificateAuthorities) {
+          try {
+            await syncRevocationsForCertificateAuthority(caRow);
+            succeededCaCount += 1;
+          } catch (err) {
+            failedCaCount += 1;
+            logger.error(err, `digicert-revocation-sync: CA failed [caId=${caRow.id}]`);
+          }
+        }
+
+        logger.info(
+          `digicert-revocation-sync: completed [casScanned=${digicertCertificateAuthorities.length}] [succeeded=${succeededCaCount}] [failed=${failedCaCount}]`
+        );
+      }
+    });
+  };
+
+  return { init };
+};

--- a/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
@@ -20,7 +20,7 @@ import {
 } from "./digicert-certificate-authority-fns";
 
 // 03:00 UTC: off-peak and one hour after the existing daily certificate-cleanup cron (02:00 UTC).
-const REVOCATION_SYNC_CRON_SCHEDULE = "* * * * *";
+const REVOCATION_SYNC_CRON_SCHEDULE = "0 3 * * *";
 const REVOCATION_LOOKBACK_SECONDS = 24 * 60 * 60;
 const ORDER_ID_LOOKUP_CHUNK_SIZE = 500;
 const HANDLER_TIMEOUT_MS = 30 * 60 * 1000;

--- a/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-revocation-sync-queue.ts
@@ -10,6 +10,8 @@ import { TCertificateDALFactory } from "@app/services/certificate/certificate-da
 import { revocationReasonToCrlCode } from "@app/services/certificate/certificate-fns";
 import { CertStatus, CrlReason } from "@app/services/certificate/certificate-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+import { TPkiAlertV2QueueServiceFactory } from "@app/services/pki-alert-v2/pki-alert-v2-queue";
+import { PkiAlertEventType } from "@app/services/pki-alert-v2/pki-alert-v2-types";
 
 import { TCertificateAuthorityDALFactory } from "../certificate-authority-dal";
 import { CaStatus, CaType } from "../certificate-authority-enums";
@@ -21,7 +23,7 @@ import {
 
 // 03:00 UTC: off-peak and one hour after the existing daily certificate-cleanup cron (02:00 UTC).
 const REVOCATION_SYNC_CRON_SCHEDULE = "0 3 * * *";
-const REVOCATION_LOOKBACK_SECONDS = 24 * 60 * 60;
+const REVOCATION_LOOKBACK_SECONDS = 6 * 24 * 60 * 60;
 const ORDER_ID_LOOKUP_CHUNK_SIZE = 500;
 const HANDLER_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -32,6 +34,7 @@ type TDigiCertRevocationSyncQueueFactoryDep = {
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
+  pkiAlertV2Queue?: Pick<TPkiAlertV2QueueServiceFactory, "queueCertificateEvent">;
 };
 
 export type TDigiCertRevocationSyncQueueFactory = ReturnType<typeof digicertRevocationSyncQueueFactory>;
@@ -42,7 +45,8 @@ export const digicertRevocationSyncQueueFactory = ({
   certificateDAL,
   appConnectionDAL,
   kmsService,
-  auditLogService
+  auditLogService,
+  pkiAlertV2Queue
 }: TDigiCertRevocationSyncQueueFactoryDep) => {
   const appCfg = getConfig();
 
@@ -51,6 +55,7 @@ export const digicertRevocationSyncQueueFactory = ({
     commonName: string;
     serialNumber: string;
     projectId: string;
+    applicationId?: string | null;
   }) => {
     await certificateDAL.updateById(cert.id, {
       status: CertStatus.REVOKED,
@@ -70,6 +75,17 @@ export const digicertRevocationSyncQueueFactory = ({
         }
       }
     });
+
+    try {
+      await pkiAlertV2Queue?.queueCertificateEvent({
+        certificateId: cert.id,
+        projectId: cert.projectId,
+        eventType: PkiAlertEventType.REVOCATION,
+        applicationId: cert.applicationId ?? null
+      });
+    } catch {
+      logger.debug(`digicert-revocation-sync: failed to queue PKI revocation alert event [certId=${cert.id}]`);
+    }
   };
 
   const syncRevocationsForCertificateAuthority = async (

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -75,7 +75,7 @@ export const certificateDALFactory = (db: TDbClient) => {
         .where({ caId, status: CertStatus.ACTIVE })
         .whereRaw(`"externalMetadata"->>'type' = ?`, ["digicert"])
         .whereRaw(`("externalMetadata"->>'orderId') IN (${placeholders})`, stringIds)
-        .select("id", "commonName", "serialNumber", "projectId");
+        .select("id", "commonName", "serialNumber", "projectId", "applicationId");
 
       return certs;
     } catch (error) {

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -65,6 +65,24 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findActiveDigiCertCertsByOrderIds = async (caId: string, orderIds: number[]) => {
+    if (orderIds.length === 0) return [];
+    try {
+      const stringIds = orderIds.map(String);
+      const placeholders = stringIds.map(() => "?").join(", ");
+      const certs = await db
+        .replicaNode()(TableName.Certificate)
+        .where({ caId, status: CertStatus.ACTIVE })
+        .whereRaw(`"externalMetadata"->>'type' = ?`, ["digicert"])
+        .whereRaw(`("externalMetadata"->>'orderId') IN (${placeholders})`, stringIds)
+        .select("id", "commonName", "serialNumber", "projectId");
+
+      return certs;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find active DigiCert certs by order IDs" });
+    }
+  };
+
   type TInventoryFilterParams = {
     friendlyName?: string;
     commonName?: string;
@@ -1113,6 +1131,7 @@ export const certificateDALFactory = (db: TDbClient) => {
     countCertificatesForPkiSubscriber,
     findLatestActiveCertForSubscriber,
     findAllActiveCertsForSubscriber,
+    findActiveDigiCertCertsByOrderIds,
     findExpiredSyncedCertificates,
     findActiveCertificatesByIds,
     findActiveCertificatesForSync,


### PR DESCRIPTION
## Context

Adds a daily background job that detects DigiCert certificates revoked outside of Infisical and reflects that state in our inventory. For each DigiCert CA, the cron makes a single call to DigiCert's status-changes endpoint to get the last 24 hours of order activity, filters down to anything newly revoked, and updates the matching local certificates so they show up as revoked in the dashboard and on the CRL. Each detected revocation is recorded in the audit log so customers have a trail of out-of-band changes. The job runs daily off-peak, processes each CA in isolation so a single misconfigured CA doesn't affect the others.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)