### PR TITLE
fix(pki): prevent ACME order finalization bypass via duplicate identifiers

### DIFF
--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -773,6 +773,11 @@ export const pkiAcmeServiceFactory = ({
       }
     }
 
+    const uniqueIdentifiers = new Set(payload.identifiers.map((id) => `${id.type}:${id.value.toLowerCase()}`));
+    if (uniqueIdentifiers.size !== payload.identifiers.length) {
+      throw new AcmeMalformedError({ message: "Duplicate identifiers are not permitted" });
+    }
+
     const order = await acmeOrderDAL.transaction(async (tx) => {
       const account = (await acmeAccountDAL.findByProjectIdAndAccountId(profileId, accountId))!;
       const createdOrder = await acmeOrderDAL.create(
@@ -1146,12 +1151,15 @@ export const pkiAcmeServiceFactory = ({
             : AcmeIdentifierType.DNS;
           csrIdentifierPairs.add(`${cnType}:${certificateRequest.commonName.toLowerCase()}`);
         }
-        if (
-          csrIdentifierPairs.size !== orderWithAuthorizations.authorizations.length ||
-          !orderWithAuthorizations.authorizations.every((auth) => {
+        const authIdentifierPairs = new Set(
+          orderWithAuthorizations.authorizations.map((auth) => {
             const value = auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue;
-            return csrIdentifierPairs.has(`${auth.identifierType}:${value.toLowerCase()}`);
+            return `${auth.identifierType}:${value.toLowerCase()}`;
           })
+        );
+        if (
+          csrIdentifierPairs.size !== authIdentifierPairs.size ||
+          ![...authIdentifierPairs].every((id) => csrIdentifierPairs.has(id))
         ) {
           throw new AcmeBadCSRError({ message: "Invalid CSR: Common name + SANs mismatch with order identifiers" });
         }


### PR DESCRIPTION
## Context

Reject duplicate identifiers at order creation and use bijective set comparison at finalization to ensure CSR domains exactly match authorized domains.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)