### PR TITLE
fix(license): preserve numeric feature values in self-hosted plan table

### DIFF
--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -603,7 +603,7 @@ export const licenseServiceFactory = ({
 
     const mappedRows = Object.values(BillingPlanRows).map(({ name, field }) => ({
       name,
-      allowed: onPremFeatures[field as keyof TFeatureSet] || false,
+      allowed: onPremFeatures[field as keyof TFeatureSet] ?? false,
       used: calculateUsageValue(name, field, projectCount, totalIdentities)
     }));
 

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -603,7 +603,7 @@ export const licenseServiceFactory = ({
 
     const mappedRows = Object.values(BillingPlanRows).map(({ name, field }) => ({
       name,
-      allowed: onPremFeatures[field as keyof TFeatureSet] ?? false,
+      allowed: onPremFeatures[field as keyof TFeatureSet] as boolean | number | null,
       used: calculateUsageValue(name, field, projectCount, totalIdentities)
     }));
 


### PR DESCRIPTION
## Context

The self-hosted billing plan table (`getOrgPlanTable`) was building `allowed` with `onPremFeatures[field] || false`, which coerced any falsy value to `false`. That incorrectly turned numeric limits like `0` into `false` instead of preserving the actual feature value.

This change returns the raw feature value (`boolean | number | null`) so limit fields display correctly for OSS/offline self-hosted instances.

## Screenshots

Before:

<img width="1549" height="865" alt="image" src="https://github.com/user-attachments/assets/f65fc117-f33f-4ddf-a7b0-f7f4987a2ab9" />

After:

<img width="1483" height="802" alt="image" src="https://github.com/user-attachments/assets/f99a264e-a12a-4468-8465-1265227fb5d4" />

## Steps to verify the change

1. Run the app locally
2. Open org billing/plan table as an org admin.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)