### PR TITLE
fix(pki): enforce authorization before cert-manager membership cleanup

### DIFF
--- a/backend/src/server/plugins/inject-cert-manager-project-id.ts
+++ b/backend/src/server/plugins/inject-cert-manager-project-id.ts
@@ -2,6 +2,8 @@ import { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 import RE2 from "re2";
 
+import { BadRequestError } from "@app/lib/errors";
+
 const CERT_MANAGER_PREFIXES = ["/api/v1/cert-manager/", "/api/v1/pki/", "/api/v2/pki/"];
 
 const COOKIE_PREFIX = "infisical-cm-active-project-";
@@ -50,6 +52,18 @@ export const injectCertManagerProjectId: FastifyPluginAsync = fp(async (server) 
 
     const explicit = readProjectIdFromRequest(req);
     if (explicit) {
+      if (!isUuid(explicit)) {
+        throw new BadRequestError({ message: "Invalid Certificate Manager project." });
+      }
+      const isValidForOrg = await server.services.certManagerProjectResolver.isCertManagerProject(
+        explicit,
+        req.permission.orgId
+      );
+      if (!isValidForOrg) {
+        throw new BadRequestError({
+          message: "Invalid Certificate Manager project."
+        });
+      }
       req.internalCertManagerProjectId = explicit;
       return;
     }

--- a/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
@@ -219,11 +219,6 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     },
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: "group",
-        actorId: req.params.groupId
-      });
       const { membership: groupMembership } = await server.services.membershipGroup.deleteMembership({
         permission: req.permission,
         selector: { groupId: req.params.groupId },
@@ -236,6 +231,11 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
           type: EventType.REMOVE_CERT_MANAGER_GROUP,
           metadata: { groupId: req.params.groupId, membershipId: groupMembership.id }
         }
+      });
+      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
+        projectId,
+        actorKind: "group",
+        actorId: req.params.groupId
       });
       return {
         groupMembership: {

--- a/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
@@ -12,6 +12,7 @@ import { ms } from "@app/lib/ms";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { ApplicationMemberKind } from "@app/services/pki-application/pki-application-types";
 
 import { RolesUpdateBodySchema } from "./schemas";
 
@@ -234,7 +235,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
       });
       await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
         projectId,
-        actorKind: "group",
+        actorKind: ApplicationMemberKind.Group,
         actorId: req.params.groupId
       });
       return {

--- a/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
@@ -220,10 +220,19 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     },
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      const { membership: groupMembership } = await server.services.membershipGroup.deleteMembership({
-        permission: req.permission,
-        selector: { groupId: req.params.groupId },
-        scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId }
+      const { membership: groupMembership } = await server.services.pkiApplicationMembership.deleteMemberAndCleanup({
+        projectId,
+        actorKind: ApplicationMemberKind.Group,
+        actorId: req.params.groupId,
+        performDelete: (tx) =>
+          server.services.membershipGroup.deleteMembership(
+            {
+              permission: req.permission,
+              selector: { groupId: req.params.groupId },
+              scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId }
+            },
+            tx
+          )
       });
       await server.services.auditLog.createAuditLog({
         ...req.auditLogInfo,
@@ -232,11 +241,6 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
           type: EventType.REMOVE_CERT_MANAGER_GROUP,
           metadata: { groupId: req.params.groupId, membershipId: groupMembership.id }
         }
-      });
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: ApplicationMemberKind.Group,
-        actorId: req.params.groupId
       });
       return {
         groupMembership: {

--- a/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
@@ -14,6 +14,7 @@ import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { ApplicationMemberKind } from "@app/services/pki-application/pki-application-types";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { MembershipRoleSchema, RolesUpdateBodySchema } from "./schemas";
@@ -280,7 +281,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
       });
       await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
         projectId,
-        actorKind: "identity",
+        actorKind: ApplicationMemberKind.Identity,
         actorId: req.params.identityId
       });
       return { identityMembership: { ...membership, identityId: req.params.identityId } };

--- a/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
@@ -266,10 +266,19 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
     },
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      const { membership } = await server.services.membershipIdentity.deleteMembership({
-        permission: req.permission,
-        scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
-        selector: { identityId: req.params.identityId }
+      const { membership } = await server.services.pkiApplicationMembership.deleteMemberAndCleanup({
+        projectId,
+        actorKind: ApplicationMemberKind.Identity,
+        actorId: req.params.identityId,
+        performDelete: (tx) =>
+          server.services.membershipIdentity.deleteMembership(
+            {
+              permission: req.permission,
+              scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
+              selector: { identityId: req.params.identityId }
+            },
+            tx
+          )
       });
       await server.services.auditLog.createAuditLog({
         ...req.auditLogInfo,
@@ -278,11 +287,6 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
           type: EventType.REMOVE_CERT_MANAGER_IDENTITY,
           metadata: { identityId: req.params.identityId, membershipId: membership.id }
         }
-      });
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: ApplicationMemberKind.Identity,
-        actorId: req.params.identityId
       });
       return { identityMembership: { ...membership, identityId: req.params.identityId } };
     }

--- a/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
@@ -265,11 +265,6 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
     },
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: "identity",
-        actorId: req.params.identityId
-      });
       const { membership } = await server.services.membershipIdentity.deleteMembership({
         permission: req.permission,
         scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
@@ -282,6 +277,11 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
           type: EventType.REMOVE_CERT_MANAGER_IDENTITY,
           metadata: { identityId: req.params.identityId, membershipId: membership.id }
         }
+      });
+      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
+        projectId,
+        actorKind: "identity",
+        actorId: req.params.identityId
       });
       return { identityMembership: { ...membership, identityId: req.params.identityId } };
     }

--- a/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
@@ -218,11 +218,6 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      await server.services.pkiApplicationMembership.removeUsersFromApplicationMemberships({
-        projectId,
-        emails: req.body.emails,
-        usernames: req.body.usernames
-      });
       const memberships = await server.services.projectMembership.deleteProjectMemberships({
         actorId: req.permission.id,
         actor: req.permission.type,
@@ -245,6 +240,11 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
           }
         }
       });
+      await server.services.pkiApplicationMembership.removeUsersFromApplicationMemberships({
+        projectId,
+        emails: req.body.emails,
+        usernames: req.body.usernames
+      });
       return {
         memberships: memberships.map((el) => ({ ...el, userId: el.actorUserId as string }))
       };
@@ -264,11 +264,6 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { userId } = req.params;
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: "user",
-        actorId: userId
-      });
       const { membership } = await server.services.membershipUser.deleteMembership({
         permission: req.permission,
         scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
@@ -281,6 +276,11 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
           type: EventType.REMOVE_CERT_MANAGER_USER,
           metadata: { userId: membership.actorUserId as string, membershipId: membership.id }
         }
+      });
+      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
+        projectId,
+        actorKind: "user",
+        actorId: userId
       });
       return { membership: { ...membership, userId } };
     }

--- a/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
@@ -219,14 +219,23 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
-      const memberships = await server.services.projectMembership.deleteProjectMemberships({
-        actorId: req.permission.id,
-        actor: req.permission.type,
-        actorAuthMethod: req.permission.authMethod,
-        actorOrgId: req.permission.orgId,
+      const memberships = await server.services.pkiApplicationMembership.deleteMembersAndCleanup({
         projectId,
         emails: req.body.emails,
-        usernames: req.body.usernames
+        usernames: req.body.usernames,
+        performDelete: (tx) =>
+          server.services.projectMembership.deleteProjectMemberships(
+            {
+              actorId: req.permission.id,
+              actor: req.permission.type,
+              actorAuthMethod: req.permission.authMethod,
+              actorOrgId: req.permission.orgId,
+              projectId,
+              emails: req.body.emails,
+              usernames: req.body.usernames
+            },
+            tx
+          )
       });
       await server.services.auditLog.createAuditLog({
         ...req.auditLogInfo,
@@ -240,11 +249,6 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
             membershipIds: memberships.map((m) => m.id)
           }
         }
-      });
-      await server.services.pkiApplicationMembership.removeUsersFromApplicationMemberships({
-        projectId,
-        emails: req.body.emails,
-        usernames: req.body.usernames
       });
       return {
         memberships: memberships.map((el) => ({ ...el, userId: el.actorUserId as string }))
@@ -265,10 +269,19 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { userId } = req.params;
-      const { membership } = await server.services.membershipUser.deleteMembership({
-        permission: req.permission,
-        scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
-        selector: { userId }
+      const { membership } = await server.services.pkiApplicationMembership.deleteMemberAndCleanup({
+        projectId,
+        actorKind: ApplicationMemberKind.User,
+        actorId: userId,
+        performDelete: (tx) =>
+          server.services.membershipUser.deleteMembership(
+            {
+              permission: req.permission,
+              scopeData: { scope: AccessScope.Project, orgId: req.permission.orgId, projectId },
+              selector: { userId }
+            },
+            tx
+          )
       });
       await server.services.auditLog.createAuditLog({
         ...req.auditLogInfo,
@@ -277,11 +290,6 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
           type: EventType.REMOVE_CERT_MANAGER_USER,
           metadata: { userId: membership.actorUserId as string, membershipId: membership.id }
         }
-      });
-      await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: ApplicationMemberKind.User,
-        actorId: userId
       });
       return { membership: { ...membership, userId } };
     }

--- a/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
@@ -12,6 +12,7 @@ import { ApiDocsTags } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { ApplicationMemberKind } from "@app/services/pki-application/pki-application-types";
 
 import { SanitizedUserSchema } from "../../sanitizedSchemas";
 import { MembershipRoleSchema, RolesUpdateBodySchema } from "./schemas";
@@ -279,7 +280,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
       });
       await server.services.pkiApplicationMembership.removeActorFromApplicationMemberships({
         projectId,
-        actorKind: "user",
+        actorKind: ApplicationMemberKind.User,
         actorId: userId
       });
       return { membership: { ...membership, userId } };

--- a/backend/src/services/membership-group/membership-group-service.ts
+++ b/backend/src/services/membership-group/membership-group-service.ts
@@ -1,3 +1,5 @@
+import { Knex } from "knex";
+
 import {
   AccessScope,
   ProjectMembershipRole,
@@ -300,7 +302,7 @@ export const membershipGroupServiceFactory = ({
     return { membership: membershipDoc, group };
   };
 
-  const deleteMembership = async (dto: TDeleteMembershipGroupDTO) => {
+  const deleteMembership = async (dto: TDeleteMembershipGroupDTO, externalTx?: Knex) => {
     const { scopeData } = dto;
     const factory = scopeFactory[scopeData.scope];
 
@@ -366,11 +368,15 @@ export const membershipGroupServiceFactory = ({
       }
     }
 
-    const membershipDoc = await membershipGroupDAL.transaction(async (tx) => {
+    const performDelete = async (tx: Knex) => {
       await membershipRoleDAL.delete({ membershipId: existingMembership.id }, tx);
       const doc = await membershipGroupDAL.deleteById(existingMembership.id, tx);
       return doc;
-    });
+    };
+
+    const membershipDoc = externalTx
+      ? await performDelete(externalTx)
+      : await membershipGroupDAL.transaction(performDelete);
     return { membership: membershipDoc, group };
   };
 

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -1,3 +1,5 @@
+import { Knex } from "knex";
+
 import { AccessScope, ProjectMembershipRole, TemporaryPermissionMode, TMembershipRolesInsert } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -287,7 +289,7 @@ export const membershipIdentityServiceFactory = ({
     return { membership: membershipDoc };
   };
 
-  const deleteMembership = async (dto: TDeleteMembershipIdentityDTO) => {
+  const deleteMembership = async (dto: TDeleteMembershipIdentityDTO, externalTx?: Knex) => {
     const { scopeData } = dto;
     const factory = scopeFactory[scopeData.scope];
 
@@ -310,7 +312,7 @@ export const membershipIdentityServiceFactory = ({
         message: "You can't delete your own membership"
       });
 
-    const membershipDoc = await membershipIdentityDAL.transaction(async (tx) => {
+    const performDelete = async (tx: Knex) => {
       await additionalPrivilegeDAL.delete(
         {
           actorIdentityId: dto.selector.identityId,
@@ -321,7 +323,11 @@ export const membershipIdentityServiceFactory = ({
       await membershipRoleDAL.delete({ membershipId: existingMembership.id }, tx);
       const doc = await membershipIdentityDAL.deleteById(existingMembership.id, tx);
       return doc;
-    });
+    };
+
+    const membershipDoc = externalTx
+      ? await performDelete(externalTx)
+      : await membershipIdentityDAL.transaction(performDelete);
     return { membership: membershipDoc };
   };
 

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -1,3 +1,5 @@
+import { Knex } from "knex";
+
 import {
   AccessScope,
   OrgMembershipRole,
@@ -443,7 +445,7 @@ export const membershipUserServiceFactory = ({
     return { membership: membershipDoc };
   };
 
-  const deleteMembership = async (dto: TDeleteMembershipUserDTO) => {
+  const deleteMembership = async (dto: TDeleteMembershipUserDTO, externalTx?: Knex) => {
     const { scopeData } = dto;
     const factory = scopeFactory[scopeData.scope];
 
@@ -465,7 +467,7 @@ export const membershipUserServiceFactory = ({
         message: "You can't delete your own membership"
       });
 
-    const membershipDoc = await membershipUserDAL.transaction(async (tx) => {
+    const performDelete = async (tx: Knex) => {
       if (dto.scopeData.scope === AccessScope.Organization) {
         const [doc] = await deleteOrgMembershipsFn({
           orgMembershipIds: [existingMembership.id],
@@ -496,7 +498,11 @@ export const membershipUserServiceFactory = ({
       await membershipRoleDAL.delete({ membershipId: existingMembership.id }, tx);
       const doc = await membershipUserDAL.deleteById(existingMembership.id, tx);
       return doc;
-    });
+    };
+
+    const membershipDoc = externalTx
+      ? await performDelete(externalTx)
+      : await membershipUserDAL.transaction(performDelete);
     return { membership: membershipDoc };
   };
 

--- a/backend/src/services/pki-application/pki-application-membership-service.ts
+++ b/backend/src/services/pki-application/pki-application-membership-service.ts
@@ -1,4 +1,5 @@
 import { ForbiddenError } from "@casl/ability";
+import { Knex } from "knex";
 
 import {
   AccessScope,
@@ -660,15 +661,18 @@ export const pkiApplicationMembershipServiceFactory = ({
     return applications.map((app) => ({ id: app.id, name: app.name }));
   };
 
-  const removeActorFromApplicationMemberships = async ({
-    projectId,
-    actorKind,
-    actorId
-  }: {
-    projectId: string;
-    actorKind: ApplicationMemberKind;
-    actorId: string;
-  }): Promise<{
+  const removeActorFromApplicationMemberships = async (
+    {
+      projectId,
+      actorKind,
+      actorId
+    }: {
+      projectId: string;
+      actorKind: ApplicationMemberKind;
+      actorId: string;
+    },
+    externalTx?: Knex
+  ): Promise<{
     applications: Array<{ id: string; name: string }>;
     approvalPolicies: Array<{ id: string; name: string }>;
   }> => {
@@ -701,7 +705,7 @@ export const pkiApplicationMembershipServiceFactory = ({
 
     let approvalPoliciesTouched: Array<{ id: string; name: string }> = [];
 
-    await membershipDAL.transaction(async (tx) => {
+    const performCleanup = async (tx: Knex) => {
       if (actorKind !== ApplicationMemberKind.Identity && applicationIds.length > 0) {
         for (const applicationId of applicationIds) {
           // eslint-disable-next-line no-await-in-loop
@@ -730,33 +734,60 @@ export const pkiApplicationMembershipServiceFactory = ({
         await membershipRoleDAL.delete({ $in: { membershipId: membershipIds } }, tx);
         await membershipDAL.delete({ $in: { id: membershipIds } }, tx);
       }
-    });
+    };
+
+    if (externalTx) {
+      await performCleanup(externalTx);
+    } else {
+      await membershipDAL.transaction(performCleanup);
+    }
 
     return { applications: applicationsTouched, approvalPolicies: approvalPoliciesTouched };
   };
 
-  const removeUsersFromApplicationMemberships = async ({
+  const deleteMemberAndCleanup = async <T>({
+    projectId,
+    actorKind,
+    actorId,
+    performDelete
+  }: {
+    projectId: string;
+    actorKind: ApplicationMemberKind;
+    actorId: string;
+    performDelete: (tx: Knex) => Promise<T>;
+  }): Promise<T> => {
+    return membershipDAL.transaction(async (tx) => {
+      const result = await performDelete(tx);
+      await removeActorFromApplicationMemberships({ projectId, actorKind, actorId }, tx);
+      return result;
+    });
+  };
+
+  const deleteMembersAndCleanup = async <T>({
     projectId,
     emails,
-    usernames
+    usernames,
+    performDelete
   }: {
     projectId: string;
     emails: string[];
     usernames: string[];
-  }): Promise<void> => {
-    if (!emails.length && !usernames.length) return;
-
-    const users = await userDAL.findByEmailsOrUsernames({ emails, usernames });
-    if (!users.length) return;
-
-    for (const user of users) {
-      // eslint-disable-next-line no-await-in-loop
-      await removeActorFromApplicationMemberships({
-        projectId,
-        actorKind: ApplicationMemberKind.User,
-        actorId: user.id
-      });
-    }
+    performDelete: (tx: Knex) => Promise<T>;
+  }): Promise<T> => {
+    return membershipDAL.transaction(async (tx) => {
+      const result = await performDelete(tx);
+      if (emails.length || usernames.length) {
+        const users = await userDAL.findByEmailsOrUsernames({ emails, usernames });
+        for (const user of users) {
+          // eslint-disable-next-line no-await-in-loop
+          await removeActorFromApplicationMemberships(
+            { projectId, actorKind: ApplicationMemberKind.User, actorId: user.id },
+            tx
+          );
+        }
+      }
+      return result;
+    });
   };
 
   return {
@@ -766,7 +797,7 @@ export const pkiApplicationMembershipServiceFactory = ({
     updateMemberRole,
     removeMember,
     listApplicationsForActor,
-    removeActorFromApplicationMemberships,
-    removeUsersFromApplicationMemberships
+    deleteMemberAndCleanup,
+    deleteMembersAndCleanup
   };
 };

--- a/backend/src/services/pki-application/pki-application-membership-service.ts
+++ b/backend/src/services/pki-application/pki-application-membership-service.ts
@@ -632,11 +632,11 @@ export const pkiApplicationMembershipServiceFactory = ({
     actorId
   }: {
     projectId: string;
-    actorKind: "user" | "identity" | "group";
+    actorKind: ApplicationMemberKind;
     actorId: string;
   }): Promise<Array<{ id: string; name: string }>> => {
     const memberships =
-      actorKind === "group"
+      actorKind === ApplicationMemberKind.Group
         ? await membershipDAL.findResourceMembershipsForGroup({
             projectId,
             resourceType: ResourceType.CertificateApplication,
@@ -645,7 +645,7 @@ export const pkiApplicationMembershipServiceFactory = ({
         : await membershipDAL.findResourceMembershipsForActor({
             projectId,
             resourceType: ResourceType.CertificateApplication,
-            actorType: actorKind === "user" ? ActorType.USER : ActorType.IDENTITY,
+            actorType: actorKind === ApplicationMemberKind.User ? ActorType.USER : ActorType.IDENTITY,
             actorId
           });
 
@@ -666,14 +666,14 @@ export const pkiApplicationMembershipServiceFactory = ({
     actorId
   }: {
     projectId: string;
-    actorKind: "user" | "identity" | "group";
+    actorKind: ApplicationMemberKind;
     actorId: string;
   }): Promise<{
     applications: Array<{ id: string; name: string }>;
     approvalPolicies: Array<{ id: string; name: string }>;
   }> => {
     const memberships =
-      actorKind === "group"
+      actorKind === ApplicationMemberKind.Group
         ? await membershipDAL.findResourceMembershipsForGroup({
             projectId,
             resourceType: ResourceType.CertificateApplication,
@@ -682,14 +682,16 @@ export const pkiApplicationMembershipServiceFactory = ({
         : await membershipDAL.findResourceMembershipsForActor({
             projectId,
             resourceType: ResourceType.CertificateApplication,
-            actorType: actorKind === "user" ? ActorType.USER : ActorType.IDENTITY,
+            actorType: actorKind === ApplicationMemberKind.User ? ActorType.USER : ActorType.IDENTITY,
             actorId
           });
 
     const directMemberships =
-      actorKind === "group"
+      actorKind === ApplicationMemberKind.Group
         ? memberships
-        : memberships.filter((m) => (actorKind === "user" ? m.actorUserId === actorId : m.actorIdentityId === actorId));
+        : memberships.filter((m) =>
+            actorKind === ApplicationMemberKind.User ? m.actorUserId === actorId : m.actorIdentityId === actorId
+          );
 
     const applicationIds = Array.from(
       new Set(directMemberships.map((m) => m.scopeResourceId).filter((id): id is string => Boolean(id)))
@@ -700,7 +702,7 @@ export const pkiApplicationMembershipServiceFactory = ({
     let approvalPoliciesTouched: Array<{ id: string; name: string }> = [];
 
     await membershipDAL.transaction(async (tx) => {
-      if (actorKind !== "identity" && applicationIds.length > 0) {
+      if (actorKind !== ApplicationMemberKind.Identity && applicationIds.length > 0) {
         for (const applicationId of applicationIds) {
           // eslint-disable-next-line no-await-in-loop
           const affected = await approvalPolicyDAL.deleteStepApproversBySubject(
@@ -708,8 +710,8 @@ export const pkiApplicationMembershipServiceFactory = ({
               projectId,
               scopeType: ApprovalPolicyScope.PkiApplication,
               scopeId: applicationId,
-              userId: actorKind === "user" ? actorId : undefined,
-              groupId: actorKind === "group" ? actorId : undefined
+              userId: actorKind === ApplicationMemberKind.User ? actorId : undefined,
+              groupId: actorKind === ApplicationMemberKind.Group ? actorId : undefined
             },
             tx
           );
@@ -751,7 +753,7 @@ export const pkiApplicationMembershipServiceFactory = ({
       // eslint-disable-next-line no-await-in-loop
       await removeActorFromApplicationMemberships({
         projectId,
-        actorKind: "user",
+        actorKind: ApplicationMemberKind.User,
         actorId: user.id
       });
     }

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { ForbiddenError } from "@casl/ability";
+import { Knex } from "knex";
 
 import { AccessScope, ActionProjectType, ProjectMembershipRole, ProjectVersion, TableName } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
@@ -292,15 +293,10 @@ export const projectMembershipServiceFactory = ({
     return orgMembers;
   };
 
-  const deleteProjectMemberships = async ({
-    actorId,
-    actor,
-    actorOrgId,
-    actorAuthMethod,
-    projectId,
-    emails,
-    usernames
-  }: TDeleteProjectMembershipsDTO) => {
+  const deleteProjectMemberships = async (
+    { actorId, actor, actorOrgId, actorAuthMethod, projectId, emails, usernames }: TDeleteProjectMembershipsDTO,
+    externalTx?: Knex
+  ) => {
     const { permission } = await permissionService.getProjectPermission({
       actor,
       actorId,
@@ -340,7 +336,7 @@ export const projectMembershipServiceFactory = ({
       await userGroupMembershipDAL.findUserGroupMembershipsInProject(usernamesAndEmails, projectId)
     );
 
-    const memberships = await membershipUserDAL.transaction(async (tx) => {
+    const performDelete = async (tx: Knex) => {
       await additionalPrivilegeDAL.delete(
         {
           projectId,
@@ -387,7 +383,11 @@ export const projectMembershipServiceFactory = ({
       );
 
       return deletedMemberships;
-    });
+    };
+
+    const memberships = externalTx
+      ? await performDelete(externalTx)
+      : await membershipUserDAL.transaction(performDelete);
 
     return memberships;
   };


### PR DESCRIPTION
## Context

Cert-manager access DELETE endpoints could be exploited by any authenticated user to permanently delete PKI application memberships and approval-policy approvers — even in projects they have no access to, including projects in other organizations.

**Root cause:** Each DELETE handler cleaned up PKI application memberships in a committed DB transaction *before* checking whether the caller had permission to delete from the project. If the permission check rejected the request (403), the cleanup was already permanent. The `inject-cert-manager-project-id` plugin also accepted explicit `projectId` from query/body without verifying org ownership, enabling cross-tenant targeting.

**Fix:**
- Reordered all 4 DELETE handlers (`/users`, `/users/:userId`, `/groups/:groupId`, `/identities/:identityId`) so the authorized deletion runs first, with cleanup after
- Both deletion and PKI cleanup now run in a single database transaction via new coordinating methods (`deleteMemberAndCleanup`, `deleteMembersAndCleanup`) in `pkiApplicationMembership`, using a callback pattern to pass the shared `tx`
- Added optional `externalTx` to the membership deletion services so they can participate in a caller-provided transaction
- Switched inline `actorKind` string literals to `ApplicationMemberKind` enum
- Added `isUuid()` + `isCertManagerProject(projectId, orgId)` validation for explicit project IDs in the injection plugin, matching the existing cookie-path validation

Resolves [SEC-29](https://linear.app/infisical/issue/SEC-29), [SEC-25](https://linear.app/infisical/issue/SEC-25), [SEC-15](https://linear.app/infisical/issue/SEC-15)

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)