### PR TITLE
fix(redlock): release mechanism error edge-case

### DIFF
--- a/backend/src/lib/red-lock/index.ts
+++ b/backend/src/lib/red-lock/index.ts
@@ -2,6 +2,7 @@
 // Source code credits: https://github.com/mike-marcacci/node-redlock
 // Taken to avoid external dependency
 import { crypto } from "@app/lib/crypto/cryptography";
+import { logger } from "@app/lib/logger";
 import { EventEmitter } from "events";
 
 // AbortController became available as a global in node version 16. Once version
@@ -155,8 +156,21 @@ export class Lock {
     public expiration: number
   ) {}
 
+  // Release is best-effort: the lock auto-expires on TTL, and callers run
+  // this in `finally` blocks after the protected work has already committed.
+  // A throw here would propagate past the committed work and skip downstream
+  // side effects (audit logs, response writes), so failures are logged and
+  // swallowed.
   async release(): Promise<ExecutionResult> {
-    return this.redlock.release(this);
+    try {
+      return await this.redlock.release(this);
+    } catch (error) {
+      logger.error(
+        { err: error, resources: this?.resources },
+        `Failed to release redlock [resources=${this?.resources?.join(",") || "unknown"}]`
+      );
+      return { attempts: [], start: Date.now() };
+    }
   }
 
   async extend(duration: number): Promise<Lock> {


### PR DESCRIPTION
## Context

lock.release can in very rare cases, throw an error after the actual deletion has happened, which causes the request to fail although the operation was successful. which in turn means that sequential audit logs never gets registered

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x]  Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)