### PR TITLE
improvement: add link to sub-org settings and improve nav sub-org display

### DIFF
--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -468,9 +468,46 @@ export const Navbar = () => {
                         </CommandItem>
                       </CommandGroup>
                       {/* Sub-Organizations */}
-                      {subscription.subOrganization && subOrganizations.length > 0 && (
+                      {subscription.subOrganization && (
                         <>
-                          <CommandGroup className="ml-6" heading="Sub-Organizations">
+                          <CommandGroup
+                            className="mb-3 ml-4.5 border-l border-border pt-0 pl-3 [&_[cmdk-group-heading]]:pt-0"
+                            heading={
+                              <div className="flex items-center justify-between">
+                                <span>Sub-Organizations</span>
+                                <OrgPermissionCan
+                                  I={OrgPermissionSubOrgActions.Edit}
+                                  a={OrgPermissionSubjects.SubOrganization}
+                                >
+                                  {(isAllowed) =>
+                                    isAllowed ? (
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <IconButton
+                                            variant="ghost-muted"
+                                            size="xs"
+                                            aria-label="Sub-Organization Settings"
+                                            className="-mr-1 size-5"
+                                            onClick={() => {
+                                              setIsOrgSelectOpen(false);
+                                              navigate({
+                                                to: "/organizations/$orgId/settings",
+                                                params: { orgId: rootOrg.id },
+                                                search: { selectedTab: "tab-sub-organizations" }
+                                              });
+                                            }}
+                                          >
+                                            <Settings className="size-3.5!" />
+                                          </IconButton>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Sub-Organization Settings</TooltipContent>
+                                      </Tooltip>
+                                    ) : null
+                                  }
+                                </OrgPermissionCan>
+                              </div>
+                            }
+                          >
                             {subOrganizations.map((subOrg) => (
                               <CommandItem
                                 key={subOrg.id}
@@ -531,7 +568,7 @@ export const Navbar = () => {
                         </CommandGroup>
                       )}
                     </CommandList>
-                    <div className="border-t border-border p-1">
+                    <div className="p-1">
                       <button
                         type="button"
                         className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground hover:bg-foreground/5"


### PR DESCRIPTION
## Context

This PR adds a link to sub-org settings page to the nav header display and also improves the layout and styling of the sub-org menu display

## Screenshots
 
<img width="3400" height="1892" alt="CleanShot 2026-05-25 at 14 51 30@2x" src="https://github.com/user-attachments/assets/a07a0e0c-8f4f-4023-9ddb-4e7f673193e4" />

## Steps to verify the change

- click link? does it navigate
- view visual changes

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)