### PR TITLE
improvement: update identity modals to v3

### DIFF
--- a/frontend/src/components/roles/RoleOption.tsx
+++ b/frontend/src/components/roles/RoleOption.tsx
@@ -1,6 +1,5 @@
 import { components, OptionProps } from "react-select";
-import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { CheckIcon } from "lucide-react";
 
 export const RoleOption = ({
   isSelected,
@@ -20,9 +19,7 @@ export const RoleOption = ({
             <p className="text-xs leading-4 text-mineshaft-400/50">No Description</p>
           )}
         </div>
-        {isSelected && (
-          <FontAwesomeIcon className="ml-2 text-primary" icon={faCheckCircle} size="sm" />
-        )}
+        {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
       </div>
     </components.Option>
   );

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentitySection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentitySection.tsx
@@ -1,17 +1,10 @@
 import { useState } from "react";
 import { InfoIcon, PlusIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import {
-  Button as ButtonV2,
-  DeleteActionModal,
-  Modal,
-  ModalContent,
-  Tooltip
-} from "@app/components/v2";
+import { DeleteActionModal } from "@app/components/v2";
 import {
   Button,
   Card,
@@ -20,7 +13,18 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  DocumentationLinkBadge
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DocumentationLinkBadge,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import {
   OrgPermissionIdentityActions,
@@ -212,8 +216,8 @@ export const IdentitySection = withPermission(
           }
         />
         <IdentityTokenAuthTokenModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
-        <Modal
-          isOpen={popUp.identity.isOpen}
+        <Dialog
+          open={popUp.identity.isOpen}
           onOpenChange={(open) => {
             handlePopUpToggle("identity", open);
             if (!open) {
@@ -221,88 +225,61 @@ export const IdentitySection = withPermission(
             }
           }}
         >
-          <ModalContent
-            bodyClassName="overflow-visible"
-            title={
-              isSubOrganization
-                ? "Add Machine Identity to Sub-Organization"
-                : "Create Organization Machine Identity"
-            }
-            subTitle={
-              isSubOrganization
-                ? "Create a new machine identity or assign an existing one"
-                : undefined
-            }
-          >
+          <DialogContent className="max-w-xl overflow-visible">
+            <DialogHeader>
+              <DialogTitle>
+                {isSubOrganization
+                  ? "Add Machine Identity to Sub-Organization"
+                  : "Create Organization Machine Identity"}
+              </DialogTitle>
+              <DialogDescription>
+                {isSubOrganization
+                  ? "Create a new machine identity or assign an existing one"
+                  : "Create a new machine identity in the organization"}
+              </DialogDescription>
+            </DialogHeader>
             {isSubOrganization && (
-              <div className="mb-4 flex items-center justify-center gap-x-2">
-                <div className="flex w-3/4 gap-x-0.5 rounded-md border border-mineshaft-600 bg-mineshaft-800 p-1">
-                  <ButtonV2
-                    variant="outline_bg"
-                    onClick={() => {
-                      setWizardStep(IdentityWizardSteps.CreateIdentity);
-                    }}
-                    size="xs"
-                    className={twMerge(
-                      "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                      wizardStep === IdentityWizardSteps.CreateIdentity
-                        ? "bg-mineshaft-500"
-                        : "bg-transparent"
-                    )}
-                  >
-                    Create New
-                  </ButtonV2>
-                  <ButtonV2
-                    variant="outline_bg"
-                    onClick={() => {
-                      setWizardStep(IdentityWizardSteps.LinkIdentity);
-                    }}
-                    size="xs"
-                    className={twMerge(
-                      "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                      wizardStep === IdentityWizardSteps.LinkIdentity
-                        ? "bg-mineshaft-500"
-                        : "bg-transparent"
-                    )}
-                  >
-                    Assign Existing
-                  </ButtonV2>
-                </div>
-                <Tooltip
-                  className="max-w-sm"
-                  position="right"
-                  align="start"
-                  content={
-                    <>
-                      <p className="mb-2 text-mineshaft-300">
-                        You can add machine identities to your sub-organization in one of two ways:
-                      </p>
-                      <ul className="ml-3.5 flex list-disc flex-col gap-y-4">
-                        <li className="text-mineshaft-200">
-                          <strong className="font-medium text-mineshaft-100">Create New</strong> -
-                          Create a new machine identity specifically for this sub-organization. This
-                          machine identity will be managed at the sub-organization level.
-                          <p className="mt-2">
-                            This method is recommended for autonomous teams that need to manage
-                            machine identity authentication.
-                          </p>
-                        </li>
-                        <li>
-                          <strong className="font-medium text-mineshaft-100">
-                            Assign Existing
-                          </strong>{" "}
-                          Assign an existing machine identity from your parent organization. The
-                          machine identity will continue to be managed at its original scope.
-                          <p className="mt-2">
-                            This method is recommended for organizations that need to maintain
-                            centralized control.
-                          </p>
-                        </li>
-                      </ul>
-                    </>
-                  }
+              <div className="mx-auto flex items-center gap-2">
+                <Tabs
+                  value={wizardStep}
+                  onValueChange={(value) => setWizardStep(value as IdentityWizardSteps)}
                 >
-                  <InfoIcon size={16} className="text-mineshaft-400" />
+                  <TabsList className="w-fit">
+                    <TabsTrigger value={IdentityWizardSteps.CreateIdentity}>Create New</TabsTrigger>
+                    <TabsTrigger value={IdentityWizardSteps.LinkIdentity}>
+                      Assign Existing
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <InfoIcon size={16} className="text-mineshaft-400" />
+                  </TooltipTrigger>
+                  <TooltipContent side="right" align="start" className="max-w-sm">
+                    <p className="mb-2 text-mineshaft-300">
+                      You can add machine identities to your sub-organization in one of two ways:
+                    </p>
+                    <ul className="ml-3.5 flex list-disc flex-col gap-y-4">
+                      <li className="text-mineshaft-200">
+                        <strong className="font-medium text-mineshaft-100">Create New</strong> -
+                        Create a new machine identity specifically for this sub-organization. This
+                        machine identity will be managed at the sub-organization level.
+                        <p className="mt-2">
+                          This method is recommended for autonomous teams that need to manage
+                          machine identity authentication.
+                        </p>
+                      </li>
+                      <li>
+                        <strong className="font-medium text-mineshaft-100">Assign Existing</strong>{" "}
+                        Assign an existing machine identity from your parent organization. The
+                        machine identity will continue to be managed at its original scope.
+                        <p className="mt-2">
+                          This method is recommended for organizations that need to maintain
+                          centralized control.
+                        </p>
+                      </li>
+                    </ul>
+                  </TooltipContent>
                 </Tooltip>
               </div>
             )}
@@ -312,8 +289,8 @@ export const IdentitySection = withPermission(
             {wizardStep === IdentityWizardSteps.LinkIdentity && (
               <OrgIdentityLinkForm onClose={() => handlePopUpClose("identity")} />
             )}
-          </ModalContent>
-        </Modal>
+          </DialogContent>
+        </Dialog>
         <DeleteActionModal
           isOpen={popUp.deleteIdentity.isOpen}
           title={`Are you sure you want to delete ${

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityLinkForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityLinkForm.tsx
@@ -5,7 +5,15 @@ import { useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FilterableSelect, FormControl } from "@app/components/v2";
+import { RoleOption } from "@app/components/roles";
+import {
+  Button,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { useGetOrgRoles } from "@app/hooks/api";
 import { useCreateOrgIdentityMembership } from "@app/hooks/api/orgIdentityMembership";
@@ -73,59 +81,59 @@ export const OrgIdentityLinkForm = ({ onClose }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
+    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       <Controller
         control={control}
         name="identity"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl label="Machine Identity" errorText={error?.message} isError={Boolean(error)}>
-            <FilterableSelect
-              value={value}
-              onChange={onChange}
-              placeholder="Select machine identity..."
-              // onInputChange={setSearchValue}
-              autoFocus
-              options={rootOrgIdentities}
-              getOptionValue={(option) => option.id}
-              getOptionLabel={(option) => option.name}
-              isLoading={isRootOrgLoading}
-            />
-          </FormControl>
+          <Field>
+            <FieldLabel>Machine Identity</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                value={value}
+                onChange={onChange}
+                placeholder="Select machine identity..."
+                // onInputChange={setSearchValue}
+                autoFocus
+                options={rootOrgIdentities}
+                getOptionValue={(option) => option.id}
+                getOptionLabel={(option) => option.name}
+                isLoading={isRootOrgLoading}
+                isError={Boolean(error)}
+              />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
       <Controller
         control={control}
         name="role"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl
-            label="Role"
-            errorText={error?.message}
-            isError={Boolean(error)}
-            className="mt-4"
-          >
-            <FilterableSelect
-              value={value}
-              onChange={onChange}
-              options={roles}
-              placeholder="Select role..."
-              getOptionValue={(option) => option.slug}
-              getOptionLabel={(option) => option.name}
-            />
-          </FormControl>
+          <Field>
+            <FieldLabel>Role</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                value={value}
+                onChange={onChange}
+                options={roles}
+                placeholder="Select role..."
+                getOptionValue={(option) => option.slug}
+                getOptionLabel={(option) => option.name}
+                components={{ Option: RoleOption }}
+                isError={Boolean(error)}
+              />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
-      <div className="flex items-center">
-        <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-        >
-          Link
-        </Button>
-        <Button colorSchema="secondary" variant="plain" onClick={() => onClose()}>
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={() => onClose()}>
           Cancel
+        </Button>
+        <Button type="submit" variant="sub-org" isPending={isSubmitting} isDisabled={isSubmitting}>
+          Assign to Sub-Organization
         </Button>
       </div>
     </form>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
@@ -1,22 +1,27 @@
 import { useEffect } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
+import { RoleOption } from "@app/components/roles";
 import {
   Button,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   FilterableSelect,
-  FormControl,
-  FormLabel,
   IconButton,
   Input,
+  Label,
   Switch
-} from "@app/components/v2";
+} from "@app/components/v3";
 import { useOrganization, useSubscription } from "@app/context";
 import { findOrgMembershipRole, isCustomOrgRole } from "@app/helpers/roles";
 import { useCreateOrgIdentity, useGetOrgRoles, useUpdateOrgIdentity } from "@app/hooks/api";
@@ -48,7 +53,7 @@ type Props = {
 
 export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
   const navigate = useNavigate();
-  const { currentOrg } = useOrganization();
+  const { currentOrg, isSubOrganization } = useOrganization();
   const orgId = currentOrg?.id || "";
   const { subscription } = useSubscription();
   const {
@@ -73,7 +78,7 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
     resolver: zodResolver(schema),
     defaultValues: {
       name: "",
-      hasDeleteProtection: false
+      hasDeleteProtection: true
     }
   });
 
@@ -107,7 +112,7 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
       reset({
         name: "",
         role: findOrgMembershipRole(roles, currentOrg!.defaultMembershipRole),
-        hasDeleteProtection: false
+        hasDeleteProtection: true
       });
     }
   }, [popUp?.identity?.data, roles]);
@@ -184,21 +189,20 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
+    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       {isOrgIdentity && (
         <Controller
           control={control}
           defaultValue=""
           name="name"
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              className="mb-4"
-              label="Name"
-              isError={Boolean(error)}
-              errorText={error?.message}
-            >
-              <Input {...field} autoFocus placeholder="Machine 1" />
-            </FormControl>
+            <Field>
+              <FieldLabel>Name</FieldLabel>
+              <FieldContent>
+                <Input {...field} autoFocus placeholder="Machine 1" isError={Boolean(error)} />
+              </FieldContent>
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
           )}
         />
       )}
@@ -206,121 +210,128 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
         control={control}
         name="role"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl
-            label={`${popUp?.identity?.data ? "Update" : ""} Role`}
-            errorText={error?.message}
-            isError={Boolean(error)}
-          >
-            <FilterableSelect
-              placeholder="Select role..."
-              options={roles}
-              onChange={onChange}
-              value={value}
-              getOptionValue={(option) => option.slug}
-              getOptionLabel={(option) => option.name}
-            />
-          </FormControl>
+          <Field>
+            <FieldLabel>{`${popUp?.identity?.data ? "Update " : ""}Role`}</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                placeholder="Select role..."
+                options={roles}
+                onChange={onChange}
+                value={value}
+                getOptionValue={(option) => option.slug}
+                getOptionLabel={(option) => option.name}
+                components={{ Option: RoleOption }}
+                isError={Boolean(error)}
+              />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
       {isOrgIdentity && (
         <Controller
           control={control}
           name="hasDeleteProtection"
-          render={({ field: { onChange, value }, fieldState: { error } }) => (
-            <FormControl errorText={error?.message} isError={Boolean(error)}>
+          render={({ field: { onChange, value } }) => (
+            <Field orientation="horizontal">
               <Switch
-                className="mr-2 ml-0 bg-mineshaft-400/80 shadow-inner data-[state=checked]:bg-green/80"
-                containerClassName="flex-row-reverse w-fit"
                 id="delete-protection-enabled"
-                thumbClassName="bg-mineshaft-800"
+                variant={isSubOrganization ? "sub-org" : "org"}
+                checked={value}
                 onCheckedChange={onChange}
-                isChecked={value}
-              >
-                <p>Delete Protection {value ? "Enabled" : "Disabled"}</p>
-              </Switch>
-            </FormControl>
+              />
+              <FieldContent>
+                <Label htmlFor="delete-protection-enabled">Delete Protection</Label>
+                <FieldDescription>
+                  Prevents this identity from being deleted while enabled.
+                </FieldDescription>
+              </FieldContent>
+            </Field>
           )}
         />
       )}
       {isOrgIdentity && (
-        <>
+        <div className="flex flex-col gap-2">
+          <Label>Metadata</Label>
+          <div
+            className={`flex max-h-[30vh] thin-scrollbar flex-col gap-3 overflow-y-auto rounded-md border border-border bg-container/50 p-4 ${
+              metadataFormFields.fields.length === 0 ? "border-dashed" : ""
+            }`}
+          >
+            {metadataFormFields.fields.length === 0 ? (
+              <p className="text-center text-sm text-muted">
+                No metadata entries. Click below to add.
+              </p>
+            ) : (
+              metadataFormFields.fields.map(({ id: metadataFieldId }, i) => (
+                <div key={metadataFieldId} className="flex items-start gap-2">
+                  <Field className="flex-1">
+                    {i === 0 && <FieldLabel className="text-xs">Key</FieldLabel>}
+                    <FieldContent>
+                      <Controller
+                        control={control}
+                        name={`metadata.${i}.key`}
+                        render={({ field, fieldState: { error } }) => (
+                          <>
+                            <Input {...field} isError={Boolean(error)} />
+                            {error && <FieldError>{error.message}</FieldError>}
+                          </>
+                        )}
+                      />
+                    </FieldContent>
+                  </Field>
+                  <Field className="flex-1">
+                    {i === 0 && <FieldLabel className="text-xs">Value</FieldLabel>}
+                    <FieldContent>
+                      <Controller
+                        control={control}
+                        name={`metadata.${i}.value`}
+                        render={({ field, fieldState: { error } }) => (
+                          <>
+                            <Input {...field} isError={Boolean(error)} />
+                            {error && <FieldError>{error.message}</FieldError>}
+                          </>
+                        )}
+                      />
+                    </FieldContent>
+                  </Field>
+                  <IconButton
+                    aria-label="Remove metadata entry"
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    className={twMerge(i === 0 ? "mt-[27px]" : "mt-[3px]", "hover:text-danger")}
+                    onClick={() => metadataFormFields.remove(i)}
+                  >
+                    <TrashIcon />
+                  </IconButton>
+                </div>
+              ))
+            )}
+          </div>
           <div>
-            <FormLabel label="Metadata" />
+            <Button
+              variant="ghost"
+              size="xs"
+              type="button"
+              onClick={() => metadataFormFields.append({ key: "", value: "" })}
+            >
+              <PlusIcon className="mr-1 size-4" />
+              Add Entry
+            </Button>
           </div>
-          <div className="mb-3 flex flex-col space-y-2">
-            {metadataFormFields.fields.map(({ id: metadataFieldId }, i) => (
-              <div key={metadataFieldId} className="flex items-end space-x-2">
-                <div className="grow">
-                  {i === 0 && <span className="text-xs text-mineshaft-400">Key</span>}
-                  <Controller
-                    control={control}
-                    name={`metadata.${i}.key`}
-                    render={({ field, fieldState: { error } }) => (
-                      <FormControl
-                        isError={Boolean(error?.message)}
-                        errorText={error?.message}
-                        className="mb-0"
-                      >
-                        <Input {...field} />
-                      </FormControl>
-                    )}
-                  />
-                </div>
-                <div className="grow">
-                  {i === 0 && <FormLabel label="Value" className="text-xs text-mineshaft-400" />}
-                  <Controller
-                    control={control}
-                    name={`metadata.${i}.value`}
-                    render={({ field, fieldState: { error } }) => (
-                      <FormControl
-                        isError={Boolean(error?.message)}
-                        errorText={error?.message}
-                        className="mb-0"
-                      >
-                        <Input {...field} />
-                      </FormControl>
-                    )}
-                  />
-                </div>
-                <IconButton
-                  ariaLabel="delete key"
-                  className="bottom-0.5 h-9"
-                  variant="outline_bg"
-                  onClick={() => metadataFormFields.remove(i)}
-                >
-                  <FontAwesomeIcon icon={faTrash} />
-                </IconButton>
-              </div>
-            ))}
-            <div className="mt-2 flex justify-end">
-              <Button
-                leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                size="xs"
-                variant="outline_bg"
-                onClick={() => metadataFormFields.append({ key: "", value: "" })}
-              >
-                Add Key
-              </Button>
-            </div>
-          </div>
-        </>
+        </div>
       )}
-      <div className="flex items-center">
+      <div className="flex items-center justify-end gap-2">
         <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-        >
-          {popUp?.identity?.data ? "Update" : "Create"}
-        </Button>
-        <Button
-          colorSchema="secondary"
-          variant="plain"
+          type="button"
+          variant="outline"
           onClick={() => handlePopUpToggle("identity", false)}
         >
           Cancel
+        </Button>
+        <Button type="submit" variant="org" isPending={isSubmitting} isDisabled={isSubmitting}>
+          {popUp?.identity?.data ? "Update" : "Create"}
         </Button>
       </div>
       <UpgradePlanModal

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/OrgIdentityModal.tsx
@@ -330,7 +330,12 @@ export const OrgIdentityModal = ({ popUp, handlePopUpToggle }: Props) => {
         >
           Cancel
         </Button>
-        <Button type="submit" variant="org" isPending={isSubmitting} isDisabled={isSubmitting}>
+        <Button
+          type="submit"
+          variant={isSubOrganization ? "sub-org" : "org"}
+          isPending={isSubmitting}
+          isDisabled={isSubmitting}
+        >
           {popUp?.identity?.data ? "Update" : "Create"}
         </Button>
       </div>

--- a/frontend/src/pages/organization/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
+++ b/frontend/src/pages/organization/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
@@ -6,7 +6,7 @@ import { ChevronLeftIcon, EllipsisIcon } from "lucide-react";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { DeleteActionModal, Modal, ModalContent, PageHeader } from "@app/components/v2";
+import { DeleteActionModal, PageHeader } from "@app/components/v2";
 import {
   Alert,
   AlertDescription,
@@ -17,6 +17,11 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -208,17 +213,24 @@ const Page = () => {
           </div>
         </>
       )}
-      <Modal
-        isOpen={popUp?.identity?.isOpen}
+      <Dialog
+        open={popUp?.identity?.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("identity", isOpen)}
       >
-        <ModalContent
-          bodyClassName="overflow-visible"
-          title={`${popUp?.identity?.data ? "Update" : "Create"} Machine Identity`}
-        >
+        <DialogContent className="max-w-xl overflow-visible">
+          <DialogHeader>
+            <DialogTitle>
+              {`${popUp?.identity?.data ? "Update" : "Create"} Machine Identity`}
+            </DialogTitle>
+            <DialogDescription>
+              {popUp?.identity?.data
+                ? "Update the identity's name, role, and metadata."
+                : "Create a new machine identity in the organization."}
+            </DialogDescription>
+          </DialogHeader>
           <OrgIdentityModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
-        </ModalContent>
-      </Modal>
+        </DialogContent>
+      </Dialog>
       <IdentityAuthMethodModal
         popUp={popUp}
         handlePopUpOpen={handlePopUpOpen}

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -635,6 +635,9 @@ export const IdentityTab = withProjectPermission(
           open={popUp.createIdentity.isOpen}
           onOpenChange={(open) => {
             handlePopUpToggle("createIdentity", open);
+            if (!open) {
+              setAddMachineIdentityType(AddIdentityType.CreateNew);
+            }
           }}
         >
           <DialogContent className="max-w-xl overflow-visible">

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -17,7 +17,7 @@ import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { DeleteActionModal, Modal, ModalContent, Spinner } from "@app/components/v2";
+import { DeleteActionModal, Spinner } from "@app/components/v2";
 import { Blur } from "@app/components/v2/Blur";
 import {
   Badge,
@@ -28,6 +28,11 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   DocumentationLinkBadge,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -57,6 +62,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   Tooltip,
   TooltipContent,
   TooltipTrigger
@@ -92,8 +100,8 @@ import { ProjectLinkIdentityModal } from "./components/ProjectLinkIdentityModal"
 const MAX_ROLES_TO_BE_SHOWN_IN_TABLE = 2;
 
 enum AddIdentityType {
-  CreateNew,
-  AssignExisting
+  CreateNew = "create-new",
+  AssignExisting = "assign-existing"
 }
 
 export const IdentityTab = withProjectPermission(
@@ -623,50 +631,29 @@ export const IdentityTab = withProjectPermission(
             </div>
           </CardContent>
         </Card>
-        <Modal
-          isOpen={popUp.createIdentity.isOpen}
+        <Dialog
+          open={popUp.createIdentity.isOpen}
           onOpenChange={(open) => {
             handlePopUpToggle("createIdentity", open);
           }}
         >
-          <ModalContent
-            bodyClassName="overflow-visible"
-            title={`Add Machine Identity to ${productLabel}`}
-            subTitle="Create a new machine identity or assign an existing one"
-          >
-            <div className="mb-4 flex items-center justify-center gap-x-2">
-              <div className="flex w-3/4 gap-x-0.5 rounded-md border border-mineshaft-600 bg-mineshaft-800 p-1">
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setAddMachineIdentityType(AddIdentityType.CreateNew);
-                  }}
-                  size="xs"
-                  className={twMerge(
-                    "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                    addMachineIdentityType === AddIdentityType.CreateNew
-                      ? "bg-mineshaft-500"
-                      : "bg-transparent"
-                  )}
-                >
-                  Create New
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setAddMachineIdentityType(AddIdentityType.AssignExisting);
-                  }}
-                  size="xs"
-                  className={twMerge(
-                    "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                    addMachineIdentityType === AddIdentityType.AssignExisting
-                      ? "bg-mineshaft-500"
-                      : "bg-transparent"
-                  )}
-                >
-                  Assign Existing
-                </Button>
-              </div>
+          <DialogContent className="max-w-xl overflow-visible">
+            <DialogHeader>
+              <DialogTitle>{`Add Machine Identity to ${productLabel}`}</DialogTitle>
+              <DialogDescription>
+                Create a new machine identity or assign an existing one
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mx-auto flex items-center gap-2">
+              <Tabs
+                value={addMachineIdentityType}
+                onValueChange={(value) => setAddMachineIdentityType(value as AddIdentityType)}
+              >
+                <TabsList>
+                  <TabsTrigger value={AddIdentityType.CreateNew}>Create New</TabsTrigger>
+                  <TabsTrigger value={AddIdentityType.AssignExisting}>Assign Existing</TabsTrigger>
+                </TabsList>
+              </Tabs>
               <Tooltip>
                 <TooltipTrigger>
                   <InfoIcon size={16} className="text-mineshaft-400" />
@@ -708,8 +695,8 @@ export const IdentityTab = withProjectPermission(
             {addMachineIdentityType === AddIdentityType.AssignExisting && (
               <ProjectLinkIdentityModal handlePopUpToggle={handlePopUpToggle} />
             )}
-          </ModalContent>
-        </Modal>
+          </DialogContent>
+        </Dialog>
         <DeleteActionModal
           isOpen={popUp.deleteIdentity.isOpen}
           title={`Are you sure you want to remove ${

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
@@ -1,22 +1,25 @@
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { RoleOption } from "@app/components/roles";
 import {
   Button,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   FilterableSelect,
-  FormControl,
-  FormLabel,
   IconButton,
   Input,
-  ModalClose,
+  Label,
   Switch
-} from "@app/components/v2";
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import { getProjectBaseURL } from "@app/helpers/project";
 import {
@@ -79,7 +82,7 @@ export const ProjectIdentityModal = ({ onClose, identity }: ContentProps) => {
     resolver: zodResolver(schema),
     defaultValues: {
       name: identity?.name ?? "",
-      hasDeleteProtection: identity?.hasDeleteProtection ?? false,
+      hasDeleteProtection: identity?.hasDeleteProtection ?? true,
       metadata: identity?.metadata ?? [],
       role: isUpdate ? undefined : defaultRole
     }
@@ -166,20 +169,19 @@ export const ProjectIdentityModal = ({ onClose, identity }: ContentProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
+    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       <Controller
         control={control}
         defaultValue=""
         name="name"
         render={({ field, fieldState: { error } }) => (
-          <FormControl
-            className="mb-4"
-            label="Name"
-            isError={Boolean(error)}
-            errorText={error?.message}
-          >
-            <Input {...field} autoFocus placeholder="Machine 1" />
-          </FormControl>
+          <Field>
+            <FieldLabel>Name</FieldLabel>
+            <FieldContent>
+              <Input {...field} autoFocus placeholder="Machine 1" isError={Boolean(error)} />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
       {!isUpdate && (
@@ -187,112 +189,122 @@ export const ProjectIdentityModal = ({ onClose, identity }: ContentProps) => {
           control={control}
           name="role"
           render={({ field: { onChange, value }, fieldState: { error } }) => (
-            <FormControl label="Role" errorText={error?.message} isError={Boolean(error)}>
-              <FilterableSelect
-                placeholder="Select role..."
-                options={roles}
-                onChange={onChange}
-                value={value}
-                getOptionValue={(option) => option.slug}
-                getOptionLabel={(option) => option.name}
-                components={{ Option: RoleOption }}
-              />
-            </FormControl>
+            <Field>
+              <FieldLabel>Role</FieldLabel>
+              <FieldContent>
+                <FilterableSelect
+                  placeholder="Select role..."
+                  options={roles}
+                  onChange={onChange}
+                  value={value}
+                  getOptionValue={(option) => option.slug}
+                  getOptionLabel={(option) => option.name}
+                  components={{ Option: RoleOption }}
+                  isError={Boolean(error)}
+                />
+              </FieldContent>
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
           )}
         />
       )}
       <Controller
         control={control}
         name="hasDeleteProtection"
-        render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl errorText={error?.message} isError={Boolean(error)}>
+        render={({ field: { onChange, value } }) => (
+          <Field orientation="horizontal">
             <Switch
-              className="mr-2 ml-0 bg-mineshaft-400/80 shadow-inner data-[state=checked]:bg-green/80"
-              containerClassName="flex-row-reverse w-fit"
               id="delete-protection-enabled"
-              thumbClassName="bg-mineshaft-800"
+              variant="project"
+              checked={value}
               onCheckedChange={onChange}
-              isChecked={value}
-            >
-              <p>Delete Protection {value ? "Enabled" : "Disabled"}</p>
-            </Switch>
-          </FormControl>
+            />
+            <FieldContent>
+              <Label htmlFor="delete-protection-enabled">Delete Protection</Label>
+              <FieldDescription>
+                Prevents this identity from being deleted while enabled.
+              </FieldDescription>
+            </FieldContent>
+          </Field>
         )}
       />
-      <div>
-        <FormLabel label="Metadata" />
-      </div>
-      <div className="mb-3 flex flex-col space-y-2">
-        {metadataFormFields.fields.map(({ id: metadataFieldId }, i) => (
-          <div key={metadataFieldId} className="flex items-end space-x-2">
-            <div className="grow">
-              {i === 0 && <span className="text-xs text-mineshaft-400">Key</span>}
-              <Controller
-                control={control}
-                name={`metadata.${i}.key`}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                    className="mb-0"
-                  >
-                    <Input {...field} />
-                  </FormControl>
-                )}
-              />
-            </div>
-            <div className="grow">
-              {i === 0 && <FormLabel label="Value" className="text-xs text-mineshaft-400" />}
-              <Controller
-                control={control}
-                name={`metadata.${i}.value`}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                    className="mb-0"
-                  >
-                    <Input {...field} />
-                  </FormControl>
-                )}
-              />
-            </div>
-            <IconButton
-              ariaLabel="delete key"
-              className="bottom-0.5 h-9"
-              variant="outline_bg"
-              onClick={() => metadataFormFields.remove(i)}
-            >
-              <FontAwesomeIcon icon={faTrash} />
-            </IconButton>
-          </div>
-        ))}
-        <div className="mt-2 flex justify-end">
+      <div className="flex flex-col gap-2">
+        <Label>Metadata</Label>
+        <div
+          className={`flex max-h-[30vh] thin-scrollbar flex-col gap-3 overflow-y-auto rounded-md border border-border bg-container/50 p-4 ${
+            metadataFormFields.fields.length === 0 ? "border-dashed" : ""
+          }`}
+        >
+          {metadataFormFields.fields.length === 0 ? (
+            <p className="text-center text-sm text-muted">
+              No metadata entries. Click below to add.
+            </p>
+          ) : (
+            metadataFormFields.fields.map(({ id: metadataFieldId }, i) => (
+              <div key={metadataFieldId} className="flex items-start gap-2">
+                <Field className="flex-1">
+                  {i === 0 && <FieldLabel className="text-xs">Key</FieldLabel>}
+                  <FieldContent>
+                    <Controller
+                      control={control}
+                      name={`metadata.${i}.key`}
+                      render={({ field, fieldState: { error } }) => (
+                        <>
+                          <Input {...field} isError={Boolean(error)} />
+                          {error && <FieldError>{error.message}</FieldError>}
+                        </>
+                      )}
+                    />
+                  </FieldContent>
+                </Field>
+                <Field className="flex-1">
+                  {i === 0 && <FieldLabel className="text-xs">Value</FieldLabel>}
+                  <FieldContent>
+                    <Controller
+                      control={control}
+                      name={`metadata.${i}.value`}
+                      render={({ field, fieldState: { error } }) => (
+                        <>
+                          <Input {...field} isError={Boolean(error)} />
+                          {error && <FieldError>{error.message}</FieldError>}
+                        </>
+                      )}
+                    />
+                  </FieldContent>
+                </Field>
+                <IconButton
+                  aria-label="Remove metadata entry"
+                  variant="ghost"
+                  size="sm"
+                  type="button"
+                  className={twMerge(i === 0 ? "mt-[27px]" : "mt-[3px]", "hover:text-danger")}
+                  onClick={() => metadataFormFields.remove(i)}
+                >
+                  <TrashIcon />
+                </IconButton>
+              </div>
+            ))
+          )}
+        </div>
+        <div>
           <Button
-            leftIcon={<FontAwesomeIcon icon={faPlus} />}
+            variant="ghost"
             size="xs"
-            variant="outline_bg"
+            type="button"
             onClick={() => metadataFormFields.append({ key: "", value: "" })}
           >
-            Add Key
+            <PlusIcon className="mr-1 size-4" />
+            Add Entry
           </Button>
         </div>
       </div>
-      <div className="flex items-center">
-        <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-        >
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button type="submit" variant="project" isPending={isSubmitting} isDisabled={isSubmitting}>
           {isUpdate ? "Update" : "Create"}
         </Button>
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
       </div>
     </form>
   );

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectLinkIdentityModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectLinkIdentityModal.tsx
@@ -5,7 +5,15 @@ import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FilterableSelect, FormControl, ModalClose } from "@app/components/v2";
+import { RoleOption } from "@app/components/roles";
+import {
+  Button,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import {
   projectIdentityMembershipQuery,
@@ -108,66 +116,68 @@ export const ProjectLinkIdentityModal = ({ handlePopUpToggle }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
+    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       <Controller
         control={control}
         name="identity"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl label="Machine Identity" errorText={error?.message} isError={Boolean(error)}>
-            <FilterableSelect
-              value={value}
-              onChange={onChange}
-              isLoading={isMembershipsLoading}
-              placeholder="Select machine identity..."
-              autoFocus
-              // onInputChange={setSearchValue}
-              options={filteredIdentityMembershipOrgs.map((membership) => ({
-                name: membership.name,
-                id: membership.id
-              }))}
-              getOptionValue={(option) => option.id}
-              getOptionLabel={(option) => option.name}
-            />
-          </FormControl>
+          <Field>
+            <FieldLabel>Machine Identity</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                value={value}
+                onChange={onChange}
+                isLoading={isMembershipsLoading}
+                placeholder="Select machine identity..."
+                autoFocus
+                // onInputChange={setSearchValue}
+                options={filteredIdentityMembershipOrgs.map((membership) => ({
+                  name: membership.name,
+                  id: membership.id
+                }))}
+                getOptionValue={(option) => option.id}
+                getOptionLabel={(option) => option.name}
+                isError={Boolean(error)}
+              />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
       <Controller
         control={control}
         name="role"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl
-            label="Role"
-            errorText={error?.message}
-            isError={Boolean(error)}
-            className="mt-4"
-          >
-            <FilterableSelect
-              value={value}
-              isLoading={isRolesLoading}
-              onChange={onChange}
-              options={roles}
-              placeholder="Select role..."
-              getOptionValue={(option) => option.slug}
-              getOptionLabel={(option) => option.name}
-            />
-          </FormControl>
+          <Field>
+            <FieldLabel>Role</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                value={value}
+                isLoading={isRolesLoading}
+                onChange={onChange}
+                options={roles}
+                placeholder="Select role..."
+                getOptionValue={(option) => option.slug}
+                getOptionLabel={(option) => option.name}
+                components={{ Option: RoleOption }}
+                isError={Boolean(error)}
+              />
+            </FieldContent>
+            {error && <FieldError>{error.message}</FieldError>}
+          </Field>
         )}
       />
-      <div className="flex items-center">
+      <div className="flex items-center justify-end gap-2">
         <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
+          type="button"
+          variant="outline"
+          onClick={() => handlePopUpToggle("createIdentity", false)}
         >
+          Cancel
+        </Button>
+        <Button type="submit" variant="project" isPending={isSubmitting} isDisabled={isSubmitting}>
           Assign to Project
         </Button>
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
       </div>
     </form>
   );

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityDetailsSection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityDetailsSection.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import { BanIcon, CheckIcon, ClipboardListIcon, PencilIcon } from "lucide-react";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Modal, ModalContent, Tooltip } from "@app/components/v2";
+import { Tooltip } from "@app/components/v2";
 import {
   Badge,
   ButtonGroup,
@@ -17,6 +17,11 @@ import {
   DetailGroup,
   DetailLabel,
   DetailValue,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   IconButton,
   OrgIcon,
   ProjectIcon,
@@ -196,17 +201,23 @@ export const ProjectIdentityDetailsSection = ({
           </DetailGroup>
         </CardContent>
       </Card>
-      <Modal
-        isOpen={popUp.editIdentity.isOpen}
+      <Dialog
+        open={popUp.editIdentity.isOpen}
         onOpenChange={(open) => handlePopUpToggle("editIdentity", open)}
       >
-        <ModalContent bodyClassName="overflow-visible" title="Edit Project Identity">
+        <DialogContent className="max-w-xl overflow-visible">
+          <DialogHeader>
+            <DialogTitle>Edit Project Identity</DialogTitle>
+            <DialogDescription>
+              Update the identity&apos;s name, delete protection, and metadata.
+            </DialogDescription>
+          </DialogHeader>
           <ProjectIdentityModal
             identity={identity}
             onClose={() => handlePopUpToggle("editIdentity", false)}
           />
-        </ModalContent>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };


### PR DESCRIPTION
## Context

This PR updates the create/edit modals for project, orgs, and sub-orgs (including linking) to v3 components.

Also:
- adds labels to delete protection, now defaults to enables it
- updated metadata section to be more cohesive and scroll on overflow
- added role description display to select

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-05-25 at 16 17 23@2x" src="https://github.com/user-attachments/assets/b9b78059-c3f5-4717-a3e1-fd8d475a2c08" />
<img width="3456" height="1924" alt="CleanShot 2026-05-25 at 16 18 25@2x" src="https://github.com/user-attachments/assets/74e46e9a-2ee1-4746-9949-89db34b5f44c" />
<img width="3456" height="1924" alt="CleanShot 2026-05-25 at 16 17 53@2x" src="https://github.com/user-attachments/assets/d75420e5-f7e4-4d17-ac4f-5613102a07fa" />

## Steps to verify the change

- create, edit and link an identity at every scope to verify form integrity, zero regressions and UI/UX changes

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)