### PR TITLE
improvement(aws): use project-scoped External ID for Assume Role connections

### DIFF
--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -528,6 +528,8 @@ export const appConnectionServiceFactory = ({
         credentials,
         method,
         orgId: actor.orgId,
+        projectId,
+        version: 2,
         gatewayId: validationGatewayId
       } as TAppConnectionConfig,
       gatewayService,

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -563,6 +563,7 @@ export const appConnectionServiceFactory = ({
               gatewayPoolId: gatewayPoolId ?? null,
               projectId,
               isAutoRotationEnabled,
+              version: 2, // v1 (legacy) always used orgId as AWS ExternalId; v2 uses scope-based ID
               ...params
             },
             tx

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -29,7 +29,7 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
   let secretAccessKey: string;
   let sessionToken: undefined | string;
 
-  const { method, credentials, orgId } = appConnection;
+  const { method, credentials, orgId, projectId, version } = appConnection;
 
   switch (method) {
     case AwsConnectionMethod.AssumeRole: {
@@ -46,11 +46,14 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
             : undefined // if hosting on AWS
       });
 
+      // v1 (legacy) always used orgId; v2+ uses projectId when available, orgId otherwise.
+      const externalId = (version ?? 1) >= 2 ? (projectId ?? orgId) : orgId;
+
       const command = new AssumeRoleCommand({
         RoleArn: credentials.roleArn,
         RoleSessionName: `infisical-app-connection-${crypto.nativeCrypto.randomUUID()}`,
         DurationSeconds: 900, // 15 mins
-        ExternalId: orgId
+        ExternalId: externalId
       });
 
       const assumeRes = await client.send(command);

--- a/backend/src/services/app-connection/aws/aws-connection-types.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-types.ts
@@ -19,4 +19,6 @@ export type TValidateAwsConnectionCredentialsSchema = typeof ValidateAwsConnecti
 
 export type TAwsConnectionConfig = DiscriminativePick<TAwsConnectionInput, "method" | "app" | "credentials"> & {
   orgId: string;
+  projectId?: string | null;
+  version?: number;
 };

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -77,7 +77,7 @@ Infisical supports two methods for connecting to AWS.
                     <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>
 
                     <Note>
-                        **Upgrading existing project-scoped connections:** Connections created before **May 26, 2026** (cloud) or release **v0.160.6** (self-hosted) use the Organization ID as the External ID (legacy behavior). To adopt the stronger project-scoped External ID, delete and recreate the connection, then update your IAM role’s trust policy to use your Project ID instead.
+                        **Upgrading existing project-scoped connections:** Connections created before **May 26, 2026** (cloud) or release **v0.160.7** (self-hosted) use the Organization ID as the External ID (legacy behavior). To adopt the stronger project-scoped External ID, delete and recreate the connection, then update your IAM role’s trust policy to use your Project ID instead.
                     </Note>
                 </Warning>
             </Step>

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -61,14 +61,24 @@ Infisical supports two methods for connecting to AWS.
                 <Note>
                   **For Dedicated Instances**: Your AWS account ID differs from the one provided above. Please reach out to Infisical support to obtain your AWS account ID.
                 </Note>
-                4. (Recommended) <strong>Enable "Require external ID"</strong> and input your **Organization ID** to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).
+                4. (Recommended) <strong>Enable "Require external ID"</strong> and input the appropriate ID to strengthen security and mitigate the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html):
+                   - **Project-scoped connections** — use your **Project ID** as the External ID.
+                   - **Organization-scoped connections** — use your **Organization ID** as the External ID.
 
                 <Warning type="warning" title="Security Best Practice: Use External ID to Prevent Confused Deputy Attacks">
-                    When configuring an IAM Role that Infisical will assume, it’s highly recommended to enable the **"Require external ID"** option and specify your **Organization ID**.
+                    When configuring an IAM Role that Infisical will assume, it’s highly recommended to enable the **"Require external ID"** option.
 
                     This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
-                    <strong>Always enable "Require external ID" and use your Organization ID when setting up the IAM Role.</strong>
+                    Infisical automatically sends the correct External ID based on the connection’s scope:
+                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project.
+                    - **Organization-scoped connections** use the **Organization ID** as the External ID.
+
+                    <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>
+
+                    <Note>
+                        **Upgrading existing project-scoped connections:** Connections created before **May 26, 2026** (cloud) or release **v0.160.6** (self-hosted) use the Organization ID as the External ID (legacy behavior). To adopt the stronger project-scoped External ID, delete and recreate the connection, then update your IAM role’s trust policy to use your Project ID instead.
+                    </Note>
                 </Warning>
             </Step>
 


### PR DESCRIPTION
## Context

Project-scoped AWS Assume Role connections previously always sent the **Organization ID** as the IAM External ID, even when the connection was scoped to a single project. That weakened the confused-deputy protection for project-scoped roles.

This change introduces connection **version 2**, which sends the **Project ID** as the External ID for project-scoped connections and the **Organization ID** for org-scoped connections. Existing connections remain on version 1 (legacy org ID behavior) with no migration required.

## Steps to verify the change

- [ ] Create a new **project-scoped** AWS Assume Role connection and confirm `AssumeRole` uses the **Project ID** as `ExternalId` (check backend logs or AWS CloudTrail).
- [ ] Create a new **org-scoped** AWS Assume Role connection and confirm `ExternalId` is the **Organization ID**.
- [ ] Verify an existing v1 connection still assumes the role using the **Organization ID** (no regression).

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)