### PR TITLE
fix(acme): redact EAB HMAC key from API responses

### DIFF
--- a/backend/src/server/routes/v1/certificate-authority-routers/acme-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/acme-certificate-authority-router.ts
@@ -1,6 +1,6 @@
 import {
-  AcmeCertificateAuthoritySchema,
   CreateAcmeCertificateAuthoritySchema,
+  SanitizedAcmeCertificateAuthoritySchema,
   UpdateAcmeCertificateAuthoritySchema
 } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
 import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
@@ -11,7 +11,7 @@ export const registerAcmeCertificateAuthorityRouter = async (server: FastifyZodP
   registerCertificateAuthorityEndpoints({
     caType: CaType.ACME,
     server,
-    responseSchema: AcmeCertificateAuthoritySchema,
+    responseSchema: SanitizedAcmeCertificateAuthoritySchema,
     createSchema: CreateAcmeCertificateAuthoritySchema,
     updateSchema: UpdateAcmeCertificateAuthoritySchema
   });

--- a/backend/src/server/routes/v1/certificate-authority-routers/general-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/general-certificate-authority-router.ts
@@ -6,7 +6,7 @@ import { readLimit } from "@app/server/config/rateLimiter";
 import { openApiHidden } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
-import { AcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
+import { SanitizedAcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
 import { AwsAcmPublicCaCertificateAuthoritySchema } from "@app/services/certificate-authority/aws-acm-public-ca/aws-acm-public-ca-certificate-authority-schemas";
 import { AwsPcaCertificateAuthoritySchema } from "@app/services/certificate-authority/aws-pca/aws-pca-certificate-authority-schemas";
 import { AzureAdCsCertificateAuthoritySchema } from "@app/services/certificate-authority/azure-ad-cs/azure-ad-cs-certificate-authority-schemas";
@@ -17,7 +17,7 @@ import { VenafiTppCertificateAuthoritySchema } from "@app/services/certificate-a
 
 const CertificateAuthoritySchema = z.discriminatedUnion("type", [
   InternalCertificateAuthoritySchema,
-  AcmeCertificateAuthoritySchema,
+  SanitizedAcmeCertificateAuthoritySchema,
   AzureAdCsCertificateAuthoritySchema,
   AwsPcaCertificateAuthoritySchema,
   DigiCertCertificateAuthoritySchema,

--- a/backend/src/server/routes/v1/deprecated-certificate-authority-routers/acme-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/deprecated-certificate-authority-routers/acme-certificate-authority-router.ts
@@ -1,4 +1,4 @@
-import { AcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
+import { SanitizedAcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
 import {
   CreateAcmeCertificateAuthoritySchema,
   UpdateAcmeCertificateAuthoritySchema
@@ -11,7 +11,7 @@ export const registerAcmeCertificateAuthorityRouter = async (server: FastifyZodP
   registerCertificateAuthorityEndpoints({
     caType: CaType.ACME,
     server,
-    responseSchema: AcmeCertificateAuthoritySchema,
+    responseSchema: SanitizedAcmeCertificateAuthoritySchema,
     createSchema: CreateAcmeCertificateAuthoritySchema,
     updateSchema: UpdateAcmeCertificateAuthoritySchema
   });

--- a/backend/src/server/routes/v2/certificate-authority-router.ts
+++ b/backend/src/server/routes/v2/certificate-authority-router.ts
@@ -6,7 +6,7 @@ import { readLimit } from "@app/server/config/rateLimiter";
 import { openApiHidden } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
-import { AcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
+import { SanitizedAcmeCertificateAuthoritySchema } from "@app/services/certificate-authority/acme/acme-certificate-authority-schemas";
 import { AwsAcmPublicCaCertificateAuthoritySchema } from "@app/services/certificate-authority/aws-acm-public-ca/aws-acm-public-ca-certificate-authority-schemas";
 import { AwsPcaCertificateAuthoritySchema } from "@app/services/certificate-authority/aws-pca/aws-pca-certificate-authority-schemas";
 import { AzureAdCsCertificateAuthoritySchema } from "@app/services/certificate-authority/azure-ad-cs/azure-ad-cs-certificate-authority-schemas";
@@ -17,7 +17,7 @@ import { VenafiTppCertificateAuthoritySchema } from "@app/services/certificate-a
 
 const CertificateAuthoritySchema = z.discriminatedUnion("type", [
   InternalCertificateAuthoritySchema,
-  AcmeCertificateAuthoritySchema,
+  SanitizedAcmeCertificateAuthoritySchema,
   AzureAdCsCertificateAuthoritySchema,
   AwsPcaCertificateAuthoritySchema,
   DigiCertCertificateAuthoritySchema,

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -132,7 +132,7 @@ type TAcmeCertificateAuthorityFnsDeps = {
     TCertificateAuthorityDALFactory,
     "create" | "transaction" | "findByIdWithAssociatedCa" | "updateById" | "findWithAssociatedCa" | "findById"
   >;
-  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update">;
+  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update" | "findOne">;
   certificateDAL: Pick<TCertificateDALFactory, "create" | "transaction" | "updateById">;
   certificateBodyDAL: Pick<TCertificateBodyDALFactory, "create">;
   certificateSecretDAL: Pick<TCertificateSecretDALFactory, "create">;
@@ -197,7 +197,6 @@ export const castDbEntryToAcmeCertificateAuthority = (
       directoryUrl: dbConfigurationCol.directoryUrl,
       accountEmail: dbConfigurationCol.accountEmail,
       eabKid: dbConfigurationCol.eabKid,
-      eabHmacKey: dbConfigurationCol.eabHmacKey,
       dnsResolver: dbConfigurationCol.dnsResolver
     },
     status: ca.status as CaStatus
@@ -813,6 +812,18 @@ export const AcmeCertificateAuthorityFns = ({
           actor
         );
 
+        let resolvedEabHmacKey = eabHmacKey;
+        if (eabHmacKey === "__INFISICAL_UNCHANGED__" || eabHmacKey === undefined) {
+          const existingExternalCa = await externalCertificateAuthorityDAL.findOne(
+            { caId: id, type: CaType.ACME },
+            tx
+          );
+          const existingConfig = existingExternalCa?.configuration as DBConfigurationColumn | undefined;
+          resolvedEabHmacKey = existingConfig?.eabHmacKey;
+        } else if (eabHmacKey === "") {
+          resolvedEabHmacKey = undefined;
+        }
+
         await externalCertificateAuthorityDAL.update(
           {
             caId: id,
@@ -826,7 +837,7 @@ export const AcmeCertificateAuthorityFns = ({
               dnsProvider: dnsProviderConfig.provider,
               hostedZoneId: dnsProviderConfig.hostedZoneId,
               eabKid,
-              eabHmacKey,
+              eabHmacKey: resolvedEabHmacKey,
               dnsResolver
             }
           },

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -57,6 +57,8 @@ import { azureDnsDeleteTxtRecord, azureDnsInsertTxtRecord } from "./dns-provider
 import { cloudflareDeleteTxtRecord, cloudflareInsertTxtRecord } from "./dns-providers/cloudflare";
 import { dnsMadeEasyDeleteTxtRecord, dnsMadeEasyInsertTxtRecord } from "./dns-providers/dns-made-easy";
 
+const UNCHANGED_CREDENTIAL_SENTINEL = "__INFISICAL_UNCHANGED__";
+
 const validateDnsResolver = (resolver: string): void => {
   const appCfg = getConfig();
 
@@ -814,7 +816,7 @@ export const AcmeCertificateAuthorityFns = ({
         );
 
         let resolvedEabHmacKey = eabHmacKey;
-        if (eabHmacKey === "__INFISICAL_UNCHANGED__" || eabHmacKey === undefined) {
+        if (eabHmacKey === UNCHANGED_CREDENTIAL_SENTINEL || eabHmacKey === undefined) {
           const existingExternalCa = await externalCertificateAuthorityDAL.findOne({ caId: id, type: CaType.ACME }, tx);
           const existingConfig = existingExternalCa?.configuration as DBConfigurationColumn | undefined;
           resolvedEabHmacKey = existingConfig?.eabHmacKey;

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -197,6 +197,7 @@ export const castDbEntryToAcmeCertificateAuthority = (
       directoryUrl: dbConfigurationCol.directoryUrl,
       accountEmail: dbConfigurationCol.accountEmail,
       eabKid: dbConfigurationCol.eabKid,
+      eabHmacKey: dbConfigurationCol.eabHmacKey,
       dnsResolver: dbConfigurationCol.dnsResolver
     },
     status: ca.status as CaStatus

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -814,10 +814,7 @@ export const AcmeCertificateAuthorityFns = ({
 
         let resolvedEabHmacKey = eabHmacKey;
         if (eabHmacKey === "__INFISICAL_UNCHANGED__" || eabHmacKey === undefined) {
-          const existingExternalCa = await externalCertificateAuthorityDAL.findOne(
-            { caId: id, type: CaType.ACME },
-            tx
-          );
+          const existingExternalCa = await externalCertificateAuthorityDAL.findOne({ caId: id, type: CaType.ACME }, tx);
           const existingConfig = existingExternalCa?.configuration as DBConfigurationColumn | undefined;
           resolvedEabHmacKey = existingConfig?.eabHmacKey;
         } else if (eabHmacKey === "") {

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-schemas.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-schemas.ts
@@ -33,6 +33,14 @@ export const AcmeCertificateAuthoritySchema = BaseCertificateAuthoritySchema.ext
   configuration: AcmeCertificateAuthorityConfigurationSchema
 });
 
+const SanitizedAcmeCertificateAuthorityConfigurationSchema =
+  AcmeCertificateAuthorityConfigurationSchema.omit({ eabHmacKey: true });
+
+export const SanitizedAcmeCertificateAuthoritySchema = BaseCertificateAuthoritySchema.extend({
+  type: z.literal(CaType.ACME),
+  configuration: SanitizedAcmeCertificateAuthorityConfigurationSchema
+});
+
 export const CreateAcmeCertificateAuthoritySchema = GenericCreateCertificateAuthorityFieldsSchema(CaType.ACME).extend({
   configuration: AcmeCertificateAuthorityConfigurationSchema
 });

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-schemas.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-schemas.ts
@@ -33,8 +33,9 @@ export const AcmeCertificateAuthoritySchema = BaseCertificateAuthoritySchema.ext
   configuration: AcmeCertificateAuthorityConfigurationSchema
 });
 
-const SanitizedAcmeCertificateAuthorityConfigurationSchema =
-  AcmeCertificateAuthorityConfigurationSchema.omit({ eabHmacKey: true });
+const SanitizedAcmeCertificateAuthorityConfigurationSchema = AcmeCertificateAuthorityConfigurationSchema.omit({
+  eabHmacKey: true
+});
 
 export const SanitizedAcmeCertificateAuthoritySchema = BaseCertificateAuthoritySchema.extend({
   type: z.literal(CaType.ACME),

--- a/backend/src/services/certificate-authority/certificate-authority-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-queue.ts
@@ -39,7 +39,7 @@ type TCertificateAuthorityQueueFactoryDep = {
   certificateAuthorityDAL: TCertificateAuthorityDALFactory;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
   appConnectionService: Pick<TAppConnectionServiceFactory, "validateAppConnectionUsageById">;
-  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update">;
+  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update" | "findOne">;
   keyStore: Pick<TKeyStoreFactory, "acquireLock" | "setItemWithExpiry" | "getItem">;
   certificateAuthorityCrlDAL: TCertificateAuthorityCrlDALFactory;
   certificateAuthoritySecretDAL: TCertificateAuthoritySecretDALFactory;

--- a/backend/src/services/certificate-authority/certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-service.ts
@@ -104,7 +104,7 @@ type TCertificateAuthorityServiceFactoryDep = {
     | "findWithAssociatedCa"
     | "findByNameAndProjectIdWithAssociatedCa"
   >;
-  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update">;
+  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update" | "findOne">;
   internalCertificateAuthorityService: TInternalCertificateAuthorityServiceFactory;
   projectDAL: Pick<TProjectDALFactory, "findProjectBySlug" | "findOne" | "updateById" | "findById" | "transaction">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -116,7 +116,7 @@ type TCertificateIssuanceQueueFactoryDep = {
   certificateAuthorityDAL: TCertificateAuthorityDALFactory;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "update" | "updateById">;
   appConnectionService: Pick<TAppConnectionServiceFactory, "validateAppConnectionUsageById">;
-  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update">;
+  externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update" | "findOne">;
   certificateDAL: TCertificateDALFactory;
   projectDAL: Pick<TProjectDALFactory, "findProjectBySlug" | "findOne" | "updateById" | "findById" | "transaction">;
   kmsService: Pick<

--- a/frontend/src/hooks/api/ca/types.ts
+++ b/frontend/src/hooks/api/ca/types.ts
@@ -17,7 +17,6 @@ export type TAcmeCertificateAuthority = {
     directoryUrl: string;
     accountEmail: string;
     eabKid?: string;
-    eabHmacKey?: string;
     dnsResolver?: string;
   };
 };

--- a/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/ExternalCaModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/ExternalCaModal.tsx
@@ -105,13 +105,6 @@ const acmeConfigurationSchema = z
           path: ["eabKid"]
         });
       }
-      if (!data.eabHmacKey || data.eabHmacKey.trim() === "") {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "EAB HMAC Key is required for this directory URL",
-          path: ["eabHmacKey"]
-        });
-      }
     }
   });
 
@@ -463,7 +456,7 @@ export const ExternalCaModal = ({ popUp, handlePopUpToggle }: Props) => {
             directoryUrl: ca.configuration.directoryUrl,
             accountEmail: ca.configuration.accountEmail,
             eabKid: ca.configuration.eabKid,
-            eabHmacKey: ca.configuration.eabHmacKey,
+            eabHmacKey: "__INFISICAL_UNCHANGED__",
             dnsResolver: ca.configuration.dnsResolver || ""
           }
         });
@@ -929,12 +922,17 @@ export const ExternalCaModal = ({ popUp, handlePopUpToggle }: Props) => {
                     label="EAB HMAC Key"
                     isError={Boolean(error)}
                     errorText={error?.message}
-                    isOptional={!REQUIRED_EAB_DIRECTORIES.includes(directoryUrl || "")}
-                    isRequired={REQUIRED_EAB_DIRECTORIES.includes(directoryUrl || "")}
+                    isOptional
                   >
                     <Input
+                      type="password"
+                      autoComplete="new-password"
                       {...field}
-                      placeholder="dGhpc2lzYW5leGFtcGxlaG1hY2tleWZvcmRpZ2ljZXJ0YWNtZXRlc3RpbmcxMjM0NTY3ODkw"
+                      placeholder={
+                        ca
+                          ? "Leave blank to keep existing"
+                          : "dGhpc2lzYW5leGFtcGxlaG1hY2tleWZvcmRpZ2ljZXJ0YWNtZXRlc3RpbmcxMjM0NTY3ODkw"
+                      }
                     />
                   </FormControl>
                 )}

--- a/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/ExternalCaModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificateAuthoritiesPage/components/ExternalCaModal.tsx
@@ -57,6 +57,8 @@ import {
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { slugSchema } from "@app/lib/schemas";
 
+const UNCHANGED_CREDENTIAL_SENTINEL = "__INFISICAL_UNCHANGED__";
+
 const REQUIRED_EAB_DIRECTORIES = [
   "https://acme.digicert.com/v2/acme/directory",
   "https://acme.zerossl.com/v2/DV90",
@@ -456,7 +458,7 @@ export const ExternalCaModal = ({ popUp, handlePopUpToggle }: Props) => {
             directoryUrl: ca.configuration.directoryUrl,
             accountEmail: ca.configuration.accountEmail,
             eabKid: ca.configuration.eabKid,
-            eabHmacKey: "__INFISICAL_UNCHANGED__",
+            eabHmacKey: UNCHANGED_CREDENTIAL_SENTINEL,
             dnsResolver: ca.configuration.dnsResolver || ""
           }
         });
@@ -930,7 +932,7 @@ export const ExternalCaModal = ({ popUp, handlePopUpToggle }: Props) => {
                       {...field}
                       placeholder={
                         ca
-                          ? "Leave blank to keep existing"
+                          ? undefined
                           : "dGhpc2lzYW5leGFtcGxlaG1hY2tleWZvcmRpZ2ljZXJ0YWNtZXRlc3RpbmcxMjM0NTY3ODkw"
                       }
                     />


### PR DESCRIPTION
## Context

`eabHmacKey` was returned in plaintext in all ACME CA read endpoints — any user with `CertificateAuthorities:Read` (including default Member and Viewer roles) could extract it. With the EAB credentials, someone could register a new ACME account under the organization's billing with the external CA provider (DigiCert, ZeroSSL, etc.) and issue certificates against it.

- Strip `eabHmacKey` from all CA API responses via `SanitizedAcmeCertificateAuthoritySchema`
- Preserve existing key on update using `__INFISICAL_UNCHANGED__` sentinel, support explicit clearing via empty string
- Mask frontend input with `type="password"`

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)