### PR TITLE
feat(pki): show disabled tabs and permission tooltips for non-member application viewers

### DIFF
--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -104,7 +104,10 @@ export const ApplicationDetailsByIDPage = () => {
 
   const requestedTab = search.selectedTab ?? "";
   const defaultTab = isNonMemberAdmin ? "members" : "certificates";
-  const selectedTab = requestedTab || defaultTab;
+  const selectedTab =
+    isNonMemberAdmin && requestedTab !== "members" && requestedTab !== "settings"
+      ? defaultTab
+      : requestedTab || defaultTab;
 
   const handleCopyId = () => {
     if (!application) return;

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -9,10 +9,11 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { AxiosError } from "axios";
 import { ChevronLeftIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import { DeleteActionModal, PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { AccessRestrictedBanner, DeleteActionModal, PageHeader } from "@app/components/v2";
 import {
   Button,
   DocumentationLinkBadge,
@@ -21,7 +22,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   PageLoader,
-  ResourceIcon
+  ResourceIcon,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import { usePopUp, useToggle } from "@app/hooks";
 import {
@@ -53,12 +61,20 @@ export const ApplicationDetailsByIDPage = () => {
   const search = useSearch({ strict: false }) as { selectedTab?: string; search?: string };
   const navigate = useNavigate();
 
-  const { data: application, isPending } = useGetPkiApplicationByName(applicationName ?? "");
+  const {
+    data: application,
+    isPending,
+    isError: isAppError,
+    error: appError
+  } = useGetPkiApplicationByName(applicationName ?? "");
   const { data: profiles = [] } = useListPkiApplicationProfiles(application?.id ?? "");
   const { data: members = [] } = useListPkiApplicationMembers(application?.id ?? "");
-  const { data: permissionData, isPending: isPermissionsPending } = useGetPkiApplicationPermissions(
-    application?.id ?? ""
-  );
+  const {
+    data: permissionData,
+    isPending: isPermissionsPending,
+    isError: isPermissionsError,
+    error: permissionsError
+  } = useGetPkiApplicationPermissions(application?.id ?? "");
   const deleteApp = useDeletePkiApplication();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isIdCopied, setIsIdCopied] = useToggle(false);
@@ -84,17 +100,19 @@ export const ApplicationDetailsByIDPage = () => {
   const canDeleteApplication = Boolean(
     ability?.can(PkiApplicationResourceActions.Delete, PkiApplicationResourceSub.Application)
   );
+  const isNonMemberAdmin = Boolean(permissionData && permissionData.memberships.length === 0);
 
-  const requestedTab = search.selectedTab ?? "";
-  const tabIsVisible: Record<string, boolean> = {
-    certificates: Boolean(canViewCertificates),
-    requests: Boolean(canViewRequests),
-    syncs: Boolean(canViewSyncs),
+  const tabEnabled: Record<string, boolean> = {
+    certificates: !isNonMemberAdmin && Boolean(canViewCertificates),
+    requests: !isNonMemberAdmin && Boolean(canViewRequests),
+    syncs: !isNonMemberAdmin && Boolean(canViewSyncs),
     members: true,
     settings: true
   };
-  const defaultTab = canViewCertificates ? "certificates" : "members";
-  const selectedTab = tabIsVisible[requestedTab] ? requestedTab : defaultTab;
+  const allTabs = ["certificates", "requests", "syncs", "members", "settings"] as const;
+  const defaultTab = allTabs.find((t) => tabEnabled[t]) ?? "members";
+  const requestedTab = search.selectedTab ?? "";
+  const selectedTab = tabEnabled[requestedTab] ? requestedTab : defaultTab;
 
   const handleCopyId = () => {
     if (!application) return;
@@ -122,6 +140,20 @@ export const ApplicationDetailsByIDPage = () => {
 
   if (isPending) {
     return <PageLoader />;
+  }
+
+  const isAccessForbidden =
+    (isAppError && appError instanceof AxiosError && appError.response?.status === 403) ||
+    (isPermissionsError &&
+      permissionsError instanceof AxiosError &&
+      permissionsError.response?.status === 403);
+
+  if (isAccessForbidden) {
+    return (
+      <div className="container mx-auto flex h-full items-center justify-center p-16">
+        <AccessRestrictedBanner body="You do not have access to this application. Reach out to an administrator to request access." />
+      </div>
+    );
   }
 
   if (!application) {
@@ -213,61 +245,94 @@ export const ApplicationDetailsByIDPage = () => {
                 })
               }
             >
-              <TabList>
-                {canViewCertificates && (
-                  <Tab variant="project" value="certificates">
-                    Certificate Inventory
-                  </Tab>
-                )}
-                {canViewRequests && (
-                  <Tab variant="project" value="requests">
-                    Certificate Requests
-                  </Tab>
-                )}
-                {canViewSyncs && (
-                  <Tab variant="project" value="syncs">
-                    Certificate Syncs
-                  </Tab>
-                )}
-                <Tab variant="project" value="members">
+              <TabsList variant="project" className="w-full justify-start">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <TabsTrigger
+                        value="certificates"
+                        disabled={!tabEnabled.certificates}
+                        className="flex-none"
+                      >
+                        Certificate Inventory
+                      </TabsTrigger>
+                    </span>
+                  </TooltipTrigger>
+                  {!tabEnabled.certificates && (
+                    <TooltipContent>You do not have permission to view certificates</TooltipContent>
+                  )}
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <TabsTrigger
+                        value="requests"
+                        disabled={!tabEnabled.requests}
+                        className="flex-none"
+                      >
+                        Certificate Requests
+                      </TabsTrigger>
+                    </span>
+                  </TooltipTrigger>
+                  {!tabEnabled.requests && (
+                    <TooltipContent>
+                      You do not have permission to view certificate requests
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <TabsTrigger value="syncs" disabled={!tabEnabled.syncs} className="flex-none">
+                        Certificate Syncs
+                      </TabsTrigger>
+                    </span>
+                  </TooltipTrigger>
+                  {!tabEnabled.syncs && (
+                    <TooltipContent>
+                      You do not have permission to view certificate syncs
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+                <TabsTrigger value="members" className="flex-none">
                   Members
-                </Tab>
-                <Tab variant="project" value="settings">
+                </TabsTrigger>
+                <TabsTrigger value="settings" className="flex-none">
                   Settings
-                </Tab>
-              </TabList>
-              {canViewCertificates && (
-                <TabPanel value="certificates">
+                </TabsTrigger>
+              </TabsList>
+              {tabEnabled.certificates && (
+                <TabsContent className="pt-2" value="certificates">
                   <ApplicationCertificatesTab
                     applicationId={application.id}
                     applicationName={application.name}
                     initialSearch={search.search}
                   />
-                </TabPanel>
+                </TabsContent>
               )}
-              {canViewRequests && (
-                <TabPanel value="requests">
+              {tabEnabled.requests && (
+                <TabsContent className="pt-2" value="requests">
                   <ApplicationRequestsTab
                     applicationId={application.id}
                     applicationName={application.name}
                   />
-                </TabPanel>
+                </TabsContent>
               )}
-              {canViewSyncs && (
-                <TabPanel value="syncs">
+              {tabEnabled.syncs && (
+                <TabsContent className="pt-2" value="syncs">
                   <ApplicationSyncsTab
                     applicationId={application.id}
                     applicationName={application.name}
                     projectId={projectId ?? ""}
                   />
-                </TabPanel>
+                </TabsContent>
               )}
-              <TabPanel value="members">
+              <TabsContent className="pt-2" value="members">
                 <ApplicationMembersTab members={members} applicationId={application.id} />
-              </TabPanel>
-              <TabPanel value="settings">
+              </TabsContent>
+              <TabsContent className="pt-2" value="settings">
                 <ApplicationSettingsTab application={application} profiles={profiles} />
-              </TabPanel>
+              </TabsContent>
             </Tabs>
           </div>
         </div>

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -103,7 +103,7 @@ export const ApplicationDetailsByIDPage = () => {
   const isNonMemberAdmin = Boolean(permissionData && permissionData.memberships.length === 0);
 
   const requestedTab = search.selectedTab ?? "";
-  const defaultTab = canViewCertificates ? "certificates" : "members";
+  const defaultTab = canViewCertificates && !isNonMemberAdmin ? "certificates" : "members";
   const selectedTab = requestedTab || defaultTab;
 
   const handleCopyId = () => {

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -102,17 +102,9 @@ export const ApplicationDetailsByIDPage = () => {
   );
   const isNonMemberAdmin = Boolean(permissionData && permissionData.memberships.length === 0);
 
-  const tabEnabled: Record<string, boolean> = {
-    certificates: !isNonMemberAdmin && Boolean(canViewCertificates),
-    requests: !isNonMemberAdmin && Boolean(canViewRequests),
-    syncs: !isNonMemberAdmin && Boolean(canViewSyncs),
-    members: true,
-    settings: true
-  };
-  const allTabs = ["certificates", "requests", "syncs", "members", "settings"] as const;
-  const defaultTab = allTabs.find((t) => tabEnabled[t]) ?? "members";
   const requestedTab = search.selectedTab ?? "";
-  const selectedTab = tabEnabled[requestedTab] ? requestedTab : defaultTab;
+  const defaultTab = canViewCertificates ? "certificates" : "members";
+  const selectedTab = requestedTab || defaultTab;
 
   const handleCopyId = () => {
     if (!application) return;
@@ -246,60 +238,60 @@ export const ApplicationDetailsByIDPage = () => {
               }
             >
               <TabsList variant="project" className="w-full justify-start">
-                {(tabEnabled.certificates || isNonMemberAdmin) && (
+                {(canViewCertificates || isNonMemberAdmin) && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>
                         <TabsTrigger
                           value="certificates"
-                          disabled={!tabEnabled.certificates}
+                          disabled={isNonMemberAdmin}
                           className="flex-none"
                         >
                           Certificate Inventory
                         </TabsTrigger>
                       </span>
                     </TooltipTrigger>
-                    {!tabEnabled.certificates && (
+                    {isNonMemberAdmin && (
                       <TooltipContent>
                         You do not have permission to view certificates
                       </TooltipContent>
                     )}
                   </Tooltip>
                 )}
-                {(tabEnabled.requests || isNonMemberAdmin) && (
+                {(canViewRequests || isNonMemberAdmin) && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>
                         <TabsTrigger
                           value="requests"
-                          disabled={!tabEnabled.requests}
+                          disabled={isNonMemberAdmin}
                           className="flex-none"
                         >
                           Certificate Requests
                         </TabsTrigger>
                       </span>
                     </TooltipTrigger>
-                    {!tabEnabled.requests && (
+                    {isNonMemberAdmin && (
                       <TooltipContent>
                         You do not have permission to view certificate requests
                       </TooltipContent>
                     )}
                   </Tooltip>
                 )}
-                {(tabEnabled.syncs || isNonMemberAdmin) && (
+                {(canViewSyncs || isNonMemberAdmin) && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span>
                         <TabsTrigger
                           value="syncs"
-                          disabled={!tabEnabled.syncs}
+                          disabled={isNonMemberAdmin}
                           className="flex-none"
                         >
                           Certificate Syncs
                         </TabsTrigger>
                       </span>
                     </TooltipTrigger>
-                    {!tabEnabled.syncs && (
+                    {isNonMemberAdmin && (
                       <TooltipContent>
                         You do not have permission to view certificate syncs
                       </TooltipContent>
@@ -313,7 +305,7 @@ export const ApplicationDetailsByIDPage = () => {
                   Settings
                 </TabsTrigger>
               </TabsList>
-              {tabEnabled.certificates && (
+              {canViewCertificates && (
                 <TabsContent className="pt-2" value="certificates">
                   <ApplicationCertificatesTab
                     applicationId={application.id}
@@ -322,7 +314,7 @@ export const ApplicationDetailsByIDPage = () => {
                   />
                 </TabsContent>
               )}
-              {tabEnabled.requests && (
+              {canViewRequests && (
                 <TabsContent className="pt-2" value="requests">
                   <ApplicationRequestsTab
                     applicationId={application.id}
@@ -330,7 +322,7 @@ export const ApplicationDetailsByIDPage = () => {
                   />
                 </TabsContent>
               )}
-              {tabEnabled.syncs && (
+              {canViewSyncs && (
                 <TabsContent className="pt-2" value="syncs">
                   <ApplicationSyncsTab
                     applicationId={application.id}

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -246,54 +246,66 @@ export const ApplicationDetailsByIDPage = () => {
               }
             >
               <TabsList variant="project" className="w-full justify-start">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <TabsTrigger
-                        value="certificates"
-                        disabled={!tabEnabled.certificates}
-                        className="flex-none"
-                      >
-                        Certificate Inventory
-                      </TabsTrigger>
-                    </span>
-                  </TooltipTrigger>
-                  {!tabEnabled.certificates && (
-                    <TooltipContent>You do not have permission to view certificates</TooltipContent>
-                  )}
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <TabsTrigger
-                        value="requests"
-                        disabled={!tabEnabled.requests}
-                        className="flex-none"
-                      >
-                        Certificate Requests
-                      </TabsTrigger>
-                    </span>
-                  </TooltipTrigger>
-                  {!tabEnabled.requests && (
-                    <TooltipContent>
-                      You do not have permission to view certificate requests
-                    </TooltipContent>
-                  )}
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span>
-                      <TabsTrigger value="syncs" disabled={!tabEnabled.syncs} className="flex-none">
-                        Certificate Syncs
-                      </TabsTrigger>
-                    </span>
-                  </TooltipTrigger>
-                  {!tabEnabled.syncs && (
-                    <TooltipContent>
-                      You do not have permission to view certificate syncs
-                    </TooltipContent>
-                  )}
-                </Tooltip>
+                {(tabEnabled.certificates || isNonMemberAdmin) && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <TabsTrigger
+                          value="certificates"
+                          disabled={!tabEnabled.certificates}
+                          className="flex-none"
+                        >
+                          Certificate Inventory
+                        </TabsTrigger>
+                      </span>
+                    </TooltipTrigger>
+                    {!tabEnabled.certificates && (
+                      <TooltipContent>
+                        You do not have permission to view certificates
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                )}
+                {(tabEnabled.requests || isNonMemberAdmin) && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <TabsTrigger
+                          value="requests"
+                          disabled={!tabEnabled.requests}
+                          className="flex-none"
+                        >
+                          Certificate Requests
+                        </TabsTrigger>
+                      </span>
+                    </TooltipTrigger>
+                    {!tabEnabled.requests && (
+                      <TooltipContent>
+                        You do not have permission to view certificate requests
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                )}
+                {(tabEnabled.syncs || isNonMemberAdmin) && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>
+                        <TabsTrigger
+                          value="syncs"
+                          disabled={!tabEnabled.syncs}
+                          className="flex-none"
+                        >
+                          Certificate Syncs
+                        </TabsTrigger>
+                      </span>
+                    </TooltipTrigger>
+                    {!tabEnabled.syncs && (
+                      <TooltipContent>
+                        You do not have permission to view certificate syncs
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                )}
                 <TabsTrigger value="members" className="flex-none">
                   Members
                 </TabsTrigger>

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -103,7 +103,7 @@ export const ApplicationDetailsByIDPage = () => {
   const isNonMemberAdmin = Boolean(permissionData && permissionData.memberships.length === 0);
 
   const requestedTab = search.selectedTab ?? "";
-  const defaultTab = canViewCertificates && !isNonMemberAdmin ? "certificates" : "members";
+  const defaultTab = isNonMemberAdmin ? "members" : "certificates";
   const selectedTab = requestedTab || defaultTab;
 
   const handleCopyId = () => {

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
@@ -676,14 +676,26 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
             Require approval before certificates are issued for this application.
           </CardDescription>
           <CardAction>
-            <Button
-              variant="outline"
-              onClick={() => handlePopUpOpen("policy")}
-              isDisabled={!canManagePolicies}
-            >
-              <FontAwesomeIcon icon={faPlus} />
-              Create Policy
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper required so the tooltip surfaces on keyboard focus despite the inner button being disabled */}
+                <span tabIndex={0}>
+                  <Button
+                    variant="outline"
+                    onClick={() => handlePopUpOpen("policy")}
+                    isDisabled={!canManagePolicies}
+                  >
+                    <FontAwesomeIcon icon={faPlus} />
+                    Create Policy
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {!canManagePolicies && (
+                <TooltipContent side="left">
+                  You don&apos;t have permission to create policies
+                </TooltipContent>
+              )}
+            </Tooltip>
           </CardAction>
         </CardHeader>
         <CardContent>
@@ -705,14 +717,26 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
           </CardTitle>
           <CardDescription>Get notified about certificate events.</CardDescription>
           <CardAction>
-            <Button
-              variant="outline"
-              onClick={() => setAlertModal({ isOpen: true })}
-              isDisabled={!canManageAlerts}
-            >
-              <FontAwesomeIcon icon={faPlus} />
-              Create Alert
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper required so the tooltip surfaces on keyboard focus despite the inner button being disabled */}
+                <span tabIndex={0}>
+                  <Button
+                    variant="outline"
+                    onClick={() => setAlertModal({ isOpen: true })}
+                    isDisabled={!canManageAlerts}
+                  >
+                    <FontAwesomeIcon icon={faPlus} />
+                    Create Alert
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {!canManageAlerts && (
+                <TooltipContent side="left">
+                  You don&apos;t have permission to create alerts
+                </TooltipContent>
+              )}
+            </Tooltip>
           </CardAction>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Context

Adds access control UX for PKI application detail pages when a user is not a member of the application:

- **Project admin, not app member**: All content tabs (Certificate Inventory, Certificate Requests, Certificate Syncs) are visible but disabled with permission tooltips on hover. Members and Settings tabs remain accessible so the admin can add themselves. URL params pointing to disabled tabs redirect to the Members tab
- **Regular project member, not app member**: Full-page `AccessRestrictedBanner` shown when the backend returns a 403

Also migrates the application detail page from v2 to v3 Tabs, and adds permission tooltips to the disabled Create Policy and Create Alert buttons in the settings tab.

## Screenshots

<img width="3448" height="1916" alt="CleanShot 2026-05-27 at 06 16 43@2x" src="https://github.com/user-attachments/assets/4df0b681-8780-418c-9e54-625e21a72472" />

<img width="3456" height="2076" alt="CleanShot 2026-05-27 at 06 17 05@2x" src="https://github.com/user-attachments/assets/8c9cd531-7385-4f8d-908f-a4286005cf75" />

## Steps to verify the change

## Type

- [x] Feature
- [ ] Fix
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)