### PR TITLE
feat(frontend): add project settings preference to configure default secret download format

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       redis:
         condition: service_started
     image: infisical/infisical:latest # PIN THIS TO A SPECIFIC TAG
-    pull_policy: never
+    pull_policy: always
     env_file: .env
     ports:
       - 80:8080

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       redis:
         condition: service_started
     image: infisical/infisical:latest # PIN THIS TO A SPECIFIC TAG
-    pull_policy: always
+    pull_policy: never
     env_file: .env
     ports:
       - 80:8080

--- a/frontend/src/helpers/download.ts
+++ b/frontend/src/helpers/download.ts
@@ -91,6 +91,142 @@ export const downloadSecretEnvFile = (
   downloadTxtFile(`${environment}.env`, file);
 };
 
+export const downloadSecretAppSettingsJsonFile = (
+  environment: string,
+  localSecrets: {
+    secretKey: string;
+    secretValue?: string;
+    secretComment?: string;
+    type?: string;
+  }[],
+  importedSecrets: {
+    secrets: { secretKey: string; secretValue?: string; secretComment?: string; type?: string }[];
+  }[]
+) => {
+  const secretsPicked = new Set<string>();
+  const secretsToDownload: { key: string; value: string }[] = [];
+
+  // Build a map of personal override values (personal overrides take precedence)
+  const personalOverrides = new Map<string, { value?: string }>();
+  localSecrets.forEach((el) => {
+    if (el.type === SecretType.Personal) {
+      personalOverrides.set(el.secretKey, { value: el.secretValue });
+    }
+  });
+  importedSecrets.forEach((imp) => {
+    imp.secrets.forEach((el) => {
+      if (el.type === SecretType.Personal) {
+        personalOverrides.set(el.secretKey, { value: el.secretValue });
+      }
+    });
+  });
+
+  localSecrets.forEach((el) => {
+    if (el.type === SecretType.Personal) return;
+
+    secretsPicked.add(el.secretKey);
+    const override = personalOverrides.get(el.secretKey);
+    secretsToDownload.push({
+      key: el.secretKey,
+      value: (override ? override.value : el.secretValue) ?? ""
+    });
+  });
+
+  for (let i = importedSecrets.length - 1; i >= 0; i -= 1) {
+    for (let j = importedSecrets[i].secrets.length - 1; j >= 0; j -= 1) {
+      const secret = importedSecrets[i].secrets[j];
+      // eslint-disable-next-line no-continue
+      if (secret.type === SecretType.Personal) continue;
+
+      if (!secretsPicked.has(secret.secretKey)) {
+        const override = personalOverrides.get(secret.secretKey);
+        secretsToDownload.push({
+          key: secret.secretKey,
+          value: (override ? override.value : secret.secretValue) ?? ""
+        });
+      }
+      secretsPicked.add(secret.secretKey);
+    }
+  }
+
+  const parseSecretValue = (val: string): any => {
+    const trimmed = val.trim();
+    try {
+      return JSON.parse(trimmed);
+    } catch (e) {
+      return val;
+    }
+  };
+
+  const mergeObjects = (dest: any, src: any) => {
+    for (const key of Object.keys(src)) {
+      if (dest[key] !== undefined) {
+        if (typeof dest[key] === "object" && dest[key] !== null && typeof src[key] === "object" && src[key] !== null) {
+          mergeObjects(dest[key], src[key]);
+        } else {
+          dest[key] = src[key];
+        }
+      } else {
+        dest[key] = src[key];
+      }
+    }
+  };
+
+  const buildAppSettingsJson = (secrets: { key: string; value: string }[]): any => {
+    const result: any = {};
+
+    for (const { key, value } of secrets) {
+      const val = parseSecretValue(value);
+      const normalizedKey = key.replace(/__/g, ":");
+      const parts = normalizedKey.split(":");
+
+      let current = result;
+      for (let i = 0; i < parts.length; i += 1) {
+        const part = parts[i];
+        if (i === parts.length - 1) {
+          if (current[part] !== undefined && typeof current[part] === "object" && current[part] !== null && typeof val === "object" && val !== null) {
+            mergeObjects(current[part], val);
+          } else {
+            current[part] = val;
+          }
+        } else {
+          if (current[part] === undefined) {
+            current[part] = {};
+            current = current[part];
+          } else {
+            if (typeof current[part] !== "object" || current[part] === null) {
+              current[part] = {};
+            }
+            current = current[part];
+          }
+        }
+      }
+    }
+
+    return result;
+  };
+
+  const getAppSettingsFilename = (env: string): string => {
+    const envLower = env.toLowerCase();
+    let envName = env;
+    if (envLower === "dev" || envLower === "development") {
+      envName = "Development";
+    } else if (envLower === "prod" || envLower === "production") {
+      envName = "Production";
+    } else if (envLower === "staging") {
+      envName = "Staging";
+    } else {
+      envName = env.charAt(0).toUpperCase() + env.slice(1);
+    }
+    return `appsettings.${envName}.json`;
+  };
+
+  const appSettingsObj = buildAppSettingsJson(secretsToDownload);
+  const fileContent = JSON.stringify(appSettingsObj, null, 2);
+  const filename = getAppSettingsFilename(environment);
+  downloadTxtFile(filename, fileContent);
+};
+
 export const downloadFile = (content: string, filename: string, mimeType: string = "text/csv") => {
   const blob = new Blob([content], { type: mimeType });
   const url = window.URL.createObjectURL(blob);

--- a/frontend/src/pages/project/SettingsPage/components/ProjectGeneralTab/ProjectGeneralTab.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/ProjectGeneralTab/ProjectGeneralTab.tsx
@@ -3,11 +3,13 @@ import { ProjectOverviewChangeSection } from "@app/components/project/ProjectOve
 import { AuditLogsRetentionSection } from "../AuditLogsRetentionSection";
 import { DeleteProjectProtection } from "../DeleteProjectProtection";
 import { DeleteProjectSection } from "../DeleteProjectSection";
+import { ProjectSecretDownloadFormatSection } from "../ProjectSecretDownloadFormatSection";
 
 export const ProjectGeneralTab = () => {
   return (
     <div>
       <ProjectOverviewChangeSection showSlugField />
+      <ProjectSecretDownloadFormatSection />
       <AuditLogsRetentionSection />
       <DeleteProjectProtection />
       <DeleteProjectSection />

--- a/frontend/src/pages/project/SettingsPage/components/ProjectSecretDownloadFormatSection/ProjectSecretDownloadFormatSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/ProjectSecretDownloadFormatSection/ProjectSecretDownloadFormatSection.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+import { createNotification } from "@app/components/notifications";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@app/components/v3";
+import { useProject } from "@app/context";
+
+export const ProjectSecretDownloadFormatSection = () => {
+  const { currentProject } = useProject();
+  const [downloadFormat, setDownloadFormat] = useState<"env" | "appsettings">("env");
+
+  useEffect(() => {
+    if (currentProject?.id) {
+      const savedFormat = localStorage.getItem(`infisical-secret-download-format-${currentProject.id}`);
+      if (savedFormat === "appsettings") {
+        setDownloadFormat("appsettings");
+      } else {
+        setDownloadFormat("env");
+      }
+    }
+  }, [currentProject]);
+
+  const handleFormatChange = (value: string) => {
+    if (!currentProject?.id) return;
+    localStorage.setItem(`infisical-secret-download-format-${currentProject.id}`, value);
+    setDownloadFormat(value as "env" | "appsettings");
+    createNotification({
+      text: `Successfully updated default download format to ${value === "env" ? ".env" : "appsettings.json"}`,
+      type: "success"
+    });
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+      <div className="mb-4">
+        <p className="text-xl font-medium text-mineshaft-100">Secret Download Preferences</p>
+        <p className="text-sm text-mineshaft-300">
+          Configure the default file format when downloading secrets for this project.
+        </p>
+      </div>
+      <div className="max-w-md">
+        <Select value={downloadFormat} onValueChange={handleFormatChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="env">Environment Variables (.env)</SelectItem>
+            <SelectItem value="appsettings">ASP.NET Core (appsettings.json)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/project/SettingsPage/components/ProjectSecretDownloadFormatSection/index.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/ProjectSecretDownloadFormatSection/index.tsx
@@ -1,0 +1,1 @@
+export { ProjectSecretDownloadFormatSection } from "./ProjectSecretDownloadFormatSection";

--- a/frontend/src/pages/secret-manager/OverviewPage/components/DownloadEnvButton/DownloadEnvButton.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/DownloadEnvButton/DownloadEnvButton.tsx
@@ -4,7 +4,7 @@ import { DownloadIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { IconButton, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
-import { downloadSecretEnvFile } from "@app/helpers/download";
+import { downloadSecretAppSettingsJsonFile, downloadSecretEnvFile } from "@app/helpers/download";
 import { fetchProjectSecrets } from "@app/hooks/api/secrets/queries";
 import { ApiErrorTypes, ProjectEnv, TApiErrors } from "@app/hooks/api/types";
 
@@ -21,6 +21,7 @@ export const DownloadEnvButton = ({ environments, projectId, secretPath }: Props
     if (environments.length !== 1) return;
 
     const environment = environments[0].slug;
+    const format = typeof window !== "undefined" ? localStorage.getItem(`infisical-secret-download-format-${projectId}`) || "env" : "env";
 
     setIsDownloading(true);
     try {
@@ -32,7 +33,11 @@ export const DownloadEnvButton = ({ environments, projectId, secretPath }: Props
         secretPath
       });
 
-      downloadSecretEnvFile(environment, localSecrets, localImportedSecrets);
+      if (format === "appsettings") {
+        downloadSecretAppSettingsJsonFile(environment, localSecrets, localImportedSecrets);
+      } else {
+        downloadSecretEnvFile(environment, localSecrets, localImportedSecrets);
+      }
     } catch (err) {
       if (err instanceof AxiosError) {
         const error = err?.response?.data as TApiErrors;
@@ -56,9 +61,11 @@ export const DownloadEnvButton = ({ environments, projectId, secretPath }: Props
     }
   };
 
+  const currentFormat = typeof window !== "undefined" ? localStorage.getItem(`infisical-secret-download-format-${projectId}`) || "env" : "env";
+
   return (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger asChild>
         <IconButton
           variant="outline"
           size="md"
@@ -72,7 +79,7 @@ export const DownloadEnvButton = ({ environments, projectId, secretPath }: Props
       <TooltipContent>
         {environments.length !== 1
           ? "Select a single environment to download secrets"
-          : "Download secrets"}
+          : `Download secrets (${currentFormat === "appsettings" ? "appsettings.json" : ".env"})`}
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
### Summary
This PR adds a project-level configuration tab in the settings page to let developers select their preferred default download format (.env vs appsettings.json).

* **Why**: Support developers building ASP.NET Core applications who expect hierarchical JSON files without cluttering the secrets manager dashboard with dropdown choices.
* **What**: Stored per-project in localStorage to avoid database migrations. Updates the download button's direct action to read from localStorage.