### PR TITLE
fix(ui): render apostrophe in Review Changes panel description

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/CommitForm/CommitForm.tsx
@@ -623,7 +623,7 @@ export const CommitForm: React.FC<CommitFormProps> = ({
               </Badge>
             </SheetTitle>
             <SheetDescription>
-              Write a commit message and review the changes you&apos;re about to save.
+              Write a commit message and review the changes you’re about to save.
             </SheetDescription>
           </SheetHeader>
 


### PR DESCRIPTION
## Context

The description in the Secret Dashboard's **Review Changes** panel rendered the literal HTML entity `&apos;` instead of an apostrophe — it read "…the changes you&apos;re about to save." The frontend's JSX transform is SWC (`@vitejs/plugin-react-swc`), which does not decode named HTML entities in JSX text, so `&apos;` was shown verbatim.

The fix uses a real Unicode right single quotation mark (U+2019), which needs no entity decoding, passes the `react/no-unescaped-entities` ESLint rule (it only flags ASCII `'`), and survives Prettier (which unwraps a `{"…"}` string expression back into raw JSX text).

Fixes #6322.

## Screenshots

Text-only change. Before: `…review the changes you&apos;re about to save.` After: `…review the changes you’re about to save.`

## Steps to verify the change

1. In the Secret Dashboard, stage a batch change (e.g. delete a secret).
2. Open the **Review Changes** panel.
3. The description renders a proper apostrophe: "Write a commit message and review the changes you’re about to save."

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (`npm run lint:fix` + `npm run type:check`)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
