### PR TITLE
fix(projects): allow spaces in project search name filter

### DIFF
--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1025,13 +1025,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         orderBy: z.nativeEnum(SearchProjectSortBy).optional().default(SearchProjectSortBy.NAME),
         orderDirection: z.nativeEnum(SortDirection).optional().default(SortDirection.ASC),
         projectIds: z.string().trim().array().optional(),
-        name: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
+        name: z.string().trim().max(256).optional()
       }),
       response: {
         200: z.object({


### PR DESCRIPTION
## Context

In **Organization → Projects → All Projects**, searching by a multi-word project name (with spaces) failed: the backend schema for `POST /api/v1/projects/search` validated the `name` filter with `characterValidator([AlphaNumeric, Hyphen])`, so any query containing a space (e.g. `My Project`) was rejected with a validation error.

The value is safe to relax — the DAL applies it via `whereILike` with `sanitizeSqlLikeString()` (escapes `%`, `_`, `\`) and Knex parameterizes it. The validator is now a trimmed string bounded to 256 characters.

Fixes #5813.

## Steps to verify the change

1. Go to **Organization → Projects → All Projects**.
2. Type a query containing a space (e.g. `My Project`).
3. The search succeeds and returns matching projects instead of a validation error.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (`npm run lint:fix` + `npm run type:check`)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
