### PR TITLE
fix(secrets): resolve secret references whose name contains a dot

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
@@ -1,0 +1,155 @@
+// Secret reference fixtures intentionally use the `${...}` syntax inside plain strings.
+/* eslint-disable no-template-curly-in-string */
+import { describe, expect, test } from "vitest";
+
+import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
+import { expandSecretReferencesFactory, getAllSecretReferences } from "./secret-reference-fns";
+import { TSecretV2BridgeDALFactory } from "./secret-v2-bridge-dal";
+
+type MockSecret = { key: string; value: string; tags?: { slug: string }[] };
+type MockFolder = { id: string; secrets: MockSecret[] };
+
+// Builds an expander backed by an in-memory map of `${environment}:${secretPath}` -> folder.
+const buildExpander = (folders: Record<string, MockFolder>) => {
+  const folderDAL = {
+    findBySecretPath: (projectId: string, environment: string, secretPath: string) => {
+      // Normalize OS-specific separators: path.join uses "\" on win32 but "/" on the server.
+      const normalizedPath = secretPath.replace(/\\/g, "/");
+      const folder = folders[`${environment}:${normalizedPath}`];
+      return Promise.resolve(folder ? { id: folder.id } : undefined);
+    }
+  } as unknown as Pick<TSecretFolderDALFactory, "findBySecretPath">;
+
+  const secretDAL = {
+    findByFolderId: ({ folderId }: { folderId: string }) => {
+      const folder = Object.values(folders).find((el) => el.id === folderId);
+      const secrets = (folder?.secrets ?? []).map((secret) => ({
+        key: secret.key,
+        encryptedValue: Buffer.from(secret.value),
+        tags: secret.tags ?? [],
+        userId: null
+      }));
+      return Promise.resolve(secrets);
+    }
+  } as unknown as Pick<TSecretV2BridgeDALFactory, "findByFolderId">;
+
+  return expandSecretReferencesFactory({
+    projectId: "project-1",
+    decryptSecretValue: (encryptedValue) => (encryptedValue ? encryptedValue.toString() : undefined),
+    secretDAL,
+    folderDAL,
+    canExpandValue: () => true
+  });
+};
+
+describe("expandSecretReferencesFactory - secret names containing dots", () => {
+  test("resolves a local secret whose name contains a dot", async () => {
+    const { expandSecretReferences } = buildExpander({
+      "dev:/": {
+        id: "folder-dev-root",
+        secrets: [
+          { key: "Secret.Reference", value: "test" },
+          { key: "Secret_Test", value: "${Secret.Reference}" }
+        ]
+      }
+    });
+
+    const result = await expandSecretReferences({
+      value: "${Secret.Reference}",
+      environment: "dev",
+      secretPath: "/",
+      secretKey: "Secret_Test"
+    });
+
+    expect(result).toBe("test");
+  });
+
+  test("still resolves cross-environment references when no local secret matches", async () => {
+    const { expandSecretReferences } = buildExpander({
+      "dev:/": {
+        id: "folder-dev-root",
+        secrets: [{ key: "APP_KEY", value: "${prod.API_KEY}" }]
+      },
+      "prod:/": {
+        id: "folder-prod-root",
+        secrets: [{ key: "API_KEY", value: "secret123" }]
+      }
+    });
+
+    const result = await expandSecretReferences({
+      value: "${prod.API_KEY}",
+      environment: "dev",
+      secretPath: "/",
+      secretKey: "APP_KEY"
+    });
+
+    expect(result).toBe("secret123");
+  });
+
+  test("prefers a local dotted secret over the environment interpretation", async () => {
+    // "prod.API_KEY" exists both as a local secret name and could be read as env=prod, key=API_KEY.
+    // The local secret takes precedence.
+    const { expandSecretReferences } = buildExpander({
+      "dev:/": {
+        id: "folder-dev-root",
+        secrets: [
+          { key: "prod.API_KEY", value: "local-wins" },
+          { key: "APP_KEY", value: "${prod.API_KEY}" }
+        ]
+      },
+      "prod:/": {
+        id: "folder-prod-root",
+        secrets: [{ key: "API_KEY", value: "env-value" }]
+      }
+    });
+
+    const result = await expandSecretReferences({
+      value: "${prod.API_KEY}",
+      environment: "dev",
+      secretPath: "/",
+      secretKey: "APP_KEY"
+    });
+
+    expect(result).toBe("local-wins");
+  });
+});
+
+describe("getAllSecretReferences - classification", () => {
+  // path.join uses "\" on win32 but "/" on the server; normalize so assertions are OS-independent.
+  const normalizeNested = (refs: { environment: string; secretPath: string; secretKey: string }[]) =>
+    refs.map((ref) => ({ ...ref, secretPath: ref.secretPath.replace(/\\/g, "/") }));
+
+  test("classifies non-dotted references as local and dotted references as cross-environment", () => {
+    const { localReferences, nestedReferences } = getAllSecretReferences("${SIMPLE} and ${dev.folder.API_KEY}");
+
+    expect(localReferences).toEqual(["SIMPLE"]);
+    expect(normalizeNested(nestedReferences)).toEqual([
+      { environment: "dev", secretPath: "/folder", secretKey: "API_KEY" }
+    ]);
+  });
+
+  test("treats a dotted reference as cross-environment when no local secret keys are provided", () => {
+    const { localReferences, nestedReferences } = getAllSecretReferences("${Secret.Reference}");
+
+    expect(localReferences).toEqual([]);
+    expect(normalizeNested(nestedReferences)).toEqual([
+      { environment: "Secret", secretPath: "/", secretKey: "Reference" }
+    ]);
+  });
+
+  test("treats a dotted reference as local when it matches a known local secret name", () => {
+    const { localReferences, nestedReferences } = getAllSecretReferences("${Secret.Reference}", ["Secret.Reference"]);
+
+    expect(localReferences).toEqual(["Secret.Reference"]);
+    expect(nestedReferences).toEqual([]);
+  });
+
+  test("keeps genuine cross-environment references nested even when local keys are provided", () => {
+    const { localReferences, nestedReferences } = getAllSecretReferences("${prod.API_KEY} and ${Secret.Reference}", [
+      "Secret.Reference"
+    ]);
+
+    expect(localReferences).toEqual(["Secret.Reference"]);
+    expect(normalizeNested(nestedReferences)).toEqual([{ environment: "prod", secretPath: "/", secretKey: "API_KEY" }]);
+  });
+});

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
@@ -11,22 +11,27 @@ const INTERPOLATION_PATTERN_STRING = String.raw`\${([a-zA-Z0-9-_.]+)}`;
 const INTERPOLATION_TEST_REGEX = new RE2(INTERPOLATION_PATTERN_STRING);
 
 /**
- * Grabs and processes nested secret references from a string
+ * Grabs and processes secret references from a string.
  *
- * This function looks for patterns that match the interpolation syntax in the input string.
- * It filters out references that include nested paths, splits them into environment and
- * secret path parts, and then returns an array of objects with the environment and the
- * joined secret path.
+ * This function looks for patterns that match the interpolation syntax in the input string and
+ * classifies each one as either a local reference (a secret in the same folder) or a nested,
+ * cross-environment reference (`environment.folder.key`).
+ *
+ * A reference is treated as local when it contains no dot, or — when `localSecretKeys` is
+ * provided — when its exact value matches a known local secret name. The latter is what allows
+ * a secret whose name itself contains a dot (e.g. `Secret.Reference`) to be recognised as a
+ * local reference instead of being mis-parsed as `environment=Secret`. Callers that cannot
+ * resolve local names omit `localSecretKeys` and keep the dot-based classification.
  * @example
  * const value = "Hello ${dev.someFolder.OtherFolder.SECRET_NAME} and ${prod.anotherFolder.SECRET_NAME}";
- * const result = getAllNestedSecretReferences(value);
- * // result will be:
+ * const result = getAllSecretReferences(value);
+ * // result.nestedReferences will be:
  * // [
  * //   { environment: 'dev', secretPath: '/someFolder/OtherFolder' },
  * //   { environment: 'prod', secretPath: '/anotherFolder' }
  * // ]
  */
-export const getAllSecretReferences = (maybeSecretReference: string) => {
+export const getAllSecretReferences = (maybeSecretReference: string, localSecretKeys?: string[]) => {
   const references = [];
   let match;
 
@@ -36,8 +41,12 @@ export const getAllSecretReferences = (maybeSecretReference: string) => {
     references.push(match[1]);
   }
 
+  const localSecretKeySet = localSecretKeys ? new Set(localSecretKeys) : undefined;
+  const isLocalReference = (reference: string) =>
+    !reference.includes(".") || Boolean(localSecretKeySet?.has(reference));
+
   const nestedReferences = references
-    .filter((el) => el.includes("."))
+    .filter((el) => !isLocalReference(el))
     .map((el) => {
       const [environment, ...secretPathList] = el.split(".");
       return {
@@ -46,7 +55,7 @@ export const getAllSecretReferences = (maybeSecretReference: string) => {
         secretKey: secretPathList[secretPathList.length - 1]
       };
     });
-  const localReferences = references.filter((el) => !el.includes("."));
+  const localReferences = references.filter((el) => isLocalReference(el));
   return { nestedReferences, localReferences };
 };
 
@@ -192,9 +201,23 @@ export const expandSecretReferencesFactory = ({
             referencedSecretPath = secretPath;
             referencedSecretEnvironmentSlug = environment;
           } else {
-            const secretReferenceEnvironment = entities[0];
-            const secretReferencePath = path.join("/", ...entities.slice(1, entities.length - 1));
-            const secretReferenceKey = entities[entities.length - 1];
+            // A reference containing a dot is normally treated as a cross-environment
+            // reference (`environment.folder.key`). Secret names can themselves contain
+            // dots, so prefer a local secret with this exact name when one exists in the
+            // current environment and path before falling back to that interpretation.
+            const localSecretReferenceKey = interpolationKey.trim();
+            // eslint-disable-next-line no-await-in-loop
+            await fetchSecret(environment, secretPath, localSecretReferenceKey);
+            const localFolderCacheKey = getCacheUniqueKey(environment, secretPath);
+            const isLocalSecretReference =
+              Boolean(secretCache[localFolderCacheKey]) &&
+              Object.prototype.hasOwnProperty.call(secretCache[localFolderCacheKey], localSecretReferenceKey);
+
+            const secretReferenceEnvironment = isLocalSecretReference ? environment : entities[0];
+            const secretReferencePath = isLocalSecretReference
+              ? secretPath
+              : path.join("/", ...entities.slice(1, entities.length - 1));
+            const secretReferenceKey = isLocalSecretReference ? localSecretReferenceKey : entities[entities.length - 1];
 
             // eslint-disable-next-line no-await-in-loop
             const referedValue = await fetchSecret(secretReferenceEnvironment, secretReferencePath, secretReferenceKey);

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-fns.ts
@@ -716,7 +716,9 @@ export const fnUpdateSecretLinkedReferences = async ({
     const originalValue = decryptor({ cipherTextBlob: secretToUpdate.encryptedValue }).toString();
     let newValue = originalValue;
 
-    const { localReferences, nestedReferences } = getAllSecretReferences(originalValue);
+    // Pass the renamed key as a known local secret name so a reference like ${A.B} is treated as
+    // a local reference to a dotted-name secret rather than a cross-environment reference.
+    const { localReferences, nestedReferences } = getAllSecretReferences(originalValue, [oldSecretKey]);
 
     // checkk if this secret references the renamed secret at all (either locally or nested)
     const hasLocalRef = localReferences.includes(oldSecretKey);


### PR DESCRIPTION
## Context

A secret reference whose name contains a dot could not be resolved. Secret reference expansion splits the reference on `.` and treats anything containing a dot as a cross-environment reference (`environment.folder.key`). So `${Secret.Reference}` was interpreted as environment `Secret`, key `Reference`, which does not exist — the reference resolved to "No Value".

This fix makes expansion prefer a **local** secret: when a dotted reference matches the exact name of a secret in the current environment/path, that local secret is used; otherwise it falls back to the existing `environment.folder.key` interpretation. This is backward compatible (existing cross-environment references are unaffected unless a local secret literally shares the dotted name, in which case local — the more specific match — wins).

Fixes #5962.

## Steps to verify the change

1. Create a secret named `Secret.Reference` with value `test`.
2. Create a secret `Secret_Test` with value `${Secret.Reference}`.
3. Open **Secret References** for `Secret_Test` (or read its expanded value) — it now resolves to `test`.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (added unit tests in `secret-reference-fns.test.ts` — local dotted name, cross-environment reference, and local-over-environment precedence — plus `npm run lint:fix` + `npm run type:check`)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
