### PR TITLE
fix(memberships): count distinct members in user and identity list queries

### DIFF
--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -414,30 +414,21 @@ export const identityOrgDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
-      const searchQuery = (tx || db.replicaNode())(TableName.Membership)
+      // Base filtered query (joins + filters, no pagination) shared by the count and the
+      // paginated ID subquery. The data query JOINs membership_roles (one-to-many), so a
+      // window count over the joined rows would tally role assignments instead of distinct
+      // identities. Count distinct memberships separately instead.
+      const baseFilterQuery = (tx || db.replicaNode())(TableName.Membership)
         .where(`${TableName.Membership}.scope`, AccessScope.Organization)
         .whereNotNull(`${TableName.Membership}.actorIdentityId`)
         .where(`${TableName.Membership}.scopeOrgId`, orgId)
         .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
         .whereNull(`${TableName.Identity}.projectId`)
         .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)
-        .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .orderBy(
-          orderBy === OrgIdentityOrderBy.Role
-            ? `${TableName.MembershipRole}.${orderBy}`
-            : `${TableName.Identity}.${orderBy}`,
-          orderDirection
-        )
-        .select(`${TableName.Membership}.id`)
-        .select<{ id: string; total_count: string }>(
-          db.raw(
-            `count(${TableName.Membership}."actorIdentityId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total_count`
-          )
-        )
-        .as("searchedIdentities");
+        .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`);
 
       if (searchFilter) {
-        buildKnexFilterForSearchResource(searchQuery, searchFilter, (attr) => {
+        buildKnexFilterForSearchResource(baseFilterQuery, searchFilter, (attr) => {
           switch (attr) {
             case "role":
               return [`${TableName.Role}.slug`, `${TableName.MembershipRole}.role`];
@@ -448,6 +439,37 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           }
         });
       }
+
+      const [countResult] = (await baseFilterQuery
+        .clone()
+        .countDistinct(`${TableName.Membership}.id as total_count`)) as [{ total_count: string | number }?];
+      const totalCount = Number(countResult?.total_count ?? 0);
+
+      // Collapse the one-to-many membership_roles join to one row per identity so pagination
+      // selects distinct identities rather than role assignments. Order consistently with the
+      // outer query below: by identity name, or by the effective role (custom role slug, else
+      // role) aggregated with MIN over the grouped rows.
+      const searchQuery = baseFilterQuery.clone().clearSelect().select(`${TableName.Membership}.id`);
+
+      if (orderBy === OrgIdentityOrderBy.Role) {
+        void searchQuery
+          .groupBy(`${TableName.Membership}.id`)
+          .orderByRaw(`MIN(CASE WHEN ??.role = ? THEN ??.slug ELSE ??.role END) ?`, [
+            TableName.MembershipRole,
+            "custom",
+            TableName.Role,
+            TableName.MembershipRole,
+            db.raw(orderDirection)
+          ])
+          .orderBy(`${TableName.Membership}.id`, "asc");
+      } else {
+        void searchQuery
+          .groupBy(`${TableName.Membership}.id`, `${TableName.Identity}.name`)
+          .orderBy(`${TableName.Identity}.name`, orderDirection)
+          .orderBy(`${TableName.Membership}.id`, "asc");
+      }
+
+      void searchQuery.as("searchedIdentities");
 
       if (limit) {
         void searchQuery.offset(offset).limit(limit);
@@ -527,7 +549,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         )
         .select(
           db.ref("id").withSchema(TableName.Membership),
-          db.ref("total_count").withSchema("searchedIdentities"),
           db.ref("role").withSchema(TableName.MembershipRole),
           db.ref("customRoleId").withSchema(TableName.MembershipRole).as("roleId"),
           db.ref("scopeOrgId").withSchema(TableName.Membership).as("orgId"),
@@ -596,7 +617,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           hasDeleteProtection,
           role,
           roleId,
-          total_count,
           id,
           uaId,
           alicloudId,
@@ -619,7 +639,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           roleId,
           identityId: identityId as string,
           id,
-          total_count: total_count as string,
           orgId,
           createdAt,
           updatedAt,
@@ -668,7 +687,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         ]
       });
 
-      return { docs: formattedDocs, totalCount: Number(formattedDocs?.[0]?.total_count ?? 0) };
+      return { docs: formattedDocs, totalCount };
     } catch (error) {
       throw new DatabaseError({ error, name: "FindByOrgId" });
     }

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -167,9 +167,6 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         });
 
-      if (filter.limit) void paginatedUsers.limit(filter.limit);
-      if (filter.offset) void paginatedUsers.offset(filter.offset);
-
       if (filter.username || filter.role) {
         buildKnexFilterForSearchResource(
           paginatedUsers,
@@ -189,6 +186,15 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         );
       }
+
+      // Count distinct memberships before pagination. The data query JOINs membership_roles
+      // (one-to-many), so a window count would tally role assignments instead of users.
+      const countQuery = await (tx || db.replicaNode())
+        .count("* as total")
+        .from(paginatedUsers.clone().as("distinctMemberships"));
+
+      if (filter.limit) void paginatedUsers.limit(filter.limit);
+      if (filter.offset) void paginatedUsers.offset(filter.offset);
 
       const docs = await (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
@@ -223,11 +229,6 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           db.ref("firstName").withSchema(TableName.Users).as("userFirstName"),
           db.ref("lastName").withSchema(TableName.Users).as("userLastName"),
           db.ref("id").withSchema(TableName.Users).as("userId")
-        )
-        .select(
-          db.raw(
-            `count(${TableName.Membership}."actorUserId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total`
-          )
         );
 
       const data = sqlNestRelationships({
@@ -277,7 +278,7 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((data?.[0] as unknown as { total: number })?.total ?? 0) };
+      return { data, totalCount: Number((countQuery?.[0] as unknown as { total: number })?.total ?? 0) };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindUser" });
     }


### PR DESCRIPTION
## Context

Follow-up to #5850, which fixed an inflated total count in the project identity membership list. The same bug remained in two sibling queries:

- `membership-user-dal.ts` (`findUsers`)
- `identity-org-dal.ts` (`searchIdentities`)

Both derived `totalCount` from a window function (`count(...) OVER (PARTITION BY ...)`) running over rows JOINed against `membership_roles` (one-to-many). A member with N role assignments was counted N times, so an org with 5 users where 2 have multiple roles reported 8 instead of 5.

Both now count distinct memberships with a dedicated query before pagination, mirroring the fix in `membership-identity-dal.ts` (#5850) and the already-correct `membership-group-dal.ts` (which uses `countDistinct`). The group DAL was already fixed and is left unchanged.

Fixes #5885.

## Steps to verify the change

1. In an org with N users, give some users multiple roles.
2. List org users (and search org identities) and confirm the reported total equals the number of distinct users/identities, not the number of role assignments.

These are PostgreSQL/Knex query changes; they are exercised by the membership/identity list e2e tests (which require a database). Locally verified via `npm run lint:fix` + `npm run type:check`.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (`npm run lint:fix` + `npm run type:check`; DB-level behavior covered by the same pattern as #5850 — recommend running the membership e2e suite)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
