### PR TITLE
fix(pki): return private key in certificate renewal response

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -1844,6 +1844,8 @@ describe("CertificateV3Service", () => {
 
       expect(result).toHaveProperty("certificate", "renewed-cert");
       expect(result).toHaveProperty("certificateId", "cert-456");
+      // The renewed certificate's freshly issued private key must be returned to the caller.
+      expect(result).toHaveProperty("privateKey", "private-key");
       expect(mockCertificateDAL.updateById).toHaveBeenCalledWith(
         "cert-456",
         {

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2494,6 +2494,9 @@ export const certificateV3ServiceFactory = ({
       let issuingCaCertificate: string;
       let serialNumber: string;
       let newCert: TCertificates;
+      // Renewal generates a fresh key pair, so the newly issued private key is returned to the
+      // caller (the renewed certificate is otherwise unusable without it).
+      let privateKey: string | undefined;
 
       if (issuerType === IssuerType.CA) {
         // CA-signed certificate renewal
@@ -2544,6 +2547,7 @@ export const certificateV3ServiceFactory = ({
           certificateChain = caResult.certificateChain;
           issuingCaCertificate = caResult.issuingCaCertificate;
           serialNumber = caResult.serialNumber;
+          privateKey = caResult.privateKey;
 
           const foundCert = await certificateDAL.findById(caResult.certificateId, tx);
           if (!foundCert) {
@@ -2601,6 +2605,7 @@ export const certificateV3ServiceFactory = ({
         certificateChain = selfSignedRenewalResult.selfSignedResult.certificate.toString("utf8"); // Self-signed has no chain
         issuingCaCertificate = ""; // No issuing CA for self-signed
         serialNumber = selfSignedRenewalResult.selfSignedResult.serialNumber;
+        privateKey = selfSignedRenewalResult.selfSignedResult.privateKey.toString("utf8");
         newCert = selfSignedRenewalResult.certificateData;
       }
 
@@ -2704,6 +2709,7 @@ export const certificateV3ServiceFactory = ({
         certificateChain,
         issuingCaCertificate,
         serialNumber,
+        privateKey,
         newCert,
         originalCert,
         profile,
@@ -2830,6 +2836,7 @@ export const certificateV3ServiceFactory = ({
       issuingCaCertificate: renewalResult.issuingCaCertificate,
       certificateChain: finalCertificateChain,
       serialNumber: renewalResult.serialNumber,
+      privateKey: renewalResult.privateKey,
       certificateId: renewalResult.newCert.id,
       certificateRequestId,
       projectId: renewalResult.originalCert.projectId,


### PR DESCRIPTION
## Context

The certificate renewal endpoint (`POST /api/v1/pki/certificates/:id/renew`) documents a `privateKey` field in its response, and the route schema already declares it, but the renewal service never populated it. The freshly generated leaf private key returned by `issueCertFromCa` (internal CA) and by the self-signed generator was discarded, so the response omitted `privateKey`.

Because renewal mints a **new** key pair, the renewed certificate is unusable to the caller without its private key. This change threads the newly issued private key through `renewCertificate` for both internal-CA and self-signed renewals. External-CA renewals are async (issued later via queue) and are unaffected — no synchronous key to return. Only certificates whose key was generated/stored by Infisical are renewable (CSR-based certs are rejected earlier), so no externally-held key is ever exposed.

Fixes #6454.

## Steps to verify the change

1. Issue a certificate from an API-enrollment profile (internal CA or self-signed).
2. Call `POST /api/v1/pki/certificates/:id/renew`.
3. The response body now includes `privateKey` alongside `certificate`, `certificateChain`, etc.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (added a `privateKey` assertion to the `renewCertificate` unit test in `certificate-v3-service.test.ts`; `npm run type:check` passes. The unit suite runs in CI.)
- [ ] Updated docs (not needed — response already documented)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
