### PR TITLE
improvement(migrations): make migration history mismatch error actionable

### DIFF
--- a/backend/src/auto-start-migrations.ts
+++ b/backend/src/auto-start-migrations.ts
@@ -43,7 +43,7 @@ const getImageVersionTag = (): string => {
   if (!version) {
     return "development";
   }
-  return `v${version}`;
+  return version.startsWith("v") ? version : `v${version}`;
 };
 
 const getMigrationDateRange = (migrationNames: string[]): { earliest: string; latest: string } | null => {

--- a/backend/src/auto-start-migrations.ts
+++ b/backend/src/auto-start-migrations.ts
@@ -38,6 +38,33 @@ const migrationConfig = {
   tableName: "infisical_migrations"
 };
 
+const getImageVersionTag = (): string => {
+  const version = getConfig().INFISICAL_PLATFORM_VERSION;
+  if (!version) {
+    return "development";
+  }
+  return `v${version}`;
+};
+
+const getMigrationDateRange = (migrationNames: string[]): { earliest: string; latest: string } | null => {
+  if (!migrationNames.length) {
+    return null;
+  }
+  const timestamps = migrationNames
+    .map((name) => name.match(/^(\d{8})/)?.[1])
+    .filter((timestamp): timestamp is string => Boolean(timestamp))
+    .sort();
+  if (!timestamps.length) {
+    return null;
+  }
+  const formatDate = (timestamp: string) =>
+    `${timestamp.slice(0, 4)}-${timestamp.slice(4, 6)}-${timestamp.slice(6, 8)}`;
+  return {
+    earliest: formatDate(timestamps[0]),
+    latest: formatDate(timestamps[timestamps.length - 1])
+  };
+};
+
 const logUnknownAppliedMigrations = ({
   databaseName,
   logger,
@@ -47,13 +74,31 @@ const logUnknownAppliedMigrations = ({
   logger: Logger;
   unknownAppliedMigrationNames: string[];
 }) => {
+  const imageVersion = getImageVersionTag();
+  const dateRange = getMigrationDateRange(unknownAppliedMigrationNames);
+
+  const sections = [
+    `Database has migrations newer than this image [database=${databaseName}] [imageVersion=${imageVersion}].`,
+    `Skipping startup migrations.`,
+    `This is expected during rolling deployments when a peer instance on a newer image has already applied them.`
+  ];
+  if (dateRange) {
+    sections.push(
+      `The database contains migrations dated up to ${dateRange.latest} that this image does not bundle. If this is not a rolling deployment, verify the intended image version is deployed — an Infisical image released on or after ${dateRange.latest} should include them.`
+    );
+  } else {
+    sections.push(`If this is not a rolling deployment, verify that the intended image version is deployed.`);
+  }
+
   logger.warn(
     {
       databaseName,
+      imageVersion,
       unknownAppliedMigrationCount: unknownAppliedMigrationNames.length,
+      unknownAppliedMigrationDateRange: dateRange,
       unknownAppliedMigrationNames: unknownAppliedMigrationNames.slice(-5)
     },
-    `Database has migrations newer than this image [database=${databaseName}]. Skipping startup migrations.`
+    sections.join(" ")
   );
 };
 
@@ -66,13 +111,40 @@ const throwInvalidMigrationHistory = ({
   pendingMigrationNames: string[];
   unknownAppliedMigrationNames: string[];
 }): never => {
-  throw new Error(
-    [
-      `Invalid migration history detected [database=${databaseName}].`,
-      `Unknown applied migrations: ${unknownAppliedMigrationNames.join(", ") || "none"}.`,
-      `Pending bundled migrations: ${pendingMigrationNames.join(", ") || "none"}.`
-    ].join(" ")
-  );
+  const imageVersion = getImageVersionTag();
+  const unknownAppliedList = unknownAppliedMigrationNames.join(", ") || "none";
+  const pendingList = pendingMigrationNames.join(", ") || "none";
+  const unknownDateRange = getMigrationDateRange(unknownAppliedMigrationNames);
+  const pendingDateRange = getMigrationDateRange(pendingMigrationNames);
+
+  const sections = [
+    `Database migration history does not match this image [database=${databaseName}] [imageVersion=${imageVersion}].`,
+    `This usually means the database was migrated by a different (typically newer) Infisical image than the one currently running — for example after a rollback or a mixed-version rollout.`,
+    `Unknown applied migrations (in DB but not in this image, count=${unknownAppliedMigrationNames.length}): ${unknownAppliedList}.`,
+    `Pending bundled migrations (in this image but not yet applied, count=${pendingMigrationNames.length}): ${pendingList}.`
+  ];
+
+  if (unknownDateRange && pendingDateRange) {
+    sections.push(
+      `Timeline: this image's pending migrations are dated ${pendingDateRange.earliest} to ${pendingDateRange.latest}; the unknown applied migrations in the database are dated ${unknownDateRange.earliest} to ${unknownDateRange.latest}.`
+    );
+  } else if (unknownDateRange) {
+    sections.push(
+      `Timeline: the unknown applied migrations in the database are dated ${unknownDateRange.earliest} to ${unknownDateRange.latest}.`
+    );
+  }
+
+  if (unknownDateRange) {
+    sections.push(
+      `To resolve: deploy an Infisical image released on or after ${unknownDateRange.latest} so its bundled migrations include the unknown ones above, or restore the database to a state matching this image's migrations.`
+    );
+  } else {
+    sections.push(
+      `To resolve: deploy a newer Infisical image whose bundled migrations include the unknown ones above, or restore the database to a state matching this image's migrations.`
+    );
+  }
+
+  throw new Error(sections.join(" "));
 };
 
 const getLockTableName = (tableName: string): string => {


### PR DESCRIPTION
## Context

When boot-up migration history doesn't match the running image, the thrown error was hard to act on — no image version, no cause, no remediation. Operators (and customers) were left guessing.

- Drop alarmist "Invalid migration history detected" phrasing for a neutral "Database migration history does not match this image".
- Add the running image version (`INFISICAL_PLATFORM_VERSION`) inline so it's clear which build is complaining.
- Add a plain-language likely cause (rollback / mixed-version rollout).
- Label each migration list with direction ("in DB but not in this image" vs "in this image but not yet applied") and a count.
- Derive a date range from migration filename timestamps and add a concrete remediation step: deploy an image released on or after the latest unknown-migration date, or restore the DB.
- Apply the same enrichment (image version + date-bounded hint) to the "ahead" warning log, plus a structured `unknownAppliedMigrationDateRange` field for dashboards.

## Steps to verify the change

- `getMigrationDateRange` parses the `YYYYMMDD` filename prefix; all 432 existing migrations match the convention, and it returns `null` (falling back to a generic hint) if a name doesn't.
- No tests assert on the message text, so wording change is safe; `backend/src/auto-start-migrations.test.ts` covers the boot-direction helpers, which are unchanged.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`.
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)