### PR TITLE
fix: authorization check in certificate renewal path

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2333,7 +2333,7 @@ export const certificateV3ServiceFactory = ({
         const projectId = profile?.projectId || originalCert.projectId;
 
         if (originalCert.applicationId) {
-          const originalProfile = await certificateProfileDAL.findByIdWithConfigs(originalCert.profileId!);
+          const originalProfile = await certificateProfileDAL.findByIdWithConfigs(originalCert.profileId);
           if (!originalProfile) {
             throw new NotFoundError({ message: "Original certificate profile not found" });
           }

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2334,7 +2334,7 @@ export const certificateV3ServiceFactory = ({
 
         if (originalCert.applicationId) {
           await $resolveApplicationIdForProfile(
-            profile!,
+            profile,
             originalCert.applicationId,
             {
               actor,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2333,8 +2333,12 @@ export const certificateV3ServiceFactory = ({
         const projectId = profile?.projectId || originalCert.projectId;
 
         if (originalCert.applicationId) {
+          const originalProfile = await certificateProfileDAL.findByIdWithConfigs(originalCert.profileId!);
+          if (!originalProfile) {
+            throw new NotFoundError({ message: "Original certificate profile not found" });
+          }
           await $resolveApplicationIdForProfile(
-            profile,
+            originalProfile,
             originalCert.applicationId,
             {
               actor,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2333,11 +2333,8 @@ export const certificateV3ServiceFactory = ({
         const projectId = profile?.projectId || originalCert.projectId;
 
         if (originalCert.applicationId) {
-          if (!profile) {
-            throw new NotFoundError({ message: "Certificate profile not found" });
-          }
           await $resolveApplicationIdForProfile(
-            profile,
+            profile!,
             originalCert.applicationId,
             {
               actor,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2333,18 +2333,19 @@ export const certificateV3ServiceFactory = ({
         const projectId = profile?.projectId || originalCert.projectId;
 
         if (originalCert.applicationId) {
-          const { permission } = await permissionService.getResourcePermission({
-            actor,
-            actorId,
-            projectId,
-            resourceType: ResourceType.CertificateApplication,
-            resourceId: originalCert.applicationId,
-            actorAuthMethod,
-            actorOrgId
-          });
-          ForbiddenError.from(permission).throwUnlessCan(
-            ResourcePermissionCertificateActions.Create,
-            ResourcePermissionSub.Certificates
+          if (!profile) {
+            throw new NotFoundError({ message: "Certificate profile not found" });
+          }
+          await $resolveApplicationIdForProfile(
+            profile,
+            originalCert.applicationId,
+            {
+              actor,
+              actorId,
+              actorAuthMethod,
+              actorOrgId
+            },
+            EnrollmentType.API
           );
         } else if (profile) {
           const { permission } = await permissionService.getProjectPermission({


### PR DESCRIPTION
## Summary
- Align the renewal authorization path with the standard issuance authorization path for application-associated certificates