### PR TITLE
improvement(secret-share): add external emails on audit log

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -4470,6 +4470,7 @@ interface CreateSharedSecretEvent {
     expiresAfterViews?: number;
     usingPassword: boolean;
     expiresAt: string;
+    emails?: string[];
   };
 }
 

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -362,6 +362,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         event: {
           type: EventType.CREATE_SHARED_SECRET,
           metadata: {
+            emails: authorizedEmails,
             accessType: req.body.accessType,
             expiresAt: sharedSecret.expiresAt.toISOString(),
             expiresAfterViews: req.body.maxViews,


### PR DESCRIPTION
## Context

Add emails on audit log for secret share. We were not saving this. 


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- share a secret that has an email defined
- check the audit logs to see that the emails are there.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)