### PR TITLE
fix(ci): assign upgrade-impact PR reviewer to current release author

### DIFF
--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -102,18 +102,16 @@ jobs:
           git commit -m "$PR_TITLE"
           git push --set-upstream origin "$BRANCH_NAME"
 
-          # Request review from whoever cut the previous GitHub release so a real
-          # human gets pinged rather than only the github-actions bot.
+          # Request review from whoever cut this GitHub release so a real
+          # human with context on the changes gets pinged rather than only the
+          # github-actions bot.
           REVIEWER_FLAG=()
-          PREVIOUS_TAG="$(awk '/^previousTag:/ { print $2; exit }' "upgrade-impact/data/releases/${TAG_NAME}.yaml")"
-          if [ -n "$PREVIOUS_TAG" ]; then
-            PREVIOUS_AUTHOR="$(gh release view "$PREVIOUS_TAG" --json author --jq .author.login 2>/dev/null || true)"
-            if [ -n "$PREVIOUS_AUTHOR" ]; then
-              REVIEWER_FLAG=(--reviewer "$PREVIOUS_AUTHOR")
-              echo "Requesting review from previous release author: $PREVIOUS_AUTHOR"
-            else
-              echo "Skipping reviewer assignment (could not resolve previous release author)."
-            fi
+          RELEASE_AUTHOR="$(gh release view "$TAG_NAME" --json author --jq .author.login 2>/dev/null || true)"
+          if [ -n "$RELEASE_AUTHOR" ]; then
+            REVIEWER_FLAG=(--reviewer "$RELEASE_AUTHOR")
+            echo "Requesting review from release author: $RELEASE_AUTHOR"
+          else
+            echo "Skipping reviewer assignment (could not resolve release author)."
           fi
 
           gh pr create \


### PR DESCRIPTION
## Context

- The `generate-upgrade-impact` workflow requested review from the author of the **previous** release — it read the `previousTag` field and ran `gh release view "$PREVIOUS_TAG"` — so each upgrade-impact PR got assigned whoever cut the *prior* release instead of the person who shipped the changes being documented.
- Example: PR #6614 (upgrade impact for v0.160.7) was assigned to the v0.160.6 release author rather than the v0.160.7 author who has context on the changes.
- Fix: request review from the current release author via `gh release view "$TAG_NAME"`. Drops the now-unused `PREVIOUS_TAG` lookup (the `previousTag` YAML field is untouched — still written by the generator, just no longer read here).

## Steps to verify the change

- Trigger the workflow for a stable tag and confirm the opened PR requests review from that release's author.
- Confirm the workflow still skips reviewer assignment gracefully when the author can't be resolved.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
