### PR TITLE
improvement(platfor-286): commit e2e package-lock for npm ci determinism

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-package-lock.json
 playwright-report
 test-results
 .env

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -92,7 +92,7 @@ These external dependencies have to stay in sync — if you change the backend o
 - **Worker changes ship via `wrangler deploy`**, not the gamma deploy. After editing Worker code (`/saml-idp/*` routes, IdP templates), deploy from the `preview-environments` repo before running the test or it'll hit the previous version. `tsc` passing here doesn't prove the Worker is up to date.
 - **SCIM POST + SAML signup leak a user row per test run** because the SAML signup branch creates a fresh `users` row even though SCIM already created one. SCIM `DELETE /Users/:id` removes the membership but not the orphan user. Tractable but accumulates; revisit if it becomes noisy.
 - **Don't add a `.npmrc` here for the 7-day minimum-release-age rule** — `e2e/` is a test harness, not a runtime artifact. The supply-chain concern that motivates the rule in `backend/`/`frontend/` doesn't apply.
-- **CI uses `npm install`, not `npm ci`** — we don't commit a lockfile yet. If you commit `package-lock.json`, switch the workflow to `npm ci` for determinism. Both are fine; just keep them consistent.
+- **CI uses `npm ci`** against the committed `package-lock.json` for determinism. If you change deps, regenerate the lockfile (`npm install`) and commit it in the same change, otherwise `npm ci` fails the prod gate.
 - **Don't widen what the seed script creates** unless you've thought through the safety. It already refuses prod (host/dbname regex + `INFISICAL_ENV=prod` + interactive confirmation). Adding more powerful operations means re-evaluating the guard surface.
 
 ## Where context lives

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "@infisical/e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@infisical/e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.1",
+        "@types/node": "20.17.10",
+        "dotenv": "16.4.7",
+        "typescript": "5.6.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -16,6 +16,8 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30,6 +32,8 @@
     },
     "node_modules/@types/node": {
       "version": "20.17.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
+      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -38,6 +42,8 @@
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -64,6 +70,8 @@
     },
     "node_modules/playwright": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -81,6 +89,8 @@
     },
     "node_modules/playwright-core": {
       "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -92,6 +102,8 @@
     },
     "node_modules/typescript": {
       "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -104,6 +116,8 @@
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     }


### PR DESCRIPTION
## Description

- Un-ignore + commit `e2e/package-lock.json` (was gitignored in `e2e/.gitignore`) so CI installs are deterministic.
- Update `e2e/CLAUDE.md` note: CI now uses `npm ci`; regenerate + commit the lockfile whenever deps change.
- Unblocks the `infrastructure` repo switching `gamma-playwright-e2e` from `npm install` to `npm ci` (infrastructure#184).

Lockfile regenerated cleanly with `npm install --package-lock-only`; `npm ci` verified green against it.

Linear: PLATFOR-286

## Sequencing

`infrastructure#184` swaps to `npm ci`, which reads this lockfile at the deployed image SHA. Merge this PR and let a new image build before merging the infra `npm ci` swap, otherwise deploys at SHAs predating this commit will fail the e2e gate.