### PR TITLE
feat: add enforceIdentityLimit flag to enforce identity limits regardless of plan

### DIFF
--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -196,8 +196,9 @@ export const throwOnPlanSeatLimitReached = async (
   type?: UserAliasType
 ) => {
   const plan = await licenseService.getPlan(orgId);
+  const isEnterpriseBypass = plan?.slug === "enterprise" && !plan?.enforceIdentityLimit;
 
-  if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
+  if (!isEnterpriseBypass && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
     // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
     throw new BadRequestError({
       message: `Failed to create new member${type ? ` via ${type.toUpperCase()}` : ""} due to member limit reached. Upgrade plan to add more members.`

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -42,6 +42,7 @@ export type TFeatureSet = {
   membersUsed: number;
   identityLimit: null;
   identitiesUsed: number;
+  enforceIdentityLimit?: boolean;
   subOrganization: false;
   environmentLimit: null;
   environmentsUsed: 0;

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -62,8 +62,9 @@ export const identityV2ServiceFactory = ({
     await factory.onCreateIdentityGuard(dto);
 
     const plan = await licenseService.getPlan(dto.permission.orgId);
+    const isEnterpriseBypass = plan?.slug === "enterprise" && !plan?.enforceIdentityLimit;
 
-    if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
+    if (!isEnterpriseBypass && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
       // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
       throw new BadRequestError({
         message: "Failed to create identity due to identity limit reached. Upgrade plan to create more identities."

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -129,7 +129,8 @@ export const identityServiceFactory = ({
       // Check identity limit inside the transaction after acquiring the lock
       // We count directly from the database to get the accurate count, not the cached plan value
       const plan = await licenseService.getPlan(orgId);
-      if (plan?.slug !== "enterprise" && plan?.identityLimit) {
+      const isEnterpriseBypass = plan?.slug === "enterprise" && !plan?.enforceIdentityLimit;
+      if (!isEnterpriseBypass && plan?.identityLimit) {
         const currentIdentityCount = await licenseDAL.countOrgUsersAndIdentities(orgId, tx);
         if (currentIdentityCount >= plan.identityLimit) {
           throw new BadRequestError({

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -109,7 +109,8 @@ export const newOrgMembershipUserFactory = ({
     }
 
     const plan = await licenseService.getPlan(dto.permission.orgId);
-    if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
+    const isEnterpriseBypass = plan?.slug === "enterprise" && !plan?.enforceIdentityLimit;
+    if (!isEnterpriseBypass && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
       // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
       throw new BadRequestError({
         name: "InviteUser",

--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -855,7 +855,8 @@ export const superAdminServiceFactory = ({
           );
         }
 
-        if (plan?.slug !== "enterprise" && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
+        const isEnterpriseBypass = plan?.slug === "enterprise" && !plan?.enforceIdentityLimit;
+        if (!isEnterpriseBypass && plan?.identityLimit && plan.identitiesUsed >= plan.identityLimit) {
           // limit imposed on number of identities allowed / number of identities used exceeds the number of identities allowed
           throw new BadRequestError({
             name: "InviteUser",


### PR DESCRIPTION
## Context

Add an optional `enforceIdentityLimit` flag to the plan feature set. When set on an org's plan, the identity-limit check during identity creation runs even when the plan slug is `enterprise`, which otherwise skips the check. The flag defaults falsy, so behavior is unchanged for any org that doesn't set it.

- `TFeatureSet` gains optional `enforceIdentityLimit?: boolean`
- v2 and legacy `createIdentity` guards enforce the limit when `enforceIdentityLimit` is set, regardless of plan slug
- The flag is supplied on the cloud plan by a companion license-server change; it must be paired with a non-null `identityLimit` to take effect

## Steps to verify the change

With a plan where `slug === "enterprise"`, `identityLimit` set, and `identitiesUsed >= identityLimit`:
- `enforceIdentityLimit` unset/false → identity creation still succeeds (unchanged)
- `enforceIdentityLimit: true` → identity creation fails with the identity-limit error

`make reviewable-api` passes (type:check + lint).

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the contributing guide