### PR TITLE
fix: project env cleanup cron errors

### DIFF
--- a/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
+++ b/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
@@ -658,14 +658,11 @@ export const snapshotDALFactory = (db: TDbClient) => {
                   );
               })
               .join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Snapshot}.folderId`)
-              .join(TableName.Environment, function joinActiveEnvForSnapshot() {
-                this.on(`${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`).andOnNull(
-                  `${TableName.Environment}.deleteAfter`
-                );
-              })
+              .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
               .join(TableName.Project, `${TableName.Project}.id`, `${TableName.Environment}.projectId`)
               .join("snapshot_cte", "snapshot_cte.id", `${TableName.Snapshot}.id`)
               .whereRaw(`snapshot_cte.row_num > ${TableName.Project}."pitVersionLimit"`)
+              .whereNull(`${TableName.Environment}.deleteAfter`)
               .delete();
           } catch (err) {
             logger.error(
@@ -715,14 +712,11 @@ export const snapshotDALFactory = (db: TDbClient) => {
                 `${TableName.SecretFolderVersion}.folderId`,
                 `${TableName.Snapshot}.folderId`
               )
-              .join(TableName.Environment, function joinActiveEnvForSnapshot() {
-                this.on(`${TableName.SecretFolderVersion}.envId`, `${TableName.Environment}.id`).andOnNull(
-                  `${TableName.Environment}.deleteAfter`
-                );
-              })
+              .join(TableName.Environment, `${TableName.SecretFolderVersion}.envId`, `${TableName.Environment}.id`)
               .join(TableName.Project, `${TableName.Project}.id`, `${TableName.Environment}.projectId`)
               .join("snapshot_cte", "snapshot_cte.id", `${TableName.Snapshot}.id`)
               .whereRaw(`snapshot_cte.row_num > ${TableName.Project}."pitVersionLimit"`)
+              .whereNull(`${TableName.Environment}.deleteAfter`)
               .delete();
           } catch (err) {
             logger.error(

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -172,11 +172,7 @@ export const secretVersionDALFactory = (db: TDbClient) => {
             );
         })
         .join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.SecretVersion}.folderId`)
-        .join(TableName.Environment, function joinActiveEnvForSecretVersion() {
-          this.on(`${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`).andOnNull(
-            `${TableName.Environment}.deleteAfter`
-          );
-        })
+        .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
         .join(TableName.Project, `${TableName.Project}.id`, `${TableName.Environment}.projectId`)
         .join("version_cte", "version_cte.id", `${TableName.SecretVersion}.id`)
         .whereRaw(`version_cte.row_num > ${TableName.Project}."pitVersionLimit"`)


### PR DESCRIPTION
## Context
Fixed cron errors caused by project environment soft deletion-related SQL joins.

The reason why something like this works:
```
.join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Snapshot}.folderId`)
```
But not:
```
  .join(TableName.Environment, function joinActiveEnvForSnapshot() {
         this.on(`${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`).andOnNull(`${TableName.Environment}.deleteAfter`);
   })
```

Is because Knex is able to rewrite the join into a USING clause directly, but with more complex joins, Knex can't do the translation and produces incorrect SQL

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)