### PR TITLE
feat: add certificate metadata search to inventory UI

### DIFF
--- a/backend/src/server/routes/v1/certificate-inventory-view-router.ts
+++ b/backend/src/server/routes/v1/certificate-inventory-view-router.ts
@@ -21,7 +21,16 @@ const InventoryViewFiltersSchema = z
     caIds: z.array(z.string().uuid()).max(50).optional(),
     profileIds: z.array(z.string().uuid()).max(50).optional(),
     applicationIds: z.array(z.string().uuid()).max(50).optional(),
-    source: z.union([z.string().max(64), z.array(z.string().max(64)).max(10)]).optional()
+    source: z.union([z.string().max(64), z.array(z.string().max(64)).max(10)]).optional(),
+    metadata: z
+      .array(
+        z.object({
+          key: z.string().trim().min(1).max(255),
+          value: z.string().trim().max(1020).optional()
+        })
+      )
+      .max(20)
+      .optional()
   })
   .strict();
 

--- a/frontend/src/hooks/api/certificateInventoryViews/types.ts
+++ b/frontend/src/hooks/api/certificateInventoryViews/types.ts
@@ -11,6 +11,7 @@ export type TInventoryViewFilters = {
   profileIds?: string[];
   applicationIds?: string[];
   source?: string | string[];
+  metadata?: Array<{ key: string; value?: string }>;
 };
 
 export type TCertificateInventoryView = {

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesTable.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificatesTable.tsx
@@ -363,6 +363,7 @@ export const CertificatesTable = ({
       ? new Date(filterSearchParams.notBeforeTo)
       : undefined,
     source: filterSearchParams.source,
+    metadataFilter: filterSearchParams.metadata,
     applicationId,
     applicationIds: filterSearchParams.applicationIds,
     sortBy,
@@ -607,6 +608,16 @@ export const CertificatesTable = ({
             field: "source",
             operator: "in",
             value: sourceValue
+          });
+        }
+        if (customFilters.metadata && customFilters.metadata.length > 0) {
+          customFilters.metadata.forEach((m, i) => {
+            rules.push({
+              id: `cv-meta-${i}`,
+              field: "metadata",
+              operator: "is",
+              value: [m.key, m.value ?? ""]
+            });
           });
         }
         setAppliedFilters(rules);

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/FilterBuilder.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/FilterBuilder.tsx
@@ -88,7 +88,14 @@ const DatePickerInput = ({
 const isRuleEmpty = (rule: FilterRule): boolean => {
   if (rule.value === null || rule.value === undefined || rule.value === "") return true;
   if (Array.isArray(rule.value) && rule.value.length === 0) return true;
+  if (rule.field === "metadata" && Array.isArray(rule.value) && !rule.value[0]) return true;
   return false;
+};
+
+const getDefaultValue = (vt: FilterFieldDefinition["valueType"]): FilterRule["value"] => {
+  if (vt === "multi-select") return [];
+  if (vt === "metadata-kv") return ["", ""];
+  return null;
 };
 
 const FilterRow = ({
@@ -112,7 +119,7 @@ const FilterRow = ({
       ...rule,
       field: newField,
       operator: newDef.operators[0]?.value || "is",
-      value: newDef.valueType === "multi-select" ? [] : null
+      value: getDefaultValue(newDef.valueType)
     });
   };
 
@@ -120,6 +127,25 @@ const FilterRow = ({
     const options = fieldDef.options || [];
 
     switch (fieldDef.valueType) {
+      case "metadata-kv": {
+        const kvPair = Array.isArray(rule.value) ? rule.value : ["", ""];
+        return (
+          <div className="flex gap-1.5">
+            <Input
+              value={kvPair[0] || ""}
+              onChange={(e) => onUpdate({ ...rule, value: [e.target.value, kvPair[1] || ""] })}
+              placeholder="Key"
+              className="flex-1"
+            />
+            <Input
+              value={kvPair[1] || ""}
+              onChange={(e) => onUpdate({ ...rule, value: [kvPair[0] || "", e.target.value] })}
+              placeholder="Value (optional)"
+              className="flex-1"
+            />
+          </div>
+        );
+      }
       case "multi-select": {
         const currentValues = Array.isArray(rule.value) ? rule.value : [];
         const selectedOptions = currentValues
@@ -210,21 +236,23 @@ const FilterRow = ({
         </SelectContent>
       </Select>
 
-      <Select
-        value={rule.operator}
-        onValueChange={(newOp: string) => onUpdate({ ...rule, operator: newOp })}
-      >
-        <SelectTrigger className="w-[100px] shrink-0">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent position="popper" align="start">
-          {fieldDef.operators.map((op) => (
-            <SelectItem key={op.value} value={op.value}>
-              {op.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      {fieldDef.valueType !== "metadata-kv" && (
+        <Select
+          value={rule.operator}
+          onValueChange={(newOp: string) => onUpdate({ ...rule, operator: newOp })}
+        >
+          <SelectTrigger className="w-[100px] shrink-0">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent position="popper" align="start">
+            {fieldDef.operators.map((op) => (
+              <SelectItem key={op.value} value={op.value}>
+                {op.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
 
       <div className="min-w-0 flex-1">{renderValueInput()}</div>
 
@@ -274,7 +302,7 @@ export const FilterBuilder = ({
         id: crypto.randomUUID(),
         field: defaultField.key,
         operator: defaultField.operators[0]?.value || "is",
-        value: defaultField.valueType === "multi-select" ? [] : null
+        value: getDefaultValue(defaultField.valueType)
       }
     ]);
   };

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/inventory-types.ts
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/inventory-types.ts
@@ -11,7 +11,7 @@ export type FilterFieldDefinition = {
   key: string;
   label: string;
   operators: { value: string; label: string }[];
-  valueType: "text" | "number" | "date" | "select" | "multi-select";
+  valueType: "text" | "number" | "date" | "select" | "multi-select" | "metadata-kv";
   options?: { value: string; label: string }[];
 };
 
@@ -119,6 +119,12 @@ export const FILTER_FIELDS: FilterFieldDefinition[] = [
     operators: [{ value: "in", label: "in" }],
     valueType: "multi-select",
     options: []
+  },
+  {
+    key: "metadata",
+    label: "Metadata",
+    operators: [{ value: "is", label: "is" }],
+    valueType: "metadata-kv"
   }
 ];
 
@@ -185,6 +191,15 @@ export const filtersToSearchParams = (rules: FilterRule[]): TInventoryViewFilter
           params.applicationIds = rule.value;
         }
         break;
+      case "metadata":
+        if (Array.isArray(rule.value) && rule.value.length >= 1 && rule.value[0]) {
+          if (!params.metadata) params.metadata = [];
+          params.metadata.push({
+            key: rule.value[0],
+            ...(rule.value[1] ? { value: rule.value[1] } : {})
+          });
+        }
+        break;
       default:
         break;
     }
@@ -199,6 +214,11 @@ export const getFilterChipLabel = (
 ): string => {
   const baseDef = FILTER_FIELDS.find((f) => f.key === rule.field);
   const fieldLabel = baseDef?.label || rule.field;
+
+  if (rule.field === "metadata" && Array.isArray(rule.value)) {
+    const [key, val] = rule.value;
+    return val ? `${fieldLabel}: ${key} = ${val}` : `${fieldLabel}: ${key}`;
+  }
 
   const options =
     dynamicFieldOptions && dynamicFieldOptions[rule.field]


### PR DESCRIPTION
## Summary
- Adds metadata key-value filtering to the certificate inventory FilterBuilder


## Test plan
- [x] Filter certificates by metadata key + value
- [x] Filter by key only (no value)
- [x] Save view with metadata filters
- [x] Restore saved view with metadata filters
- [x] Clear all filters includes metadata
- [x] Empty metadata rows stripped on apply/save