### PR TITLE
chore: increase max group names and slugs to 255

### DIFF
--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -44,7 +44,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       operationId: "createGroup",
       tags: [ApiDocsTags.Groups],
       body: z.object({
-        name: z.string().trim().min(1).max(50).describe(GROUPS.CREATE.name),
+        name: z.string().trim().min(1).max(255).describe(GROUPS.CREATE.name),
         slug: slugSchema({ min: 5, max: 255 }).optional().describe(GROUPS.CREATE.slug),
         role: z.string().trim().min(1).default(OrgMembershipRole.NoAccess).describe(GROUPS.CREATE.role)
       }),
@@ -168,7 +168,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       }),
       body: z
         .object({
-          name: z.string().trim().min(1).describe(GROUPS.UPDATE.name),
+          name: z.string().trim().min(1).max(255).describe(GROUPS.UPDATE.name),
           slug: slugSchema({ min: 5, max: 255 }).describe(GROUPS.UPDATE.slug),
           role: z.string().trim().min(1).describe(GROUPS.UPDATE.role)
         })

--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -45,7 +45,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       tags: [ApiDocsTags.Groups],
       body: z.object({
         name: z.string().trim().min(1).max(50).describe(GROUPS.CREATE.name),
-        slug: slugSchema({ min: 5, max: 36 }).optional().describe(GROUPS.CREATE.slug),
+        slug: slugSchema({ min: 5, max: 255 }).optional().describe(GROUPS.CREATE.slug),
         role: z.string().trim().min(1).default(OrgMembershipRole.NoAccess).describe(GROUPS.CREATE.role)
       }),
       response: {
@@ -169,7 +169,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
       body: z
         .object({
           name: z.string().trim().min(1).describe(GROUPS.UPDATE.name),
-          slug: slugSchema({ min: 5, max: 36 }).describe(GROUPS.UPDATE.slug),
+          slug: slugSchema({ min: 5, max: 255 }).describe(GROUPS.UPDATE.slug),
           role: z.string().trim().min(1).describe(GROUPS.UPDATE.role)
         })
         .partial(),

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
@@ -24,7 +24,7 @@ import { GroupWizardSteps } from "./groupWizardSteps";
 import { OrgGroupLinkForm } from "./OrgGroupLinkForm";
 
 const GroupFormSchema = z.object({
-  name: z.string().min(1, "Name cannot be empty").max(50, "Name must be 50 characters or fewer"),
+  name: z.string().min(1, "Name cannot be empty").max(255, "Name must be 255 characters or fewer"),
   slug: z
     .string()
     .min(5, "Slug must be at least 5 characters long")

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
@@ -28,7 +28,7 @@ const GroupFormSchema = z.object({
   slug: z
     .string()
     .min(5, "Slug must be at least 5 characters long")
-    .max(36, "Slug must be 36 characters or fewer")
+    .max(255, "Slug must be 255 characters or fewer")
     .regex(/^[a-z0-9-]+$/, "Slug can only contain lowercase letters, numbers, and hyphens"),
   role: z.object({ name: z.string(), slug: z.string() })
 });

--- a/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupCreateUpdateModal.tsx
+++ b/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupCreateUpdateModal.tsx
@@ -22,7 +22,7 @@ const GroupFormSchema = z.object({
   slug: z
     .string()
     .min(5, "Slug must be at least 5 characters long")
-    .max(36, "Slug must be 36 characters or fewer")
+    .max(255, "Slug must be 255 characters or fewer")
     .regex(/^[a-z0-9-]+$/, "Slug can only contain lowercase letters, numbers, and hyphens"),
   role: z.object({ name: z.string(), slug: z.string() })
 });

--- a/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupCreateUpdateModal.tsx
+++ b/frontend/src/pages/organization/GroupDetailsByIDPage/components/GroupCreateUpdateModal.tsx
@@ -18,7 +18,7 @@ import { useCreateGroup, useGetOrgRoles, useUpdateGroup } from "@app/hooks/api";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 const GroupFormSchema = z.object({
-  name: z.string().min(1, "Name cannot be empty").max(50, "Name must be 50 characters or fewer"),
+  name: z.string().min(1, "Name cannot be empty").max(255, "Name must be 255 characters or fewer"),
   slug: z
     .string()
     .min(5, "Slug must be at least 5 characters long")


### PR DESCRIPTION
## Context

Increased max group name and slug to 255 chars, which is the max we allow on the DB-level as well.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)