### PR TITLE
feat: seed pre-defined PKI certificate policies at org creation

### DIFF
--- a/backend/src/ee/services/sub-org/sub-org-service.ts
+++ b/backend/src/ee/services/sub-org/sub-org-service.ts
@@ -5,6 +5,7 @@ import { AccessScope, OrganizationActionScope, OrgMembershipRole, OrgMembershipS
 import { BadRequestError } from "@app/lib/errors";
 import { ActorType } from "@app/services/auth/auth-type";
 import { bootstrapCertManagerProject } from "@app/services/cert-manager-instance/cert-manager-project-bootstrap";
+import { TCertificatePolicyDALFactory } from "@app/services/certificate-policy/certificate-policy-dal";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
@@ -25,6 +26,7 @@ type TSubOrgServiceFactoryDep = {
   membershipDAL: Pick<TMembershipDALFactory, "create" | "findOne">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "create">;
   projectDAL: Pick<TProjectDALFactory, "create" | "findOne">;
+  certificatePolicyDAL: Pick<TCertificatePolicyDALFactory, "create">;
 };
 
 export type TSubOrgServiceFactory = ReturnType<typeof subOrgServiceFactory>;
@@ -35,7 +37,8 @@ export const subOrgServiceFactory = ({
   licenseService,
   membershipDAL,
   membershipRoleDAL,
-  projectDAL
+  projectDAL,
+  certificatePolicyDAL
 }: TSubOrgServiceFactoryDep) => {
   const createSubOrg = async ({ name, slug, permission }: TCreateSubOrgDTO) => {
     const { permission: orgPermission } = await permissionService.getOrgPermission({
@@ -99,7 +102,7 @@ export const subOrgServiceFactory = ({
           adminUserIds: permission.type === ActorType.USER ? [permission.id] : [],
           adminIdentityIds: permission.type === ActorType.IDENTITY ? [permission.id] : []
         },
-        { projectDAL, membershipDAL, membershipRoleDAL },
+        { projectDAL, membershipDAL, membershipRoleDAL, certificatePolicyDAL },
         tx
       );
 

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1134,6 +1134,8 @@ export const registerRoutes = async (
     secretV2BridgeDAL
   });
 
+  const certificatePolicyDAL = certificatePolicyDALFactory(db);
+
   const orgService = orgServiceFactory({
     userAliasDAL,
     identityMetadataDAL,
@@ -1163,7 +1165,8 @@ export const registerRoutes = async (
     membershipDAL,
     roleDAL,
     userGroupMembershipDAL,
-    additionalPrivilegeDAL
+    additionalPrivilegeDAL,
+    certificatePolicyDAL
   });
 
   const subOrgService = subOrgServiceFactory({
@@ -1172,7 +1175,8 @@ export const registerRoutes = async (
     membershipRoleDAL,
     orgDAL,
     projectDAL,
-    permissionService
+    permissionService,
+    certificatePolicyDAL
   });
 
   const signupService = authSignupServiceFactory({
@@ -1312,7 +1316,6 @@ export const registerRoutes = async (
   const certificateAuthorityCrlDAL = certificateAuthorityCrlDALFactory(db);
   const certificateTemplateDAL = certificateTemplateDALFactory(db);
   const certificateTemplateEstConfigDAL = certificateTemplateEstConfigDALFactory(db);
-  const certificatePolicyDAL = certificatePolicyDALFactory(db);
   const certificateProfileDAL = certificateProfileDALFactory(db);
   const pkiApplicationDAL = pkiApplicationDALFactory(db);
   const pkiApplicationProfileDAL = pkiApplicationProfileDALFactory(db);

--- a/backend/src/services/cert-manager-instance/cert-manager-project-bootstrap.ts
+++ b/backend/src/services/cert-manager-instance/cert-manager-project-bootstrap.ts
@@ -3,6 +3,16 @@ import { Knex } from "knex";
 
 import { AccessScope, ProjectMembershipRole, ProjectType, ProjectVersion, TProjects } from "@app/db/schemas";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import {
+  ALGORITHM_FAMILIES,
+  CertExtendedKeyUsageType,
+  CertKeyUsageType,
+  CertPolicyState,
+  CertSubjectAlternativeNameType,
+  CertSubjectAttributeType
+} from "@app/services/certificate-common/certificate-constants";
+import { TCertificatePolicyDALFactory } from "@app/services/certificate-policy/certificate-policy-dal";
+import { TCertificatePolicyInsert } from "@app/services/certificate-policy/certificate-policy-types";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -11,6 +21,7 @@ type TBootstrapDeps = {
   projectDAL: Pick<TProjectDALFactory, "create" | "findOne">;
   membershipDAL: Pick<TMembershipDALFactory, "create">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "create">;
+  certificatePolicyDAL: Pick<TCertificatePolicyDALFactory, "create">;
 };
 
 type TBootstrapInput = {
@@ -19,9 +30,184 @@ type TBootstrapInput = {
   adminIdentityIds?: string[];
 };
 
+const PRESET_POLICIES: Omit<TCertificatePolicyInsert, "projectId">[] = [
+  {
+    name: "tls-server-certificate",
+    description: "Standard TLS/SSL server certificate for HTTPS services and API endpoints.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [
+      { type: CertSubjectAlternativeNameType.DNS_NAME, allowed: ["*"] },
+      { type: CertSubjectAlternativeNameType.IP_ADDRESS, allowed: ["*"] }
+    ],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_ENCIPHERMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.SERVER_AUTH],
+      allowed: [CertExtendedKeyUsageType.SERVER_AUTH]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "tls-client-certificate",
+    description: "Client certificate for mutual TLS authentication and API access.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [
+      { type: CertSubjectAlternativeNameType.EMAIL, allowed: ["*"] },
+      { type: CertSubjectAlternativeNameType.DNS_NAME, allowed: ["*"] }
+    ],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_AGREEMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.CLIENT_AUTH],
+      allowed: [CertExtendedKeyUsageType.CLIENT_AUTH]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "code-signing-certificate",
+    description: "Certificate for signing software, executables, and packages. Requires hardware security modules.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [{ type: CertSubjectAlternativeNameType.EMAIL, allowed: ["*"] }],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.NON_REPUDIATION],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.NON_REPUDIATION]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.CODE_SIGNING],
+      allowed: [CertExtendedKeyUsageType.CODE_SIGNING, CertExtendedKeyUsageType.TIME_STAMPING]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.RSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.RSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "device-certificate",
+    description: "Certificate for IoT devices and embedded systems authentication. IEEE 802.1AR compliant.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [
+      { type: CertSubjectAlternativeNameType.DNS_NAME, allowed: ["*"] },
+      { type: CertSubjectAlternativeNameType.IP_ADDRESS, allowed: ["*"] }
+    ],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_AGREEMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.CLIENT_AUTH],
+      allowed: [CertExtendedKeyUsageType.CLIENT_AUTH, CertExtendedKeyUsageType.SERVER_AUTH]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "user-certificate",
+    description: "Personal certificate for user authentication and email signing. FIPS 201 PIV compliant.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [{ type: CertSubjectAlternativeNameType.EMAIL, allowed: ["*"] }],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_ENCIPHERMENT, CertKeyUsageType.KEY_AGREEMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.CLIENT_AUTH, CertExtendedKeyUsageType.EMAIL_PROTECTION],
+      allowed: [CertExtendedKeyUsageType.CLIENT_AUTH, CertExtendedKeyUsageType.EMAIL_PROTECTION]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "email-protection-certificate",
+    description: "S/MIME certificate for email encryption and digital signing. RFC 8550 compliant.",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [{ type: CertSubjectAlternativeNameType.EMAIL, allowed: ["*"] }],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_ENCIPHERMENT, CertKeyUsageType.KEY_AGREEMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.EMAIL_PROTECTION],
+      allowed: [CertExtendedKeyUsageType.EMAIL_PROTECTION]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.RSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.RSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "dual-purpose-server-certificate",
+    description: "Certificate for services requiring both server and client authentication capabilities",
+    subject: [{ type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] }],
+    sans: [
+      { type: CertSubjectAlternativeNameType.DNS_NAME, allowed: ["*"] },
+      { type: CertSubjectAlternativeNameType.IP_ADDRESS, allowed: ["*"] }
+    ],
+    keyUsages: {
+      required: [CertKeyUsageType.DIGITAL_SIGNATURE],
+      allowed: [CertKeyUsageType.DIGITAL_SIGNATURE, CertKeyUsageType.KEY_ENCIPHERMENT, CertKeyUsageType.KEY_AGREEMENT]
+    },
+    extendedKeyUsages: {
+      required: [CertExtendedKeyUsageType.SERVER_AUTH, CertExtendedKeyUsageType.CLIENT_AUTH],
+      allowed: [CertExtendedKeyUsageType.SERVER_AUTH, CertExtendedKeyUsageType.CLIENT_AUTH]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "365d" }
+  },
+  {
+    name: "intermediate-ca-certificate",
+    description:
+      "Certificate for intermediate Certificate Authorities. Allows signing end-entity certificates and CRLs.",
+    subject: [
+      { type: CertSubjectAttributeType.COMMON_NAME, allowed: ["*"] },
+      { type: CertSubjectAttributeType.ORGANIZATION, allowed: ["*"] }
+    ],
+    sans: [],
+    keyUsages: {
+      required: [CertKeyUsageType.KEY_CERT_SIGN, CertKeyUsageType.CRL_SIGN],
+      allowed: [CertKeyUsageType.KEY_CERT_SIGN, CertKeyUsageType.CRL_SIGN, CertKeyUsageType.DIGITAL_SIGNATURE]
+    },
+    extendedKeyUsages: {
+      required: [],
+      allowed: [CertExtendedKeyUsageType.OCSP_SIGNING]
+    },
+    algorithms: {
+      signature: [...ALGORITHM_FAMILIES.RSA.signature, ...ALGORITHM_FAMILIES.ECDSA.signature],
+      keyAlgorithm: [...ALGORITHM_FAMILIES.RSA.key, ...ALGORITHM_FAMILIES.ECDSA.key]
+    },
+    validity: { max: "10y" },
+    basicConstraints: {
+      isCA: CertPolicyState.REQUIRED,
+      maxPathLength: 0
+    }
+  }
+];
+
 export const bootstrapCertManagerProject = async (
   { orgId, adminUserIds = [], adminIdentityIds = [] }: TBootstrapInput,
-  { projectDAL, membershipDAL, membershipRoleDAL }: TBootstrapDeps,
+  { projectDAL, membershipDAL, membershipRoleDAL, certificatePolicyDAL }: TBootstrapDeps,
   tx: Knex
 ): Promise<{ project: TProjects; created: boolean }> => {
   const existing = await projectDAL.findOne({ orgId, type: ProjectType.CertificateManager }, tx);
@@ -87,6 +273,11 @@ export const bootstrapCertManagerProject = async (
       },
       tx
     );
+  }
+
+  for (const preset of PRESET_POLICIES) {
+    // eslint-disable-next-line no-await-in-loop
+    await certificatePolicyDAL.create({ ...preset, projectId: project.id }, tx);
   }
 
   return { project, created: true };

--- a/backend/src/services/certificate-common/certificate-constants.ts
+++ b/backend/src/services/certificate-common/certificate-constants.ts
@@ -246,6 +246,17 @@ export const CERTIFICATE_RENEWAL_CONFIG = {
 
 export const DEFAULT_CRL_VALIDITY_DAYS = 7;
 
+export const ALGORITHM_FAMILIES = {
+  ECDSA: {
+    signature: ["SHA256-ECDSA", "SHA384-ECDSA", "SHA512-ECDSA"],
+    key: ["ECDSA-P256", "ECDSA-P384", "ECDSA-P521"]
+  },
+  RSA: {
+    signature: ["SHA256-RSA", "SHA384-RSA", "SHA512-RSA"],
+    key: ["RSA-2048", "RSA-3072", "RSA-4096"]
+  }
+} as const;
+
 export const SAN_TYPE_OPTIONS = Object.values(CertSubjectAlternativeNameType);
 export const KEY_USAGE_OPTIONS = Object.values(CertKeyUsageType);
 export const EXTENDED_KEY_USAGE_OPTIONS = Object.values(CertExtendedKeyUsageType);

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -46,6 +46,7 @@ import { ActorAuthMethod, ActorType, AuthMethod, AuthModeJwtTokenPayload, AuthTo
 import { TAuthTokenServiceFactory } from "../auth-token/auth-token-service";
 import { TokenType } from "../auth-token/auth-token-types";
 import { bootstrapCertManagerProject } from "../cert-manager-instance/cert-manager-project-bootstrap";
+import { TCertificatePolicyDALFactory } from "../certificate-policy/certificate-policy-dal";
 import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TMembershipDALFactory } from "../membership/membership-dal";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
@@ -121,6 +122,7 @@ type TOrgServiceFactoryDep = {
   reminderService: Pick<TReminderServiceFactory, "deleteReminderBySecretId">;
   userGroupMembershipDAL: TUserGroupMembershipDALFactory;
   additionalPrivilegeDAL: TAdditionalPrivilegeDALFactory;
+  certificatePolicyDAL: Pick<TCertificatePolicyDALFactory, "create">;
 };
 
 export type TOrgServiceFactory = ReturnType<typeof orgServiceFactory>;
@@ -154,7 +156,8 @@ export const orgServiceFactory = ({
   membershipUserDAL,
   membershipDAL,
   userGroupMembershipDAL,
-  additionalPrivilegeDAL
+  additionalPrivilegeDAL,
+  certificatePolicyDAL
 }: TOrgServiceFactoryDep) => {
   /*
    * Get organization details by the organization id
@@ -685,7 +688,7 @@ export const orgServiceFactory = ({
           orgId: org.id,
           adminUserIds: userId ? [userId] : []
         },
-        { projectDAL, membershipDAL, membershipRoleDAL },
+        { projectDAL, membershipDAL, membershipRoleDAL, certificatePolicyDAL },
         tx
       );
 


### PR DESCRIPTION
## Summary
- Automatically seeds 8 certificate policy presets when a cert-manager project is bootstrapped during org/sub-org creation

## Test plan
- [x] Create a new sub-org and verify 8 policies appear in the Certificate Policies tab
- [x] Open a seeded policy and verify correct key usages, algorithms, SANs, and validity
- [x] Verify existing orgs are unaffected (bootstrap early-returns if project exists)
- [x] Verify policies can be edited and deleted
- [x] Verify manual policy creation still works alongside seeded policies