### PR TITLE
feat: add checks to ensure scope retains at least one admin on membership mutation

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -37,7 +37,9 @@ export const PgSqlLock = {
   KmsOrgDataKeyCreation: (orgId: string) => pgAdvisoryLockHashText(`kms-org-data-key:${orgId}`),
   KmsProjectKeyCreation: (projectId: string) => pgAdvisoryLockHashText(`kms-project-key:${projectId}`),
   KmsProjectDataKeyCreation: (projectId: string) => pgAdvisoryLockHashText(`kms-project-data-key:${projectId}`),
-  ScimGroupUpdate: (groupId: string) => pgAdvisoryLockHashText(`scim-group-update:${groupId}`)
+  ScimGroupUpdate: (groupId: string) => pgAdvisoryLockHashText(`scim-group-update:${groupId}`),
+  LastAdminGuard: (scope: "org" | "project", scopeId: string) =>
+    pgAdvisoryLockHashText(`last-admin-guard:${scope}:${scopeId}`)
 } as const;
 
 // all the key prefixes used must be set here to avoid conflict

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -1,8 +1,8 @@
 import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
-import { AccessScope, AccessScopeData, MembershipsSchema, TableName } from "@app/db/schemas";
-import { BadRequestError, DatabaseError } from "@app/lib/errors";
+import { AccessScope, AccessScopeData, MembershipsSchema, OrgMembershipRole, TableName } from "@app/db/schemas";
+import { BadRequestError, DatabaseError, InternalServerError } from "@app/lib/errors";
 import { ormify, selectAllTableCols, sqlNestRelationships } from "@app/lib/knex";
 import { buildKnexFilterForSearchResource } from "@app/lib/search-resource/db";
 import { TSearchResourceOperator } from "@app/lib/search-resource/search";
@@ -315,5 +315,47 @@ export const membershipUserDALFactory = (db: TDbClient) => {
     }
   };
 
-  return { ...orm, findUsers, getUserById, listAvailableUsers };
+  const countActiveAdmins = async ({
+    scope,
+    scopeOrgId,
+    scopeProjectId,
+    excludeMembershipIds,
+    tx
+  }: {
+    scope: AccessScope;
+    scopeOrgId: string;
+    scopeProjectId?: string;
+    excludeMembershipIds?: string[];
+    tx?: Knex;
+  }): Promise<number> => {
+    try {
+      if (scope === AccessScope.Project && !scopeProjectId) {
+        throw new InternalServerError({ message: "scopeProjectId required for project scope admin count" });
+      }
+
+      const query = (tx || db.replicaNode())(TableName.Membership)
+        .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
+        .whereNotNull(`${TableName.Membership}.actorUserId`)
+        .where(`${TableName.Membership}.isActive`, true)
+        .where(`${TableName.MembershipRole}.role`, OrgMembershipRole.Admin)
+        .where(`${TableName.MembershipRole}.isTemporary`, false)
+        .where(`${TableName.Membership}.scope`, scope)
+        .where(`${TableName.Membership}.scopeOrgId`, scopeOrgId);
+
+      if (scope === AccessScope.Project) {
+        void query.where(`${TableName.Membership}.scopeProjectId`, scopeProjectId as string);
+      }
+
+      if (excludeMembershipIds?.length) {
+        void query.whereNotIn(`${TableName.Membership}.id`, excludeMembershipIds);
+      }
+
+      const result = await query.countDistinct<{ count: string }[]>(`${TableName.Membership}.id as count`).first();
+      return Number(result?.count ?? 0);
+    } catch (error) {
+      throw new DatabaseError({ error, name: "MembershipUserCountActiveAdmins" });
+    }
+  };
+
+  return { ...orm, findUsers, getUserById, listAvailableUsers, countActiveAdmins };
 };

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -333,7 +333,9 @@ export const membershipUserDALFactory = (db: TDbClient) => {
         throw new InternalServerError({ message: "scopeProjectId required for project scope admin count" });
       }
 
-      const query = (tx || db.replicaNode())(TableName.Membership)
+      // Always read from primary — this powers a safety guard against zero-admin state, so
+      // replica lag cannot be tolerated.
+      const query = (tx || db)(TableName.Membership)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
         .where(`${TableName.Membership}.isActive`, true)

--- a/backend/src/services/membership-user/membership-user-fns.ts
+++ b/backend/src/services/membership-user/membership-user-fns.ts
@@ -1,6 +1,7 @@
 import { Knex } from "knex";
 
 import { AccessScope } from "@app/db/schemas";
+import { PgSqlLock } from "@app/keystore/keystore";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 
 import { TMembershipUserDALFactory } from "./membership-user-dal";
@@ -11,9 +12,12 @@ type TAssertWillRetainAdminArg = {
   scopeProjectId?: string;
   excludeMembershipIds: string[];
   dal: Pick<TMembershipUserDALFactory, "countActiveAdmins">;
-  tx?: Knex;
+  tx: Knex;
 };
 
+// Must run inside the same transaction as the membership mutation. The advisory lock keyed on
+// (scope, scopeId) serializes admin mutations per org/project so concurrent demote-and-remove
+// operations can't both pass the count check and then both proceed.
 export const assertWillRetainAdmin = async ({
   scope,
   scopeOrgId,
@@ -25,6 +29,10 @@ export const assertWillRetainAdmin = async ({
   if (scope === AccessScope.Project && !scopeProjectId) {
     throw new InternalServerError({ message: "scopeProjectId required for project scope admin guard" });
   }
+
+  const lockScope = scope === AccessScope.Project ? "project" : "org";
+  const lockId = scope === AccessScope.Project ? (scopeProjectId as string) : scopeOrgId;
+  await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.LastAdminGuard(lockScope, lockId)]);
 
   const remainingAdmins = await dal.countActiveAdmins({
     scope,

--- a/backend/src/services/membership-user/membership-user-fns.ts
+++ b/backend/src/services/membership-user/membership-user-fns.ts
@@ -1,0 +1,43 @@
+import { Knex } from "knex";
+
+import { AccessScope } from "@app/db/schemas";
+import { BadRequestError, InternalServerError } from "@app/lib/errors";
+
+import { TMembershipUserDALFactory } from "./membership-user-dal";
+
+type TAssertWillRetainAdminArg = {
+  scope: AccessScope;
+  scopeOrgId: string;
+  scopeProjectId?: string;
+  excludeMembershipIds: string[];
+  dal: Pick<TMembershipUserDALFactory, "countActiveAdmins">;
+  tx?: Knex;
+};
+
+export const assertWillRetainAdmin = async ({
+  scope,
+  scopeOrgId,
+  scopeProjectId,
+  excludeMembershipIds,
+  dal,
+  tx
+}: TAssertWillRetainAdminArg) => {
+  if (scope === AccessScope.Project && !scopeProjectId) {
+    throw new InternalServerError({ message: "scopeProjectId required for project scope admin guard" });
+  }
+
+  const remainingAdmins = await dal.countActiveAdmins({
+    scope,
+    scopeOrgId,
+    scopeProjectId,
+    excludeMembershipIds,
+    tx
+  });
+
+  if (remainingAdmins < 1) {
+    const target = scope === AccessScope.Project ? "project" : "organization";
+    throw new BadRequestError({
+      message: `This action would leave the ${target} with no admin. Promote another user to admin first.`
+    });
+  }
+};

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -35,6 +35,7 @@ import { LoginMethod } from "../super-admin/super-admin-types";
 import { TUserDALFactory } from "../user/user-dal";
 import { TUserAliasDALFactory } from "../user-alias/user-alias-dal";
 import { TMembershipUserDALFactory } from "./membership-user-dal";
+import { assertWillRetainAdmin } from "./membership-user-fns";
 import {
   TCreateMembershipUserDTO,
   TDeleteMembershipUserDTO,
@@ -378,6 +379,19 @@ export const membershipUserServiceFactory = ({
         message: "User doesn't have membership"
       });
 
+    const newIsActive = typeof data.isActive === "undefined" ? existingMembership.isActive : data.isActive;
+    const newRolesHavePermanentAdmin =
+      newIsActive && data.roles.some((r) => r.role === OrgMembershipRole.Admin && !r.isTemporary);
+    if (!newRolesHavePermanentAdmin) {
+      await assertWillRetainAdmin({
+        scope: scopeData.scope,
+        scopeOrgId: scopeData.orgId,
+        scopeProjectId: scopeData.scope === AccessScope.Project ? scopeData.projectId : undefined,
+        excludeMembershipIds: [existingMembership.id],
+        dal: membershipUserDAL
+      });
+    }
+
     const scopeField = factory.getScopeField(dto.scopeData);
     const customRoles = hasCustomRole
       ? await roleDAL.find({
@@ -466,6 +480,14 @@ export const membershipUserServiceFactory = ({
       throw new BadRequestError({
         message: "You can't delete your own membership"
       });
+
+    await assertWillRetainAdmin({
+      scope: scopeData.scope,
+      scopeOrgId: scopeData.orgId,
+      scopeProjectId: scopeData.scope === AccessScope.Project ? scopeData.projectId : undefined,
+      excludeMembershipIds: [existingMembership.id],
+      dal: membershipUserDAL
+    });
 
     const performDelete = async (tx: Knex) => {
       if (dto.scopeData.scope === AccessScope.Organization) {

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -382,15 +382,6 @@ export const membershipUserServiceFactory = ({
     const newIsActive = typeof data.isActive === "undefined" ? existingMembership.isActive : data.isActive;
     const newRolesHavePermanentAdmin =
       newIsActive && data.roles.some((r) => r.role === OrgMembershipRole.Admin && !r.isTemporary);
-    if (!newRolesHavePermanentAdmin) {
-      await assertWillRetainAdmin({
-        scope: scopeData.scope,
-        scopeOrgId: scopeData.orgId,
-        scopeProjectId: scopeData.scope === AccessScope.Project ? scopeData.projectId : undefined,
-        excludeMembershipIds: [existingMembership.id],
-        dal: membershipUserDAL
-      });
-    }
 
     const scopeField = factory.getScopeField(dto.scopeData);
     const customRoles = hasCustomRole
@@ -406,6 +397,17 @@ export const membershipUserServiceFactory = ({
     const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
 
     const membershipDoc = await membershipUserDAL.transaction(async (tx) => {
+      if (!newRolesHavePermanentAdmin) {
+        await assertWillRetainAdmin({
+          scope: scopeData.scope,
+          scopeOrgId: scopeData.orgId,
+          scopeProjectId: scopeData.scope === AccessScope.Project ? scopeData.projectId : undefined,
+          excludeMembershipIds: [existingMembership.id],
+          dal: membershipUserDAL,
+          tx
+        });
+      }
+
       const doc =
         typeof data?.isActive === "undefined"
           ? existingMembership
@@ -481,16 +483,10 @@ export const membershipUserServiceFactory = ({
         message: "You can't delete your own membership"
       });
 
-    await assertWillRetainAdmin({
-      scope: scopeData.scope,
-      scopeOrgId: scopeData.orgId,
-      scopeProjectId: scopeData.scope === AccessScope.Project ? scopeData.projectId : undefined,
-      excludeMembershipIds: [existingMembership.id],
-      dal: membershipUserDAL
-    });
-
     const performDelete = async (tx: Knex) => {
       if (dto.scopeData.scope === AccessScope.Organization) {
+        // Org-scope last-admin guard runs inside deleteOrgMembershipsFn's transaction so the
+        // advisory lock and count are race-safe with the delete itself.
         const [doc] = await deleteOrgMembershipsFn({
           orgMembershipIds: [existingMembership.id],
           orgId: dto.permission.orgId,
@@ -508,6 +504,15 @@ export const membershipUserServiceFactory = ({
       }
 
       if (dto.scopeData.scope === AccessScope.Project) {
+        await assertWillRetainAdmin({
+          scope: AccessScope.Project,
+          scopeOrgId: scopeData.orgId,
+          scopeProjectId: dto.scopeData.projectId,
+          excludeMembershipIds: [existingMembership.id],
+          dal: membershipUserDAL,
+          tx
+        });
+
         await additionalPrivilegeDAL.delete(
           {
             actorUserId: dto.selector.userId,

--- a/backend/src/services/org/org-fns.ts
+++ b/backend/src/services/org/org-fns.ts
@@ -9,13 +9,14 @@ import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
 import { TAdditionalPrivilegeDALFactory } from "../additional-privilege/additional-privilege-dal";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
+import { assertWillRetainAdmin } from "../membership-user/membership-user-fns";
 
 type TDeleteOrgMemberships = {
   orgMembershipIds: string[];
   orgId: string;
   orgDAL: Pick<TOrgDALFactory, "transaction" | "find">;
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "delete">;
-  membershipUserDAL: Pick<TMembershipUserDALFactory, "delete" | "find">;
+  membershipUserDAL: Pick<TMembershipUserDALFactory, "delete" | "find" | "countActiveAdmins">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "delete">;
   projectKeyDAL: Pick<TProjectKeyDALFactory, "find" | "delete">;
   userAliasDAL: Pick<TUserAliasDALFactory, "delete">;
@@ -36,6 +37,13 @@ export const deleteOrgMembershipsFn = async ({
   userGroupMembershipDAL,
   additionalPrivilegeDAL
 }: TDeleteOrgMemberships) => {
+  await assertWillRetainAdmin({
+    scope: AccessScope.Organization,
+    scopeOrgId: orgId,
+    excludeMembershipIds: orgMembershipIds,
+    dal: membershipUserDAL
+  });
+
   const deletedMemberships = await orgDAL.transaction(async (tx) => {
     const orgMemberships = await membershipUserDAL.delete(
       {
@@ -53,7 +61,6 @@ export const deleteOrgMembershipsFn = async ({
       .map((member) => member.actorUserId) as string[];
 
     if (userId && membershipUserIds.includes(userId)) {
-      // scott: this is temporary, we will add a leave org endpoint with proper handling to ensure org isn't abandoned/broken
       throw new BadRequestError({ message: "You cannot remove yourself from an organization" });
     }
 

--- a/backend/src/services/org/org-fns.ts
+++ b/backend/src/services/org/org-fns.ts
@@ -37,14 +37,15 @@ export const deleteOrgMembershipsFn = async ({
   userGroupMembershipDAL,
   additionalPrivilegeDAL
 }: TDeleteOrgMemberships) => {
-  await assertWillRetainAdmin({
-    scope: AccessScope.Organization,
-    scopeOrgId: orgId,
-    excludeMembershipIds: orgMembershipIds,
-    dal: membershipUserDAL
-  });
-
   const deletedMemberships = await orgDAL.transaction(async (tx) => {
+    await assertWillRetainAdmin({
+      scope: AccessScope.Organization,
+      scopeOrgId: orgId,
+      excludeMembershipIds: orgMembershipIds,
+      dal: membershipUserDAL,
+      tx
+    });
+
     const orgMemberships = await membershipUserDAL.delete(
       {
         scopeOrgId: orgId,

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -50,6 +50,7 @@ import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TMembershipDALFactory } from "../membership/membership-dal";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
+import { assertWillRetainAdmin } from "../membership-user/membership-user-fns";
 import { TProjectDALFactory } from "../project/project-dal";
 import { TProjectBotServiceFactory } from "../project-bot/project-bot-service";
 import { TProjectKeyDALFactory } from "../project-key/project-key-dal";
@@ -853,6 +854,18 @@ export const orgServiceFactory = ({
         "Cannot assign a role exceeding your own privileges to an org member"
       );
     }
+
+    const updatesToActiveAdmin = role === OrgMembershipRole.Admin && isActive !== false;
+    const noRoleOrActivationChange = role === undefined && (isActive === undefined || isActive === true);
+    if (!updatesToActiveAdmin && !noRoleOrActivationChange) {
+      await assertWillRetainAdmin({
+        scope: AccessScope.Organization,
+        scopeOrgId: orgId,
+        excludeMembershipIds: [membershipId],
+        dal: membershipUserDAL
+      });
+    }
+
     const membership = await orgDAL.transaction(async (tx) => {
       // this is because if isActive is undefined then this would fail due to knexjs error
       const [updatedOrgMembership] =

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -857,16 +857,18 @@ export const orgServiceFactory = ({
 
     const updatesToActiveAdmin = role === OrgMembershipRole.Admin && isActive !== false;
     const noRoleOrActivationChange = role === undefined && (isActive === undefined || isActive === true);
-    if (!updatesToActiveAdmin && !noRoleOrActivationChange) {
-      await assertWillRetainAdmin({
-        scope: AccessScope.Organization,
-        scopeOrgId: orgId,
-        excludeMembershipIds: [membershipId],
-        dal: membershipUserDAL
-      });
-    }
 
     const membership = await orgDAL.transaction(async (tx) => {
+      if (!updatesToActiveAdmin && !noRoleOrActivationChange) {
+        await assertWillRetainAdmin({
+          scope: AccessScope.Organization,
+          scopeOrgId: orgId,
+          excludeMembershipIds: [membershipId],
+          dal: membershipUserDAL,
+          tx
+        });
+      }
+
       // this is because if isActive is undefined then this would fail due to knexjs error
       const [updatedOrgMembership] =
         typeof isActive === "undefined"

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -329,13 +329,6 @@ export const projectMembershipServiceFactory = ({
     }
 
     const project = await projectDAL.findById(projectId);
-    await assertWillRetainAdmin({
-      scope: AccessScope.Project,
-      scopeOrgId: project.orgId,
-      scopeProjectId: projectId,
-      excludeMembershipIds: projectMembers.map(({ id }) => id),
-      dal: membershipUserDAL
-    });
 
     await checkUserApproverPolicies(
       projectMembers.map((m) => m.user.id),
@@ -347,6 +340,15 @@ export const projectMembershipServiceFactory = ({
     );
 
     const performDelete = async (tx: Knex) => {
+      await assertWillRetainAdmin({
+        scope: AccessScope.Project,
+        scopeOrgId: project.orgId,
+        scopeProjectId: projectId,
+        excludeMembershipIds: projectMembers.map(({ id }) => id),
+        dal: membershipUserDAL,
+        tx
+      });
+
       await additionalPrivilegeDAL.delete(
         {
           projectId,
@@ -433,14 +435,6 @@ export const projectMembershipServiceFactory = ({
       throw new BadRequestError({ message: "You are not a member of this project" });
     }
 
-    await assertWillRetainAdmin({
-      scope: AccessScope.Project,
-      scopeOrgId: project.orgId,
-      scopeProjectId: project.id,
-      excludeMembershipIds: [actorMembership.id],
-      dal: membershipUserDAL
-    });
-
     await checkUserApproverPolicies(
       [actorId],
       project.id,
@@ -448,6 +442,15 @@ export const projectMembershipServiceFactory = ({
     );
 
     const deletedMembership = await membershipUserDAL.transaction(async (tx) => {
+      await assertWillRetainAdmin({
+        scope: AccessScope.Project,
+        scopeOrgId: project.orgId,
+        scopeProjectId: project.id,
+        excludeMembershipIds: [actorMembership.id],
+        dal: membershipUserDAL,
+        tx
+      });
+
       await additionalPrivilegeDAL.delete(
         {
           projectId: project.id,

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -22,6 +22,7 @@ import { ActorType } from "../auth/auth-type";
 import { TGroupProjectDALFactory } from "../group-project/group-project-dal";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
+import { assertWillRetainAdmin } from "../membership-user/membership-user-fns";
 import { TNotificationServiceFactory } from "../notification/notification-service";
 import { NotificationType } from "../notification/notification-types";
 import { TProjectDALFactory } from "../project/project-dal";
@@ -327,6 +328,15 @@ export const projectMembershipServiceFactory = ({
       });
     }
 
+    const project = await projectDAL.findById(projectId);
+    await assertWillRetainAdmin({
+      scope: AccessScope.Project,
+      scopeOrgId: project.orgId,
+      scopeProjectId: projectId,
+      excludeMembershipIds: projectMembers.map(({ id }) => id),
+      dal: membershipUserDAL
+    });
+
     await checkUserApproverPolicies(
       projectMembers.map((m) => m.user.id),
       projectId
@@ -418,14 +428,18 @@ export const projectMembershipServiceFactory = ({
       throw new BadRequestError({ message: "You cannot leave the project as you are the only member" });
     }
 
-    const adminMembers = projectMembers.filter(
-      (member) => member.roles.map((r) => r.role).includes("admin") && member.userId !== actorId
-    );
-    if (!adminMembers.length) {
-      throw new BadRequestError({
-        message: "You cannot leave the project as you are the only admin. Promote another user to admin before leaving."
-      });
+    const actorMembership = projectMembers.find((member) => member.userId === actorId);
+    if (!actorMembership) {
+      throw new BadRequestError({ message: "You are not a member of this project" });
     }
+
+    await assertWillRetainAdmin({
+      scope: AccessScope.Project,
+      scopeOrgId: project.orgId,
+      scopeProjectId: project.id,
+      excludeMembershipIds: [actorMembership.id],
+      dal: membershipUserDAL
+    });
 
     await checkUserApproverPolicies(
       [actorId],


### PR DESCRIPTION
## Context

This PR adds a check to ensure there is at least one active admin at the relevant scope when:
- removing a member 
- when updating a member role
- when deactivating a user
- when leaving a project

## Screenshots

<img width="3456" height="2184" alt="CleanShot 2026-05-28 at 16 14 28@2x" src="https://github.com/user-attachments/assets/e3a87562-d2df-48fa-8558-31d6b3e2922b" />

## Steps to verify the change

attempt to delete, deactivate or update the a membership being the last admin role at each scope and ensure error is thrown

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)