### PR TITLE
improvement: migrate project create modal to v3 components

### DIFF
--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -1,30 +1,41 @@
 import { FC, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
+import { InfoIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import z from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
+import { Lottie } from "@app/components/v2";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
   Button,
-  FormControl,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  Lottie,
-  Modal,
-  ModalClose,
-  ModalContent,
   Select,
+  SelectContent,
   SelectItem,
-  TextArea
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  TextArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -136,7 +147,6 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
     template,
     type
   }: TAddProjectFormData) => {
-    // type check
     if (!currentOrg) return;
     if (!user) return;
     const {
@@ -158,25 +168,27 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
       params: { projectId: project.id, orgId: currentOrg.id }
     });
   };
-  const onSubmit = handleSubmit((data) => {
-    return onCreateProject(data);
-  });
+
+  const onSubmit = handleSubmit((data) => onCreateProject(data));
+
   return (
-    <form onSubmit={onSubmit}>
-      <div className="flex flex-col gap-2">
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
         <Controller
           control={control}
           name="name"
           defaultValue=""
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              label="Project Name"
-              isError={Boolean(error)}
-              errorText={error?.message}
-              className="flex-1"
-            >
-              <Input {...field} placeholder="Type your project name" />
-            </FormControl>
+            <Field>
+              <FieldLabel htmlFor="new-project-name">Project Name</FieldLabel>
+              <Input
+                id="new-project-name"
+                {...field}
+                placeholder="Type your project name"
+                isError={Boolean(error)}
+              />
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
           )}
         />
         {!fixedProjectType && (
@@ -185,20 +197,15 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
             name="type"
             defaultValue={ProjectType.SecretManager}
             render={({ field, fieldState: { error } }) => (
-              <FormControl
-                label="Project Type"
-                isError={Boolean(error)}
-                errorText={error?.message}
-                className="flex-1"
-              >
-                <div className="mt-2 grid grid-cols-3 gap-3">
+              <Field>
+                <FieldLabel>Project Type</FieldLabel>
+                <div className="grid grid-cols-3 gap-3">
                   {PROJECT_TYPE_MENU_ITEMS.map((el) => (
                     <div
                       key={el.value}
                       className={twMerge(
-                        "flex cursor-pointer flex-col items-center gap-2 rounded-sm border border-mineshaft-600 px-2 py-4 opacity-75 transition-all hover:border-primary-400 hover:bg-mineshaft-600",
-                        field.value === el.value &&
-                          "border-primary-400 bg-mineshaft-600 opacity-100"
+                        "flex cursor-pointer flex-col items-center gap-2 rounded-md border border-border bg-transparent px-2 py-4 opacity-75 transition-colors hover:bg-container-hover",
+                        field.value === el.value && "border-primary bg-container-hover opacity-100"
                       )}
                       onClick={() => field.onChange(el.value)}
                       role="button"
@@ -214,7 +221,8 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
                     </div>
                   ))}
                 </div>
-              </FormControl>
+                {error && <FieldError>{error.message}</FieldError>}
+              </Field>
             )}
           />
         )}
@@ -223,23 +231,22 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
           name="description"
           defaultValue=""
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              label="Project Description"
-              isError={Boolean(error)}
-              isOptional
-              errorText={error?.message}
-              className="flex-1"
-            >
+            <Field>
+              <FieldLabel htmlFor="new-project-description">
+                Project Description <span className="text-muted">- Optional</span>
+              </FieldLabel>
               <TextArea
+                id="new-project-description"
                 placeholder="Project description"
                 {...field}
                 rows={3}
-                className="thin-scrollbar w-full resize-none! bg-mineshaft-900"
+                isError={Boolean(error)}
+                className="thin-scrollbar resize-none"
               />
-            </FormControl>
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
           )}
         />
-
         <Controller
           control={control}
           name="template"
@@ -249,69 +256,67 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
               a={OrgPermissionSubjects.ProjectTemplates}
             >
               {(isAllowed) => (
-                <FormControl
-                  label="Project Template"
-                  icon={<FontAwesomeIcon icon={faInfoCircle} size="sm" />}
-                  tooltipText={
-                    <>
-                      <p>
-                        Create this project from a template to provision it with custom environments
-                        and roles.
-                      </p>
-                      {subscription && !subscription.projectTemplates && (
-                        <p className="pt-2">Project templates are a paid feature.</p>
-                      )}
-                    </>
-                  }
-                >
+                <Field>
+                  <FieldLabel htmlFor="new-project-template">
+                    Project Template
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon className="text-muted" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        <p>
+                          Create this project from a template to provision it with custom
+                          environments and roles.
+                        </p>
+                        {subscription && !subscription.projectTemplates && (
+                          <p className="pt-2">Project templates are a paid feature.</p>
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Select
-                    defaultValue={InfisicalProjectTemplate.Default}
-                    placeholder={InfisicalProjectTemplate.Default}
-                    isDisabled={!isAllowed || !subscription?.projectTemplates}
                     value={value}
                     onValueChange={onChange}
-                    className="w-full"
-                    position="popper"
-                    dropdownContainerClassName="max-w-none"
+                    disabled={!isAllowed || !subscription?.projectTemplates}
                   >
-                    {projectTemplates.length
-                      ? projectTemplates.map((template) => (
-                          <SelectItem key={template.id} value={template.name}>
-                            {template.name}
-                          </SelectItem>
-                        ))
-                      : Object.values(InfisicalProjectTemplate).map((template) => (
-                          <SelectItem key={template} value={template}>
-                            {template}
-                          </SelectItem>
-                        ))}
+                    <SelectTrigger id="new-project-template" className="w-full">
+                      <SelectValue placeholder={InfisicalProjectTemplate.Default} />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
+                      {projectTemplates.length
+                        ? projectTemplates.map((template) => (
+                            <SelectItem key={template.id} value={template.name}>
+                              {template.name}
+                            </SelectItem>
+                          ))
+                        : Object.values(InfisicalProjectTemplate).map((template) => (
+                            <SelectItem key={template} value={template}>
+                              {template}
+                            </SelectItem>
+                          ))}
+                    </SelectContent>
                   </Select>
-                </FormControl>
+                </Field>
               )}
             </OrgPermissionCan>
           )}
         />
       </div>
-      <div className="mt-4 flex">
-        <Accordion type="single" collapsible className="w-full">
-          <AccordionItem value="advance-settings" className="data-[state=open]:border-none">
-            <AccordionTrigger className="h-fit flex-none pl-1 text-sm">
-              <div className="order-1 ml-3">Advanced Settings</div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <Controller
-                render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                  <FormControl errorText={error?.message} isError={Boolean(error)} label="KMS">
-                    <Select
-                      {...field}
-                      onValueChange={(e) => {
-                        onChange(e);
-                      }}
-                      className="mb-12 w-full bg-mineshaft-600"
-                      position="popper"
-                      dropdownContainerClassName="max-w-none -top-1"
-                      side="top"
-                    >
+      <Accordion type="single" collapsible variant="ghost">
+        <AccordionItem value="advance-settings" className="border-b-0">
+          <AccordionTrigger>Advanced Settings</AccordionTrigger>
+          <AccordionContent>
+            <Controller
+              control={control}
+              name="kmsKeyId"
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="new-project-kms">KMS</FieldLabel>
+                  <Select value={value} onValueChange={onChange}>
+                    <SelectTrigger id="new-project-kms" className="w-full">
+                      <SelectValue placeholder="Default Infisical KMS" />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
                       <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
                         Default Infisical KMS
                       </SelectItem>
@@ -320,26 +325,25 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
                           {kms.name}
                         </SelectItem>
                       ))}
-                    </Select>
-                  </FormControl>
-                )}
-                control={control}
-                name="kmsKeyId"
-              />
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-        <div className="absolute right-0 bottom-0 mr-6 mb-6 flex items-start justify-end">
-          <ModalClose>
-            <Button colorSchema="secondary" variant="plain" className="py-2">
-              Cancel
-            </Button>
-          </ModalClose>
-          <Button isDisabled={isSubmitting} isLoading={isSubmitting} className="ml-4" type="submit">
-            Create Project
+                    </SelectContent>
+                  </Select>
+                  {error && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button type="button" variant="ghost">
+            Cancel
           </Button>
-        </div>
-      </div>
+        </DialogClose>
+        <Button type="submit" variant="project" isPending={isSubmitting} isDisabled={isSubmitting}>
+          Create Project
+        </Button>
+      </DialogFooter>
     </form>
   );
 };
@@ -356,10 +360,14 @@ export const NewProjectModal: FC<NewProjectModalProps> = ({
     : "This project will contain your secrets and configurations.";
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent title={title} subTitle={subTitle}>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{subTitle}</DialogDescription>
+        </DialogHeader>
         <NewProjectForm onOpenChange={onOpenChange} projectType={projectType} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
## Context

This PR migrates the create project modal to v3 components

## Screenshots

<img width="3456" height="2184" alt="CleanShot 2026-05-28 at 17 02 34@2x" src="https://github.com/user-attachments/assets/de7161a8-1ad6-4c74-baec-10d51dab52f1" />

## Steps to verify the change

- test creating a project and updating form fields

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)