### PR TITLE
fix: invalidate project CAs query after CA cert install

### DIFF
--- a/frontend/src/hooks/api/ca/mutations.tsx
+++ b/frontend/src/hooks/api/ca/mutations.tsx
@@ -132,6 +132,9 @@ export const useImportCaCertificate = () => {
       queryClient.invalidateQueries({
         queryKey: caKeys.listCasByProjectId()
       });
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("project-cas")
+      });
     }
   });
 };
@@ -390,6 +393,9 @@ export const useGenerateCaCertificate = () => {
       });
       queryClient.invalidateQueries({
         queryKey: caKeys.listCasByProjectId()
+      });
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("project-cas")
       });
     }
   });

--- a/frontend/src/hooks/api/ca/mutations.tsx
+++ b/frontend/src/hooks/api/ca/mutations.tsx
@@ -245,6 +245,9 @@ export const useInstallCaCertificateVenafi = () => {
       queryClient.invalidateQueries({
         queryKey: caKeys.listCasByProjectId()
       });
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("project-cas")
+      });
     }
   });
 };
@@ -274,6 +277,9 @@ export const useInstallCaCertificateAdcs = () => {
       });
       queryClient.invalidateQueries({
         queryKey: caKeys.listCasByProjectId()
+      });
+      queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey.includes("project-cas")
       });
     }
   });


### PR DESCRIPTION
## Context

After installing a certificate on an intermediate CA, the parent CA dropdown in the install cert modal shows stale data. This causes newly-installed intermediate CAs to not appear as selectable parents when setting up a 3-level CA chain (Root → Intermediate → Issuing). A hard refresh was required as a workaround.

The root cause is that the `useGenerateCaCertificate` and `useImportCaCertificate` mutations were not invalidating the `project-cas` query key used by `useListWorkspaceCas`.

## Steps to verify the change

1. Create a Root CA and install its certificate
2. Create an Intermediate CA and install its certificate (selecting the Root CA as parent, path length 1)
3. Create a third CA (Issuing CA) and open the install certificate modal
4. Verify the Intermediate CA appears in the parent dropdown without a hard refresh

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)