### PR TITLE
fix(pam): cap session duration to grant remaining lifetime

### DIFF
--- a/backend/src/ee/routes/v1/pam-account-routers/pam-account-router.ts
+++ b/backend/src/ee/routes/v1/pam-account-routers/pam-account-router.ts
@@ -824,6 +824,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
             actorEmail: z.string(),
             actorName: z.string(),
             reason: z.string().nullable().optional(),
+            grantExpiresAt: z.string().nullable().optional(),
             auditLogInfo: z.object({
               ipAddress: z.string().optional(),
               userAgent: z.string().optional(),
@@ -857,6 +858,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
           actorIp: req.realIp ?? "",
           actorUserAgent: req.headers["user-agent"] ?? "",
           reason: payload.reason,
+          grantExpiresAt: payload.grantExpiresAt ?? null,
           preAuthMessages,
           preAuthHandler
         });

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -4,6 +4,7 @@ import picomatch from "picomatch";
 import { ActionProjectType, OrganizationActionScope, TableName, TPamAccounts, TPamResources } from "@app/db/schemas";
 import { decryptDomainConnectionDetails } from "@app/ee/services/pam-domain/pam-domain-fns";
 import {
+  AWS_STS_MIN_DURATION_SECONDS,
   exchangeCredentialsForConsoleUrl,
   extractAwsAccountIdFromArn,
   generateAwsIamSessionCredentials,
@@ -822,10 +823,10 @@ export const pamAccountServiceFactory = ({
       accountName: accountIdentity
     };
 
-    const canAccess = await fac.canAccess(approvalRequestGrantsDAL, resource.projectId, actor.id, inputs);
+    const activeGrant = await fac.canAccess(approvalRequestGrantsDAL, resource.projectId, actor.id, inputs);
 
     // Grant does not exist, check policy and fallback to permission check
-    if (!canAccess) {
+    if (!activeGrant) {
       const policy = await fac.matchPolicy(approvalPolicyDAL, resource.projectId, inputs);
 
       if (policy) {
@@ -873,6 +874,16 @@ export const pamAccountServiceFactory = ({
           metadata: accountMeta[account.id] || []
         })
       );
+    }
+
+    // Cap the requested duration to the grant's remaining lifetime
+    let effectiveDuration = duration;
+    if (activeGrant?.expiresAt) {
+      const grantRemainingMs = activeGrant.expiresAt.getTime() - Date.now();
+      if (grantRemainingMs <= 0) {
+        throw new ForbiddenRequestError({ message: "Approval grant has expired" });
+      }
+      effectiveDuration = Math.min(duration, grantRemainingMs);
     }
 
     // Reason check is intentionally placed after the approval/permission gates so
@@ -987,12 +998,24 @@ export const pamAccountServiceFactory = ({
         projectId: account.projectId
       })) as TAwsIamAccountCredentials;
 
+      let sessionDuration = awsCredentials.defaultSessionDuration;
+      if (activeGrant?.expiresAt) {
+        const grantRemainingSeconds = Math.floor((activeGrant.expiresAt.getTime() - Date.now()) / 1000);
+        // STS rejects DurationSeconds below the floor, so a grant shorter than that can't be honored
+        if (grantRemainingSeconds < AWS_STS_MIN_DURATION_SECONDS) {
+          throw new ForbiddenRequestError({
+            message: "Approval grant has insufficient remaining time for an AWS IAM session"
+          });
+        }
+        sessionDuration = Math.min(sessionDuration, grantRemainingSeconds);
+      }
+
       const credentials = await generateAwsIamSessionCredentials({
         connectionDetails,
         targetRoleArn: awsCredentials.targetRoleArn,
         roleSessionName: actorEmail,
         projectId: account.projectId, // Use project ID as External ID for security
-        sessionDuration: awsCredentials.defaultSessionDuration
+        sessionDuration
       });
 
       const session = await pamSessionDAL.create({
@@ -1060,7 +1083,7 @@ export const pamAccountServiceFactory = ({
       selectedResourceId: isDomainAccount ? resource.id : null,
       userId: actor.id,
       gatewayId,
-      expiresAt: new Date(Date.now() + duration),
+      expiresAt: new Date(Date.now() + effectiveDuration),
       reason: trimmedReason
     });
 
@@ -1086,7 +1109,7 @@ export const pamAccountServiceFactory = ({
 
     const gatewayConnectionDetails = await gatewayV2Service.getPAMConnectionDetails({
       gatewayId,
-      duration,
+      duration: effectiveDuration,
       sessionId: session.id,
       resourceType: resource.resourceType as PamResource,
       host,

--- a/backend/src/ee/services/pam-resource/aws-iam/aws-iam-federation.ts
+++ b/backend/src/ee/services/pam-resource/aws-iam/aws-iam-federation.ts
@@ -8,7 +8,7 @@ import { BadRequestError, InternalServerError } from "@app/lib/errors";
 
 import { TAwsIamResourceConnectionDetails } from "./aws-iam-resource-types";
 
-const AWS_STS_MIN_DURATION_SECONDS = 900;
+export const AWS_STS_MIN_DURATION_SECONDS = 900;
 
 // We hardcode us-east-1 because:
 // 1. IAM is global - roles can be assumed from any STS regional endpoint

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -120,6 +120,7 @@ type THandleWebSocketConnectionDTO = {
   actorIp: string;
   actorUserAgent: string;
   reason?: string | null;
+  grantExpiresAt?: string | null;
   preAuthMessages: TEarlyBufferedMsg[];
   preAuthHandler: (raw: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => void;
 };
@@ -262,14 +263,14 @@ export const pamWebAccessServiceFactory = ({
       accountName: accountIdentity
     };
 
-    const hasApprovalGrant = await approvalPolicy.canAccess(
+    const approvalGrant = await approvalPolicy.canAccess(
       approvalRequestGrantsDAL,
       resource.projectId,
       actor.id,
       policyInputs
     );
 
-    if (!hasApprovalGrant) {
+    if (!approvalGrant) {
       const matchedPolicy = await approvalPolicy.matchPolicy(approvalPolicyDAL, resource.projectId, policyInputs);
 
       if (matchedPolicy) {
@@ -396,7 +397,8 @@ export const pamWebAccessServiceFactory = ({
         actorEmail,
         actorName,
         auditLogInfo,
-        reason: trimmedReason
+        reason: trimmedReason,
+        grantExpiresAt: approvalGrant?.expiresAt?.toISOString() ?? null
       })
     });
 
@@ -432,6 +434,7 @@ export const pamWebAccessServiceFactory = ({
     actorIp,
     actorUserAgent,
     reason: accessReason,
+    grantExpiresAt: grantExpiresAtIso,
     preAuthMessages,
     preAuthHandler
   }: THandleWebSocketConnectionDTO): Promise<void> => {
@@ -594,7 +597,16 @@ export const pamWebAccessServiceFactory = ({
 
       // 3. CREATE SESSION
       const user = await requestMemoize(requestMemoKeys.userFindById(userId), () => userDAL.findById(userId));
-      const expiresAt = new Date(Date.now() + DEFAULT_WEB_SESSION_DURATION_MS);
+      let sessionDurationMs = DEFAULT_WEB_SESSION_DURATION_MS;
+      if (grantExpiresAtIso) {
+        const grantRemainingMs = new Date(grantExpiresAtIso).getTime() - Date.now();
+        if (grantRemainingMs <= 0) {
+          sendSessionEndAndClose(socket, SessionEndReason.SessionGrantExpired);
+          return;
+        }
+        sessionDurationMs = Math.min(sessionDurationMs, grantRemainingMs);
+      }
+      const expiresAt = new Date(Date.now() + sessionDurationMs);
 
       const isDomainAccount = !account.resourceId;
 
@@ -627,7 +639,7 @@ export const pamWebAccessServiceFactory = ({
         resourceType: resource.resourceType as PamResource,
         host,
         port,
-        duration: DEFAULT_WEB_SESSION_DURATION_MS,
+        duration: sessionDurationMs,
         actorMetadata: {
           id: userId,
           type: ActorType.USER,
@@ -775,7 +787,7 @@ export const pamWebAccessServiceFactory = ({
           void cleanup();
           sendSessionEndAndClose(socket, SessionEndReason.SessionCompleted);
         }
-      }, DEFAULT_WEB_SESSION_DURATION_MS);
+      }, sessionDurationMs);
 
       // WebSocket close/error
       socket.on("close", () => {

--- a/backend/src/ee/services/pam-web-access/pam-web-access-types.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-types.ts
@@ -10,7 +10,8 @@ export enum SessionEndReason {
   ConnectionLost = "Connection lost",
   SetupFailed = "Failed to establish connection",
   IdleTimeout = "Session closed due to inactivity",
-  SessionLimitReached = "Maximum concurrent sessions reached"
+  SessionLimitReached = "Maximum concurrent sessions reached",
+  SessionGrantExpired = "Approval grant has expired"
 }
 
 export enum TerminalServerMessageType {

--- a/backend/src/services/approval-policy/approval-policy-service.ts
+++ b/backend/src/services/approval-policy/approval-policy-service.ts
@@ -1642,7 +1642,7 @@ export const approvalPolicyServiceFactory = ({
       return { requiresApproval: false, hasActiveGrant: false };
     }
 
-    const hasActiveGrant = await fac.canAccess(approvalRequestGrantsDAL, projectId, actor.id, inputs);
+    const activeGrant = await fac.canAccess(approvalRequestGrantsDAL, projectId, actor.id, inputs);
 
     const innerConstraints = policy.constraints?.constraints;
     const constraints =
@@ -1651,8 +1651,8 @@ export const approvalPolicyServiceFactory = ({
         : undefined;
 
     return {
-      requiresApproval: !hasActiveGrant,
-      hasActiveGrant,
+      requiresApproval: !activeGrant,
+      hasActiveGrant: !!activeGrant,
       constraints
     };
   };

--- a/backend/src/services/approval-policy/approval-policy-types.ts
+++ b/backend/src/services/approval-policy/approval-policy-types.ts
@@ -1,6 +1,6 @@
 import { Knex } from "knex";
 
-import { TApprovalPolicies } from "@app/db/schemas";
+import { TApprovalPolicies, TApprovalRequestGrants } from "@app/db/schemas";
 import { TApprovalPolicyDALFactory } from "@app/services/approval-policy/approval-policy-dal";
 import { TApprovalRequestGrantsDALFactory } from "@app/services/approval-policy/approval-request-dal";
 import { ActorAuthMethod, ActorType } from "@app/services/auth/auth-type";
@@ -144,7 +144,7 @@ export type TApprovalRequestFactoryCanAccess<I extends TApprovalPolicyInputs> = 
   projectId: string,
   userId: string,
   inputs: I
-) => Promise<boolean>;
+) => Promise<TApprovalRequestGrants | null>;
 export type TApprovalRequestFactoryValidateConstraints<P extends TApprovalPolicy, R extends TApprovalRequestData> = (
   policy: P,
   inputs: R

--- a/backend/src/services/approval-policy/cert-request/cert-request-policy-factory.ts
+++ b/backend/src/services/approval-policy/cert-request/cert-request-policy-factory.ts
@@ -45,7 +45,7 @@ export const certRequestPolicyFactory: TApprovalResourceFactory<
   };
 
   const canAccess: TApprovalRequestFactoryCanAccess<TCertRequestPolicyInputs> = async () => {
-    return false;
+    return null;
   };
 
   const validateConstraints: TApprovalRequestFactoryValidateConstraints<

--- a/backend/src/services/approval-policy/code-signing/code-signing-policy-factory.ts
+++ b/backend/src/services/approval-policy/code-signing/code-signing-policy-factory.ts
@@ -64,15 +64,15 @@ export const codeSigningPolicyFactory: TApprovalResourceFactory<
 
     const now = new Date();
 
-    const hasMatchingGrant = grants.some((grant) => {
-      const attributes = grant.attributes as TCodeSigningGrantAttributes | null;
-      if (!attributes || attributes.signerId !== inputs.signerId) return false;
-      if (attributes.windowStart && new Date(attributes.windowStart) > now) return false;
-      if (grant.expiresAt && new Date(grant.expiresAt) < now) return false;
-      return true;
-    });
-
-    return hasMatchingGrant;
+    return (
+      grants.find((grant) => {
+        const attributes = grant.attributes as TCodeSigningGrantAttributes | null;
+        if (!attributes || attributes.signerId !== inputs.signerId) return false;
+        if (attributes.windowStart && new Date(attributes.windowStart) > now) return false;
+        if (grant.expiresAt && new Date(grant.expiresAt) < now) return false;
+        return true;
+      }) ?? null
+    );
   };
 
   const validateConstraints: TApprovalRequestFactoryValidateConstraints<TCodeSigningPolicy, TCodeSigningRequestData> = (

--- a/backend/src/services/approval-policy/pam-access/pam-access-policy-factory.ts
+++ b/backend/src/services/approval-policy/pam-access/pam-access-policy-factory.ts
@@ -117,32 +117,34 @@ export const pamAccessPolicyFactory: TApprovalResourceFactory<
     });
 
     // TODO(andrey): Move some of this check to be part of SQL query
-    return grants.some((grant) => {
-      const grantAttributes = grant.attributes as TPamAccessPolicyInputs;
+    return (
+      grants.find((grant) => {
+        const grantAttributes = grant.attributes as TPamAccessPolicyInputs;
 
-      if (inputs.resourceName || inputs.accountName) {
-        let resourceMatches = true;
-        let accountMatches = true;
+        if (inputs.resourceName || inputs.accountName) {
+          let resourceMatches = true;
+          let accountMatches = true;
 
-        if (inputs.resourceName && grantAttributes.resourceName) {
-          resourceMatches = picomatch(grantAttributes.resourceName)(inputs.resourceName);
-        } else if (inputs.resourceName && !grantAttributes.resourceName) {
-          resourceMatches = false;
+          if (inputs.resourceName && grantAttributes.resourceName) {
+            resourceMatches = picomatch(grantAttributes.resourceName)(inputs.resourceName);
+          } else if (inputs.resourceName && !grantAttributes.resourceName) {
+            resourceMatches = false;
+          }
+
+          if (inputs.accountName && grantAttributes.accountName) {
+            accountMatches = picomatch(grantAttributes.accountName)(inputs.accountName);
+          } else if (inputs.accountName && !grantAttributes.accountName) {
+            accountMatches = false;
+          }
+
+          if (resourceMatches && accountMatches && (!grant.expiresAt || grant.expiresAt > new Date())) {
+            return true;
+          }
         }
 
-        if (inputs.accountName && grantAttributes.accountName) {
-          accountMatches = picomatch(grantAttributes.accountName)(inputs.accountName);
-        } else if (inputs.accountName && !grantAttributes.accountName) {
-          accountMatches = false;
-        }
-
-        if (resourceMatches && accountMatches && (!grant.expiresAt || grant.expiresAt > new Date())) {
-          return true;
-        }
-      }
-
-      return false;
-    });
+        return false;
+      }) ?? null
+    );
   };
 
   const validateConstraints: TApprovalRequestFactoryValidateConstraints<TPamAccessPolicy, TPamAccessRequestData> = (


### PR DESCRIPTION
## Context

PAM session duration was not capped against the approval grant's remaining lifetime. A user with an active grant (e.g. approved for 1 hour) could call the `/access` endpoint with `duration: "365d"` and receive a session, gateway certificate, and SSH certificate valid for a full year. The `canAccess` function returned a boolean, discarding the grant object and its `expiresAt`, so callers had no way to enforce the time-bounded control.

`canAccess` now returns the matching grant object instead of a boolean. The PAM access and web-access paths use its `expiresAt` to cap the requested duration to the grant's remaining time.

## Steps to verify the change

1. Create a PAM approval policy with a short max access duration (e.g. 5m)
2. Request and approve access, creating a grant with a short expiration
3. Call `POST /api/v1/pam/accounts/access` with `duration: "30d"`
4. Verify the session `expiresAt` is capped to the grant's remaining lifetime, not 30 days
5. Verify the no-grant path (no approval policy, just CASL permissions) still allows the requested duration unchanged
6. Verify web-access sessions are capped when a grant exists

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)