### PR TITLE
fix(hashicorp-vault): list namespaces root on old versions

### DIFF
--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -569,10 +569,10 @@ export const listHCVaultNamespaces = async (
       }
 
       // vault 1.0.0 does not support namespace root or /, so we need to handle this case
-      // if the error is 301 and the namespace path is /, try to fetch the namespaces at the root
+      // if the error is 301 and the namespace path is /, try to fetch the namespaces without the namespace header
       if (
         ((error instanceof AxiosError && error.response?.status === 301) || isGateway301Error(error)) &&
-        namespacePath === "/"
+        (namespacePath === "/" || namespacePath === "root")
       ) {
         return fetchHCVaultNamespacesWithoutNamespaceHeader({
           connection,

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -70,6 +70,10 @@ const isGateway404Error = (error: unknown): boolean => {
   return error instanceof BadRequestError && error.message?.includes("Request failed with status code 404");
 };
 
+const isGateway301Error = (error: unknown): boolean => {
+  return error instanceof BadRequestError && error.message?.includes("Request failed with status code 301");
+};
+
 // Helper to extract error message from Vault API errors
 const getVaultErrorMessage = (error: unknown, fallback: string): string => {
   if (error instanceof AxiosError) {
@@ -489,6 +493,41 @@ export const listHCVaultPolicies = async (
   }
 };
 
+const fetchHCVaultNamespacesWithoutNamespaceHeader = async ({
+  connection,
+  gatewayService,
+  gatewayV2Service,
+  instanceUrl,
+  accessToken
+}: {
+  connection: THCVaultConnection;
+  gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">;
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+  instanceUrl: string;
+  accessToken: string;
+}): Promise<string[]> => {
+  try {
+    const { data } = await requestWithHCVaultGateway<{
+      data: { keys: string[] };
+    }>(connection, gatewayService, gatewayV2Service, {
+      url: `${instanceUrl}/v1/sys/namespaces?list=true`,
+      method: "GET",
+      headers: {
+        "X-Vault-Token": accessToken
+      }
+    });
+
+    return data.data.keys || [];
+  } catch (error: unknown) {
+    if (error instanceof AxiosError) {
+      throw new BadRequestError({
+        message: `Failed to list namespaces: ${error.message || "Unknown error"}`
+      });
+    }
+    throw error;
+  }
+};
+
 export const listHCVaultNamespaces = async (
   connection: THCVaultConnection,
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
@@ -528,6 +567,22 @@ export const listHCVaultNamespaces = async (
         // No child namespaces at this path
         return null;
       }
+
+      // vault 1.0.0 does not support namespace root or /, so we need to handle this case
+      // if the error is 301 and the namespace path is /, try to fetch the namespaces at the root
+      if (
+        ((error instanceof AxiosError && error.response?.status === 301) || isGateway301Error(error)) &&
+        namespacePath === "/"
+      ) {
+        return fetchHCVaultNamespacesWithoutNamespaceHeader({
+          connection,
+          gatewayService,
+          gatewayV2Service,
+          instanceUrl,
+          accessToken
+        });
+      }
+
       throw error;
     }
   };


### PR DESCRIPTION
## Context
The header `X-Vault-Namespace=root` or `X-Vault-Namespace=/` does not work on old versions of vault, it sends a 301 error and does not allow them to list the possible namespaces. The right way to list the namespaces in the old version is just calling `/v1/sys/namespaces?list=true` without the `X-Vault-Namespace` or with a namespace that exists. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
This is hard to test locally or using vault cloud. We checked this with an user that is running an old version

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)