### PR TITLE
update(docs): Update github action version in docs

### DIFF
--- a/docs/documentation/platform/identities/oidc-auth/github.mdx
+++ b/docs/documentation/platform/identities/oidc-auth/github.mdx
@@ -145,7 +145,7 @@ In the following steps, we explore how to create and use identities to access th
             build:
                 runs-on: ubuntu-latest
                 steps:
-                    - uses: Infisical/secrets-action@v1.0.7
+                    - uses: Infisical/secrets-action@v1.0.9
                     with:
                         method: "oidc"
                         env-slug: "dev"


### PR DESCRIPTION
I saw the video on YoutTube and it used a more updated version (1.0.9)

## Context

documentation

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [X] Docs
- [ ] Chore

## Checklist

- [X] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)