### PR TITLE
fix(go): validate trusted proxies before trusting X-Forwarded-For

### DIFF
--- a/backend-go/cmd/infisical/main.go
+++ b/backend-go/cmd/infisical/main.go
@@ -91,7 +91,7 @@ func run(cfg *config.Config, logger *slog.Logger) error {
 	defer cleanup()
 
 	// Create server.
-	srv := server.NewServer(services, logger)
+	srv := server.NewServer(services, cfg, logger)
 
 	// Create error channel for signal handling and server errors.
 	// Buffered to prevent blocking if multiple senders (signal, queue, HTTP) fire after first receive.

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
 )
@@ -330,6 +331,9 @@ type Config struct {
 	PITCheckpointWindow     string
 	PITTreeCheckpointWindow string
 
+	// Reverse Proxy
+	TrustedProxyCIDRs string
+
 	// CORS
 	CORSAllowedOrigins string
 	CORSAllowedHeaders string
@@ -352,6 +356,7 @@ type Config struct {
 	DNSMadeEasySandboxEnabled                   bool
 
 	// Derived (not from env)
+	ParsedTrustedProxyCIDRs      []net.IPNet
 	IsCloud                      bool
 	IsSmtpConfigured             bool
 	IsRedisConfigured            bool
@@ -693,6 +698,9 @@ func LoadConfig() (*Config, error) {
 		Optional(&cfg.PITCheckpointWindow, "PIT_CHECKPOINT_WINDOW", "100").
 		Optional(&cfg.PITTreeCheckpointWindow, "PIT_TREE_CHECKPOINT_WINDOW", "200").
 
+		// Reverse Proxy
+		Optional(&cfg.TrustedProxyCIDRs, "TRUSTED_PROXY_CIDRS", "").
+
 		// CORS
 		Optional(&cfg.CORSAllowedOrigins, "CORS_ALLOWED_ORIGINS", "").
 		Optional(&cfg.CORSAllowedHeaders, "CORS_ALLOWED_HEADERS", "").
@@ -809,6 +817,21 @@ func LoadConfig() (*Config, error) {
 		cfg.ParsedRedisReadReplicas, issues = parseHostPortList(cfg.RedisReadReplicas, "REDIS_READ_REPLICAS")
 		parseIssues = append(parseIssues, issues...)
 	}
+	if cfg.TrustedProxyCIDRs != "" {
+		for entry := range strings.SplitSeq(cfg.TrustedProxyCIDRs, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			_, ipNet, err := net.ParseCIDR(entry)
+			if err != nil {
+				parseIssues = append(parseIssues, fmt.Sprintf("TRUSTED_PROXY_CIDRS: invalid CIDR %q: %v", entry, err))
+				continue
+			}
+			cfg.ParsedTrustedProxyCIDRs = append(cfg.ParsedTrustedProxyCIDRs, *ipNet)
+		}
+	}
+
 	if len(parseIssues) > 0 {
 		return nil, &ValidationError{Issues: parseIssues}
 	}

--- a/backend-go/internal/server/middlewares/httpinfo.go
+++ b/backend-go/internal/server/middlewares/httpinfo.go
@@ -35,8 +35,10 @@ func HTTPInfoMiddleware(trustedCIDRs []net.IPNet) func(http.Handler) http.Handle
 // getRealIP extracts the real client IP address from the request.
 //
 // When trustedCIDRs is non-empty (strict mode), forwarded headers are only
-// used if RemoteAddr belongs to a trusted proxy. Otherwise, RemoteAddr is
-// returned directly — preventing clients from spoofing their IP via headers.
+// used if RemoteAddr belongs to a trusted proxy. The X-Forwarded-For header
+// is walked right-to-left, skipping trusted proxy IPs, and the first
+// non-trusted IP is returned — this prevents attackers from injecting a fake
+// IP at the front of the header before the proxy appends the real client IP.
 //
 // When trustedCIDRs is empty (legacy mode), headers are trusted
 // unconditionally for backwards compatibility.
@@ -48,9 +50,31 @@ func getRealIP(r *http.Request, trustedCIDRs []net.IPNet) string {
 		if !isIPTrusted(remoteIP, trustedCIDRs) {
 			return remoteIP
 		}
+
+		// Walk X-Forwarded-For right-to-left, skipping trusted proxy IPs.
+		// Proxies append the real client IP, so attacker-controlled values
+		// are at the front. The rightmost non-trusted IP is the real client.
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			for i := len(parts) - 1; i >= 0; i-- {
+				ip := strings.TrimSpace(parts[i])
+				if ip == "" {
+					continue
+				}
+				if !isIPTrusted(ip, trustedCIDRs) {
+					return ip
+				}
+			}
+		}
+
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			return strings.TrimSpace(xri)
+		}
+
+		return remoteIP
 	}
 
-	// Trust forwarded headers (either legacy mode or request is from a trusted proxy).
+	// Legacy mode: trust forwarded headers unconditionally.
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		if before, _, ok := strings.Cut(xff, ","); ok {
 			return strings.TrimSpace(before)

--- a/backend-go/internal/server/middlewares/httpinfo.go
+++ b/backend-go/internal/server/middlewares/httpinfo.go
@@ -11,40 +11,81 @@ import (
 
 // HTTPInfoMiddleware extracts HTTP request information and stores it in context.
 // This must run before the auth handler so Identity can be populated with this info.
-func HTTPInfoMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		userAgent := r.Header.Get("User-Agent")
-		info := &auth.HTTPInfo{
-			IPAddress:     getRealIP(r),
-			UserAgent:     userAgent,
-			UserAgentType: auditlog.GetUserAgentType(userAgent),
-		}
-		ctx := auth.WithHTTPInfo(r.Context(), info)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+//
+// trustedCIDRs controls how the client IP is resolved:
+//   - When non-empty, X-Forwarded-For / X-Real-IP headers are only trusted if the
+//     request's direct source (RemoteAddr) falls within one of the listed CIDRs.
+//   - When empty, headers are trusted unconditionally (legacy behavior, preserved
+//     for backwards compatibility with existing self-hosted deployments).
+func HTTPInfoMiddleware(trustedCIDRs []net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userAgent := r.Header.Get("User-Agent")
+			info := &auth.HTTPInfo{
+				IPAddress:     getRealIP(r, trustedCIDRs),
+				UserAgent:     userAgent,
+				UserAgentType: auditlog.GetUserAgentType(userAgent),
+			}
+			ctx := auth.WithHTTPInfo(r.Context(), info)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 // getRealIP extracts the real client IP address from the request.
-// It checks X-Forwarded-For and X-Real-IP headers before falling back to RemoteAddr.
-func getRealIP(r *http.Request) string {
-	// Check X-Forwarded-For header (may contain multiple IPs)
+//
+// When trustedCIDRs is non-empty (strict mode), forwarded headers are only
+// used if RemoteAddr belongs to a trusted proxy. Otherwise, RemoteAddr is
+// returned directly — preventing clients from spoofing their IP via headers.
+//
+// When trustedCIDRs is empty (legacy mode), headers are trusted
+// unconditionally for backwards compatibility.
+func getRealIP(r *http.Request, trustedCIDRs []net.IPNet) string {
+	remoteIP := extractIP(r.RemoteAddr)
+
+	// Strict mode: only trust headers from known proxies.
+	if len(trustedCIDRs) > 0 {
+		if !isIPTrusted(remoteIP, trustedCIDRs) {
+			return remoteIP
+		}
+	}
+
+	// Trust forwarded headers (either legacy mode or request is from a trusted proxy).
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP (original client)
 		if before, _, ok := strings.Cut(xff, ","); ok {
 			return strings.TrimSpace(before)
 		}
 		return strings.TrimSpace(xff)
 	}
 
-	// Check X-Real-IP header
 	if xri := r.Header.Get("X-Real-IP"); xri != "" {
 		return strings.TrimSpace(xri)
 	}
 
-	// Fall back to RemoteAddr
-	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	return remoteIP
+}
+
+// extractIP extracts the IP address from an address string, stripping the port
+// if present (e.g. "1.2.3.4:8080" → "1.2.3.4").
+func extractIP(addr string) string {
+	ip, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return r.RemoteAddr
+		return addr
 	}
 	return ip
+}
+
+// isIPTrusted checks whether the given IP string falls within any of the
+// trusted CIDR ranges.
+func isIPTrusted(ipStr string, trustedCIDRs []net.IPNet) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for i := range trustedCIDRs {
+		if trustedCIDRs[i].Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend-go/internal/server/middlewares/httpinfo_test.go
+++ b/backend-go/internal/server/middlewares/httpinfo_test.go
@@ -1,0 +1,145 @@
+package middlewares
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func mustParseCIDR(s string) net.IPNet {
+	_, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return *ipNet
+}
+
+func newRequest(remoteAddr string, headers map[string]string) *http.Request {
+	r, _ := http.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+	r.RemoteAddr = remoteAddr
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func TestGetRealIP_LegacyMode_TrustsHeaders(t *testing.T) {
+	// No trusted CIDRs → legacy mode, headers trusted from anyone
+	r := newRequest("5.5.5.5:12345", map[string]string{
+		"X-Forwarded-For": "9.9.9.9",
+	})
+	got := getRealIP(r, nil)
+	if got != "9.9.9.9" {
+		t.Errorf("getRealIP = %q, want %q", got, "9.9.9.9")
+	}
+}
+
+func TestGetRealIP_LegacyMode_FallsBackToRemoteAddr(t *testing.T) {
+	r := newRequest("5.5.5.5:12345", nil)
+	got := getRealIP(r, nil)
+	if got != "5.5.5.5" {
+		t.Errorf("getRealIP = %q, want %q", got, "5.5.5.5")
+	}
+}
+
+func TestGetRealIP_StrictMode_TrustedProxy(t *testing.T) {
+	// Request from a trusted proxy → trust the header
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("10.0.0.1:8080", map[string]string{
+		"X-Forwarded-For": "1.2.3.4",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "1.2.3.4" {
+		t.Errorf("getRealIP = %q, want %q", got, "1.2.3.4")
+	}
+}
+
+func TestGetRealIP_StrictMode_UntrustedSource(t *testing.T) {
+	// Request from an untrusted IP → ignore header, use RemoteAddr
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("5.5.5.5:12345", map[string]string{
+		"X-Forwarded-For": "9.9.9.9",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "5.5.5.5" {
+		t.Errorf("getRealIP = %q, want %q (should ignore spoofed header)", got, "5.5.5.5")
+	}
+}
+
+func TestGetRealIP_StrictMode_XRealIP(t *testing.T) {
+	// Trusted proxy with X-Real-IP instead of X-Forwarded-For
+	cidrs := []net.IPNet{mustParseCIDR("172.16.0.0/12")}
+	r := newRequest("172.20.0.5:443", map[string]string{
+		"X-Real-IP": "8.8.8.8",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "8.8.8.8" {
+		t.Errorf("getRealIP = %q, want %q", got, "8.8.8.8")
+	}
+}
+
+func TestGetRealIP_StrictMode_MultipleForwardedIPs(t *testing.T) {
+	// X-Forwarded-For with multiple IPs → take the first (original client)
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("10.0.0.1:8080", map[string]string{
+		"X-Forwarded-For": "1.2.3.4, 10.0.0.50",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "1.2.3.4" {
+		t.Errorf("getRealIP = %q, want %q", got, "1.2.3.4")
+	}
+}
+
+func TestGetRealIP_StrictMode_NoHeaders(t *testing.T) {
+	// Trusted proxy but no forwarded headers → fall back to RemoteAddr
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("10.0.0.1:8080", nil)
+	got := getRealIP(r, cidrs)
+	if got != "10.0.0.1" {
+		t.Errorf("getRealIP = %q, want %q", got, "10.0.0.1")
+	}
+}
+
+func TestGetRealIP_StrictMode_MultipleCIDRs(t *testing.T) {
+	// Multiple trusted CIDR ranges
+	cidrs := []net.IPNet{
+		mustParseCIDR("10.0.0.0/8"),
+		mustParseCIDR("192.168.0.0/16"),
+	}
+	r := newRequest("192.168.1.1:3000", map[string]string{
+		"X-Forwarded-For": "203.0.113.50",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "203.0.113.50" {
+		t.Errorf("getRealIP = %q, want %q", got, "203.0.113.50")
+	}
+}
+
+func TestIsIPTrusted(t *testing.T) {
+	cidrs := []net.IPNet{
+		mustParseCIDR("10.0.0.0/8"),
+		mustParseCIDR("172.16.0.0/12"),
+	}
+
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.0.0.1", true},
+		{"10.255.255.255", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"192.168.1.1", false},
+		{"8.8.8.8", false},
+		{"invalid", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		got := isIPTrusted(tc.ip, cidrs)
+		if got != tc.want {
+			t.Errorf("isIPTrusted(%q) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}

--- a/backend-go/internal/server/middlewares/httpinfo_test.go
+++ b/backend-go/internal/server/middlewares/httpinfo_test.go
@@ -80,10 +80,40 @@ func TestGetRealIP_StrictMode_XRealIP(t *testing.T) {
 }
 
 func TestGetRealIP_StrictMode_MultipleForwardedIPs(t *testing.T) {
-	// X-Forwarded-For with multiple IPs → take the first (original client)
+	// X-Forwarded-For with multiple IPs, last one is a trusted proxy →
+	// walk right-to-left, skip trusted, return first non-trusted
 	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
 	r := newRequest("10.0.0.1:8080", map[string]string{
 		"X-Forwarded-For": "1.2.3.4, 10.0.0.50",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "1.2.3.4" {
+		t.Errorf("getRealIP = %q, want %q", got, "1.2.3.4")
+	}
+}
+
+func TestGetRealIP_StrictMode_ProxyAppendAttack(t *testing.T) {
+	// Attacker sets X-Forwarded-For: 9.9.9.9 before the proxy appends real client IP.
+	// Header arrives as "9.9.9.9, 5.5.5.5" where 5.5.5.5 is the real client.
+	// Walking right-to-left: 5.5.5.5 is not trusted → return it, ignore the fake 9.9.9.9.
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("10.0.0.1:8080", map[string]string{
+		"X-Forwarded-For": "9.9.9.9, 5.5.5.5",
+	})
+	got := getRealIP(r, cidrs)
+	if got != "5.5.5.5" {
+		t.Errorf("getRealIP = %q, want %q (should ignore attacker-injected IP)", got, "5.5.5.5")
+	}
+}
+
+func TestGetRealIP_StrictMode_MultiHopProxy(t *testing.T) {
+	// Request passes through two trusted proxies:
+	// Client (1.2.3.4) → Proxy A (10.0.0.1) → Proxy B (10.0.0.2) → Server
+	// XFF: 1.2.3.4, 10.0.0.1
+	// Walking right-to-left: 10.0.0.1 is trusted (skip), 1.2.3.4 is not → return it.
+	cidrs := []net.IPNet{mustParseCIDR("10.0.0.0/8")}
+	r := newRequest("10.0.0.2:8080", map[string]string{
+		"X-Forwarded-For": "1.2.3.4, 10.0.0.1",
 	})
 	got := getRealIP(r, cidrs)
 	if got != "1.2.3.4" {

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
 
+	"github.com/infisical/api/internal/config"
 	"github.com/infisical/api/internal/libs/requestid"
 	"github.com/infisical/api/internal/server/api"
 	"github.com/infisical/api/internal/server/middlewares"
@@ -18,12 +19,13 @@ import (
 // Server is the HTTP server for the Infisical API.
 type Server struct {
 	services *api.Services
+	config   *config.Config
 	logger   *slog.Logger
 	router   chi.Router
 }
 
 // NewServer creates a new HTTP server with chi routing.
-func NewServer(services *api.Services, logger *slog.Logger) *Server {
+func NewServer(services *api.Services, cfg *config.Config, logger *slog.Logger) *Server {
 	router := chi.NewRouter()
 
 	// Register domain routes
@@ -32,6 +34,7 @@ func NewServer(services *api.Services, logger *slog.Logger) *Server {
 
 	return &Server{
 		services: services,
+		config:   cfg,
 		logger:   logger,
 		router:   router,
 	}
@@ -43,7 +46,7 @@ func (s *Server) Listen(ctx context.Context, addr string, wg *sync.WaitGroup, er
 
 	// Middleware stack (applied in reverse order - last wraps first)
 	handler = requestLogger(handler, s.logger)
-	handler = middlewares.HTTPInfoMiddleware(handler)
+	handler = middlewares.HTTPInfoMiddleware(s.config.ParsedTrustedProxyCIDRs)(handler)
 	handler = chimw.StripSlashes(handler)
 	handler = requestid.Middleware(handler)
 


### PR DESCRIPTION
## Summary

`getRealIP` in `backend-go` unconditionally trusts `X-Forwarded-For` and `X-Real-IP` headers from any client. An attacker connecting directly to the server can spoof their IP, which:
- **Poisons audit logs** with fake source IPs
- **Bypasses rate limiting** by rotating a different fake IP per request

This PR adds `TRUSTED_PROXY_CIDRS` support to the Go backend, matching the Node.js backend's existing implementation (`backend/src/server/plugins/ip.ts`):
- **Strict mode** (env var set): Only trust forwarded headers when `RemoteAddr` is within a configured CIDR range
- **Legacy mode** (env var unset): Preserve current header-trusting behavior for backwards compatibility

Uses the same `TRUSTED_PROXY_CIDRS` env var as the Node.js backend — self-hosted deployments that already have it configured will automatically get the protection in the Go backend too.

## Changes

| File | Change |
|------|--------|
| `config/config.go` | Add `TrustedProxyCIDRs` field, parse comma-separated CIDRs into `[]net.IPNet` |
| `middlewares/httpinfo.go` | `getRealIP` checks `RemoteAddr` against trusted CIDRs before trusting headers |
| `server/server.go` | Pass parsed CIDRs from config into `HTTPInfoMiddleware` |
| `cmd/infisical/main.go` | Pass config to `NewServer` |
| `middlewares/httpinfo_test.go` | 9 test cases: legacy mode, strict mode (trusted/untrusted), multiple CIDRs, edge cases |

## Test plan

- [x] All 9 unit tests pass (`go test ./internal/server/middlewares/`)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `golangci-lint` clean on changed packages (0 issues)
- [ ] CI

Fixes #6645