### PR TITLE
chore: mark root make targets as phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build push up-dev up-dev-ldap up-dev-metrics up-prod down reviewable-ui reviewable-api reviewable up-dev-sso go-generate validate-upgrade-impact generate-upgrade-impact generate-upgrade-impact-dry-run
+
 build:
 	docker-compose -f docker-compose.yml build
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->
Adds a `.PHONY` declaration for the root `Makefile` command targets.
These targets are command aliases and do not produce files with matching names. Without `.PHONY`, `make` may skip a target if a file or directory with the same name exists, for example `build` or `push`.

This change makes the Makefile behavior more reliable and consistent with the other Makefiles in the repository.



## Screenshots
Not applicable. This is a Makefile-only change.

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
1. Run `make -n build`
2. Run `make -n reviewable`
3. Confirm the expected commands are printed and targets are treated as command targets.


## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)