### PR TITLE
fix: signup page cutoff on desktop screens

### DIFF
--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -71,7 +71,7 @@ export const SignUpPage = () => {
   }
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
+    <div className="flex min-h-screen flex-col items-center justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6 py-8">
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>
         <link rel="icon" href="/infisical.ico" />


### PR DESCRIPTION
## Summary
Removes `max-h-screen` from the admin signup page container and adds vertical centering with padding to ensure the signup form displays fully on all desktop viewport sizes.

## Changes
- `frontend/src/pages/admin/SignUpPage/SignUpPage.tsx`: Replaced `max-h-screen` with `items-center` and `py-8` for proper content display without cutoff

Fixes #1411