### PR TITLE
chore: skip email verification whenever enforce sso is on

### DIFF
--- a/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
@@ -1,0 +1,91 @@
+import crypto from "node:crypto";
+
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+import { ProviderAuthResult } from "@app/services/auth/auth-type";
+
+import { TTestSmtpService } from "../../mocks/smtp";
+import { cleanupEmailDomains, seedVerifiedEmailDomain } from "../../testUtils/email-domains";
+
+const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
+const smtp = () => (globalThis as unknown as { testSmtp: TTestSmtpService }).testSmtp;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getServices = () => (globalThis as any).testServices;
+
+const TEST_ORG_ID = seedData1.organization.id;
+const TEST_DOMAIN = "sso-enforced-test.local";
+
+describe("Auth SSO Signup V3 (SSO enforced)", () => {
+  const createdUserIds: string[] = [];
+
+  beforeAll(async () => {
+    await seedVerifiedEmailDomain(TEST_ORG_ID, TEST_DOMAIN, getDb());
+    // When SSO is enforced, the verified domain + IdP are authoritative.
+    await getDb()(TableName.Organization).where({ id: TEST_ORG_ID }).update({ authEnforced: true });
+  });
+
+  afterAll(async () => {
+    const db = getDb();
+    // Restore the shared seed org so other specs see the default (non-enforced) state.
+    await db(TableName.Organization).where({ id: TEST_ORG_ID }).update({ authEnforced: false });
+    if (createdUserIds.length > 0) {
+      await db(TableName.UserAliases).whereIn("userId", createdUserIds).del();
+      await db(TableName.Membership).whereIn("actorUserId", createdUserIds).del();
+      await db(TableName.Users).whereIn("id", createdUserIds).where("id", "!=", seedData1.id).del();
+    }
+    await cleanupEmailDomains(TEST_ORG_ID, db);
+  });
+
+  beforeEach(() => {
+    smtp().clear();
+  });
+
+  test("SAML login for new user with SSO enforced returns a SESSION (no email verification)", async () => {
+    const email = `sso-enforced-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+
+    const result = await getServices().saml.samlLogin({
+      externalId: `sso-enforced-${crypto.randomUUID()}`,
+      email,
+      firstName: "SSO",
+      lastName: "Enforced",
+      authProvider: "okta-saml",
+      orgId: TEST_ORG_ID,
+      ip: "127.0.0.1",
+      userAgent: "test-agent"
+    });
+
+    expect(result.result).toBe(ProviderAuthResult.SESSION);
+    expect(result.tokens).toBeDefined();
+    createdUserIds.push(result.userId);
+
+    // No email-verification code should have been sent.
+    const verificationEmail = smtp()
+      .getEmails()
+      .find((e) => e.recipients?.includes(email));
+    expect(verificationEmail).toBeUndefined();
+
+    // The new user is provisioned as accepted + email-verified directly.
+    const user = await getDb()(TableName.Users).where({ id: result.userId }).first();
+    expect(user?.isAccepted).toBe(true);
+    expect(user?.isEmailVerified).toBe(true);
+  });
+
+  test("Email/password signup is blocked for a verified domain owned by an SSO-enforced org", async () => {
+    const email = `pw-blocked-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+
+    const res = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/signup/email/signup",
+      body: { email }
+    });
+
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    // No signup verification email should have been sent.
+    const signupEmail = smtp()
+      .getEmails()
+      .find((e) => e.recipients?.includes(email));
+    expect(signupEmail).toBeUndefined();
+  });
+});

--- a/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
@@ -126,6 +126,13 @@ describe("Auth SSO Signup V3 (SSO enforced)", () => {
     const victimAfter = await getDb()(TableName.Users).where({ id: victim.id }).first();
     expect(victimAfter?.isAccepted).toBe(true);
     expect(victimAfter?.isEmailVerified).toBe(true);
+
+    // The stale-alias guard must run BEFORE any state mutation: the victim is not enrolled into the
+    // org (no membership created) since the IdP never proved control of the victim's account.
+    const victimMembership = await getDb()(TableName.Membership)
+      .where({ actorUserId: victim.id, scopeOrgId: TEST_ORG_ID })
+      .first();
+    expect(victimMembership).toBeUndefined();
   });
 
   test("SAML login promotes an unverified alias when the asserted email matches the account", async () => {

--- a/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
@@ -8,6 +8,7 @@ import { ProviderAuthResult } from "@app/services/auth/auth-type";
 
 import { TTestSmtpService } from "../../mocks/smtp";
 import { cleanupEmailDomains, seedVerifiedEmailDomain } from "../../testUtils/email-domains";
+import { cleanupSamlConfig, seedSamlConfig } from "../../testUtils/saml-config";
 
 const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
 const smtp = () => (globalThis as unknown as { testSmtp: TTestSmtpService }).testSmtp;
@@ -22,6 +23,8 @@ describe("Auth SSO Signup V3 (SSO enforced)", () => {
 
   beforeAll(async () => {
     await seedVerifiedEmailDomain(TEST_ORG_ID, TEST_DOMAIN, getDb());
+    // samlLogin reads the org's SAML config, so seed one to keep this spec self-contained.
+    await seedSamlConfig(TEST_ORG_ID, getDb(), { authProvider: "okta-saml" });
     // When SSO is enforced, the verified domain + IdP are authoritative.
     await getDb()(TableName.Organization).where({ id: TEST_ORG_ID }).update({ authEnforced: true });
   });
@@ -35,6 +38,7 @@ describe("Auth SSO Signup V3 (SSO enforced)", () => {
       await db(TableName.Membership).whereIn("actorUserId", createdUserIds).del();
       await db(TableName.Users).whereIn("id", createdUserIds).where("id", "!=", seedData1.id).del();
     }
+    await cleanupSamlConfig(TEST_ORG_ID, db);
     await cleanupEmailDomains(TEST_ORG_ID, db);
   });
 

--- a/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-signup-sso-enforced.spec.ts
@@ -76,6 +76,105 @@ describe("Auth SSO Signup V3 (SSO enforced)", () => {
     expect(user?.isEmailVerified).toBe(true);
   });
 
+  test("SAML login for a stale unverified alias is NOT promoted when the asserted email mismatches", async () => {
+    // Simulate the legacy flow that persisted an alias before email verification completed: an
+    // unverified SAML alias for `externalId` points at user A's account.
+    const victimEmail = `victim-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+    const [victim] = await getDb()(TableName.Users)
+      .insert({
+        username: victimEmail,
+        email: victimEmail,
+        isAccepted: true,
+        isEmailVerified: true,
+        isGhost: false,
+        authMethods: []
+      })
+      .returning("*");
+    createdUserIds.push(victim.id);
+
+    const externalId = `stale-alias-${crypto.randomUUID()}`;
+    const [alias] = await getDb()(TableName.UserAliases)
+      .insert({
+        userId: victim.id,
+        aliasType: "saml",
+        externalId,
+        emails: [victimEmail],
+        orgId: TEST_ORG_ID,
+        isEmailVerified: false
+      })
+      .returning("*");
+
+    // A different identity (same verified domain) presents the externalId of the stale alias.
+    const attackerEmail = `attacker-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+    const result = await getServices().saml.samlLogin({
+      externalId,
+      email: attackerEmail,
+      firstName: "Stale",
+      lastName: "Alias",
+      authProvider: "okta-saml",
+      orgId: TEST_ORG_ID,
+      ip: "127.0.0.1",
+      userAgent: "test-agent"
+    });
+
+    // No session should be issued for the victim's account.
+    expect(result.result).not.toBe(ProviderAuthResult.SESSION);
+
+    // The stale alias must remain unverified, and the victim's account must be untouched.
+    const aliasAfter = await getDb()(TableName.UserAliases).where({ id: alias.id }).first();
+    expect(aliasAfter?.isEmailVerified).toBe(false);
+    const victimAfter = await getDb()(TableName.Users).where({ id: victim.id }).first();
+    expect(victimAfter?.isAccepted).toBe(true);
+    expect(victimAfter?.isEmailVerified).toBe(true);
+  });
+
+  test("SAML login promotes an unverified alias when the asserted email matches the account", async () => {
+    const email = `match-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+    const [user] = await getDb()(TableName.Users)
+      .insert({
+        username: email,
+        email,
+        // Provisioned before enforcement: not yet accepted/verified.
+        isAccepted: false,
+        isEmailVerified: false,
+        isGhost: false,
+        authMethods: []
+      })
+      .returning("*");
+    createdUserIds.push(user.id);
+
+    const externalId = `match-alias-${crypto.randomUUID()}`;
+    const [alias] = await getDb()(TableName.UserAliases)
+      .insert({
+        userId: user.id,
+        aliasType: "saml",
+        externalId,
+        emails: [email],
+        orgId: TEST_ORG_ID,
+        isEmailVerified: false
+      })
+      .returning("*");
+
+    const result = await getServices().saml.samlLogin({
+      externalId,
+      email, // the user's own email — matches the aliased account
+      firstName: "Match",
+      lastName: "User",
+      authProvider: "okta-saml",
+      orgId: TEST_ORG_ID,
+      ip: "127.0.0.1",
+      userAgent: "test-agent"
+    });
+
+    expect(result.result).toBe(ProviderAuthResult.SESSION);
+
+    const aliasAfter = await getDb()(TableName.UserAliases).where({ id: alias.id }).first();
+    expect(aliasAfter?.isEmailVerified).toBe(true);
+    const userAfter = await getDb()(TableName.Users).where({ id: user.id }).first();
+    expect(userAfter?.isAccepted).toBe(true);
+    expect(userAfter?.isEmailVerified).toBe(true);
+  });
+
   test("Email/password signup is blocked for a verified domain owned by an SSO-enforced org", async () => {
     const email = `pw-blocked-${crypto.randomUUID()}@${TEST_DOMAIN}`;
 

--- a/backend/e2e-test/testUtils/saml-config.ts
+++ b/backend/e2e-test/testUtils/saml-config.ts
@@ -1,0 +1,31 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+// Seeds a minimal SAML config so SSO-login specs are self-contained rather than relying on the
+// absence of a config. samlLogin() only reads `enableGroupSync` and stamps `lastUsed` from this row
+// (the SAML assertion itself is validated upstream by passport), so the encrypted blobs only need to
+// satisfy the NOT NULL constraints — they're never decrypted on this path.
+export const seedSamlConfig = async (
+  orgId: string,
+  knex: Knex,
+  { authProvider = "okta-saml" }: { authProvider?: string } = {}
+) => {
+  const placeholder = Buffer.from("placeholder");
+  const [record] = await knex(TableName.SamlConfig)
+    .insert({
+      orgId,
+      authProvider,
+      isActive: true,
+      encryptedSamlEntryPoint: placeholder,
+      encryptedSamlIssuer: placeholder,
+      encryptedSamlCertificate: placeholder,
+      enableGroupSync: false
+    })
+    .returning("*");
+  return record;
+};
+
+export const cleanupSamlConfig = async (orgId: string, knex: Knex) => {
+  await knex(TableName.SamlConfig).where({ orgId }).del();
+};

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -38,7 +38,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
-import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
+import { ensureSsoAccountVerified, isStaleSsoAlias } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -486,6 +486,11 @@ export const ldapConfigServiceFactory = ({
     // org owns this domain, and password signup is blocked for enforced domains).
     const skipEmailVerification = Boolean(organization.authEnforced);
 
+    // A stale, still-unverified alias may point at another user's account. Don't mutate that
+    // account's org membership / group state until the IdP proves control of it (the
+    // email-verification fallback below issues no session). Resolved against the existing alias
+    // before any mutation; freshly created aliases are never stale.
+    let isStaleAlias = false;
     if (userAlias) {
       // Verify the existing user's stored email domain + cross-org check
       const existingUser = await userDAL.findOne({ id: userAlias.userId });
@@ -495,41 +500,43 @@ export const ldapConfigServiceFactory = ({
           orgId,
           emailDomainDAL
         });
+        isStaleAlias = isStaleSsoAlias({ user: existingUser, userAlias, assertedEmail: sanitizedEmail });
       }
-      await userDAL.transaction(async (tx) => {
-        const [orgMembership] = await orgDAL.findMembership(
-          {
-            [`${TableName.Membership}.actorUserId` as "actorUserId"]: userAlias.userId,
-            [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: orgId,
-            [`${TableName.Membership}.scope` as "scope"]: AccessScope.Organization
-          },
-          { tx }
-        );
-        if (!orgMembership) {
-          const { role, roleId } = await getDefaultOrgMembershipRole(organization.defaultMembershipRole);
+      if (!isStaleAlias)
+        await userDAL.transaction(async (tx) => {
+          const [orgMembership] = await orgDAL.findMembership(
+            {
+              [`${TableName.Membership}.actorUserId` as "actorUserId"]: userAlias.userId,
+              [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: orgId,
+              [`${TableName.Membership}.scope` as "scope"]: AccessScope.Organization
+            },
+            { tx }
+          );
+          if (!orgMembership) {
+            const { role, roleId } = await getDefaultOrgMembershipRole(organization.defaultMembershipRole);
 
-          const membership = await orgDAL.createMembership(
-            {
-              actorUserId: userAlias.userId,
-              scopeOrgId: orgId,
-              scope: AccessScope.Organization,
-              status: OrgMembershipStatus.Invited,
-              isActive: true
-            },
-            tx
-          );
-          await membershipRoleDAL.create(
-            {
-              membershipId: membership.id,
-              role,
-              customRoleId: roleId
-            },
-            tx
-          );
-        } else if (!orgMembership.isActive) {
-          throw new ForbiddenRequestError({ message: "User organization membership is inactive" });
-        }
-      });
+            const membership = await orgDAL.createMembership(
+              {
+                actorUserId: userAlias.userId,
+                scopeOrgId: orgId,
+                scope: AccessScope.Organization,
+                status: OrgMembershipStatus.Invited,
+                isActive: true
+              },
+              tx
+            );
+            await membershipRoleDAL.create(
+              {
+                membershipId: membership.id,
+                role,
+                customRoleId: roleId
+              },
+              tx
+            );
+          } else if (!orgMembership.isActive) {
+            throw new ForbiddenRequestError({ message: "User organization membership is inactive" });
+          }
+        });
     } else {
       let isNewUser = false;
       userAlias = await userDAL.transaction(async (tx) => {
@@ -622,7 +629,7 @@ export const ldapConfigServiceFactory = ({
 
     let user = await userDAL.transaction(async (tx) => {
       const newUser = await userDAL.findOne({ id: userAlias.userId }, tx);
-      if (groups) {
+      if (groups && !isStaleAlias) {
         const ldapGroupIdsToBePartOf = (
           await ldapGroupMapDAL.find({
             ldapConfigId,

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -38,6 +38,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
+import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -86,7 +87,7 @@ type TLdapConfigServiceFactoryDep = {
     | "find"
     | "findUserEncKeyByUserId"
   >;
-  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne" | "updateById">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan" | "updateSubscriptionOrgMemberCount">;
   tokenService: Pick<TAuthTokenServiceFactory, "createTokenForUser">;
@@ -480,6 +481,11 @@ export const ldapConfigServiceFactory = ({
     const organization = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
     if (!organization) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
 
+    // When the org enforces SSO, the verified domain + IdP are authoritative, so we skip the
+    // separate email-verification step (the email-domain ownership check above already proves the
+    // org owns this domain, and password signup is blocked for enforced domains).
+    const skipEmailVerification = Boolean(organization.authEnforced);
+
     if (userAlias) {
       // Verify the existing user's stored email domain + cross-org check
       const existingUser = await userDAL.findOne({ id: userAlias.userId });
@@ -539,7 +545,9 @@ export const ldapConfigServiceFactory = ({
               firstName,
               lastName,
               authMethods: [],
-              isGhost: false
+              isGhost: false,
+              isEmailVerified: skipEmailVerification,
+              isAccepted: skipEmailVerification
             },
             tx
           );
@@ -553,7 +561,8 @@ export const ldapConfigServiceFactory = ({
             aliasType: UserAliasType.LDAP,
             externalId,
             emails: [sanitizedEmail],
-            orgId
+            orgId,
+            isEmailVerified: skipEmailVerification
           },
           tx
         );
@@ -611,7 +620,7 @@ export const ldapConfigServiceFactory = ({
     }
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
-    const user = await userDAL.transaction(async (tx) => {
+    let user = await userDAL.transaction(async (tx) => {
       const newUser = await userDAL.findOne({ id: userAlias.userId }, tx);
       if (groups) {
         const ldapGroupIdsToBePartOf = (
@@ -689,6 +698,11 @@ export const ldapConfigServiceFactory = ({
 
       return newUser;
     });
+
+    // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
+    if (skipEmailVerification) {
+      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+    }
 
     if (user.email && !userAlias.isEmailVerified) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -701,7 +701,13 @@ export const ldapConfigServiceFactory = ({
 
     // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
     if (skipEmailVerification) {
-      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+      ({ user, userAlias } = await ensureSsoAccountVerified({
+        user,
+        userAlias,
+        assertedEmail: sanitizedEmail,
+        userDAL,
+        userAliasDAL
+      }));
     }
 
     if (user.email && !userAlias.isEmailVerified) {

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -46,7 +46,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
-import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
+import { ensureSsoAccountVerified, isStaleSsoAlias } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -223,6 +223,11 @@ export const oidcConfigServiceFactory = ({
     const skipEmailVerification = Boolean(organization.authEnforced);
 
     let user: TUsers;
+    // A stale, still-unverified alias may point at another user's account. Don't mutate that
+    // account's org membership / group state until the IdP proves control of it (the
+    // email-verification fallback below issues no session). Resolved against the existing alias
+    // before any mutation; freshly created aliases are never stale.
+    let isStaleAlias = false;
     if (userAlias) {
       user = await userDAL.transaction(async (tx) => {
         const foundUser = await userDAL.findById(userAlias.userId, tx);
@@ -232,6 +237,11 @@ export const oidcConfigServiceFactory = ({
           orgId,
           emailDomainDAL
         });
+        isStaleAlias = isStaleSsoAlias({ user: foundUser, userAlias, assertedEmail: sanitizedEmail });
+        if (isStaleAlias) {
+          return foundUser;
+        }
+
         const [orgMembership] = await orgDAL.findMembership(
           {
             [`${TableName.Membership}.actorUserId` as "actorUserId"]: userAlias.userId,
@@ -360,7 +370,7 @@ export const oidcConfigServiceFactory = ({
       }
     }
 
-    if (manageGroupMemberships) {
+    if (manageGroupMemberships && !isStaleAlias) {
       const userGroups = await userGroupMembershipDAL.findGroupMembershipsByUserIdInOrg(user.id, orgId);
       const orgGroups = await groupDAL.findByOrgId(orgId);
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -443,7 +443,13 @@ export const oidcConfigServiceFactory = ({
 
     // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
     if (skipEmailVerification) {
-      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+      ({ user, userAlias } = await ensureSsoAccountVerified({
+        user,
+        userAlias,
+        assertedEmail: sanitizedEmail,
+        userDAL,
+        userAliasDAL
+      }));
     }
 
     if (user.email && !userAlias.isEmailVerified) {

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -46,6 +46,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
+import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -71,7 +72,7 @@ type TOidcConfigServiceFactoryDep = {
     | "find"
     | "transaction"
   >;
-  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne" | "updateById">;
   orgDAL: Pick<
     TOrgDALFactory,
     "createMembership" | "updateMembershipById" | "findMembership" | "findOrgById" | "findOne" | "updateById"
@@ -216,6 +217,11 @@ export const oidcConfigServiceFactory = ({
     const organization = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
     if (!organization) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
 
+    // When the org enforces SSO, the verified domain + IdP are authoritative, so we skip the
+    // separate email-verification step (the email-domain ownership check above already proves the
+    // org owns this domain, and password signup is blocked for enforced domains).
+    const skipEmailVerification = Boolean(organization.authEnforced);
+
     let user: TUsers;
     if (userAlias) {
       user = await userDAL.transaction(async (tx) => {
@@ -281,7 +287,9 @@ export const oidcConfigServiceFactory = ({
               username: sanitizedEmail,
               lastName,
               authMethods: [],
-              isGhost: false
+              isGhost: false,
+              isEmailVerified: skipEmailVerification,
+              isAccepted: skipEmailVerification
             },
             tx
           );
@@ -294,7 +302,8 @@ export const oidcConfigServiceFactory = ({
             aliasType: UserAliasType.OIDC,
             externalId,
             emails: sanitizedEmail ? [sanitizedEmail] : [],
-            orgId
+            orgId,
+            isEmailVerified: skipEmailVerification
           },
           tx
         );
@@ -431,6 +440,11 @@ export const oidcConfigServiceFactory = ({
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
     await oidcConfigDAL.update({ orgId }, { lastUsed: new Date() });
+
+    // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
+    if (skipEmailVerification) {
+      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+    }
 
     if (user.email && !userAlias.isEmailVerified) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -40,7 +40,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
-import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
+import { ensureSsoAccountVerified, isStaleSsoAlias } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -566,7 +566,16 @@ export const samlConfigServiceFactory = ({
         orgId,
         emailDomainDAL
       });
+      // A stale, still-unverified alias may point at another user's account. Don't mutate that
+      // account's org membership / identity metadata / group state until the IdP proves control of
+      // it (the email-verification fallback below issues no session). This guard must run before the
+      // mutations, not just before ensureSsoAccountVerified at the end.
+      const isStaleAlias = isStaleSsoAlias({ user: foundUser, userAlias, assertedEmail: sanitizedEmail });
       user = await userDAL.transaction(async (tx) => {
+        if (isStaleAlias) {
+          return foundUser;
+        }
+
         const [orgMembership] = await orgDAL.findMembership(
           {
             [`${TableName.Membership}.actorUserId` as "actorUserId"]: userAlias.userId,

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -749,7 +749,13 @@ export const samlConfigServiceFactory = ({
 
     // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
     if (skipEmailVerification) {
-      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+      ({ user, userAlias } = await ensureSsoAccountVerified({
+        user,
+        userAlias,
+        assertedEmail: sanitizedEmail,
+        userDAL,
+        userAliasDAL
+      }));
     }
 
     if (user.email && !userAlias.isEmailVerified) {

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -40,6 +40,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
+import { ensureSsoAccountVerified } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -69,7 +70,7 @@ type TSamlConfigServiceFactoryDep = {
     | "findUserEncKeyByUserId"
     | "findUserEncKeyByUserIdsBatch"
   >;
-  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "create" | "findOne" | "updateById">;
   orgDAL: Pick<
     TOrgDALFactory,
     "createMembership" | "updateMembershipById" | "findMembership" | "findOrgById" | "findOne" | "updateById"
@@ -545,6 +546,11 @@ export const samlConfigServiceFactory = ({
     const organization = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
     if (!organization) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
 
+    // When the org enforces SSO, the verified domain + IdP are authoritative, so we skip the
+    // separate email-verification step (the email-domain ownership check above already proves the
+    // org owns this domain, and password signup is blocked for enforced domains).
+    const skipEmailVerification = Boolean(organization.authEnforced);
+
     const samlConfig = await samlConfigDAL.findOne({ orgId });
     const groupsMetadata = metadata?.find(({ key }) => key === "groups");
 
@@ -636,7 +642,8 @@ export const samlConfigServiceFactory = ({
             {
               username: sanitizedEmail,
               email: sanitizedEmail,
-              isEmailVerified: false,
+              isEmailVerified: skipEmailVerification,
+              isAccepted: skipEmailVerification,
               firstName,
               lastName,
               authMethods: [],
@@ -654,7 +661,7 @@ export const samlConfigServiceFactory = ({
             externalId,
             emails: sanitizedEmail ? [sanitizedEmail] : [],
             orgId,
-            isEmailVerified: false
+            isEmailVerified: skipEmailVerification
           },
           tx
         );
@@ -739,6 +746,11 @@ export const samlConfigServiceFactory = ({
     await licenseService.updateSubscriptionOrgMemberCount(organization.id);
 
     await samlConfigDAL.update({ orgId }, { lastUsed: new Date() });
+
+    // When SSO is enforced, mark the user + alias as verified/accepted before issuing a session.
+    if (skipEmailVerification) {
+      ({ user, userAlias } = await ensureSsoAccountVerified({ user, userAlias, userDAL, userAliasDAL }));
+    }
 
     if (user.email && !userAlias.isEmailVerified) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1182,7 +1182,8 @@ export const registerRoutes = async (
     userAliasDAL,
     orgDAL,
     orgService,
-    loginService
+    loginService,
+    emailDomainDAL
   });
 
   const microsoftTeamsService = microsoftTeamsServiceFactory({

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -1,4 +1,6 @@
 import { AccessScope, OrgMembershipStatus } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
+import { findOrgIdByVerifiedDomain } from "@app/ee/services/email-domain/email-domain-fns";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
@@ -27,6 +29,7 @@ type TAuthSignupDep = {
   tokenService: TAuthTokenServiceFactory;
   smtpService: TSmtpService;
   loginService: Pick<TAuthLoginFactory, "generateUserTokens">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "findOne">;
 };
 
 const DUMMY_USER_ID = "00000000-0000-0000-0000-000000000000";
@@ -40,7 +43,8 @@ export const authSignupServiceFactory = ({
   smtpService,
   orgService,
   orgDAL,
-  loginService
+  loginService,
+  emailDomainDAL
 }: TAuthSignupDep) => {
   // First step of signup to send OTP email
   const beginEmailSignupProcess = async (email: string): Promise<{ cooldownSeconds: number }> => {
@@ -49,6 +53,23 @@ export const authSignupServiceFactory = ({
     const isEmailInvalid = await isDisposableEmail(sanitizedEmail);
     if (isEmailInvalid) {
       throw new Error("Provided a disposable email");
+    }
+
+    // Block email/password signup for domains owned by an org that enforces SSO. The org's verified
+    // domain + IdP are authoritative, so allowing a competing password account would reopen an
+    // account-takeover vector. Domain ownership isn't secret, so surfacing this is acceptable.
+    const emailDomain = sanitizedEmail.split("@")?.[1];
+    if (emailDomain) {
+      const verifiedDomain = await findOrgIdByVerifiedDomain({ domain: emailDomain, emailDomainDAL });
+      if (verifiedDomain?.orgId) {
+        const org = await orgDAL.findById(verifiedDomain.orgId);
+        if (org?.authEnforced) {
+          throw new BadRequestError({
+            message:
+              "Your organization requires single sign-on. Please sign in through your identity provider instead of email and password."
+          });
+        }
+      }
     }
 
     // Acquire cooldown before any operation to avoid reliable enumeration oracle

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -55,6 +55,10 @@ export const authSignupServiceFactory = ({
       throw new Error("Provided a disposable email");
     }
 
+    // Acquire cooldown before any operation to avoid reliable enumeration oracle and to throttle the
+    // unauthenticated DB queries below (e.g. the SSO-enforced domain lookup).
+    const { emailHash, cooldownSeconds } = await tokenService.acquireEmailSignupCooldown(sanitizedEmail);
+
     // Block email/password signup for domains owned by an org that enforces SSO. The org's verified
     // domain + IdP are authoritative, so allowing a competing password account would reopen an
     // account-takeover vector. Domain ownership isn't secret, so surfacing this is acceptable.
@@ -71,9 +75,6 @@ export const authSignupServiceFactory = ({
         }
       }
     }
-
-    // Acquire cooldown before any operation to avoid reliable enumeration oracle
-    const { emailHash, cooldownSeconds } = await tokenService.acquireEmailSignupCooldown(sanitizedEmail);
 
     // Case sensitive email resolution
     const existingUser = await userDAL.findOne({ username: sanitizedEmail });

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -6,6 +6,7 @@ import { TUserAliasDALFactory } from "./user-alias-dal";
 type TEnsureSsoAccountVerifiedDTO = {
   user: TUsers;
   userAlias: TUserAliases;
+  assertedEmail: string;
   userDAL: Pick<TUserDALFactory, "transaction" | "updateById">;
   userAliasDAL: Pick<TUserAliasDALFactory, "updateById">;
 };
@@ -16,15 +17,35 @@ type TEnsureSsoAccountVerifiedDTO = {
  * issued, covering accounts provisioned before enforcement was enabled as well as freshly created
  * ones. No-op when everything is already verified. Returns the (possibly updated) records so the
  * caller can keep its in-memory copies in sync.
+ *
+ * Anti-stale-alias guard: the legacy SSO flow persisted aliases before email verification
+ * completed, so an unverified alias may point at a different user's account. We therefore only
+ * promote an as-yet-unverified alias when the email asserted by the IdP in this login matches the
+ * aliased account's known emails. Otherwise we return the records unchanged so the caller falls
+ * back to the email-verification flow (no session is issued). Once an alias is already verified it
+ * is trusted, so the user record is still accepted without re-checking the email.
  */
 export const ensureSsoAccountVerified = async ({
   user,
   userAlias,
+  assertedEmail,
   userDAL,
   userAliasDAL
 }: TEnsureSsoAccountVerifiedDTO): Promise<{ user: TUsers; userAlias: TUserAliases }> => {
   if (userAlias.isEmailVerified && user.isAccepted && user.isEmailVerified) {
     return { user, userAlias };
+  }
+
+  if (!userAlias.isEmailVerified) {
+    const normalizedAssertedEmail = assertedEmail?.toLowerCase().trim();
+    const accountEmails = new Set(
+      [user.username, user.email, ...(userAlias.emails ?? [])]
+        .filter((email): email is string => Boolean(email))
+        .map((email) => email.toLowerCase().trim())
+    );
+    if (!normalizedAssertedEmail || !accountEmails.has(normalizedAssertedEmail)) {
+      return { user, userAlias };
+    }
   }
 
   await userDAL.transaction(async (tx) => {

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -1,0 +1,43 @@
+import { TUserAliases, TUsers } from "@app/db/schemas";
+
+import { TUserDALFactory } from "../user/user-dal";
+import { TUserAliasDALFactory } from "./user-alias-dal";
+
+type TEnsureSsoAccountVerifiedDTO = {
+  user: TUsers;
+  userAlias: TUserAliases;
+  userDAL: Pick<TUserDALFactory, "transaction" | "updateById">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "updateById">;
+};
+
+/**
+ * When an org enforces SSO, the verified domain + IdP are authoritative, so we skip the separate
+ * email-verification step. This marks the user + alias as verified/accepted before a session is
+ * issued, covering accounts provisioned before enforcement was enabled as well as freshly created
+ * ones. No-op when everything is already verified. Returns the (possibly updated) records so the
+ * caller can keep its in-memory copies in sync.
+ */
+export const ensureSsoAccountVerified = async ({
+  user,
+  userAlias,
+  userDAL,
+  userAliasDAL
+}: TEnsureSsoAccountVerifiedDTO): Promise<{ user: TUsers; userAlias: TUserAliases }> => {
+  if (userAlias.isEmailVerified && user.isAccepted && user.isEmailVerified) {
+    return { user, userAlias };
+  }
+
+  await userDAL.transaction(async (tx) => {
+    if (!userAlias.isEmailVerified) {
+      await userAliasDAL.updateById(userAlias.id, { isEmailVerified: true }, tx);
+    }
+    if (!user.isAccepted || !user.isEmailVerified) {
+      await userDAL.updateById(user.id, { isAccepted: true, isEmailVerified: true }, tx);
+    }
+  });
+
+  return {
+    user: { ...user, isAccepted: true, isEmailVerified: true },
+    userAlias: { ...userAlias, isEmailVerified: true }
+  };
+};

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -11,6 +11,34 @@ type TEnsureSsoAccountVerifiedDTO = {
   userAliasDAL: Pick<TUserAliasDALFactory, "updateById">;
 };
 
+type TIsStaleSsoAliasDTO = {
+  user: Pick<TUsers, "username" | "email">;
+  userAlias: Pick<TUserAliases, "isEmailVerified" | "emails">;
+  assertedEmail: string;
+};
+
+/**
+ * The legacy SSO flow persisted aliases before email verification completed, so an as-yet-unverified
+ * alias may point at a different user's account. Such an alias is "stale" when the email asserted by
+ * the IdP in this login does not match any of the aliased account's known emails — i.e. the IdP has
+ * not proven control of the aliased account. Callers must not provision org membership, identity
+ * metadata, or group memberships onto that account (nor issue a session for it) until ownership is
+ * proven via the separate email-verification flow. A verified alias is already trusted, so it is
+ * never considered stale.
+ */
+export const isStaleSsoAlias = ({ user, userAlias, assertedEmail }: TIsStaleSsoAliasDTO): boolean => {
+  if (userAlias.isEmailVerified) return false;
+
+  const normalizedAssertedEmail = assertedEmail?.toLowerCase().trim();
+  const accountEmails = new Set(
+    [user.username, user.email, ...(userAlias.emails ?? [])]
+      .filter((email): email is string => Boolean(email))
+      .map((email) => email.toLowerCase().trim())
+  );
+
+  return !normalizedAssertedEmail || !accountEmails.has(normalizedAssertedEmail);
+};
+
 /**
  * When an org enforces SSO, the verified domain + IdP are authoritative, so we skip the separate
  * email-verification step. This marks the user + alias as verified/accepted before a session is
@@ -36,16 +64,10 @@ export const ensureSsoAccountVerified = async ({
     return { user, userAlias };
   }
 
-  if (!userAlias.isEmailVerified) {
-    const normalizedAssertedEmail = assertedEmail?.toLowerCase().trim();
-    const accountEmails = new Set(
-      [user.username, user.email, ...(userAlias.emails ?? [])]
-        .filter((email): email is string => Boolean(email))
-        .map((email) => email.toLowerCase().trim())
-    );
-    if (!normalizedAssertedEmail || !accountEmails.has(normalizedAssertedEmail)) {
-      return { user, userAlias };
-    }
+  // A still-unverified alias whose asserted email doesn't match the aliased account is stale and
+  // must not be promoted — the caller falls back to the email-verification flow (no session issued).
+  if (isStaleSsoAlias({ user, userAlias, assertedEmail })) {
+    return { user, userAlias };
   }
 
   await userDAL.transaction(async (tx) => {

--- a/docs/documentation/platform/email-domain.mdx
+++ b/docs/documentation/platform/email-domain.mdx
@@ -171,7 +171,11 @@ When [SCIM provisioning](/documentation/platform/scim/overview) is enabled, emai
 
 <Accordion title="Do I need to verify domains for email/password login?">
   No. Email domain verification is required only for SSO (SAML, OIDC, LDAP) and
-  SCIM provisioning flows. Email/password login is not affected.
+  SCIM provisioning flows.
+
+  Note, however, that if your organization [enforces SSO](/documentation/platform/sso/overview#sso-enforcement),
+  email & password signup is blocked for your verified domain(s) — new password
+  accounts can no longer be created for addresses on those domains.
 </Accordion>
 
 <Accordion title="Does verifying a parent domain cover all subdomains?">

--- a/docs/documentation/platform/sso/overview.mdx
+++ b/docs/documentation/platform/sso/overview.mdx
@@ -44,6 +44,17 @@ If your required identity provider is not shown in the list above, please reach 
   For enhanced security, Infisical enforces PKCE (Proof Key for Code Exchange) with the OAuth 2.0-based SSO providers and OIDC. This provides additional protection against authorization code interception attacks and strengthens your authentication flow security.
 </Info>
 
+## SSO Enforcement
+
+When you enforce SAML or OIDC SSO for your organization, members can only access Infisical by logging in through your identity provider. Enforcement has two additional effects tied to your [verified email domain(s)](/documentation/platform/email-domain):
+
+- **Email & password signup is blocked for your verified domain(s).** Once SSO is enforced, new email/password accounts can no longer be created for addresses on your verified domain(s). The verified domain and IdP are authoritative, so allowing a competing password account would reopen an account-takeover vector.
+- **Email verification is skipped for SSO sign-ins.** Because the verified domain and IdP already prove ownership of the email, Infisical skips the additional email-verification step that normally applies to SSO logins (see the FAQ below).
+
+<Warning>
+  Before enforcing SSO, make sure a break-glass organization admin already has a password and SSO bypass access. After enforcement is enabled, the signup block prevents creating new password accounts for the domain.
+</Warning>
+
 ## SSO Break Glass
 
 In the event your SSO provider experiences downtime, and you need to access Infisical, Organization Admins can utilize the Admin Login Portal to bypass SSO enforcement.
@@ -66,6 +77,8 @@ This portal is accessible at `/login/admin` (e.g., https://app.infisical.com/log
 
         If you're running a self-hosted instance of Infisical and would like it to trust emails from external identity providers,
         you can configure this behavior in the Server Admin Console.
+
+        This additional verification step is also skipped when your organization [enforces SSO](#sso-enforcement) for a [verified email domain](/documentation/platform/email-domain), since the verified domain and IdP are already authoritative for that email.
     </Accordion>
     <Accordion title="Why do I get redirected to SSO when trying to use the Admin Login Portal?">
         You are likely being redirected because you do not have email authentication mode enabled, or you're not an **Organization Admin**. This portal requires **Organization Admin** status and direct credential login (email and password). **Server Admin** status alone is insufficient.

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
@@ -140,7 +140,7 @@ export const OrgGeneralAuthSection = ({
       }
 
       if (value) {
-        setBypassEnabledInModal(currentOrg?.bypassOrgAuthEnabled ?? false);
+        setBypassEnabledInModal(true);
         setEnforcementTypeInModal(EnforceAuthType.SAML);
         handlePopUpOpen("enforceSamlSsoConfirmation");
         return;
@@ -165,7 +165,7 @@ export const OrgGeneralAuthSection = ({
       }
 
       if (value) {
-        setBypassEnabledInModal(currentOrg?.bypassOrgAuthEnabled ?? false);
+        setBypassEnabledInModal(true);
         setEnforcementTypeInModal(EnforceAuthType.GOOGLE);
         handlePopUpOpen("enforceSamlSsoConfirmation");
         return;

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgGeneralAuthSection.tsx
@@ -253,7 +253,10 @@ export const OrgGeneralAuthSection = ({
             >
               <FieldContent>
                 <FieldTitle>Enforce SAML SSO</FieldTitle>
-                <FieldDescription>Only allow members to sign in via SAML.</FieldDescription>
+                <FieldDescription>
+                  Only allow members to sign in via SAML. Also disables email & password signup for
+                  your verified domain(s) and skips email verification for SSO sign-ins.
+                </FieldDescription>
               </FieldContent>
               <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
                 {(isAllowed) => (
@@ -276,7 +279,10 @@ export const OrgGeneralAuthSection = ({
             >
               <FieldContent>
                 <FieldTitle>Enforce OIDC SSO</FieldTitle>
-                <FieldDescription>Only allow members to sign in via OIDC.</FieldDescription>
+                <FieldDescription>
+                  Only allow members to sign in via OIDC. Also disables email & password signup for
+                  your verified domain(s) and skips email verification for SSO sign-ins.
+                </FieldDescription>
               </FieldContent>
               <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
                 {(isAllowed) => (
@@ -411,6 +417,14 @@ export const OrgGeneralAuthSection = ({
                 Before proceeding, ensure your {enforcementLabel} provider is available and properly
                 configured to avoid access issues.
               </p>
+              {enforcementTypeInModal !== EnforceAuthType.GOOGLE && (
+                <p>
+                  This also disables email & password signup for your verified domain(s) and skips
+                  email verification for SSO sign-ins. Make sure a break-glass admin already has a
+                  password and SSO bypass access before continuing — the signup block prevents
+                  creating new password accounts for the domain afterwards.
+                </p>
+              )}
             </AlertDescription>
           </Alert>
 


### PR DESCRIPTION
## Context

  What

  When an organization enforces SAML/OIDC SSO (authEnforced), SSO logins now provision and sign in users directly without the extra email-verification step, and email/password signup is blocked for that org's verified domain(s).

  Why

  When SSO is enforced, the org's DNS-verified domain plus the IdP are already authoritative proof of email ownership, so the separate verification code is redundant friction. Blocking password signup for those domains also closes an account-takeover vector, a competing password account can no longer be created for a domain the org owns and federates.

  Changes

  - SAML / OIDC / LDAP login (*-config-service.ts): when org.authEnforced, create new users as isAccepted/isEmailVerified and skip sending the verification
  email. A shared ensureSsoAccountVerified helper also upgrades pre-existing accounts (provisioned before enforcement) on next SSO login.
  - Signup (auth-signup-service.ts): beginEmailSignupProcess rejects email/password signup when the email's domain is verified by an SSO-enforced org.
  - Frontend (OrgGeneralAuthSection.tsx): clarified the enforce-SSO copy and added a break-glass warning in the confirmation modal (non-Google).
  - Test: e2e spec covering both the SSO-session-without-verification path and the blocked password signup.

  Notes

  - Only applies to SAML/OIDC enforcement — Google SSO enforcement (googleSsoAuthEnforced, mutually exclusive) is untouched.
  - Password login for enforced orgs was already blocked; this extends the same guarantee to signup.
  - ⚠️ Admins should ensure a break-glass account exists before enabling, since password signup for the domain is blocked afterward (surfaced in the modal
  warning).

## Screenshots

<img width="854" height="798" alt="Screenshot 2026-05-31 at 20 12 56" src="https://github.com/user-attachments/assets/7f2c6506-3247-4c39-b530-8a141db4a9ad" />
<img width="1217" height="609" alt="Screenshot 2026-05-31 at 22 52 47" src="https://github.com/user-attachments/assets/dc66686f-8cde-4308-ad90-e2449928e3c0" />
<img width="1102" height="683" alt="Screenshot 2026-05-31 at 22 56 09" src="https://github.com/user-attachments/assets/57830afd-3824-4c08-bc47-f412868b169a" />
<img width="702" height="382" alt="Screenshot 2026-05-31 at 22 58 11" src="https://github.com/user-attachments/assets/61f40846-2ec3-44ac-be0e-c4277a70a116" />



## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)