### PR TITLE
fix(saml): guard JSON.parse on attacker-controlled RelayState

### DIFF
--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -97,8 +97,19 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
               // Setting wantAuthnResponseSigned to false allows both "Sign SAML assertion" and
               // "Sign SAML response and assertion" configurations to work.
               samlConfig.wantAuthnResponseSigned = false;
-              if (req.body?.RelayState && JSON.parse(req.body.RelayState).spInitiated) {
-                samlConfig.audience = `spn:${ssoConfig.issuer}`;
+              // RelayState is attacker-controlled — wrap the JSON.parse so a malformed value
+              // doesn't crash the auth flow with a 500. Mirrors the defensive shape used
+              // for callbackPort parsing below (1KB cap + try/catch + log-and-fall-through).
+              const relayState =
+                typeof req?.body === "object" ? (req.body as { RelayState?: string })?.RelayState : undefined;
+              if (relayState && Buffer.byteLength(relayState) <= 1024) {
+                try {
+                  if ((JSON.parse(relayState) as { spInitiated?: boolean })?.spInitiated) {
+                    samlConfig.audience = `spn:${ssoConfig.issuer}`;
+                  }
+                } catch (err) {
+                  logger.error(err, "RelayState parsing failed in SAML config");
+                }
               }
             }
             if (


### PR DESCRIPTION
## Context

Closes #6688.

The Azure SAML branch of \`getSamlOptions\` in \`backend/src/ee/routes/v1/saml-router.ts\` called \`JSON.parse(req.body.RelayState)\` with no try/catch:

\`\`\`ts
if (req.body?.RelayState && JSON.parse(req.body.RelayState).spInitiated) {
  samlConfig.audience = \`spn:\${ssoConfig.issuer}\`;
}
\`\`\`

\`RelayState\` is attacker-controlled. A malformed value (e.g. \`RelayState=not-json\` on the POST that triggers \`getSamlOptions\`) raises a \`SyntaxError\` caught only by the outer try/catch, which calls \`done(error)\` and surfaces as a 500 — enough for a remote attacker to disrupt SAML SSO for a tenant by sending one bad request.

The neighbouring callback (line ~165) already parses \`RelayState\` defensively for \`callbackPort\` extraction: type-checked \`req.body\`, 1KB \`Buffer.byteLength\` cap, \`try/catch\` with \`logger.error\` log-and-fall-through. This PR mirrors that exact shape for the audience override so the two parse sites can't drift apart, and so \`spInitiated\` falls back to \`false\` (the safe default) when the input is malformed.

## Type

- [x] Fix

## Steps to verify the change

1. Configure an Azure SAML SSO provider.
2. \`curl -X POST https://<host>/api/v1/sso/saml2/<configId> -d 'RelayState=not-valid-json' -H 'Content-Type: application/x-www-form-urlencoded'\`.
3. Before this fix: SAML auth fails with a 500.
4. After this fix: \`samlConfig.audience\` falls back to the default (\`appCfg.SITE_URL\`) and the auth flow proceeds; the parse failure is logged via \`logger.error(err, "RelayState parsing failed in SAML config")\`.
5. Well-formed \`RelayState=%7B%22spInitiated%22%3Atrue%7D\` still flips \`samlConfig.audience\` to \`spn:<issuer>\` as before.

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally — manual repro per the steps above; existing SAML auth tests unaffected (no behavioural change for valid inputs)
- [ ] Updated docs (no docs change — the RelayState protocol contract is unchanged for valid inputs)
- [ ] Updated CLAUDE.md files (no architectural shift)
- [x] Read the contributing guide