### PR TITLE
fix(dynamic-secret): add SSRF host validation to LDAP provider

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -11,6 +11,7 @@ import { sanitizeString } from "@app/lib/fn";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
+import { verifyHostInputValidity } from "../dynamic-secret-fns";
 import { LdapCredentialType, LdapSchema, TDynamicProviderFns } from "./models";
 import { generateUsername } from "./templateUtils";
 
@@ -73,6 +74,24 @@ export const LdapProvider = (): TDynamicProviderFns => {
   };
 
   const $getClient = async (providerInputs: z.infer<typeof LdapSchema>): Promise<ldapjs.Client> => {
+    // SSRF guard — every other dynamic-secret provider (redis, mongo, sql,
+    // azure-sql, elastic-search, clickhouse, vertica, sap-ase, …) calls
+    // verifyHostInputValidity before opening the network connection so that
+    // operators with permission to configure a dynamic secret can't point
+    // Infisical at an internal LDAP server. Mirror that here.
+    let ldapHost: string;
+    try {
+      ldapHost = new URL(providerInputs.url).hostname;
+    } catch {
+      throw new BadRequestError({
+        message: "Invalid LDAP URL. Expected ldap:// or ldaps:// with a parseable host."
+      });
+    }
+    if (!ldapHost) {
+      throw new BadRequestError({ message: "Invalid LDAP URL. Missing host." });
+    }
+    await verifyHostInputValidity({ host: ldapHost, isDynamicSecret: true });
+
     return new Promise((resolve, reject) => {
       const client = ldapjs.createClient({
         url: providerInputs.url,


### PR DESCRIPTION
## Context

Closes #6687.

The LDAP dynamic-secret provider in \`backend/src/ee/services/dynamic-secret/providers/ldap.ts\` was the only provider that handed a user-supplied host straight to a network client without running it through \`verifyHostInputValidity\` first. Every other provider — \`redis.ts\`, \`mongo.ts\`, \`sql-database.ts\`, \`azure-sql-database.ts\`, \`elastic-search.ts\`, \`clickhouse.ts\`, \`vertica.ts\`, \`sap-ase.ts\`, etc. — gates its host through that helper, which blocks:

- Private IP addresses (e.g. \`10.0.0.0/8\`, \`172.16.0.0/12\`, \`192.168.0.0/16\`) unless \`DYNAMIC_SECRET_ALLOW_INTERNAL_IP\` is set.
- \`localhost\` and \`host.docker.internal\`.
- Any host whose resolved IP overlaps with Infisical's own DB / Redis / ClickHouse infrastructure.

Without it, an operator with permission to configure a dynamic secret could point the backend at an internal LDAP server — using Infisical as a network proxy / SSRF reflector.

## Changes

\`backend/src/ee/services/dynamic-secret/providers/ldap.ts\`:

- Inside \`\$getClient\` (which is the single chokepoint for \`validateProviderInputs\`, \`validateConnection\`, \`create\`, \`revoke\` and \`renew\`), parse \`providerInputs.url\` with \`new URL()\` and extract the hostname. If the URL doesn't parse or has no host, throw \`BadRequestError\` — better than letting \`ldapjs\` fail mid-handshake.
- Call \`await verifyHostInputValidity({ host: ldapHost, isDynamicSecret: true })\` before \`ldapjs.createClient\`. The LDAP schema doesn't carry gateway fields, so no \`isGateway\` flag is needed.

## Type

- [x] Fix

## Steps to verify the change

1. Spin up a dev instance with default config (\`DYNAMIC_SECRET_ALLOW_INTERNAL_IP\` unset).
2. Try to create an LDAP dynamic secret with \`url: "ldap://10.0.0.1:389"\`. Expected: \`BadRequestError\` with the standard "Private IP addresses are not allowed" message — same wording every other provider already produces.
3. Try \`url: "ldap://localhost:389"\` — same rejection.
4. Try \`url: "not a url"\` — \`BadRequestError\` "Invalid LDAP URL".
5. With \`DYNAMIC_SECRET_ALLOW_INTERNAL_IP=true\`, every case from step 2-3 succeeds again (back-compat for self-hosters who intentionally point at internal LDAP).
6. A public LDAP host continues to work unchanged.

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally — manual repro per the steps above
- [ ] Updated docs (no docs change — the LDAP provider's public configuration surface is unchanged for valid inputs)
- [ ] Updated CLAUDE.md files (no architectural shift)
- [x] Read the contributing guide