### PR TITLE
fix(auth): reject non-JWT 4+ segment tokens in peekJWTClaims

### DIFF
--- a/backend-go/internal/services/auth/apiauth/classify.go
+++ b/backend-go/internal/services/auth/apiauth/classify.go
@@ -44,8 +44,12 @@ func ClassifyToken(token string) auth.AuthMode {
 // peekJWTClaims decodes the JWT payload segment (no signature verification)
 // to inspect the authTokenType claim.
 func peekJWTClaims(token string) peekClaims {
-	parts := strings.SplitN(token, ".", 4)
-	if len(parts) < 3 {
+	// A valid JWT has exactly three dot-separated segments (header.payload.signature).
+	// SplitN(..., 4) used to collapse 4+ segments into a single trailing element,
+	// which let tokens like "a.b.c.d" through with a usable parts[1]. Use unlimited
+	// Split + an exact-3 check so anything else is rejected up front.
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
 		return peekClaims{}
 	}
 

--- a/backend-go/internal/services/auth/apiauth/classify_test.go
+++ b/backend-go/internal/services/auth/apiauth/classify_test.go
@@ -69,6 +69,23 @@ func TestClassifyToken_VariousInputTypes(t *testing.T) {
 		}
 	})
 
+	// Regression: peekJWTClaims used SplitN(..., 4) + len(parts) < 3, which
+	// let 4+ segment tokens through because SplitN collapses the tail into
+	// the final element. A non-JWT four-segment token with a valid-looking
+	// middle segment got classified as a JWT and decoded.
+	// @see https://github.com/Infisical/infisical/issues/6651
+	t.Run("four-segment token is not classified as JWT", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+		payload, _ := json.Marshal(map[string]any{"authTokenType": string(auth.AuthTokenTypeAccessToken)})
+		payloadEnc := base64.RawURLEncoding.EncodeToString(payload)
+		// header.payload.signature.extra — four dot-separated segments.
+		token := header + "." + payloadEnc + ".sig.extra"
+		mode := ClassifyToken(token)
+		if mode != "" {
+			t.Errorf("expected empty (4-segment token rejected), got %q", mode)
+		}
+	})
+
 	t.Run("JWT with invalid base64 payload returns empty", func(t *testing.T) {
 		mode := ClassifyToken("header.!!!invalid!!!.signature")
 		if mode != "" {


### PR DESCRIPTION
## Context

Closes #6651.

\`peekJWTClaims\` in \`backend-go/internal/services/auth/apiauth/classify.go\` used:

\`\`\`go
parts := strings.SplitN(token, ".", 4)
if len(parts) < 3 {
    return peekClaims{}
}
\`\`\`

\`SplitN(s, sep, 4)\` returns **at most** 4 elements; anything past the third \`.\` is folded into the last element. So a four-segment token like \`a.b.c.d\` came back as \`["a", "b", "c.d"]\` — three parts — and passed the \`< 3\` gate. The function then base64-decoded \`parts[1]\` and \`json.Unmarshal\`ed it. If a non-JWT input happens to have a JWT-looking middle segment, the function returned a populated \`peekClaims\` and \`ClassifyToken\` treated the token as a JWT.

## Changes

\`backend-go/internal/services/auth/apiauth/classify.go\`:
- Drop \`SplitN\`'s collapsing-tail behaviour: switch to plain \`strings.Split\` so all segments stay separate.
- Require **exactly three** parts (\`len(parts) != 3\` returns empty), matching the RFC 7519 JWT shape.
- Add an inline comment explaining the pitfall so this doesn't regress under a future "performance" sweep.

## Type

- [x] Fix

## Steps to verify the change

- \`cd backend-go && go test ./internal/services/auth/apiauth/ -run TestClassifyToken\` passes both the existing cases and the new regression case.
- The new \`four-segment token is not classified as JWT\` subtest constructs a header + payload + signature + extra suffix and asserts \`ClassifyToken\` returns the empty \`AuthMode\` (the rejection sentinel).
- Verified the new subtest fails on \`main\` (\`expected empty (4-segment token rejected), got "jwt"\`) and passes after the change.

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally — Go unit tests pass, new regression case fails on main
- [ ] Updated docs (no public API change)
- [ ] Updated CLAUDE.md files (no architectural shift)
- [x] Read the contributing guide