### PR TITLE
pki sync jobs get stuck when two run at the same time

### DIFF
--- a/backend/src/services/pki-sync/pki-sync-queue.ts
+++ b/backend/src/services/pki-sync/pki-sync-queue.ts
@@ -865,6 +865,10 @@ export const pkiSyncQueueFactory = ({
         5 * 60 * 1000
       );
     } catch (e) {
+      if (job.name === QueueJobs.PkiSyncSyncCertificates) {
+        await $releaseConnectionConcurrency(connectionId);
+      }
+
       await $handleAcquireLockFailure(job as PkiSyncActionJob);
 
       return;

--- a/backend/src/services/pki-sync/pki-sync-queue.ts
+++ b/backend/src/services/pki-sync/pki-sync-queue.ts
@@ -83,6 +83,7 @@ const JITTER_MS = 10 * 1000;
 const REQUEUE_MS = 30 * 1000;
 const REQUEUE_LIMIT = 30;
 const CONNECTION_CONCURRENCY_LIMIT = 3;
+const CONNECTION_CONCURRENCY_TTL_SECONDS = (REQUEUE_MS * REQUEUE_LIMIT) / 1000 / 2;
 
 const getRequeueDelay = (failureCount?: number) => {
   const jitter = Math.random() * JITTER_MS;
@@ -125,44 +126,19 @@ export const pkiSyncQueueFactory = ({
     unit: "1"
   });
 
-  const $isConnectionConcurrencyLimitReached = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    if (!concurrencyCount) return false;
-
-    const count = Number.parseInt(concurrencyCount, 10);
-
-    if (Number.isNaN(count)) return false;
-
-    return count >= CONNECTION_CONCURRENCY_LIMIT;
+  const $tryAdmitConnectionConcurrency = async (connectionId: string) => {
+    const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
+    const count = await keyStore.incrementByAndRefreshExpiryIfUnderLimit(
+      key,
+      CONNECTION_CONCURRENCY_LIMIT,
+      CONNECTION_CONCURRENCY_TTL_SECONDS
+    );
+    return count !== -1;
   };
 
-  const $incrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const incrementedCount = Number.isNaN(currentCount) ? 1 : currentCount + 1;
-
-    await keyStore.setItemWithExpiry(
-      KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      incrementedCount
-    );
-  };
-
-  const $decrementConnectionConcurrencyCount = async (connectionId: string) => {
-    const concurrencyCount = await keyStore.getItem(KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId));
-
-    const currentCount = Number.parseInt(concurrencyCount || "0", 10);
-
-    const decrementedCount = Math.max(0, Number.isNaN(currentCount) ? 0 : currentCount - 1);
-
-    await keyStore.setItemWithExpiry(
-      KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId),
-      (REQUEUE_MS * REQUEUE_LIMIT) / 1000, // in seconds
-      decrementedCount
-    );
+  const $releaseConnectionConcurrency = async (connectionId: string) => {
+    const key = KeyStorePrefixes.AppConnectionConcurrentJobs(connectionId);
+    await keyStore.decrementByOrDelete(key);
   };
 
   const $getInfisicalCertificates = async (
@@ -871,9 +847,9 @@ export const pkiSyncQueueFactory = ({
     const { connectionId } = pkiSync;
 
     if (job.name === QueueJobs.PkiSyncSyncCertificates) {
-      const isConcurrentLimitReached = await $isConnectionConcurrencyLimitReached(connectionId);
+      const admitted = await $tryAdmitConnectionConcurrency(connectionId);
 
-      if (isConcurrentLimitReached) {
+      if (!admitted) {
         await $handleAcquireLockFailure(job as PkiSyncActionJob);
 
         return;
@@ -897,7 +873,6 @@ export const pkiSyncQueueFactory = ({
     try {
       switch (job.name) {
         case QueueJobs.PkiSyncSyncCertificates: {
-          await $incrementConnectionConcurrencyCount(connectionId);
           await $handleSyncCertificatesJob(job as TPkiSyncSyncCertificatesDTO, pkiSync);
           break;
         }
@@ -912,7 +887,7 @@ export const pkiSyncQueueFactory = ({
       }
     } finally {
       if (job.name === QueueJobs.PkiSyncSyncCertificates) {
-        await $decrementConnectionConcurrencyCount(connectionId);
+        await $releaseConnectionConcurrency(connectionId);
       }
 
       await lock.release();

--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -71,7 +71,7 @@ export const SignUpPage = () => {
   }
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
+    <div className="flex min-h-screen flex-col items-center justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6 py-8">
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>
         <link rel="icon" href="/infisical.ico" />


### PR DESCRIPTION
fixes #5563.

the concurrency counter used separate read and write calls to redis.
when two sync jobs ran at once, both could see the same count and both
could increment past the limit, or a decrement could get lost. once the
counter got stuck above zero, every new sync job was rejected —
"concurrency limit reached" — until someone went in and reset it by hand.

replaced the three non-atomic functions with two atomic ones. they use
the same lua scripts that secret-sync-queue.ts already uses, so the
pattern is tested and consistent.