### PR TITLE
improvement: fix and improve assume identity components

### DIFF
--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -317,8 +317,7 @@ export const roleServiceFactory = ({
         );
         if (!userDetails)
           throw new NotFoundError({ message: `User with ID ${assumedPrivilegeDetails.actorId} not found` });
-        assumedPrivilegeDetails.actorName =
-          `${userDetails?.firstName ?? ""} ${userDetails?.lastName ?? ""}`.trim();
+        assumedPrivilegeDetails.actorName = `${userDetails?.firstName ?? ""} ${userDetails?.lastName ?? ""}`.trim();
         assumedPrivilegeDetails.actorEmail = userDetails?.email || "";
       }
 

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -317,7 +317,8 @@ export const roleServiceFactory = ({
         );
         if (!userDetails)
           throw new NotFoundError({ message: `User with ID ${assumedPrivilegeDetails.actorId} not found` });
-        assumedPrivilegeDetails.actorName = `${userDetails?.firstName} ${userDetails?.lastName || ""}`;
+        assumedPrivilegeDetails.actorName =
+          `${userDetails?.firstName ?? ""} ${userDetails?.lastName ?? ""}`.trim();
         assumedPrivilegeDetails.actorEmail = userDetails?.email || "";
       }
 

--- a/frontend/src/components/assume-privileges/AssumePrivilegesModal.tsx
+++ b/frontend/src/components/assume-privileges/AssumePrivilegesModal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
+import { useOrganization, useProject } from "@app/context";
+import { getProjectHomePage } from "@app/helpers/project";
+import { useAssumeProjectPrivileges } from "@app/hooks/api";
+import { ActorType } from "@app/hooks/api/auditLogs/enums";
+
+const CONFIRM_KEY = "assume";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  actorType: ActorType;
+  actorId?: string;
+};
+
+export const AssumePrivilegesModal = ({ isOpen, onOpenChange, actorType, actorId }: Props) => {
+  const { currentOrg } = useOrganization();
+  const { currentProject } = useProject();
+  const assumePrivileges = useAssumeProjectPrivileges();
+  const [inputData, setInputData] = useState("");
+
+  useEffect(() => {
+    setInputData("");
+  }, [isOpen]);
+
+  const isUser = actorType === ActorType.USER;
+  const noun = isUser ? "user" : "machine identity";
+  const isConfirmed = inputData === CONFIRM_KEY;
+
+  const handleConfirm = () => {
+    if (!isConfirmed || !actorId || !currentOrg?.id || !currentProject?.id) return;
+
+    assumePrivileges.mutate(
+      {
+        actorId,
+        actorType,
+        projectId: currentProject.id
+      },
+      {
+        onSuccess: () => {
+          createNotification({
+            type: "success",
+            text: `${isUser ? "User" : "Machine identity"} privilege assumption has started`
+          });
+
+          const url = getProjectHomePage(currentProject.type, currentProject.environments);
+          window.location.assign(
+            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
+          );
+        }
+      }
+    );
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Do you want to assume privileges of this {noun}?</DialogTitle>
+          <DialogDescription>
+            This will set your privileges to those of the {noun} for the next hour.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleConfirm();
+          }}
+        >
+          <Field>
+            <FieldLabel>
+              Type <span className="font-bold">{CONFIRM_KEY}</span> to perform this action
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                value={inputData}
+                onChange={(e) => setInputData(e.target.value)}
+                placeholder={`Type ${CONFIRM_KEY} here`}
+                autoComplete="off"
+              />
+            </FieldContent>
+          </Field>
+        </form>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <Button
+            variant="project"
+            onClick={handleConfirm}
+            isPending={assumePrivileges.isPending}
+            isDisabled={!isConfirmed || assumePrivileges.isPending}
+          >
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/assume-privileges/index.ts
+++ b/frontend/src/components/assume-privileges/index.ts
@@ -1,0 +1,1 @@
+export * from "./AssumePrivilegesModal";

--- a/frontend/src/hooks/api/roles/queries.tsx
+++ b/frontend/src/hooks/api/roles/queries.tsx
@@ -142,7 +142,7 @@ export const fetchUserProjectPermissions = async ({ projectId }: TGetUserProject
         actorId: string;
         actorType: ActorType;
         actorEmail: string;
-        actorName: string;
+        actorName: string | null;
       };
     };
   }>(`/api/v1/projects/${projectId}/permissions`, {});

--- a/frontend/src/layouts/ProjectLayout/components/AssumePrivilegeModeBanner/AssumePrivilegeModeBanner.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/AssumePrivilegeModeBanner/AssumePrivilegeModeBanner.tsx
@@ -20,7 +20,7 @@ export const AssumePrivilegeModeBanner = () => {
       You are currently viewing the project with privileges of&nbsp;
       <b>
         {assumedPrivilegeDetails.actorType === ActorType.IDENTITY ? "identity" : "user"}{" "}
-        {assumedPrivilegeDetails.actorName}
+        {assumedPrivilegeDetails.actorName || assumedPrivilegeDetails.actorEmail}
       </b>
       <Button
         size="xs"

--- a/frontend/src/layouts/ProjectLayout/components/AssumePrivilegeModeBanner/AssumePrivilegeModeBanner.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/AssumePrivilegeModeBanner/AssumePrivilegeModeBanner.tsx
@@ -1,7 +1,6 @@
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Info } from "lucide-react";
 
-import { Button } from "@app/components/v2";
+import { Button } from "@app/components/v3";
 import { useOrganization, useProject, useProjectPermission } from "@app/context";
 import { getProjectHomePage } from "@app/helpers/project";
 import { useRemoveAssumeProjectPrivilege } from "@app/hooks/api";
@@ -16,39 +15,37 @@ export const AssumePrivilegeModeBanner = () => {
   if (!assumedPrivilegeDetails) return null;
 
   return (
-    <div className="flex w-full items-center border-b border-yellow/50 bg-yellow/30 px-4 py-2 text-sm text-yellow-200">
-      <div>
-        <FontAwesomeIcon icon={faInfoCircle} className="mr-2" />
-        You are currently viewing the project with privileges of{" "}
-        <b>
-          {assumedPrivilegeDetails?.actorType === ActorType.IDENTITY ? "identity" : "user"}{" "}
-          {assumedPrivilegeDetails?.actorName}
-        </b>
-      </div>
-      <div className="ml-auto">
-        <Button
-          size="xs"
-          variant="outline_bg"
-          className="hover:bg-mineshaft-500"
-          onClick={() => {
-            exitAssumePrivilegeMode.mutate(
-              {
-                projectId: currentProject.id
-              },
-              {
-                onSuccess: () => {
-                  const url = getProjectHomePage(currentProject.type, currentProject.environments);
-                  window.location.assign(
-                    url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-                  );
-                }
+    <div className="flex w-full items-center border-b border-info/20 bg-info/5 px-4 py-2 text-sm text-foreground">
+      <Info className="mr-2.5 size-4 text-info" />
+      You are currently viewing the project with privileges of&nbsp;
+      <b>
+        {assumedPrivilegeDetails.actorType === ActorType.IDENTITY ? "identity" : "user"}{" "}
+        {assumedPrivilegeDetails.actorName}
+      </b>
+      <Button
+        size="xs"
+        variant="outline"
+        className="ml-auto"
+        isPending={exitAssumePrivilegeMode.isPending}
+        isDisabled={exitAssumePrivilegeMode.isPending}
+        onClick={() => {
+          exitAssumePrivilegeMode.mutate(
+            {
+              projectId: currentProject.id
+            },
+            {
+              onSuccess: () => {
+                const url = getProjectHomePage(currentProject.type, currentProject.environments);
+                window.location.assign(
+                  url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
+                );
               }
-            );
-          }}
-        >
-          Click to exit
-        </Button>
-      </div>
+            }
+          );
+        }}
+      >
+        Click to exit
+      </Button>
     </div>
   );
 };

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -13,9 +13,10 @@ import {
 } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
+import { AssumePrivilegesModal } from "@app/components/assume-privileges";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { ConfirmActionModal, DeleteActionModal, Spinner } from "@app/components/v2";
+import { DeleteActionModal, Spinner } from "@app/components/v2";
 import { Blur } from "@app/components/v2/Blur";
 import {
   Badge,
@@ -72,7 +73,7 @@ import {
   useOrganization,
   useProject
 } from "@app/context";
-import { getProjectBaseURL, getProjectHomePage } from "@app/helpers/project";
+import { getProjectBaseURL } from "@app/helpers/project";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -81,7 +82,6 @@ import {
 import { withProjectPermission } from "@app/hoc";
 import { usePagination, useResetPageHelper } from "@app/hooks";
 import {
-  useAssumeProjectPrivileges,
   useDeleteProjectIdentity,
   useDeleteProjectIdentityMembership,
   useGetProjectRoles,
@@ -176,7 +176,6 @@ export const IdentityTab = withProjectPermission(
 
     const { mutateAsync: deleteMembershipMutateAsync } = useDeleteProjectIdentityMembership();
     const { mutateAsync: deleteProjectIdentity } = useDeleteProjectIdentity();
-    const assumePrivileges = useAssumeProjectPrivileges();
 
     const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
       "createIdentity",
@@ -185,32 +184,6 @@ export const IdentityTab = withProjectPermission(
       "addOptions",
       "assumePrivileges"
     ] as const);
-
-    const handleAssumePrivileges = async () => {
-      const identityId = (popUp?.assumePrivileges?.data as { identityId: string })?.identityId;
-      if (!currentOrg?.id || !currentProject?.id) return;
-
-      assumePrivileges.mutate(
-        {
-          actorId: identityId,
-          actorType: ActorType.IDENTITY,
-          projectId
-        },
-        {
-          onSuccess: () => {
-            createNotification({
-              type: "success",
-              text: "Machine identity privilege assumption has started"
-            });
-
-            const url = getProjectHomePage(currentProject.type, currentProject.environments);
-            window.location.assign(
-              url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-            );
-          }
-        }
-      );
-    };
 
     const onRemoveIdentitySubmit = async (identityId: string, isProjectIdentity: boolean) => {
       if (isProjectIdentity) {
@@ -502,13 +475,15 @@ export const IdentityTab = withProjectPermission(
                                               }}
                                             >
                                               Assume Privileges
-                                              <InfoIcon className="text-muted" />
+                                              {isAllowed && <InfoIcon className="text-muted" />}
                                             </DropdownMenuItem>
                                           </TooltipTrigger>
-                                          <TooltipContent className="max-w-80" side="left">
-                                            Assume the privileges of this machine identity, allowing
-                                            you to replicate their access behavior.
-                                          </TooltipContent>
+                                          {isAllowed && (
+                                            <TooltipContent className="max-w-80" side="left">
+                                              Assume the privileges of this machine identity,
+                                              allowing you to replicate their access behavior.
+                                            </TooltipContent>
+                                          )}
                                         </Tooltip>
                                       )}
                                     </ProjectPermissionCan>
@@ -661,14 +636,11 @@ export const IdentityTab = withProjectPermission(
             )
           }
         />
-        <ConfirmActionModal
+        <AssumePrivilegesModal
           isOpen={popUp.assumePrivileges.isOpen}
-          confirmKey="assume"
-          title="Do you want to assume privileges of this machine identity?"
-          subTitle="This will set your privileges to those of the machine identity for the next hour."
-          onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
-          onConfirmed={handleAssumePrivileges}
-          buttonText="Confirm"
+          onOpenChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+          actorType={ActorType.IDENTITY}
+          actorId={(popUp.assumePrivileges.data as { identityId: string })?.identityId}
         />
       </>
     );

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -15,7 +15,7 @@ import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { DeleteActionModal, Spinner } from "@app/components/v2";
+import { ConfirmActionModal, DeleteActionModal, Spinner } from "@app/components/v2";
 import { Blur } from "@app/components/v2/Blur";
 import {
   Badge,
@@ -67,11 +67,12 @@ import {
 } from "@app/components/v3";
 import {
   ProjectPermissionActions,
+  ProjectPermissionIdentityActions,
   ProjectPermissionSub,
   useOrganization,
   useProject
 } from "@app/context";
-import { getProjectBaseURL } from "@app/helpers/project";
+import { getProjectBaseURL, getProjectHomePage } from "@app/helpers/project";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -80,11 +81,13 @@ import {
 import { withProjectPermission } from "@app/hoc";
 import { usePagination, useResetPageHelper } from "@app/hooks";
 import {
+  useAssumeProjectPrivileges,
   useDeleteProjectIdentity,
   useDeleteProjectIdentityMembership,
   useGetProjectRoles,
   useListProjectIdentityMemberships
 } from "@app/hooks/api";
+import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { OrderByDirection } from "@app/hooks/api/generic/types";
 import { ProjectIdentityOrderBy, ProjectType } from "@app/hooks/api/projects/types";
 import { usePopUp } from "@app/hooks/usePopUp";
@@ -173,13 +176,41 @@ export const IdentityTab = withProjectPermission(
 
     const { mutateAsync: deleteMembershipMutateAsync } = useDeleteProjectIdentityMembership();
     const { mutateAsync: deleteProjectIdentity } = useDeleteProjectIdentity();
+    const assumePrivileges = useAssumeProjectPrivileges();
 
     const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
       "createIdentity",
       "deleteIdentity",
       "upgradePlan",
-      "addOptions"
+      "addOptions",
+      "assumePrivileges"
     ] as const);
+
+    const handleAssumePrivileges = async () => {
+      const identityId = (popUp?.assumePrivileges?.data as { identityId: string })?.identityId;
+      if (!currentOrg?.id || !currentProject?.id) return;
+
+      assumePrivileges.mutate(
+        {
+          actorId: identityId,
+          actorType: ActorType.IDENTITY,
+          projectId
+        },
+        {
+          onSuccess: () => {
+            createNotification({
+              type: "success",
+              text: "Machine identity privilege assumption has started"
+            });
+
+            const url = getProjectHomePage(currentProject.type, currentProject.environments);
+            window.location.assign(
+              url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
+            );
+          }
+        }
+      );
+    };
 
     const onRemoveIdentitySubmit = async (identityId: string, isProjectIdentity: boolean) => {
       if (isProjectIdentity) {
@@ -452,6 +483,36 @@ export const IdentityTab = withProjectPermission(
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent sideOffset={2} align="end">
                                     <ProjectPermissionCan
+                                      I={ProjectPermissionIdentityActions.AssumePrivileges}
+                                      a={subject(ProjectPermissionSub.Identity, {
+                                        identityId: id
+                                      })}
+                                    >
+                                      {(isAllowed) => (
+                                        <Tooltip>
+                                          <TooltipTrigger className="block w-full">
+                                            <DropdownMenuItem
+                                              isDisabled={!isAllowed}
+                                              onClick={(evt) => {
+                                                evt.stopPropagation();
+                                                evt.preventDefault();
+                                                handlePopUpOpen("assumePrivileges", {
+                                                  identityId: id
+                                                });
+                                              }}
+                                            >
+                                              Assume Privileges
+                                              <InfoIcon className="text-muted" />
+                                            </DropdownMenuItem>
+                                          </TooltipTrigger>
+                                          <TooltipContent className="max-w-80" side="left">
+                                            Assume the privileges of this machine identity, allowing
+                                            you to replicate their access behavior.
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      )}
+                                    </ProjectPermissionCan>
+                                    <ProjectPermissionCan
                                       I={ProjectPermissionActions.Delete}
                                       a={subject(ProjectPermissionSub.Identity, {
                                         identityId: id
@@ -599,6 +660,15 @@ export const IdentityTab = withProjectPermission(
               popUp?.deleteIdentity?.data?.isProjectIdentity
             )
           }
+        />
+        <ConfirmActionModal
+          isOpen={popUp.assumePrivileges.isOpen}
+          confirmKey="assume"
+          title="Do you want to assume privileges of this machine identity?"
+          subTitle="This will set your privileges to those of the machine identity for the next hour."
+          onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+          onConfirmed={handleAssumePrivileges}
+          buttonText="Confirm"
         />
       </>
     );

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
@@ -1,8 +1,9 @@
 import { UserPlusIcon } from "lucide-react";
 
+import { AssumePrivilegesModal } from "@app/components/assume-privileges";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { ConfirmActionModal, DeleteActionModal } from "@app/components/v2";
+import { DeleteActionModal } from "@app/components/v2";
 import {
   Button,
   Card,
@@ -19,9 +20,8 @@ import {
   useOrganization,
   useProject
 } from "@app/context";
-import { getProjectHomePage } from "@app/helpers/project";
 import { usePopUp } from "@app/hooks";
-import { useAssumeProjectPrivileges, useDeleteUserFromWorkspace } from "@app/hooks/api";
+import { useDeleteUserFromWorkspace } from "@app/hooks/api";
 import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -35,39 +35,12 @@ export const MembersSection = () => {
   const productLabel = isCertManager ? "Certificate Manager" : "Project";
 
   const { mutateAsync: removeUserFromWorkspace } = useDeleteUserFromWorkspace();
-  const assumePrivileges = useAssumeProjectPrivileges();
 
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "addMember",
     "removeMember",
     "assumePrivileges"
   ] as const);
-
-  const handleAssumePrivileges = async () => {
-    const userId = (popUp?.assumePrivileges?.data as { userId: string })?.userId;
-    if (!currentOrg?.id || !currentProject?.id) return;
-
-    assumePrivileges.mutate(
-      {
-        actorId: userId,
-        actorType: ActorType.USER,
-        projectId: currentProject.id
-      },
-      {
-        onSuccess: () => {
-          createNotification({
-            type: "success",
-            text: "User privilege assumption has started"
-          });
-
-          const url = getProjectHomePage(currentProject.type, currentProject.environments);
-          window.location.assign(
-            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-          );
-        }
-      }
-    );
-  };
 
   const handleRemoveUser = async () => {
     const username = (popUp?.removeMember?.data as { username: string })?.username;
@@ -128,14 +101,11 @@ export const MembersSection = () => {
         onChange={(isOpen) => handlePopUpToggle("removeMember", isOpen)}
         onDeleteApproved={handleRemoveUser}
       />
-      <ConfirmActionModal
+      <AssumePrivilegesModal
         isOpen={popUp.assumePrivileges.isOpen}
-        confirmKey="assume"
-        title="Do you want to assume privileges of this user?"
-        subTitle="This will set your privileges to those of the user for the next hour."
-        onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
-        onConfirmed={handleAssumePrivileges}
-        buttonText="Confirm"
+        onOpenChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+        actorType={ActorType.USER}
+        actorId={(popUp.assumePrivileges.data as { userId: string })?.userId}
       />
     </>
   );

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersSection.tsx
@@ -2,7 +2,7 @@ import { UserPlusIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { DeleteActionModal } from "@app/components/v2";
+import { ConfirmActionModal, DeleteActionModal } from "@app/components/v2";
 import {
   Button,
   Card,
@@ -19,8 +19,10 @@ import {
   useOrganization,
   useProject
 } from "@app/context";
+import { getProjectHomePage } from "@app/helpers/project";
 import { usePopUp } from "@app/hooks";
-import { useDeleteUserFromWorkspace } from "@app/hooks/api";
+import { useAssumeProjectPrivileges, useDeleteUserFromWorkspace } from "@app/hooks/api";
+import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 import { AddMemberModal } from "./AddMemberModal";
@@ -33,11 +35,39 @@ export const MembersSection = () => {
   const productLabel = isCertManager ? "Certificate Manager" : "Project";
 
   const { mutateAsync: removeUserFromWorkspace } = useDeleteUserFromWorkspace();
+  const assumePrivileges = useAssumeProjectPrivileges();
 
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "addMember",
-    "removeMember"
+    "removeMember",
+    "assumePrivileges"
   ] as const);
+
+  const handleAssumePrivileges = async () => {
+    const userId = (popUp?.assumePrivileges?.data as { userId: string })?.userId;
+    if (!currentOrg?.id || !currentProject?.id) return;
+
+    assumePrivileges.mutate(
+      {
+        actorId: userId,
+        actorType: ActorType.USER,
+        projectId: currentProject.id
+      },
+      {
+        onSuccess: () => {
+          createNotification({
+            type: "success",
+            text: "User privilege assumption has started"
+          });
+
+          const url = getProjectHomePage(currentProject.type, currentProject.environments);
+          window.location.assign(
+            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
+          );
+        }
+      }
+    );
+  };
 
   const handleRemoveUser = async () => {
     const username = (popUp?.removeMember?.data as { username: string })?.username;
@@ -97,6 +127,15 @@ export const MembersSection = () => {
         title={`Do you want to remove this user from the ${productLabel.toLowerCase()}?`}
         onChange={(isOpen) => handlePopUpToggle("removeMember", isOpen)}
         onDeleteApproved={handleRemoveUser}
+      />
+      <ConfirmActionModal
+        isOpen={popUp.assumePrivileges.isOpen}
+        confirmKey="assume"
+        title="Do you want to assume privileges of this user?"
+        subTitle="This will set your privileges to those of the user for the next hour."
+        onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+        onConfirmed={handleAssumePrivileges}
+        buttonText="Confirm"
       />
     </>
   );

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersTable.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersTable.tsx
@@ -5,6 +5,7 @@ import {
   ClockAlertIcon,
   ClockIcon,
   FilterIcon,
+  InfoIcon,
   MoreHorizontalIcon,
   SearchIcon,
   UserXIcon
@@ -43,7 +44,13 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub, useProject, useUser } from "@app/context";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionMemberActions,
+  ProjectPermissionSub,
+  useProject,
+  useUser
+} from "@app/context";
 import { getProjectBaseURL } from "@app/helpers/project";
 import { formatProjectRoleName } from "@app/helpers/roles";
 import {
@@ -60,7 +67,10 @@ import { UsePopUpState } from "@app/hooks/usePopUp";
 const MAX_ROLES_TO_BE_SHOWN_IN_TABLE = 2;
 
 type Props = {
-  handlePopUpOpen: (popUpName: keyof UsePopUpState<["removeMember"]>, data?: object) => void;
+  handlePopUpOpen: (
+    popUpName: keyof UsePopUpState<["removeMember", "assumePrivileges"]>,
+    data?: object
+  ) => void;
 };
 
 enum MembersOrderBy {
@@ -448,6 +458,36 @@ export const MembersTable = ({ handlePopUpOpen }: Props) => {
                             )}
                           </Tooltip>
                           <DropdownMenuContent sideOffset={2} align="end">
+                            {!isCertManager && (
+                              <ProjectPermissionCan
+                                I={ProjectPermissionMemberActions.AssumePrivileges}
+                                a={ProjectPermissionSub.Member}
+                              >
+                                {(isAllowed) => (
+                                  <Tooltip>
+                                    <TooltipTrigger className="block w-full">
+                                      <DropdownMenuItem
+                                        isDisabled={!isAllowed}
+                                        onClick={(evt) => {
+                                          evt.preventDefault();
+                                          evt.stopPropagation();
+                                          handlePopUpOpen("assumePrivileges", {
+                                            userId: u.id
+                                          });
+                                        }}
+                                      >
+                                        Assume Privileges
+                                        <InfoIcon className="text-muted" />
+                                      </DropdownMenuItem>
+                                    </TooltipTrigger>
+                                    <TooltipContent className="max-w-80" side="left">
+                                      Assume the privileges of this user, allowing you to replicate
+                                      their access behavior.
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
+                              </ProjectPermissionCan>
+                            )}
                             <ProjectPermissionCan
                               I={ProjectPermissionActions.Delete}
                               a={ProjectPermissionSub.Member}

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersTable.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/MembersTable.tsx
@@ -477,13 +477,15 @@ export const MembersTable = ({ handlePopUpOpen }: Props) => {
                                         }}
                                       >
                                         Assume Privileges
-                                        <InfoIcon className="text-muted" />
+                                        {isAllowed && <InfoIcon className="text-muted" />}
                                       </DropdownMenuItem>
                                     </TooltipTrigger>
-                                    <TooltipContent className="max-w-80" side="left">
-                                      Assume the privileges of this user, allowing you to replicate
-                                      their access behavior.
-                                    </TooltipContent>
+                                    {isAllowed && (
+                                      <TooltipContent className="max-w-80" side="left">
+                                        Assume the privileges of this user, allowing you to
+                                        replicate their access behavior.
+                                      </TooltipContent>
+                                    )}
                                   </Tooltip>
                                 )}
                               </ProjectPermissionCan>

--- a/frontend/src/pages/project/GroupDetailsByIDPage/components/GroupMembersSection/GroupMembersTable.tsx
+++ b/frontend/src/pages/project/GroupDetailsByIDPage/components/GroupMembersSection/GroupMembersTable.tsx
@@ -3,8 +3,8 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ChevronDownIcon, FilterIcon, HardDriveIcon, UserIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
-import { createNotification } from "@app/components/notifications";
-import { ConfirmActionModal, Lottie } from "@app/components/v2";
+import { AssumePrivilegesModal } from "@app/components/assume-privileges";
+import { Lottie } from "@app/components/v2";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -24,15 +24,12 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
-import { useOrganization, useProject } from "@app/context";
-import { getProjectHomePage } from "@app/helpers/project";
 import {
   getUserTablePreference,
   PreferenceKey,
   setUserTablePreference
 } from "@app/helpers/userTablePreferences";
 import { usePagination, usePopUp, useResetPageHelper } from "@app/hooks";
-import { useAssumeProjectPrivileges } from "@app/hooks/api";
 import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { OrderByDirection } from "@app/hooks/api/generic/types";
 import { useListGroupMembers } from "@app/hooks/api/groups/queries";
@@ -91,9 +88,6 @@ export const GroupMembersTable = ({ groupMembership }: Props) => {
     setUserTablePreference("projectGroupMembersTable", PreferenceKey.PerPage, newPerPage);
   };
 
-  const { currentOrg } = useOrganization();
-  const { currentProject } = useProject();
-
   const { data: groupMemberships, isPending } = useListGroupMembers({
     id: groupMembership.group.id,
     groupSlug: groupMembership.group.slug,
@@ -114,38 +108,6 @@ export const GroupMembersTable = ({ groupMembership }: Props) => {
     offset,
     setPage
   });
-
-  const assumePrivileges = useAssumeProjectPrivileges();
-
-  const handleAssumePrivileges = async () => {
-    const { actorId, actorType } = popUp?.assumePrivileges?.data as {
-      actorId: string;
-      actorType: ActorType;
-    };
-    assumePrivileges.mutate(
-      {
-        actorId,
-        actorType,
-        projectId: currentProject.id
-      },
-      {
-        onSuccess: () => {
-          createNotification({
-            type: "success",
-            text:
-              actorType === ActorType.IDENTITY
-                ? "Machine identity privilege assumption has started"
-                : "User privilege assumption has started"
-          });
-
-          const url = getProjectHomePage(currentProject.type, currentProject.environments);
-          window.location.assign(
-            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-          );
-        }
-      }
-    );
-  };
 
   const filterOptions = [
     {
@@ -278,14 +240,11 @@ export const GroupMembersTable = ({ groupMembership }: Props) => {
           onChangePerPage={handlePerPageChange}
         />
       )}
-      <ConfirmActionModal
+      <AssumePrivilegesModal
         isOpen={popUp.assumePrivileges.isOpen}
-        confirmKey="assume"
-        title={`Do you want to assume privileges of this ${popUp.assumePrivileges?.data?.actorType === ActorType.IDENTITY ? "machine identity" : "user"}?`}
-        subTitle={`This will set your privileges to those of the ${popUp.assumePrivileges?.data?.actorType === ActorType.IDENTITY ? "machine identity" : "user"} for the next hour.`}
-        onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
-        onConfirmed={handleAssumePrivileges}
-        buttonText="Confirm"
+        onOpenChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+        actorType={(popUp.assumePrivileges.data as { actorType: ActorType })?.actorType}
+        actorId={(popUp.assumePrivileges.data as { actorId: string })?.actorId}
       />
     </>
   );

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
@@ -6,9 +6,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { ChevronLeftIcon, EllipsisIcon, InfoIcon, ShieldIcon } from "lucide-react";
 
+import { AssumePrivilegesModal } from "@app/components/assume-privileges";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan, ProjectPermissionCan } from "@app/components/permissions";
-import { ConfirmActionModal, DeleteActionModal, EmptyState, PageHeader } from "@app/components/v2";
+import { DeleteActionModal, EmptyState, PageHeader } from "@app/components/v2";
 import {
   Alert,
   AlertDescription,
@@ -39,10 +40,9 @@ import {
   useOrganization,
   useProject
 } from "@app/context";
-import { getProjectBaseURL, getProjectHomePage } from "@app/helpers/project";
+import { getProjectBaseURL } from "@app/helpers/project";
 import { usePopUp } from "@app/hooks";
 import {
-  useAssumeProjectPrivileges,
   useDeleteProjectIdentityMembership,
   useGetProjectIdentityMembershipV2
 } from "@app/hooks/api";
@@ -93,31 +93,7 @@ const Page = () => {
     "deleteIdentity",
     "assumePrivileges"
   ] as const);
-  const assumePrivileges = useAssumeProjectPrivileges();
-
   const [isPermissionAuditOpen, setIsPermissionAuditOpen] = useState(false);
-
-  const handleAssumePrivileges = async () => {
-    assumePrivileges.mutate(
-      {
-        actorId: identityId,
-        actorType: ActorType.IDENTITY,
-        projectId
-      },
-      {
-        onSuccess: () => {
-          createNotification({
-            type: "success",
-            text: "Machine identity privilege assumption has started"
-          });
-          const url = getProjectHomePage(currentProject.type, currentProject.environments);
-          window.location.assign(
-            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-          );
-        }
-      }
-    );
-  };
 
   const onRemoveIdentitySubmit = async () => {
     await removeIdentityMutateAsync({
@@ -241,13 +217,15 @@ const Page = () => {
                             onClick={() => handlePopUpOpen("assumePrivileges")}
                           >
                             Assume Privileges
-                            <InfoIcon className="text-muted" />
+                            {isAllowed && <InfoIcon className="text-muted" />}
                           </DropdownMenuItem>
                         </TooltipTrigger>
-                        <TooltipContent className="max-w-80" side="left">
-                          Assume the privileges of this machine identity, allowing you to replicate
-                          their access behavior.
-                        </TooltipContent>
+                        {isAllowed && (
+                          <TooltipContent className="max-w-80" side="left">
+                            Assume the privileges of this machine identity, allowing you to
+                            replicate their access behavior.
+                          </TooltipContent>
+                        )}
                       </Tooltip>
                     )}
                   </ProjectPermissionCan>
@@ -355,14 +333,11 @@ const Page = () => {
             deleteKey="remove"
             onDeleteApproved={() => onRemoveIdentitySubmit()}
           />
-          <ConfirmActionModal
+          <AssumePrivilegesModal
             isOpen={popUp.assumePrivileges.isOpen}
-            confirmKey="assume"
-            title="Do you want to assume privileges of this machine identity?"
-            subTitle="This will set your privileges to those of the machine identity for the next hour."
-            onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
-            onConfirmed={handleAssumePrivileges}
-            buttonText="Confirm"
+            onOpenChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+            actorType={ActorType.IDENTITY}
+            actorId={identityId}
           />
           <DeleteActionModal
             isOpen={popUp.deleteIdentity.isOpen}

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/IdentityDetailsByIDPage.tsx
@@ -8,13 +8,7 @@ import { ChevronLeftIcon, EllipsisIcon, InfoIcon, ShieldIcon } from "lucide-reac
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan, ProjectPermissionCan } from "@app/components/permissions";
-import {
-  ConfirmActionModal,
-  DeleteActionModal,
-  EmptyState,
-  PageHeader,
-  Tooltip
-} from "@app/components/v2";
+import { ConfirmActionModal, DeleteActionModal, EmptyState, PageHeader } from "@app/components/v2";
 import {
   Alert,
   AlertDescription,
@@ -31,7 +25,10 @@ import {
   DropdownMenuTrigger,
   OrgIcon,
   PageLoader,
-  SubOrgIcon
+  SubOrgIcon,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import {
   OrgPermissionIdentityActions,
@@ -237,20 +234,21 @@ const Page = () => {
                     })}
                   >
                     {(isAllowed) => (
-                      <DropdownMenuItem
-                        isDisabled={!isAllowed}
-                        onClick={() => handlePopUpOpen("assumePrivileges")}
-                      >
-                        Assume Privileges
-                        <Tooltip
-                          side="bottom"
-                          content="Assume the privileges of this machine identity, allowing you to replicate their access behavior."
-                        >
-                          <div>
+                      <Tooltip>
+                        <TooltipTrigger className="block w-full">
+                          <DropdownMenuItem
+                            isDisabled={!isAllowed}
+                            onClick={() => handlePopUpOpen("assumePrivileges")}
+                          >
+                            Assume Privileges
                             <InfoIcon className="text-muted" />
-                          </div>
-                        </Tooltip>
-                      </DropdownMenuItem>
+                          </DropdownMenuItem>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-80" side="left">
+                          Assume the privileges of this machine identity, allowing you to replicate
+                          their access behavior.
+                        </TooltipContent>
+                      </Tooltip>
                     )}
                   </ProjectPermissionCan>
                   <ProjectPermissionCan

--- a/frontend/src/pages/project/MemberDetailsByIDPage/MemberDetailsByIDPage.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/MemberDetailsByIDPage.tsx
@@ -14,8 +14,7 @@ import {
   DeleteActionModal,
   EmptyState,
   PageHeader,
-  Spinner,
-  Tooltip
+  Spinner
 } from "@app/components/v2";
 import {
   Badge,
@@ -23,7 +22,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import {
   ProjectPermissionActions,
@@ -175,17 +177,17 @@ export const Page = () => {
                 </Button>
               )}
               {isOwnProjectMembershipDetails ? (
-                <Tooltip
-                  side="right"
-                  content={
-                    isCertManager
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="info" className="ml-2">
+                      <InfoIcon /> {isCertManager ? "Your membership" : "Your project membership"}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    {isCertManager
                       ? "You cannot modify your own membership. Ask a Certificate Manager admin to make changes to your membership."
-                      : "You cannot modify your own membership. Ask a project admin to make changes to your membership."
-                  }
-                >
-                  <Badge variant="info" className="ml-2">
-                    <InfoIcon /> {isCertManager ? "Your membership" : "Your project membership"}
-                  </Badge>
+                      : "You cannot modify your own membership. Ask a project admin to make changes to your membership."}
+                  </TooltipContent>
                 </Tooltip>
               ) : (
                 <DropdownMenu>
@@ -213,24 +215,25 @@ export const Page = () => {
                         a={ProjectPermissionSub.Member}
                       >
                         {(isAllowed) => (
-                          <DropdownMenuItem
-                            isDisabled={!isAllowed}
-                            onClick={() =>
-                              handlePopUpOpen("assumePrivileges", {
-                                userId: membershipDetails.user.id
-                              })
-                            }
-                          >
-                            Assume Privileges
-                            <Tooltip
-                              side="bottom"
-                              content="Assume the privileges of this user, allowing you to replicate their access behavior."
-                            >
-                              <div>
+                          <Tooltip>
+                            <TooltipTrigger className="block w-full">
+                              <DropdownMenuItem
+                                isDisabled={!isAllowed}
+                                onClick={() =>
+                                  handlePopUpOpen("assumePrivileges", {
+                                    userId: membershipDetails.user.id
+                                  })
+                                }
+                              >
+                                Assume Privileges
                                 <InfoIcon className="text-muted" />
-                              </div>
-                            </Tooltip>
-                          </DropdownMenuItem>
+                              </DropdownMenuItem>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-80" side="left">
+                              Assume the privileges of this user, allowing you to replicate their
+                              access behavior.
+                            </TooltipContent>
+                          </Tooltip>
                         )}
                       </ProjectPermissionCan>
                     )}

--- a/frontend/src/pages/project/MemberDetailsByIDPage/MemberDetailsByIDPage.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/MemberDetailsByIDPage.tsx
@@ -6,16 +6,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { EllipsisIcon, InfoIcon, ShieldIcon } from "lucide-react";
 
+import { AssumePrivilegesModal } from "@app/components/assume-privileges";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import {
-  ConfirmActionModal,
-  DeleteActionModal,
-  EmptyState,
-  PageHeader,
-  Spinner
-} from "@app/components/v2";
+import { DeleteActionModal, EmptyState, PageHeader, Spinner } from "@app/components/v2";
 import {
   Badge,
   Button,
@@ -35,13 +30,9 @@ import {
   useProject,
   useUser
 } from "@app/context";
-import { getProjectBaseURL, getProjectHomePage } from "@app/helpers/project";
+import { getProjectBaseURL } from "@app/helpers/project";
 import { usePopUp } from "@app/hooks";
-import {
-  useAssumeProjectPrivileges,
-  useDeleteUserFromWorkspace,
-  useGetWorkspaceUserDetails
-} from "@app/hooks/api";
+import { useDeleteUserFromWorkspace, useGetWorkspaceUserDetails } from "@app/hooks/api";
 import { ActorType } from "@app/hooks/api/auditLogs/enums";
 import { ProjectType } from "@app/hooks/api/projects/types";
 import { ProjectAccessControlTabs } from "@app/types/project";
@@ -67,7 +58,6 @@ export const Page = () => {
     useGetWorkspaceUserDetails(projectId, membershipId, currentProject?.type);
 
   const { mutateAsync: removeUserFromWorkspace } = useDeleteUserFromWorkspace();
-  const assumePrivileges = useAssumeProjectPrivileges();
 
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "removeMember",
@@ -76,30 +66,6 @@ export const Page = () => {
   ] as const);
 
   const [isPermissionAuditOpen, setIsPermissionAuditOpen] = useState(false);
-
-  const handleAssumePrivileges = async () => {
-    const { userId } = popUp?.assumePrivileges?.data as { userId: string };
-    assumePrivileges.mutate(
-      {
-        actorId: userId,
-        actorType: ActorType.USER,
-        projectId
-      },
-      {
-        onSuccess: () => {
-          createNotification({
-            type: "success",
-            text: "User privilege assumption has started"
-          });
-
-          const url = getProjectHomePage(currentProject.type, currentProject.environments);
-          window.location.assign(
-            url.replace("$orgId", currentOrg.id).replace("$projectId", currentProject.id)
-          );
-        }
-      }
-    );
-  };
 
   const handleRemoveUser = async () => {
     if (!currentOrg?.id || !currentProject?.id || !membershipDetails?.user?.username) return;
@@ -226,13 +192,15 @@ export const Page = () => {
                                 }
                               >
                                 Assume Privileges
-                                <InfoIcon className="text-muted" />
+                                {isAllowed && <InfoIcon className="text-muted" />}
                               </DropdownMenuItem>
                             </TooltipTrigger>
-                            <TooltipContent className="max-w-80" side="left">
-                              Assume the privileges of this user, allowing you to replicate their
-                              access behavior.
-                            </TooltipContent>
+                            {isAllowed && (
+                              <TooltipContent className="max-w-80" side="left">
+                                Assume the privileges of this user, allowing you to replicate their
+                                access behavior.
+                              </TooltipContent>
+                            )}
                           </Tooltip>
                         )}
                       </ProjectPermissionCan>
@@ -283,14 +251,11 @@ export const Page = () => {
             onChange={(isOpen) => handlePopUpToggle("removeMember", isOpen)}
             onDeleteApproved={handleRemoveUser}
           />
-          <ConfirmActionModal
+          <AssumePrivilegesModal
             isOpen={popUp.assumePrivileges.isOpen}
-            confirmKey="assume"
-            title="Do you want to assume privileges of this user?"
-            subTitle="This will set your privileges to those of the user for the next hour."
-            onChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
-            onConfirmed={handleAssumePrivileges}
-            buttonText="Confirm"
+            onOpenChange={(isOpen) => handlePopUpToggle("assumePrivileges", isOpen)}
+            actorType={ActorType.USER}
+            actorId={(popUp.assumePrivileges.data as { userId: string })?.userId}
           />
           <UpgradePlanModal
             isOpen={popUp.upgradePlan.isOpen}


### PR DESCRIPTION
## Context

This PR adds various improvements to the assume privs UI:
- add assume privilege menu item to users/identities table 
- update confirm assume modal to v3
- update assume priv banner to v3 styling
- fix display of user if no name set

## Screenshots

<img width="3456" height="1926" alt="CleanShot 2026-06-01 at 11 49 43@2x" src="https://github.com/user-attachments/assets/eb54d801-ae31-4813-9441-8e52ac8b03a0" />

## Steps to verify the change

- test assume priv options from all 4 locations: user table, user page, identity table, identity page

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)