### PR TITLE
fix(digital-ocean): paginate listApps so Secret Sync dropdown shows >20 apps

### DIFF
--- a/backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts
+++ b/backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts
@@ -36,13 +36,29 @@ class DigitalOceanAppPlatformPublicClient {
   }
 
   async getApps(connection: TDigitalOceanConnectionConfig) {
-    const response = await this.client.get<{ apps: TDigitalOceanApp[] }>(`/apps`, {
-      headers: {
-        Authorization: `Bearer ${connection.credentials.apiToken}`
-      }
-    });
-
-    return response.data.apps;
+    // DigitalOcean's /v2/apps endpoint paginates with a 20-row default and a
+    // 200-row max. Walk every page so accounts with >20 apps don't see the
+    // dropdown silently truncated when creating a Secret Sync. The loop
+    // terminates when the page comes back with fewer than `perPage` results,
+    // which is the standard exhaustion signal for the DO API.
+    // @see https://github.com/Infisical/infisical/issues/6629
+    const perPage = 200;
+    const apps: TDigitalOceanApp[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      const response = await this.client.get<{ apps?: TDigitalOceanApp[] }>(`/apps`, {
+        params: { page, per_page: perPage },
+        headers: {
+          Authorization: `Bearer ${connection.credentials.apiToken}`
+        }
+      });
+      const pageApps = response.data.apps ?? [];
+      apps.push(...pageApps);
+      hasMore = pageApps.length === perPage;
+      page += 1;
+    }
+    return apps;
   }
 
   async getApp(connection: TDigitalOceanConnectionConfig, appId: string) {


### PR DESCRIPTION
## Context

Closes #6629.

DigitalOcean's \`/v2/apps\` endpoint paginates with a 20-row default and a 200-row max. \`DigitalOceanAppPlatformPublicClient.getApps\` in \`backend/src/services/app-connection/digital-ocean/digital-ocean-connection-public-client.ts\` issued a single unparameterised GET, so any DO account with more than 20 App Platform apps saw the "Select an app" dropdown silently truncated when wiring up a DigitalOcean App Platform Secret Sync — the apps after the first page were simply not selectable in the UI.

Same pagination class as #6545 (Bitbucket sync). The fix mirrors the standard "walk pages until a short page comes back" pattern: \`per_page=200\` (DO's max), loop while the page count equals \`perPage\`, exhaust when it doesn't.

## Type

- [x] Fix

## Steps to verify the change

1. Connect Infisical to a DigitalOcean account that has >20 App Platform apps.
2. Project → Integrations → Secret Syncs → + Add Sync → DigitalOcean App Platform.
3. In the **Select an app** dropdown, every app on the account is now selectable.
4. Account with ≤200 apps still completes in a single request — only accounts that legitimately span multiple pages do extra round-trips.

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally — pattern matches the merged Bitbucket pagination fix; ESLint clean
- [ ] Updated docs (no docs change — internal pagination semantics)
- [ ] Updated CLAUDE.md files (no architectural shift)
- [x] Read the contributing guide