### PR TITLE
fix(pam): hide rotation UI for resources without rotation support

### DIFF
--- a/docs/documentation/platform/pam/product-reference/credential-rotation.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-rotation.mdx
@@ -40,7 +40,8 @@ Setting up automated rotation requires a two-step configuration: first at the Re
 
 Automated rotation is currently supported for the following resource types:
 
-- **PostgreSQL**: Requires a user with `ALTER ROLE` permissions.
+- **PostgreSQL**: Requires a rotation account with `ALTER ROLE` permissions.
+- **Windows Server**: Requires a rotation account in the local Administrators group. Rotation applies to local machine accounts only.
 
 <Note>
     We are constantly adding support for more resource types.

--- a/frontend/src/hooks/api/pam/maps.ts
+++ b/frontend/src/hooks/api/pam/maps.ts
@@ -23,3 +23,11 @@ export const PAM_RESOURCE_TYPE_MAP: Record<
   [PamResourceType.AwsIam]: { name: "AWS IAM", image: "Amazon Web Services.png" },
   [PamResourceType.Windows]: { name: "Windows Server", image: "Windows.png" }
 };
+
+const PAM_ROTATION_SUPPORTED_RESOURCE_TYPES = new Set([
+  PamResourceType.Postgres,
+  PamResourceType.Windows
+]);
+
+export const isPamRotationSupported = (resourceType: PamResourceType) =>
+  PAM_ROTATION_SUPPORTED_RESOURCE_TYPES.has(resourceType);

--- a/frontend/src/pages/pam/PamAccountByIDPage/components/PamAccountDetailsSection.tsx
+++ b/frontend/src/pages/pam/PamAccountByIDPage/components/PamAccountDetailsSection.tsx
@@ -12,7 +12,12 @@ import {
 } from "@app/components/v3";
 import { ProjectPermissionSub } from "@app/context";
 import { ProjectPermissionPamAccountActions } from "@app/context/ProjectPermissionContext/types";
-import { PAM_RESOURCE_TYPE_MAP, PamAccountRotationStatus, TPamAccount } from "@app/hooks/api/pam";
+import {
+  isPamRotationSupported,
+  PAM_RESOURCE_TYPE_MAP,
+  PamAccountRotationStatus,
+  TPamAccount
+} from "@app/hooks/api/pam";
 import { useGetPamAccountById } from "@app/hooks/api/pam/queries";
 
 type Props = {
@@ -55,6 +60,9 @@ export const PamAccountDetailsSection = ({ account, onEdit }: Props) => {
     ? PAM_RESOURCE_TYPE_MAP[account.resource.resourceType]
     : null;
   const isRotating = account.rotationStatus === PamAccountRotationStatus.Rotating;
+  const rotationSupported = account.resource
+    ? isPamRotationSupported(account.resource.resourceType)
+    : false;
 
   // Poll for status updates while rotation is in progress
   useGetPamAccountById(account.id, {
@@ -112,40 +120,44 @@ export const PamAccountDetailsSection = ({ account, onEdit }: Props) => {
           <DetailLabel>Created</DetailLabel>
           <DetailValue>{format(new Date(account.createdAt), "MM/dd/yyyy, hh:mm a")}</DetailValue>
         </Detail>
-        <Detail>
-          <DetailLabel>Rotation Status</DetailLabel>
-          <DetailValue>
-            <Badge
-              variant={rotationStatusVariant(account.rotationStatus)}
-              className={isRotating ? "animate-pulse" : undefined}
-            >
-              {rotationStatusLabel(account.rotationStatus)}
-            </Badge>
-          </DetailValue>
-        </Detail>
-        {(account.rotationStatus === PamAccountRotationStatus.Failed ||
-          account.rotationStatus === PamAccountRotationStatus.PartialSuccess) &&
-          account.lastRotationMessage && (
+        {rotationSupported && (
+          <>
             <Detail>
-              <DetailLabel>Last Rotation Message</DetailLabel>
-              <DetailValue
-                className={`text-xs break-words ${
-                  account.rotationStatus === PamAccountRotationStatus.Failed
-                    ? "text-danger"
-                    : "text-warning"
-                }`}
-              >
-                {account.lastRotationMessage}
+              <DetailLabel>Rotation Status</DetailLabel>
+              <DetailValue>
+                <Badge
+                  variant={rotationStatusVariant(account.rotationStatus)}
+                  className={isRotating ? "animate-pulse" : undefined}
+                >
+                  {rotationStatusLabel(account.rotationStatus)}
+                </Badge>
               </DetailValue>
             </Detail>
-          )}
-        {"lastRotatedAt" in account && account.lastRotatedAt && (
-          <Detail>
-            <DetailLabel>Last Rotated</DetailLabel>
-            <DetailValue>
-              {format(new Date(account.lastRotatedAt as string), "MM/dd/yyyy, hh:mm a")}
-            </DetailValue>
-          </Detail>
+            {(account.rotationStatus === PamAccountRotationStatus.Failed ||
+              account.rotationStatus === PamAccountRotationStatus.PartialSuccess) &&
+              account.lastRotationMessage && (
+                <Detail>
+                  <DetailLabel>Last Rotation Message</DetailLabel>
+                  <DetailValue
+                    className={`text-xs break-words ${
+                      account.rotationStatus === PamAccountRotationStatus.Failed
+                        ? "text-danger"
+                        : "text-warning"
+                    }`}
+                  >
+                    {account.lastRotationMessage}
+                  </DetailValue>
+                </Detail>
+              )}
+            {"lastRotatedAt" in account && account.lastRotatedAt && (
+              <Detail>
+                <DetailLabel>Last Rotated</DetailLabel>
+                <DetailValue>
+                  {format(new Date(account.lastRotatedAt as string), "MM/dd/yyyy, hh:mm a")}
+                </DetailValue>
+              </Detail>
+            )}
+          </>
         )}
       </DetailGroup>
     </div>

--- a/frontend/src/pages/pam/PamResourceByIDPage/PamResourceByIDPage.tsx
+++ b/frontend/src/pages/pam/PamResourceByIDPage/PamResourceByIDPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "@app/components/v3";
 import { ProjectPermissionActions, ProjectPermissionSub, useOrganization } from "@app/context";
 import {
+  isPamRotationSupported,
   PAM_RESOURCE_TYPE_MAP,
   PamResourceType,
   useDeletePamResource,
@@ -207,10 +208,12 @@ const PageContent = () => {
             resource={resource}
             onEdit={() => setIsEditModalOpen(true)}
           />
-          <PamResourceRotationPolicySection
-            resource={resource}
-            onEdit={() => setIsRotationPolicyModalOpen(true)}
-          />
+          {isPamRotationSupported(resource.resourceType) && (
+            <PamResourceRotationPolicySection
+              resource={resource}
+              onEdit={() => setIsRotationPolicyModalOpen(true)}
+            />
+          )}
           {[PamResourceType.Postgres, PamResourceType.SSH].includes(resource.resourceType) && (
             <PamResourceSessionRecordingSection
               config={resource.sessionSummaryConfig ?? null}
@@ -255,11 +258,13 @@ const PageContent = () => {
         onDeleteApproved={handleDeleteConfirm}
       />
 
-      <PamRotationPolicyModal
-        isOpen={isRotationPolicyModalOpen}
-        onOpenChange={setIsRotationPolicyModalOpen}
-        resource={resource}
-      />
+      {isPamRotationSupported(resource.resourceType) && (
+        <PamRotationPolicyModal
+          isOpen={isRotationPolicyModalOpen}
+          onOpenChange={setIsRotationPolicyModalOpen}
+          resource={resource}
+        />
+      )}
 
       {[PamResourceType.Postgres, PamResourceType.SSH].includes(resource.resourceType) && (
         <PamSessionRecordingModal


### PR DESCRIPTION
## Context

Credential rotation is only actually implemented for PostgreSQL and Windows Server, but the rotation policy box, its settings modal, and the per-account rotation status were shown for every resource type, including ones whose rotation throws or is a no-op (MySQL, MsSQL, SSH, Redis, MongoDB, Oracle, Kubernetes, AWS IAM). This gates that UI behind a supported-resource check so it only appears for resources where rotation works.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Open a PostgreSQL or Windows Server resource: the "Rotation Policy" box and edit modal still appear, and accounts show "Rotation Status".
2. Open any other resource type (e.g. SSH, MySQL, MsSQL, Redis): the "Rotation Policy" box is gone, and accounts no longer show rotation status.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
