### PR TITLE
fix(permission): stop ETag busting on every login

### DIFF
--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -1012,7 +1012,11 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         })
         .select(
           db.ref("id").withSchema(TableName.Membership).as("mId"),
-          db.ref("updatedAt").withSchema(TableName.Membership).as("mUp"),
+          // Track isActive/status rather than updatedAt: every login bumps Membership.updatedAt
+          // (lastLoginTime/lastLoginAuthMethod), which would needlessly bust the fingerprint/ETag on
+          // every auth. isActive/status are the membership columns that actually gate permissions.
+          db.ref("isActive").withSchema(TableName.Membership).as("mActive"),
+          db.ref("status").withSchema(TableName.Membership).as("mStatus"),
           db.ref("id").withSchema(TableName.MembershipRole).as("rId"),
           db.ref("updatedAt").withSchema(TableName.MembershipRole).as("rUp"),
           db.ref("updatedAt").withSchema(TableName.Role).as("crUp"),


### PR DESCRIPTION
## Context

- `getPermissionFingerprint` hashed `Membership.updatedAt`, which every identity login bumps via `lastLoginAuthMethod`/`lastLoginTime` (all 8 auth services do this). That forced a fresh fingerprint → new ETag on every auth, defeating the ETag work in PLATFOR-304.
- Track `Membership.isActive`/`status` instead — the membership columns that actually gate permissions — so deactivation/status changes still bust the cache, but logins no longer do.
- Role/privilege/metadata edits are still caught via their own `updatedAt` columns, which only move on real permission changes.
- Fixes both the `secret-v2-bridge` getSecrets ETag and the `getProjectPermission` fingerprint cache, since they share the same fingerprint function.

Linear: PLATFOR-340

## Steps to verify the change

- Authenticate the same identity twice against an unchanged project; the returned `ETag` for `getSecrets` stays stable across logins (previously rotated each login).
- Toggle a membership's `isActive`/`status` or edit a role → fingerprint changes and the ETag/cache correctly invalidates.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally