### PR TITLE
feat(kms): increase CMEK payload limit to 1MB

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2541,7 +2541,7 @@ export const KMS = {
   },
   VERIFY: {
     keyId: "The ID of the key to verify the data with.",
-    data: "The data in string format to be verified (base64 encoded). For data larger than 4096 bytes you must first create a digest of the data and then pass the digest in the data parameter.",
+    data: "The data in string format to be verified (base64 encoded). For data larger than 1MB you must first create a digest of the data and then pass the digest in the data parameter.",
     signature: "The signature to be verified (base64 encoded).",
     isDigest: "Whether the data is already digested or not."
   }

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -23,37 +23,35 @@ const CmekSchema = KmsKeysSchema.merge(InternalKmsSchema.pick({ version: true, e
   isReserved: true
 });
 
-const base64Schema = z.string().superRefine((val, ctx) => {
-  if (!isBase64(val)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "plaintext must be base64 encoded"
-    });
-  }
+const MAX_KMS_PAYLOAD_BYTES = 1024 * 1024;
+// AES-GCM ciphertext carries a 12-byte IV, 16-byte auth tag, and 3-byte version blob on top of the plaintext,
+// so the decrypt limit must exceed the encrypt limit or a max-size encrypt's output can't be decrypted.
+const MAX_KMS_CIPHERTEXT_BYTES = MAX_KMS_PAYLOAD_BYTES + 1024;
+const MAX_KMS_SIGNATURE_BYTES = 8192;
+// A 1MB payload is ~1.37MB once base64 encoded, plus the JSON envelope, so the raw request body exceeds
+// Fastify's 1MB default bodyLimit. Override per-route so the body isn't rejected before schema validation runs.
+const KMS_PAYLOAD_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
 
-  if (getBase64SizeInBytes(val) > 4096) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "data cannot exceed 4096 bytes"
-    });
-  }
-});
+const createBase64Schema = (field: string, maxBytes: number) =>
+  z.string().superRefine((val, ctx) => {
+    if (!isBase64(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${field} must be base64 encoded`
+      });
+    }
 
-const signatureBase64Schema = z.string().superRefine((val, ctx) => {
-  if (!isBase64(val)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "signature must be base64 encoded"
-    });
-  }
+    if (getBase64SizeInBytes(val) > maxBytes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${field} cannot exceed ${maxBytes} bytes`
+      });
+    }
+  });
 
-  if (getBase64SizeInBytes(val) > 8192) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "signature cannot exceed 8192 bytes"
-    });
-  }
-});
+const base64Schema = createBase64Schema("data", MAX_KMS_PAYLOAD_BYTES);
+const ciphertextBase64Schema = createBase64Schema("ciphertext", MAX_KMS_CIPHERTEXT_BYTES);
+const signatureBase64Schema = createBase64Schema("signature", MAX_KMS_SIGNATURE_BYTES);
 
 export const registerCmekRouter = async (server: FastifyZodProvider) => {
   // create encryption key
@@ -412,6 +410,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
   // encrypt data
   server.route({
     method: "POST",
+    bodyLimit: KMS_PAYLOAD_BODY_LIMIT_BYTES,
     url: "/keys/:keyId/encrypt",
     config: {
       rateLimit: writeLimit
@@ -754,6 +753,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "POST",
+    bodyLimit: KMS_PAYLOAD_BODY_LIMIT_BYTES,
     url: "/keys/:keyId/sign",
     config: {
       rateLimit: writeLimit
@@ -810,6 +810,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "POST",
+    bodyLimit: KMS_PAYLOAD_BODY_LIMIT_BYTES,
     url: "/keys/:keyId/verify",
     config: {
       rateLimit: writeLimit
@@ -869,6 +870,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "POST",
+    bodyLimit: KMS_PAYLOAD_BODY_LIMIT_BYTES,
     url: "/keys/:keyId/decrypt",
     config: {
       rateLimit: writeLimit
@@ -882,7 +884,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         keyId: z.string().uuid().describe(KMS.DECRYPT.keyId)
       }),
       body: z.object({
-        ciphertext: base64Schema.describe(KMS.DECRYPT.ciphertext)
+        ciphertext: ciphertextBase64Schema.describe(KMS.DECRYPT.ciphertext)
       }),
       response: {
         200: z.object({

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -28,6 +28,24 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+    # KMS encrypt/decrypt/sign/verify accept payloads up to 1MB (~1.37MB base64 + JSON on the wire).
+    # Scoped here so the larger body limit applies only to these endpoints, not all of /api.
+    location ~ ^/api/v1/kms/keys/[^/]+/(encrypt|decrypt|sign|verify)$ {
+        client_max_body_size 2M;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        # proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+    }
+
     location ~ ^/(api|secret-scanning/webhooks) {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -35,6 +35,23 @@ server {
         proxy_cookie_path / "/; SameSite=strict";
     }
 
+    # KMS encrypt/decrypt/sign/verify accept payloads up to 1MB (~1.37MB base64 + JSON on the wire).
+    # Scoped here so the larger body limit applies only to these endpoints, not all of /api.
+    location ~ ^/api/v1/kms/keys/[^/]+/(encrypt|decrypt|sign|verify)$ {
+        client_max_body_size 2M;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://api;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; SameSite=strict";
+    }
+
     location ~ ^/(api|secret-scanning/webhooks) {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Context

The CMEK encrypt/decrypt/sign/verify endpoints capped payloads at 4KB, which blocked customers from encrypting files rather than just keys. This raises the limit to 1MB (matching HashiCorp Transit) across the backend schema, per-route body limits, and the bundled nginx configs.

## Steps to verify the change

1. Create a KMS key via the API.
2. Base64-encode a payload larger than 4KB and up to 1MB, POST to `/api/v1/kms/keys/{keyId}/encrypt` — succeeds (previously a validation error).
3. Decrypt the returned ciphertext via `/api/v1/kms/keys/{keyId}/decrypt` — returns the original plaintext.
4. POST a payload over 1MB — rejected with `data cannot exceed 1048576 bytes`.

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
