### PR TITLE
fix(secrets-overview): check secret type on batch mode

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -1550,7 +1550,7 @@ const OverviewPageContent = () => {
     value: string,
     type = SecretType.Shared
   ) => {
-    if (isBatchModeActive) {
+    if (isBatchModeActive && type !== SecretType.Personal) {
       addPendingChange(
         {
           id: crypto.randomUUID(),
@@ -1637,7 +1637,7 @@ const OverviewPageContent = () => {
     skipMultilineEncoding?: boolean | null;
     originalValue?: string;
   }) => {
-    if (isBatchModeActive) {
+    if (isBatchModeActive && type !== SecretType.Personal) {
       const existingSecret = getSecretByKey(env, key);
 
       let batchSecretValue: string | undefined = value;
@@ -1753,7 +1753,7 @@ const OverviewPageContent = () => {
     secretId?: string,
     type = SecretType.Shared
   ) => {
-    if (isBatchModeActive) {
+    if (isBatchModeActive && type !== SecretType.Personal) {
       const existingSecret = getSecretByKey(env, key);
 
       if (!existingSecret) {


### PR DESCRIPTION
## Context
Check if the secret is not personal when on batch mode. If the secret is personal and batch mode is active, this will try to create (or update if you are updating) the secret as public, and there will have a validation on the UI that won't allow it, saying that the secret already exists.


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- batch mode on
- try to save a personal secret. 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)