### PR TITLE
fix: make oidc group membership handling case insensitive

### DIFF
--- a/backend/src/ee/services/oidc/oidc-config-fns.test.ts
+++ b/backend/src/ee/services/oidc/oidc-config-fns.test.ts
@@ -49,6 +49,18 @@ describe("resolveOidcGroupMembershipChanges", () => {
     expect(groupsToAddUserTo.map((g) => g.id).sort()).toEqual(["1", "2"]);
   });
 
+  test("adds the user to a case-variant they have not joined even when already in another variant", () => {
+    // User is in "Engineering" (id 1) but not "engineering" (id 2). A name-based "already member"
+    // check would wrongly skip id 2; keying on group ID adds them to the variant they actually lack.
+    const { groupsToAddUserTo } = resolveOidcGroupMembershipChanges({
+      idpGroups: ["engineering"],
+      userGroupMemberships: [makeMembership("1", "Engineering")],
+      orgGroups: [makeGroup("1", "Engineering"), makeGroup("2", "engineering")]
+    });
+
+    expect(groupsToAddUserTo.map((g) => g.id)).toEqual(["2"]);
+  });
+
   test("only removes groups the user is actually a member of, even when a case-variant exists", () => {
     // The user is a member of "Engineering" (id 1); a case-variant "engineering" (id 2) also exists
     // but the user never joined it, so it must not be queued for removal.

--- a/backend/src/ee/services/oidc/oidc-config-fns.test.ts
+++ b/backend/src/ee/services/oidc/oidc-config-fns.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveOidcGroupMembershipChanges } from "./oidc-config-fns";
+
+const makeGroup = (id: string, name: string) => ({ id, name });
+const makeMembership = (groupId: string, groupName: string) => ({ groupId, groupName });
+
+describe("resolveOidcGroupMembershipChanges", () => {
+  test("matches IdP group claims to org groups case-insensitively when adding", () => {
+    const { groupsToAddUserTo, groupsToRemoveUserFrom } = resolveOidcGroupMembershipChanges({
+      idpGroups: ["engineering", "DESIGN"],
+      userGroupMemberships: [],
+      orgGroups: [makeGroup("1", "Engineering"), makeGroup("2", "Design"), makeGroup("3", "Sales")]
+    });
+
+    expect(groupsToAddUserTo.map((g) => g.name).sort()).toEqual(["Design", "Engineering"]);
+    expect(groupsToRemoveUserFrom).toEqual([]);
+  });
+
+  test("does not re-add a group the user already belongs to (case-insensitive)", () => {
+    const { groupsToAddUserTo, groupsToRemoveUserFrom } = resolveOidcGroupMembershipChanges({
+      idpGroups: ["ENGINEERING"],
+      userGroupMemberships: [makeMembership("1", "Engineering")],
+      orgGroups: [makeGroup("1", "Engineering")]
+    });
+
+    expect(groupsToAddUserTo).toEqual([]);
+    expect(groupsToRemoveUserFrom).toEqual([]);
+  });
+
+  test("removes the user from groups no longer present in the claim (case-insensitive)", () => {
+    const { groupsToAddUserTo, groupsToRemoveUserFrom } = resolveOidcGroupMembershipChanges({
+      idpGroups: ["design"],
+      userGroupMemberships: [makeMembership("1", "Engineering"), makeMembership("2", "Design")],
+      orgGroups: [makeGroup("1", "Engineering"), makeGroup("2", "Design")]
+    });
+
+    expect(groupsToAddUserTo).toEqual([]);
+    expect(groupsToRemoveUserFrom.map((g) => g.name)).toEqual(["Engineering"]);
+  });
+
+  test("adds the user to every case-variant when the org has groups differing only by case", () => {
+    const { groupsToAddUserTo } = resolveOidcGroupMembershipChanges({
+      idpGroups: ["engineering"],
+      userGroupMemberships: [],
+      orgGroups: [makeGroup("1", "Engineering"), makeGroup("2", "engineering")]
+    });
+
+    expect(groupsToAddUserTo.map((g) => g.id).sort()).toEqual(["1", "2"]);
+  });
+
+  test("only removes groups the user is actually a member of, even when a case-variant exists", () => {
+    // The user is a member of "Engineering" (id 1); a case-variant "engineering" (id 2) also exists
+    // but the user never joined it, so it must not be queued for removal.
+    const { groupsToRemoveUserFrom } = resolveOidcGroupMembershipChanges({
+      idpGroups: [],
+      userGroupMemberships: [makeMembership("1", "Engineering")],
+      orgGroups: [makeGroup("1", "Engineering"), makeGroup("2", "engineering")]
+    });
+
+    expect(groupsToRemoveUserFrom.map((g) => g.id)).toEqual(["1"]);
+  });
+});

--- a/backend/src/ee/services/oidc/oidc-config-fns.ts
+++ b/backend/src/ee/services/oidc/oidc-config-fns.ts
@@ -1,0 +1,44 @@
+type TResolveOidcGroupMembershipChangesDTO<TGroup extends { id: string; name: string }> = {
+  // The raw "groups" claim from the OIDC IdP. Casing is preserved by the caller (it is recorded in
+  // audit logs); matching below is case-insensitive.
+  idpGroups: string[];
+  // The user's current org group memberships.
+  userGroupMemberships: { groupId: string; groupName: string }[];
+  // Every group that exists in the org.
+  orgGroups: TGroup[];
+};
+
+/**
+ * Decides which org groups a user should be added to / removed from when syncing OIDC group
+ * memberships. Group names are matched against the IdP "groups" claim case-insensitively — the
+ * email claim is already lowercased on ingest, so group names are treated the same way.
+ *
+ * Because the groups table's unique constraint on (orgId, name) is case-sensitive, an org can
+ * legally hold case-variant groups (e.g. "Engineering" and "engineering"). In that case a single
+ * IdP claim adds the user to every variant they are not already a member of, and removal is driven
+ * by the user's actual memberships so a group the user never joined is never queued for removal.
+ */
+export const resolveOidcGroupMembershipChanges = <TGroup extends { id: string; name: string }>({
+  idpGroups,
+  userGroupMemberships,
+  orgGroups
+}: TResolveOidcGroupMembershipChangesDTO<TGroup>): {
+  groupsToAddUserTo: TGroup[];
+  groupsToRemoveUserFrom: TGroup[];
+} => {
+  const idpGroupNames = new Set(idpGroups.map((groupName) => groupName.toLowerCase()));
+  const userGroupNames = new Set(userGroupMemberships.map((membership) => membership.groupName.toLowerCase()));
+
+  const groupsToAddUserTo = orgGroups.filter(
+    (group) => idpGroupNames.has(group.name.toLowerCase()) && !userGroupNames.has(group.name.toLowerCase())
+  );
+
+  const groupIdsToRemoveUserFrom = new Set(
+    userGroupMemberships
+      .filter((membership) => !idpGroupNames.has(membership.groupName.toLowerCase()))
+      .map((membership) => membership.groupId)
+  );
+  const groupsToRemoveUserFrom = orgGroups.filter((group) => groupIdsToRemoveUserFrom.has(group.id));
+
+  return { groupsToAddUserTo, groupsToRemoveUserFrom };
+};

--- a/backend/src/ee/services/oidc/oidc-config-fns.ts
+++ b/backend/src/ee/services/oidc/oidc-config-fns.ts
@@ -27,10 +27,13 @@ export const resolveOidcGroupMembershipChanges = <TGroup extends { id: string; n
   groupsToRemoveUserFrom: TGroup[];
 } => {
   const idpGroupNames = new Set(idpGroups.map((groupName) => groupName.toLowerCase()));
-  const userGroupNames = new Set(userGroupMemberships.map((membership) => membership.groupName.toLowerCase()));
+  // Track current memberships by group ID (not name): when an org holds case-variant groups, the
+  // user must still be added to every matching variant they are not actually a member of. Keying on
+  // ID also keeps this consistent with how the removal path below is constructed.
+  const userGroupIds = new Set(userGroupMemberships.map((membership) => membership.groupId));
 
   const groupsToAddUserTo = orgGroups.filter(
-    (group) => idpGroupNames.has(group.name.toLowerCase()) && !userGroupNames.has(group.name.toLowerCase())
+    (group) => idpGroupNames.has(group.name.toLowerCase()) && !userGroupIds.has(group.id)
   );
 
   const groupIdsToRemoveUserFrom = new Set(

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -60,6 +60,7 @@ import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
 import { findOrgIdByVerifiedDomain, verifyEmailDomainOwnership } from "../email-domain/email-domain-fns";
 import { TOidcConfigDALFactory } from "./oidc-config-dal";
+import { resolveOidcGroupMembershipChanges } from "./oidc-config-fns";
 import {
   OIDCConfigurationType,
   TCreateOidcCfgDTO,
@@ -382,9 +383,11 @@ export const oidcConfigServiceFactory = ({
       const userGroups = await userGroupMembershipDAL.findGroupMembershipsByUserIdInOrg(user.id, orgId);
       const orgGroups = await groupDAL.findByOrgId(orgId);
 
-      const userGroupsNames = userGroups.map((membership) => membership.groupName);
-      const missingGroupsMemberships = groups.filter((groupName) => !userGroupsNames.includes(groupName));
-      const groupsToAddUserTo = orgGroups.filter((group) => missingGroupsMemberships.includes(group.name));
+      const { groupsToAddUserTo, groupsToRemoveUserFrom } = resolveOidcGroupMembershipChanges({
+        idpGroups: groups,
+        userGroupMemberships: userGroups,
+        orgGroups
+      });
 
       for await (const group of groupsToAddUserTo) {
         await addUsersToGroupByUserIds({
@@ -418,11 +421,6 @@ export const oidcConfigServiceFactory = ({
           }
         });
       }
-
-      const membershipsToRemove = userGroups
-        .filter((membership) => !groups.includes(membership.groupName))
-        .map((membership) => membership.groupId);
-      const groupsToRemoveUserFrom = orgGroups.filter((group) => membershipsToRemove.includes(group.id));
 
       for await (const group of groupsToRemoveUserFrom) {
         await removeUsersFromGroupByUserIds({


### PR DESCRIPTION
## Context

This PR updates the oidc group membership mapping to be case insensitive of claim/group names

## Screenshots

N/A

## Steps to verify the change

setup keycloak and verify user is added to single and multiple groups regardless of casing misalignment

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)