### PR TITLE
feat: add tags to cli's secret cmd doc page

### DIFF
--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -235,6 +235,15 @@ $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jeb
     ```
 
   </Accordion>
+  <Accordion title="--tag">
+    Used to attach tags to the secret. If a tag does not exist on the server, it will be created automatically. This flag overrides any existing tags on the secret. If not provided, existing tags are kept intact. You can specify multiple `--tag` flags to add multiple tags.
+
+    ```bash
+    # Example
+    infisical secrets set DOMAIN=example.com --tag=backend --tag=production
+    ```
+
+  </Accordion>
   <Accordion title="--file">
     Used to set secrets from a file, supporting both `.env` and `YAML` formats. The file path can be either absolute or relative to the current working directory.
 

--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -236,7 +236,7 @@ $ infisical secrets set STRIPE_API_KEY=sjdgwkeudyjwe DOMAIN=example.com HASH=jeb
 
   </Accordion>
   <Accordion title="--tag">
-    Used to attach tags to the secret. If a tag does not exist on the server, it will be created automatically. This flag overrides any existing tags on the secret. If not provided, existing tags are kept intact. You can specify multiple `--tag` flags to add multiple tags.
+    Used to attach tags to the secret. If a tag does not exist on the server, it will be created automatically. **This flag overrides any existing tags on the secret**. If not provided, existing tags are kept intact. You can specify multiple `--tag` flags to add multiple tags.
 
     ```bash
     # Example


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Add doc for new flag for `infisical secret set`

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->
<img width="852" height="827" alt="image" src="https://github.com/user-attachments/assets/ce61c873-7d30-45fb-bbf2-f40b228ecc70" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)