### PR TITLE
fix: update slack and microsoft team integration callback urls to reflect new org structure

### DIFF
--- a/backend/src/server/routes/v1/slack-router.ts
+++ b/backend/src/server/routes/v1/slack-router.ts
@@ -339,7 +339,13 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
           return res.redirect(appCfg.SITE_URL as string);
         },
         successAsync: async (installation) => {
-          const metadata = JSON.parse(installation.metadata || "{}") as { orgId: string };
+          const metadata = JSON.parse(installation.metadata || "{}") as { orgId?: string };
+
+          // Fall back to the site root (like the failure path) if orgId is missing, rather than
+          // redirecting to a broken /organizations/undefined/settings page.
+          if (!metadata.orgId) {
+            return res.redirect(appCfg.SITE_URL as string);
+          }
 
           return res.redirect(
             `${appCfg.SITE_URL}/organizations/${metadata.orgId}/settings?selectedTab=workflow-integrations`

--- a/backend/src/server/routes/v1/slack-router.ts
+++ b/backend/src/server/routes/v1/slack-router.ts
@@ -338,8 +338,12 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         failureAsync: async () => {
           return res.redirect(appCfg.SITE_URL as string);
         },
-        successAsync: async () => {
-          return res.redirect(`${appCfg.SITE_URL}/organization/settings?selectedTab=workflow-integrations`);
+        successAsync: async (installation) => {
+          const metadata = JSON.parse(installation.metadata || "{}") as { orgId: string };
+
+          return res.redirect(
+            `${appCfg.SITE_URL}/organizations/${metadata.orgId}/settings?selectedTab=workflow-integrations`
+          );
         }
       });
     }

--- a/frontend/src/pages/redirects/settings-oauth-callback-redirect.tsx
+++ b/frontend/src/pages/redirects/settings-oauth-callback-redirect.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute(
+  "/_authenticate/_inject-org-details/organization/settings/oauth/callback"
+)({
+  beforeLoad: ({ context, search }) => {
+    throw redirect({
+      to: "/organizations/$orgId/settings/oauth/callback",
+      params: {
+        orgId: context.organizationId
+      },
+      search
+    });
+  }
+});

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -49,6 +49,7 @@ import { Route as adminCachingPageRouteImport } from './pages/admin/CachingPage/
 import { Route as adminAuthenticationPageRouteImport } from './pages/admin/AuthenticationPage/route'
 import { Route as adminAccessManagementPageRouteImport } from './pages/admin/AccessManagementPage/route'
 import { Route as adminGeneralPageRouteImport } from './pages/admin/GeneralPage/route'
+import { Route as redirectsSettingsOauthCallbackRedirectImport } from './pages/redirects/settings-oauth-callback-redirect'
 import { Route as adminResourceOverviewPageRouteImport } from './pages/admin/ResourceOverviewPage/route'
 import { Route as organizationProjectsPageRouteImport } from './pages/organization/ProjectsPage/route'
 import { Route as organizationBillingPageRouteImport } from './pages/organization/BillingPage/route'
@@ -701,6 +702,13 @@ const adminGeneralPageRouteRoute = adminGeneralPageRouteImport.update({
   path: '/',
   getParentRoute: () => adminLayoutRoute,
 } as any)
+
+const redirectsSettingsOauthCallbackRedirectRoute =
+  redirectsSettingsOauthCallbackRedirectImport.update({
+    id: '/organization/settings/oauth/callback',
+    path: '/organization/settings/oauth/callback',
+    getParentRoute: () => middlewaresInjectOrgDetailsRoute,
+  } as any)
 
 const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsRoute =
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsImport.update({
@@ -3076,6 +3084,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/organizations/$orgId/settings'
       preLoaderRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsImport
       parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdImport
+    }
+    '/_authenticate/_inject-org-details/organization/settings/oauth/callback': {
+      id: '/_authenticate/_inject-org-details/organization/settings/oauth/callback'
+      path: '/organization/settings/oauth/callback'
+      fullPath: '/organization/settings/oauth/callback'
+      preLoaderRoute: typeof redirectsSettingsOauthCallbackRedirectImport
+      parentRoute: typeof middlewaresInjectOrgDetailsImport
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections/': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections/'
@@ -6096,6 +6111,7 @@ const AuthenticateInjectOrgDetailsAdminRouteWithChildren =
 interface middlewaresInjectOrgDetailsRouteChildren {
   organizationLayoutRoute: typeof organizationLayoutRouteWithChildren
   AuthenticateInjectOrgDetailsAdminRoute: typeof AuthenticateInjectOrgDetailsAdminRouteWithChildren
+  redirectsSettingsOauthCallbackRedirectRoute: typeof redirectsSettingsOauthCallbackRedirectRoute
   redirectsOauthCallbackRedirectRoute: typeof redirectsOauthCallbackRedirectRoute
   pamPamAccountAccessPageRouteRoute: typeof pamPamAccountAccessPageRouteRoute
 }
@@ -6105,6 +6121,8 @@ const middlewaresInjectOrgDetailsRouteChildren: middlewaresInjectOrgDetailsRoute
     organizationLayoutRoute: organizationLayoutRouteWithChildren,
     AuthenticateInjectOrgDetailsAdminRoute:
       AuthenticateInjectOrgDetailsAdminRouteWithChildren,
+    redirectsSettingsOauthCallbackRedirectRoute:
+      redirectsSettingsOauthCallbackRedirectRoute,
     redirectsOauthCallbackRedirectRoute: redirectsOauthCallbackRedirectRoute,
     pamPamAccountAccessPageRouteRoute: pamPamAccountAccessPageRouteRoute,
   }
@@ -6282,6 +6300,7 @@ export interface FileRoutesByFullPath {
   '/organizations/$orgId/networking': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdNetworkingRouteWithChildren
   '/organizations/$orgId/secret-sharing': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSecretSharingRouteWithChildren
   '/organizations/$orgId/settings': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsRouteWithChildren
+  '/organization/settings/oauth/callback': typeof redirectsSettingsOauthCallbackRedirectRoute
   '/organizations/$orgId/app-connections/': typeof organizationAppConnectionsAppConnectionsPageRouteRoute
   '/organizations/$orgId/networking/': typeof organizationNetworkingPageRouteRoute
   '/organizations/$orgId/secret-sharing/': typeof organizationSecretSharingPageRouteRoute
@@ -6567,6 +6586,7 @@ export interface FileRoutesByTo {
   '/organizations/$orgId/billing': typeof organizationBillingPageRouteRoute
   '/organizations/$orgId/projects': typeof organizationProjectsPageRouteRouteWithChildren
   '/admin/resources/overview': typeof adminResourceOverviewPageRouteRoute
+  '/organization/settings/oauth/callback': typeof redirectsSettingsOauthCallbackRedirectRoute
   '/organizations/$orgId/app-connections': typeof organizationAppConnectionsAppConnectionsPageRouteRoute
   '/organizations/$orgId/networking': typeof organizationNetworkingPageRouteRoute
   '/organizations/$orgId/secret-sharing': typeof organizationSecretSharingPageRouteRoute
@@ -6845,6 +6865,7 @@ export interface FileRoutesById {
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdNetworkingRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/secret-sharing': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSecretSharingRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsRouteWithChildren
+  '/_authenticate/_inject-org-details/organization/settings/oauth/callback': typeof redirectsSettingsOauthCallbackRedirectRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections/': typeof organizationAppConnectionsAppConnectionsPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/': typeof organizationNetworkingPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/secret-sharing/': typeof organizationSecretSharingPageRouteRoute
@@ -7147,6 +7168,7 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/networking'
     | '/organizations/$orgId/secret-sharing'
     | '/organizations/$orgId/settings'
+    | '/organization/settings/oauth/callback'
     | '/organizations/$orgId/app-connections/'
     | '/organizations/$orgId/networking/'
     | '/organizations/$orgId/secret-sharing/'
@@ -7431,6 +7453,7 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/billing'
     | '/organizations/$orgId/projects'
     | '/admin/resources/overview'
+    | '/organization/settings/oauth/callback'
     | '/organizations/$orgId/app-connections'
     | '/organizations/$orgId/networking'
     | '/organizations/$orgId/secret-sharing'
@@ -7707,6 +7730,7 @@ export interface FileRouteTypes {
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/secret-sharing'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings'
+    | '/_authenticate/_inject-org-details/organization/settings/oauth/callback'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/secret-sharing/'
@@ -8066,6 +8090,7 @@ export const routeTree = rootRoute
       "children": [
         "/_authenticate/_inject-org-details/_org-layout",
         "/_authenticate/_inject-org-details/admin",
+        "/_authenticate/_inject-org-details/organization/settings/oauth/callback",
         "/_authenticate/_inject-org-details/organization/app-connections/$appConnection/oauth/callback",
         "/_authenticate/_inject-org-details/organizations/$orgId/projects/pam/$projectId/resources/$resourceType/$resourceId/accounts/$accountId/access"
       ]
@@ -8309,6 +8334,10 @@ export const routeTree = rootRoute
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback"
       ]
+    },
+    "/_authenticate/_inject-org-details/organization/settings/oauth/callback": {
+      "filePath": "redirects/settings-oauth-callback-redirect.tsx",
+      "parent": "/_authenticate/_inject-org-details"
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections/": {
       "filePath": "organization/AppConnections/AppConnectionsPage/route.tsx",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -509,6 +509,10 @@ export const routes = rootRoute("root.tsx", [
         "/organization/app-connections/$appConnection/oauth/callback",
         "redirects/oauth-callback-redirect.tsx"
       ),
+      route(
+        "/organization/settings/oauth/callback",
+        "redirects/settings-oauth-callback-redirect.tsx"
+      ),
       layout("org-layout", "organization/layout.tsx", [
         organizationRoutes,
         route("/organizations/$orgId/secret-manager/$projectId", [


### PR DESCRIPTION
## Context

This PR updates the slack and microsoft team workflow redirects to point at the new location of the workflow integrations tab

## Screenshots

N/A

## Steps to verify the change

- setup slack and microsoft teams integration, verify the redirect properly navigates back to the tab

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)