### PR TITLE
fix: boot when DB migration history is interleaved but not forked

### DIFF
--- a/backend/src/auto-start-migrations-fns.test.ts
+++ b/backend/src/auto-start-migrations-fns.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+
+import { getMigrationBootDirection } from "./auto-start-migrations-fns";
+
+describe("getMigrationBootDirection", () => {
+  test("returns 'current' when applied and bundled match exactly", () => {
+    const result = getMigrationBootDirection({
+      appliedMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs"],
+      bundledMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs"]
+    });
+    expect(result.direction).toBe("current");
+  });
+
+  test("returns 'behind' when the image bundles migrations not yet applied", () => {
+    const result = getMigrationBootDirection({
+      appliedMigrationNames: ["20260101000000_a.mjs"],
+      bundledMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs"]
+    });
+    expect(result.direction).toBe("behind");
+    expect(result.pendingMigrationNames).toEqual(["20260102000000_b.mjs"]);
+  });
+
+  test("returns 'ahead' on a clean rolling deploy (DB has strictly-newer migrations, nothing pending)", () => {
+    const result = getMigrationBootDirection({
+      appliedMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs", "20260103000000_c.mjs"],
+      bundledMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs"]
+    });
+    expect(result.direction).toBe("ahead");
+    expect(result.unknownAppliedMigrationNames).toEqual(["20260103000000_c.mjs"]);
+  });
+
+  // INC-62: a backdated migration merged after later-timestamped ones (common on long-lived branches).
+  // The DB has an unknown migration whose timestamp is OLDER than the image's newest bundled migration,
+  // but the image has nothing pending. Its bundled set is still a strict subset of what's applied, so it
+  // must boot ('ahead'), not fail ('invalid').
+  test("returns 'ahead' for an interleaved/backdated unknown migration when nothing is pending", () => {
+    const result = getMigrationBootDirection({
+      appliedMigrationNames: [
+        "20260101000000_a.mjs",
+        "20260102000000_b.mjs",
+        "20260102120000_backdated.mjs", // older than the image's newest bundled migration
+        "20260103000000_c.mjs"
+      ],
+      bundledMigrationNames: ["20260101000000_a.mjs", "20260102000000_b.mjs", "20260103000000_c.mjs"]
+    });
+    expect(result.direction).toBe("ahead");
+    expect(result.unknownAppliedMigrationNames).toEqual(["20260102120000_backdated.mjs"]);
+    expect(result.pendingMigrationNames).toEqual([]);
+  });
+
+  test("returns 'invalid' only on a true fork (DB has unknown migrations AND the image has pending ones)", () => {
+    const result = getMigrationBootDirection({
+      appliedMigrationNames: ["20260101000000_a.mjs", "20260102000000_db_only.mjs"],
+      bundledMigrationNames: ["20260101000000_a.mjs", "20260103000000_image_only.mjs"]
+    });
+    expect(result.direction).toBe("invalid");
+    expect(result.unknownAppliedMigrationNames).toEqual(["20260102000000_db_only.mjs"]);
+    expect(result.pendingMigrationNames).toEqual(["20260103000000_image_only.mjs"]);
+  });
+});

--- a/backend/src/auto-start-migrations-fns.ts
+++ b/backend/src/auto-start-migrations-fns.ts
@@ -14,8 +14,6 @@ type TMigrationBootDirection = {
   pendingMigrationNames: string[];
 };
 
-const getMigrationTimestamp = (migrationName: string) => migrationName.match(/^(\d+)/)?.[1] ?? "";
-
 export const getMigrationBootDirection = ({
   appliedMigrationNames,
   bundledMigrationNames
@@ -34,6 +32,9 @@ export const getMigrationBootDirection = ({
     (migrationName) => !appliedMigrationNameSet.has(migrationName)
   );
 
+  // A true fork: the database has migrations this image lacks AND this image has migrations to apply on
+  // top of that diverged history. Applying pending migrations onto a divergent DB is the only genuinely
+  // unsafe case, so this is the one that must fail loud.
   if (unknownAppliedMigrationNames.length && pendingMigrationNames.length) {
     return {
       direction: "invalid",
@@ -42,24 +43,15 @@ export const getMigrationBootDirection = ({
     };
   }
 
-  const latestBundledMigrationTimestamp = bundledMigrationNames.map(getMigrationTimestamp).sort().at(-1) ?? "";
-  const hasOnlyNewerUnknownMigrations = unknownAppliedMigrationNames.every(
-    (migrationName) => getMigrationTimestamp(migrationName) > latestBundledMigrationTimestamp
-  );
-
-  if (unknownAppliedMigrationNames.length && hasOnlyNewerUnknownMigrations) {
+  // The database has migrations this image lacks, but this image has nothing pending to apply — its bundled
+  // migrations are a strict subset of what's already applied. This is safe to skip and boot regardless of
+  // timestamp ordering: backdated / late-merged migrations (common on long-lived branches) leave the history
+  // interleaved-but-compatible, not forked.
+  if (unknownAppliedMigrationNames.length) {
     return {
       direction: "ahead",
       unknownAppliedMigrationNames,
       pendingMigrationNames: []
-    };
-  }
-
-  if (unknownAppliedMigrationNames.length) {
-    return {
-      direction: "invalid",
-      unknownAppliedMigrationNames,
-      pendingMigrationNames
     };
   }
 

--- a/backend/src/auto-start-migrations.ts
+++ b/backend/src/auto-start-migrations.ts
@@ -78,9 +78,9 @@ const logUnknownAppliedMigrations = ({
   const dateRange = getMigrationDateRange(unknownAppliedMigrationNames);
 
   const sections = [
-    `Database has migrations newer than this image [database=${databaseName}] [imageVersion=${imageVersion}].`,
-    `Skipping startup migrations.`,
-    `This is expected during rolling deployments when a peer instance on a newer image has already applied them.`
+    `Database has applied migrations that this image does not bundle [database=${databaseName}] [imageVersion=${imageVersion}].`,
+    `This image has nothing pending to apply, so startup migrations are skipped.`,
+    `This is expected during rolling deployments or rollbacks when a peer instance on a different image has already applied them.`
   ];
   if (dateRange) {
     sections.push(


### PR DESCRIPTION
## Context

The startup migration check (`getMigrationBootDirection`) failed boot (`process.exit(1)`) whenever the database contained an applied migration the running image didn't bundle **and** that migration's filename timestamp fell *behind* the image's newest bundled migration — even when the image had nothing pending to apply.

- This misfires on a common, benign pattern: a migration authored on a long-lived branch (so it carries an older filename timestamp) that merges *after* later-timestamped migrations. Once it's applied to the DB, any older image lacking it can no longer boot — including rollback targets.
- The real unsafe state is a **fork** (the DB has migrations the image lacks *and* the image has pending migrations to apply on top of that diverged history). When `pending === 0`, the image's bundled migrations are a strict subset of what's applied — additive, safe to skip and boot — regardless of timestamp ordering.
- For reference, vanilla Knex `latest()` is stricter still: `validateMigrationList` throws "migration directory is corrupt" for *any* applied-but-not-bundled migration. This boot layer exists to be more lenient than Knex; the timestamp heuristic just made the leniency incomplete.

Change:
- Decide on `pending` alone — fail (`invalid`) only on a true fork (`unknownApplied > 0 && pending > 0`); treat any `pending === 0` with unknown applied migrations as `ahead` (boot + skip).
- Drop the `latestBundledMigrationTimestamp` / `hasOnlyNewerUnknownMigrations` heuristic.
- Reword the skip warning to be accurate for the interleaved/rollback case.
- Add unit tests for `getMigrationBootDirection` (none existed), incl. the interleaved-backdated regression guard.

## Steps to verify the change

- `cd backend && npx vitest run -c vitest.unit.config.mts src/auto-start-migrations-fns.test.ts` — 5/5 pass (current, behind, clean ahead, interleaved-backdated ahead, true-fork invalid).
- lint + type check clean on the touched files.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)