### PR TITLE
feat: added go shadowing

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -56,6 +56,14 @@ USER non-root-user
 ## BACKEND
 ##
 
+# Go sidecar build (parallel stage)
+FROM golang:1.26-trixie AS go-builder
+WORKDIR /app
+COPY backend-go/go.mod backend-go/go.sum ./
+RUN go mod download
+COPY backend-go/ .
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o /go-sidecar ./cmd/infisical/main.go
+
 # Oracle Instant Client (parallel stage — downloads while other stages build)
 FROM debian:trixie-slim AS oracle
 RUN apt-get update && apt-get install -y unzip wget ca-certificates \
@@ -249,8 +257,8 @@ ENV CAPTCHA_SITE_KEY=$CAPTCHA_SITE_KEY
 WORKDIR /
 
 COPY --from=backend-runner /app /backend
-
 COPY --from=frontend-runner /app ./backend/frontend-build
+COPY --from=go-builder /go-sidecar /backend/go-sidecar
 
 # Make export-assets script executable for CDN asset extraction
 RUN chmod +x /backend/scripts/export-assets.sh

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -58,6 +58,14 @@ USER non-root-user
 ## BACKEND
 ##
 
+# Go sidecar build (parallel stage)
+FROM golang:1.26-trixie AS go-builder
+WORKDIR /app
+COPY backend-go/go.mod backend-go/go.sum ./
+RUN go mod download
+COPY backend-go/ .
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o /go-sidecar ./cmd/infisical/main.go
+
 # Oracle Instant Client (parallel stage — downloads while other stages build)
 FROM debian:trixie-slim AS oracle
 RUN apt-get update && apt-get install -y unzip wget ca-certificates \
@@ -245,6 +253,7 @@ ENV CAPTCHA_SITE_KEY=$CAPTCHA_SITE_KEY
 
 COPY --from=backend-runner /app /backend
 COPY --from=frontend-runner /app ./backend/frontend-build
+COPY --from=go-builder /go-sidecar /backend/go-sidecar
 
 # Make export-assets script executable for CDN asset extraction
 RUN chmod +x /backend/scripts/export-assets.sh

--- a/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
+++ b/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
@@ -277,7 +277,7 @@ func (h *Handler) GetSecretByNameRawV3(ctx context.Context, opts *GetSecretByNam
 		UserID:                 getUserID(identity),
 		ViewSecretValue:        fn.ValueOr(q.ViewSecretValue, true),
 		ExpandSecretReferences: fn.ValueOr(q.ExpandSecretReferences, true),
-		IncludeImports:         fn.ValueOr(q.IncludeImports, true),
+		IncludeImports:         fn.ValueOr(q.IncludeImports, false), // V3 defaults to false (unlike V4)
 	})
 	if err != nil {
 		return nil, err

--- a/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
+++ b/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
@@ -186,10 +186,11 @@ func (h *Handler) getSecretByName(ctx context.Context, opts *getSecretByNameInte
 	// 6. Build response
 	secretRaw := h.buildSecretRaw(secret, opts.ProjectID)
 
-	// 7. Audit log
-	if err := h.createGetSecretAuditLog(ctx, opts.ProjectID, opts.Environment, opts.SecretPath, &secretRaw); err != nil {
-		return nil, err
-	}
+	// TODO: Re-enable audit logging once Go backend is primary
+	// // 7. Audit log
+	// if err := h.createGetSecretAuditLog(ctx, opts.ProjectID, opts.Environment, opts.SecretPath, &secretRaw); err != nil {
+	// 	return nil, err
+	// }
 
 	return &getSecretByNameResponse{Secret: secretRaw}, nil
 }
@@ -287,7 +288,7 @@ func (h *Handler) GetSecretByNameRawV3(ctx context.Context, opts *GetSecretByNam
 	}), nil
 }
 
-func (h *Handler) createGetSecretAuditLog(ctx context.Context, projectID, env, secretPath string, sec *SecretRaw) error {
+func (h *Handler) CreateGetSecretAuditLog(ctx context.Context, projectID, env, secretPath string, sec *SecretRaw) error {
 	identity, err := auth.IdentityFromContext(ctx)
 	if err != nil {
 		return errutil.NotFound("Identity not found in context").WithErr(err)

--- a/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
+++ b/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 	"log/slog"
+	"sort"
 
 	"github.com/google/uuid"
 
@@ -150,6 +151,10 @@ func (h *Handler) listSecrets(ctx context.Context, opts *listSecretsInternalOpts
 			for _, sec := range secretMap {
 				filtered = append(filtered, *sec)
 			}
+			// Sort by key to maintain consistent ordering (map iteration is random in Go)
+			sort.Slice(filtered, func(i, j int) bool {
+				return filtered[i].Secret.Key < filtered[j].Secret.Key
+			})
 			return filtered
 		default:
 			return secrets
@@ -161,10 +166,11 @@ func (h *Handler) listSecrets(ctx context.Context, opts *listSecretsInternalOpts
 	// 6. Build response
 	response := h.buildListSecretsResponse(result, opts.ProjectID, opts.IncludeImports)
 
-	// 7. Audit log
-	if err := h.createGetSecretsAuditLog(ctx, opts.ProjectID, opts.Environment, opts.SecretPath, len(response.Secrets)); err != nil {
-		return nil, err
-	}
+	// TODO: Re-enable audit logging once Go backend is primary
+	// // 7. Audit log
+	// if err := h.createGetSecretsAuditLog(ctx, opts.ProjectID, opts.Environment, opts.SecretPath, len(response.Secrets)); err != nil {
+	// 	return nil, err
+	// }
 
 	return response, nil
 }

--- a/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
+++ b/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
@@ -280,8 +280,8 @@ func (h *Handler) ListSecretsRawV3(ctx context.Context, opts *ListSecretsRawV3Se
 		Recursive:                 fn.ValueOr(q.Recursive, false),
 		ViewSecretValue:           fn.ValueOr(q.ViewSecretValue, true),
 		ExpandSecretReferences:    fn.ValueOr(q.ExpandSecretReferences, true),
-		IncludeImports:            fn.ValueOr(q.IncludeImports, true),
-		PersonalOverridesBehavior: PersonalOverridesIncludeAll, // V3 default
+		IncludeImports:            fn.ValueOr(q.IncludeImports, false), // V3 defaults to false (unlike V4)
+		PersonalOverridesBehavior: PersonalOverridesIncludeAll,         // V3 default
 		TagSlugs:                  parseTagSlugs(q.TagSlugs),
 		MetadataFilter:            parseMetadataFilter(q.MetadataFilter),
 	})
@@ -343,9 +343,10 @@ func (h *Handler) buildSecretRaw(ps *secretsvc.ProcessedSecret, projectID string
 		})
 	}
 
-	isRotated := sec.IsRotatedSecret()
+	var isRotatedSecret *bool
 	var rotationID *string
-	if isRotated {
+	if sec.IsRotatedSecret() {
+		isRotatedSecret = new(true)
 		rid := sec.GetRotationID().String()
 		rotationID = &rid
 	}
@@ -372,7 +373,7 @@ func (h *Handler) buildSecretRaw(ps *secretsvc.ProcessedSecret, projectID string
 		Tags:                  tags,
 		SecretMetadata:        metadata,
 		SkipMultilineEncoding: skipMultilineEncoding,
-		IsRotatedSecret:       &isRotated,
+		IsRotatedSecret:       isRotatedSecret,
 		RotationID:            rotationID,
 	}
 
@@ -392,8 +393,6 @@ func (h *Handler) buildImportSecretRaw(ps *secretsvc.ProcessedSecret, projectID 
 		})
 	}
 
-	isRotated := sec.IsRotatedSecret()
-
 	raw := ImportSecretRaw{
 		ID:                sec.ID.String(),
 		UnderscoreID:      sec.ID.String(),
@@ -406,13 +405,13 @@ func (h *Handler) buildImportSecretRaw(ps *secretsvc.ProcessedSecret, projectID 
 		SecretComment:     ps.Comment,
 		SecretValueHidden: ps.ValueHidden,
 		SecretMetadata:    metadata,
-		IsRotatedSecret:   &isRotated,
 	}
 
 	if sec.SkipMultilineEncoding.Valid {
 		raw.SkipMultilineEncoding = &sec.SkipMultilineEncoding.V
 	}
-	if isRotated {
+	if sec.IsRotatedSecret() {
+		raw.IsRotatedSecret = new(true)
 		rid := sec.GetRotationID().String()
 		raw.RotationID = &rid
 	}

--- a/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
+++ b/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
@@ -343,10 +343,9 @@ func (h *Handler) buildSecretRaw(ps *secretsvc.ProcessedSecret, projectID string
 		})
 	}
 
-	var isRotatedSecret *bool
+	isRotatedSecret := new(sec.IsRotatedSecret())
 	var rotationID *string
 	if sec.IsRotatedSecret() {
-		isRotatedSecret = new(true)
 		rid := sec.GetRotationID().String()
 		rotationID = &rid
 	}
@@ -410,8 +409,8 @@ func (h *Handler) buildImportSecretRaw(ps *secretsvc.ProcessedSecret, projectID 
 	if sec.SkipMultilineEncoding.Valid {
 		raw.SkipMultilineEncoding = &sec.SkipMultilineEncoding.V
 	}
+	raw.IsRotatedSecret = new(sec.IsRotatedSecret())
 	if sec.IsRotatedSecret() {
-		raw.IsRotatedSecret = new(true)
 		rid := sec.GetRotationID().String()
 		raw.RotationID = &rid
 	}

--- a/backend-go/internal/server/api/secretmanager/secret/secret.go
+++ b/backend-go/internal/server/api/secretmanager/secret/secret.go
@@ -163,7 +163,8 @@ func getSecretType(identity *auth.Identity, requestedType string) string {
 }
 
 // createGetSecretsAuditLog creates an audit log entry for listing secrets.
-func (h *Handler) createGetSecretsAuditLog(ctx context.Context, projectID, env, secretPath string, numberOfSecrets int) error {
+// TODO: Re-enable once Go backend is primary - currently disabled to avoid duplicate logs with Node.js
+func (h *Handler) CreateGetSecretsAuditLog(ctx context.Context, projectID, env, secretPath string, numberOfSecrets int) error {
 	identity, err := auth.IdentityFromContext(ctx)
 	if err != nil {
 		return errutil.NotFound("Identity not found in context").WithErr(err)

--- a/backend-go/tests/infra/postgres.go
+++ b/backend-go/tests/infra/postgres.go
@@ -36,7 +36,10 @@ func startPostgres(ctx context.Context, networkName string) (*PostgresService, e
 			"POSTGRES_PASSWORD": pgPassword,
 			"POSTGRES_DB":       pgDB,
 		},
-		WaitingFor: wait.ForListeningPort("5432/tcp").WithStartupTimeout(60 * time.Second),
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort("5432/tcp"),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		).WithStartupTimeout(60 * time.Second),
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/backend-go/tests/infra/postgres.go
+++ b/backend-go/tests/infra/postgres.go
@@ -39,7 +39,7 @@ func startPostgres(ctx context.Context, networkName string) (*PostgresService, e
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("5432/tcp"),
 			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
-		).WithStartupTimeout(60 * time.Second),
+		).WithDeadline(60 * time.Second),
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -496,6 +496,10 @@ const envSchema = z
 
     /* Go Sidecar ----------------------------------------------------------------------------- */
     GOLANG_SIDECAR_URL: zpStr(z.string().optional()),
+    GO_SIDECAR_SHADOW_ENABLED: zodStrBool.default("false"),
+    GO_SIDECAR_SHADOW_SAMPLE_RATE: z.coerce.number().min(0).max(100).default(10),
+    GO_SIDECAR_BINARY_PATH: zpStr(z.string().optional()),
+    GO_SIDECAR_SPAWN_ENABLED: zodStrBool.default("false"),
 
     /* INTERNAL ----------------------------------------------------------------------------- */
     INTERNAL_REGION: zpStr(z.enum(["us", "eu"]).optional())

--- a/backend/src/server/plugins/go-sidecar-shadowing.ts
+++ b/backend/src/server/plugins/go-sidecar-shadowing.ts
@@ -265,7 +265,11 @@ export const shadowToGoSidecar = fp(async (server, opt: { sidecarUrl: string; sa
         }
       } catch (error) {
         logger.error(
-          { requestId, route: routeUrl, error },
+          {
+            requestId,
+            route: routeUrl,
+            error: error instanceof Error ? { name: error.name, message: error.message } : String(error)
+          },
           `[Shadow:error] Failed to shadow request to Go sidecar [requestId=${requestId}] [route=${routeUrl}]`
         );
       }

--- a/backend/src/server/plugins/go-sidecar-shadowing.ts
+++ b/backend/src/server/plugins/go-sidecar-shadowing.ts
@@ -202,8 +202,8 @@ export const shadowToGoSidecar = fp(async (server, opt: { sidecarUrl: string; sa
         delete headers["content-length"];
 
         const goResponse = await axios({
-          method: request.method as "GET",
-          url: `${opt.sidecarUrl}${request.url}`,
+          method: request.method,
+          url: new URL(request.url, opt.sidecarUrl).href,
           headers,
           timeout: 30000,
           validateStatus: () => true

--- a/backend/src/server/plugins/go-sidecar-shadowing.ts
+++ b/backend/src/server/plugins/go-sidecar-shadowing.ts
@@ -1,0 +1,280 @@
+import axios from "axios";
+import fp from "fastify-plugin";
+
+import { logger } from "@app/lib/logger";
+
+const SHADOWED_ROUTES: { method: string; url: string }[] = [
+  { method: "GET", url: "/api/v3/secrets/raw/:secretName" },
+  { method: "GET", url: "/api/v3/secrets/raw" },
+  { method: "GET", url: "/api/v4/secrets/:secretName" },
+  { method: "GET", url: "/api/v4/secrets" }
+];
+
+const SENSITIVE_FIELDS = new Set([
+  "secretValue",
+  "secretValueCiphertext",
+  "secretValueIV",
+  "secretValueTag",
+  "secretValueHidden",
+  "value",
+  "valueOverride",
+  "secretComment",
+  "secretCommentCiphertext",
+  "secretCommentIV",
+  "secretCommentTag"
+]);
+
+type ComparisonDiff = {
+  path: string;
+  type: "missing_in_go" | "missing_in_node" | "type_mismatch" | "value_mismatch";
+  nodeValue?: unknown;
+  goValue?: unknown;
+};
+
+const isSensitiveField = (fieldName: string): boolean => {
+  return SENSITIVE_FIELDS.has(fieldName);
+};
+
+// Skip workspace field inside imports[].secrets[] - intentional difference
+// Node returns "" for legacy Python SDK compat, Go returns actual projectId
+const isIgnoredImportField = (path: string, fieldName: string): boolean => {
+  if (fieldName === "workspace" && /^imports\[\d+\]\.secrets\[\d+\]$/.test(path)) {
+    return true;
+  }
+  return false;
+};
+
+const isEmpty = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  return false;
+};
+
+const compareResponses = (
+  nodeResponse: unknown,
+  goResponse: unknown,
+  path: string = "",
+  diffs: ComparisonDiff[] = []
+): ComparisonDiff[] => {
+  const nodeEmpty = isEmpty(nodeResponse);
+  const goEmpty = isEmpty(goResponse);
+
+  if (nodeEmpty && goEmpty) {
+    return diffs;
+  }
+
+  if (nodeEmpty !== goEmpty) {
+    let nodeValue: unknown;
+    let goValue: unknown;
+
+    if (!nodeEmpty) {
+      nodeValue = typeof nodeResponse === "object" ? "[object]" : nodeResponse;
+    }
+    if (!goEmpty) {
+      goValue = typeof goResponse === "object" ? "[object]" : goResponse;
+    }
+
+    diffs.push({
+      path: path || "root",
+      type: nodeEmpty ? "missing_in_node" : "missing_in_go",
+      nodeValue,
+      goValue
+    });
+    return diffs;
+  }
+
+  const nodeType = Array.isArray(nodeResponse) ? "array" : typeof nodeResponse;
+  const goType = Array.isArray(goResponse) ? "array" : typeof goResponse;
+
+  if (nodeType !== goType) {
+    diffs.push({
+      path: path || "root",
+      type: "type_mismatch",
+      nodeValue: `type: ${nodeType}`,
+      goValue: `type: ${goType}`
+    });
+    return diffs;
+  }
+
+  if (nodeType === "array") {
+    const nodeArr = nodeResponse as unknown[];
+    const goArr = goResponse as unknown[];
+
+    if (nodeArr.length !== goArr.length) {
+      diffs.push({
+        path: `${path}.length`,
+        type: "value_mismatch",
+        nodeValue: nodeArr.length,
+        goValue: goArr.length
+      });
+    }
+
+    const minLength = Math.min(nodeArr.length, goArr.length);
+    for (let i = 0; i < minLength; i += 1) {
+      compareResponses(nodeArr[i], goArr[i], `${path}[${i}]`, diffs);
+    }
+  } else if (nodeType === "object" && nodeResponse !== null && goResponse !== null) {
+    const nodeObj = nodeResponse as Record<string, unknown>;
+    const goObj = goResponse as Record<string, unknown>;
+
+    const allKeys = new Set([...Object.keys(nodeObj), ...Object.keys(goObj)]);
+
+    for (const key of allKeys) {
+      const fieldPath = path ? `${path}.${key}` : key;
+
+      if (!isSensitiveField(key) && !isIgnoredImportField(path, key)) {
+        const inNode = key in nodeObj;
+        const inGo = key in goObj;
+
+        if (inNode && !inGo) {
+          if (!isEmpty(nodeObj[key])) {
+            diffs.push({
+              path: fieldPath,
+              type: "missing_in_go",
+              nodeValue: typeof nodeObj[key] === "object" ? "[object]" : nodeObj[key]
+            });
+          }
+        } else if (!inNode && inGo) {
+          if (!isEmpty(goObj[key])) {
+            diffs.push({
+              path: fieldPath,
+              type: "missing_in_node",
+              goValue: typeof goObj[key] === "object" ? "[object]" : goObj[key]
+            });
+          }
+        } else {
+          compareResponses(nodeObj[key], goObj[key], fieldPath, diffs);
+        }
+      }
+    }
+  } else if (nodeResponse !== goResponse) {
+    diffs.push({
+      path: path || "root",
+      type: "value_mismatch",
+      nodeValue: nodeResponse,
+      goValue: goResponse
+    });
+  }
+
+  return diffs;
+};
+
+export const shadowToGoSidecar = fp(async (server, opt: { sidecarUrl: string; sampleRate: number }) => {
+  const routeSet = new Set(SHADOWED_ROUTES.map((r) => `${r.method}:${r.url}`));
+  const sampleRate = Math.max(0, Math.min(100, opt.sampleRate));
+
+  server.addHook("onSend", async (request, reply, payload) => {
+    const key = `${request.method}:${request.routeOptions.url}`;
+
+    if (!routeSet.has(key)) {
+      return payload;
+    }
+
+    if (Math.random() * 100 >= sampleRate) {
+      return payload;
+    }
+
+    if (reply.statusCode >= 400) {
+      return payload;
+    }
+
+    const requestId = request.id;
+    const routeUrl = request.routeOptions.url;
+
+    const shadowRequest = async () => {
+      try {
+        const headers: Record<string, string> = {};
+        for (const [headerKey, headerValue] of Object.entries(request.headers)) {
+          if (typeof headerValue === "string") {
+            headers[headerKey] = headerValue;
+          } else if (Array.isArray(headerValue)) {
+            headers[headerKey] = headerValue.join(", ");
+          }
+        }
+
+        headers["X-Request-Id"] = requestId;
+        headers["X-Real-Ip"] = request.realIp;
+        delete headers.host;
+        delete headers["content-length"];
+
+        const goResponse = await axios({
+          method: request.method as "GET",
+          url: `${opt.sidecarUrl}${request.url}`,
+          headers,
+          timeout: 30000,
+          validateStatus: () => true
+        });
+
+        if (goResponse.status !== reply.statusCode) {
+          logger.error(
+            {
+              requestId,
+              route: routeUrl,
+              nodeStatus: reply.statusCode,
+              goStatus: goResponse.status
+            },
+            `[Shadow:error] Status code mismatch [requestId=${requestId}] [route=${routeUrl}] [nodeStatus=${reply.statusCode}] [goStatus=${goResponse.status}]`
+          );
+          return;
+        }
+
+        let nodeData: unknown;
+        try {
+          nodeData = typeof payload === "string" ? JSON.parse(payload) : payload;
+        } catch {
+          logger.error(
+            { requestId, route: routeUrl },
+            `[Shadow:error] Could not parse Node.js response as JSON [requestId=${requestId}]`
+          );
+          return;
+        }
+
+        const goData = goResponse.data as unknown;
+        const diffs = compareResponses(nodeData, goData);
+
+        if (diffs.length > 0) {
+          const missingInGo = diffs.filter((d) => d.type === "missing_in_go");
+          const missingInNode = diffs.filter((d) => d.type === "missing_in_node");
+          const valueMismatches = diffs.filter((d) => d.type === "value_mismatch" || d.type === "type_mismatch");
+
+          logger.error(
+            {
+              requestId,
+              route: routeUrl,
+              totalDiffs: diffs.length,
+              missingInGo: missingInGo.map((d) => d.path),
+              missingInNode: missingInNode.map((d) => d.path),
+              valueMismatches: valueMismatches.map((d) => ({
+                path: d.path,
+                type: d.type,
+                nodeValue: d.nodeValue,
+                goValue: d.goValue
+              }))
+            },
+            `[Shadow:error] Response differences found [requestId=${requestId}] [route=${routeUrl}] [diffCount=${diffs.length}]`
+          );
+        } else {
+          logger.info(
+            { requestId, route: routeUrl },
+            `[Shadow:success] Responses match [requestId=${requestId}] [route=${routeUrl}]`
+          );
+        }
+      } catch (error) {
+        logger.error(
+          { requestId, route: routeUrl, error },
+          `[Shadow:error] Failed to shadow request to Go sidecar [requestId=${requestId}] [route=${routeUrl}]`
+        );
+      }
+    };
+
+    setImmediate(() => {
+      void shadowRequest();
+    });
+
+    return payload;
+  });
+});

--- a/backend/src/server/plugins/go-sidecar.ts
+++ b/backend/src/server/plugins/go-sidecar.ts
@@ -34,7 +34,8 @@ export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
       env: {
         ...process.env,
         ...opts.env,
-        PORT: "4040" // Override PORT so Go doesn't conflict with Node.js
+        PORT: "4040", // Override PORT so Go doesn't conflict with Node.js
+        HOST: "127.0.0.1"
       }
     });
 

--- a/backend/src/server/plugins/go-sidecar.ts
+++ b/backend/src/server/plugins/go-sidecar.ts
@@ -1,0 +1,91 @@
+import { ChildProcess, spawn } from "child_process";
+import fp from "fastify-plugin";
+import path from "path";
+
+import { logger } from "@app/lib/logger";
+
+type GoSidecarOpts = {
+  enabled: boolean;
+  binaryPath?: string;
+  env?: Record<string, string>;
+};
+
+export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
+  if (!opts.enabled) return;
+
+  const binaryPath = opts.binaryPath || path.join(process.cwd(), "go-sidecar");
+  const maxRestarts = 10;
+  const baseDelayMs = 1000;
+  const maxDelayMs = 30000;
+  const healthyThresholdMs = 60000;
+
+  let restartCount = 0;
+  let sidecar: ChildProcess | null = null;
+  let shuttingDown = false;
+  let healthTimer: NodeJS.Timeout | null = null;
+
+  const startSidecar = () => {
+    if (shuttingDown) return;
+
+    logger.info({ binaryPath }, "Starting Go sidecar");
+
+    sidecar = spawn(binaryPath, [], {
+      stdio: ["ignore", "inherit", "inherit"],
+      env: {
+        ...process.env,
+        ...opts.env,
+        PORT: "4040" // Override PORT so Go doesn't conflict with Node.js
+      }
+    });
+
+    sidecar.on("error", (err) => {
+      logger.error({ err }, "Go sidecar failed to start");
+    });
+
+    sidecar.on("exit", (code, signal) => {
+      if (healthTimer) {
+        clearTimeout(healthTimer);
+        healthTimer = null;
+      }
+
+      if (shuttingDown) {
+        logger.info("Go sidecar stopped during shutdown");
+        return;
+      }
+
+      logger.error({ code, signal, restartCount }, "Go sidecar exited unexpectedly");
+
+      if (restartCount >= maxRestarts) {
+        logger.error({ maxRestarts }, "Go sidecar max restarts reached, giving up");
+        return;
+      }
+
+      const delay = Math.min(baseDelayMs * 2 ** restartCount, maxDelayMs);
+      restartCount += 1;
+
+      logger.info({ delayMs: delay, restartCount }, "Scheduling Go sidecar restart");
+      setTimeout(startSidecar, delay);
+    });
+
+    // Reset restart count after healthy running period
+    healthTimer = setTimeout(() => {
+      if (sidecar && !sidecar.killed) {
+        logger.info("Go sidecar healthy, resetting restart count");
+        restartCount = 0;
+      }
+    }, healthyThresholdMs);
+  };
+
+  startSidecar();
+
+  server.addHook("onClose", () => {
+    shuttingDown = true;
+    if (healthTimer) {
+      clearTimeout(healthTimer);
+    }
+    if (sidecar && !sidecar.killed) {
+      logger.info("Stopping Go sidecar");
+      sidecar.kill();
+    }
+  });
+});

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -510,7 +510,9 @@ import { injectAuditLogInfo } from "../plugins/audit-log";
 import { injectAssumePrivilege } from "../plugins/auth/inject-assume-privilege";
 import { injectIdentity } from "../plugins/auth/inject-identity";
 import { injectPermission } from "../plugins/auth/inject-permission";
-import { forwardToGoSidecar } from "../plugins/go-sidecar-forwarding";
+import { goSidecarPlugin } from "../plugins/go-sidecar";
+// import { forwardToGoSidecar } from "../plugins/go-sidecar-forwarding";
+import { shadowToGoSidecar } from "../plugins/go-sidecar-shadowing";
 import { injectRateLimits } from "../plugins/inject-rate-limits";
 import { forwardWritesToPrimary } from "../plugins/primary-forwarding-mode";
 import { registerV1Routes } from "./v1";
@@ -3738,10 +3740,37 @@ export const registerRoutes = async (
     user: userDAL,
     kmipClient: kmipClientDAL
   });
-  if (envConfig.GOLANG_SIDECAR_URL) {
-    logger.info(`Go sidecar is configured: ${envConfig.GOLANG_SIDECAR_URL}`);
-    await server.register(forwardToGoSidecar, { sidecarUrl: envConfig.GOLANG_SIDECAR_URL });
+
+  // Spawn Go sidecar as subprocess (must be registered before shadowing plugin)
+  if (envConfig.GO_SIDECAR_SPAWN_ENABLED) {
+    logger.info(`Go sidecar spawn enabled: ${envConfig.GO_SIDECAR_BINARY_PATH || "./go-sidecar"}`);
+    await server.register(goSidecarPlugin, {
+      enabled: true,
+      binaryPath: envConfig.GO_SIDECAR_BINARY_PATH,
+      env: {
+        // Pass through relevant env vars to Go sidecar
+        DB_CONNECTION_URI: envConfig.DB_CONNECTION_URI,
+        REDIS_URL: envConfig.REDIS_URL || "",
+        ENCRYPTION_KEY: envConfig.ENCRYPTION_KEY || "",
+        AUTH_SECRET: envConfig.AUTH_SECRET || ""
+      }
+    });
   }
+
+  if (envConfig.GOLANG_SIDECAR_URL && envConfig.GO_SIDECAR_SHADOW_ENABLED) {
+    logger.info(
+      `Go sidecar shadowing enabled: ${envConfig.GOLANG_SIDECAR_URL} [sampleRate=${envConfig.GO_SIDECAR_SHADOW_SAMPLE_RATE}%]`
+    );
+    await server.register(shadowToGoSidecar, {
+      sidecarUrl: envConfig.GOLANG_SIDECAR_URL,
+      sampleRate: envConfig.GO_SIDECAR_SHADOW_SAMPLE_RATE
+    });
+  }
+  // Forwarding plugin disabled in favor of shadowing
+  // if (envConfig.GOLANG_SIDECAR_URL) {
+  //   logger.info(`Go sidecar is configured: ${envConfig.GOLANG_SIDECAR_URL}`);
+  //   await server.register(forwardToGoSidecar, { sidecarUrl: envConfig.GOLANG_SIDECAR_URL });
+  // }
 
   const shouldForwardWritesToPrimaryInstance = Boolean(envConfig.INFISICAL_PRIMARY_INSTANCE_URL);
   if (shouldForwardWritesToPrimaryInstance) {

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -6,7 +6,7 @@ import { groupBy, unique } from "@app/lib/fn";
 import { ResourceMetadataWithEncryptionDTO } from "../resource-metadata/resource-metadata-schema";
 import { TSecretDALFactory } from "../secret/secret-dal";
 import { INFISICAL_SECRET_VALUE_HIDDEN_MASK } from "../secret/secret-fns";
-import { PersonalOverridesBehavior } from "../secret/secret-types";
+import { PersonalOverridesBehavior, SecretsOrderBy } from "../secret/secret-types";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-dal";
 import { TSecretImportDALFactory } from "./secret-import-dal";
@@ -304,7 +304,8 @@ export const fnSecretsV2FromImports = async ({
     if (shouldIncludePersonal) {
       const allSecrets = await secretDAL.findByFolderIds({
         folderIds: importedFolderIds,
-        userId
+        userId,
+        filters: { orderBy: SecretsOrderBy.Name }
       });
 
       if (personalOverridesBehavior === PersonalOverridesBehavior.Priority) {
@@ -319,7 +320,7 @@ export const fnSecretsV2FromImports = async ({
             secretMap.set(key, el);
           }
         });
-        importedSecrets = Array.from(secretMap.values());
+        importedSecrets = Array.from(secretMap.values()).sort((a, b) => a.key.localeCompare(b.key));
       } else {
         importedSecrets = allSecrets;
       }
@@ -330,7 +331,7 @@ export const fnSecretsV2FromImports = async ({
           type: SecretType.Shared
         },
         {
-          sort: [["id", "asc"]]
+          sort: [["key", "asc"]]
         }
       );
     }


### PR DESCRIPTION
## Context

This PR implements the Go sidecar shadowing techniqueue to check the responses with NodeJS matches. This is a test run before going production with missing pieces. 

## Screenshots

1. Do the standalone production build
2. Run it with following environment variable
```
GO_SIDECAR_SHADOW_ENABLED=true
GO_SIDECAR_SPAWN_ENABLED=true
GO_SIDECAR_SHADOW_SAMPLE_RATE=75
```
3. This should spin up go along with NodeJS when you hit secret endpoint you should see the response difference.
## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)