### PR TITLE
fix(auth): handle stale refresh token gracefully on /login page

### DIFF
--- a/frontend/src/hooks/api/auth/refresh.ts
+++ b/frontend/src/hooks/api/auth/refresh.ts
@@ -64,6 +64,12 @@ export const fetchAuthToken = async (): Promise<GetAuthTokenAPI> => {
 
       return data;
     })
+    .catch((error) => {
+      // Stale or invalid refresh token — clear any in-memory token and re-throw
+      // so the caller (ensureQueryData / fetchQuery) can handle it gracefully
+      setAuthToken("");
+      throw error;
+    })
     .finally(() => {
       activeRefreshPromise = null;
     });

--- a/frontend/src/pages/middlewares/restrict-login-signup.tsx
+++ b/frontend/src/pages/middlewares/restrict-login-signup.tsx
@@ -87,7 +87,11 @@ export const Route = createFileRoute("/_restrict-login-signup")({
         queryKey: authKeys.getAuthToken,
         queryFn: fetchAuthToken
       })
-      .catch(() => null);
+      .catch(() => {
+        // Refresh token failed (stale/rotated) — clear the cache so we don't retry with stale data
+        context.queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
+        return null;
+      });
     if (!data) return;
 
     setAuthToken(data.token);


### PR DESCRIPTION
## Context

When a user visits `/login` with a stale `jid` (refresh-token) cookie — one that has been rotated, expired, or no longer exists server-side — the React app crashes with "TypeError: Cannot read properties of undefined (reading 'component')" instead of rendering the login form. The user sees a white error page and is locked out until they manually clear cookies.

**Before:** App crashes on `/login` with stale refresh token. User is locked out.
**After:** App renders the login form unconditionally when the refresh token is invalid.

Fixes #6639

## Screenshots

N/A — this is a logic fix, not a UI change. The "UI change" is that the login form renders instead of a crash screen.

## Steps to verify the change

1. Sign in to Infisical (sets the `jid` httpOnly cookie)
2. Rotate the refresh token (sign in on another browser, or restart the container to clear server-side tokens)
3. Return to the first browser and load `/login`
4. **Expected:** Login form renders normally
5. **Before fix:** React crash — "Something went wrong" / TypeError

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `fix(auth): handle stale refresh token gracefully on /login page`
- [x] Tested locally (type:check ✅, lint:fix ✅)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)