### PR TITLE
feat: migrate general, product and security settings tabs to v3 and update org settings title based on tab

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/organization/SettingsPage/SettingsPage.tsx
@@ -1,44 +1,11 @@
-import { Helmet } from "react-helmet";
-import { useTranslation } from "react-i18next";
-import { Link } from "@tanstack/react-router";
-import { InfoIcon } from "lucide-react";
-
-import { PageHeader } from "@app/components/v2";
-import { useOrganization } from "@app/context";
-
 import { OrgTabGroup } from "./components";
 
 export const SettingsPage = () => {
-  const { t } = useTranslation();
-  const { isSubOrganization, currentOrg } = useOrganization();
-
   return (
-    <>
-      <Helmet>
-        <title>{t("common.head-title", { title: t("settings.org.title") })}</title>
-      </Helmet>
-      <div className="flex w-full justify-center bg-bunker-800 text-white">
-        <div className="w-full max-w-8xl">
-          <PageHeader
-            scope={isSubOrganization ? "namespace" : "org"}
-            description={`Configure ${isSubOrganization ? "sub-" : ""}organization-wide settings`}
-            title={isSubOrganization ? "Sub-Organization Settings" : "Organization Settings"}
-          >
-            {isSubOrganization && (
-              <Link
-                to="/organizations/$orgId/settings"
-                params={{
-                  orgId: currentOrg.rootOrgId ?? ""
-                }}
-                className="flex items-center gap-x-1.5 text-xs whitespace-nowrap text-neutral hover:underline"
-              >
-                <InfoIcon size={12} /> Looking for root organization settings?
-              </Link>
-            )}
-          </PageHeader>
-          <OrgTabGroup />
-        </div>
+    <div className="flex w-full justify-center bg-bunker-800 text-white">
+      <div className="w-full max-w-8xl">
+        <OrgTabGroup />
       </div>
-    </>
+    </div>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgCertManagerTab/OrgCertManagerTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgCertManagerTab/OrgCertManagerTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   BoxIcon,
+  FileBadgeIcon,
   MoreHorizontalIcon,
   StarIcon,
   Trash2Icon,
@@ -16,6 +17,10 @@ import {
   AlertDescription,
   Badge,
   Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -87,14 +92,19 @@ export const OrgCertManagerTab = () => {
 
   if (isPending) {
     return (
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-6">
-        <div className="mb-6">
-          <h2 className="text-xl font-medium text-mineshaft-100">Certificate Manager</h2>
-        </div>
-        <div className="h-32">
-          <PageLoader lottieClassName="w-16" />
-        </div>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <FileBadgeIcon className="size-4 text-accent" />
+            Certificate Manager
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-32">
+            <PageLoader lottieClassName="w-16" />
+          </div>
+        </CardContent>
+      </Card>
     );
   }
   if (instances.length <= 1) return null;
@@ -131,80 +141,94 @@ export const OrgCertManagerTab = () => {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-6">
-      <div className="mb-6">
-        <h2 className="text-xl font-medium text-mineshaft-100">Certificate Manager</h2>
-      </div>
-      {isMultiInstance && (
-        <Alert variant="warning" className="mb-4">
-          <TriangleAlertIcon />
-          <AlertDescription>
-            <p>
-              Your organization has multiple Certificate Manager projects. Going forward, only one
-              project per organization is supported. Select your active project and remove the
-              others once migrated.{" "}
-              <a
-                href="https://infisical.com/docs/documentation/platform/pki/migration"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-mineshaft-200"
-              >
-                Learn more →
-              </a>
-            </p>
-          </AlertDescription>
-        </Alert>
-      )}
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-full">Project</TableHead>
-            <TableHead className="whitespace-nowrap">Status</TableHead>
-            <TableHead className="w-5" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {instances.map((instance) => (
-            <TableRow key={instance.id}>
-              <TableCell className="w-full">
-                <div className="flex items-center gap-x-2">
-                  <BoxIcon className="size-4 shrink-0 text-project" />
-                  <span className="font-mono">{instance.name}</span>
-                  <span className="font-mono text-xs text-accent">{instance.slug}</span>
-                </div>
-              </TableCell>
-              <TableCell className="whitespace-nowrap">
-                {instance.isActive ? <Badge variant="success">Active</Badge> : null}
-              </TableCell>
-              <TableCell>
-                {canManage && !instance.isActive ? (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <IconButton variant="ghost" size="xs" aria-label={`Manage ${instance.name}`}>
-                        <MoreHorizontalIcon />
-                      </IconButton>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="min-w-56" align="end" sideOffset={2}>
-                      <DropdownMenuItem onClick={() => setPendingExport(instance)}>
-                        <UploadIcon />
-                        Export to active project
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => setPendingActive(instance)}>
-                        <StarIcon />
-                        Set as active
-                      </DropdownMenuItem>
-                      <DropdownMenuItem variant="danger" onClick={() => setPendingDelete(instance)}>
-                        <Trash2Icon />
-                        Delete project
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                ) : null}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <FileBadgeIcon className="size-4 text-accent" />
+            Certificate Manager
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isMultiInstance && (
+            <Alert variant="warning" className="mb-4">
+              <TriangleAlertIcon />
+              <AlertDescription>
+                <p>
+                  Your organization has multiple Certificate Manager projects. Going forward, only
+                  one project per organization is supported. Select your active project and remove
+                  the others once migrated.{" "}
+                  <a
+                    href="https://infisical.com/docs/documentation/platform/pki/migration"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-mineshaft-200"
+                  >
+                    Learn more →
+                  </a>
+                </p>
+              </AlertDescription>
+            </Alert>
+          )}
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-full">Project</TableHead>
+                <TableHead className="whitespace-nowrap">Status</TableHead>
+                <TableHead className="w-5" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {instances.map((instance) => (
+                <TableRow key={instance.id}>
+                  <TableCell className="w-full">
+                    <div className="flex items-center gap-x-2">
+                      <BoxIcon className="size-4 shrink-0 text-project" />
+                      <span className="font-mono">{instance.name}</span>
+                      <span className="font-mono text-xs text-accent">{instance.slug}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    {instance.isActive ? <Badge variant="success">Active</Badge> : null}
+                  </TableCell>
+                  <TableCell>
+                    {canManage && !instance.isActive ? (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <IconButton
+                            variant="ghost"
+                            size="xs"
+                            aria-label={`Manage ${instance.name}`}
+                          >
+                            <MoreHorizontalIcon />
+                          </IconButton>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent className="min-w-56" align="end" sideOffset={2}>
+                          <DropdownMenuItem onClick={() => setPendingExport(instance)}>
+                            <UploadIcon />
+                            Export to active project
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => setPendingActive(instance)}>
+                            <StarIcon />
+                            Set as active
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            variant="danger"
+                            onClick={() => setPendingDelete(instance)}
+                          >
+                            <Trash2Icon />
+                            Delete project
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : null}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
 
       <Dialog
         open={Boolean(pendingActive)}
@@ -262,6 +286,6 @@ export const OrgCertManagerTab = () => {
         source={pendingExport}
         activeInstance={activeInstance}
       />
-    </div>
+    </>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgDeleteSection/OrgDeleteSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgDeleteSection/OrgDeleteSection.tsx
@@ -1,22 +1,50 @@
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { TriangleAlert } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, DeleteActionModal } from "@app/components/v2";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldTitle,
+  Input,
+  Label
+} from "@app/components/v3";
 import { useOrganization, useOrgPermission } from "@app/context";
 import { OrgMembershipRole } from "@app/helpers/roles";
 import { useDeleteOrgById } from "@app/hooks/api";
 import { clearSession } from "@app/hooks/api/users/queries";
 import { usePopUp } from "@app/hooks/usePopUp";
 
+const CONFIRM_KEYWORD = "confirm";
+
 export const OrgDeleteSection = () => {
   const navigate = useNavigate();
   const { currentOrg } = useOrganization();
-
   const { hasOrgRole } = useOrgPermission();
 
   const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["deleteOrg"] as const);
+  const [confirmInput, setConfirmInput] = useState("");
 
   const { mutateAsync, isPending } = useDeleteOrgById();
+
+  const isAdmin = hasOrgRole(OrgMembershipRole.Admin);
 
   const handleDeleteOrgSubmit = async () => {
     if (!currentOrg?.id) return;
@@ -35,29 +63,75 @@ export const OrgDeleteSection = () => {
   };
 
   return (
-    <>
-      <hr className="border-mineshaft-600" />
-      <div className="py-4">
-        <p className="text-md mb-4 text-mineshaft-100">Danger Zone</p>
-        <Button
-          isLoading={isPending}
-          colorSchema="danger"
-          variant="outline_bg"
-          type="submit"
-          onClick={() => handlePopUpOpen("deleteOrg")}
-          isDisabled={Boolean(!hasOrgRole(OrgMembershipRole.Admin))}
-        >
-          {`Delete ${currentOrg?.name}`}
-        </Button>
-      </div>
-      <DeleteActionModal
-        isOpen={popUp.deleteOrg.isOpen}
-        title="Are you sure you want to delete this organization?"
-        subTitle={`Permanently remove ${currentOrg?.name} and all of its data. This action is not reversible, so please be careful.`}
-        onChange={(isOpen) => handlePopUpToggle("deleteOrg", isOpen)}
-        deleteKey="confirm"
-        onDeleteApproved={handleDeleteOrgSubmit}
-      />
-    </>
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <TriangleAlert className="size-4 text-danger" />
+          Danger Zone
+        </CardTitle>
+        <CardDescription>Irreversible and destructive actions.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldTitle>Delete this organization</FieldTitle>
+            <FieldDescription>
+              Permanently remove {currentOrg?.name} and all of its data. This action cannot be
+              undone.
+            </FieldDescription>
+          </FieldContent>
+          <Button
+            variant="danger"
+            isPending={isPending}
+            isDisabled={!isAdmin}
+            onClick={() => handlePopUpOpen("deleteOrg")}
+          >
+            Delete Organization
+          </Button>
+        </Field>
+      </CardContent>
+      <AlertDialog
+        open={popUp.deleteOrg.isOpen}
+        onOpenChange={(isOpen) => {
+          handlePopUpToggle("deleteOrg", isOpen);
+          setConfirmInput("");
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <TriangleAlert />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Delete {currentOrg?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Permanently remove {currentOrg?.name} and all of its data. This action is not
+              reversible, so please be careful.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="delete-org-confirm">
+              Type <span className="font-bold">{CONFIRM_KEYWORD}</span> to confirm
+            </Label>
+            <Input
+              id="delete-org-confirm"
+              value={confirmInput}
+              onChange={(e) => setConfirmInput(e.target.value)}
+              autoComplete="off"
+              placeholder={`Type ${CONFIRM_KEYWORD} here`}
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="danger"
+              disabled={confirmInput !== CONFIRM_KEYWORD || isPending}
+              onClick={handleDeleteOrgSubmit}
+            >
+              Delete Organization
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgGeneralTab/OrgGeneralTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgGeneralTab/OrgGeneralTab.tsx
@@ -9,7 +9,7 @@ export const OrgGeneralTab = () => {
   const { hasOrgRole } = useOrgPermission();
   const { isSubOrganization } = useOrganization();
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-6">
+    <div className="flex flex-col gap-4">
       {isSubOrganization ? <SubOrgNameChangeSection /> : <OrgNameChangeSection />}
       {!isSubOrganization && <OrgIncidentContactsSection />}
       {hasOrgRole(OrgMembershipRole.Admin) && <OrgDeleteSection />}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/AddOrgIncidentContactModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/AddOrgIncidentContactModal.tsx
@@ -3,7 +3,19 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Modal, ModalContent } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { useAddIncidentContact } from "@app/hooks/api";
 import { useFetchServerStatus } from "@app/hooks/api/serverDetails";
@@ -55,42 +67,48 @@ export const AddOrgIncidentContactModal = ({
   };
 
   return (
-    <Modal
-      isOpen={popUp?.addContact?.isOpen}
+    <Dialog
+      open={popUp?.addContact?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("addContact", isOpen);
         reset();
       }}
     >
-      <ModalContent
-        title="Add an Incident Contact"
-        subTitle="This contact will be notified in the unlikely event of a severe incident."
-      >
-        <form onSubmit={handleSubmit(onFormSubmit)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add an Incident Contact</DialogTitle>
+          <DialogDescription>
+            This contact will be notified in the unlikely event of a severe incident.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-6">
           <Controller
             control={control}
             defaultValue=""
             name="email"
             render={({ field, fieldState: { error } }) => (
-              <FormControl label="Email" isError={Boolean(error)} errorText={error?.message}>
-                <Input {...field} />
-              </FormControl>
+              <Field>
+                <FieldLabel htmlFor="incident-contact-email">Email</FieldLabel>
+                <Input
+                  id="incident-contact-email"
+                  placeholder="contact@acme.com"
+                  isError={Boolean(error)}
+                  {...field}
+                />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
             )}
           />
-          <div className="mt-8 flex items-center space-x-4">
-            <Button size="sm" type="submit" isLoading={isPending} isDisabled={isPending}>
-              Add Incident Contact
-            </Button>
-            <Button
-              colorSchema="secondary"
-              variant="plain"
-              onClick={() => handlePopUpClose("addContact")}
-            >
+          <DialogFooter>
+            <Button variant="ghost" type="button" onClick={() => handlePopUpClose("addContact")}>
               Cancel
             </Button>
-          </div>
+            <Button variant="org" type="submit" isPending={isPending} isDisabled={isPending}>
+              Add Incident Contact
+            </Button>
+          </DialogFooter>
         </form>
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/OrgIncidentContactsSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/OrgIncidentContactsSection.tsx
@@ -1,9 +1,15 @@
-import { useTranslation } from "react-i18next";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Plus, Siren } from "lucide-react";
 
 import { OrgPermissionCan, PermissionDeniedBanner } from "@app/components/permissions";
-import { Button } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@app/components/v3";
 import { OrgPermissionActions, OrgPermissionSubjects, useOrgPermission } from "@app/context";
 import { usePopUp } from "@app/hooks";
 
@@ -11,7 +17,6 @@ import { AddOrgIncidentContactModal } from "./AddOrgIncidentContactModal";
 import { OrgIncidentContactsTable } from "./OrgIncidentContactsTable";
 
 export const OrgIncidentContactsSection = () => {
-  const { t } = useTranslation();
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
     "addContact"
   ] as const);
@@ -19,30 +24,41 @@ export const OrgIncidentContactsSection = () => {
 
   return (
     <>
-      <hr className="border-mineshaft-600" />
-      <div className="flex items-center justify-between pt-4">
-        <p className="text-md text-mineshaft-100">{t("section.incident.incident-contacts")}</p>
-        <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.IncidentAccount}>
-          {(isAllowed) => (
-            <Button
-              colorSchema="secondary"
-              type="submit"
-              isDisabled={!isAllowed}
-              leftIcon={<FontAwesomeIcon icon={faPlus} />}
-              onClick={() => handlePopUpOpen("addContact")}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Siren className="size-4 text-accent" />
+            Incident Contacts
+          </CardTitle>
+          <CardDescription>
+            Contacts notified in the unlikely event of a severe incident.
+          </CardDescription>
+          <CardAction>
+            <OrgPermissionCan
+              I={OrgPermissionActions.Create}
+              a={OrgPermissionSubjects.IncidentAccount}
             >
-              Add contact
-            </Button>
+              {(isAllowed) => (
+                <Button
+                  variant="outline"
+                  isDisabled={!isAllowed}
+                  onClick={() => handlePopUpOpen("addContact")}
+                >
+                  <Plus />
+                  Add Contact
+                </Button>
+              )}
+            </OrgPermissionCan>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          {permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.IncidentAccount) ? (
+            <OrgIncidentContactsTable />
+          ) : (
+            <PermissionDeniedBanner />
           )}
-        </OrgPermissionCan>
-      </div>
-      <div className="py-4">
-        {permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.IncidentAccount) ? (
-          <OrgIncidentContactsTable />
-        ) : (
-          <PermissionDeniedBanner />
-        )}
-      </div>
+        </CardContent>
+      </Card>
       <AddOrgIncidentContactModal
         popUp={popUp}
         handlePopUpClose={handlePopUpClose}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/OrgIncidentContactsTable.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgIncidentContactsSection/OrgIncidentContactsTable.tsx
@@ -1,23 +1,38 @@
 import { useState } from "react";
-import { faContactBook, faMagnifyingGlass, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { MoreHorizontal, Search, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  DeleteActionModal,
-  EmptyState,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
   IconButton,
-  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Skeleton,
   Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
 import { OrgPermissionActions, OrgPermissionSubjects, useOrganization } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import { useDeleteIncidentContact, useGetOrgIncidentContact } from "@app/hooks/api";
@@ -27,8 +42,7 @@ export const OrgIncidentContactsTable = () => {
   const { data: contacts, isPending } = useGetOrgIncidentContact(currentOrg?.id ?? "");
   const [searchContact, setSearchContact] = useState("");
   const { handlePopUpToggle, popUp, handlePopUpOpen, handlePopUpClose } = usePopUp([
-    "removeContact",
-    "setUpEmail"
+    "removeContact"
   ] as const);
   const { mutateAsync } = useDeleteIncidentContact();
 
@@ -50,62 +64,106 @@ export const OrgIncidentContactsTable = () => {
   };
 
   const filteredContacts = contacts
-    ? contacts.filter(({ email }) => email.toLocaleLowerCase().includes(searchContact))
+    ? contacts.filter(({ email }) => email.toLowerCase().includes(searchContact.toLowerCase()))
     : [];
 
   return (
-    <div>
-      <Input
-        value={searchContact}
-        onChange={(e) => setSearchContact(e.target.value)}
-        leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-        placeholder="Search incident contact by email..."
-      />
-      <TableContainer className="mt-4">
+    <div className="flex flex-col gap-4">
+      <InputGroup>
+        <InputGroupAddon>
+          <Search />
+        </InputGroupAddon>
+        <InputGroupInput
+          placeholder="Search incident contacts by email"
+          value={searchContact}
+          onChange={(e) => setSearchContact(e.target.value)}
+        />
+      </InputGroup>
+      {!isPending && filteredContacts.length === 0 ? (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>No incident contacts found</EmptyTitle>
+            <EmptyDescription>
+              Add an incident contact to be notified during severe incidents.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
         <Table>
-          <THead>
-            <Tr>
-              <Th>Email</Th>
-              <Th aria-label="actions" />
-            </Tr>
-          </THead>
-          <TBody>
-            {isPending && <TableSkeleton columns={2} innerKey="incident-contact" />}
-            {filteredContacts?.map(({ email, id }) => (
-              <Tr key={email}>
-                <Td className="w-full">{email}</Td>
-                <Td className="mr-4">
-                  <OrgPermissionCan
-                    I={OrgPermissionActions.Delete}
-                    an={OrgPermissionSubjects.IncidentAccount}
-                  >
-                    {(isAllowed) => (
-                      <IconButton
-                        ariaLabel="delete"
-                        colorSchema="danger"
-                        onClick={() => handlePopUpOpen("removeContact", { email, id })}
-                        isDisabled={!isAllowed}
-                      >
-                        <FontAwesomeIcon icon={faTrash} />
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead className="w-px text-right" aria-label="Actions" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isPending &&
+              Array.from({ length: 3 }).map((_, idx) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <TableRow key={`incident-contact-skeleton-${idx}`}>
+                  <TableCell colSpan={2}>
+                    <Skeleton className="h-5 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            {filteredContacts.map(({ email, id }) => (
+              <TableRow key={id}>
+                <TableCell className="font-medium text-foreground">{email}</TableCell>
+                <TableCell className="text-right">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <IconButton variant="ghost" size="xs" aria-label={`Actions for ${email}`}>
+                        <MoreHorizontal />
                       </IconButton>
-                    )}
-                  </OrgPermissionCan>
-                </Td>
-              </Tr>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-44">
+                      <OrgPermissionCan
+                        I={OrgPermissionActions.Delete}
+                        an={OrgPermissionSubjects.IncidentAccount}
+                      >
+                        {(isAllowed) => (
+                          <DropdownMenuItem
+                            variant="danger"
+                            isDisabled={!isAllowed}
+                            onClick={() => handlePopUpOpen("removeContact", { email, id })}
+                          >
+                            <Trash2 />
+                            Delete
+                          </DropdownMenuItem>
+                        )}
+                      </OrgPermissionCan>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
             ))}
-          </TBody>
+          </TableBody>
         </Table>
-        {filteredContacts?.length === 0 && !isPending && (
-          <EmptyState title="No incident contacts found" icon={faContactBook} />
-        )}
-      </TableContainer>
-      <DeleteActionModal
-        isOpen={popUp.removeContact.isOpen}
-        deleteKey="remove"
-        title="Do you want to remove this email from incident contact?"
-        onChange={(isOpen) => handlePopUpToggle("removeContact", isOpen)}
-        onDeleteApproved={onRemoveIncidentContact}
-      />
+      )}
+      <AlertDialog
+        open={popUp.removeContact.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("removeContact", isOpen)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <Trash2 />
+            </AlertDialogMedia>
+            <AlertDialogTitle>
+              Remove &quot;{(popUp?.removeContact?.data as { email?: string })?.email}&quot;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This email will no longer be notified about severe incidents.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="danger" onClick={onRemoveIncidentContact}>
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/OrgNameChangeSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/OrgNameChangeSection.tsx
@@ -185,7 +185,7 @@ export const OrgNameChangeSection = (): JSX.Element => {
                 />
               )}
             </FieldGroup>
-            <div className="mt-6 flex justify-end">
+            <div className="mt-6 flex">
               <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
                 {(isAllowed) => (
                   <Button variant="org" type="submit" isPending={isPending} isDisabled={!isAllowed}>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/OrgNameChangeSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/OrgNameChangeSection.tsx
@@ -1,11 +1,31 @@
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Building2 } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, Input, Select, SelectItem, Spinner } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton
+} from "@app/components/v3";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -71,95 +91,112 @@ export const OrgNameChangeSection = (): JSX.Element => {
     });
   };
 
-  if (!isFormInitialized) {
-    return (
-      <div className="flex h-101 w-full items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
-
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)} className="py-4">
-      <div className="">
-        <h2 className="text-md mb-2 text-mineshaft-100">Organization Name</h2>
-        <Controller
-          defaultValue=""
-          render={({ field, fieldState: { error } }) => (
-            <FormControl isError={Boolean(error)} errorText={error?.message} className="max-w-md">
-              <Input placeholder="Acme Corp" {...field} />
-            </FormControl>
-          )}
-          control={control}
-          name="name"
-        />
-      </div>
-      <div>
-        <h2 className="text-md mb-2 text-mineshaft-100">Organization ID</h2>
-        <FormControl className="max-w-md">
-          <Input isDisabled value={currentOrg.id} />
-        </FormControl>
-      </div>
-      <div>
-        <h2 className="text-md mb-2 text-mineshaft-100">Organization Slug</h2>
-        <Controller
-          defaultValue=""
-          render={({ field, fieldState: { error } }) => (
-            <FormControl isError={Boolean(error)} errorText={error?.message} className="max-w-md">
-              <Input placeholder="acme" {...field} />
-            </FormControl>
-          )}
-          control={control}
-          name="slug"
-        />
-      </div>
-      {canReadOrgRoles && (
-        <div className="pb-4">
-          <h2 className="text-md mb-2 text-mineshaft-100">Default Organization Member Role</h2>
-          <p className="text-mineshaft-400" />
-          <Controller
-            defaultValue=""
-            control={control}
-            name="defaultMembershipRole"
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                helperText="Users joining your organization will be assigned this role unless otherwise specified."
-                isError={Boolean(error)}
-                errorText={error?.message}
-                className="max-w-md"
-              >
-                <Select
-                  isDisabled={isRolesLoading}
-                  className="w-full capitalize"
-                  value={value}
-                  onValueChange={!roles?.length ? undefined : onChange}
-                >
-                  {roles?.map((role) => {
-                    return (
-                      <SelectItem key={role.id} value={role.slug}>
-                        {role.name}
-                      </SelectItem>
-                    );
-                  })}
-                </Select>
-              </FormControl>
-            )}
-          />
-        </div>
-      )}
-      <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
-        {(isAllowed) => (
-          <Button
-            isLoading={isPending}
-            isDisabled={!isAllowed}
-            colorSchema="primary"
-            variant="outline_bg"
-            type="submit"
-          >
-            Save
-          </Button>
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Building2 className="size-4 text-accent" />
+          Organization Details
+        </CardTitle>
+        <CardDescription>
+          Update your organization&apos;s name, slug, and default member role.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!isFormInitialized ? (
+          <FieldGroup>
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-full" />
+          </FieldGroup>
+        ) : (
+          <form onSubmit={handleSubmit(onFormSubmit)}>
+            <FieldGroup>
+              <Controller
+                defaultValue=""
+                control={control}
+                name="name"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="org-name">Organization Name</FieldLabel>
+                    <Input
+                      id="org-name"
+                      placeholder="Acme Corp"
+                      isError={Boolean(error)}
+                      {...field}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Field>
+                <FieldLabel htmlFor="org-id">Organization ID</FieldLabel>
+                <Input id="org-id" value={currentOrg.id} disabled />
+              </Field>
+              <Controller
+                defaultValue=""
+                control={control}
+                name="slug"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="org-slug">Organization Slug</FieldLabel>
+                    <Input id="org-slug" placeholder="acme" isError={Boolean(error)} {...field} />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              {canReadOrgRoles && (
+                <Controller
+                  defaultValue=""
+                  control={control}
+                  name="defaultMembershipRole"
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <Field>
+                      <FieldLabel htmlFor="org-default-role">
+                        Default Organization Member Role
+                      </FieldLabel>
+                      <Select
+                        value={value}
+                        onValueChange={!roles?.length ? undefined : onChange}
+                        disabled={isRolesLoading}
+                      >
+                        <SelectTrigger
+                          id="org-default-role"
+                          isError={Boolean(error)}
+                          className="w-full capitalize"
+                        >
+                          <SelectValue placeholder="Select role" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roles?.map((role) => (
+                            <SelectItem key={role.id} value={role.slug} className="capitalize">
+                              {role.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FieldDescription>
+                        Users joining your organization will be assigned this role unless otherwise
+                        specified.
+                      </FieldDescription>
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
+              )}
+            </FieldGroup>
+            <div className="mt-6 flex justify-end">
+              <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
+                {(isAllowed) => (
+                  <Button variant="org" type="submit" isPending={isPending} isDisabled={!isAllowed}>
+                    Save
+                  </Button>
+                )}
+              </OrgPermissionCan>
+            </div>
+          </form>
         )}
-      </OrgPermissionCan>
-    </form>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/SubOrgNameChangeSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgNameChangeSection/SubOrgNameChangeSection.tsx
@@ -3,11 +3,25 @@ import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useRouter } from "@tanstack/react-router";
+import { Building2 } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, Input } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -50,6 +64,8 @@ export const SubOrgNameChangeSection = (): JSX.Element => {
 
   const { mutateAsync, isPending } = useUpdateSubOrganization();
 
+  const cannotEdit = permission.cannot(OrgPermissionActions.Edit, OrgPermissionSubjects.Settings);
+
   const onFormSubmit = async ({ name, slug }: FormData) => {
     await mutateAsync({
       name,
@@ -71,71 +87,74 @@ export const SubOrgNameChangeSection = (): JSX.Element => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)} className="py-4">
-      <div className="mb-4">
-        <h2 className="text-md mb-2 text-mineshaft-100">Sub-Organization Display Name</h2>
-        <Controller
-          defaultValue=""
-          render={({ field, fieldState: { error } }) => (
-            <FormControl isError={Boolean(error)} errorText={error?.message} className="max-w-md">
-              <Input
-                isDisabled={permission.cannot(
-                  OrgPermissionActions.Edit,
-                  OrgPermissionSubjects.Settings
-                )}
-                placeholder="Acme Corp"
-                {...field}
-              />
-            </FormControl>
-          )}
-          control={control}
-          name="name"
-        />
-      </div>
-      <div className="mb-4">
-        <h2 className="text-md mb-2 text-mineshaft-100">Sub-Organization ID</h2>
-        <FormControl className="max-w-md">
-          <Input isDisabled value={currentOrg.id} />
-        </FormControl>
-      </div>
-      <div className="mb-4">
-        <h2 className="text-md mb-2 text-mineshaft-100">Sub-Organization Slug</h2>
-        <Controller
-          defaultValue=""
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              isError={Boolean(error)}
-              errorText={error?.message}
-              helperText="Must be slug-friendly (lowercase letters, numbers, and hyphens only)"
-              className="max-w-md"
-            >
-              <Input
-                isDisabled={permission.cannot(
-                  OrgPermissionActions.Edit,
-                  OrgPermissionSubjects.Settings
-                )}
-                placeholder="acme-corp"
-                {...field}
-              />
-            </FormControl>
-          )}
-          control={control}
-          name="slug"
-        />
-      </div>
-      <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
-        {(isAllowed) => (
-          <Button
-            isLoading={isPending}
-            isDisabled={!isAllowed}
-            colorSchema="primary"
-            variant="outline_bg"
-            type="submit"
-          >
-            Save
-          </Button>
-        )}
-      </OrgPermissionCan>
-    </form>
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Building2 className="size-4 text-accent" />
+          Sub-Organization Details
+        </CardTitle>
+        <CardDescription>
+          Update your sub-organization&apos;s display name and slug.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onFormSubmit)}>
+          <FieldGroup>
+            <Controller
+              defaultValue=""
+              control={control}
+              name="name"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="sub-org-name">Sub-Organization Display Name</FieldLabel>
+                  <Input
+                    id="sub-org-name"
+                    placeholder="Acme Corp"
+                    isError={Boolean(error)}
+                    disabled={cannotEdit}
+                    {...field}
+                  />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+            />
+            <Field>
+              <FieldLabel htmlFor="sub-org-id">Sub-Organization ID</FieldLabel>
+              <Input id="sub-org-id" value={currentOrg.id} disabled />
+            </Field>
+            <Controller
+              defaultValue=""
+              control={control}
+              name="slug"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="sub-org-slug">Sub-Organization Slug</FieldLabel>
+                  <Input
+                    id="sub-org-slug"
+                    placeholder="acme-corp"
+                    isError={Boolean(error)}
+                    disabled={cannotEdit}
+                    {...field}
+                  />
+                  <FieldDescription>
+                    Must be slug-friendly (lowercase letters, numbers, and hyphens only).
+                  </FieldDescription>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+            />
+          </FieldGroup>
+          <div className="mt-6 flex justify-end">
+            <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
+              {(isAllowed) => (
+                <Button variant="org" type="submit" isPending={isPending} isDisabled={!isAllowed}>
+                  Save
+                </Button>
+              )}
+            </OrgPermissionCan>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenModal.tsx
@@ -2,9 +2,8 @@ import crypto from "crypto";
 
 import { useEffect, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { faCheck, faCopy, faEye, faEyeSlash, faTerminal } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ClipboardCheckIcon, Copy, Eye, EyeOff, Terminal } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -15,15 +14,20 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
-  Dialog,
-  DialogContent,
+  ButtonGroup,
   Field,
-  FieldContent,
   FieldError,
+  FieldGroup,
   FieldLabel,
   FilterableSelect,
   IconButton,
-  Input
+  Input,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
 } from "@app/components/v3";
 import { OrgPermissionHoneyTokenActions, OrgPermissionSubjects } from "@app/context";
 import { AWS_REGIONS } from "@app/helpers/appConnections";
@@ -208,28 +212,31 @@ export const HoneyTokenModal = ({ isOpen, onOpenChange }: Props) => {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
-        <div className="mb-4">
-          <h2 className="text-lg font-medium text-mineshaft-100">Configure AWS Honey Tokens</h2>
-          <p className="mt-1 text-sm text-mineshaft-400">
-            Plant a decoy IAM credential in your AWS account. Infisical alerts on every access
-            attempt.
-          </p>
-        </div>
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-2xl">
+        <form
+          onSubmit={handleSubmit(hasSavedConfig ? onSave : onNext)}
+          className="flex h-full min-h-0 flex-col"
+        >
+          <SheetHeader>
+            <SheetTitle>Configure AWS Honey Tokens</SheetTitle>
+            <SheetDescription>
+              Plant a decoy IAM credential in your AWS account. Infisical alerts on every access
+              attempt.
+            </SheetDescription>
+          </SheetHeader>
 
-        <form onSubmit={handleSubmit(hasSavedConfig ? onSave : onNext)}>
-          <div className="mb-4 space-y-4">
-            <Controller
-              control={control}
-              name="connectionId"
-              render={({ field, fieldState: { error } }) => {
-                const selectedConnection = awsConnections.find((conn) => conn.id === field.value);
+          <div className="thin-scrollbar flex-1 overflow-y-auto px-4">
+            <FieldGroup>
+              <Controller
+                control={control}
+                name="connectionId"
+                render={({ field, fieldState: { error } }) => {
+                  const selectedConnection = awsConnections.find((conn) => conn.id === field.value);
 
-                return (
-                  <Field>
-                    <FieldLabel>App Connection</FieldLabel>
-                    <FieldContent>
+                  return (
+                    <Field>
+                      <FieldLabel>App Connection</FieldLabel>
                       <FilterableSelect
                         value={selectedConnection || null}
                         onChange={(newValue) => {
@@ -248,132 +255,125 @@ export const HoneyTokenModal = ({ isOpen, onOpenChange }: Props) => {
                         getOptionValue={(option) => option.id}
                       />
                       <FieldError errors={[error]} />
-                    </FieldContent>
-                  </Field>
-                );
-              }}
-            />
+                    </Field>
+                  );
+                }}
+              />
 
-            <Field>
-              <FieldLabel>Webhook Signing Key</FieldLabel>
-              <FieldContent>
-                <div className="flex items-center gap-2">
-                  <Controller
-                    control={control}
-                    name="webhookSigningKey"
-                    render={({ field, fieldState: { error } }) => (
+              <Controller
+                control={control}
+                name="webhookSigningKey"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel>Webhook Signing Key</FieldLabel>
+                    <ButtonGroup className="w-full">
                       <Input
                         {...field}
                         type={isTokenVisible ? "text" : "password"}
                         placeholder="Enter webhook signing key..."
                         isError={Boolean(error)}
                         readOnly={hasSavedConfig}
-                        className="flex-1 font-mono"
+                        className="font-mono"
                       />
-                    )}
-                  />
-                  <IconButton
-                    aria-label="toggle signing key visibility"
-                    variant="outline"
-                    size="md"
-                    onClick={() => setIsTokenVisible.toggle()}
-                  >
-                    <FontAwesomeIcon icon={isTokenVisible ? faEyeSlash : faEye} />
-                  </IconButton>
-                  <IconButton
-                    aria-label="copy signing key"
-                    variant="outline"
-                    size="md"
-                    onClick={() => {
-                      navigator.clipboard.writeText(webhookSigningKey);
-                      setTokenCopied(true);
-                    }}
-                  >
-                    <FontAwesomeIcon icon={isTokenCopied ? faCheck : faCopy} />
-                  </IconButton>
-                </div>
-              </FieldContent>
-            </Field>
+                      <IconButton
+                        aria-label="toggle signing key visibility"
+                        variant="outline"
+                        onClick={() => setIsTokenVisible.toggle()}
+                      >
+                        {isTokenVisible ? <EyeOff /> : <Eye />}
+                      </IconButton>
+                      <IconButton
+                        aria-label="copy signing key"
+                        variant="outline"
+                        onClick={() => {
+                          navigator.clipboard.writeText(webhookSigningKey);
+                          setTokenCopied(true);
+                        }}
+                      >
+                        {isTokenCopied ? <ClipboardCheckIcon /> : <Copy />}
+                      </IconButton>
+                    </ButtonGroup>
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
 
-            <Accordion type="single" collapsible variant="ghost">
-              <AccordionItem value="advanced">
-                <AccordionTrigger>Advanced Options</AccordionTrigger>
-                <AccordionContent>
-                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                    <Controller
-                      control={control}
-                      name="stackName"
-                      render={({ field, fieldState: { error } }) => (
-                        <Field>
-                          <FieldLabel>CloudFormation Stack Name</FieldLabel>
-                          <FieldContent>
+              <Accordion type="single" collapsible variant="ghost">
+                <AccordionItem value="advanced">
+                  <AccordionTrigger>Advanced Options</AccordionTrigger>
+                  <AccordionContent>
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      <Controller
+                        control={control}
+                        name="stackName"
+                        render={({ field, fieldState: { error } }) => (
+                          <Field>
+                            <FieldLabel>CloudFormation Stack Name</FieldLabel>
                             <Input
                               {...field}
                               placeholder={DEFAULT_STACK_NAME}
                               isError={Boolean(error)}
                             />
                             <FieldError errors={[error]} />
-                          </FieldContent>
-                        </Field>
-                      )}
-                    />
-                    <Controller
-                      control={control}
-                      name="awsRegion"
-                      render={({ field, fieldState: { error } }) => (
-                        <Field>
-                          <FieldLabel>AWS Region</FieldLabel>
-                          <FieldContent>
+                          </Field>
+                        )}
+                      />
+                      <Controller
+                        control={control}
+                        name="awsRegion"
+                        render={({ field, fieldState: { error } }) => (
+                          <Field>
+                            <FieldLabel>AWS Region</FieldLabel>
                             <Input
                               {...field}
                               placeholder={DEFAULT_AWS_REGION}
                               isError={Boolean(error)}
                             />
                             <FieldError errors={[error]} />
-                          </FieldContent>
-                        </Field>
-                      )}
-                    />
-                  </div>
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
+                          </Field>
+                        )}
+                      />
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            </FieldGroup>
+
+            {hasSavedConfig && (
+              <div className="mt-4 rounded-md border border-border bg-container p-4">
+                <div className="mb-3 flex items-center gap-2 text-sm text-mineshaft-300">
+                  <Terminal className="size-4 text-mineshaft-400" />
+                  <span className="font-medium tracking-wide uppercase">
+                    Deploy CloudFormation Stack
+                  </span>
+                </div>
+                <p className="mb-3 text-sm text-mineshaft-400">
+                  Run this command to create the CloudFormation stack that provisions the decoy IAM
+                  user and wires CloudTrail alerts back to Infisical.
+                </p>
+                <div className="relative">
+                  <pre className="rounded-md border border-border bg-card p-4 pr-12 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap text-mineshaft-300">
+                    <span className="text-mineshaft-400 select-none">$ </span>
+                    {cfCommand}
+                  </pre>
+                  <IconButton
+                    aria-label="copy CloudFormation command"
+                    variant="outline"
+                    size="xs"
+                    className="absolute top-2 right-2"
+                    onClick={() => {
+                      navigator.clipboard.writeText(cfCommand);
+                      setCommandCopied(true);
+                    }}
+                  >
+                    {isCommandCopied ? <ClipboardCheckIcon /> : <Copy />}
+                  </IconButton>
+                </div>
+              </div>
+            )}
           </div>
 
-          {hasSavedConfig && (
-            <div className="mb-4 rounded-md border border-border bg-container p-4">
-              <div className="mb-3 flex items-center gap-2 text-sm text-mineshaft-300">
-                <FontAwesomeIcon icon={faTerminal} className="text-mineshaft-400" />
-                <span className="font-medium tracking-wide uppercase">
-                  Deploy CloudFormation Stack
-                </span>
-              </div>
-              <p className="mb-3 text-sm text-mineshaft-400">
-                Run this command to create the CloudFormation stack that provisions the decoy IAM
-                user and wires CloudTrail alerts back to Infisical.
-              </p>
-              <div className="relative">
-                <pre className="rounded-md border border-border bg-card p-4 pr-12 font-mono text-xs leading-relaxed break-all whitespace-pre-wrap text-mineshaft-300">
-                  <span className="text-mineshaft-400 select-none">$ </span>
-                  {cfCommand}
-                </pre>
-                <IconButton
-                  aria-label="copy CloudFormation command"
-                  variant="outline"
-                  size="xs"
-                  className="absolute top-2 right-2"
-                  onClick={() => {
-                    navigator.clipboard.writeText(cfCommand);
-                    setCommandCopied(true);
-                  }}
-                >
-                  <FontAwesomeIcon icon={isCommandCopied ? faCheck : faCopy} />
-                </IconButton>
-              </div>
-            </div>
-          )}
-
-          <div className="flex justify-end gap-2">
+          <SheetFooter>
             <Button variant="ghost" onClick={() => onOpenChange(false)} type="button">
               Cancel
             </Button>
@@ -392,9 +392,9 @@ export const HoneyTokenModal = ({ isOpen, onOpenChange }: Props) => {
                 </Button>
               )}
             </OrgPermissionCan>
-          </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/HoneyTokenSection.tsx
@@ -1,6 +1,16 @@
+import { ShieldAlert } from "lucide-react";
+
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Badge, Button } from "@app/components/v3";
+import {
+  Badge,
+  Button,
+  Card,
+  CardAction,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@app/components/v3";
 import { OrgPermissionHoneyTokenActions, OrgPermissionSubjects } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import {
@@ -48,53 +58,56 @@ export const HoneyTokenSection = () => {
   };
 
   return (
-    <div className="mt-6 border-t border-mineshaft-600 pt-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            <h3 className="text-lg font-medium text-mineshaft-100">AWS Honey Tokens</h3>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <ShieldAlert className="size-4 text-accent" />
+            AWS Honey Tokens
             {hasConfig && (
               <Badge variant={isConfigVerified ? "success" : "warning"}>
                 {isConfigVerified ? "Verified" : "Pending Verification"}
               </Badge>
             )}
-          </div>
-          <p className="mt-1 text-sm text-mineshaft-400">
+          </CardTitle>
+          <CardDescription>
             Plant decoy IAM credentials in your AWS account. Infisical alerts on every access
             attempt.
-          </p>
-        </div>
-        <OrgPermissionCan
-          I={OrgPermissionHoneyTokenActions.Setup}
-          a={OrgPermissionSubjects.HoneyTokens}
-        >
-          {(isAllowed) => (
-            <div className="flex gap-2">
-              {hasConfig && (
-                <Button
-                  variant="outline"
-                  isDisabled={!isAllowed || isTesting}
-                  isPending={isTesting}
-                  onClick={handleTestConnection}
-                >
-                  Verify Connection
-                </Button>
+          </CardDescription>
+          <CardAction>
+            <OrgPermissionCan
+              I={OrgPermissionHoneyTokenActions.Setup}
+              a={OrgPermissionSubjects.HoneyTokens}
+            >
+              {(isAllowed) => (
+                <div className="flex gap-2">
+                  {hasConfig && (
+                    <Button
+                      variant="outline"
+                      isDisabled={!isAllowed || isTesting}
+                      isPending={isTesting}
+                      onClick={handleTestConnection}
+                    >
+                      Verify Connection
+                    </Button>
+                  )}
+                  <Button
+                    variant="org"
+                    isDisabled={!isAllowed}
+                    onClick={() => handlePopUpOpen("honeyTokenModal")}
+                  >
+                    {hasConfig ? "Manage" : "Connect"}
+                  </Button>
+                </div>
               )}
-              <Button
-                variant="org"
-                isDisabled={!isAllowed}
-                onClick={() => handlePopUpOpen("honeyTokenModal")}
-              >
-                {hasConfig ? "Manage" : "Connect"}
-              </Button>
-            </div>
-          )}
-        </OrgPermissionCan>
-      </div>
+            </OrgPermissionCan>
+          </CardAction>
+        </CardHeader>
+      </Card>
       <HoneyTokenModal
         isOpen={popUp.honeyTokenModal.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("honeyTokenModal", isOpen)}
       />
-    </div>
+    </>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/OrgProductSettingsTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProductSettingsTab/OrgProductSettingsTab.tsx
@@ -1,8 +1,20 @@
-import { useState } from "react";
+import { KeyRound } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Switch } from "@app/components/v2";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldTitle,
+  Switch
+} from "@app/components/v3";
 import { OrgPermissionActions, OrgPermissionSubjects, useOrganization } from "@app/context";
 import { useUpdateOrg } from "@app/hooks/api/organization/queries";
 
@@ -11,63 +23,61 @@ import { HoneyTokenSection } from "./HoneyTokenSection";
 
 export const OrgProductSettingsTab = () => {
   const { currentOrg } = useOrganization();
-  const { mutateAsync: updateOrg } = useUpdateOrg();
-
-  const [isLoading, setIsLoading] = useState(false);
+  const { mutateAsync: updateOrg, isPending } = useUpdateOrg();
 
   const handleToggle = async (state: boolean) => {
-    setIsLoading(true);
+    if (!currentOrg?.id) return;
 
-    try {
-      if (!currentOrg?.id) {
-        setIsLoading(false);
-        return;
-      }
+    await updateOrg({
+      orgId: currentOrg.id,
+      blockDuplicateSecretSyncDestinations: state
+    });
 
-      await updateOrg({
-        orgId: currentOrg.id,
-        blockDuplicateSecretSyncDestinations: state
-      });
-
-      createNotification({
-        text: `Successfully ${state ? "enabled" : "disabled"} blocking duplicate secret sync destinations for this organization`,
-        type: "success"
-      });
-    } finally {
-      setIsLoading(false);
-    }
+    createNotification({
+      text: `Successfully ${state ? "enabled" : "disabled"} blocking duplicate secret sync destinations for this organization`,
+      type: "success"
+    });
   };
 
   return (
-    <>
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-6">
-        <div className="mb-6">
-          <h2 className="text-xl font-medium text-mineshaft-100">Secrets Management</h2>
-        </div>
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="mb-2 text-lg font-medium text-mineshaft-100">
-              Unique Secret Sync Destination Policy
-            </h3>
-            <p className="text-sm text-mineshaft-400">
-              When enabled, ensures each destination can only be used by one secret sync
-              configuration, preventing potential conflicts or overwrites.
-            </p>
-          </div>
-          <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
-            {(isAllowed) => (
-              <Switch
-                id="blockDuplicateSecretSyncDestinations"
-                isDisabled={!isAllowed || isLoading}
-                isChecked={currentOrg?.blockDuplicateSecretSyncDestinations ?? false}
-                onCheckedChange={(state) => handleToggle(state as boolean)}
-              />
-            )}
-          </OrgPermissionCan>
-        </div>
-        <HoneyTokenSection />
-      </div>
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <KeyRound className="size-4 text-accent" />
+            Secrets Management
+          </CardTitle>
+          <CardDescription>
+            Configure organization-wide policies for secrets management.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <FieldGroup>
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>Unique Secret Sync Destination Policy</FieldTitle>
+                <FieldDescription>
+                  When enabled, ensures each destination can only be used by one secret sync
+                  configuration, preventing potential conflicts or overwrites.
+                </FieldDescription>
+              </FieldContent>
+              <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
+                {(isAllowed) => (
+                  <Switch
+                    id="block-duplicate-secret-sync-destinations"
+                    variant="org"
+                    checked={currentOrg?.blockDuplicateSecretSyncDestinations ?? false}
+                    onCheckedChange={(value) => handleToggle(value)}
+                    disabled={!isAllowed || isPending}
+                  />
+                )}
+              </OrgPermissionCan>
+            </Field>
+          </FieldGroup>
+        </CardContent>
+      </Card>
+      <HoneyTokenSection />
       <OrgCertManagerTab />
-    </>
+    </div>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgGenericAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgGenericAuthSection.tsx
@@ -117,7 +117,7 @@ export const OrgGenericAuthSection = () => {
                   value={currentOrg.selectedMfaMethod ?? MfaMethod.EMAIL}
                   onValueChange={(value) => handleUpdateSelectedMfa(value as MfaMethod)}
                 >
-                  <SelectTrigger id="org-mfa-method" className="w-full">
+                  <SelectTrigger id="org-mfa-method" className="w-full max-w-sm">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent position="popper">

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgGenericAuthSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgGenericAuthSection.tsx
@@ -1,7 +1,28 @@
+import { Fingerprint } from "lucide-react";
+
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { FormControl, Select, SelectItem, Switch } from "@app/components/v2";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch
+} from "@app/components/v3";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -56,49 +77,71 @@ export const OrgGenericAuthSection = () => {
   };
 
   return (
-    <div className="mb-4 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-6">
-      <div className="py-4">
-        <div className="mb-2 flex justify-between">
-          <h3 className="text-md text-mineshaft-100">Enforce Multi-factor Authentication</h3>
-          <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
-            {(isAllowed) => (
-              <Switch
-                id="enforce-org-mfa"
-                onCheckedChange={(value) => handleEnforceMfaToggle(value)}
-                isChecked={currentOrg?.enforceMfa ?? false}
-                isDisabled={!isAllowed}
-              />
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Fingerprint className="size-4 text-accent" />
+            Multi-Factor Authentication
+            {currentOrg?.enforceMfa && <Badge variant="success">Enforced</Badge>}
+          </CardTitle>
+          <CardDescription>
+            Require members to authenticate with MFA to access the organization.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <FieldGroup>
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>Enforce MFA</FieldTitle>
+                <FieldDescription>
+                  Members must complete a second authentication factor to sign in.
+                </FieldDescription>
+              </FieldContent>
+              <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Sso}>
+                {(isAllowed) => (
+                  <Switch
+                    id="enforce-org-mfa"
+                    variant="org"
+                    checked={currentOrg?.enforceMfa ?? false}
+                    onCheckedChange={handleEnforceMfaToggle}
+                    disabled={!isAllowed}
+                  />
+                )}
+              </OrgPermissionCan>
+            </Field>
+            {currentOrg?.enforceMfa && (
+              <Field>
+                <FieldLabel htmlFor="org-mfa-method">MFA Method</FieldLabel>
+                <Select
+                  value={currentOrg.selectedMfaMethod ?? MfaMethod.EMAIL}
+                  onValueChange={(value) => handleUpdateSelectedMfa(value as MfaMethod)}
+                >
+                  <SelectTrigger id="org-mfa-method" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    <SelectItem value={MfaMethod.EMAIL} key="mfa-method-email">
+                      Email
+                    </SelectItem>
+                    <SelectItem value={MfaMethod.TOTP} key="mfa-method-totp">
+                      Mobile Authenticator
+                    </SelectItem>
+                    <SelectItem value={MfaMethod.WEBAUTHN} key="mfa-method-webauthn">
+                      Passkey (WebAuthn)
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
             )}
-          </OrgPermissionCan>
-        </div>
-        <p className="text-sm text-mineshaft-300">
-          Enforce members to authenticate with MFA in order to access the organization
-        </p>
-        {currentOrg?.enforceMfa && (
-          <FormControl label="Selected 2FA method" className="mt-3">
-            <Select
-              className="min-w-[20rem] border border-mineshaft-500"
-              onValueChange={handleUpdateSelectedMfa}
-              defaultValue={currentOrg.selectedMfaMethod ?? MfaMethod.EMAIL}
-            >
-              <SelectItem value={MfaMethod.EMAIL} key="mfa-method-email">
-                Email
-              </SelectItem>
-              <SelectItem value={MfaMethod.TOTP} key="mfa-method-totp">
-                Mobile Authenticator
-              </SelectItem>
-              <SelectItem value={MfaMethod.WEBAUTHN} key="mfa-method-webauthn">
-                Passkey (WebAuthn)
-              </SelectItem>
-            </Select>
-          </FormControl>
-        )}
-      </div>
+          </FieldGroup>
+        </CardContent>
+      </Card>
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
         text="Your current plan does not include access to enforce user MFA. To unlock this feature, please upgrade to Infisical Pro plan."
       />
-    </div>
+    </>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgSecurityTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgSecurityTab.tsx
@@ -7,10 +7,10 @@ import { OrgUserAccessTokenLimitSection } from "./OrgUserAccessTokenLimitSection
 export const OrgSecurityTab = withPermission(
   () => {
     return (
-      <>
+      <div className="flex flex-col gap-4">
         <OrgGenericAuthSection />
         <OrgUserAccessTokenLimitSection />
-      </>
+      </div>
     );
   },
   { action: OrgPermissionSsoActions.Read, subject: OrgPermissionSubjects.Sso }

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgUserAccessTokenLimitSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSecurityTab/OrgUserAccessTokenLimitSection.tsx
@@ -1,10 +1,27 @@
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Clock } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, Input, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
 import { OrgPermissionActions, OrgPermissionSubjects, useOrganization } from "@app/context";
 import { useUpdateOrg } from "@app/hooks/api";
 
@@ -79,83 +96,87 @@ export const OrgUserAccessTokenLimitSection = () => {
   ];
 
   return (
-    <div className="mb-4 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-      <div className="flex w-full items-center justify-between">
-        <p className="text-xl font-medium">Session Length</p>
-      </div>
-      <p className="mt-2 mb-4 text-sm text-gray-400">
-        Specify the duration of each login session for users in this organization.
-      </p>
-      <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
-        {(isAllowed) => (
-          <form onSubmit={handleSubmit(handleUserTokenExpirationSubmit)} autoComplete="off">
-            <div className="flex max-w-sm gap-4">
-              <Controller
-                control={control}
-                name="expirationValue"
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                    label="Expiration value"
-                    className="w-full"
-                  >
-                    <Input
-                      {...field}
-                      type="number"
-                      min={1}
-                      step={1}
-                      value={field.value}
-                      onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
-                      disabled={!isAllowed}
-                    />
-                  </FormControl>
-                )}
-              />
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Clock className="size-4 text-accent" />
+          Session Length
+        </CardTitle>
+        <CardDescription>
+          Specify the duration of each login session for users in this organization.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Settings}>
+          {(isAllowed) => (
+            <form onSubmit={handleSubmit(handleUserTokenExpirationSubmit)} autoComplete="off">
+              <div className="flex max-w-sm gap-4">
+                <Controller
+                  control={control}
+                  name="expirationValue"
+                  render={({ field, fieldState: { error } }) => (
+                    <Field className="flex-1">
+                      <FieldLabel htmlFor="expiration-value">Expiration Value</FieldLabel>
+                      <Input
+                        {...field}
+                        id="expiration-value"
+                        type="number"
+                        min={1}
+                        step={1}
+                        value={field.value}
+                        onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
+                        isError={Boolean(error)}
+                        disabled={!isAllowed}
+                      />
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
 
-              <Controller
-                control={control}
-                name="expirationUnit"
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                    label="Time unit"
-                  >
-                    <Select
-                      value={field.value}
-                      className="pr-2"
-                      onValueChange={field.onChange}
-                      placeholder="Select time unit"
-                      isDisabled={!isAllowed}
-                    >
-                      {timeUnits.map(({ value, label }) => (
-                        <SelectItem
-                          key={value}
-                          value={value}
-                          className="relative py-2 pr-8 pl-6 text-sm hover:bg-mineshaft-700"
+                <Controller
+                  control={control}
+                  name="expirationUnit"
+                  render={({ field, fieldState: { error } }) => (
+                    <Field className="flex-1">
+                      <FieldLabel htmlFor="expiration-unit">Time Unit</FieldLabel>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        disabled={!isAllowed}
+                      >
+                        <SelectTrigger
+                          id="expiration-unit"
+                          className="w-full"
+                          isError={Boolean(error)}
                         >
-                          <div className="ml-3 font-medium">{label}</div>
-                        </SelectItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
-              />
-            </div>
-            <Button
-              colorSchema="secondary"
-              type="submit"
-              isLoading={isSubmitting}
-              disabled={!isDirty}
-              className="mt-4"
-              isDisabled={!isAllowed}
-            >
-              Save
-            </Button>
-          </form>
-        )}
-      </OrgPermissionCan>
-    </div>
+                          <SelectValue placeholder="Select time unit" />
+                        </SelectTrigger>
+                        <SelectContent position="popper">
+                          {timeUnits.map(({ value, label }) => (
+                            <SelectItem key={value} value={value}>
+                              {label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
+              </div>
+              <Button
+                variant="org"
+                type="submit"
+                isPending={isSubmitting}
+                isDisabled={!isAllowed || !isDirty}
+                className="mt-4"
+              >
+                Save
+              </Button>
+            </form>
+          )}
+        </OrgPermissionCan>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
@@ -1,7 +1,10 @@
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { InfoIcon } from "lucide-react";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
-import { TabPanel, Tabs } from "@app/components/v2";
+import { PageHeader, TabPanel, Tabs } from "@app/components/v2";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization, useSubscription } from "@app/context";
 import { usePopUp } from "@app/hooks/usePopUp";
@@ -19,6 +22,7 @@ import { OrgWorkflowIntegrationTab } from "../OrgWorkflowIntegrationTab";
 import { ProjectTemplatesTab } from "../ProjectTemplatesTab";
 
 export const OrgTabGroup = () => {
+  const { t } = useTranslation();
   const search = useSearch({
     from: ROUTE_PATHS.Organization.SettingsPage.id
   });
@@ -83,14 +87,17 @@ export const OrgTabGroup = () => {
   ];
 
   const visibleTabs = tabs.filter((el) => !el.isHidden);
-  const defaultTab = visibleTabs.find((t) => !t.requiresFeature)?.key ?? visibleTabs[0].key;
+  const defaultTab = visibleTabs.find((item) => !item.requiresFeature)?.key ?? visibleTabs[0].key;
   const selectedTab = search.selectedTab
-    ? (visibleTabs.find((t) => t.key === search.selectedTab && !t.requiresFeature)?.key ??
+    ? (visibleTabs.find((item) => item.key === search.selectedTab && !item.requiresFeature)?.key ??
       defaultTab)
     : defaultTab;
+  const selectedTabName = visibleTabs.find((item) => item.key === selectedTab)?.name;
+  const settingsTitle = `${isSubOrganization ? "Sub-Organization" : "Organization"} Settings`;
+  const pageTitle = selectedTabName ? `${selectedTabName} - ${settingsTitle}` : settingsTitle;
 
   const handleTabChange = (key: string) => {
-    const tab = visibleTabs.find((t) => t.key === key);
+    const tab = visibleTabs.find((item) => item.key === key);
     if (tab?.requiresFeature) {
       handlePopUpOpen("upgradePlan");
       return;
@@ -104,6 +111,26 @@ export const OrgTabGroup = () => {
 
   return (
     <>
+      <Helmet>
+        <title>{t("common.head-title", { title: pageTitle })}</title>
+      </Helmet>
+      <PageHeader
+        scope={isSubOrganization ? "namespace" : "org"}
+        description={`Configure ${isSubOrganization ? "sub-" : ""}organization-wide settings`}
+        title={selectedTabName ?? settingsTitle}
+      >
+        {isSubOrganization && (
+          <Link
+            to="/organizations/$orgId/settings"
+            params={{
+              orgId: currentOrg.rootOrgId ?? ""
+            }}
+            className="flex items-center gap-x-1.5 text-xs whitespace-nowrap text-neutral hover:underline"
+          >
+            <InfoIcon size={12} /> Looking for root organization settings?
+          </Link>
+        )}
+      </PageHeader>
       <Tabs orientation="vertical" value={selectedTab} onValueChange={handleTabChange}>
         {visibleTabs
           .filter((tab) => !tab.requiresFeature)


### PR DESCRIPTION
## Context

This PR updates the org settings tab title to update relative to the selected tab and also migrates the following tabs to v3 components:

- org general settings
- org security settings
- org project settings

## Screenshots
<img width="3456" height="1920" alt="CleanShot 2026-06-05 at 11 04 33@2x" src="https://github.com/user-attachments/assets/f28be68c-bc5d-4cf1-96a7-96cd408343cd" />

<img width="3456" height="1920" alt="CleanShot 2026-06-05 at 11 04 31@2x" src="https://github.com/user-attachments/assets/0b223125-a7a8-4f21-aea2-f3ab7d3dadb1" />

<img width="3456" height="1920" alt="CleanShot 2026-06-05 at 11 04 26@2x" src="https://github.com/user-attachments/assets/753211e3-89e0-4c44-8611-19df924bcabc" />

## Steps to verify the change

- view all org settings tabs to check title
- test the 3 migrated pages for no functional regressions

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)