### PR TITLE
feat(auth): auto-submit email verification code when all digits entered (#1582)

### DIFF
--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -91,6 +91,12 @@ export default function CodeInputStep({
     onComplete();
   };
 
+  useEffect(() => {
+    if (code.length === 6 && !isVerifying) {
+      handleVerify();
+    }
+  }, [code]);
+
   const handleResend = async () => {
     try {
       const { cooldownSeconds } = await resendEmail({ email });

--- a/frontend/src/components/auth/CodeInputStep.tsx
+++ b/frontend/src/components/auth/CodeInputStep.tsx
@@ -70,6 +70,7 @@ export default function CodeInputStep({
   const [code, setCode] = useState("");
 
   const endTimeRef = useRef<number>(initialCooldown > 0 ? Date.now() + initialCooldown * 1000 : 0);
+  const autoSubmittedRef = useRef(false);
   const [, forceRender] = useState(0);
 
   // Tick every second
@@ -92,10 +93,14 @@ export default function CodeInputStep({
   };
 
   useEffect(() => {
-    if (code.length === 6 && !isVerifying) {
+    if (code.length === 6 && !isVerifying && !autoSubmittedRef.current) {
+      autoSubmittedRef.current = true;
       handleVerify();
     }
-  }, [code]);
+    if (code.length !== 6) {
+      autoSubmittedRef.current = false;
+    }
+  }, [code, isVerifying]);
 
   const handleResend = async () => {
     try {

--- a/frontend/src/pages/MfaSessionPage/MfaSessionPage.tsx
+++ b/frontend/src/pages/MfaSessionPage/MfaSessionPage.tsx
@@ -79,6 +79,12 @@ export const MfaSessionPage = () => {
     }
   }, [sessionStatus?.status]);
 
+  useEffect(() => {
+    if (isCodeComplete && !isLoading) {
+      handleVerifyMfa();
+    }
+  }, [isCodeComplete]);
+
   // Handle status error (session not found or expired)
   useEffect(() => {
     if (isStatusError) {
@@ -94,8 +100,8 @@ export const MfaSessionPage = () => {
 
   const isCodeComplete = mfaCode.length === getExpectedCodeLength();
 
-  const handleVerifyMfa = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const handleVerifyMfa = async (event?: React.FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
 
     if (!mfaCode.trim() || !isCodeComplete || !sessionStatus?.mfaMethod) return;
 

--- a/frontend/src/pages/MfaSessionPage/MfaSessionPage.tsx
+++ b/frontend/src/pages/MfaSessionPage/MfaSessionPage.tsx
@@ -79,19 +79,6 @@ export const MfaSessionPage = () => {
     }
   }, [sessionStatus?.status]);
 
-  useEffect(() => {
-    if (isCodeComplete && !isLoading) {
-      handleVerifyMfa();
-    }
-  }, [isCodeComplete]);
-
-  // Handle status error (session not found or expired)
-  useEffect(() => {
-    if (isStatusError) {
-      setError("MFA session not found or expired. Please try again.");
-    }
-  }, [isStatusError]);
-
   const getExpectedCodeLength = () => {
     if (sessionStatus?.mfaMethod === MfaMethod.EMAIL) return 6;
     if (sessionStatus?.mfaMethod === MfaMethod.TOTP) return 6;
@@ -99,6 +86,19 @@ export const MfaSessionPage = () => {
   };
 
   const isCodeComplete = mfaCode.length === getExpectedCodeLength();
+
+  useEffect(() => {
+    if (isCodeComplete && !isLoading) {
+      handleVerifyMfa();
+    }
+  }, [isCodeComplete, isLoading]);
+
+  // Handle status error (session not found or expired)
+  useEffect(() => {
+    if (isStatusError) {
+      setError("MFA session not found or expired. Please try again.");
+    }
+  }, [isStatusError]);
 
   const handleVerifyMfa = async (event?: React.FormEvent<HTMLFormElement>) => {
     event?.preventDefault();


### PR DESCRIPTION
Automatically submits the email verification code when all 6 digits are entered, eliminating the need to press Enter or click Verify. Applied to both signup email verification (`CodeInputStep`) and MFA session (`MfaSessionPage`) flows.

## Changes

- **CodeInputStep.tsx**: Added a `useEffect` that triggers `handleVerify` when `code.length === 6` and the request is not already in-flight. Uses a ref guard (`autoSubmittedRef`) to prevent duplicate submissions when `isVerifying` flips back to false after the API resolves.
- **MfaSessionPage.tsx**: Added a `useEffect` with `isCodeComplete` and `isLoading` in the dependency array. Fixed a TDZ bug where `isCodeComplete` was declared after the effect that referenced it.

The Verify button remains as a fallback for accessibility.

Closes #1582