### PR TITLE
feat: add webhook type for triggered honey tokens

### DIFF
--- a/backend/src/ee/services/honey-token/honey-token-service.ts
+++ b/backend/src/ee/services/honey-token/honey-token-service.ts
@@ -21,6 +21,7 @@ import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
+import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
 import { TSecretQueueFactory } from "@app/services/secret/secret-queue";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
@@ -32,6 +33,9 @@ import { TSecretVersionV2TagDALFactory } from "@app/services/secret-v2-bridge/se
 import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
+import { TWebhookDALFactory } from "@app/services/webhook/webhook-dal";
+import { fnTriggerWebhook } from "@app/services/webhook/webhook-fns";
+import { WebhookEvents } from "@app/services/webhook/webhook-types";
 
 import { EventType, TAuditLogServiceFactory } from "../audit-log/audit-log-types";
 import { THoneyTokenConfigDALFactory } from "../honey-token-config/honey-token-config-dal";
@@ -106,6 +110,8 @@ export type THoneyTokenServiceFactoryDep = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany">;
   snapshotService: Pick<TSecretSnapshotServiceFactory, "performSnapshot">;
   secretQueueService: Pick<TSecretQueueFactory, "syncSecrets" | "removeSecretReminder">;
+  webhookDAL: Pick<TWebhookDALFactory, "findAllWebhooks" | "transaction" | "update" | "bulkUpdate">;
+  projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
 };
@@ -150,6 +156,8 @@ export const honeyTokenServiceFactory = ({
   resourceMetadataDAL,
   snapshotService,
   secretQueueService,
+  webhookDAL,
+  projectEnvDAL,
   telemetryService,
   auditLogService
 }: THoneyTokenServiceFactoryDep) => {
@@ -175,6 +183,8 @@ export const honeyTokenServiceFactory = ({
     resourceMetadataDAL,
     snapshotService,
     secretQueueService,
+    webhookDAL,
+    projectEnvDAL,
     telemetryService,
     auditLogService
   });
@@ -980,6 +990,52 @@ export const honeyTokenServiceFactory = ({
     }
   };
 
+  const $triggerWebhookNotification = async ({ orgId, honeyToken, eventMetadata }: TSendTriggerNotificationInput) => {
+    try {
+      const [project, folderInfo] = await Promise.all([
+        projectDAL.findById(honeyToken.projectId),
+        folderDAL.findSecretPathByFolderIds(honeyToken.projectId, [honeyToken.folderId]).then((res) => res[0])
+      ]);
+
+      if (!project || !folderInfo) return;
+
+      const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+        type: KmsDataKey.SecretManager,
+        projectId: honeyToken.projectId
+      });
+
+      await fnTriggerWebhook({
+        projectId: honeyToken.projectId,
+        environment: folderInfo.environmentSlug,
+        secretPath: folderInfo.path || "/",
+        webhookDAL,
+        projectEnvDAL,
+        projectDAL,
+        auditLogService,
+        secretManagerDecryptor: (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString(),
+        event: {
+          type: WebhookEvents.HoneyTokenTriggered,
+          payload: {
+            honeyTokenName: honeyToken.name,
+            projectId: honeyToken.projectId,
+            projectName: project.name,
+            environment: folderInfo.environmentSlug,
+            environmentName: folderInfo.environmentName,
+            secretPath: folderInfo.path || "/",
+            eventName: eventMetadata.eventName,
+            sourceIp: eventMetadata.sourceIp ?? "Unknown",
+            awsRegion: eventMetadata.awsRegion
+          }
+        }
+      });
+    } catch (err) {
+      logger.error(
+        { err, orgId, honeyTokenId: honeyToken.id },
+        `Failed to trigger honey token webhook [orgId=${orgId}] [honeyTokenId=${honeyToken.id}]`
+      );
+    }
+  };
+
   const handleTrigger = async ({ type, signature, rawBody, payload }: THandleTriggerInput) => {
     logger.info({ signature, type }, `Honey token trigger received [type=${type}]`);
 
@@ -1093,6 +1149,7 @@ export const honeyTokenServiceFactory = ({
       .catch(() => {});
     if (updatedToken) {
       void $sendTriggerNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata });
+      void $triggerWebhookNotification({ orgId: honeyTokenWithOrg.orgId, honeyToken, eventMetadata });
 
       await auditLogService.createAuditLog({
         actor: {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2625,6 +2625,8 @@ export const registerRoutes = async (
     resourceMetadataDAL,
     snapshotService,
     secretQueueService,
+    webhookDAL,
+    projectEnvDAL,
     appConnectionService,
     telemetryService,
     auditLogService

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -270,6 +270,127 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
     }
   }
 
+  if (event.type === WebhookEvents.HoneyTokenTriggered) {
+    const {
+      honeyTokenName,
+      projectName,
+      projectId,
+      environment,
+      environmentName,
+      secretPath,
+      type,
+      eventName,
+      sourceIp,
+      awsRegion
+    } = event.payload;
+
+    switch (type) {
+      case WebhookType.SLACK:
+        return {
+          text: "A honey token has been triggered!",
+          attachments: [
+            {
+              color: "#FF0000",
+              fields: [
+                {
+                  title: "Honey Token",
+                  value: honeyTokenName,
+                  short: false
+                },
+                {
+                  title: "Project",
+                  value: projectName,
+                  short: false
+                },
+                {
+                  title: "Environment",
+                  value: environment,
+                  short: false
+                },
+                {
+                  title: "Environment Name",
+                  value: environmentName,
+                  short: false
+                },
+                {
+                  title: "Secret Path",
+                  value: secretPath,
+                  short: false
+                },
+                {
+                  title: "AWS Event",
+                  value: eventName,
+                  short: false
+                },
+                {
+                  title: "Source IP",
+                  value: sourceIp || "Unknown",
+                  short: false
+                },
+                {
+                  title: "AWS Region",
+                  value: awsRegion,
+                  short: false
+                }
+              ]
+            }
+          ]
+        };
+      case WebhookType.MICROSOFT_TEAMS:
+        return {
+          type: "message",
+          attachments: [
+            {
+              contentType: "application/vnd.microsoft.card.adaptive",
+              content: {
+                type: "AdaptiveCard",
+                version: "1.2",
+                body: [
+                  {
+                    type: "TextBlock",
+                    size: "Medium",
+                    weight: "Bolder",
+                    text: "A honey token has been triggered!"
+                  },
+                  {
+                    type: "FactSet",
+                    facts: [
+                      { title: "Honey Token", value: honeyTokenName || "" },
+                      { title: "Project", value: projectName || "" },
+                      { title: "Environment", value: environment },
+                      { title: "Environment Name", value: environmentName || "" },
+                      { title: "Secret Path", value: secretPath || "" },
+                      { title: "AWS Event", value: eventName || "" },
+                      { title: "Source IP", value: sourceIp || "Unknown" },
+                      { title: "AWS Region", value: awsRegion || "" }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        };
+      case WebhookType.GENERAL:
+      default:
+        return {
+          event: event.type,
+          project: {
+            projectId,
+            projectName,
+            environment,
+            environmentName,
+            secretPath
+          },
+          honeyToken: {
+            name: honeyTokenName,
+            eventName,
+            sourceIp: sourceIp || "Unknown",
+            awsRegion
+          }
+        };
+    }
+  }
+
   if (event.type === WebhookEvents.TestEvent) {
     const { projectName, projectId, environment, environmentName, secretPath } = event.payload;
     return {

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -361,7 +361,7 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                       { title: "Environment Name", value: environmentName || "" },
                       { title: "Secret Path", value: secretPath || "" },
                       { title: "AWS Event", value: eventName || "" },
-                      { title: "Source IP", value: sourceIp || "" },
+                      { title: "Source IP", value: sourceIp || "Unknown" },
                       { title: "AWS Region", value: awsRegion || "" }
                     ]
                   }

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -361,7 +361,6 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                       { title: "Environment Name", value: environmentName || "" },
                       { title: "Secret Path", value: secretPath || "" },
                       { title: "AWS Event", value: eventName || "" },
-                      { title: "Source IP", value: sourceIp || "Unknown" },
                       { title: "AWS Region", value: awsRegion || "" }
                     ]
                   }

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -361,6 +361,7 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
                       { title: "Environment Name", value: environmentName || "" },
                       { title: "Secret Path", value: secretPath || "" },
                       { title: "AWS Event", value: eventName || "" },
+                      { title: "Source IP", value: sourceIp || "" },
                       { title: "AWS Region", value: awsRegion || "" }
                     ]
                   }

--- a/backend/src/services/webhook/webhook-types.ts
+++ b/backend/src/services/webhook/webhook-types.ts
@@ -43,10 +43,15 @@ export enum WebhookType {
 export enum WebhookEvents {
   SecretModified = "secrets.modified",
   SecretRotationFailed = "secrets.rotation-failed",
+  HoneyTokenTriggered = "honey-token.triggered",
   TestEvent = "test"
 }
 
-export const SUBSCRIBABLE_WEBHOOK_EVENTS = [WebhookEvents.SecretModified, WebhookEvents.SecretRotationFailed] as const;
+export const SUBSCRIBABLE_WEBHOOK_EVENTS = [
+  WebhookEvents.SecretModified,
+  WebhookEvents.SecretRotationFailed,
+  WebhookEvents.HoneyTokenTriggered
+] as const;
 
 export type TSubscribableWebhookEvent = (typeof SUBSCRIBABLE_WEBHOOK_EVENTS)[number];
 
@@ -80,6 +85,22 @@ type TWebhookSecretRotationFailedEventPayload = {
   };
 };
 
+type TWebhookHoneyTokenTriggeredEventPayload = {
+  type: WebhookEvents.HoneyTokenTriggered;
+  payload: {
+    honeyTokenName: string;
+    projectName?: string;
+    projectId: string;
+    environment: string;
+    environmentName: string;
+    secretPath?: string;
+    type?: string | null;
+    eventName: string;
+    sourceIp?: string;
+    awsRegion: string;
+  };
+};
+
 type TWebhookTestEventPayload = {
   type: WebhookEvents.TestEvent;
   payload: {
@@ -95,4 +116,5 @@ type TWebhookTestEventPayload = {
 export type TWebhookPayloads =
   | TWebhookSecretModifiedEventPayload
   | TWebhookSecretRotationFailedEventPayload
+  | TWebhookHoneyTokenTriggeredEventPayload
   | TWebhookTestEventPayload;

--- a/docs/documentation/platform/webhooks.mdx
+++ b/docs/documentation/platform/webhooks.mdx
@@ -31,6 +31,7 @@ Supported events:
 
 - **Secret Modified** (`secrets.modified`) — triggered when secrets in the configured scope are created, updated, or deleted.
 - **Secret Rotation Failed** (`secrets.rotation-failed`) — triggered when a secret rotation in the configured scope fails.
+- **Honey Token Triggered** (`honey-token.triggered`) — triggered when a honey token is activated.
 
 ### Webhook Payload Format
 
@@ -40,7 +41,7 @@ Supported events:
 	"project": {
 		"workspaceId": "the workspace id",
 		"environment": "project environment (slug)",
-		"environmentName": "project environment (name)"
+		"environmentName": "project environment (name)",
 		"secretPath": "project folder path",
 		"changedBy": "Actor that changed the secret",
 		"changedByActorType": "The actor type that triggered the change. Possible values: `service`, `user`, `identity`."
@@ -57,12 +58,31 @@ Supported events:
 		"projectId": "the project id",
 		"projectName": "the project name",
 		"environment": "project environment",
-		"environmentName": "project environment (name)"
+		"environmentName": "project environment (name)",
 		"secretPath": "project folder path",
 		"rotationName": "name of the failed rotation",
 		"errorMessage": "error details",
 		"triggeredManually": false
 	},
 	"timestamp": ""
+}
+```
+
+```json
+{
+	"event": "honey-token.triggered",
+	"project": {
+		"projectId": "the project id",
+		"projectName": "the project name",
+		"environment": "project environment (slug)",
+		"environmentName": "project environment (name)",
+		"secretPath": "project folder path"
+	},
+	"honeyToken": {
+		"name": "name of the honey token",
+		"eventName": "the AWS event that triggered the honey token",
+		"sourceIp": "IP address of the caller",
+		"awsRegion": "AWS region where the event occurred"
+	}
 }
 ```

--- a/frontend/src/hooks/api/webhooks/types.ts
+++ b/frontend/src/hooks/api/webhooks/types.ts
@@ -6,7 +6,8 @@ export enum WebhookType {
 
 export enum WebhookEvent {
   SecretModified = "secrets.modified",
-  SecretRotationFailed = "secrets.rotation-failed"
+  SecretRotationFailed = "secrets.rotation-failed",
+  HoneyTokenTriggered = "honey-token.triggered"
 }
 
 export type TWebhookEventMetadata = {
@@ -24,6 +25,10 @@ export const WEBHOOK_EVENT_METADATA: Record<WebhookEvent, TWebhookEventMetadata>
   [WebhookEvent.SecretModified]: {
     label: "Secret Modified",
     description: "Triggered when secrets are modified"
+  },
+  [WebhookEvent.HoneyTokenTriggered]: {
+    label: "Honey Token Triggered",
+    description: "Triggered when a honey token is activated"
   }
 };
 

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -64,7 +64,8 @@ const formSchema = z
     type: z.nativeEnum(WebhookType).describe("Type").default(WebhookType.GENERAL),
     enabledEvents: z.record(z.nativeEnum(WebhookEvent), z.boolean()).default({
       [WebhookEvent.SecretModified]: true,
-      [WebhookEvent.SecretRotationFailed]: true
+      [WebhookEvent.SecretRotationFailed]: true,
+      [WebhookEvent.HoneyTokenTriggered]: true
     })
   })
   .superRefine((data, ctx) => {
@@ -105,7 +106,8 @@ export const AddWebhookForm = ({
       type: WebhookType.GENERAL,
       enabledEvents: {
         [WebhookEvent.SecretModified]: true,
-        [WebhookEvent.SecretRotationFailed]: true
+        [WebhookEvent.SecretRotationFailed]: true,
+        [WebhookEvent.HoneyTokenTriggered]: true
       }
     }
   });
@@ -177,7 +179,8 @@ export const AddWebhookForm = ({
         type: WebhookType.GENERAL,
         enabledEvents: {
           [WebhookEvent.SecretModified]: true,
-          [WebhookEvent.SecretRotationFailed]: true
+          [WebhookEvent.SecretRotationFailed]: true,
+          [WebhookEvent.HoneyTokenTriggered]: true
         },
         environment: environments?.[0]?.slug,
         secretPath: ""

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/EditWebhookEventsModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/EditWebhookEventsModal.tsx
@@ -69,7 +69,8 @@ export const EditWebhookEventsModal = ({
   const defaultSettings = useMemo<TWebhookEventSettings>(
     () => ({
       [WebhookEvent.SecretModified]: true,
-      [WebhookEvent.SecretRotationFailed]: true
+      [WebhookEvent.SecretRotationFailed]: true,
+      [WebhookEvent.HoneyTokenTriggered]: true
     }),
     []
   );


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Honey tokens triggered are now supported by the Secrets Management Webhooks. So now it supports:

* General webhook
* Slack
* MS Teams

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)