### PR TITLE
improvement: migrate toast to v3, improve behavior, add stories and u…

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -84,3 +84,4 @@ Tailwind CSS v4 with PostCSS. Dark theme configured via CSS custom properties in
 - Import ordering via `simple-import-sort`: node builtins → react/external packages → `@app/` → internal → relative → styles.
 - Forms use `react-hook-form` with `@hookform/resolvers` (Zod schemas).
 - Search params validated with `zodValidator()` from `@tanstack/zod-adapter`.
+- Toasts: call `createNotification({ title?, text, type, callToAction?, copyActions? })` from `@app/components/notifications`. Backed by **sonner** (the v3 `Toaster` in `components/v3/generic/Toast`), mounted once via `NotificationContainer` in `pages/root.tsx`. `react-toastify` has been removed, so do not reintroduce it.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -100,7 +100,6 @@
         "react-icons": "^5.4.0",
         "react-markdown": "^10.0.1",
         "react-select": "^5.9.0",
-        "react-toastify": "^10.0.6",
         "recharts": "^3.8.1",
         "rehype-raw": "^7.0.0",
         "sonner": "^2.0.7",
@@ -14435,19 +14434,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
-      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,7 +131,6 @@
     "react-icons": "^5.4.0",
     "react-markdown": "^10.0.1",
     "react-select": "^5.9.0",
-    "react-toastify": "^10.0.6",
     "recharts": "^3.8.1",
     "rehype-raw": "^7.0.0",
     "sonner": "^2.0.7",

--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -19,11 +19,10 @@ export type TNotification = {
   copyActions?: { icon?: IconDefinition; value: string; name: string; label?: string }[];
 };
 
-// Back-compat shim for the old react-toastify second argument. Across the codebase only
-// `autoClose` and `closeOnClick` were ever passed, so we map those and ignore the rest.
+// Back-compat shim for the old react-toastify second argument. Only `autoClose` is ever passed
+// at call sites; it maps to sonner's `duration`.
 type TNotificationOptions = {
   autoClose?: number | false;
-  closeOnClick?: boolean;
   duration?: number;
 };
 
@@ -43,8 +42,12 @@ const ToastCopyButton = ({ value, name }: { value: string; name: string }) => {
           className="size-5"
           onClick={(e) => {
             e.stopPropagation();
-            setCopyText("Copied");
-            navigator.clipboard.writeText(value);
+            navigator.clipboard
+              .writeText(value)
+              .then(() => setCopyText("Copied"))
+              .catch(() => {
+                // clipboard write failed (e.g. denied permissions); leave the state unchanged
+              });
           }}
         >
           {isCopying ? <CheckIcon className="size-3!" /> : <CopyIcon className="size-3!" />}

--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -1,9 +1,15 @@
 import { ReactNode } from "react";
-import { Id, toast, ToastContainer, ToastOptions, TypeOptions } from "react-toastify";
-import { faCopy, IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { type IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
 
-import { CopyButton } from "../v2/CopyButton";
+import { IconButton } from "@app/components/v3/generic/IconButton";
+import { Toaster } from "@app/components/v3/generic/Toast";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3/generic/Tooltip";
+import { useTimedReset } from "@app/hooks";
+
+export type NotificationType = "success" | "error" | "info" | "warning" | "default";
 
 export type TNotification = {
   title?: string;
@@ -13,74 +19,119 @@ export type TNotification = {
   copyActions?: { icon?: IconDefinition; value: string; name: string; label?: string }[];
 };
 
-export const NotificationContent = ({
-  title,
+// Back-compat shim for the old react-toastify second argument. Across the codebase only
+// `autoClose` and `closeOnClick` were ever passed, so we map those and ignore the rest.
+type TNotificationOptions = {
+  autoClose?: number | false;
+  closeOnClick?: boolean;
+  duration?: number;
+};
+
+// v3 copy button used inside toast bodies (e.g. the request-id copy on error toasts).
+const ToastCopyButton = ({ value, name }: { value: string; name: string }) => {
+  const [copyText, isCopying, setCopyText] = useTimedReset<string>({
+    initialState: `Copy ${name}`
+  });
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <IconButton
+          aria-label={copyText}
+          variant="ghost-muted"
+          size="xs"
+          className="size-5"
+          onClick={(e) => {
+            e.stopPropagation();
+            setCopyText("Copied");
+            navigator.clipboard.writeText(value);
+          }}
+        >
+          {isCopying ? <CheckIcon className="size-3!" /> : <CopyIcon className="size-3!" />}
+        </IconButton>
+      </TooltipTrigger>
+      {/* Render above the sonner toaster (z-index 999999999) so the tooltip isn't occluded. */}
+      <TooltipContent className="z-[2147483647]">{copyText}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+// Everything that renders below sonner's headline: the body text (only when a title takes
+// the headline), children, the call-to-action and the copy buttons.
+const NotificationBody = ({
   text,
   children,
   callToAction,
   copyActions
-}: TNotification) => {
-  return (
-    <div className="msg-container">
-      {title && <div className="text-md mb-1 font-medium">{title}</div>}
+}: Omit<TNotification, "title">) => (
+  <div className="msg-container">
+    {text && <div className="whitespace-pre-line">{text}</div>}
+    {children && <div className="mt-2">{children}</div>}
+    {(callToAction || copyActions) && (
       <div
-        className={
-          title ? "text-sm whitespace-pre-line text-neutral-400" : "text-md whitespace-pre-line"
-        }
+        className={twMerge(
+          "mt-2 flex h-7 w-full flex-row items-end gap-2",
+          callToAction ? "justify-between" : "justify-end"
+        )}
       >
-        {text}
+        {callToAction}
+        {copyActions && (
+          <div className="flex h-7 flex-row items-center gap-2">
+            {copyActions.map((action) => (
+              <div className="flex flex-row items-center gap-1.5" key={`copy-${action.name}`}>
+                {action.label && (
+                  <span className="ml-2 text-xs text-mineshaft-400">{action.label}</span>
+                )}
+                <ToastCopyButton value={action.value} name={action.name} />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-      {children && <div className="mt-2">{children}</div>}
-      {(callToAction || copyActions) && (
-        <div
-          className={twMerge(
-            "mt-2 flex h-7 w-full flex-row items-end gap-2",
-            callToAction ? "justify-between" : "justify-end"
-          )}
-        >
-          {callToAction}
-          {copyActions && (
-            <div className="flex h-7 flex-row items-center gap-2">
-              {copyActions.map((action) => (
-                <div className="flex flex-row items-center gap-2" key={`copy-${action.name}`}>
-                  {action.label && (
-                    <span className="ml-2 text-xs text-mineshaft-400">{action.label}</span>
-                  )}
-                  <CopyButton
-                    value={action.value}
-                    name={action.name}
-                    size="xs"
-                    variant="plain"
-                    color="text-mineshaft-400"
-                    icon={action.icon ?? faCopy}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
+    )}
+  </div>
+);
+
+const toastByType = {
+  success: toast.success,
+  error: toast.error,
+  info: toast.info,
+  warning: toast.warning,
+  default: toast.message
+} satisfies Record<NotificationType, typeof toast.message>;
 
 export const createNotification = (
-  myProps: TNotification & { type?: TypeOptions },
-  toastProps: ToastOptions = {}
-): Id =>
-  toast(<NotificationContent {...myProps} />, {
-    position: "bottom-right",
-    ...toastProps,
-    autoClose: toastProps.autoClose || (myProps?.type === "error" ? 8000 : 3000),
-    theme: "dark",
-    type: myProps?.type || "info",
-    className: `pointer-events-auto ${toastProps.className}`
-  });
+  {
+    title,
+    text,
+    children,
+    callToAction,
+    copyActions,
+    type = "info"
+  }: TNotification & { type?: NotificationType },
+  options: TNotificationOptions = {}
+) => {
+  // When a title is present it becomes sonner's headline and the text drops into the body;
+  // otherwise the text itself is the headline.
+  const bodyText = title ? text : undefined;
+  const hasBody = Boolean(bodyText || children || callToAction || copyActions);
 
-export const NotificationContainer = () => (
-  <ToastContainer
-    pauseOnHover
-    toastClassName="border border-mineshaft-500"
-    style={{ width: "400px" }}
-  />
-);
+  const duration =
+    options.autoClose === false
+      ? Infinity
+      : (options.duration ?? options.autoClose ?? (type === "error" ? 8000 : 3000));
+
+  const notify = toastByType[type] ?? toast.message;
+
+  return notify(title || text, {
+    description: hasBody ? (
+      <NotificationBody text={bodyText} callToAction={callToAction} copyActions={copyActions}>
+        {children}
+      </NotificationBody>
+    ) : undefined,
+    duration
+  });
+};
+
+// All styling/position/close-button config lives in the v3 Toaster itself.
+export const NotificationContainer = () => <Toaster />;

--- a/frontend/src/components/notifications/index.tsx
+++ b/frontend/src/components/notifications/index.tsx
@@ -1,1 +1,2 @@
+export type { NotificationType, TNotification } from "./Notifications";
 export { createNotification, NotificationContainer } from "./Notifications";

--- a/frontend/src/components/v2/Drawer/Drawer.tsx
+++ b/frontend/src/components/v2/Drawer/Drawer.tsx
@@ -57,7 +57,7 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
         className={twMerge(drawerContentVariation({ direction, className }))}
         onPointerDownOutside={(e) => {
           const target = e.target as HTMLElement;
-          const toastElement = target.closest('[class*="Toastify"]');
+          const toastElement = target.closest("[data-sonner-toast]");
           if (toastElement) {
             e.preventDefault();
             return;

--- a/frontend/src/components/v2/Modal/Modal.tsx
+++ b/frontend/src/components/v2/Modal/Modal.tsx
@@ -45,7 +45,7 @@ export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
         ref={forwardedRef}
         onPointerDownOutside={(e) => {
           const target = e.target as HTMLElement;
-          const toastElement = target.closest('[class*="Toastify"]');
+          const toastElement = target.closest("[data-sonner-toast]");
           if (toastElement) {
             e.preventDefault();
             return;

--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -42,6 +42,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onPointerDownOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
@@ -55,6 +56,14 @@ function DialogContent({
           "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
+        onPointerDownOutside={(e) => {
+          // Keep the dialog open when a toast rendered above it is clicked.
+          if ((e.target as HTMLElement)?.closest?.("[data-sonner-toast]")) {
+            e.preventDefault();
+            return;
+          }
+          onPointerDownOutside?.(e);
+        }}
         {...props}
       >
         {children}

--- a/frontend/src/components/v3/generic/Sheet/Sheet.tsx
+++ b/frontend/src/components/v3/generic/Sheet/Sheet.tsx
@@ -55,7 +55,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         onPointerDownOutside={(e) => {
-          if ((e.target as HTMLElement)?.closest?.(".Toastify")) {
+          if ((e.target as HTMLElement)?.closest?.("[data-sonner-toast]")) {
             e.preventDefault();
           }
           onPointerDownOutside?.(e);

--- a/frontend/src/components/v3/generic/Toast/Toast.stories.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.stories.tsx
@@ -1,0 +1,265 @@
+import { createPortal } from "react-dom";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { toast } from "sonner";
+
+import { Button, type ButtonProps } from "../Button";
+import { Toaster } from "./Toast";
+
+/**
+ * Toasts surface transient, post-action feedback that does not interrupt the user's flow.
+ * Trigger them imperatively with `toast` from `sonner`; the `<Toaster />` (mounted once near
+ * the app root) renders them. The toast type sets the semantic tone (a tinted surface, a
+ * matching border, and a colored icon) while title and description stay neutral.
+ *
+ * In the app, prefer the `createNotification` helper from `@app/components/notifications`,
+ * which maps our payloads onto this component.
+ */
+
+// sonner renders inline (it does not portal) and scopes toasts to a Toaster by `id`. In
+// Storybook's aggregated docs view each story mounts its own Toaster, so an unscoped toast
+// would appear in every example and get clipped inside the story frame. Each story therefore
+// renders a Toaster scoped to a unique id and portaled to the document body, so its toast
+// shows exactly once, at the viewport corner.
+const ToastExample = ({
+  toasterId,
+  variant,
+  label,
+  onShow
+}: {
+  toasterId: string;
+  variant: ButtonProps["variant"];
+  label: string;
+  onShow: (toasterId: string) => void;
+}) => (
+  <>
+    <Button variant={variant} onClick={() => onShow(toasterId)}>
+      {label}
+    </Button>
+    {createPortal(<Toaster id={toasterId} />, document.body)}
+  </>
+);
+
+const meta = {
+  title: "Generic/Toast",
+  component: Toaster,
+  parameters: {
+    layout: "centered"
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  name: "Variant: Success",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use this variant to confirm a completed action. Keep the copy past tense and specific."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-success"
+      variant="success"
+      label="Show Success Toast"
+      onShow={(toasterId) => toast.success('Secret "API_KEY" created', { toasterId })}
+    />
+  )
+};
+
+export const Info: Story = {
+  name: "Variant: Info",
+  parameters: {
+    docs: {
+      description: {
+        story: "Use this variant for neutral, informational feedback such as a copy confirmation."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-info"
+      variant="info"
+      label="Show Info Toast"
+      onShow={(toasterId) => toast.info("Request ID copied to clipboard", { toasterId })}
+    />
+  )
+};
+
+export const Warning: Story = {
+  name: "Variant: Warning",
+  parameters: {
+    docs: {
+      description: {
+        story: "Use this variant to flag an attention-warranting state the user should notice."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-warning"
+      variant="warning"
+      label="Show Warning Toast"
+      onShow={(toasterId) => toast.warning("Access token expires in 24 hours", { toasterId })}
+    />
+  )
+};
+
+export const ErrorToast: Story = {
+  name: "Variant: Error",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use this variant to surface a failure. Name the failure and the remedy in the description."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-error"
+      variant="danger"
+      label="Show Error Toast"
+      onShow={(toasterId) =>
+        toast.error("Could not rotate secret", {
+          description: "Token lacks the secrets:write permission.",
+          toasterId
+        })
+      }
+    />
+  )
+};
+
+export const Default: Story = {
+  name: "Variant: Default",
+  parameters: {
+    docs: {
+      description: {
+        story: "Use this variant for neutral messages that do not warrant a semantic tone."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-default"
+      variant="outline"
+      label="Show Default Toast"
+      onShow={(toasterId) => toast("Syncing started", { toasterId })}
+    />
+  )
+};
+
+export const WithDescription: Story = {
+  name: "Example: With Description",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Add a description for a second line of supporting detail. The title stays the prominent line."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-description"
+      variant="success"
+      label="Show Toast With Description"
+      onShow={(toasterId) =>
+        toast.success("Integration connected", {
+          description: "Secrets will begin syncing to the target environment within a minute.",
+          toasterId
+        })
+      }
+    />
+  )
+};
+
+export const WithAction: Story = {
+  name: "Example: With Action",
+  parameters: {
+    docs: {
+      description: {
+        story: "Pair a toast with a single follow-up action, such as undoing the change just made."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-action"
+      variant="outline"
+      label="Show Toast With Action"
+      onShow={(toasterId) =>
+        toast("Secret value updated", {
+          description: "The previous value was archived.",
+          toasterId,
+          action: {
+            label: "Undo",
+            onClick: () => toast.success("Reverted to previous value", { toasterId })
+          }
+        })
+      }
+    />
+  )
+};
+
+export const PromiseToast: Story = {
+  name: "Example: Promise",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Drive the toast from a promise to reflect an async operation's lifecycle: loading, then success or error."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-promise"
+      variant="info"
+      label="Show Promise Toast"
+      onShow={(toasterId) =>
+        toast.promise(
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 2000);
+          }),
+          {
+            loading: "Rotating secret...",
+            success: "Secret rotated",
+            error: "Rotation failed",
+            toasterId
+          }
+        )
+      }
+    />
+  )
+};
+
+export const Persistent: Story = {
+  name: "Example: Persistent",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Set `duration: Infinity` to keep a toast until the user dismisses it. Use sparingly for states that must be acknowledged."
+      }
+    }
+  },
+  render: () => (
+    <ToastExample
+      toasterId="toast-persistent"
+      variant="warning"
+      label="Show Persistent Toast"
+      onShow={(toasterId) =>
+        toast.warning("Connection lost", {
+          description: "Reconnect to resume syncing secrets.",
+          duration: Infinity,
+          toasterId
+        })
+      }
+    />
+  )
+};

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -29,20 +29,20 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           // pointer-events-auto keeps the toast clickable over a modal (Radix sets
           // pointer-events:none outside itself); items-start aligns the icon with the title;
-          // flex-wrap drops the action button to its own row; pl-5 clears the accent strip.
-          toast: "!pointer-events-auto !items-start !flex-wrap !rounded-md !pl-5",
-          // Let the content fill the first row so the action button wraps below, bottom-right.
-          content: "!flex-1",
+          // pl-5 clears the accent strip.
+          toast: "!pointer-events-auto !items-start !rounded-md !pl-5",
           icon: "!mt-0.5",
           title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
           description: "!text-xs !text-foreground/75 whitespace-pre-line",
           // Square close button seated inside the toast body at the top-right.
           closeButton:
             "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
+          // self-end seats the action at the bottom of the toast; sonner's margin-left:auto
+          // pushes it right, so it lands bottom-right, clear of the top-right close button.
           actionButton:
-            "!rounded !border !border-border !bg-foreground/10 !text-foreground hover:!bg-foreground/20",
+            "!self-end !rounded !border !border-border !bg-foreground/10 !text-foreground hover:!bg-foreground/20",
           cancelButton:
-            "!rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
+            "!self-end !rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
           // Status accent: a 4px strip painted as a hard-stop gradient so the card's radius
           // rounds the strip's outer corner while the gradient stop keeps the inner edge
           // straight (a left border would curve on the inside and look crescent-shaped).

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -39,8 +39,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
           // self-end seats the action at the bottom of the toast; sonner's margin-left:auto
           // pushes it right, so it lands bottom-right, clear of the top-right close button.
+          // Styled to match the v3 outline Button variant.
           actionButton:
-            "!self-end !rounded !border !border-border !bg-foreground/10 !text-foreground hover:!bg-foreground/20",
+            "!self-end !rounded-sm !border !border-border !bg-transparent !text-foreground hover:!bg-foreground/10 hover:!border-foreground/20",
           cancelButton:
             "!self-end !rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
           // Status accent: a 4px strip painted as a hard-stop gradient so the card's radius

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -7,10 +7,7 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
-// The v3 toast keeps a neutral container surface and carries intent through a colored icon and
-// a left accent strip in the status color, while the title and description stay neutral. sonner
-// is CSS-variable driven, so the shared surface is set via --normal-* and the per-type accent is
-// added through sonner's per-type classNames.
+
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
@@ -27,26 +24,16 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       toastOptions={{
         classNames: {
-          // pointer-events-auto keeps the toast clickable over a modal (Radix sets
-          // pointer-events:none outside itself); items-start aligns the icon with the title;
-          // pl-5 clears the accent strip.
           toast: "!pointer-events-auto !items-start !rounded-md !pl-5",
           icon: "!mt-0.5",
           title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
           description: "!text-xs !text-foreground/75 whitespace-pre-line",
-          // Square close button seated inside the toast body at the top-right.
           closeButton:
             "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
-          // self-end seats the action at the bottom of the toast; sonner's margin-left:auto
-          // pushes it right, so it lands bottom-right, clear of the top-right close button.
-          // Styled to match the v3 outline Button variant.
           actionButton:
             "!self-end !rounded-sm !border !border-border !bg-transparent !text-foreground hover:!bg-foreground/10 hover:!border-foreground/20",
           cancelButton:
             "!self-end !rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
-          // Status accent: a 4px strip painted as a hard-stop gradient so the card's radius
-          // rounds the strip's outer corner while the gradient stop keeps the inner edge
-          // straight (a left border would curve on the inside and look crescent-shaped).
           success:
             "!border-l-0 !bg-[linear-gradient(to_right,var(--color-success)_4px,transparent_4px)]",
           info: "!border-l-0 !bg-[linear-gradient(to_right,var(--color-info)_4px,transparent_4px)]",

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -7,7 +7,6 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
-
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -7,24 +7,61 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+// The v3 toast keeps a neutral container surface and carries intent through a colored icon and
+// a left accent strip in the status color, while the title and description stay neutral. sonner
+// is CSS-variable driven, so the shared surface is set via --normal-* and the per-type accent is
+// added through sonner's per-type classNames.
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme="dark"
-      className="toaster group !bg-container text-foreground"
+      position="bottom-right"
+      closeButton
+      className="toaster group"
       icons={{
-        success: <CircleCheckIcon className="size-4" />,
+        success: <CircleCheckIcon className="size-4 text-success" />,
         info: <InfoIcon className="size-4 text-info" />,
-        warning: <TriangleAlertIcon className="size-4" />,
-        error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />
+        warning: <TriangleAlertIcon className="size-4 text-warning" />,
+        error: <OctagonXIcon className="size-4 text-danger" />,
+        loading: <Loader2Icon className="size-4 animate-spin text-foreground/60" />
+      }}
+      toastOptions={{
+        classNames: {
+          // pointer-events-auto keeps the toast clickable over a modal (Radix sets
+          // pointer-events:none outside itself); items-start aligns the icon with the title;
+          // flex-wrap drops the action button to its own row; pl-5 clears the accent strip.
+          toast: "!pointer-events-auto !items-start !flex-wrap !rounded-md !pl-5",
+          // Let the content fill the first row so the action button wraps below, bottom-right.
+          content: "!flex-1",
+          icon: "!mt-0.5",
+          title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
+          description: "!text-xs !text-foreground/75 whitespace-pre-line",
+          // Square close button seated inside the toast body at the top-right.
+          closeButton:
+            "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
+          actionButton:
+            "!rounded !border !border-border !bg-foreground/10 !text-foreground hover:!bg-foreground/20",
+          cancelButton:
+            "!rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
+          // Status accent: a 4px strip painted as a hard-stop gradient so the card's radius
+          // rounds the strip's outer corner while the gradient stop keeps the inner edge
+          // straight (a left border would curve on the inside and look crescent-shaped).
+          success:
+            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-success)_4px,transparent_4px)]",
+          info: "!border-l-0 !bg-[linear-gradient(to_right,var(--color-info)_4px,transparent_4px)]",
+          warning:
+            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-warning)_4px,transparent_4px)]",
+          error:
+            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-danger)_4px,transparent_4px)]"
+        }
       }}
       style={
         {
-          "--normal-bg": "#131B1F",
-          //     "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "#63b0bd44"
-          //     "--border-radius": "var(--radius)"
+          "--width": "400px",
+          "--border-radius": "0.375rem",
+          "--normal-bg": "var(--color-container)",
+          "--normal-border": "var(--color-border)",
+          "--normal-text": "var(--color-foreground)"
         } as React.CSSProperties
       }
       {...props}

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -92,123 +92,112 @@ export const onRequestError = (error: unknown) => {
         requestBody = undefined;
       }
 
-      createNotification(
-        {
-          title: "Validation Error",
-          type: "error",
-          text: "Please check the input and try again.",
-          callToAction: (
-            <ValidationErrorModal serverResponse={serverResponse} requestBody={requestBody} />
-          ),
-          copyActions: [
-            {
-              value: serverResponse.reqId,
-              name: "Request ID",
-              label: `Request ID: ${serverResponse.reqId}`
-            }
-          ]
-        },
-        { closeOnClick: false }
-      );
+      createNotification({
+        title: "Validation Error",
+        type: "error",
+        text: "Please check the input and try again.",
+        callToAction: (
+          <ValidationErrorModal serverResponse={serverResponse} requestBody={requestBody} />
+        ),
+        copyActions: [
+          {
+            value: serverResponse.reqId,
+            name: "Request ID",
+            label: `Request ID: ${serverResponse.reqId}`
+          }
+        ]
+      });
       return;
     }
     if (serverResponse?.error === ApiErrorTypes.ForbiddenError) {
-      createNotification(
-        {
-          title: "Forbidden Access",
-          type: "error",
-          text: `${serverResponse.message}.`,
-          callToAction: serverResponse?.details?.length ? (
-            <Modal>
-              <ModalTrigger asChild>
-                <Button variant="outline_bg" size="xs">
-                  Show more
-                </Button>
-              </ModalTrigger>
-              <ModalContent
-                title="Validation Rules"
-                subTitle="Please review the allowed rules below."
-              >
-                <div className="flex flex-col gap-2">
-                  {serverResponse.details?.map((el, index) => {
-                    const hasConditions = Boolean(Object.keys(el.conditions || {}).length);
-                    return (
-                      <div
-                        key={`Forbidden-error-details-${index + 1}`}
-                        className="rounded-md border border-gray-600 p-4"
-                      >
-                        <div>
-                          {el.inverted ? "Cannot" : "Can"}{" "}
-                          <span className="text-yellow-600">
-                            {el.action.toString().replaceAll(",", ", ")}
-                          </span>{" "}
-                          {el.subject.toString()} {hasConditions && "with conditions:"}
-                        </div>
-                        {hasConditions && (
-                          <ul className="flex list-disc flex-col gap-1 pt-2 pl-5 text-sm">
-                            {Object.keys(el.conditions || {}).flatMap((field, fieldIndex) => {
-                              const operators = (
-                                el.conditions as Record<
-                                  string,
-                                  | string
-                                  | { [K in PermissionConditionOperators]: string | string[] }
-                                >
-                              )[field];
-
-                              const formattedFieldName = camelCaseToSpaces(field).toLowerCase();
-                              if (typeof operators === "string") {
-                                return (
-                                  <li
-                                    key={`Forbidden-error-details-${index + 1}-${fieldIndex + 1}`}
-                                  >
-                                    <span className="font-bold capitalize">
-                                      {formattedFieldName}
-                                    </span>{" "}
-                                    <span className="text-mineshaft-200">equal to</span>{" "}
-                                    <span className="text-yellow-600">{operators}</span>
-                                  </li>
-                                );
-                              }
-
-                              return Object.keys(operators).map((operator, operatorIndex) => (
-                                <li
-                                  key={`Forbidden-error-details-${index + 1}-${
-                                    fieldIndex + 1
-                                  }-${operatorIndex + 1}`}
-                                >
-                                  <span className="font-bold capitalize">{formattedFieldName}</span>{" "}
-                                  <span className="text-mineshaft-200">
-                                    {
-                                      formatedConditionsOperatorNames[
-                                        operator as PermissionConditionOperators
-                                      ]
-                                    }
-                                  </span>{" "}
-                                  <span className="text-yellow-600">
-                                    {operators[operator as PermissionConditionOperators].toString()}
-                                  </span>
-                                </li>
-                              ));
-                            })}
-                          </ul>
-                        )}
+      createNotification({
+        title: "Forbidden Access",
+        type: "error",
+        text: `${serverResponse.message}.`,
+        callToAction: serverResponse?.details?.length ? (
+          <Modal>
+            <ModalTrigger asChild>
+              <Button variant="outline_bg" size="xs">
+                Show more
+              </Button>
+            </ModalTrigger>
+            <ModalContent
+              title="Validation Rules"
+              subTitle="Please review the allowed rules below."
+            >
+              <div className="flex flex-col gap-2">
+                {serverResponse.details?.map((el, index) => {
+                  const hasConditions = Boolean(Object.keys(el.conditions || {}).length);
+                  return (
+                    <div
+                      key={`Forbidden-error-details-${index + 1}`}
+                      className="rounded-md border border-gray-600 p-4"
+                    >
+                      <div>
+                        {el.inverted ? "Cannot" : "Can"}{" "}
+                        <span className="text-yellow-600">
+                          {el.action.toString().replaceAll(",", ", ")}
+                        </span>{" "}
+                        {el.subject.toString()} {hasConditions && "with conditions:"}
                       </div>
-                    );
-                  })}
-                </div>
-              </ModalContent>
-            </Modal>
-          ) : undefined,
-          copyActions: [
-            {
-              value: serverResponse.reqId,
-              name: "Request ID",
-              label: `Request ID: ${serverResponse.reqId}`
-            }
-          ]
-        },
-        { closeOnClick: false }
-      );
+                      {hasConditions && (
+                        <ul className="flex list-disc flex-col gap-1 pt-2 pl-5 text-sm">
+                          {Object.keys(el.conditions || {}).flatMap((field, fieldIndex) => {
+                            const operators = (
+                              el.conditions as Record<
+                                string,
+                                string | { [K in PermissionConditionOperators]: string | string[] }
+                              >
+                            )[field];
+
+                            const formattedFieldName = camelCaseToSpaces(field).toLowerCase();
+                            if (typeof operators === "string") {
+                              return (
+                                <li key={`Forbidden-error-details-${index + 1}-${fieldIndex + 1}`}>
+                                  <span className="font-bold capitalize">{formattedFieldName}</span>{" "}
+                                  <span className="text-mineshaft-200">equal to</span>{" "}
+                                  <span className="text-yellow-600">{operators}</span>
+                                </li>
+                              );
+                            }
+
+                            return Object.keys(operators).map((operator, operatorIndex) => (
+                              <li
+                                key={`Forbidden-error-details-${index + 1}-${
+                                  fieldIndex + 1
+                                }-${operatorIndex + 1}`}
+                              >
+                                <span className="font-bold capitalize">{formattedFieldName}</span>{" "}
+                                <span className="text-mineshaft-200">
+                                  {
+                                    formatedConditionsOperatorNames[
+                                      operator as PermissionConditionOperators
+                                    ]
+                                  }
+                                </span>{" "}
+                                <span className="text-yellow-600">
+                                  {operators[operator as PermissionConditionOperators].toString()}
+                                </span>
+                              </li>
+                            ));
+                          })}
+                        </ul>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </ModalContent>
+          </Modal>
+        ) : undefined,
+        copyActions: [
+          {
+            value: serverResponse.reqId,
+            name: "Request ID",
+            label: `Request ID: ${serverResponse.reqId}`
+          }
+        ]
+      });
       return;
     }
     const errorMessage =

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -6,7 +6,21 @@ import { createNotification } from "@app/components/notifications";
 // akhilmhdh: doing individual imports to avoid cyclic import error
 import { Button } from "@app/components/v2/Button";
 import { Modal, ModalContent, ModalTrigger } from "@app/components/v2/Modal";
-import { Table, TableContainer, TBody, Td, Th, THead, Tr } from "@app/components/v2/Table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@app/components/v3/generic/Dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3/generic/Table";
 import {
   formatedConditionsOperatorNames,
   PermissionConditionOperators
@@ -34,28 +48,32 @@ function ValidationErrorModal({
   }
 
   return (
-    <Modal isOpen={open} onOpenChange={setOpen}>
-      <ModalContent title="Validation Error Details">
-        <TableContainer>
-          <Table>
-            <THead>
-              <Tr>
-                <Th>Field</Th>
-                <Th>Issue</Th>
-              </Tr>
-            </THead>
-            <TBody>
-              {serverResponse.message?.map(({ message, path }) => (
-                <Tr key={path.join(".")}>
-                  <Td>{formatValidationErrorPath(path, requestBody)}</Td>
-                  <Td>{message.toLowerCase()}</Td>
-                </Tr>
-              ))}
-            </TBody>
-          </Table>
-        </TableContainer>
-      </ModalContent>
-    </Modal>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Validation Error Details</DialogTitle>
+          <DialogDescription>These fields did not pass validation.</DialogDescription>
+        </DialogHeader>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Field</TableHead>
+              <TableHead>Issue</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {serverResponse.message?.map(({ message, path }) => (
+              <TableRow key={path.join(".")}>
+                <TableCell className="whitespace-normal">
+                  {formatValidationErrorPath(path, requestBody)}
+                </TableCell>
+                <TableCell className="whitespace-normal">{message.toLowerCase()}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,8 +49,6 @@
   font-family: var(--font-inter);
   --foreground: oklch(0.985 0 0);
   --background: oklch(0.145 0 0);
-
-  --toastify-color-dark: var(--color-mineshaft-700);
 }
 
 @theme {
@@ -465,18 +463,6 @@
   .type-reverse {
     animation: type 1.8s ease-out 0s infinite alternate-reverse both;
   }
-}
-
-.Toastify__toast {
-  @apply rounded-md;
-}
-
-.Toastify__toast-body {
-  @apply items-start;
-}
-
-.Toastify__toast-icon {
-  @apply w-4 pt-1;
 }
 
 .tags-conic-bg {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,6 @@ import "@fontsource/inter/400.css";
 import "@fontsource/inter/500.css";
 import "@xyflow/react/dist/style.css";
 import "nprogress/nprogress.css";
-import "react-toastify/dist/ReactToastify.css";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "./index.css";
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { TypeOptions } from "react-toastify";
 import { subject } from "@casl/ability";
 import {
   faAngleDown,
@@ -30,7 +29,7 @@ import FileSaver from "file-saver";
 import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
-import { createNotification } from "@app/components/notifications";
+import { createNotification, type NotificationType } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import { CreateSecretRotationV2Modal } from "@app/components/secret-rotations-v2";
 import {
@@ -376,7 +375,7 @@ export const ActionBar = ({
       });
 
       let notificationMessage = "";
-      let notificationType: TypeOptions = "info";
+      let notificationType: NotificationType = "info";
 
       if (isDestinationUpdated && isSourceUpdated) {
         notificationMessage = "Successfully moved selected secrets";


### PR DESCRIPTION
…pdate validation modal

## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<img width="3456" height="1912" alt="CleanShot 2026-06-05 at 16 32 16@2x" src="https://github.com/user-attachments/assets/c5eeeff1-df95-4f1e-82e4-6a26b7eae39c" />

## Steps to verify the change

- test interacting with toasts in modals and sheets and ensure the modal doesn't close or block interaction with the toast
- test copying request id on error (create an aws app connection with invalid arn)
- test validation error display (input an invalid org slug in org settings)

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)