### PR TITLE
docs(self-hosting): add service restart step and stale-process troubleshooting for Linux package upgrades

### DIFF
--- a/docs/self-hosting/guides/upgrading-infisical.mdx
+++ b/docs/self-hosting/guides/upgrading-infisical.mdx
@@ -53,7 +53,15 @@ Now, migrations run automatically during boot-up. This improvement streamlines t
    - In environments with multiple instances, one instance will acquire a lock and perform the migration while the other instances wait.
    - Once the migration is complete, all instances will operate with the updated schema.
 
-5. **Verify the Upgrade:**  
+5. **Restart the Infisical Service (Linux package installs only):**
+   - If you installed Infisical via the Linux package (`.deb` / `.rpm`), the upgrade replaces the on-disk binaries but does not automatically restart the long-running Node process started by `runsvdir`. The old process continues running with the previous binary (visible as `(deleted)` in `/proc/<pid>/exe`) while serving the new `index.html` that references updated asset filenames. This causes a blank UI on the next page load.
+   - After the package upgrade completes, restart the service so the new binary is loaded:
+     ```bash
+     sudo systemctl restart infisical-runsvdir
+     ```
+   - This step is not required for Docker, Kubernetes, or other container-based deployments — those restart containers automatically.
+
+6. **Verify the Upgrade:**  
    - Review the logs for any migration errors or warnings.
    - Test basic functionality to ensure the upgrade was successful.
 
@@ -64,10 +72,13 @@ Now, migrations run automatically during boot-up. This improvement streamlines t
 After upgrading your Infisical instance, you may encounter UI-related issues such as:
 - Strange loading behavior
 - Components not rendering correctly  
-- Unexpected errors in the browser console
-- Features appearing broken or unresponsive
+- Unexpected errors in the browser console (e.g. `Refused to apply style from '.../assets/index-*.css' because MIME type is 'application/json'`, `Failed to load resource: 404` for JS bundles)
+- A blank white page on the Infisical web UI
 
-These issues are often caused by browser caching of the previous version's static assets.
+There are two common causes:
+
+**1. Browser cache (most common for Docker / Kubernetes installs):**  
+The browser is holding onto the previous version's static assets. The new server returns updated asset filenames, but the old cached `index.html` still references the old ones.
 
 **Solution:**
 1. **Try a private/incognito browser window first** - This is the quickest way to test if the issue is cache-related.
@@ -77,8 +88,18 @@ These issues are often caused by browser caching of the previous version's stati
    - **Safari:** Press `Cmd+Option+E` or go to Develop menu > Empty Caches
 3. **Hard refresh the page** by pressing `Ctrl+F5` (Windows/Linux) or `Cmd+Shift+R` (Mac)
 
+**2. Stale Node process (Linux package installs only):**  
+The upgrade replaced the on-disk binary, but the `runsvdir`-managed Node process is still running the old binary. Browser cache is not the problem — the server itself is serving stale assets. An incognito window will show the same blank page.
+
+**Solution:**
+```bash
+sudo systemctl restart infisical-runsvdir
+```
+
+After the restart, reload the Infisical web UI in your browser. The issue should be resolved without clearing the browser cache.
+
 <Note>
-  Caching issues are temporary and typically resolve themselves as the cache expires, but manually clearing the cache provides immediate resolution.
+  If you only see the issue in a regular browser window but an incognito window works fine, the problem is browser cache. If both windows show the same blank page, the problem is the stale Node process and you need to restart the service.
 </Note>
 
 ## Downgrade Considerations


### PR DESCRIPTION
## Context

When a self-hosted Linux package install of Infisical is upgraded, the package manager replaces the on-disk binaries but the long-running Node process managed by `runsvdir` is not restarted. The old process continues running with the previous binary (visible as `(deleted)` in `/proc/<pid>/exe`) while serving the new `index.html` that references updated hashed asset filenames. Since the old process doesn't have access to the new assets on disk, all CSS/JS requests return the SPA fallback HTML, causing a blank UI with browser console errors.

The existing upgrade guide at `docs/self-hosting/guides/upgrading-infisical.mdx` has a "Troubleshooting → UI Caching Issues After Upgrade" section, but it only tells users to clear their browser cache. The actual cause — the stale Node process — is not mentioned, so users with package installs hit the blank page, clear their cache, and the problem doesn't go away (because the server itself is wrong, not the browser).

**Before:** A Linux package upgrade leaves a stale Node process running the old binary. Users see a blank page. Docs tell them to clear browser cache, which doesn't help.

**After:** Docs explicitly call out the `systemctl restart infisical-runsvdir` step after a Linux package upgrade, and the troubleshooting section explains both causes (browser cache vs. stale Node process) with a clear test (incognito window) to tell them apart.

Fixes #6124

## Screenshots

N/A — this is a documentation change, not a UI change. The before/after is visible in the diff itself.

## Steps to verify the change

1. Open `docs/self-hosting/guides/upgrading-infisical.mdx` and review the new "Restart the Infisical Service" step (#5) and the expanded "UI Caching Issues After Upgrade" troubleshooting section.
2. The "Restart" step is scoped to Linux package installs only, with a note that Docker / Kubernetes users do not need it.
3. The troubleshooting section now distinguishes between browser cache and stale Node process, with a test (incognito window) to tell them apart.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `docs(self-hosting): add service restart step and stale-process troubleshooting for Linux package upgrades`
- [x] Tested locally (mDX tags balanced: 3 opening, 3 closing; reviewed rendered preview)
- [x] Updated docs (this IS the docs change)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)