### PR TITLE
fix(backend): treat IPv4-compatible IPv6 (::/96) as private to prevent SSRF bypass

### DIFF
--- a/backend/src/lib/ip/ipRange.test.ts
+++ b/backend/src/lib/ip/ipRange.test.ts
@@ -1,0 +1,61 @@
+import { getIpRange, isPrivateIp } from "./ipRange";
+
+describe("isPrivateIp", () => {
+  describe("IPv4-compatible IPv6 (::/96)", () => {
+    // Deprecated ::a.b.c.d form (RFC 4291 2.5.5.1) embeds IPv4 in the low 32 bits.
+    // These must not be treated as public, otherwise they bypass SSRF checks.
+    test("blocks ::127.0.0.1 (loopback)", () => {
+      expect(isPrivateIp("::7f00:1")).toBe(true);
+    });
+
+    test("blocks ::169.254.169.254 (cloud metadata)", () => {
+      expect(isPrivateIp("::a9fe:a9fe")).toBe(true);
+    });
+
+    test("blocks ::10.0.0.1 (private)", () => {
+      expect(isPrivateIp("::a00:1")).toBe(true);
+    });
+  });
+
+  describe("other IPv4-in-IPv6 embeddings remain blocked", () => {
+    test("IPv4-mapped ::ffff:127.0.0.1", () => {
+      expect(isPrivateIp("::ffff:7f00:1")).toBe(true);
+    });
+
+    test("6to4 2002:7f00:1::", () => {
+      expect(isPrivateIp("2002:7f00:1::")).toBe(true);
+    });
+
+    test("NAT64 64:ff9b::7f00:1", () => {
+      expect(isPrivateIp("64:ff9b::7f00:1")).toBe(true);
+    });
+  });
+
+  describe("IPv4 ranges", () => {
+    test("loopback, link-local, private, unspecified are blocked", () => {
+      expect(isPrivateIp("127.0.0.1")).toBe(true);
+      expect(isPrivateIp("169.254.169.254")).toBe(true);
+      expect(isPrivateIp("10.1.2.3")).toBe(true);
+      expect(isPrivateIp("0.0.0.0")).toBe(true);
+    });
+  });
+
+  describe("public addresses stay public", () => {
+    test("public IPv4 and IPv6 are not private", () => {
+      expect(isPrivateIp("8.8.8.8")).toBe(false);
+      expect(isPrivateIp("2606:4700::1")).toBe(false);
+    });
+
+    test("the ::/96 rule does not swallow IPv4-mapped addresses", () => {
+      // ::ffff:8.8.8.8 is outside ::/96, so the new rule leaves it to the
+      // pre-existing ::ffff:0:0/96 (IPv4-mapped) classification.
+      expect(getIpRange("::ffff:8.8.8.8")).toBe("ipv4Mapped");
+    });
+  });
+
+  describe("range names", () => {
+    test("public address resolves to unicast", () => {
+      expect(getIpRange("1.1.1.1")).toBe("unicast");
+    });
+  });
+});

--- a/backend/src/lib/ip/ipRange.test.ts
+++ b/backend/src/lib/ip/ipRange.test.ts
@@ -57,5 +57,10 @@ describe("isPrivateIp", () => {
     test("public address resolves to unicast", () => {
       expect(getIpRange("1.1.1.1")).toBe("unicast");
     });
+
+    test("::/96 does not shadow :: (unspecified) or ::1 (loopback)", () => {
+      expect(getIpRange("::")).toBe("unspecified");
+      expect(getIpRange("::1")).toBe("loopback");
+    });
   });
 });

--- a/backend/src/lib/ip/ipRange.ts
+++ b/backend/src/lib/ip/ipRange.ts
@@ -43,6 +43,7 @@ const ipv6RangeLists: Record<string, BlockList> = {
   linkLocal: new BlockList(),
   uniqueLocal: new BlockList(),
   ipv4Mapped: new BlockList(),
+  ipv4Compatible: new BlockList(),
   reserved: new BlockList()
 };
 
@@ -55,6 +56,12 @@ ipv6RangeLists.linkLocal.addSubnet("fe80::", 10, "ipv6");
 ipv6RangeLists.uniqueLocal.addSubnet("fc00::", 7, "ipv6");
 // IPv4-mapped IPv6 addresses (::ffff:0:0/96) — prevents bypass via e.g. ::ffff:127.0.0.1
 ipv6RangeLists.ipv4Mapped.addSubnet("::ffff:0:0", 96, "ipv6");
+// IPv4-compatible IPv6 addresses (::/96) — the deprecated ::a.b.c.d form (RFC 4291
+// 2.5.5.1) embeds an IPv4 address in the low 32 bits, e.g. ::7f00:1 == ::127.0.0.1.
+// Without this they are classified as public and bypass SSRF checks, mirroring the
+// ::ffff:0:0/96 (mapped), 2002::/16 (6to4) and 64:ff9b::/96 (NAT64) embeddings.
+// :: and ::1 are matched earlier by the unspecified/loopback lists.
+ipv6RangeLists.ipv4Compatible.addSubnet("::", 96, "ipv6");
 // IPv6 documentation (2001:db8::/32), benchmarking (2001:2::/48), discard (100::/64)
 ipv6RangeLists.reserved.addSubnet("2001:db8::", 32, "ipv6");
 ipv6RangeLists.reserved.addSubnet("2001:2::", 48, "ipv6");


### PR DESCRIPTION
## Context

The SSRF IP-range classifier in `backend/src/lib/ip/ipRange.ts` (`isPrivateIp`, used by `blockLocalAndPrivateIpAddresses` / `validateSsrfUrl`) blocks the common ways an IPv4 address can be embedded in IPv6:

- IPv4-mapped — `::ffff:0:0/96`
- 6to4 — `2002::/16`
- NAT64 — `64:ff9b::/96` and `64:ff9b:1::/48`

…but it does **not** cover the deprecated **IPv4-compatible** form (`::/96`, RFC 4291 §2.5.5.1), where the IPv4 address sits in the low 32 bits with no `::ffff:` prefix. As a result these addresses are classified as `unicast` (public) and pass the SSRF guard:

| Input | Means | Before | After |
|---|---|---|---|
| `::7f00:1` | `::127.0.0.1` (loopback) | `unicast` ❌ | `ipv4Compatible` ✅ |
| `::a9fe:a9fe` | `::169.254.169.254` (cloud metadata) | `unicast` ❌ | `ipv4Compatible` ✅ |
| `::a00:1` | `::10.0.0.1` (private) | `unicast` ❌ | `ipv4Compatible` ✅ |

`isPrivateIp` also backs dynamic-secret host validation and PKI-ACME challenge checks, so the gap isn't limited to webhooks.

The IPv4-compatible form is deprecated and many host stacks no longer route it to the embedded IPv4, so I'm framing this as **range-table completeness / defense-in-depth + classifier correctness** rather than a confirmed live metadata fetch — it closes an inconsistency, since the other three IPv4-in-IPv6 embeddings are already handled.

The fix adds `::/96` to the blocked IPv6 ranges. `::` and `::1` are still matched first by the existing `unspecified`/`loopback` lists, and `::ffff:0:0/96` is outside `::/96`, so IPv4-mapped classification is unchanged.

## Steps to verify the change

```bash
cd backend
pnpm exec vitest run -c vitest.unit.config.mts src/lib/ip/ipRange.test.ts
```

Added `ipRange.test.ts` (10 tests): the newly-blocked IPv4-compatible addresses, regressions for IPv4-mapped/6to4/NAT64, IPv4 ranges, and that public IPv4/IPv6 addresses stay public. All pass; `eslint` clean on both files.

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
