### PR TITLE
fix(secret-requests): reveal secret modal overflow

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
@@ -31,8 +31,8 @@ const Content = ({ secretValue, onClose }: ContentProps) => {
 
   return (
     <>
-      <div className="relative flex items-center justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
-        <p className="mr-4 break-all">{secretValue}</p>
+      <div className="relative flex items-start justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
+        <p className="mr-4 max-h-128 thin-scrollbar overflow-y-auto break-all">{secretValue}</p>
         <Tooltip>
           <TooltipTrigger asChild>
             <IconButton


### PR DESCRIPTION
## Context

Fixed overflow when revealing the value of a requested secret.



## Screenshots

### Before:
<img width="1777" height="1313" alt="CleanShot 2026-06-08 at 21 32 55" src="https://github.com/user-attachments/assets/99881757-1a0a-4104-a333-bf06d256512b" />


### After:
<img width="1370" height="990" alt="CleanShot 2026-06-08 at 21 31 04" src="https://github.com/user-attachments/assets/6ab39b76-407a-40a2-839b-373832da1cca" />



## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)