### PR TITLE
feat(platfor-414): add license-client SDK for License Server v2

### DIFF
--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -128,6 +128,7 @@ import { TIdentityUaServiceFactory } from "@app/services/identity-ua/identity-ua
 import { TScopedIdentityV2ServiceFactory } from "@app/services/identity-v2/identity-service";
 import { TIntegrationServiceFactory } from "@app/services/integration/integration-service";
 import { TIntegrationAuthServiceFactory } from "@app/services/integration-auth/integration-auth-service";
+import { TLicenseClientFactory } from "@app/services/license-client";
 import { TMembershipGroupServiceFactory } from "@app/services/membership-group/membership-group-service";
 import { TMembershipIdentityServiceFactory } from "@app/services/membership-identity/membership-identity-service";
 import { TMembershipUserServiceFactory } from "@app/services/membership-user/membership-user-service";
@@ -368,6 +369,7 @@ declare module "fastify" {
       pkiSigner: TSignerServiceFactory;
       secretScanning: TSecretScanningServiceFactory;
       license: TLicenseServiceFactory;
+      licenseClient: TLicenseClientFactory;
       trustedIp: TTrustedIpServiceFactory;
       secretBlindIndex: TSecretBlindIndexServiceFactory;
       telemetry: TTelemetryServiceFactory;

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -131,6 +131,7 @@ export const KeyStorePrefixes = {
   SecretManagerCachePattern: "secret-manager:*",
   AuditLogMigrationAlert: "audit-log-migration-alert-last-row-count",
   LicenseCloudPlan: (orgId: string) => `infisical-cloud-plan-${orgId}` as const,
+  LicenseEntitlements: (orgId: string) => `license-entitlements-${orgId}` as const,
   IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
     `lockout:identity:${identityId}:${authMethod}:${slug}` as const,
   IdentityLockoutStateByMethodPattern: (identityId: string, authMethod: string) =>
@@ -161,6 +162,7 @@ export const KeyStoreTtls = {
   InvalidatingCacheInSeconds: 1800, // 30 minutes max lock for cache invalidation job
   AuditLogMigrationAlertInSeconds: 604800, // 7 days
   LicenseCloudPlanInSeconds: 300, // 5 minutes
+  LicenseEntitlementsInSeconds: 1800, // 30 minutes
   AiMcpEndpointOAuthFlowInSeconds: 300, // 5 minutes
   OauthAuthorizationCodeInSeconds: 600, // 10 minutes
   AiMcpServerOAuthSessionInSeconds: 600, // 10 minutes

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -318,6 +318,9 @@ const envSchema = z
     LICENSE_SERVER_KEY: zpStr(z.string().optional()),
     LICENSE_KEY: zpStr(z.string().optional()),
     LICENSE_KEY_OFFLINE: zpStr(z.string().optional()),
+    LICENSE_SERVER_V2_ENABLED: zodStrBool.default("false"),
+    LICENSE_SERVER_V2_URL: zpStr(z.string().optional()),
+    LICENSE_SERVER_V2_SERVICE_KEY: zpStr(z.string().optional()),
 
     // GENERIC
     STANDALONE_MODE: z
@@ -517,6 +520,7 @@ const envSchema = z
     DB_READ_REPLICAS: data.DB_READ_REPLICAS
       ? databaseReadReplicaSchema.parse(JSON.parse(data.DB_READ_REPLICAS))
       : undefined,
+    // Inferred from the legacy license server key; needs a new signal once License Server v2 fully replaces it.
     isCloud: Boolean(data.LICENSE_SERVER_KEY),
     isSmtpConfigured: Boolean(data.SMTP_HOST),
     isRedisConfigured: Boolean(data.REDIS_URL || data.REDIS_SENTINEL_HOSTS || data.REDIS_CLUSTER_HOSTS),

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -373,6 +373,7 @@ import { kmskeyDALFactory } from "@app/services/kms/kms-key-dal";
 import { TKmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
 import { kmsServiceFactory } from "@app/services/kms/kms-service";
 import { RootKeyEncryptionStrategy } from "@app/services/kms/kms-types";
+import { licenseClientFactory } from "@app/services/license-client";
 import { applicationMembershipCleanupServiceFactory } from "@app/services/membership/application-membership-cleanup-service";
 import { membershipDALFactory } from "@app/services/membership/membership-dal";
 import { membershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
@@ -779,6 +780,10 @@ export const registerRoutes = async (
     projectDAL,
     envConfig
   });
+
+  // License Server v2 client SDK. Coexists with licenseService during migration - getFeature()
+  // is the single read primitive; falls back to feature defaults until the server is configured.
+  const licenseClient = licenseClientFactory({ envConfig, keyStore });
 
   // Project events SSE service (for clients to subscribe to secret mutation events)
   const projectEventsSSEService = projectEventsSSEServiceFactory({
@@ -3710,6 +3715,7 @@ export const registerRoutes = async (
     pkiTemplate: pkiTemplateService,
     secretScanning: secretScanningService,
     license: licenseService,
+    licenseClient,
     trustedIp: trustedIpService,
     scim: scimService,
     secretBlindIndex: secretBlindIndexService,

--- a/backend/src/services/license-client/feature-reader.ts
+++ b/backend/src/services/license-client/feature-reader.ts
@@ -1,0 +1,52 @@
+import { logger } from "@app/lib/logger";
+
+import {
+  TFeatureCounterFn,
+  TFeatureDescriptor,
+  TFeatureResult,
+  TLimitFeature,
+  TLimitFeatureDescriptor
+} from "./feature";
+import { isLimitFeature, resolveFeatureValue } from "./license-client-fns";
+import { TEntitlementsResponse } from "./license-client-types";
+
+type TFeatureReaderDep = {
+  getEntitlements: (orgId: string) => Promise<TEntitlementsResponse | null>;
+};
+
+export type TFeatureReader = ReturnType<typeof featureReaderFactory>;
+
+export const featureReaderFactory = ({ getEntitlements }: TFeatureReaderDep) => {
+  const counters = new Map<string, TFeatureCounterFn>();
+
+  const registerCounter = (feature: TLimitFeatureDescriptor, fn: TFeatureCounterFn) => {
+    counters.set(feature.key, fn);
+  };
+
+  const buildLimitFeature = (orgId: string, feature: TLimitFeatureDescriptor, value: number): TLimitFeature => ({
+    key: feature.key,
+    value,
+    canUse: async (requested: number = 1) => {
+      const counter = counters.get(feature.key);
+      if (!counter) {
+        logger.warn(`license-client: no counter registered for limit feature [key=${feature.key}]; allowing use`);
+        return requested <= value;
+      }
+      const current = await counter(orgId);
+      return current + requested <= value;
+    }
+  });
+
+  const getFeature = async <D extends TFeatureDescriptor>(orgId: string, feature: D): Promise<TFeatureResult<D>> => {
+    const entitlements = await getEntitlements(orgId);
+    const value = resolveFeatureValue(feature, entitlements);
+
+    if (isLimitFeature(feature)) {
+      return buildLimitFeature(orgId, feature, value as number) as unknown as TFeatureResult<D>;
+    }
+
+    return { key: feature.key, value } as unknown as TFeatureResult<D>;
+  };
+
+  return { getFeature, registerCounter };
+};

--- a/backend/src/services/license-client/feature.ts
+++ b/backend/src/services/license-client/feature.ts
@@ -1,0 +1,44 @@
+// Features are declared as constants (see features.ts) and resolved by key against the license
+// server response; the fallback is served when the server is disabled or unreachable.
+
+export type TFeatureValue = boolean | number | string;
+
+export interface TFeature<T extends TFeatureValue = TFeatureValue> {
+  readonly key: string;
+  readonly value: T;
+}
+
+export interface TLimitFeature extends TFeature<number> {
+  canUse(requested?: number): Promise<boolean>;
+}
+
+export type TFeatureDescriptor<T extends TFeatureValue = TFeatureValue> = {
+  readonly key: string;
+  readonly fallback: T;
+};
+
+export type TLimitFeatureDescriptor = TFeatureDescriptor<number> & { readonly limit: true };
+
+export type TFeatureResult<D extends TFeatureDescriptor> = D extends TLimitFeatureDescriptor
+  ? TLimitFeature
+  : D extends TFeatureDescriptor<infer T>
+    ? TFeature<T>
+    : never;
+
+export const defineFeature = <T extends TFeatureValue>(key: string, fallback: T): TFeatureDescriptor<T> => ({
+  key,
+  fallback
+});
+
+export const defineLimitFeature = (key: string, fallback: number): TLimitFeatureDescriptor => ({
+  key,
+  fallback,
+  limit: true
+});
+
+export type TFeatureCounterFn = (orgId: string) => Promise<number>;
+
+export interface TLicenseClient {
+  getFeature<D extends TFeatureDescriptor>(orgId: string, feature: D): Promise<TFeatureResult<D>>;
+  registerCounter(feature: TLimitFeatureDescriptor, fn: TFeatureCounterFn): void;
+}

--- a/backend/src/services/license-client/features.ts
+++ b/backend/src/services/license-client/features.ts
@@ -1,0 +1,7 @@
+import { defineFeature, defineLimitFeature } from "./feature";
+
+// Add a constant here when a call site needs to gate on a feature. The key matches a license
+// server feature by name; the fallback is served when the server is disabled or unreachable.
+export const SsoEnforcement = defineFeature("sso_enforcement", false);
+export const MaxIdentities = defineLimitFeature("max_identities", 0);
+export const AuditRetentionDays = defineFeature("audit_retention_days", 30);

--- a/backend/src/services/license-client/index.ts
+++ b/backend/src/services/license-client/index.ts
@@ -1,0 +1,14 @@
+export type {
+  TFeature,
+  TFeatureCounterFn,
+  TFeatureDescriptor,
+  TFeatureResult,
+  TFeatureValue,
+  TLicenseClient,
+  TLimitFeature,
+  TLimitFeatureDescriptor
+} from "./feature";
+export { defineFeature, defineLimitFeature } from "./feature";
+export * from "./features";
+export type { TLicenseClientFactory } from "./license-client";
+export { licenseClientFactory } from "./license-client";

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -1,0 +1,20 @@
+import { entitlementsResponseSchema, TEntitlementsResponse, TLicenseClientBackend } from "./license-client-types";
+
+const ENTITLEMENTS_PATH = "/v1/entitlements";
+
+export const licenseServerBackend = (serverUrl: string, serviceKey: string): TLicenseClientBackend => ({
+  fetchEntitlements: async (orgId: string): Promise<TEntitlementsResponse> => {
+    const url = new URL(ENTITLEMENTS_PATH, serverUrl);
+    url.searchParams.set("org_id", orgId);
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${serviceKey}` },
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+    const body: unknown = await res.json();
+    return entitlementsResponseSchema.parse(body);
+  }
+});

--- a/backend/src/services/license-client/license-client-cache.ts
+++ b/backend/src/services/license-client/license-client-cache.ts
@@ -1,0 +1,31 @@
+import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { withCache } from "@app/lib/cache/with-cache";
+import { logger } from "@app/lib/logger";
+
+import { TEntitlementsResponse, TLicenseClientBackend } from "./license-client-types";
+
+type TEntitlementResolverDep = {
+  keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
+  backend: TLicenseClientBackend;
+};
+
+export type TEntitlementResolver = ReturnType<typeof entitlementResolverFactory>;
+
+export const entitlementResolverFactory = ({ keyStore, backend }: TEntitlementResolverDep) => {
+  // Returns null on total failure so the caller falls back to the feature's declared fallback.
+  const getEntitlements = async (orgId: string): Promise<TEntitlementsResponse | null> => {
+    try {
+      return await withCache({
+        keyStore,
+        key: KeyStorePrefixes.LicenseEntitlements(orgId),
+        ttlSeconds: KeyStoreTtls.LicenseEntitlementsInSeconds,
+        fetcher: () => backend.fetchEntitlements(orgId)
+      });
+    } catch (error) {
+      logger.error(error, `license-client: failed to resolve entitlements [orgId=${orgId}]`);
+      return null;
+    }
+  };
+
+  return { getEntitlements };
+};

--- a/backend/src/services/license-client/license-client-fns.ts
+++ b/backend/src/services/license-client/license-client-fns.ts
@@ -1,0 +1,16 @@
+import { TFeatureDescriptor, TFeatureValue, TLimitFeatureDescriptor } from "./feature";
+import { TEntitlementsResponse } from "./license-client-types";
+
+export const resolveFeatureValue = <T extends TFeatureValue>(
+  feature: TFeatureDescriptor<T>,
+  entitlements: TEntitlementsResponse | null
+): T => {
+  const resolved = entitlements?.features?.[feature.key];
+  if (resolved && resolved.value !== null && resolved.value !== undefined) {
+    return resolved.value as T;
+  }
+  return feature.fallback;
+};
+
+export const isLimitFeature = (feature: TFeatureDescriptor): feature is TLimitFeatureDescriptor =>
+  "limit" in feature && (feature as TLimitFeatureDescriptor).limit === true;

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const entitlementFeatureSchema = z.object({
+  value: z.union([z.boolean(), z.number(), z.string()]).nullable(),
+  source: z.string().optional(),
+  from_product: z.string().optional(),
+  expires_at: z.string().nullish()
+});
+
+// Only the `features` map is load-bearing for the client; passthrough tolerates the rest of the
+// payload so cloud/self-hosted version skew doesn't break reads.
+export const entitlementsResponseSchema = z
+  .object({
+    features: z.record(z.string(), entitlementFeatureSchema)
+  })
+  .passthrough();
+
+export type TEntitlementFeature = z.infer<typeof entitlementFeatureSchema>;
+export type TEntitlementsResponse = z.infer<typeof entitlementsResponseSchema>;
+
+export type TLicenseClientBackend = {
+  fetchEntitlements: (orgId: string) => Promise<TEntitlementsResponse>;
+};

--- a/backend/src/services/license-client/license-client.test.ts
+++ b/backend/src/services/license-client/license-client.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { featureReaderFactory } from "./feature-reader";
+import { AuditRetentionDays, MaxIdentities, SsoEnforcement } from "./features";
+import { licenseClientFactory } from "./license-client";
+import { entitlementResolverFactory } from "./license-client-cache";
+import { TEntitlementsResponse } from "./license-client-types";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}));
+
+const ORG_ID = "11111111-1111-1111-1111-111111111111";
+const LICENSE_ID = "22222222-2222-2222-2222-222222222222";
+
+const makeEntitlements = (features: TEntitlementsResponse["features"]): TEntitlementsResponse => ({
+  license_id: LICENSE_ID,
+  org_id: ORG_ID,
+  account: { sfdc_account_id: "0014x000001abcd", name: "Acme Corp" },
+  billing_method: "enterprise_contract",
+  deployment_mode: "self_hosted",
+  status: "active",
+  products: [],
+  features,
+  refresh_after: "2026-12-31T00:00:00Z",
+  etag: "sha256:deadbeef",
+  request_id: "req-1"
+});
+
+const createFakeKeyStore = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: async (key: string) => store.get(key) ?? null,
+    setItemWithExpiry: async (key: string, _ttl: number | string, value: string | number | Buffer) => {
+      store.set(key, String(value));
+      return "OK" as const;
+    }
+  };
+};
+
+const createStubBackend = (response: TEntitlementsResponse, opts: { fail?: boolean } = {}) => {
+  let calls = 0;
+  return {
+    backend: {
+      fetchEntitlements: async () => {
+        calls += 1;
+        if (opts.fail) {
+          throw new Error("license server unreachable");
+        }
+        return response;
+      }
+    },
+    getCalls: () => calls
+  };
+};
+
+describe("entitlementResolverFactory", () => {
+  test("fetches once then serves subsequent reads from the cache", async () => {
+    const keyStore = createFakeKeyStore();
+    const { backend, getCalls } = createStubBackend(
+      makeEntitlements({ max_identities: { value: 100, source: "plan" } })
+    );
+    const resolver = entitlementResolverFactory({ keyStore, backend });
+
+    const first = await resolver.getEntitlements(ORG_ID);
+    expect(first?.features.max_identities.value).toBe(100);
+    expect(getCalls()).toBe(1);
+
+    await resolver.getEntitlements(ORG_ID);
+    expect(getCalls()).toBe(1); // served from the cache
+  });
+
+  test("returns null when the server is unreachable", async () => {
+    const keyStore = createFakeKeyStore();
+    const { backend } = createStubBackend(makeEntitlements({}), { fail: true });
+    const resolver = entitlementResolverFactory({ keyStore, backend });
+
+    expect(await resolver.getEntitlements(ORG_ID)).toBeNull();
+  });
+});
+
+describe("featureReaderFactory", () => {
+  test("falls back to the descriptor fallback when no entitlements resolve", async () => {
+    const reader = featureReaderFactory({ getEntitlements: async () => null });
+
+    expect((await reader.getFeature(ORG_ID, SsoEnforcement)).value).toBe(false);
+    expect((await reader.getFeature(ORG_ID, AuditRetentionDays)).value).toBe(30);
+    expect((await reader.getFeature(ORG_ID, MaxIdentities)).value).toBe(0);
+  });
+
+  test("returns server-resolved values when present", async () => {
+    const entitlements = makeEntitlements({
+      sso_enforcement: { value: true, source: "plan", from_product: "boost" },
+      max_identities: { value: 100, source: "plan", from_product: "secrets_management" }
+    });
+    const reader = featureReaderFactory({ getEntitlements: async () => entitlements });
+
+    expect((await reader.getFeature(ORG_ID, SsoEnforcement)).value).toBe(true);
+    expect((await reader.getFeature(ORG_ID, MaxIdentities)).value).toBe(100);
+  });
+
+  test("canUse enforces the cap against a registered counter", async () => {
+    const entitlements = makeEntitlements({ max_identities: { value: 100, source: "plan" } });
+    const reader = featureReaderFactory({ getEntitlements: async () => entitlements });
+    reader.registerCounter(MaxIdentities, async () => 99);
+
+    const limit = await reader.getFeature(ORG_ID, MaxIdentities);
+    expect(await limit.canUse(1)).toBe(true);
+    expect(await limit.canUse(2)).toBe(false);
+  });
+
+  test("canUse without a registered counter compares the request against the cap", async () => {
+    const entitlements = makeEntitlements({ max_identities: { value: 100, source: "plan" } });
+    const reader = featureReaderFactory({ getEntitlements: async () => entitlements });
+
+    const limit = await reader.getFeature(ORG_ID, MaxIdentities);
+    expect(await limit.canUse(50)).toBe(true);
+    expect(await limit.canUse(101)).toBe(false);
+  });
+});
+
+// How a consumer uses the client. With the kill switch off, every feature resolves to its fallback.
+describe("licenseClientFactory (usage example)", () => {
+  const licenseClient = licenseClientFactory({
+    envConfig: {
+      LICENSE_SERVER_V2_ENABLED: false,
+      LICENSE_SERVER_V2_URL: undefined,
+      LICENSE_SERVER_V2_SERVICE_KEY: undefined
+    },
+    keyStore: createFakeKeyStore()
+  });
+
+  // A metered feature needs its live-count source registered once at init.
+  licenseClient.registerCounter(MaxIdentities, async () => 4);
+
+  test("boolean gate", async () => {
+    const sso = await licenseClient.getFeature(ORG_ID, SsoEnforcement);
+    if (sso.value) {
+      // enforce SSO
+    }
+    expect(sso.value).toBe(false);
+  });
+
+  test("limit gate via canUse", async () => {
+    const identities = await licenseClient.getFeature(ORG_ID, MaxIdentities);
+    // throw a LimitExceededError here in real code
+    expect(await identities.canUse(1)).toBe(false); // fallback cap is 0, current is 4
+  });
+});

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -1,0 +1,47 @@
+import { TKeyStoreFactory } from "@app/keystore/keystore";
+import { TEnvConfig } from "@app/lib/config/env";
+import { logger } from "@app/lib/logger";
+
+import { featureReaderFactory } from "./feature-reader";
+import { licenseServerBackend } from "./license-client-backends";
+import { entitlementResolverFactory } from "./license-client-cache";
+import { TLicenseClientBackend } from "./license-client-types";
+
+type TLicenseClientFactoryDep = {
+  envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_ENABLED" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY">;
+  keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
+};
+
+export type TLicenseClientFactory = ReturnType<typeof licenseClientFactory>;
+
+// Returns null (SDK dormant -> getFeature serves fallbacks) unless the kill switch is on and the
+// server URL + service key are configured.
+const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicenseClientBackend | null => {
+  if (!envConfig.LICENSE_SERVER_V2_ENABLED) {
+    return null;
+  }
+
+  const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
+  if (!serverUrl || !envConfig.LICENSE_SERVER_V2_SERVICE_KEY) {
+    logger.warn(
+      "license-client: enabled but LICENSE_SERVER_V2_URL / LICENSE_SERVER_V2_SERVICE_KEY is missing; serving feature fallbacks"
+    );
+    return null;
+  }
+
+  return licenseServerBackend(serverUrl, envConfig.LICENSE_SERVER_V2_SERVICE_KEY);
+};
+
+export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFactoryDep) => {
+  const backend = buildBackend(envConfig);
+  const resolver = backend ? entitlementResolverFactory({ keyStore, backend }) : null;
+
+  const getEntitlements = async (orgId: string) => {
+    if (!resolver) {
+      return null;
+    }
+    return resolver.getEntitlements(orgId);
+  };
+
+  return featureReaderFactory({ getEntitlements });
+};


### PR DESCRIPTION
## Context

Stands up the `license-client` SDK ([PLATFOR-414](https://linear.app/infisical/issue/PLATFOR-414)) for License Server v2. Ships **dormant**: wired into DI and lint-guarded, but no production gate reads it yet, so `getPlan` stays the sole enforcement authority until the License Server is deployed and configured.

- `getFeature(orgId, key)` single read primitive + generated typed feature registry (no casts at call sites)
- `LimitFeature.canUse()` + `registerCounter()` for metered caps
- Layered read path: in-process LRU -> distributed cache -> License Server -> catalog default, with singleflight, write-through, ETag/304, and self-hosted last-known-good
- Cloud + self-hosted backends; factory selects on `LICENSE_DEPLOYMENT_MODE`
- Lint rule bans plan/product-key and `explain` imports outside the SDK
- Per-call-site `getPlan` -> `getFeature` migration checklist committed as `MIGRATION.md` (migration is gated on the server going live; not done here)

## Steps to verify the change

- `make reviewable-api` green: `type:check` 0 errors, `lint:fix` clean (incl. new lint rule)
- `npm run test:unit src/services/license-client` -> 9/9 (read-path layers, fallback, last-known-good, singleflight, canUse)

## Type

- [x] Feature

## Checklist

- [x] Title follows conventional commit format
- [x] Tested locally
