### PR TITLE
fix(e2e): seed standing admin in gamma e2e org

### DIFF
--- a/backend/scripts/seed-gamma-fixtures.ts
+++ b/backend/scripts/seed-gamma-fixtures.ts
@@ -45,7 +45,7 @@ import { orgDALFactory } from "@app/services/org/org-dal";
 import { projectDALFactory } from "@app/services/project/project-dal";
 import { superAdminDALFactory } from "@app/services/super-admin/super-admin-dal";
 
-import { TableName } from "../src/db/schemas";
+import { AccessScope, OrgMembershipRole, OrgMembershipStatus, TableName } from "../src/db/schemas";
 import { AuthTokenType } from "../src/services/auth/auth-type";
 
 // Mock IdP hosted in preview-environments. The entryPoint is where gamma
@@ -174,6 +174,60 @@ const main = async () => {
       console.log(`[seed] enabled SCIM on existing org id=${org.id}`);
     }
     console.log(`[seed] org exists id=${org.id} slug=${orgSlug}`);
+  }
+
+  // Standing admin member: deleteOrgMembershipsFn runs an unconditional last-admin
+  // guard, so without one every SCIM DELETE of a test user 400s. Never logs in.
+  const adminUsername = `e2e-admin@${E2E_EMAIL_DOMAIN}`;
+  let adminUser = await knex(TableName.Users).where({ username: adminUsername }).first();
+  if (!adminUser) {
+    [adminUser] = await knex(TableName.Users)
+      .insert({
+        username: adminUsername,
+        email: adminUsername,
+        firstName: "E2E",
+        lastName: "Admin",
+        isAccepted: true,
+        isEmailVerified: true
+      })
+      .returning("*");
+    console.log(`[seed] created e2e admin user id=${adminUser.id} (${adminUsername})`);
+  } else {
+    console.log(`[seed] e2e admin user exists id=${adminUser.id} (${adminUsername})`);
+  }
+
+  let adminMembership = await knex(TableName.Membership)
+    .where({ scopeOrgId: org.id, scope: AccessScope.Organization, actorUserId: adminUser.id })
+    .first();
+  if (!adminMembership) {
+    [adminMembership] = await knex(TableName.Membership)
+      .insert({
+        scopeOrgId: org.id,
+        scope: AccessScope.Organization,
+        actorUserId: adminUser.id,
+        status: OrgMembershipStatus.Accepted,
+        isActive: true
+      })
+      .returning("*");
+    await knex(TableName.MembershipRole).insert({
+      membershipId: adminMembership.id,
+      role: OrgMembershipRole.Admin
+    });
+    console.log(`[seed] created e2e admin membership id=${adminMembership.id} role=admin`);
+  } else {
+    await knex(TableName.Membership).where({ id: adminMembership.id }).update({ isActive: true });
+    const adminRole = await knex(TableName.MembershipRole)
+      .where({ membershipId: adminMembership.id, role: OrgMembershipRole.Admin, isTemporary: false })
+      .first();
+    if (!adminRole) {
+      await knex(TableName.MembershipRole).insert({
+        membershipId: adminMembership.id,
+        role: OrgMembershipRole.Admin
+      });
+      console.log(`[seed] e2e admin membership id=${adminMembership.id} — restored admin role`);
+    } else {
+      console.log(`[seed] e2e admin membership exists id=${adminMembership.id} role=admin`);
+    }
   }
 
   let scimToken = await knex(TableName.ScimToken)


### PR DESCRIPTION
## Context

- gamma `gamma-playwright-e2e` went red: all 5 SCIM/SAML specs failed in `afterEach` cleanup, not their assertions.
- Root cause: `deleteOrgMembershipsFn` runs an unconditional last-admin guard (`assertWillRetainAdmin`), so SCIM `DELETE /Users/:id` 400s ("would leave the organization with no admin") whenever the org has no other active admin. The gamma e2e org had none — the seed never created a member.
- Fix: seed a persistent `e2e-admin@infisical-e2e.test` user + active, non-temporary Admin org membership. Satisfies the guard so cleanup deletes pass. Idempotent; never logs in; username can't collide with per-run SCIM externalIds.

## Steps to verify the change

- Re-run the seed against gamma; confirm `[seed] created e2e admin membership ... role=admin`.
- Re-trigger `gamma-playwright-e2e` — SCIM cleanup deletes leave 1 admin and pass.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)