### PR TITLE
docs(smvideos): add secrets management walkthrough videos

### DIFF
--- a/docs/documentation/platform/pit-recovery.mdx
+++ b/docs/documentation/platform/pit-recovery.mdx
@@ -12,6 +12,22 @@ description: "Learn how to rollback secrets and configurations to any snapshot w
 
 Infisical's point-in-time recovery functionality allows secrets to be rolled back to any point in time for any given [folder](./folder) or [environment](/documentation/platform/project#project-environments).
 
+The short video below walks through secret versioning and point-in-time recovery, covering how Infisical keeps a history of every secret change and how to roll back to a previous state.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/tWVQcx4XiAA"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 <Tabs>
   <Tab title="Commits Interface">
     ## Understanding Commits
@@ -59,7 +75,7 @@ Infisical's point-in-time recovery functionality allows secrets to be rolled bac
     - Lists all secrets that were added, updated, or removed
     - Shows the complete secret configuration including:
       - Secret key and value
-      - Comments, tags  and metadata
+      - Comments, tags, and metadata
       - Encoding settings (e.g., skipMultilineEncoding)
     - Values are displayed with appropriate masking for security
 

--- a/docs/documentation/platform/secret-reference.mdx
+++ b/docs/documentation/platform/secret-reference.mdx
@@ -4,6 +4,22 @@ sidebarTitle: "Referencing and Importing"
 description: "Learn the fundamentals of secret referencing and importing in Infisical."
 ---
 
+The short video below walks through secret referencing and importing, covering how to reuse a "base" secret's value across others and how to pull secrets from another environment or folder into the current context.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/GMcblYp34t0"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 ## Secret Referencing
 
 Infisical's secret referencing functionality makes it possible to reference the value of a "base" secret when defining the value of another secret.
@@ -58,22 +74,11 @@ To delete a secret import, hover over it and press the **X** button that appears
 
 ![delete secret import](../../images/platform/secret-references-imports/secret-import-delete.png)
 
-Lastly, note that the order of secret imports matters. If two secret imports contain secrets with the same name, then the secret value from the bottom-most secret import is taken — "the last one wins."
+Lastly, note that the order of secret imports matters. If two secret imports contain secrets with the same name, then the secret value from the bottom-most secret import is taken: "the last one wins."
 
 To reorder a secret import, hover over it and drag the arrows handle to the position you want.
 
 ![reorder secret import](../../images/platform/secret-references-imports/secret-import-reorder.png)
-
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube.com/embed/o11bMU0pXRs?si=dCprt3xLWPrSOJxy"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowfullscreen
-></iframe>
-
 
 ## Relative Reference Resolution in Imported Secrets
 
@@ -91,7 +96,7 @@ When you import secrets from one environment into another, the imported secrets 
 Resolution order for `${KEY}` inside an imported secret _(e.g. staging imports from dev)_:
 1. Look in `staging` (current environment)
 2. If not found, look in `dev` (source environment)
-3. If still not found, expand to empty string
+3. If still not found, expand to an empty string
 
 This lets you override any imported key simply by defining it in the destination environment.
 

--- a/docs/documentation/platform/secret-versioning.mdx
+++ b/docs/documentation/platform/secret-versioning.mdx
@@ -5,6 +5,22 @@ description: "Learn how secret versioning works in Infisical."
 
 Every time a secret change is performed, a new version of the same secret is created. 
 
+The short video below walks through secret versioning and point-in-time recovery, covering how Infisical keeps a history of every secret change and how to roll back to a previous state.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/tWVQcx4XiAA"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 Such versions can be accessed visually by opening up the [secret sidebar](/documentation/platform/project#drawer) (as seen below) or [retrieved via API](/api-reference/endpoints/secrets/read) 
 by specifying the `version` query parameter.
 

--- a/docs/documentation/platform/secrets-mgmt/project.mdx
+++ b/docs/documentation/platform/secrets-mgmt/project.mdx
@@ -7,7 +7,7 @@ A secrets management project in Infisical is a dedicated workspace for managing 
 
 Secrets are organized into a clear hierarchy of environments, folders, and individual secrets, making it easy to manage values across different stages of your development lifecycle (e.g., development, staging, production).
 
-The short video below walks through Infisical projects — how secrets are organized into environments, folders, and the dashboard features available to manage them.
+The short video below walks through Infisical projects, covering how secrets are organized into environments and folders, and the dashboard features available to manage them.
 
 <br />
 
@@ -26,6 +26,22 @@ The short video below walks through Infisical projects — how secrets are organ
 ## Project environments
 
 Infisical lets you split secrets into environments (e.g., development, staging, production) for both visual and organizational structure. You can customize environments in project settings.
+
+The short video below walks through how to use environments in Infisical.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/9foN4T3VP-s"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
 
 ![Project settings page showing configured environments](/images/platform/project/project-environments.png)
 
@@ -82,6 +98,22 @@ To view all secret values at once, toggle the **Reveal values** button.
 To download/export secrets back into a `.env` file, click the download button.
 
 ![Download button for exporting secrets as a .env file](/images/platform/project/download-env-2.png)
+
+The short video below walks through tagging, comments, and personal overrides, three ways to organize, annotate, and customize secrets in the dashboard.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/bhprcVcIPMs"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
 
 ### Tags
 


### PR DESCRIPTION
Embed walkthrough videos using the responsive pattern from the main secrets management overview:

- Secret versioning and point-in-time recovery on secret-versioning and pit-recovery
- Secret referencing and importing on secret-reference (replaces the older inline video on the same topic)
- How to use environments and tagging/comments/overrides on the Projects page

Also remove em dashes and fix minor grammar/spelling on the affected pages.

## Context

Adding these videos to our docs.


## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x ] Docs
- [ ] Chore

## Checklist

- [x ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ x] Tested locally
- [x ] Updated docs (if needed)
- [ x] Updated CLAUDE.md files (if needed)
- [ x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)