### PR TITLE
docs(ansible): add warning for token visibility in login task

### DIFF
--- a/docs/integrations/platforms/ansible.mdx
+++ b/docs/integrations/platforms/ansible.mdx
@@ -162,7 +162,13 @@ The recommended approach is to use the `login` module to authenticate once and r
     ```
 
     <Warning>
-      With Token Auth, the value passed to `token` is returned unchanged as the `access_token` in the registered `login_data` so it can be reused in downstream tasks. Because the token is no longer scrubbed by Ansible, it is visible in verbose output (`-v`/`-vvv`), in any file set via `ANSIBLE_LOG_PATH`, and in CI/CD logs. Set `no_log: true` on the login task to keep it out of output and logs.
+      Your token is returned as-is in `login_data.access_token` so it can be reused in later tasks. As a result, Ansible no longer masks it, and it can appear in:
+
+      - Verbose output (`-v`/`-vvv`)
+      - Log files (`ANSIBLE_LOG_PATH`)
+      - CI/CD logs
+
+      Always set `no_log: true` on the login task, as shown above, to keep the token out of output and logs.
     </Warning>
 
     You can also provide the `auth_method` and `token` parameters through environment variables:

--- a/docs/integrations/platforms/ansible.mdx
+++ b/docs/integrations/platforms/ansible.mdx
@@ -158,7 +158,12 @@ The recommended approach is to use the `login` module to authenticate once and r
         auth_method: token_auth
         token: "<your-token>"
       register: infisical_login
+      no_log: true
     ```
+
+    <Warning>
+      With Token Auth, the value passed to `token` is returned unchanged as the `access_token` in the registered `login_data` so it can be reused in downstream tasks. Because the token is no longer scrubbed by Ansible, it is visible in verbose output (`-v`/`-vvv`), in any file set via `ANSIBLE_LOG_PATH`, and in CI/CD logs. Set `no_log: true` on the login task to keep it out of output and logs.
+    </Warning>
 
     You can also provide the `auth_method` and `token` parameters through environment variables:
 


### PR DESCRIPTION
## Context

Updated the Ansible integration documentation to include a warning about the visibility of the access token when using token authentication. Added `no_log: true` to the example to prevent token exposure in logs and output.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)