### PR TITLE
docs(eng-5200): document domain in .infisical.json and INFISICAL_DOMAIN

### DIFF
--- a/docs/cli/project-config.mdx
+++ b/docs/cli/project-config.mdx
@@ -42,3 +42,28 @@ To achieve this, simply add the `gitBranchToEnvironmentMapping` property to your
 ### How it works
 After configuring this property, every time you use the CLI with the specified configuration file, it will automatically verify if there is a corresponding environment mapping for the current Github branch you are on.
 If it exists, the CLI will use that environment to retrieve secrets. You can override this behavior by explicitly using the `--env` flag while interacting with the CLI.
+
+## Set the Infisical instance domain
+If you connect to EU Cloud or a self-hosted instance, you can pin the instance URL to your project by adding a `domain` field. Every CLI command run from the project then targets that instance without needing the `--domain` flag or an environment variable.
+
+```json .infisical.json
+{
+  "workspaceId": "63ee5410a45f7a1ed39ba118",
+  "defaultEnvironment": "dev",
+  "domain": "https://eu.infisical.com"
+}
+```
+
+### How it works
+The CLI resolves the domain in the following order, from highest to lowest precedence:
+
+1. The `--domain` flag
+2. The `INFISICAL_DOMAIN` environment variable (the legacy `INFISICAL_API_URL` is still honored)
+3. The `domain` field in `.infisical.json`
+4. The default (US Cloud, `https://app.infisical.com`)
+
+The value must start with `http://` or `https://`, otherwise it is ignored.
+
+<Warning>
+  Because `.infisical.json` is usually committed to your repository, the CLI prints a warning naming the host whenever the domain is read from the file, since all requests and credentials are sent there. Only set `domain` to an instance you trust, and review it when cloning a project you do not control.
+</Warning>

--- a/docs/cli/project-config.mdx
+++ b/docs/cli/project-config.mdx
@@ -58,11 +58,11 @@ If you connect to EU Cloud or a self-hosted instance, you can pin the instance U
 The CLI resolves the domain in the following order, from highest to lowest precedence:
 
 1. The `--domain` flag
-2. The `INFISICAL_DOMAIN` environment variable (the legacy `INFISICAL_API_URL` is still honored)
+2. The `INFISICAL_DOMAIN` environment variable (the legacy `INFISICAL_API_URL` is still honored; when both are set, `INFISICAL_DOMAIN` wins)
 3. The `domain` field in `.infisical.json`
 4. The default (US Cloud, `https://app.infisical.com`)
 
-The value must start with `http://` or `https://`, otherwise it is ignored.
+The value must start with `http://` or `https://`, otherwise it is ignored. Always prefer `https://`. An `http://` domain sends your secrets and credentials over the network in plaintext, so only use it for isolated, private-network setups.
 
 <Warning>
   Because `.infisical.json` is usually committed to your repository, the CLI prints a warning naming the host whenever the domain is read from the file, since all requests and credentials are sent there. Only set `domain` to an instance you trust, and review it when cloning a project you do not control.

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -138,21 +138,24 @@ For versions prior to v0.4.0, the CLI defaults to US Cloud. To connect to EU Clo
 
 The CLI defaults to US Cloud (https://app.infisical.com). To connect to **EU Cloud (https://eu.infisical.com)** or a **self-hosted instance**, you must configure the domain in one of the following ways:
 
-- Use the `INFISICAL_API_URL` environment variable
+- Use the `INFISICAL_DOMAIN` environment variable
 - Use the `--domain` flag on every command
+- Set the `domain` field in your project's [`.infisical.json`](/cli/project-config)
+
+When more than one is set, the CLI uses this order of precedence: `--domain` flag, then `INFISICAL_DOMAIN`, then the `domain` field in `.infisical.json`, then the default. The legacy `INFISICAL_API_URL` environment variable is still honored.
 
 <Tabs>
   <Tab title='Use Environment Variable (Recommended)'>
     The easiest way to ensure all CLI commands use the correct domain is to set
-    the `INFISICAL_API_URL` environment variable. This applies the domain
+    the `INFISICAL_DOMAIN` environment variable. This applies the domain
     setting globally to all commands:
 
     ```bash
     # Linux/MacOS
-    export INFISICAL_API_URL="https://your-domain.infisical.com"
+    export INFISICAL_DOMAIN="https://your-domain.infisical.com"
 
     # Windows PowerShell
-    setx INFISICAL_API_URL "https://your-domain.infisical.com"
+    setx INFISICAL_DOMAIN "https://your-domain.infisical.com"
     ```
 
     Once set, all subsequent CLI commands will automatically use this domain:
@@ -180,6 +183,24 @@ The CLI defaults to US Cloud (https://app.infisical.com). To connect to **EU Clo
 
     <Note>
       If you use `--domain` during login but forget to include it on subsequent commands, you may encounter authentication errors.
+    </Note>
+
+  </Tab>
+  <Tab title='Use .infisical.json'>
+    If your project has a [`.infisical.json`](/cli/project-config) file, you can pin the
+    domain to the project by adding a `domain` field. Every CLI command run from the
+    project then uses it automatically, with no flag or environment variable needed:
+
+    ```json .infisical.json
+    {
+      "workspaceId": "<workspace-id>",
+      "defaultEnvironment": "dev",
+      "domain": "https://your-domain.infisical.com"
+    }
+    ```
+
+    <Note>
+      Since `.infisical.json` is usually committed to your repository, the CLI prints a warning naming the host whenever the domain is read from the file, since all requests and credentials are sent there. Only set `domain` to an instance you trust.
     </Note>
 
   </Tab>
@@ -251,32 +272,32 @@ For security and privacy concerns, we recommend you to configure your terminal t
 
      #### Method 2: Export environment variable
 
-    You can point the CLI to the self-hosted Infisical instance by exporting the environment variable `INFISICAL_API_URL` in your terminal.
+    You can point the CLI to the self-hosted Infisical instance by exporting the environment variable `INFISICAL_DOMAIN` in your terminal. (The legacy `INFISICAL_API_URL` variable still works.)
 
     <Tabs>
     <Tab title="Linux/MacOs">
       ```bash
-      # Set the API URL
-      export INFISICAL_API_URL="https://your-self-hosted-infisical.com"
+      # Set the domain
+      export INFISICAL_DOMAIN="https://your-self-hosted-infisical.com"
 
       # For EU Cloud
-      export INFISICAL_API_URL="https://eu.infisical.com"
+      export INFISICAL_DOMAIN="https://eu.infisical.com"
 
       # Remove the setting
-      unset INFISICAL_API_URL
+      unset INFISICAL_DOMAIN
       ```
 
     </Tab>
     <Tab title="Windows Powershell">
       ```bash
-      # Set the API URL
-      setx INFISICAL_API_URL "https://your-self-hosted-infisical.com"
+      # Set the domain
+      setx INFISICAL_DOMAIN "https://your-self-hosted-infisical.com"
 
       # For EU Cloud
-      setx INFISICAL_API_URL "https://eu.infisical.com"
+      setx INFISICAL_DOMAIN "https://eu.infisical.com"
 
       # Remove the setting
-      setx INFISICAL_API_URL ""
+      setx INFISICAL_DOMAIN ""
 
       # NOTE: Once set, please restart powershell for the change to take effect
       ```
@@ -299,7 +320,7 @@ For security and privacy concerns, we recommend you to configure your terminal t
     ```
 
     <Tip>
-      **Best Practice:** Use `INFISICAL_API_URL` environment variable (Method 2) to avoid having to remember the `--domain` flag on every command. This is especially important in CI/CD pipelines and automation scripts.
+      **Best Practice:** Use `INFISICAL_DOMAIN` environment variable (Method 2) to avoid having to remember the `--domain` flag on every command. This is especially important in CI/CD pipelines and automation scripts.
     </Tip>
 
   </Accordion>

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -142,7 +142,7 @@ The CLI defaults to US Cloud (https://app.infisical.com). To connect to **EU Clo
 - Use the `--domain` flag on every command
 - Set the `domain` field in your project's [`.infisical.json`](/cli/project-config)
 
-When more than one is set, the CLI uses this order of precedence: `--domain` flag, then `INFISICAL_DOMAIN`, then the `domain` field in `.infisical.json`, then the default. The legacy `INFISICAL_API_URL` environment variable is still honored.
+When more than one is set, the CLI uses this order of precedence: `--domain` flag, then `INFISICAL_DOMAIN`, then the `domain` field in `.infisical.json`, then the default. The legacy `INFISICAL_API_URL` environment variable is still honored, but `INFISICAL_DOMAIN` takes precedence when both are set.
 
 <Tabs>
   <Tab title='Use Environment Variable (Recommended)'>


### PR DESCRIPTION
Documents the CLI domain configuration added in Infisical/cli#256.

- **`docs/cli/project-config.mdx`** — new "Set the Infisical instance domain" section covering the `domain` field, full precedence (`--domain` > `INFISICAL_DOMAIN` > `.infisical.json` `domain` > default), the `http(s)` validation, and a trust warning since the file is usually committed
- **`docs/cli/usage.mdx`** — recommend `INFISICAL_DOMAIN` over the now-legacy `INFISICAL_API_URL` (still honored), add a `.infisical.json` tab, and document precedence; updated the self-hosting FAQ to match

Companion to the CLI PR Infisical/cli#256 (ENG-5200). Version-history notes referencing `INFISICAL_API_URL` for pre-v0.4.0 are left as-is since they describe older releases.