### PR TITLE
improvement: improve toast validation/forbid modal handling and update forbid modal UI

### DIFF
--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -136,5 +136,9 @@ export const createNotification = (
   });
 };
 
+// Imperatively dismiss a toast by the id returned from `createNotification`. Keeps the
+// sonner dependency encapsulated in this module.
+export const dismissNotification = (id: string | number) => toast.dismiss(id);
+
 // All styling/position/close-button config lives in the v3 Toaster itself.
 export const NotificationContainer = () => <Toaster />;

--- a/frontend/src/components/notifications/index.tsx
+++ b/frontend/src/components/notifications/index.tsx
@@ -1,2 +1,2 @@
 export type { NotificationType, TNotification } from "./Notifications";
-export { createNotification, NotificationContainer } from "./Notifications";
+export { createNotification, dismissNotification, NotificationContainer } from "./Notifications";

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -124,12 +124,21 @@ export const onRequestError = (error: unknown) => {
       return;
     }
     if (serverResponse?.error === ApiErrorTypes.ForbiddenError) {
-      createNotification({
+      const toastIdRef: { current: string | number | undefined } = { current: undefined };
+      toastIdRef.current = createNotification({
         title: "Forbidden Access",
         type: "error",
         text: `${serverResponse.message}.`,
         callToAction: serverResponse?.details?.length ? (
-          <Dialog>
+          <Dialog
+            onOpenChange={(open) => {
+              // The dialog renders inside the toast; its overlay pins sonner's dismiss timer
+              // while open. Dismiss the toast on close so it does not linger afterwards.
+              if (!open && toastIdRef.current !== undefined) {
+                dismissNotification(toastIdRef.current);
+              }
+            }}
+          >
             <DialogTrigger asChild>
               <Button variant="outline" size="xs">
                 Show more

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -1,17 +1,17 @@
-import { useState } from "react";
 import { MutationCache, QueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
-import { createNotification } from "@app/components/notifications";
+import { createNotification, dismissNotification } from "@app/components/notifications";
 // akhilmhdh: doing individual imports to avoid cyclic import error
-import { Button } from "@app/components/v2/Button";
-import { Modal, ModalContent, ModalTrigger } from "@app/components/v2/Modal";
+import { Badge } from "@app/components/v3/generic/Badge";
+import { Button } from "@app/components/v3/generic/Button";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle
+  DialogTitle,
+  DialogTrigger
 } from "@app/components/v3/generic/Dialog";
 import {
   Table,
@@ -36,19 +36,28 @@ export const AUTH_TOKEN_CACHE_KEY = ["infisical__auth-token"];
 
 function ValidationErrorModal({
   serverResponse,
-  requestBody
+  requestBody,
+  toastIdRef
 }: {
   serverResponse: TApiErrors;
   requestBody?: Record<string, unknown> | null;
+  toastIdRef: { current: string | number | undefined };
 }) {
-  const [open, setOpen] = useState(true);
-
   if (serverResponse.error !== ApiErrorTypes.ValidationError) {
     return null;
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      defaultOpen
+      onOpenChange={(open) => {
+        // The modal auto-opens inside the toast, whose overlay keeps sonner's dismiss timer
+        // paused while open. Dismiss the toast on close so it does not linger afterwards.
+        if (!open && toastIdRef.current !== undefined) {
+          dismissNotification(toastIdRef.current);
+        }
+      }}
+    >
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Validation Error Details</DialogTitle>
@@ -92,12 +101,17 @@ export const onRequestError = (error: unknown) => {
         requestBody = undefined;
       }
 
-      createNotification({
+      const toastIdRef: { current: string | number | undefined } = { current: undefined };
+      toastIdRef.current = createNotification({
         title: "Validation Error",
         type: "error",
         text: "Please check the input and try again.",
         callToAction: (
-          <ValidationErrorModal serverResponse={serverResponse} requestBody={requestBody} />
+          <ValidationErrorModal
+            serverResponse={serverResponse}
+            requestBody={requestBody}
+            toastIdRef={toastIdRef}
+          />
         ),
         copyActions: [
           {
@@ -115,33 +129,41 @@ export const onRequestError = (error: unknown) => {
         type: "error",
         text: `${serverResponse.message}.`,
         callToAction: serverResponse?.details?.length ? (
-          <Modal>
-            <ModalTrigger asChild>
-              <Button variant="outline_bg" size="xs">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="xs">
                 Show more
               </Button>
-            </ModalTrigger>
-            <ModalContent
-              title="Validation Rules"
-              subTitle="Please review the allowed rules below."
-            >
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Validation Rules</DialogTitle>
+                <DialogDescription>Please review the allowed rules below.</DialogDescription>
+              </DialogHeader>
               <div className="flex flex-col gap-2">
                 {serverResponse.details?.map((el, index) => {
                   const hasConditions = Boolean(Object.keys(el.conditions || {}).length);
+                  const actions = Array.isArray(el.action) ? el.action : [el.action];
                   return (
                     <div
                       key={`Forbidden-error-details-${index + 1}`}
-                      className="rounded-md border border-gray-600 p-4"
+                      className="rounded-md border border-border bg-card p-4 text-sm"
                     >
-                      <div>
-                        {el.inverted ? "Cannot" : "Can"}{" "}
-                        <span className="text-yellow-600">
-                          {el.action.toString().replaceAll(",", ", ")}
-                        </span>{" "}
-                        {el.subject.toString()} {hasConditions && "with conditions:"}
+                      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                        <span>{el.inverted ? "Cannot" : "Can"}</span>
+                        {actions.map((action, actionIndex) => (
+                          <Badge
+                            key={`Forbidden-error-details-${index + 1}-action-${actionIndex + 1}`}
+                            variant={el.inverted ? "danger" : "success"}
+                          >
+                            {action.toString()}
+                          </Badge>
+                        ))}
+                        <span>{el.subject.toString()}</span>
+                        {hasConditions && <span className="text-muted">with conditions:</span>}
                       </div>
                       {hasConditions && (
-                        <ul className="flex list-disc flex-col gap-1 pt-2 pl-5 text-sm">
+                        <ul className="mt-2 flex list-disc flex-col gap-1.5 pl-5 marker:text-muted">
                           {Object.keys(el.conditions || {}).flatMap((field, fieldIndex) => {
                             const operators = (
                               el.conditions as Record<
@@ -154,9 +176,11 @@ export const onRequestError = (error: unknown) => {
                             if (typeof operators === "string") {
                               return (
                                 <li key={`Forbidden-error-details-${index + 1}-${fieldIndex + 1}`}>
-                                  <span className="font-bold capitalize">{formattedFieldName}</span>{" "}
-                                  <span className="text-mineshaft-200">equal to</span>{" "}
-                                  <span className="text-yellow-600">{operators}</span>
+                                  <span className="font-medium capitalize">
+                                    {formattedFieldName}
+                                  </span>{" "}
+                                  <span className="text-muted">equal to</span>{" "}
+                                  <Badge variant="neutral">{operators}</Badge>
                                 </li>
                               );
                             }
@@ -167,17 +191,17 @@ export const onRequestError = (error: unknown) => {
                                   fieldIndex + 1
                                 }-${operatorIndex + 1}`}
                               >
-                                <span className="font-bold capitalize">{formattedFieldName}</span>{" "}
-                                <span className="text-mineshaft-200">
+                                <span className="font-medium capitalize">{formattedFieldName}</span>{" "}
+                                <span className="text-muted">
                                   {
                                     formatedConditionsOperatorNames[
                                       operator as PermissionConditionOperators
                                     ]
                                   }
                                 </span>{" "}
-                                <span className="text-yellow-600">
+                                <Badge variant="neutral">
                                   {operators[operator as PermissionConditionOperators].toString()}
-                                </span>
+                                </Badge>
                               </li>
                             ));
                           })}
@@ -187,8 +211,8 @@ export const onRequestError = (error: unknown) => {
                   );
                 })}
               </div>
-            </ModalContent>
-          </Modal>
+            </DialogContent>
+          </Dialog>
         ) : undefined,
         copyActions: [
           {


### PR DESCRIPTION
## Context

This PR improves the toast behavior when opening a validation or forbidden error modal, closing the notification on modal close to fix it never expiring

Also updates the forbidden modal ui and button to v3 components

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-06-10 at 10 46 17@2x" src="https://github.com/user-attachments/assets/53861df3-c2af-418b-9e4d-dbec39f8b884" />

## Steps to verify the change

- input an invalid org slug in org settings to confirm  validation toasts closes when modal is closed
- create a role with all secret actions allowed and then a second rule forbidding create if env isn't specific slug, assume priv and create a secret outside of that slug, see toast with view more button, click button and review ui

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)