### PR TITLE
fix: use gateway in case of private GHE server

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1688,6 +1688,7 @@ export const registerRoutes = async (
     licenseService,
     gatewayService,
     gatewayV2Service,
+    gatewayPoolService,
     gatewayDAL,
     gatewayV2DAL,
     auditLogService,

--- a/backend/src/server/routes/v1/github-app-router.ts
+++ b/backend/src/server/routes/v1/github-app-router.ts
@@ -21,7 +21,8 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
         githubOrg: z.string().trim().optional(),
         githubHost: z.string().trim().optional(),
         installState: z.string().trim().min(1),
-        projectId: z.string().trim().optional()
+        projectId: z.string().trim().optional(),
+        gatewayId: z.string().uuid().optional()
       }),
       response: {
         200: z.object({
@@ -39,7 +40,8 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
         githubOrg: req.body.githubOrg,
         githubHost: req.body.githubHost,
         installState: req.body.installState,
-        projectId: req.body.projectId
+        projectId: req.body.projectId,
+        gatewayId: req.body.gatewayId
       });
 
       return result;

--- a/backend/src/server/routes/v1/github-app-router.ts
+++ b/backend/src/server/routes/v1/github-app-router.ts
@@ -15,15 +15,21 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     schema: {
-      body: z.object({
-        name: z.string().trim().min(1).max(64),
-        instanceType: z.enum(["cloud", "server"]).default("cloud"),
-        githubOrg: z.string().trim().optional(),
-        githubHost: z.string().trim().optional(),
-        installState: z.string().trim().min(1),
-        projectId: z.string().trim().optional(),
-        gatewayId: z.string().uuid().optional()
-      }),
+      body: z
+        .object({
+          name: z.string().trim().min(1).max(64),
+          instanceType: z.enum(["cloud", "server"]).default("cloud"),
+          githubOrg: z.string().trim().optional(),
+          githubHost: z.string().trim().optional(),
+          installState: z.string().trim().min(1),
+          projectId: z.string().trim().optional(),
+          gatewayId: z.string().uuid().optional(),
+          gatewayPoolId: z.string().uuid().optional()
+        })
+        .refine((data) => !(data.gatewayId && data.gatewayPoolId), {
+          message: "Cannot specify both a gateway and a gateway pool",
+          path: ["gatewayPoolId"]
+        }),
       response: {
         200: z.object({
           state: z.string(),
@@ -41,7 +47,8 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
         githubHost: req.body.githubHost,
         installState: req.body.installState,
         projectId: req.body.projectId,
-        gatewayId: req.body.gatewayId
+        gatewayId: req.body.gatewayId,
+        gatewayPoolId: req.body.gatewayPoolId
       });
 
       return result;
@@ -110,14 +117,20 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     schema: {
-      body: z.object({
-        code: z.string().trim().min(1),
-        gitHubAppId: z.string().uuid().optional(),
-        host: z.string().trim().optional(),
-        instanceType: z.enum(["cloud", "server"]).optional(),
-        gatewayId: z.string().uuid().optional(),
-        projectId: z.string().optional()
-      }),
+      body: z
+        .object({
+          code: z.string().trim().min(1),
+          gitHubAppId: z.string().uuid().optional(),
+          host: z.string().trim().optional(),
+          instanceType: z.enum(["cloud", "server"]).optional(),
+          gatewayId: z.string().uuid().optional(),
+          gatewayPoolId: z.string().uuid().optional(),
+          projectId: z.string().optional()
+        })
+        .refine((data) => !(data.gatewayId && data.gatewayPoolId), {
+          message: "Cannot specify both a gateway and a gateway pool",
+          path: ["gatewayPoolId"]
+        }),
       response: {
         200: z.object({
           installations: z
@@ -139,6 +152,7 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
         host: req.body.host,
         instanceType: req.body.instanceType,
         gatewayId: req.body.gatewayId,
+        gatewayPoolId: req.body.gatewayPoolId,
         projectId: req.body.projectId
       });
 

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -131,7 +131,11 @@ export const gitHubAppServiceFactory = ({
   // Mirrors the gateway checks in resolveUserInstallations so the manifest exchange can route
   // through a gateway when the GitHub host (e.g. a private GitHub Enterprise Server) isn't
   // directly reachable from the Infisical backend.
-  const assertGatewayUsable = async (gatewayId: string, orgPermission: OrgServiceActor) => {
+  const assertGatewayUsable = async (
+    gatewayId: string,
+    orgPermission: OrgServiceActor,
+    prefetchedOrgPermission?: Awaited<ReturnType<typeof permissionService.getOrgPermission>>["permission"]
+  ) => {
     const plan = await licenseService.getPlan(orgPermission.orgId);
     if (!plan.gateway) {
       throw new BadRequestError({
@@ -140,14 +144,18 @@ export const gitHubAppServiceFactory = ({
       });
     }
 
-    const { permission } = await permissionService.getOrgPermission({
-      actor: orgPermission.type,
-      actorId: orgPermission.id,
-      orgId: orgPermission.orgId,
-      actorAuthMethod: orgPermission.authMethod,
-      actorOrgId: orgPermission.orgId,
-      scope: OrganizationActionScope.Any
-    });
+    const permission =
+      prefetchedOrgPermission ??
+      (
+        await permissionService.getOrgPermission({
+          actor: orgPermission.type,
+          actorId: orgPermission.id,
+          orgId: orgPermission.orgId,
+          actorAuthMethod: orgPermission.authMethod,
+          actorOrgId: orgPermission.orgId,
+          scope: OrganizationActionScope.Any
+        })
+      ).permission;
 
     ForbiddenError.from(permission).throwUnlessCan(
       OrgPermissionGatewayActions.AttachGateways,
@@ -741,26 +749,7 @@ export const gitHubAppServiceFactory = ({
     }
 
     if (gatewayId) {
-      const plan = await licenseService.getPlan(orgPermission.orgId);
-      if (!plan.gateway) {
-        throw new BadRequestError({
-          message:
-            "Your current plan does not support gateway usage with app connections. Please upgrade your plan or contact Infisical Sales for assistance."
-        });
-      }
-
-      ForbiddenError.from(orgScopedPermission).throwUnlessCan(
-        OrgPermissionGatewayActions.AttachGateways,
-        OrgPermissionSubjects.Gateway
-      );
-
-      const [gateway] = await gatewayDAL.find({ id: gatewayId, orgId: orgPermission.orgId });
-      const [gatewayV2] = await gatewayV2DAL.find({ id: gatewayId, orgId: orgPermission.orgId });
-      if (!gateway && !gatewayV2) {
-        throw new NotFoundError({
-          message: `Gateway with ID ${gatewayId} not found for org`
-        });
-      }
+      await assertGatewayUsable(gatewayId, orgPermission, orgScopedPermission);
     }
 
     const { SITE_URL } = getConfig();

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -223,6 +223,8 @@ export const gitHubAppServiceFactory = ({
       slug: app.slug,
       clientId: app.clientId,
       owner: app.owner ?? null,
+      host: app.host ?? null,
+      instanceType: app.instanceType === "server" ? "server" : "cloud",
       connectionCount: countByAppId.get(app.id) ?? 0,
       createdAt: app.createdAt,
       updatedAt: app.updatedAt
@@ -231,7 +233,8 @@ export const gitHubAppServiceFactory = ({
     const {
       INF_APP_CONNECTION_GITHUB_APP_ID,
       INF_APP_CONNECTION_GITHUB_APP_SLUG,
-      INF_APP_CONNECTION_GITHUB_APP_CLIENT_ID
+      INF_APP_CONNECTION_GITHUB_APP_CLIENT_ID,
+      INF_APP_CONNECTION_GITHUB_APP_HOST
     } = getConfig();
 
     const sharedApp: TSanitizedGitHubApp | null =
@@ -245,6 +248,8 @@ export const gitHubAppServiceFactory = ({
             slug: INF_APP_CONNECTION_GITHUB_APP_SLUG,
             clientId: INF_APP_CONNECTION_GITHUB_APP_CLIENT_ID ?? null,
             owner: null,
+            host: INF_APP_CONNECTION_GITHUB_APP_HOST ?? null,
+            instanceType: null,
             connectionCount: countByAppId.get(null) ?? 0,
             createdAt: null,
             updatedAt: null
@@ -363,6 +368,8 @@ export const gitHubAppServiceFactory = ({
         slug: existing.slug,
         clientId: existing.clientId,
         owner: existing.owner ?? null,
+        host: existing.host ?? null,
+        instanceType: existing.instanceType === "server" ? "server" : "cloud",
         connectionCount: 0,
         createdAt: existing.createdAt,
         updatedAt: existing.updatedAt

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -514,7 +514,13 @@ export const gitHubAppServiceFactory = ({
             }
           );
           manifestResponse = data;
-        } catch {
+        } catch (err) {
+          logger.error(
+            { ...sanitizeGitHubAxiosError(err), orgId, projectId, instanceType, host: githubHost || "github.com" },
+            `Failed to exchange GitHub App manifest code [orgId=${orgId}] [projectId=${
+              projectId ?? "null"
+            }] [instanceType=${instanceType}] [host=${githubHost || "github.com"}]`
+          );
           throw new BadRequestError({
             message:
               "Failed to exchange GitHub App manifest code. The code may be expired or invalid. Please try registering the GitHub App again."

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -131,11 +131,7 @@ export const gitHubAppServiceFactory = ({
   // Mirrors the gateway checks in resolveUserInstallations so the manifest exchange can route
   // through a gateway when the GitHub host (e.g. a private GitHub Enterprise Server) isn't
   // directly reachable from the Infisical backend.
-  const assertGatewayUsable = async (
-    gatewayId: string,
-    orgPermission: OrgServiceActor,
-    prefetchedOrgPermission?: Awaited<ReturnType<typeof permissionService.getOrgPermission>>["permission"]
-  ) => {
+  const assertGatewayUsable = async (gatewayId: string, orgPermission: OrgServiceActor) => {
     const plan = await licenseService.getPlan(orgPermission.orgId);
     if (!plan.gateway) {
       throw new BadRequestError({
@@ -144,18 +140,14 @@ export const gitHubAppServiceFactory = ({
       });
     }
 
-    const permission =
-      prefetchedOrgPermission ??
-      (
-        await permissionService.getOrgPermission({
-          actor: orgPermission.type,
-          actorId: orgPermission.id,
-          orgId: orgPermission.orgId,
-          actorAuthMethod: orgPermission.authMethod,
-          actorOrgId: orgPermission.orgId,
-          scope: OrganizationActionScope.Any
-        })
-      ).permission;
+    const { permission } = await permissionService.getOrgPermission({
+      actor: orgPermission.type,
+      actorId: orgPermission.id,
+      orgId: orgPermission.orgId,
+      actorAuthMethod: orgPermission.authMethod,
+      actorOrgId: orgPermission.orgId,
+      scope: OrganizationActionScope.Any
+    });
 
     ForbiddenError.from(permission).throwUnlessCan(
       OrgPermissionGatewayActions.AttachGateways,
@@ -749,7 +741,7 @@ export const gitHubAppServiceFactory = ({
     }
 
     if (gatewayId) {
-      await assertGatewayUsable(gatewayId, orgPermission, orgScopedPermission);
+      await assertGatewayUsable(gatewayId, orgPermission);
     }
 
     const { SITE_URL } = getConfig();

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -24,6 +24,7 @@ import { crypto } from "@app/lib/crypto";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { OrgServiceActor } from "@app/lib/types";
 import { safeRequest } from "@app/lib/validator/safe-request";
 import {
   assertPlatformGitHubHostAllowed,
@@ -123,6 +124,42 @@ export const gitHubAppServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(orgAction, OrgPermissionSubjects.AppConnections);
+    }
+  };
+
+  // Validates that the actor may attach the given gateway and that it exists for the org.
+  // Mirrors the gateway checks in resolveUserInstallations so the manifest exchange can route
+  // through a gateway when the GitHub host (e.g. a private GitHub Enterprise Server) isn't
+  // directly reachable from the Infisical backend.
+  const assertGatewayUsable = async (gatewayId: string, orgPermission: OrgServiceActor) => {
+    const plan = await licenseService.getPlan(orgPermission.orgId);
+    if (!plan.gateway) {
+      throw new BadRequestError({
+        message:
+          "Your current plan does not support gateway usage with app connections. Please upgrade your plan or contact Infisical Sales for assistance."
+      });
+    }
+
+    const { permission } = await permissionService.getOrgPermission({
+      actor: orgPermission.type,
+      actorId: orgPermission.id,
+      orgId: orgPermission.orgId,
+      actorAuthMethod: orgPermission.authMethod,
+      actorOrgId: orgPermission.orgId,
+      scope: OrganizationActionScope.Any
+    });
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      OrgPermissionGatewayActions.AttachGateways,
+      OrgPermissionSubjects.Gateway
+    );
+
+    const [gateway] = await gatewayDAL.find({ id: gatewayId, orgId: orgPermission.orgId });
+    const [gatewayV2] = await gatewayV2DAL.find({ id: gatewayId, orgId: orgPermission.orgId });
+    if (!gateway && !gatewayV2) {
+      throw new NotFoundError({
+        message: `Gateway with ID ${gatewayId} not found for org`
+      });
     }
   };
 
@@ -343,6 +380,7 @@ export const gitHubAppServiceFactory = ({
     githubHost,
     installState,
     projectId,
+    gatewayId,
     orgPermission
   }: TInitiateGitHubManifestDTO) => {
     await checkAppConnectionPermission({
@@ -354,6 +392,10 @@ export const gitHubAppServiceFactory = ({
     });
 
     assertPlatformGitHubHostAllowed(githubHost);
+
+    if (gatewayId) {
+      await assertGatewayUsable(gatewayId, orgPermission);
+    }
 
     const existing = await gitHubAppDAL.findOne({
       orgId: orgPermission.orgId,
@@ -386,6 +428,7 @@ export const gitHubAppServiceFactory = ({
         instanceType,
         githubOrg: githubOrg ?? "",
         githubHost: githubHost ?? "",
+        gatewayId: gatewayId ?? null,
         installState
       } satisfies TGitHubManifestStatePayload,
       AUTH_SECRET,
@@ -447,6 +490,7 @@ export const gitHubAppServiceFactory = ({
       instanceType,
       githubOrg,
       githubHost,
+      gatewayId = null,
       installState
     } = statePayload;
 
@@ -503,23 +547,40 @@ export const gitHubAppServiceFactory = ({
           const apiBaseUrl = await getGitHubInstanceApiUrl({
             credentials: { host: githubHost || undefined, instanceType }
           });
-          const { data } = await safeRequest.post<TGitHubAppManifestResponse>(
-            `https://${apiBaseUrl}/app-manifests/${encodeURIComponent(code)}/conversions`,
-            {},
-            {
-              headers: {
-                Accept: "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28"
-              }
+
+          const requestConfig: AxiosRequestConfig & { url: string } = {
+            url: `https://${apiBaseUrl}/app-manifests/${encodeURIComponent(code)}/conversions`,
+            method: "POST",
+            data: {},
+            headers: {
+              Accept: "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28"
             }
-          );
+          };
+
+          const { data } = gatewayId
+            ? await requestWithGitHubGateway<TGitHubAppManifestResponse>(
+                { gatewayId },
+                gatewayService,
+                gatewayV2Service,
+                requestConfig,
+                await getGitHubGatewayConnectionDetails(gatewayId, apiBaseUrl, gatewayV2Service)
+              )
+            : await safeRequest.request<TGitHubAppManifestResponse>(requestConfig);
           manifestResponse = data;
         } catch (err) {
           logger.error(
-            { ...sanitizeGitHubAxiosError(err), orgId, projectId, instanceType, host: githubHost || "github.com" },
+            {
+              ...sanitizeGitHubAxiosError(err),
+              orgId,
+              projectId,
+              instanceType,
+              host: githubHost || "github.com",
+              gatewayId
+            },
             `Failed to exchange GitHub App manifest code [orgId=${orgId}] [projectId=${
               projectId ?? "null"
-            }] [instanceType=${instanceType}] [host=${githubHost || "github.com"}]`
+            }] [instanceType=${instanceType}] [host=${githubHost || "github.com"}] [gatewayId=${gatewayId ?? "null"}]`
           );
           throw new BadRequestError({
             message:

--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -5,6 +5,7 @@ import { ActionProjectType, OrganizationActionScope } from "@app/db/schemas";
 import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { TGatewayDALFactory } from "@app/ee/services/gateway/gateway-dal";
 import { TGatewayServiceFactory } from "@app/ee/services/gateway/gateway-service";
+import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2DALFactory } from "@app/ee/services/gateway-v2/gateway-v2-dal";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
@@ -68,6 +69,10 @@ type TGitHubAppServiceFactoryDep = {
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+  gatewayPoolService: Pick<
+    TGatewayPoolServiceFactory,
+    "resolveAttachableGatewayFromPool" | "resolveEffectiveGatewayId"
+  >;
   gatewayDAL: Pick<TGatewayDALFactory, "find">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "find">;
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
@@ -84,6 +89,7 @@ export const gitHubAppServiceFactory = ({
   licenseService,
   gatewayService,
   gatewayV2Service,
+  gatewayPoolService,
   gatewayDAL,
   gatewayV2DAL,
   auditLogService,
@@ -159,6 +165,23 @@ export const gitHubAppServiceFactory = ({
     if (!gateway && !gatewayV2) {
       throw new NotFoundError({
         message: `Gateway with ID ${gatewayId} not found for org`
+      });
+    }
+  };
+
+  const assertGatewayConfigUsable = async (
+    { gatewayId, gatewayPoolId }: { gatewayId?: string | null; gatewayPoolId?: string | null },
+    orgPermission: OrgServiceActor
+  ) => {
+    if (gatewayId) {
+      await assertGatewayUsable(gatewayId, orgPermission);
+      return;
+    }
+    if (gatewayPoolId) {
+      await gatewayPoolService.resolveAttachableGatewayFromPool({
+        poolId: gatewayPoolId,
+        orgId: orgPermission.orgId,
+        actor: orgPermission
       });
     }
   };
@@ -381,6 +404,7 @@ export const gitHubAppServiceFactory = ({
     installState,
     projectId,
     gatewayId,
+    gatewayPoolId,
     orgPermission
   }: TInitiateGitHubManifestDTO) => {
     await checkAppConnectionPermission({
@@ -393,9 +417,7 @@ export const gitHubAppServiceFactory = ({
 
     assertPlatformGitHubHostAllowed(githubHost);
 
-    if (gatewayId) {
-      await assertGatewayUsable(gatewayId, orgPermission);
-    }
+    await assertGatewayConfigUsable({ gatewayId, gatewayPoolId }, orgPermission);
 
     const existing = await gitHubAppDAL.findOne({
       orgId: orgPermission.orgId,
@@ -429,6 +451,7 @@ export const gitHubAppServiceFactory = ({
         githubOrg: githubOrg ?? "",
         githubHost: githubHost ?? "",
         gatewayId: gatewayId ?? null,
+        gatewayPoolId: gatewayPoolId ?? null,
         installState
       } satisfies TGitHubManifestStatePayload,
       AUTH_SECRET,
@@ -491,6 +514,7 @@ export const gitHubAppServiceFactory = ({
       githubOrg,
       githubHost,
       gatewayId = null,
+      gatewayPoolId = null,
       installState
     } = statePayload;
 
@@ -558,13 +582,15 @@ export const gitHubAppServiceFactory = ({
             }
           };
 
-          const { data } = gatewayId
+          const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({ gatewayId, gatewayPoolId });
+
+          const { data } = effectiveGatewayId
             ? await requestWithGitHubGateway<TGitHubAppManifestResponse>(
-                { gatewayId },
+                { gatewayId: effectiveGatewayId },
                 gatewayService,
                 gatewayV2Service,
                 requestConfig,
-                await getGitHubGatewayConnectionDetails(gatewayId, apiBaseUrl, gatewayV2Service)
+                await getGitHubGatewayConnectionDetails(effectiveGatewayId, apiBaseUrl, gatewayV2Service)
               )
             : await safeRequest.request<TGitHubAppManifestResponse>(requestConfig);
           manifestResponse = data;
@@ -576,11 +602,14 @@ export const gitHubAppServiceFactory = ({
               projectId,
               instanceType,
               host: githubHost || "github.com",
-              gatewayId
+              gatewayId,
+              gatewayPoolId
             },
             `Failed to exchange GitHub App manifest code [orgId=${orgId}] [projectId=${
               projectId ?? "null"
-            }] [instanceType=${instanceType}] [host=${githubHost || "github.com"}] [gatewayId=${gatewayId ?? "null"}]`
+            }] [instanceType=${instanceType}] [host=${githubHost || "github.com"}] [gatewayId=${
+              gatewayId ?? "null"
+            }] [gatewayPoolId=${gatewayPoolId ?? "null"}]`
           );
           throw new BadRequestError({
             message:
@@ -694,6 +723,7 @@ export const gitHubAppServiceFactory = ({
     gitHubAppId,
     instanceType,
     gatewayId,
+    gatewayPoolId,
     projectId,
     orgPermission
   }: TResolveGitHubAppInstallationsDTO): Promise<{
@@ -740,9 +770,9 @@ export const gitHubAppServiceFactory = ({
       );
     }
 
-    if (gatewayId) {
-      await assertGatewayUsable(gatewayId, orgPermission);
-    }
+    await assertGatewayConfigUsable({ gatewayId, gatewayPoolId }, orgPermission);
+
+    const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({ gatewayId, gatewayPoolId });
 
     const { SITE_URL } = getConfig();
     if (!SITE_URL) {
@@ -780,9 +810,9 @@ export const gitHubAppServiceFactory = ({
       requestConfig: AxiosRequestConfig & { url: string },
       gatewayConnectionDetails?: Awaited<ReturnType<typeof getGitHubGatewayConnectionDetails>>
     ): Promise<AxiosResponse<T>> =>
-      gatewayId
+      effectiveGatewayId
         ? requestWithGitHubGateway<T>(
-            { gatewayId },
+            { gatewayId: effectiveGatewayId },
             gatewayService,
             gatewayV2Service,
             requestConfig,
@@ -790,8 +820,8 @@ export const gitHubAppServiceFactory = ({
           )
         : safeRequest.request<T>(requestConfig);
 
-    const oauthGatewayConnectionDetails = gatewayId
-      ? await getGitHubGatewayConnectionDetails(gatewayId, oauthHost, gatewayV2Service)
+    const oauthGatewayConnectionDetails = effectiveGatewayId
+      ? await getGitHubGatewayConnectionDetails(effectiveGatewayId, oauthHost, gatewayV2Service)
       : undefined;
 
     let tokenData: GithubTokenRespData;
@@ -825,8 +855,8 @@ export const gitHubAppServiceFactory = ({
       credentials: { host: effectiveHost, instanceType: effectiveInstanceType }
     });
 
-    const apiGatewayConnectionDetails = gatewayId
-      ? await getGitHubGatewayConnectionDetails(gatewayId, apiBaseUrl, gatewayV2Service)
+    const apiGatewayConnectionDetails = effectiveGatewayId
+      ? await getGitHubGatewayConnectionDetails(effectiveGatewayId, apiBaseUrl, gatewayV2Service)
       : undefined;
 
     const installations = await listGitHubUserInstallations(apiBaseUrl, tokenData.access_token, (requestConfig) =>

--- a/backend/src/services/github-app/github-app-types.ts
+++ b/backend/src/services/github-app/github-app-types.ts
@@ -10,6 +10,7 @@ export type TInitiateGitHubManifestDTO = {
   githubHost?: string;
   installState: string;
   projectId?: string;
+  gatewayId?: string;
   orgPermission: OrgServiceActor;
 };
 
@@ -24,6 +25,7 @@ export type TGitHubManifestStatePayload = {
   instanceType: "cloud" | "server";
   githubOrg: string;
   githubHost: string;
+  gatewayId: string | null;
   installState: string;
 };
 

--- a/backend/src/services/github-app/github-app-types.ts
+++ b/backend/src/services/github-app/github-app-types.ts
@@ -85,6 +85,8 @@ export const SanitizedGitHubAppSchema = z.object({
   slug: z.string(),
   clientId: z.string().nullable(),
   owner: z.string().nullable(),
+  host: z.string().nullable(),
+  instanceType: z.enum(["cloud", "server"]).nullable(),
   connectionCount: z.number(),
   createdAt: z.date().nullable(),
   updatedAt: z.date().nullable()

--- a/backend/src/services/github-app/github-app-types.ts
+++ b/backend/src/services/github-app/github-app-types.ts
@@ -11,6 +11,7 @@ export type TInitiateGitHubManifestDTO = {
   installState: string;
   projectId?: string;
   gatewayId?: string;
+  gatewayPoolId?: string;
   orgPermission: OrgServiceActor;
 };
 
@@ -26,6 +27,7 @@ export type TGitHubManifestStatePayload = {
   githubOrg: string;
   githubHost: string;
   gatewayId: string | null;
+  gatewayPoolId: string | null;
   installState: string;
 };
 
@@ -51,6 +53,7 @@ export type TResolveGitHubAppInstallationsDTO = {
   host?: string;
   instanceType?: "cloud" | "server";
   gatewayId?: string | null;
+  gatewayPoolId?: string | null;
   projectId?: string;
   orgPermission: OrgServiceActor;
 };

--- a/frontend/src/hooks/api/gitHubApps/queries.tsx
+++ b/frontend/src/hooks/api/gitHubApps/queries.tsx
@@ -23,6 +23,7 @@ export const resolveGitHubAppInstallations = async (params: {
   host?: string;
   instanceType?: "cloud" | "server";
   gatewayId?: string;
+  gatewayPoolId?: string;
   projectId?: string;
 }) => {
   const { data } = await apiRequest.post<{

--- a/frontend/src/hooks/api/gitHubApps/types.ts
+++ b/frontend/src/hooks/api/gitHubApps/types.ts
@@ -7,6 +7,8 @@ export type TGitHubApp = {
   slug: string;
   clientId: string | null;
   owner: string | null;
+  host: string | null;
+  instanceType: "cloud" | "server" | null;
   connectionCount: number;
   createdAt: string | null;
   updatedAt: string | null;

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
@@ -226,7 +226,7 @@ export const GitHubAppSelector = ({
                 onClick={(e) => {
                   e.stopPropagation();
                   window.open(
-                    buildGitHubAppUrl(app.slug, host, instanceType),
+                    buildGitHubAppUrl(app.slug, app.host, app.instanceType ?? instanceType),
                     "_blank",
                     "noopener,noreferrer"
                   );
@@ -367,7 +367,9 @@ export const GitHubAppSelector = ({
                   className="mb-1"
                   helperText={
                     <>
-                      github.com/apps/
+                      {`${buildGitHubHostUrl(host).replace("https://", "")}/${
+                        instanceType === "server" ? "github-apps" : "apps"
+                      }/`}
                       <span className="font-mono text-mineshaft-200">
                         {GITHUB_APP_NAME_PREFIX}
                         {newAppName.trim() ? slugify(newAppName, { lowercase: true }) : "your-app"}
@@ -457,7 +459,11 @@ export const GitHubAppSelector = ({
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     window.open(
-                                      buildGitHubAppUrl(sharedApp.slug, host, instanceType),
+                                      buildGitHubAppUrl(
+                                        sharedApp.slug,
+                                        sharedApp.host,
+                                        sharedApp.instanceType ?? instanceType
+                                      ),
                                       "_blank",
                                       "noopener,noreferrer"
                                     );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
@@ -48,6 +48,9 @@ type Props = {
   onChange: (app: TGitHubApp | null) => void;
   host?: string;
   instanceType?: "cloud" | "server";
+  // Name of the gateway/pool the parent form will route the app creation through, when one is
+  // selected. Surfaced in the create view so the user knows how Infisical reaches GitHub.
+  gatewayLabel?: string | null;
   // Kicks off the GitHub App manifest creation flow on the parent form (redirects to GitHub).
   // Returns false when the parent form is invalid so we can return to the list view.
   onCreateApp: (params: { name: string; githubOrg: string }) => Promise<boolean> | void;
@@ -65,6 +68,7 @@ export const GitHubAppSelector = ({
   onChange,
   host,
   instanceType,
+  gatewayLabel,
   onCreateApp,
   isCreating,
   projectId
@@ -399,8 +403,20 @@ export const GitHubAppSelector = ({
                 <div className="mt-3 flex items-start gap-2 rounded-md border border-mineshaft-500 bg-mineshaft-700/40 px-3 py-2.5 text-xs leading-relaxed text-mineshaft-300">
                   <FontAwesomeIcon icon={faCircleInfo} className="mt-0.5 text-mineshaft-400" />
                   <span>
-                    You&apos;ll be redirected to GitHub to complete the private app setup. GitHub
-                    fails the setup if you&apos;re signed out, so{" "}
+                    The app will be created on{" "}
+                    <span className="font-medium text-mineshaft-100">
+                      {buildGitHubHostUrl(host).replace("https://", "")}
+                    </span>
+                    {gatewayLabel ? (
+                      <>
+                        {" "}
+                        through the{" "}
+                        <span className="font-medium text-mineshaft-100">{gatewayLabel}</span>{" "}
+                        gateway
+                      </>
+                    ) : null}
+                    . You&apos;ll be redirected to complete the private app setup. GitHub fails the
+                    setup if you&apos;re signed out, so{" "}
                     <a
                       href={`${buildGitHubHostUrl(host)}/login`}
                       target="_blank"

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -285,7 +285,8 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
         githubHost: formData.credentials?.host || undefined,
         installState,
         projectId: projectId || undefined,
-        gatewayId: formData.gatewayId || undefined
+        gatewayId: formData.gatewayId || undefined,
+        gatewayPoolId: formData.gatewayPoolId || undefined
       });
 
       const formEl = document.createElement("form");

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -284,7 +284,8 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
         githubOrg: githubOrg || undefined,
         githubHost: formData.credentials?.host || undefined,
         installState,
-        projectId: projectId || undefined
+        projectId: projectId || undefined,
+        gatewayId: formData.gatewayId || undefined
       });
 
       const formEl = document.createElement("form");

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -44,6 +45,8 @@ import {
   useGetAppConnectionOption
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
+import { gatewayPoolsQueryKeys } from "@app/hooks/api/gateway-pools/queries";
+import { gatewaysQueryKeys } from "@app/hooks/api/gateways/queries";
 import { TGitHubApp, useListGitHubApps } from "@app/hooks/api/gitHubApps";
 
 import { GitHubFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
@@ -165,6 +168,24 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
   const instanceType = watch("credentials.instanceType");
   const gatewayId = watch("gatewayId");
   const gatewayPoolId = watch("gatewayPoolId");
+
+  // Resolve the selected gateway/pool name so the create-app modal can tell the user how Infisical
+  // will reach GitHub. Both lists are already cached by the gateway picker above.
+  const { data: gateways } = useQuery({
+    ...gatewaysQueryKeys.list(),
+    enabled: Boolean(gatewayId)
+  });
+  const { data: gatewayPools } = useQuery({
+    ...gatewayPoolsQueryKeys.list(),
+    enabled: Boolean(gatewayPoolId)
+  });
+
+  const getGatewayLabel = () => {
+    if (gatewayPoolId) return gatewayPools?.find((pool) => pool.id === gatewayPoolId)?.name ?? null;
+    if (gatewayId) return gateways?.find((gateway) => gateway.id === gatewayId)?.name ?? null;
+    return null;
+  };
+  const gatewayLabel = getGatewayLabel();
 
   const returnUrl = useGetAppConnectionOauthReturnUrl();
 
@@ -550,8 +571,9 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
               isLoading={isGitHubAppsLoading}
               value={selectedGitHubApp}
               onChange={setSelectedGitHubApp}
-              host={instanceType === "server" ? watch("credentials.host") : undefined}
+              host={watch("credentials.host")}
               instanceType={instanceType}
+              gatewayLabel={gatewayLabel}
               onCreateApp={handleCreateApp}
               isCreating={isRedirecting}
               projectId={projectId}

--- a/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
+++ b/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.tsx
@@ -424,8 +424,16 @@ export const OAuthCallbackPage = () => {
 
     clearState(AppConnection.GitHub);
 
-    const { connectionId, name, description, returnUrl, gatewayId, credentials, projectId } =
-      formData;
+    const {
+      connectionId,
+      name,
+      description,
+      returnUrl,
+      gatewayId,
+      gatewayPoolId,
+      credentials,
+      projectId
+    } = formData;
 
     const storedGitHubAppId = (credentials as { gitHubAppId?: string | null } | undefined)
       ?.gitHubAppId;
@@ -438,6 +446,7 @@ export const OAuthCallbackPage = () => {
           ...(credentials?.instanceType && { instanceType: credentials.instanceType }),
           ...(credentials?.host && { host: credentials.host }),
           ...(gatewayId && { gatewayId }),
+          ...(gatewayPoolId && { gatewayPoolId }),
           ...(projectId && { projectId })
         });
         setGitHubPicker({ ...result, formData });
@@ -478,7 +487,8 @@ export const OAuthCallbackPage = () => {
           app: AppConnection.GitHub,
           connectionId,
           credentials: isAppMethod ? appCredentials : oauthCredentials,
-          gatewayId
+          gatewayId,
+          gatewayPoolId
         });
       } else {
         connection = await createAppConnection.mutateAsync({
@@ -490,12 +500,14 @@ export const OAuthCallbackPage = () => {
             ? {
                 method: GitHubConnectionMethod.App,
                 credentials: appCredentials,
-                gatewayId
+                gatewayId,
+                gatewayPoolId
               }
             : {
                 method: GitHubConnectionMethod.OAuth,
                 credentials: oauthCredentials,
-                gatewayId
+                gatewayId,
+                gatewayPoolId
               })
         });
       }
@@ -523,8 +535,16 @@ export const OAuthCallbackPage = () => {
     if (!gitHubPicker) return;
 
     const { installationsToken, formData } = gitHubPicker;
-    const { connectionId, name, description, returnUrl, gatewayId, credentials, projectId } =
-      formData;
+    const {
+      connectionId,
+      name,
+      description,
+      returnUrl,
+      gatewayId,
+      gatewayPoolId,
+      credentials,
+      projectId
+    } = formData;
     const gitHubAppId = (credentials as { gitHubAppId?: string | null } | undefined)?.gitHubAppId;
 
     setPickedInstallationId(selectedInstallationId);
@@ -545,7 +565,8 @@ export const OAuthCallbackPage = () => {
           app: AppConnection.GitHub,
           connectionId,
           credentials: appCredentials,
-          gatewayId
+          gatewayId,
+          gatewayPoolId
         });
       } else {
         connection = await createAppConnection.mutateAsync({
@@ -555,7 +576,8 @@ export const OAuthCallbackPage = () => {
           projectId,
           method: GitHubConnectionMethod.App,
           credentials: appCredentials,
-          gatewayId
+          gatewayId,
+          gatewayPoolId
         });
       }
 

--- a/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.types.ts
+++ b/frontend/src/pages/organization/AppConnections/OauthCallbackPage/OauthCallbackPage.types.ts
@@ -19,7 +19,10 @@ type BaseFormData = {
 };
 
 export type GitHubFormData = BaseFormData &
-  Pick<TGitHubConnection, "name" | "method" | "description" | "gatewayId" | "credentials"> & {
+  Pick<
+    TGitHubConnection,
+    "name" | "method" | "description" | "gatewayId" | "gatewayPoolId" | "credentials"
+  > & {
     appSlug?: string;
   };
 


### PR DESCRIPTION
## Context

- Allow GitHub App manifest creation for private hosted GHE server.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)