### PR TITLE
improvement: migrate create service token modal to v3 components and sheet

### DIFF
--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -269,7 +269,7 @@ const ServiceTokenForm = () => {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */}
+                        /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */
                           tabIndex={isOnlyScope ? 0 : -1}
                           className={index === 0 ? "mt-6" : undefined}
                         >

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -1,28 +1,47 @@
 import crypto from "crypto";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { faCheck, faCopy, faPlus, faTrashCan } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ClipboardCheckIcon, Copy, Info, PlusIcon, TrashIcon } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Button,
+  ButtonGroup,
   Checkbox,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
   IconButton,
   Input,
-  Modal,
-  ModalClose,
-  ModalContent,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useProject } from "@app/context";
-import { useToggle } from "@app/hooks";
+import { useTimedReset } from "@app/hooks";
 import { useCreateServiceToken } from "@app/hooks/api";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
@@ -34,6 +53,11 @@ const apiTokenExpiry = [
   { label: "12 months", value: 31104000 },
   { label: "Never", value: null }
 ];
+
+const permissionOptions = [
+  { label: "Read (default)", value: "read" },
+  { label: "Write (optional)", value: "write" }
+] as const;
 
 const schema = z.object({
   name: z.string().max(100),
@@ -90,23 +114,14 @@ const ServiceTokenForm = () => {
   const { fields: tokenScopes, append, remove } = useFieldArray({ control, name: "scopes" });
 
   const [newToken, setToken] = useState("");
-  const [isTokenCopied, setIsTokenCopied] = useToggle(false);
+  const [, isTokenCopied, setTokenCopied] = useTimedReset<string>({ initialState: "" });
 
   const createServiceToken = useCreateServiceToken();
   const hasServiceToken = Boolean(newToken);
 
-  useEffect(() => {
-    let timer: NodeJS.Timeout;
-    if (isTokenCopied) {
-      timer = setTimeout(() => setIsTokenCopied.off(), 2000);
-    }
-
-    return () => clearTimeout(timer);
-  }, [isTokenCopied]);
-
   const copyTokenToClipboard = () => {
     navigator.clipboard.writeText(newToken);
-    setIsTokenCopied.on();
+    setTokenCopied("copied");
   };
 
   const onFormSubmit = async ({ name, scopes, expiresIn, permissions }: FormData) => {
@@ -135,183 +150,246 @@ const ServiceTokenForm = () => {
     });
   };
 
-  return !hasServiceToken ? (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
-      <Controller
-        control={control}
-        name="name"
-        defaultValue=""
-        render={({ field, fieldState: { error } }) => (
-          <FormControl
-            label={t("section.token.add-dialog.name")}
-            isError={Boolean(error)}
-            errorText={error?.message}
-          >
-            <Input {...field} placeholder="Type your token name" />
-          </FormControl>
-        )}
-      />
-      {tokenScopes.map(({ id }, index) => (
-        <div className="mb-3 flex items-start space-x-2" key={id}>
-          <Controller
-            control={control}
-            name={`scopes.${index}.environment`}
-            defaultValue={currentProject?.environments?.[0]?.slug}
-            render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-              <FormControl
-                className="mb-0"
-                label={index === 0 ? "Environment" : undefined}
-                errorText={error?.message}
-                isError={Boolean(error)}
-              >
-                <Select
-                  defaultValue={field.value}
-                  {...field}
-                  onValueChange={(e) => onChange(e)}
-                  className="w-full"
-                >
-                  {currentProject?.environments.map(({ name, slug }) => (
-                    <SelectItem value={slug} key={slug}>
-                      {name}
-                    </SelectItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-          />
-          <Controller
-            control={control}
-            name={`scopes.${index}.secretPath`}
-            defaultValue="/"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                className="mb-0 grow"
-                label={index === 0 ? "Secrets Path" : undefined}
-                isError={Boolean(error)}
-                errorText={error?.message}
-              >
-                <Input {...field} placeholder="can be /, /nested/**, /**/deep" />
-              </FormControl>
-            )}
-          />
-          <IconButton
-            className={`p-3 ${index === 0 ? "mt-7" : ""}`}
-            ariaLabel="remove"
-            colorSchema="danger"
-            onClick={() => remove(index)}
-          >
-            <FontAwesomeIcon icon={faTrashCan} size="sm" />
-          </IconButton>
-        </div>
-      ))}
-      <div className="my-4 ml-1">
-        <Button
-          variant="outline_bg"
-          onClick={() =>
-            append({
-              environment: currentProject?.environments?.[0]?.slug || "",
-              secretPath: "/"
-            })
-          }
-          leftIcon={<FontAwesomeIcon icon={faPlus} />}
-          size="xs"
-        >
-          Add Scope
-        </Button>
-      </div>
-      <Controller
-        control={control}
-        name="expiresIn"
-        defaultValue={String(apiTokenExpiry?.[0]?.value)}
-        render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-          <FormControl label="Expiration" errorText={error?.message} isError={Boolean(error)}>
-            <Select
-              defaultValue={field.value}
-              {...field}
-              onValueChange={(e) => onChange(e)}
-              className="w-full"
-            >
-              {apiTokenExpiry.map(({ label, value }) => (
-                <SelectItem value={String(value)} key={label}>
-                  {label}
-                </SelectItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-      />
-      <Controller
-        control={control}
-        name="permissions"
-        defaultValue={{
-          read: true,
-          readValue: false,
-          write: false
-        }}
-        render={({ field: { onChange, value }, fieldState: { error } }) => {
-          const options = [
-            {
-              label: "Read (default)",
-              value: "read"
-            },
-            {
-              label: "Write (optional)",
-              value: "write"
-            }
-          ] as const;
-
-          return (
-            <FormControl label="Permissions" errorText={error?.message} isError={Boolean(error)}>
-              <>
-                {options.map(({ label, value: optionValue }) => {
-                  return (
-                    <Checkbox
-                      id={String(value[optionValue])}
-                      key={optionValue}
-                      isChecked={value[optionValue]}
-                      isDisabled={optionValue === "read"}
-                      onCheckedChange={(state) => {
-                        onChange({
-                          ...value,
-                          [optionValue]: state
-                        });
-                      }}
-                    >
-                      {label}
-                    </Checkbox>
-                  );
-                })}
-              </>
-            </FormControl>
-          );
-        }}
-      />
-      <div className="mt-8 flex items-center">
-        <Button className="mr-4" type="submit" isDisabled={isSubmitting} isLoading={isSubmitting}>
-          Create
-        </Button>
-        <ModalClose asChild>
-          <Button variant="plain" colorSchema="secondary">
-            Cancel
-          </Button>
-        </ModalClose>
-      </div>
-    </form>
-  ) : (
-    <div className="mt-2 mr-2 mb-3 flex items-center justify-end rounded-md bg-white/[0.07] p-2 text-base text-gray-400">
-      <p className="mr-4 break-all">{newToken}</p>
-      <IconButton
-        ariaLabel="copy icon"
-        colorSchema="secondary"
-        className="group relative"
-        onClick={copyTokenToClipboard}
+  return (
+    <>
+      <form
+        id="add-service-token-form"
+        onSubmit={handleSubmit(onFormSubmit)}
+        className="flex flex-1 flex-col overflow-hidden"
       >
-        <FontAwesomeIcon icon={isTokenCopied ? faCheck : faCopy} />
-        <span className="group-hover:animate-fade-in absolute -top-20 -left-8 hidden w-28 translate-y-full rounded-md bg-bunker-800 py-2 pl-3 text-center text-sm text-gray-400 group-hover:flex">
-          {t("common.click-to-copy")}
-        </span>
-      </IconButton>
-    </div>
+        <div className="flex thin-scrollbar flex-1 flex-col gap-4 overflow-y-auto p-4">
+          {hasServiceToken ? (
+            <>
+              <Field>
+                <FieldLabel>{t("section.token.add-dialog.copy-service-token")}</FieldLabel>
+                <ButtonGroup className="w-full">
+                  <Input
+                    value={newToken}
+                    readOnly
+                    aria-label="Service token"
+                    className="font-mono"
+                  />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <IconButton
+                        variant="outline"
+                        aria-label="Copy service token"
+                        onClick={copyTokenToClipboard}
+                      >
+                        {isTokenCopied ? <ClipboardCheckIcon /> : <Copy />}
+                      </IconButton>
+                    </TooltipTrigger>
+                    <TooltipContent>{isTokenCopied ? "Copied" : "Copy"}</TooltipContent>
+                  </Tooltip>
+                </ButtonGroup>
+              </Field>
+              <Alert variant="info">
+                <Info />
+                <AlertTitle>Copy this token now</AlertTitle>
+                <AlertDescription>
+                  {t("section.token.add-dialog.copy-service-token-description")}
+                </AlertDescription>
+              </Alert>
+            </>
+          ) : (
+            <>
+              <Controller
+                control={control}
+                name="name"
+                defaultValue=""
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel>{t("section.token.add-dialog.name")}</FieldLabel>
+                    <FieldContent>
+                      <Input
+                        {...field}
+                        autoFocus
+                        isError={Boolean(error)}
+                        placeholder="Type your token name"
+                      />
+                      <FieldError errors={[error]} />
+                    </FieldContent>
+                  </Field>
+                )}
+              />
+              <div className="flex flex-col gap-3">
+                {tokenScopes.map(({ id }, index) => (
+                  <div className="flex items-start gap-2" key={id}>
+                    <Controller
+                      control={control}
+                      name={`scopes.${index}.environment`}
+                      defaultValue={currentProject?.environments?.[0]?.slug}
+                      render={({ field: { value, onChange }, fieldState: { error } }) => (
+                        <Field className="min-w-0 flex-1">
+                          {index === 0 && <FieldLabel>Environment</FieldLabel>}
+                          <FieldContent>
+                            <Select value={value} onValueChange={onChange}>
+                              <SelectTrigger isError={Boolean(error)} className="w-full">
+                                <SelectValue placeholder="Select environment">
+                                  <span className="truncate">
+                                    {
+                                      currentProject?.environments.find(
+                                        (env) => env.slug === value
+                                      )?.name
+                                    }
+                                  </span>
+                                </SelectValue>
+                              </SelectTrigger>
+                              <SelectContent>
+                                {currentProject?.environments.map(({ name, slug }) => (
+                                  <SelectItem value={slug} key={slug}>
+                                    {name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <FieldError errors={[error]} />
+                          </FieldContent>
+                        </Field>
+                      )}
+                    />
+                    <Controller
+                      control={control}
+                      name={`scopes.${index}.secretPath`}
+                      defaultValue="/"
+                      render={({ field, fieldState: { error } }) => (
+                        <Field className="min-w-0 flex-1">
+                          {index === 0 && <FieldLabel>Secrets Path</FieldLabel>}
+                          <FieldContent>
+                            <Input
+                              {...field}
+                              isError={Boolean(error)}
+                              placeholder="can be /, /nested/**, /**/deep"
+                            />
+                            <FieldError errors={[error]} />
+                          </FieldContent>
+                        </Field>
+                      )}
+                    />
+                    <IconButton
+                      variant="ghost"
+                      type="button"
+                      aria-label="Remove scope"
+                      className={index === 0 ? "mt-6 hover:text-danger" : "hover:text-danger"}
+                      onClick={() => remove(index)}
+                    >
+                      <TrashIcon />
+                    </IconButton>
+                  </div>
+                ))}
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  type="button"
+                  className="w-fit"
+                  onClick={() =>
+                    append({
+                      environment: currentProject?.environments?.[0]?.slug || "",
+                      secretPath: "/"
+                    })
+                  }
+                >
+                  <PlusIcon className="mr-1 size-4" />
+                  Add Scope
+                </Button>
+              </div>
+              <Controller
+                control={control}
+                name="expiresIn"
+                defaultValue={String(apiTokenExpiry?.[0]?.value)}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel>Expiration</FieldLabel>
+                    <FieldContent>
+                      <Select value={value} onValueChange={onChange}>
+                        <SelectTrigger isError={Boolean(error)} className="w-full">
+                          <SelectValue placeholder="Select expiration" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {apiTokenExpiry.map(({ label, value: optionValue }) => (
+                            <SelectItem value={String(optionValue)} key={label}>
+                              {label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FieldError errors={[error]} />
+                    </FieldContent>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                name="permissions"
+                defaultValue={{
+                  read: true,
+                  readValue: false,
+                  write: false
+                }}
+                render={({ field: { onChange, value }, fieldState: { error } }) => (
+                  <FieldSet>
+                    <FieldLegend className="mb-4" variant="label">
+                      Permissions
+                    </FieldLegend>
+                    <FieldGroup>
+                      {permissionOptions.map(({ label, value: optionValue }) => (
+                        <Field key={optionValue} orientation="horizontal">
+                          <Checkbox
+                            id={`permission-${optionValue}`}
+                            variant="project"
+                            isChecked={value[optionValue]}
+                            isDisabled={optionValue === "read"}
+                            onCheckedChange={(state) =>
+                              onChange({
+                                ...value,
+                                [optionValue]: Boolean(state)
+                              })
+                            }
+                          />
+                          <FieldLabel
+                            htmlFor={`permission-${optionValue}`}
+                            className="cursor-pointer"
+                          >
+                            {label}
+                          </FieldLabel>
+                        </Field>
+                      ))}
+                    </FieldGroup>
+                    <FieldError errors={[error]} />
+                  </FieldSet>
+                )}
+              />
+            </>
+          )}
+        </div>
+      </form>
+      <SheetFooter className="border-t">
+        {hasServiceToken ? (
+          <SheetClose asChild>
+            <Button type="button" variant="project">
+              Done
+            </Button>
+          </SheetClose>
+        ) : (
+          <>
+            <Button
+              type="submit"
+              form="add-service-token-form"
+              variant="project"
+              isPending={isSubmitting}
+              isDisabled={isSubmitting}
+            >
+              Create
+            </Button>
+            <SheetClose asChild>
+              <Button type="button" variant="outline" isDisabled={isSubmitting}>
+                Cancel
+              </Button>
+            </SheetClose>
+          </>
+        )}
+      </SheetFooter>
+    </>
   );
 };
 
@@ -320,23 +398,21 @@ export const AddServiceTokenModal = ({ popUp, handlePopUpToggle }: Props) => {
 
   const { currentProject } = useProject();
 
+  const isOpen = popUp?.createAPIToken?.isOpen;
+
   return (
-    <Modal
-      isOpen={popUp?.createAPIToken?.isOpen}
-      onOpenChange={(open) => {
-        handlePopUpToggle("createAPIToken", open);
-      }}
-    >
-      <ModalContent
-        title={
-          t("section.token.add-dialog.title", {
-            target: currentProject?.name
-          }) as string
-        }
-        subTitle={t("section.token.add-dialog.description") as string}
-      >
-        <ServiceTokenForm />
-      </ModalContent>
-    </Modal>
+    <Sheet open={isOpen} onOpenChange={(open) => handlePopUpToggle("createAPIToken", open)}>
+      <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-lg">
+        <SheetHeader className="border-b">
+          <SheetTitle>
+            {t("section.token.add-dialog.title", {
+              target: currentProject?.name
+            })}
+          </SheetTitle>
+          <SheetDescription>{t("section.token.add-dialog.description")}</SheetDescription>
+        </SheetHeader>
+        <ServiceTokenForm key={String(isOpen)} />
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -269,7 +269,7 @@ const ServiceTokenForm = () => {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                        /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */
+                          /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */
                           tabIndex={isOnlyScope ? 0 : -1}
                           className={index === 0 ? "mt-6" : undefined}
                         >

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -112,6 +112,7 @@ const ServiceTokenForm = () => {
   });
 
   const { fields: tokenScopes, append, remove } = useFieldArray({ control, name: "scopes" });
+  const isOnlyScope = tokenScopes.length === 1;
 
   const [newToken, setToken] = useState("");
   const [, isTokenCopied, setTokenCopied] = useTimedReset<string>({ initialState: "" });
@@ -265,15 +266,29 @@ const ServiceTokenForm = () => {
                         </Field>
                       )}
                     />
-                    <IconButton
-                      variant="ghost"
-                      type="button"
-                      aria-label="Remove scope"
-                      className={index === 0 ? "mt-6 hover:text-danger" : "hover:text-danger"}
-                      onClick={() => remove(index)}
-                    >
-                      <TrashIcon />
-                    </IconButton>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */}
+                        <span
+                          tabIndex={isOnlyScope ? 0 : -1}
+                          className={index === 0 ? "mt-6" : undefined}
+                        >
+                          <IconButton
+                            variant="ghost"
+                            type="button"
+                            aria-label="Remove scope"
+                            className="hover:text-danger"
+                            isDisabled={isOnlyScope}
+                            onClick={() => remove(index)}
+                          >
+                            <TrashIcon />
+                          </IconButton>
+                        </span>
+                      </TooltipTrigger>
+                      {isOnlyScope && (
+                        <TooltipContent>At least one scope is required</TooltipContent>
+                      )}
+                    </Tooltip>
                   </div>
                 ))}
                 <Button

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -268,8 +268,8 @@ const ServiceTokenForm = () => {
                     />
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */}
                         <span
+                        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- focusable wrapper so the tooltip surfaces on keyboard focus while the trash button is disabled */}
                           tabIndex={isOnlyScope ? 0 : -1}
                           className={index === 0 ? "mt-6" : undefined}
                         >

--- a/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/ServiceTokenTab/components/ServiceTokenSection/AddServiceTokenModal.tsx
@@ -228,9 +228,8 @@ const ServiceTokenForm = () => {
                                 <SelectValue placeholder="Select environment">
                                   <span className="truncate">
                                     {
-                                      currentProject?.environments.find(
-                                        (env) => env.slug === value
-                                      )?.name
+                                      currentProject?.environments.find((env) => env.slug === value)
+                                        ?.name
                                     }
                                   </span>
                                 </SelectValue>


### PR DESCRIPTION
## Context

This PR migrates the create service token modal to v3 components and a sheet

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-06-10 at 12 44 22@2x" src="https://github.com/user-attachments/assets/dc03f192-7d45-40a2-b7c6-e4489c2fa6a6" />

## Steps to verify the change

- create service token, testing all form fields and functionality

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)