### PR TITLE
improvement: migrate add members to project modal to v3

### DIFF
--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
@@ -11,12 +11,20 @@ import {
   Alert,
   AlertDescription,
   Button,
-  FilterableSelect,
-  FormControl,
-  Modal,
-  ModalContent
-} from "@app/components/v2";
-import { CreatableSelect } from "@app/components/v2/CreatableSelect";
+  CreatableSelect,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
 import {
   OrgPermissionActions,
   OrgPermissionSubjects,
@@ -226,8 +234,8 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
   );
 
   return (
-    <Modal
-      isOpen={popUp?.addMember?.isOpen}
+    <Dialog
+      open={popUp?.addMember?.isOpen}
       onOpenChange={(isOpen) => {
         if (!isOpen && requesterEmail)
           navigate({
@@ -236,32 +244,23 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
         handlePopUpToggle("addMember", isOpen);
       }}
     >
-      <ModalContent
-        bodyClassName="overflow-visible"
-        title={
-          isCertManager
-            ? "Add Members to Certificate Manager"
-            : (t("section.members.add-dialog.add-member-to-project") as string)
-        }
-        subTitle={t("section.members.add-dialog.user-will-email")}
-      >
-        <form onSubmit={handleSubmit(onAddMembers)}>
-          <div className="flex w-full flex-col items-start gap-2">
-            <Controller
-              control={control}
-              name="orgMemberships"
-              render={({ field }) => (
-                <FormControl
-                  className="w-full"
-                  isError={!!errors.orgMemberships?.length}
-                  errorText={errors.orgMemberships?.[0]?.message}
-                  label={`Invite users to ${productLabel.toLowerCase()}`}
-                  helperText={
-                    canInviteNewMembers
-                      ? "You can invite new users to your organization by typing out their email address"
-                      : undefined
-                  }
-                >
+      <DialogContent className="overflow-visible sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {isCertManager
+              ? "Add Members to Certificate Manager"
+              : (t("section.members.add-dialog.add-member-to-project") as string)}
+          </DialogTitle>
+          <DialogDescription>{t("section.members.add-dialog.user-will-email")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onAddMembers)} className="flex flex-col gap-4">
+          <Controller
+            control={control}
+            name="orgMemberships"
+            render={({ field }) => (
+              <Field>
+                <FieldLabel>{`Invite users to ${productLabel.toLowerCase()}`}</FieldLabel>
+                <FieldContent>
                   {canInviteNewMembers ? (
                     <CreatableSelect
                       /* eslint-disable-next-line react/no-unstable-nested-components */
@@ -300,39 +299,43 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
                           })
                           .includes(input)
                       }
-                      className="w-full"
                       placeholder="Add one or more users..."
                       isMulti
                       name="members"
                       options={projectInviteList.list}
                       value={field.value}
                       onChange={field.onChange}
+                      isError={!!errors.orgMemberships?.length}
                     />
                   ) : (
                     <FilterableSelect
-                      className="w-full"
                       placeholder="Add one or more users..."
                       isMulti
                       name="members"
                       options={projectInviteList.list}
                       value={field.value}
                       onChange={field.onChange}
+                      isError={!!errors.orgMemberships?.length}
                     />
                   )}
-                </FormControl>
-              )}
-            />
-            <Controller
-              control={control}
-              name="projectRoleSlugs"
-              render={({ field: { onChange, value }, fieldState: { error } }) => (
-                <FormControl
-                  className="w-full"
-                  label="Select roles"
-                  tooltipText="Select the roles that you wish to assign to the users"
-                  errorText={error?.message}
-                  isError={Boolean(error)}
-                >
+                  {canInviteNewMembers && (
+                    <FieldDescription>
+                      You can invite new users to your organization by typing out their email
+                      address
+                    </FieldDescription>
+                  )}
+                </FieldContent>
+                <FieldError>{errors.orgMemberships?.[0]?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <Controller
+            control={control}
+            name="projectRoleSlugs"
+            render={({ field: { onChange, value }, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel>Select roles</FieldLabel>
+                <FieldContent>
                   <FilterableSelect
                     options={filteredRoles}
                     components={{ Option: RoleOption }}
@@ -342,30 +345,41 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
                     isMulti
                     getOptionValue={(option) => option.slug}
                     getOptionLabel={(option) => option.name}
+                    isError={Boolean(error)}
                   />
-                </FormControl>
-              )}
-            />
-            {requesterEmail && projectInviteList.requesterStatus.isProjectUser && (
-              <Alert hideTitle variant="danger">
-                <AlertDescription>Requested user is part of the project.</AlertDescription>
-              </Alert>
+                  <FieldDescription>
+                    Select the roles that you wish to assign to the users
+                  </FieldDescription>
+                </FieldContent>
+                <FieldError>{error?.message}</FieldError>
+              </Field>
             )}
-            {requesterEmail && !projectInviteList.requesterStatus.isProjectUser && (
-              <Alert hideTitle>
-                <AlertDescription>
-                  Assign a role to provide access to requesting user{" "}
-                  <b>{projectInviteList.requesterStatus.userLabel}</b>.
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
-          <div className="mt-8 flex items-center">
+          />
+          {requesterEmail && projectInviteList.requesterStatus.isProjectUser && (
+            <Alert variant="danger">
+              <AlertDescription>Requested user is part of the project.</AlertDescription>
+            </Alert>
+          )}
+          {requesterEmail && !projectInviteList.requesterStatus.isProjectUser && (
+            <Alert>
+              <AlertDescription>
+                Assign a role to provide access to requesting user{" "}
+                <b>{projectInviteList.requesterStatus.userLabel}</b>.
+              </AlertDescription>
+            </Alert>
+          )}
+          <DialogFooter>
             <Button
-              className="mr-4"
-              size="sm"
+              variant="ghost"
+              type="button"
+              onClick={() => handlePopUpToggle("addMember", false)}
+            >
+              Cancel
+            </Button>
+            <Button
               type="submit"
-              isLoading={isSubmitting}
+              variant="project"
+              isPending={isSubmitting}
               isDisabled={
                 isSubmitting ||
                 selectedOrgMemberships.length === 0 ||
@@ -374,16 +388,9 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
             >
               Add Members
             </Button>
-            <Button
-              colorSchema="secondary"
-              variant="plain"
-              onClick={() => handlePopUpToggle("addMember", false)}
-            >
-              Cancel
-            </Button>
-          </div>
+          </DialogFooter>
         </form>
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
## Context

This PR migrates the add project member dialog to v3 components

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-06-10 at 14 35 51@2x" src="https://github.com/user-attachments/assets/38fc1b0e-50c6-4519-89eb-cdc689736d44" />

## Steps to verify the change

- add a users to a project (new user invite via email and existing via select)
- ensure no functional regression

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)