### PR TITLE
fix(frontend): gate cert manager request access on request-access permission

### DIFF
--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, Skeleton } from "@app/c
 import { useOrganization, useOrgPermission } from "@app/context";
 import {
   OrgPermissionAdminConsoleAction,
+  OrgPermissionProjectActions,
   OrgPermissionSubjects
 } from "@app/context/OrgPermissionContext/types";
 import {
@@ -97,6 +98,10 @@ export const ProjectCategoryOverview = () => {
   const navigate = useNavigate();
   const { currentOrg } = useOrganization();
   const { permission } = useOrgPermission();
+  const canRequestAccess = permission.can(
+    OrgPermissionProjectActions.RequestAccess,
+    OrgPermissionSubjects.Project
+  );
   const { data: projects = [], isPending: isProjectsLoading } = useGetUserProjects();
   const { data: certManagerInstance } = useCertManagerInstanceState();
   const { data: productStats } = useGetOrgProductStats(currentOrg?.id ?? "");
@@ -197,8 +202,13 @@ export const ProjectCategoryOverview = () => {
             err instanceof Error ? err.message : "Failed to join the Certificate Manager project."
         });
       }
-    } else {
+    } else if (canRequestAccess) {
       setIsRequestAccessOpen(true);
+    } else {
+      createNotification({
+        type: "error",
+        text: "You don't have access to this Certificate Manager project."
+      });
     }
   };
 

--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -6,7 +6,16 @@ import { createNotification } from "@app/components/notifications";
 import { CertManagerNotConfiguredModal } from "@app/components/projects/CertManagerNotConfiguredModal";
 import { CertManagerSelectInstanceModal } from "@app/components/projects/CertManagerSelectInstanceModal";
 import { RequestProjectAccessModal } from "@app/components/projects/RequestProjectAccessModal";
-import { Card, CardContent, CardDescription, CardHeader, Skeleton } from "@app/components/v3";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization, useOrgPermission } from "@app/context";
 import {
   OrgPermissionAdminConsoleAction,
@@ -120,6 +129,17 @@ export const ProjectCategoryOverview = () => {
     [certManagerInstance?.projects]
   );
 
+  const isOrgAdmin = permission.can(
+    OrgPermissionAdminConsoleAction.AccessAllProjects,
+    OrgPermissionSubjects.AdminConsole
+  );
+  const isCertManagerMember = useMemo(
+    () => cmInstances.some((instance) => projects.some((project) => project.id === instance.id)),
+    [cmInstances, projects]
+  );
+  const isCertManagerAccessBlocked =
+    cmInstances.length > 0 && !isOrgAdmin && !canRequestAccess && !isCertManagerMember;
+
   const certManagerActiveProjectId = useMemo(() => {
     const cookieValue = currentOrg?.id ? getCertManagerActiveProjectCookie(currentOrg.id) : null;
     if (cookieValue && cmInstances.some((p) => p.id === cookieValue)) return cookieValue;
@@ -187,10 +207,6 @@ export const ProjectCategoryOverview = () => {
       navigateToCertManager(projectId);
       return;
     }
-    const isOrgAdmin = permission.can(
-      OrgPermissionAdminConsoleAction.AccessAllProjects,
-      OrgPermissionSubjects.AdminConsole
-    );
     if (isOrgAdmin) {
       try {
         await orgAdminAccessProject.mutateAsync({ projectId });
@@ -288,17 +304,8 @@ export const ProjectCategoryOverview = () => {
             titleUnderlineClassName
           } = PRODUCT_STYLES[type];
 
-          return (
-            <Card
-              key={type}
-              role="button"
-              tabIndex={0}
-              onClick={() => handleTileClick(type)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleTileClick(type);
-              }}
-              className={`group h-auto cursor-pointer rounded-md transition-all duration-200 ease-out hover:scale-[1.01] ${cardClassName}`}
-            >
+          const tileBody = (
+            <>
               <CardHeader>
                 <div className="flex items-start gap-3">
                   <div
@@ -337,6 +344,37 @@ export const ProjectCategoryOverview = () => {
                   </div>
                 )}
               </CardContent>
+            </>
+          );
+
+          if (type === ProjectType.CertificateManager && isCertManagerAccessBlocked) {
+            return (
+              <Tooltip key={type}>
+                <TooltipTrigger asChild>
+                  <div aria-disabled className="cursor-not-allowed">
+                    <Card className="h-auto rounded-md opacity-50">{tileBody}</Card>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  You don&apos;t have access to Certificate Manager. Ask an organization admin for
+                  access.
+                </TooltipContent>
+              </Tooltip>
+            );
+          }
+
+          return (
+            <Card
+              key={type}
+              role="button"
+              tabIndex={0}
+              onClick={() => handleTileClick(type)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleTileClick(type);
+              }}
+              className={`group h-auto cursor-pointer rounded-md transition-all duration-200 ease-out hover:scale-[1.01] ${cardClassName}`}
+            >
+              {tileBody}
             </Card>
           );
         })}


### PR DESCRIPTION
## Context

- PR #6774 hid the **All Projects** view and the broken **Request Access** flow from users without the `request-access` permission — but only for product types that route through `ProjectTypePage`. **Certificate Manager** has its own entry flow in `ProjectCategoryOverview` and was missed.
- A user without `request-access` permission (e.g. no-access org member) who clicked the Certificate Manager tile — not a member, not an org admin — still opened the Request Access modal, which 403s on submit.
- Gate the cert manager request-access modal on the same `OrgPermissionProjectActions.RequestAccess` permission 6774 used; show a neutral "no access" notification instead when the user can't request access.

Linear: ENG-5181

## Steps to verify the change

- As a user **without** request-access permission, not a member of any Certificate Manager project: open Organization and click the **Certificate Manager** tile → no Request Access modal opens; a "You don't have access to this Certificate Manager project" notification is shown.
- As an admin/member (**has** request-access): cert manager entry and the Request Access flow are unchanged.

Verified: frontend `lint:fix` + `type:check` pass for the changed file.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
