### PR TITLE
feat: add PKI Signer connect helper

### DIFF
--- a/backend/src/services/signer/signer-service.ts
+++ b/backend/src/services/signer/signer-service.ts
@@ -1132,7 +1132,10 @@ export const signerServiceFactory = ({
 
         if (!matchingGrant) {
           throw new ForbiddenRequestError({
-            message: "Signing requires approval. Get approval before signing.",
+            message:
+              `Signing with signer '${signer.name}' requires approved access, but none is currently active. ` +
+              `Access may not have been requested or approved yet, may have expired, or may have reached its signature limit. ` +
+              `Request and approve signing access for this signer, then try again.`,
             name: "ApprovalRequired"
           });
         }

--- a/backend/src/services/signer/signer-service.ts
+++ b/backend/src/services/signer/signer-service.ts
@@ -1135,7 +1135,7 @@ export const signerServiceFactory = ({
             message:
               `Signing with signer '${signer.name}' requires approved access, but none is currently active. ` +
               `Access may not have been requested or approved yet, may have expired, or may have reached its signature limit. ` +
-              `Request and approve signing access for this signer, then try again.`,
+              `Request signing access for this signer and try again once it's approved.`,
             name: "ApprovalRequired"
           });
         }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -846,7 +846,8 @@
                       "documentation/platform/pki/code-signing/overview",
                       "documentation/platform/pki/code-signing/signers",
                       "documentation/platform/pki/code-signing/approvals",
-                      "documentation/platform/pki/code-signing/pkcs11-module"
+                      "documentation/platform/pki/code-signing/pkcs11-module",
+                      "documentation/platform/pki/code-signing/windows-ksp"
                     ]
                   },
                   {

--- a/docs/documentation/platform/pki/code-signing/overview.mdx
+++ b/docs/documentation/platform/pki/code-signing/overview.mdx
@@ -6,7 +6,7 @@ description: "Sign software artifacts with managed code-signing certificates, ce
 
 Code Signing is where teams digitally sign software (JARs, container images, Windows installers, Android APKs, Linux packages, scripts). Within Code Signing, you can:
 
-- **Sign artifacts** through any tool that supports PKCS#11, or directly via the [Sign API](/api-reference/endpoints/code-signing/signers/sign)
+- **Sign artifacts** through any tool that supports PKCS#11, with native Windows `signtool`, or directly via the [Sign API](/api-reference/endpoints/code-signing/signers/sign)
 - **Require approvals** before signatures are produced, with per-approval limits on count and time
 - **Manage who can sign** with per-Signer roles for users, machine identities, and groups
 - **Track every signing operation** in a full audit trail
@@ -55,7 +55,7 @@ sequenceDiagram
 1. A Product Admin creates a [Signer](/documentation/platform/pki/code-signing/signers) and picks the CA that issues its certificate.
 2. The Admin adds [members](/documentation/platform/pki/code-signing/signers#members) (users, machine identities, or groups) and picks a role for each.
 3. Optionally, the Admin attaches an [approval policy](/documentation/platform/pki/code-signing/approvals) so signing requires sign-off.
-4. Operators sign through the [PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module) or the [Sign API](/api-reference/endpoints/code-signing/signers/sign). Infisical produces the signature and records an audit entry on the Signer.
+4. Operators sign through the [PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module), the [Windows KSP](/documentation/platform/pki/code-signing/windows-ksp) (`signtool`), or the [Sign API](/api-reference/endpoints/code-signing/signers/sign). Infisical produces the signature and records an audit entry on the Signer.
 
 ## Signer roles
 

--- a/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
+++ b/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
@@ -94,7 +94,7 @@ export INFISICAL_TOKEN="<your-access-token>"
 ```
 
 <Warning>
-  Access tokens expire, so this access is **temporary**. The module does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off; for unattended or CI/CD signing use a machine identity, which the module re-authenticates automatically.
+  JWT tokens expire, so this access is **temporary**. The module does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off; for unattended or CI/CD signing use a machine identity with Universal Auth (client ID and secret), which the module re-authenticates automatically.
 </Warning>
 
 If you put the config somewhere other than `/etc/infisical/pkcs11.conf`:
@@ -129,7 +129,7 @@ export INFISICAL_CONFIG=/path/to/your/pkcs11.conf
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | Machine identity client ID. Overrides config. |
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | Machine identity client secret. Overrides config. |
 | `INFISICAL_TOKEN` | An Infisical access token (a user or machine identity token). Selects token auth; used instead of the client ID/secret. |
-| `INFISICAL_SERVER_URL` | Override `server_url`. |
+| `INFISICAL_SERVER_URL` | The Infisical instance URL. Sets `server_url` (and overrides the config file). |
 | `INFISICAL_CONFIG` | Path to the config file (default `/etc/infisical/pkcs11.conf`). |
 
 <Note>

--- a/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
+++ b/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
@@ -6,6 +6,10 @@ description: "Use jarsigner, cosign, osslsigncode, and other standard signing to
 
 The Infisical **PKCS#11 module** is a small native library (`.so`, `.dylib`, or `.dll`) that exposes your Infisical [Signers](/documentation/platform/pki/code-signing/signers) to any tool that supports the [PKCS#11 v2.40 standard](https://www.oasis-open.org/standard/pkcs-11-v2-40/). Tools like `jarsigner`, `osslsigncode`, `cosign`, `apksigner`, `openssl`, and `gpg` work without modification. They make their usual PKCS#11 calls; the module forwards them to Infisical and returns the signature.
 
+<Note>
+  Signing on Windows with `signtool`? Use the [Windows KSP](/documentation/platform/pki/code-signing/windows-ksp) instead.
+</Note>
+
 <Info>
   Before installing the module, ensure a Product Admin has created a [Signer](/documentation/platform/pki/code-signing/signers) and added the machine identity (or user) you plan to authenticate as. If the Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), you'll also need [active access](/documentation/platform/pki/code-signing/approvals#access-lifecycle).
 </Info>

--- a/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
+++ b/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
@@ -108,7 +108,7 @@ export INFISICAL_CONFIG=/path/to/your/pkcs11.conf
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `server_url` | Yes | None | Infisical server URL. Must use `http://` (local dev) or `https://`. |
-| `auth.method` | No | `universal-auth` | Authentication method: `universal-auth` or `token`. |
+| `auth.method` | No | inferred | Authentication method: `universal-auth` or `token`. Inferred from the credentials when unset (a token means `token`, otherwise `universal-auth`). |
 | `auth.client_id` | No | None | Machine identity client ID, for `universal-auth`. Prefer the env var. |
 | `auth.client_secret` | No | None | Machine identity client secret, for `universal-auth`. Prefer the env var. |
 | `auth.token` | No | None | An Infisical access token, for `token` auth. Prefer the env var. |

--- a/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
+++ b/docs/documentation/platform/pki/code-signing/pkcs11-module.mdx
@@ -10,8 +10,20 @@ The Infisical **PKCS#11 module** is a small native library (`.so`, `.dylib`, or 
   Signing on Windows with `signtool`? Use the [Windows KSP](/documentation/platform/pki/code-signing/windows-ksp) instead.
 </Note>
 
+## Before you start
+
+You authenticate as a member of the Signer, using either a **Machine Identity** or your own Infisical **access token**. To use a Machine Identity, set it up once:
+
+1. **Create a Machine Identity** and enable **[Universal Auth](/documentation/platform/identities/universal-auth)** on it, then copy its **Client ID** and **Client Secret**. The module uses these to authenticate, and you will set them in [Configuration](#configuration) below.
+2. **Add the identity to the Signer** with the Administrator or Operator role, from the Signer's **Members** tab. Auditors cannot sign.
+3. If the Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), get [active signing access](/documentation/platform/pki/code-signing/approvals#access-lifecycle) before signing (or use [Automatic Signing Access Requests](#automatic-signing-access-requests)).
+
+<Note>
+  To sign as yourself instead, use your own access token (see [Configuration](#configuration)). You still need to be a member of the Signer with the Administrator or Operator role.
+</Note>
+
 <Info>
-  Before installing the module, ensure a Product Admin has created a [Signer](/documentation/platform/pki/code-signing/signers) and added the machine identity (or user) you plan to authenticate as. If the Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), you'll also need [active access](/documentation/platform/pki/code-signing/approvals#access-lifecycle).
+  The [Signer](/documentation/platform/pki/code-signing/signers) itself is created by a Product Admin. If you do not have one yet, create it first.
 </Info>
 
 ## Installation
@@ -52,7 +64,7 @@ The output binary lands in the current directory.
 
 ## Configuration
 
-The module reads its config from `/etc/infisical/pkcs11.conf` (override the path with `INFISICAL_PKCS11_CONFIG`):
+The module reads its config from `/etc/infisical/pkcs11.conf` (override the path with `INFISICAL_CONFIG`):
 
 ```json
 {
@@ -72,10 +84,23 @@ export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="<machine-identity-client-secret>"
   Credentials can also live in the config file under `auth.client_id` and `auth.client_secret`, but environment variables are strongly recommended so secrets don't end up in version control, backups, or shared logs.
 </Note>
 
+#### Sign with an access token instead
+
+Instead of a machine identity, you can hand the module an Infisical access token directly, either your own or a machine identity's. Set `INFISICAL_TOKEN` and the module uses it as-is:
+
+```bash
+export INFISICAL_SERVER_URL="https://app.infisical.com"
+export INFISICAL_TOKEN="<your-access-token>"
+```
+
+<Warning>
+  Access tokens expire, so this access is **temporary**. The module does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off; for unattended or CI/CD signing use a machine identity, which the module re-authenticates automatically.
+</Warning>
+
 If you put the config somewhere other than `/etc/infisical/pkcs11.conf`:
 
 ```bash
-export INFISICAL_PKCS11_CONFIG=/path/to/your/pkcs11.conf
+export INFISICAL_CONFIG=/path/to/your/pkcs11.conf
 ```
 
 ### Configuration reference
@@ -83,9 +108,10 @@ export INFISICAL_PKCS11_CONFIG=/path/to/your/pkcs11.conf
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `server_url` | Yes | None | Infisical server URL. Must use `http://` (local dev) or `https://`. |
-| `auth.method` | No | `universal-auth` | Authentication method. |
-| `auth.client_id` | No | None | Machine identity client ID. Prefer the env var. |
-| `auth.client_secret` | No | None | Machine identity client secret. Prefer the env var. |
+| `auth.method` | No | `universal-auth` | Authentication method: `universal-auth` or `token`. |
+| `auth.client_id` | No | None | Machine identity client ID, for `universal-auth`. Prefer the env var. |
+| `auth.client_secret` | No | None | Machine identity client secret, for `universal-auth`. Prefer the env var. |
+| `auth.token` | No | None | An Infisical access token, for `token` auth. Prefer the env var. |
 | `tls.ca_cert_path` | No | None | Custom CA bundle path for self-hosted Infisical with a private CA. |
 | `tls.skip_verify` | No | `false` | Skip TLS verification (development only, never enable in production). |
 | `cache.token_ttl_seconds` | No | `300` | How long the auth token is cached. |
@@ -102,8 +128,9 @@ export INFISICAL_PKCS11_CONFIG=/path/to/your/pkcs11.conf
 |----------|-------------|
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | Machine identity client ID. Overrides config. |
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | Machine identity client secret. Overrides config. |
-| `INFISICAL_PKCS11_SERVER_URL` | Override `server_url`. |
-| `INFISICAL_PKCS11_CONFIG` | Path to the config file (default `/etc/infisical/pkcs11.conf`). |
+| `INFISICAL_TOKEN` | An Infisical access token (a user or machine identity token). Selects token auth; used instead of the client ID/secret. |
+| `INFISICAL_SERVER_URL` | Override `server_url`. |
+| `INFISICAL_CONFIG` | Path to the config file (default `/etc/infisical/pkcs11.conf`). |
 
 <Note>
   Environment variables always take precedence over values in the configuration file.

--- a/docs/documentation/platform/pki/code-signing/signers.mdx
+++ b/docs/documentation/platform/pki/code-signing/signers.mdx
@@ -144,7 +144,11 @@ Open the Signer and choose **Options → Edit settings**. The edit sheet walks y
 
 ## Signing with a Signer
 
-To sign with a Signer, use the [PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module) (works with `jarsigner`, `cosign`, `osslsigncode`, `signtool`, and more) or call the [Sign API](/api-reference/endpoints/code-signing/signers/sign) directly.
+To sign with a Signer, pick the integration that matches your tooling:
+
+- **[PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module)** for cross-platform tools (`jarsigner`, `cosign`, `osslsigncode`, `apksigner`, `openssl`, `gpg`, and more).
+- **[Windows KSP](/documentation/platform/pki/code-signing/windows-ksp)** for native `signtool` Authenticode signing on Windows.
+- **[Sign API](/api-reference/endpoints/code-signing/signers/sign)** to sign directly over HTTP.
 
 ## FAQ
 
@@ -173,5 +177,8 @@ To sign with a Signer, use the [PKCS#11 module](/documentation/platform/pki/code
   </Card>
   <Card title="PKCS#11 Module" icon="plug" href="/documentation/platform/pki/code-signing/pkcs11-module">
     Use jarsigner, cosign, osslsigncode, and friends with this Signer.
+  </Card>
+  <Card title="Windows KSP" icon="windows" href="/documentation/platform/pki/code-signing/windows-ksp">
+    Sign with native `signtool` on Windows.
   </Card>
 </CardGroup>

--- a/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
+++ b/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
@@ -12,24 +12,40 @@ Here is what happens when you sign a file: `signtool` hands the plug-in a short 
 
 This is the Windows version of the [PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module). Both use the same Infisical [Signers](/documentation/platform/pki/code-signing/signers) behind the scenes. Use the PKCS#11 module for cross-platform tools like `jarsigner`, `osslsigncode`, and `cosign`. Use the Windows KSP when you sign with `signtool`.
 
+## Before you start
+
+You authenticate as a member of the Signer, using either a **Machine Identity** or your own Infisical **access token**. To use a Machine Identity, set it up once in Infisical:
+
+1. **Create a Machine Identity** and enable **[Universal Auth](/documentation/platform/identities/universal-auth)** on it, then copy its **Client ID** and **Client Secret**. The provider uses these to authenticate, and you will set them in [Configuration](#configuration) below.
+2. **Add the identity to the Signer** with the Administrator or Operator role, from the Signer's **Members** tab. Auditors cannot sign.
+3. If the Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), get [active signing access](/documentation/platform/pki/code-signing/approvals#access-lifecycle) before signing.
+
+<Note>
+  To sign as yourself instead, use your own access token (see [Configuration](#configuration)). You still need to be a member of the Signer with the Administrator or Operator role.
+</Note>
+
 <Info>
-  Before you start, a Product Admin needs to have created a [Signer](/documentation/platform/pki/code-signing/signers) and added the machine identity you plan to use. If that Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), you also need [active access](/documentation/platform/pki/code-signing/approvals#access-lifecycle) to sign.
+  The [Signer](/documentation/platform/pki/code-signing/signers) itself is created by a Product Admin. If you do not have one yet, create it first.
 </Info>
 
 ## Requirements
 
 - A 64-bit Windows computer (Windows 10/11 or Windows Server 2016 and later) where you are an **Administrator**. Setting up the plug-in changes a system-wide Windows setting, which needs admin rights.
-- The 64-bit **`signtool`**, Microsoft's signing tool, which comes with the [Windows SDK](https://developer.microsoft.com/windows/downloads/windows-sdk/). The provider is 64-bit, so the 32-bit `signtool` cannot load it.
+- **`signtool`**, Microsoft's signing tool, which comes with the [Windows SDK](https://developer.microsoft.com/windows/downloads/windows-sdk/). Most setups use the 64-bit `signtool`; there is also a 32-bit build, with a matching plug-in. The two plug-in files are `infisical-ksp.dll` (64-bit) and `infisical-ksp-x86.dll` (32-bit). Use the one that matches the `signtool` you run.
 
 ## Installation
 
-Download the plug-in file, `infisical-ksp.dll`, from the [releases page](https://github.com/Infisical/infisical-ksp/releases) into the folder you are working in:
+Download the plug-in file from the [releases page](https://github.com/Infisical/infisical-ksp/releases) into the folder you are working in. Most people use the 64-bit `signtool`, so get `infisical-ksp.dll`:
 
 ```powershell
 Invoke-WebRequest `
   -Uri "https://github.com/Infisical/infisical-ksp/releases/latest/download/infisical-ksp.dll" `
   -OutFile "infisical-ksp.dll"
 ```
+
+<Note>
+  Signing with the 32-bit `signtool`? Download `infisical-ksp-x86.dll` instead, and see the 32-bit note under [Register the provider](#register-the-provider).
+</Note>
 
 ## Register the provider
 
@@ -49,13 +65,25 @@ $cur = @((Get-ItemProperty $iface).Providers)
 if ($cur -notcontains $prov) { Set-ItemProperty -Path $iface -Name Providers -Value ($cur + $prov) }
 ```
 
+<Note>
+  **Using the 32-bit `signtool`?** It loads plug-ins from `SysWOW64` instead of `System32`, so also place the 32-bit file there under the same name. The registry entries above are shared by both, so you do not repeat them: `Copy-Item .\infisical-ksp-x86.dll "$env:windir\SysWOW64\infisical-ksp.dll" -Force`.
+</Note>
+
 <Warning>
   **Restart the computer once after this step.** Windows keeps a saved list of its plug-ins and only notices a newly added one after a reboot.
 </Warning>
 
 ## Configuration
 
-The plug-in reads its settings from a file at `%ProgramData%\Infisical\config.json`. To use a different location, set the `INFISICAL_KSP_CONFIG` variable. Create the file with, at minimum, your Infisical address:
+The plug-in needs your Infisical address and the login it should use. The simplest setup is environment variables only, with no config file. This is the machine identity your admin added to the Signer:
+
+```powershell
+$env:INFISICAL_SERVER_URL = "https://app.infisical.com"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<machine-identity-client-id>"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<machine-identity-client-secret>"
+```
+
+If you prefer a config file, create one at `%ProgramData%\Infisical\config.json` (or point `INFISICAL_CONFIG` at a different location) with at least your Infisical address, and keep credentials in environment variables:
 
 ```json
 {
@@ -64,25 +92,32 @@ The plug-in reads its settings from a file at `%ProgramData%\Infisical\config.js
 }
 ```
 
-Next, give the plug-in the login it should use, as environment variables. This is the machine identity your admin added to the Signer:
-
-```powershell
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<machine-identity-client-id>"
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<machine-identity-client-secret>"
-```
-
 <Note>
   You can also put these credentials inside the config file (`auth.client_id` and `auth.client_secret`), but environment variables are safer, because the secret will not get saved into your code or log files. Whatever runs `signtool` must have these variables set: for a build pipeline that is the build job, and for hands-on use it is the same PowerShell window.
 </Note>
+
+#### Sign with an access token instead
+
+Instead of a machine identity, you can hand the plug-in an Infisical access token directly, either your own or a machine identity's. Set `INFISICAL_TOKEN` and the plug-in uses it as-is:
+
+```powershell
+$env:INFISICAL_SERVER_URL = "https://app.infisical.com"
+$env:INFISICAL_TOKEN = "<your-access-token>"
+```
+
+<Warning>
+  Access tokens expire, so this access is **temporary**. The plug-in does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off, but for unattended or CI/CD signing use a machine identity, which the plug-in re-authenticates automatically.
+</Warning>
 
 ### Configuration reference
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `server_url` | Yes | None | Your Infisical address. Must start with `http://` (local testing) or `https://`. |
-| `auth.method` | No | `universal-auth` | How to log in. Leave this as `universal-auth`. |
-| `auth.client_id` | No | None | The machine identity's client ID. Prefer the environment variable. |
-| `auth.client_secret` | No | None | The machine identity's secret. Prefer the environment variable. |
+| `auth.method` | No | `universal-auth` | How to log in: `universal-auth` (machine identity) or `token` (an access token used directly). |
+| `auth.client_id` | No | None | The machine identity's client ID, for `universal-auth`. Prefer the environment variable. |
+| `auth.client_secret` | No | None | The machine identity's secret, for `universal-auth`. Prefer the environment variable. |
+| `auth.token` | No | None | An Infisical access token, for `token` auth. Prefer the environment variable. |
 | `tls.ca_cert_path` | No | None | Path to a custom CA file, for self-hosted Infisical that uses a private CA. |
 | `tls.skip_verify` | No | `false` | Skip checking the server's TLS certificate. For local testing only, never in production. |
 | `cache.token_ttl_seconds` | No | `300` | How long to reuse a login token before logging in again. |
@@ -97,8 +132,9 @@ $env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<machine-identity-client-secret>"
 |----------|-------------|
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | The machine identity's client ID. Wins over the config file. |
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | The machine identity's secret. Wins over the config file. |
-| `INFISICAL_KSP_SERVER_URL` | Sets `server_url`. |
-| `INFISICAL_KSP_CONFIG` | Path to the config file (default `%ProgramData%\Infisical\config.json`). |
+| `INFISICAL_TOKEN` | An Infisical access token (a user or machine identity token). Selects token auth; used instead of the client ID/secret. |
+| `INFISICAL_SERVER_URL` | Sets `server_url`. |
+| `INFISICAL_CONFIG` | Path to the config file (default `%ProgramData%\Infisical\config.json`). |
 
 <Note>
   If a value is set both as an environment variable and in the config file, the environment variable wins.
@@ -106,7 +142,7 @@ $env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<machine-identity-client-secret>"
 
 ## Sign with signtool
 
-First, put the Signer's certificate on the computer. A certificate is the public half of your signing identity, so it is safe to share. Download it using the Signer's **certificate** action in Infisical, or paste it in:
+First, put the Signer's certificate on the computer. A certificate is the public half of your signing identity, so it is safe to share. In Infisical, open the Signer and use **Export certificate** to download it, or paste it in:
 
 ```powershell
 $certPem = @"
@@ -176,6 +212,7 @@ $iface = "$base\Configuration\Local\Default\00010001\KEY_STORAGE"
 $cur = @((Get-ItemProperty $iface -ErrorAction SilentlyContinue).Providers) | Where-Object { $_ -ne $prov }
 Set-ItemProperty -Path $iface -Name Providers -Value $cur
 Remove-Item "$env:windir\System32\infisical-ksp.dll" -Force -ErrorAction SilentlyContinue
+Remove-Item "$env:windir\SysWOW64\infisical-ksp.dll" -Force -ErrorAction SilentlyContinue
 ```
 
 This deletes the registry entries and removes the DLL from `System32`. Your `%ProgramData%\Infisical` config and log files are left in place; delete that folder too if you no longer need them.

--- a/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
+++ b/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
@@ -106,7 +106,7 @@ $env:INFISICAL_TOKEN = "<your-access-token>"
 ```
 
 <Warning>
-  Access tokens expire, so this access is **temporary**. The plug-in does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off, but for unattended or CI/CD signing use a machine identity, which the plug-in re-authenticates automatically.
+  JWT tokens expire, so this access is **temporary**. The plug-in does not refresh the token; once it expires, signing fails until you supply a new one. This is handy for signing as yourself or for a quick one-off, but for unattended or CI/CD signing use a machine identity with Universal Auth (client ID and secret), which the plug-in re-authenticates automatically.
 </Warning>
 
 ### Configuration reference
@@ -133,7 +133,7 @@ $env:INFISICAL_TOKEN = "<your-access-token>"
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | The machine identity's client ID. Wins over the config file. |
 | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | The machine identity's secret. Wins over the config file. |
 | `INFISICAL_TOKEN` | An Infisical access token (a user or machine identity token). Selects token auth; used instead of the client ID/secret. |
-| `INFISICAL_SERVER_URL` | Sets `server_url`. |
+| `INFISICAL_SERVER_URL` | The Infisical instance URL. Sets `server_url` (and overrides the config file). |
 | `INFISICAL_CONFIG` | Path to the config file (default `%ProgramData%\Infisical\config.json`). |
 
 <Note>

--- a/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
+++ b/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
@@ -1,0 +1,195 @@
+---
+title: "Windows KSP"
+sidebarTitle: "Windows KSP"
+description: "Sign Windows executables, DLLs, and MSIs with Microsoft signtool, using a signing key kept in Infisical."
+---
+
+Code signing adds a tamper-proof seal to your software, so Windows and your users can trust that it really came from you and has not been changed.
+
+The Infisical **Windows KSP** lets Microsoft's standard signing tool, `signtool`, add that seal to your `.exe`, `.dll`, and `.msi` files, using a signing key that stays locked inside Infisical. It is a small plug-in for Windows' built-in cryptography system, called [Cryptography API: Next Generation (CNG)](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-portal). "KSP" is short for **Key Storage Provider**, which is just Windows' name for a plug-in that supplies signing keys.
+
+Here is what happens when you sign a file: `signtool` hands the plug-in a short fingerprint of the file, the plug-in sends that fingerprint to Infisical, Infisical signs it and sends the signature back, and `signtool` attaches the signature to your file. Your private signing key never leaves Infisical.
+
+This is the Windows version of the [PKCS#11 module](/documentation/platform/pki/code-signing/pkcs11-module). Both use the same Infisical [Signers](/documentation/platform/pki/code-signing/signers) behind the scenes. Use the PKCS#11 module for cross-platform tools like `jarsigner`, `osslsigncode`, and `cosign`. Use the Windows KSP when you sign with `signtool`.
+
+<Info>
+  Before you start, a Product Admin needs to have created a [Signer](/documentation/platform/pki/code-signing/signers) and added the machine identity you plan to use. If that Signer has an [approval policy](/documentation/platform/pki/code-signing/approvals), you also need [active access](/documentation/platform/pki/code-signing/approvals#access-lifecycle) to sign.
+</Info>
+
+## Requirements
+
+- A 64-bit Windows computer (Windows 10/11 or Windows Server 2016 and later) where you are an **Administrator**. Setting up the plug-in changes a system-wide Windows setting, which needs admin rights.
+- The 64-bit **`signtool`**, Microsoft's signing tool, which comes with the [Windows SDK](https://developer.microsoft.com/windows/downloads/windows-sdk/). The provider is 64-bit, so the 32-bit `signtool` cannot load it.
+
+## Installation
+
+Download the plug-in file, `infisical-ksp.dll`, from the [releases page](https://github.com/Infisical/infisical-ksp/releases) into the folder you are working in:
+
+```powershell
+Invoke-WebRequest `
+  -Uri "https://github.com/Infisical/infisical-ksp/releases/latest/download/infisical-ksp.dll" `
+  -OutFile "infisical-ksp.dll"
+```
+
+## Register the provider
+
+Registering means telling Windows the plug-in exists, so `signtool` can find it. This copies the file into a Windows system folder and adds a few entries to the Windows registry (the database of system settings). Open **PowerShell as Administrator**, go to the folder that holds `infisical-ksp.dll`, and run:
+
+```powershell
+$prov = "Infisical Key Storage Provider"
+$base = "HKLM:\SYSTEM\CurrentControlSet\Control\Cryptography"
+Copy-Item .\infisical-ksp.dll "$env:windir\System32\infisical-ksp.dll" -Force
+New-Item -Path "$base\Providers\$prov\UM\00010001" -Force | Out-Null
+New-ItemProperty -Path "$base\Providers\$prov\UM" -Name Image -PropertyType String -Value "infisical-ksp.dll" -Force | Out-Null
+Set-ItemProperty -Path "$base\Providers\$prov\UM\00010001" -Name "(default)" -Value "CRYPT_KEY_STORAGE_INTERFACE"
+New-ItemProperty -Path "$base\Providers\$prov\UM\00010001" -Name Flags -PropertyType DWord -Value 0x10000 -Force | Out-Null
+New-ItemProperty -Path "$base\Providers\$prov\UM\00010001" -Name Functions -PropertyType MultiString -Value @("KEY_STORAGE") -Force | Out-Null
+$iface = "$base\Configuration\Local\Default\00010001\KEY_STORAGE"
+$cur = @((Get-ItemProperty $iface).Providers)
+if ($cur -notcontains $prov) { Set-ItemProperty -Path $iface -Name Providers -Value ($cur + $prov) }
+```
+
+<Warning>
+  **Restart the computer once after this step.** Windows keeps a saved list of its plug-ins and only notices a newly added one after a reboot.
+</Warning>
+
+## Configuration
+
+The plug-in reads its settings from a file at `%ProgramData%\Infisical\config.json`. To use a different location, set the `INFISICAL_KSP_CONFIG` variable. Create the file with, at minimum, your Infisical address:
+
+```json
+{
+  "server_url": "https://app.infisical.com",
+  "log_level": "info"
+}
+```
+
+Next, give the plug-in the login it should use, as environment variables. This is the machine identity your admin added to the Signer:
+
+```powershell
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<machine-identity-client-id>"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<machine-identity-client-secret>"
+```
+
+<Note>
+  You can also put these credentials inside the config file (`auth.client_id` and `auth.client_secret`), but environment variables are safer, because the secret will not get saved into your code or log files. Whatever runs `signtool` must have these variables set: for a build pipeline that is the build job, and for hands-on use it is the same PowerShell window.
+</Note>
+
+### Configuration reference
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `server_url` | Yes | None | Your Infisical address. Must start with `http://` (local testing) or `https://`. |
+| `auth.method` | No | `universal-auth` | How to log in. Leave this as `universal-auth`. |
+| `auth.client_id` | No | None | The machine identity's client ID. Prefer the environment variable. |
+| `auth.client_secret` | No | None | The machine identity's secret. Prefer the environment variable. |
+| `tls.ca_cert_path` | No | None | Path to a custom CA file, for self-hosted Infisical that uses a private CA. |
+| `tls.skip_verify` | No | `false` | Skip checking the server's TLS certificate. For local testing only, never in production. |
+| `cache.token_ttl_seconds` | No | `300` | How long to reuse a login token before logging in again. |
+| `cache.cert_ttl_seconds` | No | `3600` | How long to reuse a downloaded certificate. |
+| `cache.signer_ttl_seconds` | No | `300` | How long to reuse the list of Signers. |
+| `log_level` | No | `info` | How much detail to log: `trace`, `debug`, `info`, `warn`, or `error`. |
+| `log_file` | No | `%ProgramData%\Infisical\ksp.log` | Where to write the log. `signtool` has no window to print to, so the plug-in writes here by default. |
+
+### Environment variable reference
+
+| Variable | Description |
+|----------|-------------|
+| `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | The machine identity's client ID. Wins over the config file. |
+| `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | The machine identity's secret. Wins over the config file. |
+| `INFISICAL_KSP_SERVER_URL` | Sets `server_url`. |
+| `INFISICAL_KSP_CONFIG` | Path to the config file (default `%ProgramData%\Infisical\config.json`). |
+
+<Note>
+  If a value is set both as an environment variable and in the config file, the environment variable wins.
+</Note>
+
+## Sign with signtool
+
+First, put the Signer's certificate on the computer. A certificate is the public half of your signing identity, so it is safe to share. Download it using the Signer's **certificate** action in Infisical, or paste it in:
+
+```powershell
+$certPem = @"
+-----BEGIN CERTIFICATE-----
+...paste the certificate here...
+-----END CERTIFICATE-----
+"@
+Set-Content -Path "$env:ProgramData\Infisical\demo-signer.cer" -Value $certPem -Encoding ascii
+```
+
+Then sign your file. `/kc` picks the Signer by name, and `/f` points to the certificate file you just saved:
+
+```powershell
+signtool sign /fd SHA256 `
+  /f "$env:ProgramData\Infisical\demo-signer.cer" `
+  /csp "Infisical Key Storage Provider" /kc "demo-signer" `
+  MyApp.exe
+```
+
+<Note>
+  Add a timestamp so the signature stays valid even after the certificate expires (recommended for anything you ship). Put `/tr <timestamp-url> /td SHA256` before the file name, using any [RFC 3161](https://www.rfc-editor.org/rfc/rfc3161) timestamp service.
+</Note>
+
+### Verify
+
+Check that the file is signed:
+
+```powershell
+signtool verify /pa /v MyApp.exe
+```
+
+<Note>
+  If your certificate comes from your own private CA (instead of one Windows already trusts), `signtool verify` shows the warning `A certificate chain could not be built to a trusted root authority` (`0x800B010A`). The signature is still valid; Windows just does not recognize who issued the certificate. To clear the warning, add your CA to the computer's Trusted Root store.
+</Note>
+
+## Troubleshooting
+
+The plug-in writes a log to `%ProgramData%\Infisical\ksp.log`. `signtool` itself only shows a short error code, so this log is the best place to see what actually went wrong and how to fix it. For more detail, set `log_level` to `debug`.
+
+<AccordionGroup>
+  <Accordion title="signtool says 'Invalid provider specified' right after setup">
+    Windows has not picked up the new plug-in yet. **Restart the computer once** and try again.
+  </Accordion>
+  <Accordion title="Access denied (HTTP 403 in the log)">
+    Your identity is not allowed to sign yet. Either it needs approved access to sign, or it must be a member of the Signer with the Administrator or Operator role (Auditors cannot sign). Fix the access (see [Approvals](/documentation/platform/pki/code-signing/approvals)), then run the same command again.
+  </Accordion>
+  <Accordion title="HTTP 401 in the log">
+    The login is missing or wrong. Set `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` and `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET`, and check that the identity is a member of the Signer.
+  </Accordion>
+  <Accordion title="Cannot reach Infisical / connection refused">
+    A network or TLS problem. Check that `server_url` is correct and that the computer can reach it. For self-hosted Infisical with a private CA, set `tls.ca_cert_path` to the CA file.
+  </Accordion>
+  <Accordion title="'signtool' is not recognized">
+    `signtool` is not installed or is not on your `PATH`. Install the Windows SDK, or open a Developer Command Prompt, so Windows can find `signtool`.
+  </Accordion>
+</AccordionGroup>
+
+## Uninstall
+
+To remove the provider, run this in an **Administrator** PowerShell, then **restart the computer** (Windows keeps the provider in its cached list until a reboot):
+
+```powershell
+$prov = "Infisical Key Storage Provider"
+$base = "HKLM:\SYSTEM\CurrentControlSet\Control\Cryptography"
+Remove-Item "$base\Providers\$prov" -Recurse -Force -ErrorAction SilentlyContinue
+$iface = "$base\Configuration\Local\Default\00010001\KEY_STORAGE"
+$cur = @((Get-ItemProperty $iface -ErrorAction SilentlyContinue).Providers) | Where-Object { $_ -ne $prov }
+Set-ItemProperty -Path $iface -Name Providers -Value $cur
+Remove-Item "$env:windir\System32\infisical-ksp.dll" -Force -ErrorAction SilentlyContinue
+```
+
+This deletes the registry entries and removes the DLL from `System32`. Your `%ProgramData%\Infisical` config and log files are left in place; delete that folder too if you no longer need them.
+
+## What's next
+
+<CardGroup cols={3}>
+  <Card title="Cross-platform signing" icon="terminal" href="/documentation/platform/pki/code-signing/pkcs11-module">
+    The PKCS#11 module for jarsigner, osslsigncode, cosign, and more.
+  </Card>
+  <Card title="Manage Signers" icon="signature" href="/documentation/platform/pki/code-signing/signers">
+    Create and configure Signers.
+  </Card>
+  <Card title="Approvals" icon="shield-check" href="/documentation/platform/pki/code-signing/approvals">
+    Require review before signing.
+  </Card>
+</CardGroup>

--- a/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
+++ b/docs/documentation/platform/pki/code-signing/windows-ksp.mdx
@@ -114,7 +114,7 @@ $env:INFISICAL_TOKEN = "<your-access-token>"
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `server_url` | Yes | None | Your Infisical address. Must start with `http://` (local testing) or `https://`. |
-| `auth.method` | No | `universal-auth` | How to log in: `universal-auth` (machine identity) or `token` (an access token used directly). |
+| `auth.method` | No | inferred | How to log in: `universal-auth` (machine identity) or `token` (an access token used directly). Inferred from the credentials when unset (a token means `token`, otherwise `universal-auth`). |
 | `auth.client_id` | No | None | The machine identity's client ID, for `universal-auth`. Prefer the environment variable. |
 | `auth.client_secret` | No | None | The machine identity's secret, for `universal-auth`. Prefer the environment variable. |
 | `auth.token` | No | None | An Infisical access token, for `token` auth. Prefer the environment variable. |

--- a/docs/documentation/platform/pki/guides/code-signing/apksigner.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/apksigner.mdx
@@ -22,7 +22,7 @@ Sign Android APK and Android App Bundle (AAB) files using `apksigner` with the I
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -124,7 +124,7 @@ Example for a Gradle-based Android project in CI:
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 
 # Build unsigned APK
 ./gradlew assembleRelease

--- a/docs/documentation/platform/pki/guides/code-signing/cosign.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/cosign.mdx
@@ -23,7 +23,7 @@ Sign OCI container images using `cosign` (from the Sigstore project) with the In
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -141,7 +141,7 @@ Example for a container build pipeline:
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 export COSIGN_PKCS11_MODULE_PATH="/usr/local/lib/libinfisical-pkcs11.so"
 
 # Build and push the image

--- a/docs/documentation/platform/pki/guides/code-signing/gpg.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/gpg.mdx
@@ -23,7 +23,7 @@ Use GnuPG with the Infisical PKCS#11 module via `gnupg-pkcs11-scd` to sign git c
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -203,7 +203,7 @@ For CI pipelines, configure the GPG agent in non-interactive mode. You need to c
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 
 # Set up ephemeral GPG home directory
 export GNUPGHOME=$(mktemp -d)

--- a/docs/documentation/platform/pki/guides/code-signing/jarsigner.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/jarsigner.mdx
@@ -22,7 +22,7 @@ Sign Java JAR files using `jarsigner` with the Infisical PKCS#11 module. The mod
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -114,7 +114,7 @@ For automated signing in CI/CD pipelines, use environment variables for credenti
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 
 jarsigner \
   -keystore NONE \

--- a/docs/documentation/platform/pki/guides/code-signing/openssl.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/openssl.mdx
@@ -23,7 +23,7 @@ Use OpenSSL with the Infisical PKCS#11 module via the `libp11` engine for genera
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -205,7 +205,7 @@ openssl cms -sign \
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 export OPENSSL_CONF="/path/to/infisical-openssl.cnf"
 
 # Sign release artifacts

--- a/docs/documentation/platform/pki/guides/code-signing/osslsigncode.mdx
+++ b/docs/documentation/platform/pki/guides/code-signing/osslsigncode.mdx
@@ -22,7 +22,7 @@ Sign Windows Authenticode artifacts using `osslsigncode` with the Infisical PKCS
 
 Configure the Infisical PKCS#11 module with your machine identity credentials. Without this, the signing commands below fail with an auth error.
 
-Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_PKCS11_CONFIG` to point elsewhere):
+Create `/etc/infisical/pkcs11.conf` (or set `INFISICAL_CONFIG` to point elsewhere):
 
 ```yaml
 auth:
@@ -146,7 +146,7 @@ Signature verification: ok
 ```bash
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="${INFISICAL_CLIENT_ID}"
 export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}"
-export INFISICAL_PKCS11_CONFIG="/path/to/pkcs11.conf"
+export INFISICAL_CONFIG="/path/to/pkcs11.conf"
 
 osslsigncode sign \
   -pkcs11module /usr/local/lib/libinfisical-pkcs11.so \

--- a/frontend/src/pages/cert-manager/SignerDetailPage/SignerDetailPage.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/SignerDetailPage.tsx
@@ -271,7 +271,11 @@ export const SignerDetailPage = () => {
               </TabsList>
 
               <TabsContent value="activity" className="pt-2">
-                <SigningOperationsTable signerId={signerId} projectId={currentProject.id} />
+                <SigningOperationsTable
+                  signer={signer}
+                  signerId={signerId}
+                  projectId={currentProject.id}
+                />
               </TabsContent>
               <TabsContent value="approvals" className="pt-2">
                 <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,5fr)]">

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
@@ -1,0 +1,436 @@
+import { ReactNode, useEffect, useState } from "react";
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  CopyIcon,
+  FileSignatureIcon,
+  MonitorIcon,
+  TerminalIcon
+} from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Badge,
+  Button,
+  DocumentationLinkBadge,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Stepper,
+  StepperList,
+  StepperStep,
+  Tabs,
+  TabsList,
+  TabsTrigger
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+import {
+  SignerPermissionActions,
+  SignerPermissionSub,
+  useSignerPermission
+} from "@app/context/SignerPermissionContext";
+import { TSigner, useExportSignerCertificate } from "@app/hooks/api/signers";
+
+import { PkiDocsUrls } from "../../../pki-docs-urls";
+import {
+  jarsignerConfigSnippet,
+  kspCertSnippet,
+  kspConfigureSnippet,
+  kspDownloadSnippet,
+  kspRegisterSnippet,
+  kspSignSnippet,
+  OS,
+  pkcs11ConfigureSnippet,
+  pkcs11InstallSnippet,
+  pkcs11SignSnippet,
+  Pkcs11Tool,
+  Snippet
+} from "./snippets";
+
+type Props = {
+  signer: TSigner;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type Method = "pkcs11" | "ksp";
+
+const CommandBlock = ({ snippet }: { snippet: Snippet }) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet.code);
+      setCopied(true);
+    } catch {
+      createNotification({ type: "error", text: "Could not copy to clipboard" });
+    }
+  };
+
+  useEffect(() => {
+    if (!copied) return undefined;
+    const timer = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-background">
+      <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+        <span className="font-mono text-xs text-muted">{snippet.language}</span>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="flex items-center gap-1 text-xs text-accent transition hover:text-foreground"
+        >
+          {copied ? <CheckIcon className="size-3" /> : <CopyIcon className="size-3" />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-3 font-mono text-xs leading-relaxed text-foreground">
+        {snippet.code}
+      </pre>
+    </div>
+  );
+};
+
+const MethodCard = ({
+  icon,
+  title,
+  description,
+  platforms,
+  isSelected,
+  onSelect
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  platforms: string[];
+  isSelected: boolean;
+  onSelect: () => void;
+}) => (
+  <button
+    type="button"
+    aria-pressed={isSelected}
+    onClick={onSelect}
+    className={cn(
+      "flex flex-col gap-3 rounded-lg border p-4 text-left transition",
+      isSelected
+        ? "border-project bg-project/10 ring-1 ring-project"
+        : "border-border bg-card hover:bg-container-hover"
+    )}
+  >
+    <div className="flex items-start justify-between">
+      <div className="flex size-9 items-center justify-center rounded-md bg-container text-foreground">
+        {icon}
+      </div>
+      {isSelected && (
+        <span className="flex size-5 items-center justify-center rounded-full bg-project/15 text-project">
+          <CheckIcon className="size-3" />
+        </span>
+      )}
+    </div>
+    <div>
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-sm text-accent">{description}</p>
+    </div>
+    <div className="flex flex-wrap gap-1.5">
+      {platforms.map((p) => (
+        <Badge key={p} variant="neutral">
+          {p}
+        </Badge>
+      ))}
+    </div>
+  </button>
+);
+
+const SubStep = ({
+  index,
+  title,
+  description,
+  children
+}: {
+  index: number;
+  title: string;
+  description: string;
+  children: ReactNode;
+}) => (
+  <div className="flex gap-3">
+    <div className="flex size-6 flex-none items-center justify-center rounded-full border border-project/40 text-xs font-medium text-project">
+      {index}
+    </div>
+    <div className="min-w-0 flex-1 space-y-2 pb-2">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="text-sm text-accent">{description}</p>
+      {children}
+    </div>
+  </div>
+);
+
+export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) => {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [method, setMethod] = useState<Method>("ksp");
+  const [os, setOs] = useState<OS>("linux");
+  const [tool, setTool] = useState<Pkcs11Tool>("jarsigner");
+
+  useEffect(() => {
+    if (isOpen) setStep(1);
+  }, [isOpen]);
+
+  const { name, keyAlgorithm } = signer;
+  const serverUrl = window.location.origin;
+
+  const { permission } = useSignerPermission();
+  const canExportCert =
+    Boolean(signer.certificateId) &&
+    permission.can(SignerPermissionActions.ExportCertificate, SignerPermissionSub.Signer);
+
+  const { data: signerCert } = useExportSignerCertificate(
+    signer.id,
+    isOpen && method === "ksp" && canExportCert
+  );
+
+  const rightDocHref =
+    method === "ksp" ? PkiDocsUrls.codeSigning.windowsKsp : PkiDocsUrls.codeSigning.pkcs11Module;
+
+  const rightPanel =
+    step === 1 ? (
+      <>
+        <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
+        <p className="mt-2 text-sm leading-relaxed text-muted">
+          Pick the tool you already sign with.{" "}
+          <span className="font-medium">Standard signing tools</span> like jarsigner, osslsigncode,
+          and cosign work on Linux, macOS, and Windows.{" "}
+          <span className="font-medium">Windows signtool</span> is native Authenticode signing on
+          Windows. Either way, the private key stays in Infisical.
+        </p>
+      </>
+    ) : (
+      <>
+        <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
+        {method === "ksp" ? (
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            Download and register the Key Storage Provider once per machine, set your Machine
+            Identity credentials, then sign with <span className="font-mono text-xs">signtool</span>
+            . The Signer is selected by name with <span className="font-mono text-xs">/kc</span>.
+          </p>
+        ) : (
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            Download the module, point a config file at it, and set your Machine Identity
+            credentials. Then run your tool against this Signer by name:{" "}
+            <span className="font-mono text-xs">{name}</span>.
+          </p>
+        )}
+      </>
+    );
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-screen flex-col gap-0 p-0 sm:max-w-5xl">
+        <SheetHeader className="flex-row items-center gap-3 border-b">
+          <div className="flex size-10 flex-none items-center justify-center rounded-md border border-project/40 bg-project/10 text-project">
+            <FileSignatureIcon className="size-5" />
+          </div>
+          <div className="flex-1">
+            <SheetTitle className="flex items-center gap-2 text-lg">
+              How to sign with {name}
+              <DocumentationLinkBadge href={PkiDocsUrls.codeSigning.connect} />
+            </SheetTitle>
+            <SheetDescription>
+              Set up your machine to sign with this Signer using the tool you already use.
+            </SheetDescription>
+          </div>
+        </SheetHeader>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <aside className="flex w-60 shrink-0 flex-col border-r border-border px-5 py-6">
+            <p className="mb-5 text-[11px] font-medium tracking-wider text-muted uppercase">
+              Setup steps
+            </p>
+            <Stepper
+              activeStep={step - 1}
+              orientation="vertical"
+              onStepChange={(i) => {
+                if (i < step - 1) setStep((i + 1) as 1 | 2);
+              }}
+            >
+              <StepperList>
+                <StepperStep index={0} title="Choose a tool" description="What you sign with" />
+                <StepperStep index={1} title="Install & sign" description="Set up your machine" />
+              </StepperList>
+            </Stepper>
+          </aside>
+
+          <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-8 py-6">
+            {step === 1 ? (
+              <>
+                <h2 className="text-lg font-semibold text-foreground">Choose your signing tool</h2>
+                <p className="mt-1 mb-6 text-sm text-muted">
+                  Pick the tool you already sign with. Infisical plugs into it, so your build keeps
+                  working the same way.
+                </p>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <MethodCard
+                    icon={<TerminalIcon className="size-5" />}
+                    title="Standard signing tools"
+                    description="jarsigner, osslsigncode, cosign, and other common tools. Uses the Infisical PKCS#11 module."
+                    platforms={["Linux", "macOS", "Windows"]}
+                    isSelected={method === "pkcs11"}
+                    onSelect={() => setMethod("pkcs11")}
+                  />
+                  <MethodCard
+                    icon={<MonitorIcon className="size-5" />}
+                    title="Windows signtool"
+                    description="Native Windows Authenticode signing with Microsoft signtool. Uses the Infisical Key Storage Provider."
+                    platforms={["Windows"]}
+                    isSelected={method === "ksp"}
+                    onSelect={() => setMethod("ksp")}
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="text-lg font-semibold text-foreground">Install &amp; sign</h2>
+                <p className="mt-1 mb-6 text-sm text-muted">
+                  {method === "ksp"
+                    ? `Set up Microsoft signtool via the Infisical Key Storage Provider to sign with ${name}.`
+                    : `Set up jarsigner, osslsigncode, or any PKCS#11-compatible tool to sign with ${name}.`}
+                </p>
+
+                {method === "ksp" ? (
+                  <div className="space-y-5">
+                    <SubStep
+                      index={1}
+                      title="Download the provider"
+                      description="Download the Key Storage Provider DLL (Windows x86_64)."
+                    >
+                      <CommandBlock snippet={kspDownloadSnippet()} />
+                    </SubStep>
+                    <SubStep
+                      index={2}
+                      title="Register with Windows"
+                      description="Registers the provider (a few registry entries) and copies the DLL into System32. Run as Administrator, once per machine, then reboot so Windows loads it. Signing also needs signtool, included with the Windows SDK."
+                    >
+                      <CommandBlock snippet={kspRegisterSnippet()} />
+                    </SubStep>
+                    <SubStep
+                      index={3}
+                      title="Configure"
+                      description="Create the config file and set your Machine Identity credentials."
+                    >
+                      <CommandBlock snippet={kspConfigureSnippet(serverUrl)} />
+                    </SubStep>
+                    <SubStep
+                      index={4}
+                      title="Add the Signer's certificate"
+                      description="This Signer's certificate is filled in below. Run it to write the file; signtool reads it with /f."
+                    >
+                      {canExportCert ? (
+                        <CommandBlock snippet={kspCertSnippet(name, signerCert?.certificatePem)} />
+                      ) : (
+                        <p className="text-sm text-accent">
+                          You need the Export Certificate permission to view this certificate. Ask a
+                          Signer Administrator to export it for you.
+                        </p>
+                      )}
+                    </SubStep>
+                    <SubStep
+                      index={5}
+                      title="Sign"
+                      description="The Signer is selected by name with /kc."
+                    >
+                      <CommandBlock snippet={kspSignSnippet(name)} />
+                    </SubStep>
+                  </div>
+                ) : (
+                  <div className="space-y-5">
+                    <SubStep
+                      index={1}
+                      title="Install the module"
+                      description="Download and extract the module for your platform from the GitHub releases page. It unpacks to libinfisical-pkcs11-<os>-<arch>; use that path wherever a module path is needed below."
+                    >
+                      <Tabs value={os} onValueChange={(v) => setOs(v as OS)}>
+                        <TabsList variant="filled">
+                          <TabsTrigger value="linux">Linux</TabsTrigger>
+                          <TabsTrigger value="macos">macOS</TabsTrigger>
+                          <TabsTrigger value="windows">Windows</TabsTrigger>
+                        </TabsList>
+                      </Tabs>
+                      <CommandBlock snippet={pkcs11InstallSnippet(os)} />
+                    </SubStep>
+                    <SubStep
+                      index={2}
+                      title="Configure"
+                      description="Create a config file and set your Machine Identity credentials as environment variables."
+                    >
+                      <CommandBlock snippet={pkcs11ConfigureSnippet(os, serverUrl)} />
+                    </SubStep>
+                    <SubStep
+                      index={3}
+                      title="Sign"
+                      description="Sign with your tool. The Signer is selected by its name."
+                    >
+                      <Tabs value={tool} onValueChange={(v) => setTool(v as Pkcs11Tool)}>
+                        <TabsList variant="filled">
+                          <TabsTrigger value="jarsigner">jarsigner</TabsTrigger>
+                          <TabsTrigger value="osslsigncode">osslsigncode</TabsTrigger>
+                          <TabsTrigger value="pkcs11-tool">pkcs11-tool</TabsTrigger>
+                        </TabsList>
+                      </Tabs>
+                      {tool === "jarsigner" && (
+                        <>
+                          <p className="text-xs text-muted">
+                            First, point a SunPKCS11 config at the module:
+                          </p>
+                          <CommandBlock snippet={jarsignerConfigSnippet} />
+                        </>
+                      )}
+                      <CommandBlock snippet={pkcs11SignSnippet(tool, name, keyAlgorithm)} />
+                    </SubStep>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          <aside className="hidden w-80 shrink-0 flex-col gap-4 overflow-y-auto border-l border-border px-6 py-6 lg:flex">
+            <div className="mb-auto">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[11px] font-medium tracking-wider text-muted uppercase">
+                  Step {step} · {step === 1 ? "Choose a tool" : "Install & sign"}
+                </p>
+                <DocumentationLinkBadge
+                  href={step === 1 ? PkiDocsUrls.codeSigning.connect : rightDocHref}
+                />
+              </div>
+              {rightPanel}
+            </div>
+          </aside>
+        </div>
+
+        <SheetFooter className="flex-row items-center justify-between border-t">
+          <span className="text-sm text-muted">Step {step} of 2</span>
+          <div className="flex gap-2">
+            {step === 2 && (
+              <Button variant="outline" onClick={() => setStep(1)}>
+                <ChevronLeftIcon />
+                Back
+              </Button>
+            )}
+            {step === 1 ? (
+              <Button variant="project" onClick={() => setStep(2)}>
+                Continue
+              </Button>
+            ) : (
+              <Button variant="project" onClick={() => onOpenChange(false)}>
+                Done
+              </Button>
+            )}
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
@@ -384,7 +384,7 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                           <p className="text-xs text-muted">
                             First, point a SunPKCS11 config at the module:
                           </p>
-                          <CommandBlock snippet={jarsignerConfigSnippet} />
+                          <CommandBlock snippet={jarsignerConfigSnippet(os)} />
                         </>
                       )}
                       <CommandBlock snippet={pkcs11SignSnippet(tool, name, keyAlgorithm)} />

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
@@ -4,6 +4,8 @@ import {
   ChevronLeftIcon,
   CopyIcon,
   FileSignatureIcon,
+  HardDriveIcon,
+  KeyRoundIcon,
   MonitorIcon,
   TerminalIcon
 } from "lucide-react";
@@ -32,6 +34,7 @@ import {
   SignerPermissionSub,
   useSignerPermission
 } from "@app/context/SignerPermissionContext";
+import { getAuthToken } from "@app/hooks/api/reactQuery";
 import { TSigner, useExportSignerCertificate } from "@app/hooks/api/signers";
 
 import { PkiDocsUrls } from "../../../pki-docs-urls";
@@ -47,6 +50,7 @@ import {
   pkcs11InstallSnippet,
   pkcs11SignSnippet,
   Pkcs11Tool,
+  SignerAuth,
   Snippet
 } from "./snippets";
 
@@ -57,6 +61,13 @@ type Props = {
 };
 
 type Method = "pkcs11" | "ksp";
+type AuthMethod = "token" | "machine-identity";
+
+const STEP_TITLES: Record<1 | 2 | 3, string> = {
+  1: "Choose a tool",
+  2: "Authentication",
+  3: "Install & sign"
+};
 
 const CommandBlock = ({ snippet }: { snippet: Snippet }) => {
   const [copied, setCopied] = useState(false);
@@ -169,11 +180,46 @@ const SubStep = ({
   </div>
 );
 
+const AuthOptionCard = ({
+  icon,
+  title,
+  description,
+  isSelected,
+  onSelect
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}) => (
+  <button
+    type="button"
+    aria-pressed={isSelected}
+    onClick={onSelect}
+    className={cn(
+      "flex items-start gap-3 rounded-lg border p-4 text-left transition",
+      isSelected
+        ? "border-project bg-project/10 ring-1 ring-project"
+        : "border-border bg-card hover:bg-container-hover"
+    )}
+  >
+    <div className="flex size-8 flex-none items-center justify-center rounded-md bg-container text-foreground">
+      {icon}
+    </div>
+    <div className="min-w-0">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-sm text-accent">{description}</p>
+    </div>
+  </button>
+);
+
 export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) => {
-  const [step, setStep] = useState<1 | 2>(1);
+  const [step, setStep] = useState<1 | 2 | 3>(1);
   const [method, setMethod] = useState<Method>("ksp");
   const [os, setOs] = useState<OS>("linux");
   const [tool, setTool] = useState<Pkcs11Tool>("jarsigner");
+  const [authMethod, setAuthMethod] = useState<AuthMethod>("token");
 
   useEffect(() => {
     if (isOpen) setStep(1);
@@ -192,39 +238,74 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
     isOpen && method === "ksp" && canExportCert
   );
 
+  const auth: SignerAuth =
+    authMethod === "token"
+      ? { mode: "token", token: getAuthToken() || "<your-access-token>" }
+      : { mode: "machine-identity" };
+
+  const authNote =
+    authMethod === "token" ? (
+      <p className="mt-2 text-xs text-yellow-600">
+        This uses your personal access token, which expires, so this setup is temporary. For
+        unattended or CI/CD signing, use a machine identity instead.
+      </p>
+    ) : (
+      <p className="mt-2 text-xs text-accent">
+        Replace <span className="font-mono">&lt;client-id&gt;</span> and{" "}
+        <span className="font-mono">&lt;client-secret&gt;</span> with your Machine Identity&apos;s
+        Universal Auth credentials.
+      </p>
+    );
+
   const rightDocHref =
     method === "ksp" ? PkiDocsUrls.codeSigning.windowsKsp : PkiDocsUrls.codeSigning.pkcs11Module;
 
-  const rightPanel =
-    step === 1 ? (
-      <>
-        <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
-        <p className="mt-2 text-sm leading-relaxed text-muted">
-          Pick the tool you already sign with.{" "}
-          <span className="font-medium">Standard signing tools</span> like jarsigner, osslsigncode,
-          and cosign work on Linux, macOS, and Windows.{" "}
-          <span className="font-medium">Windows signtool</span> is native Authenticode signing on
-          Windows. Either way, the private key stays in Infisical.
-        </p>
-      </>
-    ) : (
+  const renderRightPanel = () => {
+    if (step === 1) {
+      return (
+        <>
+          <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            Pick the tool you already sign with.{" "}
+            <span className="font-medium">Standard signing tools</span> like jarsigner,
+            osslsigncode, and cosign work on Linux, macOS, and Windows.{" "}
+            <span className="font-medium">Windows signtool</span> is native Authenticode signing on
+            Windows. Either way, the private key stays in Infisical.
+          </p>
+        </>
+      );
+    }
+    if (step === 2) {
+      return (
+        <>
+          <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            Choose how the signing machine logs in to Infisical.{" "}
+            <span className="font-medium">Your own access token</span> is quickest, but it is
+            temporary because tokens expire. A <span className="font-medium">machine identity</span>{" "}
+            is best for unattended or CI/CD signing.
+          </p>
+        </>
+      );
+    }
+    return (
       <>
         <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
         {method === "ksp" ? (
           <p className="mt-2 text-sm leading-relaxed text-muted">
-            Download and register the Key Storage Provider once per machine, set your Machine
-            Identity credentials, then sign with <span className="font-mono text-xs">signtool</span>
-            . The Signer is selected by name with <span className="font-mono text-xs">/kc</span>.
+            Download and register the Key Storage Provider once per machine, set your credentials,
+            then sign with <span className="font-mono text-xs">signtool</span>. The Signer is
+            selected by name with <span className="font-mono text-xs">/kc</span>.
           </p>
         ) : (
           <p className="mt-2 text-sm leading-relaxed text-muted">
-            Download the module, point a config file at it, and set your Machine Identity
-            credentials. Then run your tool against this Signer by name:{" "}
-            <span className="font-mono text-xs">{name}</span>.
+            Download the module, point a config file at it, and set your credentials. Then run your
+            tool against this Signer by name: <span className="font-mono text-xs">{name}</span>.
           </p>
         )}
       </>
     );
+  };
 
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
@@ -235,11 +316,12 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
           </div>
           <div className="flex-1">
             <SheetTitle className="flex items-center gap-2 text-lg">
-              How to sign with {name}
+              Set up signing for {name}
               <DocumentationLinkBadge href={PkiDocsUrls.codeSigning.connect} />
             </SheetTitle>
             <SheetDescription>
-              Set up your machine to sign with this Signer using the tool you already use.
+              Sign with this Signer using the tool you already use. Your signing key never leaves
+              Infisical.
             </SheetDescription>
           </div>
         </SheetHeader>
@@ -253,18 +335,19 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
               activeStep={step - 1}
               orientation="vertical"
               onStepChange={(i) => {
-                if (i < step - 1) setStep((i + 1) as 1 | 2);
+                if (i < step - 1) setStep((i + 1) as 1 | 2 | 3);
               }}
             >
               <StepperList>
                 <StepperStep index={0} title="Choose a tool" description="What you sign with" />
-                <StepperStep index={1} title="Install & sign" description="Set up your machine" />
+                <StepperStep index={1} title="Authentication" description="How you log in" />
+                <StepperStep index={2} title="Install & sign" description="Set up your machine" />
               </StepperList>
             </Stepper>
           </aside>
 
           <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-8 py-6">
-            {step === 1 ? (
+            {step === 1 && (
               <>
                 <h2 className="text-lg font-semibold text-foreground">Choose your signing tool</h2>
                 <p className="mt-1 mb-6 text-sm text-muted">
@@ -290,13 +373,40 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                   />
                 </div>
               </>
-            ) : (
+            )}
+            {step === 2 && (
+              <>
+                <h2 className="text-lg font-semibold text-foreground">
+                  Choose how to authenticate
+                </h2>
+                <p className="mt-1 mb-6 text-sm text-muted">
+                  Pick how the machine running the signing tool proves who it is to Infisical.
+                </p>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <AuthOptionCard
+                    icon={<KeyRoundIcon className="size-4" />}
+                    title="Use my credentials"
+                    description="Sign as yourself with your own Infisical access token. Quickest to set up, but temporary because the token expires."
+                    isSelected={authMethod === "token"}
+                    onSelect={() => setAuthMethod("token")}
+                  />
+                  <AuthOptionCard
+                    icon={<HardDriveIcon className="size-4" />}
+                    title="Use a machine identity"
+                    description="Authenticate with a Machine Identity's Universal Auth credentials. Best for CI/CD and unattended signing."
+                    isSelected={authMethod === "machine-identity"}
+                    onSelect={() => setAuthMethod("machine-identity")}
+                  />
+                </div>
+              </>
+            )}
+            {step === 3 && (
               <>
                 <h2 className="text-lg font-semibold text-foreground">Install &amp; sign</h2>
                 <p className="mt-1 mb-6 text-sm text-muted">
                   {method === "ksp"
-                    ? `Set up Microsoft signtool via the Infisical Key Storage Provider to sign with ${name}.`
-                    : `Set up jarsigner, osslsigncode, or any PKCS#11-compatible tool to sign with ${name}.`}
+                    ? "Install the Infisical Key Storage Provider, then sign with Microsoft signtool."
+                    : "Install the Infisical PKCS#11 module, then sign with jarsigner, osslsigncode, or any PKCS#11 tool."}
                 </p>
 
                 {method === "ksp" ? (
@@ -304,28 +414,33 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                     <SubStep
                       index={1}
                       title="Download the provider"
-                      description="Download the Key Storage Provider DLL (Windows x86_64)."
+                      description="Download the Key Storage Provider DLL for 64-bit Windows."
                     >
                       <CommandBlock snippet={kspDownloadSnippet()} />
                     </SubStep>
                     <SubStep
                       index={2}
                       title="Register with Windows"
-                      description="Registers the provider (a few registry entries) and copies the DLL into System32. Run as Administrator, once per machine, then reboot so Windows loads it. Signing also needs signtool, included with the Windows SDK."
+                      description="Copies the DLL into System32 and adds the registry entries. Run as Administrator once per machine, then reboot so Windows loads it. Signing also needs signtool, from the Windows SDK."
                     >
                       <CommandBlock snippet={kspRegisterSnippet()} />
                     </SubStep>
                     <SubStep
                       index={3}
                       title="Configure"
-                      description="Create the config file and set your Machine Identity credentials."
+                      description={
+                        authMethod === "token"
+                          ? "Point the provider at Infisical with your access token."
+                          : "Create the config file and set the Machine Identity credentials."
+                      }
                     >
-                      <CommandBlock snippet={kspConfigureSnippet(serverUrl)} />
+                      <CommandBlock snippet={kspConfigureSnippet(serverUrl, auth)} />
+                      {authNote}
                     </SubStep>
                     <SubStep
                       index={4}
                       title="Add the Signer's certificate"
-                      description="This Signer's certificate is filled in below. Run it to write the file; signtool reads it with /f."
+                      description="The certificate is filled in below. Run this to save it; signtool reads it with /f."
                     >
                       {canExportCert ? (
                         <CommandBlock snippet={kspCertSnippet(name, signerCert?.certificatePem)} />
@@ -363,9 +478,14 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                     <SubStep
                       index={2}
                       title="Configure"
-                      description="Create a config file and set your Machine Identity credentials as environment variables."
+                      description={
+                        authMethod === "token"
+                          ? "Create a config file and set your access token as an environment variable."
+                          : "Create a config file and set the Machine Identity credentials as environment variables."
+                      }
                     >
-                      <CommandBlock snippet={pkcs11ConfigureSnippet(os, serverUrl)} />
+                      <CommandBlock snippet={pkcs11ConfigureSnippet(os, serverUrl, auth)} />
+                      {authNote}
                     </SubStep>
                     <SubStep
                       index={3}
@@ -399,28 +519,28 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
             <div className="mb-auto">
               <div className="flex items-center justify-between gap-2">
                 <p className="text-[11px] font-medium tracking-wider text-muted uppercase">
-                  Step {step} · {step === 1 ? "Choose a tool" : "Install & sign"}
+                  Step {step} · {STEP_TITLES[step]}
                 </p>
                 <DocumentationLinkBadge
-                  href={step === 1 ? PkiDocsUrls.codeSigning.connect : rightDocHref}
+                  href={step === 3 ? rightDocHref : PkiDocsUrls.codeSigning.connect}
                 />
               </div>
-              {rightPanel}
+              {renderRightPanel()}
             </div>
           </aside>
         </div>
 
         <SheetFooter className="flex-row items-center justify-between border-t">
-          <span className="text-sm text-muted">Step {step} of 2</span>
+          <span className="text-sm text-muted">Step {step} of 3</span>
           <div className="flex gap-2">
-            {step === 2 && (
-              <Button variant="outline" onClick={() => setStep(1)}>
+            {step > 1 && (
+              <Button variant="outline" onClick={() => setStep((step - 1) as 1 | 2 | 3)}>
                 <ChevronLeftIcon />
                 Back
               </Button>
             )}
-            {step === 1 ? (
-              <Button variant="project" onClick={() => setStep(2)}>
+            {step < 3 ? (
+              <Button variant="project" onClick={() => setStep((step + 1) as 1 | 2 | 3)}>
                 Continue
               </Button>
             ) : (

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/ConnectToSignerDrawer.tsx
@@ -60,8 +60,15 @@ type Props = {
   onOpenChange: (open: boolean) => void;
 };
 
-type Method = "pkcs11" | "ksp";
-type AuthMethod = "token" | "machine-identity";
+enum Method {
+  Pkcs11 = "pkcs11",
+  Ksp = "ksp"
+}
+
+enum AuthMethod {
+  Token = "token",
+  MachineIdentity = "machine-identity"
+}
 
 const STEP_TITLES: Record<1 | 2 | 3, string> = {
   1: "Choose a tool",
@@ -216,10 +223,10 @@ const AuthOptionCard = ({
 
 export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) => {
   const [step, setStep] = useState<1 | 2 | 3>(1);
-  const [method, setMethod] = useState<Method>("ksp");
+  const [method, setMethod] = useState<Method>(Method.Ksp);
   const [os, setOs] = useState<OS>("linux");
   const [tool, setTool] = useState<Pkcs11Tool>("jarsigner");
-  const [authMethod, setAuthMethod] = useState<AuthMethod>("token");
+  const [authMethod, setAuthMethod] = useState<AuthMethod>(AuthMethod.Token);
 
   useEffect(() => {
     if (isOpen) setStep(1);
@@ -235,16 +242,16 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
 
   const { data: signerCert } = useExportSignerCertificate(
     signer.id,
-    isOpen && method === "ksp" && canExportCert
+    isOpen && method === Method.Ksp && canExportCert
   );
 
   const auth: SignerAuth =
-    authMethod === "token"
+    authMethod === AuthMethod.Token
       ? { mode: "token", token: getAuthToken() || "<your-access-token>" }
       : { mode: "machine-identity" };
 
   const authNote =
-    authMethod === "token" ? (
+    authMethod === AuthMethod.Token ? (
       <p className="mt-2 text-xs text-yellow-600">
         This uses your personal access token, which expires, so this setup is temporary. For
         unattended or CI/CD signing, use a machine identity instead.
@@ -258,7 +265,9 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
     );
 
   const rightDocHref =
-    method === "ksp" ? PkiDocsUrls.codeSigning.windowsKsp : PkiDocsUrls.codeSigning.pkcs11Module;
+    method === Method.Ksp
+      ? PkiDocsUrls.codeSigning.windowsKsp
+      : PkiDocsUrls.codeSigning.pkcs11Module;
 
   const renderRightPanel = () => {
     if (step === 1) {
@@ -291,7 +300,7 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
     return (
       <>
         <p className="mt-4 text-sm font-semibold text-foreground">What this step does</p>
-        {method === "ksp" ? (
+        {method === Method.Ksp ? (
           <p className="mt-2 text-sm leading-relaxed text-muted">
             Download and register the Key Storage Provider once per machine, set your credentials,
             then sign with <span className="font-mono text-xs">signtool</span>. The Signer is
@@ -320,8 +329,7 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
               <DocumentationLinkBadge href={PkiDocsUrls.codeSigning.connect} />
             </SheetTitle>
             <SheetDescription>
-              Sign with this Signer using the tool you already use. Your signing key never leaves
-              Infisical.
+              Sign with this Signer using the tool you already use.
             </SheetDescription>
           </div>
         </SheetHeader>
@@ -360,16 +368,16 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                     title="Standard signing tools"
                     description="jarsigner, osslsigncode, cosign, and other common tools. Uses the Infisical PKCS#11 module."
                     platforms={["Linux", "macOS", "Windows"]}
-                    isSelected={method === "pkcs11"}
-                    onSelect={() => setMethod("pkcs11")}
+                    isSelected={method === Method.Pkcs11}
+                    onSelect={() => setMethod(Method.Pkcs11)}
                   />
                   <MethodCard
                     icon={<MonitorIcon className="size-5" />}
                     title="Windows signtool"
                     description="Native Windows Authenticode signing with Microsoft signtool. Uses the Infisical Key Storage Provider."
                     platforms={["Windows"]}
-                    isSelected={method === "ksp"}
-                    onSelect={() => setMethod("ksp")}
+                    isSelected={method === Method.Ksp}
+                    onSelect={() => setMethod(Method.Ksp)}
                   />
                 </div>
               </>
@@ -377,25 +385,25 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
             {step === 2 && (
               <>
                 <h2 className="text-lg font-semibold text-foreground">
-                  Choose how to authenticate
+                  Choose how you authenticate
                 </h2>
                 <p className="mt-1 mb-6 text-sm text-muted">
-                  Pick how the machine running the signing tool proves who it is to Infisical.
+                  Pick how the signing tool proves who it is to Infisical during signing operations.
                 </p>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <AuthOptionCard
                     icon={<KeyRoundIcon className="size-4" />}
                     title="Use my credentials"
                     description="Sign as yourself with your own Infisical access token. Quickest to set up, but temporary because the token expires."
-                    isSelected={authMethod === "token"}
-                    onSelect={() => setAuthMethod("token")}
+                    isSelected={authMethod === AuthMethod.Token}
+                    onSelect={() => setAuthMethod(AuthMethod.Token)}
                   />
                   <AuthOptionCard
                     icon={<HardDriveIcon className="size-4" />}
                     title="Use a machine identity"
                     description="Authenticate with a Machine Identity's Universal Auth credentials. Best for CI/CD and unattended signing."
-                    isSelected={authMethod === "machine-identity"}
-                    onSelect={() => setAuthMethod("machine-identity")}
+                    isSelected={authMethod === AuthMethod.MachineIdentity}
+                    onSelect={() => setAuthMethod(AuthMethod.MachineIdentity)}
                   />
                 </div>
               </>
@@ -404,12 +412,12 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
               <>
                 <h2 className="text-lg font-semibold text-foreground">Install &amp; sign</h2>
                 <p className="mt-1 mb-6 text-sm text-muted">
-                  {method === "ksp"
+                  {method === Method.Ksp
                     ? "Install the Infisical Key Storage Provider, then sign with Microsoft signtool."
                     : "Install the Infisical PKCS#11 module, then sign with jarsigner, osslsigncode, or any PKCS#11 tool."}
                 </p>
 
-                {method === "ksp" ? (
+                {method === Method.Ksp ? (
                   <div className="space-y-5">
                     <SubStep
                       index={1}
@@ -429,9 +437,9 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                       index={3}
                       title="Configure"
                       description={
-                        authMethod === "token"
-                          ? "Point the provider at Infisical with your access token."
-                          : "Create the config file and set the Machine Identity credentials."
+                        authMethod === AuthMethod.Token
+                          ? "Set your Infisical address and access token as environment variables."
+                          : "Set your Infisical address and Machine Identity credentials as environment variables."
                       }
                     >
                       <CommandBlock snippet={kspConfigureSnippet(serverUrl, auth)} />
@@ -479,9 +487,9 @@ export const ConnectToSignerDrawer = ({ signer, isOpen, onOpenChange }: Props) =
                       index={2}
                       title="Configure"
                       description={
-                        authMethod === "token"
-                          ? "Create a config file and set your access token as an environment variable."
-                          : "Create a config file and set the Machine Identity credentials as environment variables."
+                        authMethod === AuthMethod.Token
+                          ? "Set your Infisical address and access token as environment variables."
+                          : "Set your Infisical address and Machine Identity credentials as environment variables."
                       }
                     >
                       <CommandBlock snippet={pkcs11ConfigureSnippet(os, serverUrl, auth)} />

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/index.ts
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/index.ts
@@ -1,0 +1,1 @@
+export { ConnectToSignerDrawer } from "./ConnectToSignerDrawer";

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
@@ -68,13 +68,24 @@ export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="<client-secret>"`
   };
 };
 
-// The SunPKCS11 config jarsigner needs.
-export const jarsignerConfigSnippet: Snippet = {
-  language: "bash",
-  code: `cat > infisical-pkcs11.cfg <<EOF
+export const jarsignerConfigSnippet = (os: OS): Snippet => {
+  if (os === "windows") {
+    return {
+      language: "powershell",
+      code: `@"
 name = Infisical
-library = /path/to/libinfisical-pkcs11.so
+library = C:/path/to/libinfisical-pkcs11.dll
+"@ | Set-Content infisical-pkcs11.cfg`
+    };
+  }
+  const ext = os === "macos" ? "dylib" : "so";
+  return {
+    language: "bash",
+    code: `cat > infisical-pkcs11.cfg <<EOF
+name = Infisical
+library = /path/to/libinfisical-pkcs11.${ext}
 EOF`
+  };
 };
 
 export const pkcs11SignSnippet = (

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
@@ -1,0 +1,166 @@
+export type SnippetLanguage = "bash" | "powershell" | "text";
+
+export type Snippet = {
+  language: SnippetLanguage;
+  code: string;
+};
+
+export type OS = "linux" | "macos" | "windows";
+export type Pkcs11Tool = "jarsigner" | "osslsigncode" | "pkcs11-tool";
+
+const PKCS11_RELEASES = "https://github.com/Infisical/infisical-pkcs-11/releases/latest/download";
+const KSP_RELEASES = "https://github.com/Infisical/infisical-ksp/releases/latest/download";
+
+const isEcdsa = (keyAlgorithm?: string | null) =>
+  Boolean(keyAlgorithm && keyAlgorithm.toUpperCase().startsWith("EC"));
+
+// jarsigner picks the signature algorithm from the key type.
+const jarsignerSigAlg = (keyAlgorithm?: string | null) =>
+  isEcdsa(keyAlgorithm) ? "SHA256withECDSA" : "SHA256withRSA";
+
+// ---- Standard signing tools (PKCS#11) --------------------------------------
+
+export const pkcs11InstallSnippet = (os: OS): Snippet => {
+  switch (os) {
+    case "linux":
+      return {
+        language: "bash",
+        code: `curl -L -o libinfisical-pkcs11.tar.gz \\
+  ${PKCS11_RELEASES}/libinfisical-pkcs11-linux-amd64.so.tar.gz
+tar -xzf libinfisical-pkcs11.tar.gz`
+      };
+    case "macos":
+      return {
+        language: "bash",
+        code: `curl -L -o libinfisical-pkcs11.tar.gz \\
+  ${PKCS11_RELEASES}/libinfisical-pkcs11-darwin-arm64.dylib.tar.gz
+tar -xzf libinfisical-pkcs11.tar.gz`
+      };
+    case "windows":
+    default:
+      return {
+        language: "powershell",
+        code: `Invoke-WebRequest \`
+  -Uri "${PKCS11_RELEASES}/libinfisical-pkcs11-windows-amd64.dll.zip" \`
+  -OutFile "libinfisical-pkcs11.zip"
+Expand-Archive libinfisical-pkcs11.zip -DestinationPath . -Force`
+      };
+  }
+};
+
+export const pkcs11ConfigureSnippet = (os: OS, serverUrl: string): Snippet => {
+  if (os === "windows") {
+    return {
+      language: "powershell",
+      code: `New-Item -ItemType Directory -Force -Path "$env:ProgramData\\Infisical" | Out-Null
+'{ "server_url": "${serverUrl}" }' | Set-Content "$env:ProgramData\\Infisical\\pkcs11.conf"
+$env:INFISICAL_PKCS11_CONFIG = "$env:ProgramData\\Infisical\\pkcs11.conf"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<client-id>"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<client-secret>"`
+    };
+  }
+  return {
+    language: "bash",
+    code: `sudo mkdir -p /etc/infisical
+echo '{ "server_url": "${serverUrl}" }' | sudo tee /etc/infisical/pkcs11.conf > /dev/null
+export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="<client-id>"
+export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="<client-secret>"`
+  };
+};
+
+// The SunPKCS11 config jarsigner needs.
+export const jarsignerConfigSnippet: Snippet = {
+  language: "bash",
+  code: `cat > infisical-pkcs11.cfg <<EOF
+name = Infisical
+library = /path/to/libinfisical-pkcs11.so
+EOF`
+};
+
+export const pkcs11SignSnippet = (
+  tool: Pkcs11Tool,
+  signerName: string,
+  keyAlgorithm?: string | null
+): Snippet => {
+  switch (tool) {
+    case "jarsigner":
+      return {
+        language: "bash",
+        code: `jarsigner -keystore NONE -storetype PKCS11 \\
+  -addprovider SunPKCS11 -providerArg infisical-pkcs11.cfg \\
+  -sigalg ${jarsignerSigAlg(keyAlgorithm)} \\
+  myapp.jar "${signerName}"`
+      };
+    case "osslsigncode":
+      return {
+        language: "bash",
+        code: `osslsigncode sign \\
+  -pkcs11module /path/to/libinfisical-pkcs11.so \\
+  -pkcs11cert "pkcs11:object=${signerName};type=cert" \\
+  -key "pkcs11:object=${signerName};type=private" \\
+  -h sha256 \\
+  -in MyApp.exe -out MyApp-signed.exe`
+      };
+    case "pkcs11-tool":
+    default:
+      return {
+        language: "bash",
+        code: "pkcs11-tool --module ./libinfisical-pkcs11.so --list-slots"
+      };
+  }
+};
+
+// ---- Windows signtool (native KSP) -----------------------------------------
+
+export const kspDownloadSnippet = (): Snippet => ({
+  language: "powershell",
+  code: `Invoke-WebRequest -Uri "${KSP_RELEASES}/infisical-ksp.dll" -OutFile "infisical-ksp.dll"`
+});
+
+// Registering a CNG Key Storage Provider is a few registry entries plus dropping the DLL in
+// System32.
+export const kspRegisterSnippet = (): Snippet => ({
+  language: "powershell",
+  code: `$prov = "Infisical Key Storage Provider"
+$base = "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Cryptography"
+Copy-Item .\\infisical-ksp.dll "$env:windir\\System32\\infisical-ksp.dll" -Force
+New-Item -Path "$base\\Providers\\$prov\\UM\\00010001" -Force | Out-Null
+New-ItemProperty -Path "$base\\Providers\\$prov\\UM" -Name Image -PropertyType String -Value "infisical-ksp.dll" -Force | Out-Null
+Set-ItemProperty -Path "$base\\Providers\\$prov\\UM\\00010001" -Name "(default)" -Value "CRYPT_KEY_STORAGE_INTERFACE"
+New-ItemProperty -Path "$base\\Providers\\$prov\\UM\\00010001" -Name Flags -PropertyType DWord -Value 0x10000 -Force | Out-Null
+New-ItemProperty -Path "$base\\Providers\\$prov\\UM\\00010001" -Name Functions -PropertyType MultiString -Value @("KEY_STORAGE") -Force | Out-Null
+$iface = "$base\\Configuration\\Local\\Default\\00010001\\KEY_STORAGE"
+$cur = @((Get-ItemProperty $iface).Providers)
+if ($cur -notcontains $prov) { Set-ItemProperty -Path $iface -Name Providers -Value ($cur + $prov) }`
+});
+
+export const kspConfigureSnippet = (serverUrl: string): Snippet => ({
+  language: "powershell",
+  code: `New-Item -ItemType Directory -Force -Path "$env:ProgramData\\Infisical" | Out-Null
+'{ "server_url": "${serverUrl}" }' | Set-Content "$env:ProgramData\\Infisical\\config.json"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<client-id>"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<client-secret>"`
+});
+
+export const kspCertSnippet = (signerName: string, certPem?: string): Snippet => {
+  const pem =
+    certPem?.trim() ||
+    `-----BEGIN CERTIFICATE-----
+(loading this Signer's certificate...)
+-----END CERTIFICATE-----`;
+  return {
+    language: "powershell",
+    code: `$certPem = @"
+${pem}
+"@
+Set-Content -Path "$env:ProgramData\\Infisical\\${signerName}.cer" -Value $certPem -Encoding ascii`
+  };
+};
+
+export const kspSignSnippet = (signerName: string): Snippet => ({
+  language: "powershell",
+  code: `signtool sign /fd SHA256 \`
+  /f "$env:ProgramData\\Infisical\\${signerName}.cer" \`
+  /csp "Infisical Key Storage Provider" /kc "${signerName}" \`
+  MyApp.exe`
+});

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/ConnectToSignerDrawer/snippets.ts
@@ -8,6 +8,21 @@ export type Snippet = {
 export type OS = "linux" | "macos" | "windows";
 export type Pkcs11Tool = "jarsigner" | "osslsigncode" | "pkcs11-tool";
 
+export type SignerAuth = { mode: "token"; token: string } | { mode: "machine-identity" };
+
+const credLines = (auth: SignerAuth, shell: "powershell" | "bash"): string => {
+  if (shell === "powershell") {
+    return auth.mode === "token"
+      ? `$env:INFISICAL_TOKEN = "${auth.token}"`
+      : `$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<client-id>"
+$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<client-secret>"`;
+  }
+  return auth.mode === "token"
+    ? `export INFISICAL_TOKEN="${auth.token}"`
+    : `export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="<client-id>"
+export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="<client-secret>"`;
+};
+
 const PKCS11_RELEASES = "https://github.com/Infisical/infisical-pkcs-11/releases/latest/download";
 const KSP_RELEASES = "https://github.com/Infisical/infisical-ksp/releases/latest/download";
 
@@ -48,23 +63,21 @@ Expand-Archive libinfisical-pkcs11.zip -DestinationPath . -Force`
   }
 };
 
-export const pkcs11ConfigureSnippet = (os: OS, serverUrl: string): Snippet => {
+export const pkcs11ConfigureSnippet = (os: OS, serverUrl: string, auth: SignerAuth): Snippet => {
   if (os === "windows") {
     return {
       language: "powershell",
       code: `New-Item -ItemType Directory -Force -Path "$env:ProgramData\\Infisical" | Out-Null
 '{ "server_url": "${serverUrl}" }' | Set-Content "$env:ProgramData\\Infisical\\pkcs11.conf"
-$env:INFISICAL_PKCS11_CONFIG = "$env:ProgramData\\Infisical\\pkcs11.conf"
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<client-id>"
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<client-secret>"`
+$env:INFISICAL_CONFIG = "$env:ProgramData\\Infisical\\pkcs11.conf"
+${credLines(auth, "powershell")}`
     };
   }
   return {
     language: "bash",
     code: `sudo mkdir -p /etc/infisical
 echo '{ "server_url": "${serverUrl}" }' | sudo tee /etc/infisical/pkcs11.conf > /dev/null
-export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID="<client-id>"
-export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET="<client-secret>"`
+${credLines(auth, "bash")}`
   };
 };
 
@@ -145,12 +158,11 @@ $cur = @((Get-ItemProperty $iface).Providers)
 if ($cur -notcontains $prov) { Set-ItemProperty -Path $iface -Name Providers -Value ($cur + $prov) }`
 });
 
-export const kspConfigureSnippet = (serverUrl: string): Snippet => ({
+export const kspConfigureSnippet = (serverUrl: string, auth: SignerAuth): Snippet => ({
   language: "powershell",
   code: `New-Item -ItemType Directory -Force -Path "$env:ProgramData\\Infisical" | Out-Null
 '{ "server_url": "${serverUrl}" }' | Set-Content "$env:ProgramData\\Infisical\\config.json"
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_ID = "<client-id>"
-$env:INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET = "<client-secret>"`
+${credLines(auth, "powershell")}`
 });
 
 export const kspCertSnippet = (signerName: string, certPem?: string): Snippet => {

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
@@ -6,7 +6,9 @@ import { HardDriveIcon, UserIcon } from "lucide-react";
 import { createNotification } from "@app/components/notifications";
 import {
   Badge,
+  Button,
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -32,11 +34,15 @@ import {
   SigningActorType,
   SigningOperationStatus,
   signingOperationStatusLabels,
+  TSigner,
   TSigningOperation,
   useListSigningOperations
 } from "@app/hooks/api/signers";
 
+import { ConnectToSignerDrawer } from "./ConnectToSignerDrawer";
+
 type Props = {
+  signer: TSigner;
   signerId: string;
   projectId: string;
 };
@@ -79,9 +85,10 @@ const getActorDisplayName = (actorType: SigningActorType, actorName?: string | n
   }
 };
 
-export const SigningOperationsTable = ({ signerId, projectId }: Props) => {
+export const SigningOperationsTable = ({ signer, signerId, projectId }: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(SIGNER_TABLE_PAGE_SIZE);
+  const [isConnectOpen, setIsConnectOpen] = useState(false);
   const navigate = useNavigate();
   const { currentOrg } = useOrganization();
 
@@ -137,99 +144,113 @@ export const SigningOperationsTable = ({ signerId, projectId }: Props) => {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Signing History</CardTitle>
-        <CardDescription>Trail of signing operations on this signer.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Timestamp</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Algorithm</TableHead>
-              <TableHead>Data Hash</TableHead>
-              <TableHead>Actor</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading &&
-              Array.from({ length: 5 }).map((_, i) => (
-                // eslint-disable-next-line react/no-array-index-key
-                <TableRow key={`skeleton-${i}`}>
-                  {Array.from({ length: 5 }).map((__, j) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <TableCell key={`skeleton-cell-${j}`}>
-                      <div className="h-4 w-full animate-pulse rounded bg-mineshaft-700" />
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>Signing History</CardTitle>
+          <CardDescription>Trail of signing operations on this signer.</CardDescription>
+          <CardAction>
+            <Button variant="neutral" size="sm" onClick={() => setIsConnectOpen(true)}>
+              How to sign
+            </Button>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Timestamp</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Algorithm</TableHead>
+                <TableHead>Data Hash</TableHead>
+                <TableHead>Actor</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading &&
+                Array.from({ length: 5 }).map((_, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <TableRow key={`skeleton-${i}`}>
+                    {Array.from({ length: 5 }).map((__, j) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <TableCell key={`skeleton-cell-${j}`}>
+                        <div className="h-4 w-full animate-pulse rounded bg-mineshaft-700" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              {!isLoading &&
+                operations.map((op) => (
+                  <TableRow key={op.id} className="[&>td]:py-3">
+                    <TableCell>{format(new Date(op.createdAt), "MMM d, yyyy HH:mm:ss")}</TableCell>
+                    <TableCell>
+                      <Badge variant={getStatusBadgeVariant(op.status)}>
+                        {signingOperationStatusLabels[op.status] ?? op.status}
+                      </Badge>
                     </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            {!isLoading &&
-              operations.map((op) => (
-                <TableRow key={op.id} className="[&>td]:py-3">
-                  <TableCell>{format(new Date(op.createdAt), "MMM d, yyyy HH:mm:ss")}</TableCell>
-                  <TableCell>
-                    <Badge variant={getStatusBadgeVariant(op.status)}>
-                      {signingOperationStatusLabels[op.status] ?? op.status}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-xs">
-                    {ALGORITHM_DISPLAY[op.signingAlgorithm] ?? op.signingAlgorithm}
-                  </TableCell>
-                  <TableCell className="max-w-[120px] truncate font-mono text-xs">
-                    {op.dataHash}
-                  </TableCell>
-                  <TableCell>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="flex items-center gap-1.5">
-                          {op.actorType === SigningActorType.User ? (
-                            <UserIcon className="size-3.5 text-muted" />
-                          ) : (
-                            <HardDriveIcon className="size-3.5 text-muted" />
-                          )}
-                          <button
-                            type="button"
-                            onClick={isActorClickable(op) ? () => handleActorClick(op) : undefined}
-                            className={
-                              isActorClickable(op)
-                                ? "cursor-pointer font-medium text-accent underline"
-                                : "text-muted"
-                            }
-                          >
-                            {getActorDisplayName(op.actorType, op.actorName)}
-                          </button>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent>{op.actorName ?? op.actorId}</TooltipContent>
-                    </Tooltip>
-                  </TableCell>
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-        {!isLoading && operations.length === 0 && (
-          <Empty className="border border-solid">
-            <EmptyHeader>
-              <EmptyTitle>No signing operations yet</EmptyTitle>
-              <EmptyDescription>
-                Once members sign artifacts with this signer, the activity trail will appear here.
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        )}
-        {Boolean(totalCount) && (
-          <Pagination
-            count={totalCount}
-            page={page}
-            perPage={perPage}
-            onChangePage={setPage}
-            onChangePerPage={setPerPage}
-          />
-        )}
-      </CardContent>
-    </Card>
+                    <TableCell className="text-xs">
+                      {ALGORITHM_DISPLAY[op.signingAlgorithm] ?? op.signingAlgorithm}
+                    </TableCell>
+                    <TableCell className="max-w-[120px] truncate font-mono text-xs">
+                      {op.dataHash}
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-1.5">
+                            {op.actorType === SigningActorType.User ? (
+                              <UserIcon className="size-3.5 text-muted" />
+                            ) : (
+                              <HardDriveIcon className="size-3.5 text-muted" />
+                            )}
+                            <button
+                              type="button"
+                              onClick={
+                                isActorClickable(op) ? () => handleActorClick(op) : undefined
+                              }
+                              className={
+                                isActorClickable(op)
+                                  ? "cursor-pointer font-medium text-accent underline"
+                                  : "text-muted"
+                              }
+                            >
+                              {getActorDisplayName(op.actorType, op.actorName)}
+                            </button>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>{op.actorName ?? op.actorId}</TooltipContent>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+          {!isLoading && operations.length === 0 && (
+            <Empty className="border border-solid">
+              <EmptyHeader>
+                <EmptyTitle>No signing activity yet</EmptyTitle>
+                <EmptyDescription>
+                  Set up a signing tool on your machine to start signing with this Signer.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+          {Boolean(totalCount) && (
+            <Pagination
+              count={totalCount}
+              page={page}
+              perPage={perPage}
+              onChangePage={setPage}
+              onChangePerPage={setPerPage}
+            />
+          )}
+        </CardContent>
+      </Card>
+      <ConnectToSignerDrawer
+        signer={signer}
+        isOpen={isConnectOpen}
+        onOpenChange={setIsConnectOpen}
+      />
+    </>
   );
 };

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
@@ -151,7 +151,7 @@ export const SigningOperationsTable = ({ signer, signerId, projectId }: Props) =
           <CardDescription>Trail of signing operations on this signer.</CardDescription>
           <CardAction>
             <Button variant="neutral" size="sm" onClick={() => setIsConnectOpen(true)}>
-              How to sign
+              Set up signing
             </Button>
           </CardAction>
         </CardHeader>

--- a/frontend/src/pages/cert-manager/pki-docs-urls.ts
+++ b/frontend/src/pages/cert-manager/pki-docs-urls.ts
@@ -100,7 +100,9 @@ export const PkiDocsUrls = {
       requestToSign: `${PKI_DOCS_BASE_URL}/code-signing/approvals#request-to-sign`,
       grantLifecycle: `${PKI_DOCS_BASE_URL}/code-signing/approvals#access-lifecycle`
     },
-    pkcs11Module: `${PKI_DOCS_BASE_URL}/code-signing/pkcs11-module`
+    pkcs11Module: `${PKI_DOCS_BASE_URL}/code-signing/pkcs11-module`,
+    windowsKsp: `${PKI_DOCS_BASE_URL}/code-signing/windows-ksp`,
+    connect: `${PKI_DOCS_BASE_URL}/code-signing/overview`
   },
 
   // Discovery


### PR DESCRIPTION
## Context

Add native Windows code signing to Infisical. Teams can now sign their Windows apps and installers with Microsoft's standard `signtool` using a code-signing key that stays securely in Infisical, with no change to how their build pipelines already work. It includes a new "How to sign" guide in the product UI that walks users through setup with copy-paste commands, along with matching documentation, so getting started is straightforward.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)