### PR TITLE
feat(webhook): add get-by-id route and allow machine identity auth

### DIFF
--- a/backend/src/server/routes/v1/webhook-router.ts
+++ b/backend/src/server/routes/v1/webhook-router.ts
@@ -257,7 +257,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT]),
     schema: {
       operationId: "testWebhook",
       params: z.object({

--- a/backend/src/server/routes/v1/webhook-router.ts
+++ b/backend/src/server/routes/v1/webhook-router.ts
@@ -45,7 +45,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       operationId: "createWebhook",
       body: z
@@ -133,7 +133,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       operationId: "updateWebhook",
       params: z.object({
@@ -208,7 +208,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       operationId: "deleteWebhook",
       params: z.object({
@@ -257,7 +257,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       operationId: "testWebhook",
       params: z.object({
@@ -284,11 +284,41 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "GET",
+    url: "/:webhookId",
+    config: {
+      rateLimit: readLimit
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    schema: {
+      operationId: "getWebhookById",
+      params: z.object({
+        webhookId: z.string().trim()
+      }),
+      response: {
+        200: z.object({
+          webhook: sanitizedWebhookSchema.extend({ url: z.string() })
+        })
+      }
+    },
+    handler: async (req) => {
+      const webhook = await server.services.webhook.getWebhookById({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        id: req.params.webhookId
+      });
+      return { webhook };
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/",
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     schema: {
       operationId: "listWebhooks",
       querystring: z.object({

--- a/backend/src/services/webhook/webhook-service.ts
+++ b/backend/src/services/webhook/webhook-service.ts
@@ -19,6 +19,7 @@ import {
   SUBSCRIBABLE_WEBHOOK_EVENTS,
   TCreateWebhookDTO,
   TDeleteWebhookDTO,
+  TGetWebhookByIdDTO,
   TListWebhookDTO,
   TSubscribableWebhookEvent,
   TTestWebhookDTO,
@@ -251,10 +252,36 @@ export const webhookServiceFactory = ({
     });
   };
 
+  const getWebhookById = async ({ id, actor, actorId, actorAuthMethod, actorOrgId }: TGetWebhookByIdDTO) => {
+    const webhook = await webhookDAL.findById(id);
+    if (!webhook) throw new NotFoundError({ message: `Webhook with ID '${id}' not found` });
+
+    const { permission } = await permissionService.getProjectPermission({
+      actor,
+      actorId,
+      projectId: webhook.projectId,
+      actorAuthMethod,
+      actorOrgId,
+      actionProjectType: ActionProjectType.Any
+    });
+    ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Webhooks);
+
+    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId: webhook.projectId
+    });
+    const { url } = decryptWebhookDetails(webhook, (value) =>
+      secretManagerDecryptor({ cipherTextBlob: value }).toString()
+    );
+
+    return { ...withEventsFilter(webhook), url };
+  };
+
   return {
     createWebhook,
     deleteWebhook,
     listWebhooks,
+    getWebhookById,
     updateWebhook,
     testWebhook
   };

--- a/backend/src/services/webhook/webhook-service.ts
+++ b/backend/src/services/webhook/webhook-service.ts
@@ -3,7 +3,7 @@ import { ForbiddenError } from "@casl/ability";
 import { ActionProjectType, TWebhooksInsert } from "@app/db/schemas";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
@@ -253,18 +253,30 @@ export const webhookServiceFactory = ({
   };
 
   const getWebhookById = async ({ id, actor, actorId, actorAuthMethod, actorOrgId }: TGetWebhookByIdDTO) => {
-    const webhook = await webhookDAL.findById(id);
-    if (!webhook) throw new NotFoundError({ message: `Webhook with ID '${id}' not found` });
+    // Unauthorized callers get the same 404 as a missing webhook so the endpoint can't be used to enumerate webhook IDs.
+    const notFound = new NotFoundError({ message: `Webhook with ID '${id}' not found` });
 
-    const { permission } = await permissionService.getProjectPermission({
-      actor,
-      actorId,
-      projectId: webhook.projectId,
-      actorAuthMethod,
-      actorOrgId,
-      actionProjectType: ActionProjectType.Any
-    });
-    ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Webhooks);
+    const webhook = await webhookDAL.findById(id);
+    if (!webhook) {
+      throw notFound;
+    }
+
+    try {
+      const { permission } = await permissionService.getProjectPermission({
+        actor,
+        actorId,
+        projectId: webhook.projectId,
+        actorAuthMethod,
+        actorOrgId,
+        actionProjectType: ActionProjectType.Any
+      });
+      ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Webhooks);
+    } catch (error) {
+      if (error instanceof ForbiddenError || error instanceof ForbiddenRequestError) {
+        throw notFound;
+      }
+      throw error;
+    }
 
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.SecretManager,

--- a/backend/src/services/webhook/webhook-types.ts
+++ b/backend/src/services/webhook/webhook-types.ts
@@ -25,6 +25,10 @@ export type TDeleteWebhookDTO = {
   id: string;
 } & Omit<TProjectPermission, "projectId">;
 
+export type TGetWebhookByIdDTO = {
+  id: string;
+} & Omit<TProjectPermission, "projectId">;
+
 export type TListWebhookDTO = {
   environment?: string;
   secretPath?: string;


### PR DESCRIPTION
## Context

- Add `GET /api/v1/webhooks/:webhookId`, returning the webhook with its decrypted URL.
- Accept `IDENTITY_ACCESS_TOKEN` on all webhook routes (previously JWT-only) so machine identities can manage webhooks.
- Unblocks the `infisical_webhook` Terraform provider resource, whose Read/Import call this route. The provider release must lag this deploy, since without this route every provider read 404s, not just imports.
- ENG-5124

## Steps to verify the change

- `npm run type:check` clean; `eslint` clean.
- Not yet exercised at runtime: `GET /webhooks/:id` should enforce project `Webhooks` read permission, return the decrypted `url`, and 404 on unknown id.

## Type

- [x] Feature

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
