### PR TITLE
fix: additional privileges support for group members

### DIFF
--- a/backend/src/ee/services/permission/permission-dal.ts
+++ b/backend/src/ee/services/permission/permission-dal.ts
@@ -227,10 +227,14 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         .join(TableName.Organization, `${TableName.Membership}.scopeOrgId`, `${TableName.Organization}.id`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
         .leftJoin(TableName.AdditionalPrivilege, (qb) => {
+          // Match the privilege against the request's actor literal, not against
+          // Membership.actor*Id. Group-derived memberships have actorUserId/actorIdentityId
+          // NULL, so the column-to-column predicate dropped privileges for any user
+          // whose only project access is via a group.
           if (actorType === ActorType.IDENTITY) {
-            qb.on(`${TableName.Membership}.actorIdentityId`, `${TableName.AdditionalPrivilege}.actorIdentityId`);
+            qb.on(`${TableName.AdditionalPrivilege}.actorIdentityId`, db.raw("?", [actorId]));
           } else {
-            qb.on(`${TableName.Membership}.actorUserId`, `${TableName.AdditionalPrivilege}.actorUserId`);
+            qb.on(`${TableName.AdditionalPrivilege}.actorUserId`, db.raw("?", [actorId]));
           }
 
           if (scopeData.scope === AccessScope.Organization) {
@@ -966,15 +970,14 @@ export const permissionDALFactory = (db: TDbClient): TPermissionDALFactory => {
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
         .leftJoin(TableName.AdditionalPrivilege, (qb) => {
-          const memberActorCol =
-            actorType === ActorType.IDENTITY
-              ? `${TableName.Membership}.actorIdentityId`
-              : `${TableName.Membership}.actorUserId`;
+          // Match by literal actor id, not Membership.actor*Id — see getPermission for the
+          // group-derived membership rationale. Read and fingerprint must stay aligned, or
+          // the cache will think nothing changed and serve stale abilities.
           const privActorCol =
             actorType === ActorType.IDENTITY
               ? `${TableName.AdditionalPrivilege}.actorIdentityId`
               : `${TableName.AdditionalPrivilege}.actorUserId`;
-          qb.on(memberActorCol, privActorCol).andOn(
+          qb.on(privActorCol, db.raw("?", [actorId])).andOn(
             `${TableName.Membership}.scopeProjectId`,
             `${TableName.AdditionalPrivilege}.projectId`
           );

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -508,7 +508,8 @@ const OverviewPageContent = () => {
   });
 
   const canReadSecrets = singleVisibleEnv
-    ? permission.can(ProjectPermissionSecretActions.DescribeSecret, secretSubject)
+    ? permission.can(ProjectPermissionSecretActions.DescribeSecret, secretSubject) ||
+      permission.can(ProjectPermissionSecretActions.DescribeAndReadValue, secretSubject)
     : true;
 
   const canEditSecrets = singleVisibleEnv


### PR DESCRIPTION
## Context

Access approval privileges weren't being applied to users whose project access comes from a group. The privilege was getting written to the DB correctly, but the JOIN that loads it into the user's CASL ability matched `Membership.actorUserId = AdditionalPrivilege.actorUserId`, and group-derived membership rows have `actorUserId = NULL`. So the privilege existed but was invisible at evaluation time.

The fix itself is pretty straightforward; I've switched the JOIN in `getPermission` and `getPermissionFingerprint` to match on the request's actor id directly instead of the membership row's actor column. Both have to stay aligned or the fingerprint cache will serve stale abilities.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)