### PR TITLE
docs: add overview video to certificate management page

### DIFF
--- a/docs/documentation/platform/pki/overview.mdx
+++ b/docs/documentation/platform/pki/overview.mdx
@@ -6,6 +6,22 @@ description: "Manage Certificate Authorities and automate X.509 certificate life
 
 Infisical Certificate Manager is a centralized platform for managing X.509 certificates across your organization. Issue certificates for TLS, mTLS, and device authentication — whether from your own private CAs or external providers like DigiCert and Let's Encrypt.
 
+The short video below provides a guided overview of Infisical's certificate management capabilities and key concepts, helping you build the right mental model before diving into the rest of the documentation.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/jP-9Ak0tr8A"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 <Card title="Get Started" icon="rocket" href="/documentation/platform/pki/getting-started">
   New to Certificate Manager? Start here to understand the core concepts and issue your first certificate.
 </Card>


### PR DESCRIPTION
## Summary

Adds a guided overview YouTube video to the Certificate Management overview page, mirroring the existing Secrets Management overview.

- Embeds `https://www.youtube.com/watch?v=jP-9Ak0tr8A` using the same intro sentence + responsive 16:9 iframe wrapper as the Secrets Management page
- Video sits right after the intro paragraph, above the "Get Started" card

File: `docs/documentation/platform/pki/overview.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)