### PR TITLE
improvement: migrate create/link org group modal to v3 components

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupLinkForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupLinkForm.tsx
@@ -5,7 +5,15 @@ import { useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FilterableSelect, FormControl } from "@app/components/v2";
+import { RoleOption } from "@app/components/roles";
+import {
+  Button,
+  DialogFooter,
+  Field,
+  FieldError,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { useGetOrgRoles } from "@app/hooks/api";
 import { useCreateOrgGroupMembership } from "@app/hooks/api/orgGroupMembership";
@@ -68,60 +76,58 @@ export const OrgGroupLinkForm = ({ onClose }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onFormSubmit)}>
+    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       <Controller
         control={control}
         name="group"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl label="Group" errorText={error?.message} isError={Boolean(error)}>
+          <Field>
+            <FieldLabel htmlFor="group">Group</FieldLabel>
             <FilterableSelect
+              inputId="group"
               value={value}
               onChange={onChange}
               placeholder="Select group..."
               autoFocus
+              isError={Boolean(error)}
               options={rootOrgGroups ?? []}
               getOptionValue={(option) => option.id}
               getOptionLabel={(option) => option.name}
               isLoading={isRootOrgLoading}
             />
-          </FormControl>
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
       />
       <Controller
         control={control}
         name="role"
         render={({ field: { onChange, value }, fieldState: { error } }) => (
-          <FormControl
-            label="Role"
-            errorText={error?.message}
-            isError={Boolean(error)}
-            className="mt-4"
-          >
+          <Field>
+            <FieldLabel htmlFor="role">Role</FieldLabel>
             <FilterableSelect
+              inputId="role"
               value={value}
               onChange={onChange}
               options={roles ?? []}
               placeholder="Select role..."
+              isError={Boolean(error)}
               getOptionValue={(option) => option.slug}
               getOptionLabel={(option) => option.name}
+              components={{ Option: RoleOption }}
             />
-          </FormControl>
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
       />
-      <div className="flex items-center">
-        <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-        >
-          Link
-        </Button>
-        <Button colorSchema="secondary" variant="plain" onClick={() => onClose()}>
+      <DialogFooter>
+        <Button variant="ghost" type="button" onClick={() => onClose()}>
           Cancel
         </Button>
-      </div>
+        <Button variant="org" type="submit" isPending={isSubmitting} isDisabled={isSubmitting}>
+          Link
+        </Button>
+      </DialogFooter>
     </form>
   );
 };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
@@ -2,19 +2,30 @@ import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { InfoIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
+import { RoleOption } from "@app/components/roles";
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
   FilterableSelect,
-  FormControl,
   Input,
-  Modal,
-  ModalContent,
-  Tooltip
-} from "@app/components/v2";
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { findOrgMembershipRole } from "@app/helpers/roles";
 import { useCreateGroup, useGetOrgRoles, useUpdateGroup } from "@app/hooks/api";
@@ -131,8 +142,8 @@ export const OrgGroupModal = ({
   else if (isSubOrganization) modalTitle = "Add Group to Sub-Organization";
 
   return (
-    <Modal
-      isOpen={popUp?.group?.isOpen}
+    <Dialog
+      open={popUp?.group?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("group", isOpen);
         if (!isOpen) {
@@ -141,49 +152,33 @@ export const OrgGroupModal = ({
         }
       }}
     >
-      <ModalContent
-        bodyClassName="overflow-visible"
-        title={modalTitle}
-        subTitle={
-          showToggle
-            ? "Create a new group or assign an existing one from the parent organization"
-            : undefined
-        }
-      >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{modalTitle}</DialogTitle>
+          {showToggle && (
+            <DialogDescription>
+              Create a new group or assign an existing one from the parent organization
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
         {showToggle && (
-          <div className="mb-4 flex items-center justify-center gap-x-2">
-            <div className="flex w-3/4 gap-x-0.5 rounded-md border border-mineshaft-600 bg-mineshaft-800 p-1">
-              <Button
-                variant="outline_bg"
-                onClick={() => setWizardStep(GroupWizardSteps.CreateGroup)}
-                size="xs"
-                className={twMerge(
-                  "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                  wizardStep === GroupWizardSteps.CreateGroup
-                    ? "bg-mineshaft-500"
-                    : "bg-transparent"
-                )}
-              >
-                Create New
-              </Button>
-              <Button
-                variant="outline_bg"
-                onClick={() => setWizardStep(GroupWizardSteps.LinkGroup)}
-                size="xs"
-                className={twMerge(
-                  "min-w-[2.4rem] flex-1 rounded border-none hover:bg-mineshaft-600",
-                  wizardStep === GroupWizardSteps.LinkGroup ? "bg-mineshaft-500" : "bg-transparent"
-                )}
-              >
-                Assign Existing
-              </Button>
-            </div>
-            <Tooltip
-              className="max-w-sm"
-              position="right"
-              align="start"
-              content={
-                <>
+          <Tabs
+            value={wizardStep}
+            onValueChange={(value) => setWizardStep(value as GroupWizardSteps)}
+          >
+            <div className="flex items-center justify-center gap-2">
+              <TabsList>
+                <TabsTrigger value={GroupWizardSteps.CreateGroup}>Create New</TabsTrigger>
+                <TabsTrigger value={GroupWizardSteps.LinkGroup}>Assign Existing</TabsTrigger>
+              </TabsList>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex cursor-default text-mineshaft-400">
+                    <InfoIcon size={16} />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="max-w-sm">
                   <p className="mb-2 text-mineshaft-300">
                     You can add groups to your sub-organization in one of two ways:
                   </p>
@@ -199,13 +194,12 @@ export const OrgGroupModal = ({
                       parent level.
                     </li>
                   </ul>
-                </>
-              }
-            >
-              <InfoIcon size={16} className="text-mineshaft-400" />
-            </Tooltip>
-          </div>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </Tabs>
         )}
+
         {wizardStep === GroupWizardSteps.LinkGroup ? (
           <OrgGroupLinkForm
             onClose={() => {
@@ -214,66 +208,66 @@ export const OrgGroupModal = ({
             }}
           />
         ) : (
-          <form onSubmit={handleSubmit(onGroupModalSubmit)}>
+          <form onSubmit={handleSubmit(onGroupModalSubmit)} className="flex flex-col gap-4">
             <Controller
               control={control}
               name="name"
               render={({ field, fieldState: { error } }) => (
-                <FormControl label="Name" errorText={error?.message} isError={Boolean(error)}>
-                  <Input {...field} placeholder="Engineering" />
-                </FormControl>
+                <Field>
+                  <FieldLabel htmlFor="name">Name</FieldLabel>
+                  <Input id="name" placeholder="Engineering" isError={Boolean(error)} {...field} />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
             <Controller
               control={control}
               name="slug"
               render={({ field, fieldState: { error } }) => (
-                <FormControl label="Slug" errorText={error?.message} isError={Boolean(error)}>
-                  <Input {...field} placeholder="engineering" />
-                </FormControl>
+                <Field>
+                  <FieldLabel htmlFor="slug">Slug</FieldLabel>
+                  <Input id="slug" placeholder="engineering" isError={Boolean(error)} {...field} />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
             <Controller
               control={control}
               name="role"
               render={({ field: { onChange, value }, fieldState: { error } }) => (
-                <FormControl
-                  label={`${popUp?.group?.data ? "Update" : ""} Role`}
-                  errorText={error?.message}
-                  isError={Boolean(error)}
-                  className="mt-4"
-                >
+                <Field>
+                  <FieldLabel htmlFor="role">{isCreateMode ? "Role" : "Update Role"}</FieldLabel>
                   <FilterableSelect
+                    inputId="role"
                     options={roles}
                     placeholder="Select role..."
                     onChange={onChange}
                     value={value}
+                    isError={Boolean(error)}
                     getOptionValue={(option) => option.slug}
                     getOptionLabel={(option) => option.name}
+                    components={{ Option: RoleOption }}
                   />
-                </FormControl>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
-            <div className="mt-8 flex items-center">
-              <Button
-                className="mr-4"
-                size="sm"
-                type="submit"
-                isLoading={createIsLoading || updateIsLoading}
-              >
-                {!popUp?.group?.data ? "Create" : "Update"}
-              </Button>
-              <Button
-                colorSchema="secondary"
-                variant="plain"
-                onClick={() => handlePopUpClose("group")}
-              >
+            <DialogFooter>
+              <Button variant="ghost" type="button" onClick={() => handlePopUpClose("group")}>
                 Cancel
               </Button>
-            </div>
+              <Button
+                variant="org"
+                type="submit"
+                isPending={createIsLoading || updateIsLoading}
+                isDisabled={createIsLoading || updateIsLoading}
+              >
+                {isCreateMode ? "Create" : "Update"}
+              </Button>
+            </DialogFooter>
           </form>
         )}
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgGroupsTab/components/OrgGroupsSection/OrgGroupModal.tsx
@@ -20,6 +20,7 @@ import {
   FilterableSelect,
   Input,
   Tabs,
+  TabsContent,
   TabsList,
   TabsTrigger,
   Tooltip,
@@ -141,6 +142,67 @@ export const OrgGroupModal = ({
   if (!isCreateMode) modalTitle = "Update Group";
   else if (isSubOrganization) modalTitle = "Add Group to Sub-Organization";
 
+  const createGroupForm = (
+    <form onSubmit={handleSubmit(onGroupModalSubmit)} className="flex flex-col gap-4">
+      <Controller
+        control={control}
+        name="name"
+        render={({ field, fieldState: { error } }) => (
+          <Field>
+            <FieldLabel htmlFor="name">Name</FieldLabel>
+            <Input id="name" placeholder="Engineering" isError={Boolean(error)} {...field} />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
+        )}
+      />
+      <Controller
+        control={control}
+        name="slug"
+        render={({ field, fieldState: { error } }) => (
+          <Field>
+            <FieldLabel htmlFor="slug">Slug</FieldLabel>
+            <Input id="slug" placeholder="engineering" isError={Boolean(error)} {...field} />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
+        )}
+      />
+      <Controller
+        control={control}
+        name="role"
+        render={({ field: { onChange, value }, fieldState: { error } }) => (
+          <Field>
+            <FieldLabel htmlFor="role">{isCreateMode ? "Role" : "Update Role"}</FieldLabel>
+            <FilterableSelect
+              inputId="role"
+              options={roles}
+              placeholder="Select role..."
+              onChange={onChange}
+              value={value}
+              isError={Boolean(error)}
+              getOptionValue={(option) => option.slug}
+              getOptionLabel={(option) => option.name}
+              components={{ Option: RoleOption }}
+            />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
+        )}
+      />
+      <DialogFooter>
+        <Button variant="ghost" type="button" onClick={() => handlePopUpClose("group")}>
+          Cancel
+        </Button>
+        <Button
+          variant="org"
+          type="submit"
+          isPending={createIsLoading || updateIsLoading}
+          isDisabled={createIsLoading || updateIsLoading}
+        >
+          {isCreateMode ? "Create" : "Update"}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+
   return (
     <Dialog
       open={popUp?.group?.isOpen}
@@ -162,7 +224,7 @@ export const OrgGroupModal = ({
           )}
         </DialogHeader>
 
-        {showToggle && (
+        {showToggle ? (
           <Tabs
             value={wizardStep}
             onValueChange={(value) => setWizardStep(value as GroupWizardSteps)}
@@ -197,75 +259,18 @@ export const OrgGroupModal = ({
                 </TooltipContent>
               </Tooltip>
             </div>
+            <TabsContent value={GroupWizardSteps.CreateGroup}>{createGroupForm}</TabsContent>
+            <TabsContent value={GroupWizardSteps.LinkGroup}>
+              <OrgGroupLinkForm
+                onClose={() => {
+                  handlePopUpClose("group");
+                  setWizardStep(GroupWizardSteps.CreateGroup);
+                }}
+              />
+            </TabsContent>
           </Tabs>
-        )}
-
-        {wizardStep === GroupWizardSteps.LinkGroup ? (
-          <OrgGroupLinkForm
-            onClose={() => {
-              handlePopUpClose("group");
-              setWizardStep(GroupWizardSteps.CreateGroup);
-            }}
-          />
         ) : (
-          <form onSubmit={handleSubmit(onGroupModalSubmit)} className="flex flex-col gap-4">
-            <Controller
-              control={control}
-              name="name"
-              render={({ field, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="name">Name</FieldLabel>
-                  <Input id="name" placeholder="Engineering" isError={Boolean(error)} {...field} />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-            <Controller
-              control={control}
-              name="slug"
-              render={({ field, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="slug">Slug</FieldLabel>
-                  <Input id="slug" placeholder="engineering" isError={Boolean(error)} {...field} />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-            <Controller
-              control={control}
-              name="role"
-              render={({ field: { onChange, value }, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="role">{isCreateMode ? "Role" : "Update Role"}</FieldLabel>
-                  <FilterableSelect
-                    inputId="role"
-                    options={roles}
-                    placeholder="Select role..."
-                    onChange={onChange}
-                    value={value}
-                    isError={Boolean(error)}
-                    getOptionValue={(option) => option.slug}
-                    getOptionLabel={(option) => option.name}
-                    components={{ Option: RoleOption }}
-                  />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-            <DialogFooter>
-              <Button variant="ghost" type="button" onClick={() => handlePopUpClose("group")}>
-                Cancel
-              </Button>
-              <Button
-                variant="org"
-                type="submit"
-                isPending={createIsLoading || updateIsLoading}
-                isDisabled={createIsLoading || updateIsLoading}
-              >
-                {isCreateMode ? "Create" : "Update"}
-              </Button>
-            </DialogFooter>
-          </form>
+          createGroupForm
         )}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Context

This PR migrates the create group modal to v3 components

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-06-11 at 16 23 57@2x" src="https://github.com/user-attachments/assets/d2d64913-9bca-4ce6-a452-96beccc5f752" />

<img width="3456" height="1924" alt="CleanShot 2026-06-11 at 16 23 54@2x" src="https://github.com/user-attachments/assets/ff342581-80e1-4dd9-b8d8-dbdf0242cacb" />

## Steps to verify the change

- create a group at org level and link at sub-org level
- very no field/form regressions

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)