### PR TITLE
fix: netlify bug where different contexts would be deleted

### DIFF
--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -94,23 +94,30 @@ class NetlifyPublicClient {
     }
   }
 
-  async getVariables(
-    connection: TNetlifyConnectionConfig,
-    { account_id, ...params }: NetlifyParams,
-    limit: number = 50,
-    page: number = 1
-  ) {
-    const res = await this.send<TNetlifyVariable[]>(connection, {
-      method: "GET",
-      url: `/accounts/${account_id}/env`,
-      params: {
-        ...params,
-        limit,
-        page
-      }
-    });
+  async getVariables(connection: TNetlifyConnectionConfig, { account_id, ...params }: NetlifyParams) {
+    const PAGE_SIZE = 100;
+    const allVariables: TNetlifyVariable[] = [];
+    let page = 1;
 
-    return res;
+    // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+    while (true) {
+      const res = await this.send<TNetlifyVariable[]>(connection, {
+        method: "GET",
+        url: `/accounts/${account_id}/env`,
+        params: {
+          ...params,
+          limit: PAGE_SIZE,
+          page
+        }
+      });
+
+      allVariables.push(...res);
+
+      if (res.length < PAGE_SIZE) break;
+      page += 1;
+    }
+
+    return allVariables;
   }
 
   async createVariable(

--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -102,7 +102,7 @@ class NetlifyPublicClient {
   }
 
   async getVariables(connection: TNetlifyConnectionConfig, { account_id, ...params }: NetlifyParams) {
-    // This public endpoint doesn't support validation, but it also returns all variables.
+    // This public endpoint doesn't support pagination, but it also returns all variables.
     // Tested with 900 secrets.
     return this.send<TNetlifyVariable[]>(connection, {
       method: "GET",

--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -202,13 +202,13 @@ class NetlifyPublicClient {
 
   async deleteVariableValue(
     connection: TNetlifyConnectionConfig,
-    { account_id, value_id, ...params }: NetlifyParams & { value_id: string },
+    { account_id, ...params }: NetlifyParams,
     variable: Pick<TNetlifyVariable, "key" | "id">
   ) {
     try {
       const res = await this.send<TNetlifyVariable>(connection, {
         method: "DELETE",
-        url: `/accounts/${account_id}/${variable.key}/value/${value_id}`,
+        url: `/accounts/${account_id}/env/${variable.key}/value/${variable.id}`,
         params
       });
 

--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -5,10 +5,10 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse, HttpStatusCode, isAxi
 
 import { createRequestClient } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
+import { NetlifySyncContext } from "@app/services/secret-sync/netlify";
 
 import { NetlifyConnectionMethod } from "./netlify-connection-constants";
 import { TNetlifyAccount, TNetlifyConnectionConfig, TNetlifySite, TNetlifyVariable } from "./netlify-connection-types";
-import { NetlifySyncContext } from "@app/services/secret-sync/netlify";
 
 export function getNetlifyAuthHeaders(connection: TNetlifyConnectionConfig): Record<string, string> {
   switch (connection.method) {
@@ -104,7 +104,7 @@ class NetlifyPublicClient {
   async getVariables(connection: TNetlifyConnectionConfig, { account_id, ...params }: NetlifyParams) {
     // This public endpoint doesn't support validation, but it also returns all variables.
     // Tested with 900 secrets.
-    return await this.send<TNetlifyVariable[]>(connection, {
+    return this.send<TNetlifyVariable[]>(connection, {
       method: "GET",
       url: `/accounts/${account_id}/env`,
       params
@@ -129,7 +129,7 @@ class NetlifyPublicClient {
   async updateVariableValue(
     connection: TNetlifyConnectionConfig,
     { account_id, ...params }: NetlifyParams,
-    { key, ...variable }: UpdateVariableValueRequestBody,
+    { key, ...variable }: UpdateVariableValueRequestBody
   ) {
     const res = await this.send<TNetlifyVariable>(connection, {
       method: "PATCH",

--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -8,6 +8,7 @@ import { IntegrationUrls } from "@app/services/integration-auth/integration-list
 
 import { NetlifyConnectionMethod } from "./netlify-connection-constants";
 import { TNetlifyAccount, TNetlifyConnectionConfig, TNetlifySite, TNetlifyVariable } from "./netlify-connection-types";
+import { NetlifySyncContext } from "@app/services/secret-sync/netlify";
 
 export function getNetlifyAuthHeaders(connection: TNetlifyConnectionConfig): Record<string, string> {
   switch (connection.method) {
@@ -54,6 +55,12 @@ type NetlifyParams = {
   account_id: string;
   context_name?: string;
   site_id?: string;
+};
+
+type UpdateVariableValueRequestBody = {
+  key: string;
+  value: string;
+  context?: NetlifySyncContext;
 };
 
 class NetlifyPublicClient {
@@ -122,11 +129,11 @@ class NetlifyPublicClient {
   async updateVariableValue(
     connection: TNetlifyConnectionConfig,
     { account_id, ...params }: NetlifyParams,
-    variable: TNetlifyVariable
+    { key, ...variable }: UpdateVariableValueRequestBody,
   ) {
     const res = await this.send<TNetlifyVariable>(connection, {
       method: "PATCH",
-      url: `/accounts/${account_id}/env/${variable.key}`,
+      url: `/accounts/${account_id}/env/${key}`,
       data: variable,
       params
     });

--- a/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
+++ b/backend/src/services/app-connection/netlify/netlify-connection-public-client.ts
@@ -95,29 +95,13 @@ class NetlifyPublicClient {
   }
 
   async getVariables(connection: TNetlifyConnectionConfig, { account_id, ...params }: NetlifyParams) {
-    const PAGE_SIZE = 100;
-    const allVariables: TNetlifyVariable[] = [];
-    let page = 1;
-
-    // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
-    while (true) {
-      const res = await this.send<TNetlifyVariable[]>(connection, {
-        method: "GET",
-        url: `/accounts/${account_id}/env`,
-        params: {
-          ...params,
-          limit: PAGE_SIZE,
-          page
-        }
-      });
-
-      allVariables.push(...res);
-
-      if (res.length < PAGE_SIZE) break;
-      page += 1;
-    }
-
-    return allVariables;
+    // This public endpoint doesn't support validation, but it also returns all variables.
+    // Tested with 900 secrets.
+    return await this.send<TNetlifyVariable[]>(connection, {
+      method: "GET",
+      url: `/accounts/${account_id}/env`,
+      params
+    });
   }
 
   async createVariable(
@@ -185,21 +169,6 @@ class NetlifyPublicClient {
 
       throw error;
     }
-  }
-
-  async upsertVariable(connection: TNetlifyConnectionConfig, params: NetlifyParams, variable: TNetlifyVariable) {
-    const res = await this.getVariable(connection, params, variable);
-
-    if (!res) {
-      return this.createVariable(connection, params, variable);
-    }
-
-    if (res.is_secret) {
-      await this.deleteVariable(connection, params, variable);
-      return this.createVariable(connection, params, variable);
-    }
-
-    return this.updateVariable(connection, params, variable);
   }
 
   async deleteVariable(

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -83,7 +83,7 @@ export const NetlifySyncFns = {
       try {
         await NetlifyPublicAPI.updateVariableValue(secretSync.connection, params, {
           key,
-          context: config.context ?? NetlifySyncContext.All,
+          context: config.context,
           value: secretMap[key].value
         });
       } catch (error) {

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -4,7 +4,6 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
-import { NetlifySyncContext } from "./netlify-sync-constants";
 import type { TNetlifySyncWithCredentials } from "./netlify-sync-types";
 
 export const NetlifySyncFns = {

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -41,55 +41,89 @@ export const NetlifySyncFns = {
 
     const config = secretSync.destinationConfig;
 
-    const params = {
+    const baseParams = {
       account_id: config.accountId,
-      context_name: config.context,
       site_id: config.siteId
+    }
+
+    const params = {
+      ...baseParams,
+      context_name: config.context,
     };
 
-    const variables = await NetlifyPublicAPI.getVariables(secretSync.connection, params);
+    const variables = await NetlifyPublicAPI.getVariables(secretSync.connection, baseParams);
+    const existingInNetlify = Object.fromEntries(variables.map((variable) => [variable.key, variable]));
 
-    const existing = Object.fromEntries(variables.map((variable) => [variable.key, variable]));
+    const variablesToCreate = Object.keys(secretMap).filter((key) => !existingInNetlify[key]);
+    const variablesToUpdate = Object.keys(secretMap).filter((key) => existingInNetlify[key]);
+    const variablesToDelete = disableSecretDeletion
+      ? []
+      : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        Object.keys(existingInNetlify).filter(
+          (key) =>
+            !secretMap[key] &&
+            matchesSchema(key, environment?.slug || "", keySchema) &&
+            existingInNetlify[key].values.some((v) => v.context === config.context)
+        );
 
-    for await (const key of Object.keys(secretMap)) {
+    for await (const key of variablesToCreate) {
       try {
-        const entry = secretMap[key];
-
-        await NetlifyPublicAPI.upsertVariable(secretSync.connection, params, {
+        await NetlifyPublicAPI.createVariable(secretSync.connection, params, {
           key,
           is_secret: false,
-          values: [
-            {
-              value: entry.value,
-              context: config.context
-            }
-          ]
+          values: [{ context: config.context, value: secretMap[key].value }]
         });
       } catch (error) {
-        throw new SecretSyncError({
-          error,
-          secretKey: key
-        });
+        throw new SecretSyncError({ error, secretKey: key });
       }
     }
 
-    if (disableSecretDeletion) return;
-
-    for await (const key of Object.keys(existing)) {
+    for await (const key of variablesToUpdate) {
       try {
-        // eslint-disable-next-line no-continue, @typescript-eslint/no-unsafe-argument
-        if (!matchesSchema(key, environment?.slug || "", keySchema)) continue;
+        const existingVar = existingInNetlify[key];
 
-        if (!secretMap[key]) {
-          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, {
-            key
+        if (existingVar.is_secret) {
+          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
+          await NetlifyPublicAPI.createVariable(secretSync.connection, params, {
+            key,
+            is_secret: false,
+            // We don't merge existing values from other contexts here because secrets are returned with 
+            // masked values. So it would be replaced as *******
+            values: [
+              { context: config.context, value: secretMap[key].value }
+            ]
+          });
+        } else {
+          const mergedValues = [
+            ...existingVar.values.filter((v) => v.context !== config.context),
+            { context: config.context, value: secretMap[key].value }
+          ];
+          await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
+            key,
+            is_secret: false,
+            values: mergedValues
           });
         }
       } catch (error) {
-        throw new SecretSyncError({
-          error,
-          secretKey: key
-        });
+        throw new SecretSyncError({ error, secretKey: key });
+      }
+    }
+
+    for await (const key of variablesToDelete) {
+      try {
+        const variable = existingInNetlify[key];
+        const remainingValues = variable.values.filter((v) => v.context !== config.context);
+
+        if (remainingValues.length > 0) {
+          await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
+            key,
+            values: remainingValues
+          });
+        } else {
+          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
+        }
+      } catch (error) {
+        throw new SecretSyncError({ error, secretKey: key });
       }
     }
   },
@@ -97,22 +131,34 @@ export const NetlifySyncFns = {
   async removeSecrets(secretSync: TNetlifySyncWithCredentials, secretMap: TSecretMap) {
     const config = secretSync.destinationConfig;
 
-    const params = {
+    const baseParams = {
       account_id: config.accountId,
-      context_name: config.context,
       site_id: config.siteId
     };
 
-    const variables = await NetlifyPublicAPI.getVariables(secretSync.connection, params);
+    const params = {
+      ...baseParams,
+      context_name: config.context
+    };
+
+    const variables = await NetlifyPublicAPI.getVariables(secretSync.connection, baseParams);
 
     const existingSecrets = Object.fromEntries(variables.map((variable) => [variable.key, variable]));
 
     for await (const secret of Object.keys(existingSecrets)) {
       try {
         if (secret in secretMap) {
-          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, {
-            key: secret
-          });
+          const variable = existingSecrets[secret];
+          const remainingValues = variable.values.filter((v) => v.context !== config.context);
+
+          if (remainingValues.length > 0) {
+            await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
+              key: secret,
+              values: remainingValues
+            });
+          } else {
+            await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key: secret });
+          }
         }
       } catch (error) {
         throw new SecretSyncError({

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -44,11 +44,11 @@ export const NetlifySyncFns = {
     const baseParams = {
       account_id: config.accountId,
       site_id: config.siteId
-    }
+    };
 
     const params = {
       ...baseParams,
-      context_name: config.context,
+      context_name: config.context
     };
 
     const variables = await NetlifyPublicAPI.getVariables(secretSync.connection, baseParams);
@@ -87,11 +87,9 @@ export const NetlifySyncFns = {
           await NetlifyPublicAPI.createVariable(secretSync.connection, params, {
             key,
             is_secret: false,
-            // We don't merge existing values from other contexts here because secrets are returned with 
+            // We don't merge existing values from other contexts here because secrets are returned with
             // masked values. So it would be replaced as *******
-            values: [
-              { context: config.context, value: secretMap[key].value }
-            ]
+            values: [{ context: config.context, value: secretMap[key].value }]
           });
         } else {
           const mergedValues = [
@@ -114,7 +112,9 @@ export const NetlifySyncFns = {
         const variable = existingInNetlify[key];
         const remainingValues = variable.values.filter((v) => v.context !== config.context);
 
-        if (remainingValues.length > 0) {
+        // We skip updating variables in case of `is_secret`, otherwise we override the
+        // correct value with a masked one.
+        if (remainingValues.length > 0 && !variable.is_secret) {
           await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
             key,
             values: remainingValues
@@ -151,7 +151,9 @@ export const NetlifySyncFns = {
           const variable = existingSecrets[secret];
           const remainingValues = variable.values.filter((v) => v.context !== config.context);
 
-          if (remainingValues.length > 0) {
+          // We skip updating variables in case of `is_secret`, otherwise we override the
+          // correct value with a masked one.
+          if (remainingValues.length > 0 && !variable.is_secret) {
             await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
               key: secret,
               values: remainingValues

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -4,8 +4,8 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
-import type { TNetlifySyncWithCredentials } from "./netlify-sync-types";
 import { NetlifySyncContext } from "./netlify-sync-constants";
+import type { TNetlifySyncWithCredentials } from "./netlify-sync-types";
 
 export const NetlifySyncFns = {
   async getSecrets(secretSync: TNetlifySyncWithCredentials): Promise<TSecretMap> {
@@ -147,7 +147,7 @@ export const NetlifySyncFns = {
 
           // Delete variable if it doesn't have any values left.
           if (remainingValues.length === 0) {
-            await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
+            await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key: secret });
           }
         }
       } catch (error) {

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -5,6 +5,7 @@ import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
 import type { TNetlifySyncWithCredentials } from "./netlify-sync-types";
+import { NetlifySyncContext } from "./netlify-sync-constants";
 
 export const NetlifySyncFns = {
   async getSecrets(secretSync: TNetlifySyncWithCredentials): Promise<TSecretMap> {
@@ -81,27 +82,11 @@ export const NetlifySyncFns = {
     for await (const key of variablesToUpdate) {
       try {
         const existingVar = existingInNetlify[key];
-
-        if (existingVar.is_secret) {
-          await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
-          await NetlifyPublicAPI.createVariable(secretSync.connection, params, {
-            key,
-            is_secret: false,
-            // We don't merge existing values from other contexts here because secrets are returned with
-            // masked values. So it would be replaced as *******
-            values: [{ context: config.context, value: secretMap[key].value }]
-          });
-        } else {
-          const mergedValues = [
-            ...existingVar.values.filter((v) => v.context !== config.context),
-            { context: config.context, value: secretMap[key].value }
-          ];
-          await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
-            key,
-            is_secret: false,
-            values: mergedValues
-          });
-        }
+        await NetlifyPublicAPI.updateVariableValue(secretSync.connection, params, {
+          key,
+          context: config.context ?? NetlifySyncContext.All,
+          value: secretMap[key].value
+        });
       } catch (error) {
         throw new SecretSyncError({ error, secretKey: key });
       }

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -81,7 +81,6 @@ export const NetlifySyncFns = {
 
     for await (const key of variablesToUpdate) {
       try {
-        const existingVar = existingInNetlify[key];
         await NetlifyPublicAPI.updateVariableValue(secretSync.connection, params, {
           key,
           context: config.context ?? NetlifySyncContext.All,
@@ -96,15 +95,17 @@ export const NetlifySyncFns = {
       try {
         const variable = existingInNetlify[key];
         const remainingValues = variable.values.filter((v) => v.context !== config.context);
+        const variableToDelete = variable.values.filter((v) => v.context === config.context);
 
-        // We skip updating variables in case of `is_secret`, otherwise we override the
-        // correct value with a masked one.
-        if (remainingValues.length > 0 && !variable.is_secret) {
-          await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
+        if (variableToDelete.length > 0 && variableToDelete[0].id) {
+          await NetlifyPublicAPI.deleteVariableValue(secretSync.connection, params, {
             key,
-            values: remainingValues
+            id: variableToDelete[0].id
           });
-        } else {
+        }
+
+        // Delete variable if it doesn't have any values left.
+        if (remainingValues.length === 0) {
           await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
         }
       } catch (error) {
@@ -135,16 +136,18 @@ export const NetlifySyncFns = {
         if (secret in secretMap) {
           const variable = existingSecrets[secret];
           const remainingValues = variable.values.filter((v) => v.context !== config.context);
+          const variableToDelete = variable.values.filter((v) => v.context === config.context);
 
-          // We skip updating variables in case of `is_secret`, otherwise we override the
-          // correct value with a masked one.
-          if (remainingValues.length > 0 && !variable.is_secret) {
-            await NetlifyPublicAPI.updateVariable(secretSync.connection, params, {
+          if (variableToDelete.length > 0 && variableToDelete[0].id) {
+            await NetlifyPublicAPI.deleteVariableValue(secretSync.connection, params, {
               key: secret,
-              values: remainingValues
+              id: variableToDelete[0].id
             });
-          } else {
-            await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key: secret });
+          }
+
+          // Delete variable if it doesn't have any values left.
+          if (remainingValues.length === 0) {
+            await NetlifyPublicAPI.deleteVariable(secretSync.connection, params, { key });
           }
         }
       } catch (error) {

--- a/docs/integrations/secret-syncs/netlify.mdx
+++ b/docs/integrations/secret-syncs/netlify.mdx
@@ -39,6 +39,9 @@ description: "Learn how to configure a Netlify Sync for Infisical."
         - **Account**: The Netlify Account to be used.
         - **Site**: The Netlify site where secrets should be synced.
         - **Context**: The Netlify deployment context where secrets should be created in.
+        <Info>
+          If you have multiple syncs configured to the same site and context, they may conflict with each other and delete each other's secrets during sync operations. This can also happen if one of the syncs has "All Contexts" selected, since it overlaps with every other context. When setting up multiple syncs, make sure they target different contexts to prevent this.
+        </Info>
       </Step>
       <Step title="Configure Sync Options">
         Configure the **Sync Options** to specify how secrets should be synced, then click **Next**.

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
@@ -138,7 +138,7 @@ export const NetlifySyncFields = () => {
                 getOptionValue={(option) => option.value}
               />
               <FieldDescription>
-                If you do not select a context, the secrets will be synced to all contexts.
+                Avoid configuring multiple syncs with overlapping contexts for the same site. "All Contexts" overlaps with every context. Overlapping syncs may delete each other's secrets.
               </FieldDescription>
               <FieldError errors={[error]} />
             </FieldContent>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
@@ -138,7 +138,9 @@ export const NetlifySyncFields = () => {
                 getOptionValue={(option) => option.value}
               />
               <FieldDescription>
-                Avoid configuring multiple syncs with overlapping contexts for the same site. "All Contexts" overlaps with every context. Overlapping syncs may delete each other's secrets.
+                Avoid configuring multiple syncs with overlapping contexts for the same site.
+                &quot;All Contexts&quot; overlaps with every context. Overlapping syncs may delete each
+                other&apos;s secrets.
               </FieldDescription>
               <FieldError errors={[error]} />
             </FieldContent>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/NetlifySyncFields.tsx
@@ -139,8 +139,8 @@ export const NetlifySyncFields = () => {
               />
               <FieldDescription>
                 Avoid configuring multiple syncs with overlapping contexts for the same site.
-                &quot;All Contexts&quot; overlaps with every context. Overlapping syncs may delete each
-                other&apos;s secrets.
+                &quot;All Contexts&quot; overlaps with every context. Overlapping syncs may delete
+                each other&apos;s secrets.
               </FieldDescription>
               <FieldError errors={[error]} />
             </FieldContent>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
@@ -555,6 +555,8 @@ const UpdateForm = ({ appConnection, onComplete }: UpdateFormProps) => {
         return <VenafiConnectionForm onSubmit={onSubmit} appConnection={appConnection} />;
       case AppConnection.VenafiTpp:
         return <VenafiTppConnectionForm onSubmit={onSubmit} appConnection={appConnection} />;
+      case AppConnection.Netlify:
+        return <NetlifyConnectionForm onSubmit={onSubmit} appConnection={appConnection} />
       default:
         throw new Error(`Unhandled App ${(appConnection as TAppConnection).app}`);
     }

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
@@ -556,7 +556,7 @@ const UpdateForm = ({ appConnection, onComplete }: UpdateFormProps) => {
       case AppConnection.VenafiTpp:
         return <VenafiTppConnectionForm onSubmit={onSubmit} appConnection={appConnection} />;
       case AppConnection.Netlify:
-        return <NetlifyConnectionForm onSubmit={onSubmit} appConnection={appConnection} />
+        return <NetlifyConnectionForm onSubmit={onSubmit} appConnection={appConnection} />;
       default:
         throw new Error(`Unhandled App ${(appConnection as TAppConnection).app}`);
     }


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

When you have a variable with multiple values, a sync would cause the other environment values to be deleted. This fixes it and simplifies the code on how to run the sync.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Create a netlify connection
2. create two syncs for different environments (dev and prod for example)
3. Create secrets in the project, make sure to create variables with same name (ENVIRONMENT: prod/dev values for example)
4. Run the syncs and make sure all variables were added and the values are preserved

1. Create a secret in netlify with same name as a variable you have in Infisical
2. Sync it
3. See that the other environment values are deleted (this is intended because we can't get the existing value of a secret, it's resolved as `****************`

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)