### PR TITLE
fix: bump validation and forbidden modal z-indexes to not compete with v2 modals

### DIFF
--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -43,13 +43,15 @@ function DialogContent({
   children,
   showCloseButton = true,
   onPointerDownOutside,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -58,7 +58,8 @@ function ValidationErrorModal({
         }
       }}
     >
-      <DialogContent className="sm:max-w-2xl">
+      {/* z-[70] keeps this dialog above v2 Modals (z-[60]) hosting the form that errored */}
+      <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
         <DialogHeader>
           <DialogTitle>Validation Error Details</DialogTitle>
           <DialogDescription>These fields did not pass validation.</DialogDescription>
@@ -144,7 +145,8 @@ export const onRequestError = (error: unknown) => {
                 Show more
               </Button>
             </DialogTrigger>
-            <DialogContent className="sm:max-w-2xl">
+            {/* z-[70] keeps this dialog above v2 Modals (z-[60]) hosting the form that errored */}
+            <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
               <DialogHeader>
                 <DialogTitle>Validation Rules</DialogTitle>
                 <DialogDescription>Please review the allowed rules below.</DialogDescription>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
@@ -16,7 +16,7 @@ export const rotationSchema = z.object({
 });
 
 export const genericAppConnectionFieldsSchema = z.object({
-  name: slugSchema({ min: 1, max: 64, field: "Name" }),
+  name: z.any(),
   description: z.string().trim().max(256, "Description cannot exceed 256 characters").nullish(),
   gatewayId: z
     .string()

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
@@ -16,7 +16,7 @@ export const rotationSchema = z.object({
 });
 
 export const genericAppConnectionFieldsSchema = z.object({
-  name: z.any(),
+  name: slugSchema({ min: 1, max: 64, field: "Name" }),
   description: z.string().trim().max(256, "Description cannot exceed 256 characters").nullish(),
   gatewayId: z
     .string()


### PR DESCRIPTION
## Context

This PR bumps up the validation and forbidden mutation error modals z-index to not compete with the v2 modal

## Screenshots

<img width="3456" height="1806" alt="CleanShot 2026-06-11 at 18 27 42@2x" src="https://github.com/user-attachments/assets/6e2f3f2c-014d-4ada-851c-842648d15055" />

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)