### PR TITLE
improvement: migrate networking gateway and relay cards to v3 and stabilize sub-tab layout

### DIFF
--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
@@ -6,19 +6,17 @@ import {
   faEllipsisV,
   faHeartPulse,
   faInfoCircle,
-  faMagnifyingGlass,
-  faPlus,
   faSearch,
   faTrash
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { PlusIcon, SearchIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
   DeleteActionModal,
   DropdownMenu,
   DropdownMenuContent,
@@ -26,7 +24,6 @@ import {
   DropdownMenuTrigger,
   EmptyState,
   IconButton,
-  Input,
   Modal,
   ModalContent,
   Table,
@@ -39,7 +36,22 @@ import {
   Tooltip,
   Tr
 } from "@app/components/v2";
-import { DocumentationLinkBadge } from "@app/components/v3";
+import {
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DocumentationLinkBadge,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Tabs,
+  TabsList,
+  TabsTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import {
   OrgGatewayPermissionActions,
@@ -70,6 +82,7 @@ export const GatewayTab = withPermission(
     const { subscription } = useSubscription();
     const showPoolsTab = subscription?.gatewayPool;
     const [search, setSearch] = useState("");
+    const [poolSearch, setPoolSearch] = useState("");
     const { data: gateways, isPending: isGatewaysLoading } = useQuery({
       ...gatewaysQueryKeys.listWithTokens(),
       refetchInterval: 15_000
@@ -127,10 +140,10 @@ export const GatewayTab = withPermission(
     );
 
     return (
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-        <div className="mb-2 flex items-center justify-between">
-          <div className="flex grow items-center gap-x-2">
-            <h3 className="text-lg font-medium text-mineshaft-100">Gateways</h3>
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>
+            Gateways
             <DocumentationLinkBadge
               href={
                 activeSubTab === "gateway-pools"
@@ -138,29 +151,13 @@ export const GatewayTab = withPermission(
                   : "https://infisical.com/docs/documentation/platform/gateways/overview"
               }
             />
-            <div className="ml-2 flex gap-x-0.5 rounded-md border border-mineshaft-600 bg-mineshaft-800 p-0.5">
-              <Button
-                variant="outline_bg"
-                onClick={() => setActiveSubTab("all-gateways")}
-                size="xs"
-                className={`${
-                  activeSubTab === "all-gateways" ? "bg-mineshaft-500" : "bg-transparent"
-                } rounded border-none px-3 py-1 hover:bg-mineshaft-600`}
-              >
-                All Gateways
-              </Button>
-              <Button
-                variant="outline_bg"
-                onClick={() => setActiveSubTab("gateway-pools")}
-                size="xs"
-                className={`${
-                  activeSubTab === "gateway-pools" ? "bg-mineshaft-500" : "bg-transparent"
-                } rounded border-none px-3 py-1 hover:bg-mineshaft-600`}
-              >
-                Gateway Pools
-              </Button>
-            </div>
-            <div className="flex grow" />
+          </CardTitle>
+          <CardDescription>
+            {activeSubTab === "gateway-pools"
+              ? "Pool gateways for high availability and automatic failover"
+              : "Create and configure gateways to access private network resources from Infisical"}
+          </CardDescription>
+          <CardAction>
             {activeSubTab === "all-gateways" ? (
               <OrgPermissionCan
                 I={OrgGatewayPermissionActions.CreateGateways}
@@ -168,11 +165,11 @@ export const GatewayTab = withPermission(
               >
                 {(isAllowed: boolean) => (
                   <Button
-                    variant="outline_bg"
-                    leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                    variant="org"
                     onClick={() => handlePopUpOpen("deployGateway")}
                     isDisabled={!isAllowed}
                   >
+                    <PlusIcon />
                     Create Gateway
                   </Button>
                 )}
@@ -185,233 +182,255 @@ export const GatewayTab = withPermission(
                 >
                   {(isAllowed: boolean) => (
                     <Button
-                      variant="outline_bg"
-                      leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                      variant="org"
                       onClick={() => handlePopUpOpen("createPool")}
                       isDisabled={!isAllowed}
                     >
+                      <PlusIcon />
                       Create Pool
                     </Button>
                   )}
                 </OrgPermissionCan>
               )
             )}
-          </div>
-        </div>
-        {activeSubTab === "gateway-pools" ? (
-          <GatewayPoolsContent />
-        ) : (
-          <>
-            <p className="mb-4 text-sm text-mineshaft-400">
-              Create and configure gateway to access private network resources from Infisical
-            </p>
-            <div>
-              <div className="flex gap-2">
-                <Input
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <Tabs
+              value={activeSubTab}
+              onValueChange={(value) => setActiveSubTab(value as "all-gateways" | "gateway-pools")}
+            >
+              <TabsList variant="filled">
+                <TabsTrigger value="all-gateways">All Gateways</TabsTrigger>
+                <TabsTrigger value="gateway-pools">Gateway Pools</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {activeSubTab === "all-gateways" ? (
+              <InputGroup className="w-1/2 min-w-64">
+                <InputGroupAddon align="inline-start">
+                  <SearchIcon />
+                </InputGroupAddon>
+                <InputGroupInput
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
                   placeholder="Search gateway..."
-                  className="flex-1"
                 />
-              </div>
-              <TableContainer className="mt-4">
-                <Table>
-                  <THead>
-                    <Tr>
-                      <Th className="w-1/3">Name</Th>
-                      {showPoolsTab && <Th>Pools</Th>}
-                      <Th>Connected</Th>
-                      <Th>
-                        Health Check
-                        <Tooltip
-                          asChild={false}
-                          className="normal-case"
-                          content="The last known healthcheck. Triggers every 3 minutes."
-                        >
-                          <FontAwesomeIcon icon={faInfoCircle} className="ml-2" />
-                        </Tooltip>
-                      </Th>
-                      <Th className="w-5" />
-                    </Tr>
-                  </THead>
-                  <TBody>
-                    {isGatewaysLoading && (
-                      <TableSkeleton
-                        innerKey="gateway-table"
-                        columns={showPoolsTab ? 5 : 4}
-                        key="gateway-table"
-                      />
-                    )}
-                    {filteredGateway?.map((el) => {
-                      const canNavigate = !el.isV1;
-                      return (
-                        <Tr
-                          key={el.id}
-                          className={
-                            canNavigate ? "cursor-pointer hover:bg-mineshaft-700" : undefined
-                          }
-                          onClick={
-                            canNavigate
-                              ? () =>
-                                  navigate({
-                                    to: "/organizations/$orgId/networking/gateways/$gatewayId",
-                                    params: { orgId, gatewayId: el.id }
-                                  })
-                              : undefined
-                          }
-                        >
+              </InputGroup>
+            ) : (
+              showPoolsTab && (
+                <InputGroup className="w-1/2 min-w-64">
+                  <InputGroupAddon align="inline-start">
+                    <SearchIcon />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    value={poolSearch}
+                    onChange={(e) => setPoolSearch(e.target.value)}
+                    placeholder="Search pool..."
+                  />
+                </InputGroup>
+              )
+            )}
+          </div>
+          {activeSubTab === "gateway-pools" ? (
+            <GatewayPoolsContent search={poolSearch} />
+          ) : (
+            <TableContainer>
+              <Table>
+                <THead>
+                  <Tr>
+                    <Th className="w-1/3">Name</Th>
+                    {showPoolsTab && <Th>Pools</Th>}
+                    <Th>Connected</Th>
+                    <Th>
+                      Health Check
+                      <Tooltip
+                        asChild={false}
+                        className="normal-case"
+                        content="The last known healthcheck. Triggers every 3 minutes."
+                      >
+                        <FontAwesomeIcon icon={faInfoCircle} className="ml-2" />
+                      </Tooltip>
+                    </Th>
+                    <Th className="w-5" />
+                  </Tr>
+                </THead>
+                <TBody>
+                  {isGatewaysLoading && (
+                    <TableSkeleton
+                      innerKey="gateway-table"
+                      columns={showPoolsTab ? 5 : 4}
+                      key="gateway-table"
+                    />
+                  )}
+                  {filteredGateway?.map((el) => {
+                    const canNavigate = !el.isV1;
+                    return (
+                      <Tr
+                        key={el.id}
+                        className={
+                          canNavigate ? "cursor-pointer hover:bg-mineshaft-700" : undefined
+                        }
+                        onClick={
+                          canNavigate
+                            ? () =>
+                                navigate({
+                                  to: "/organizations/$orgId/networking/gateways/$gatewayId",
+                                  params: { orgId, gatewayId: el.id }
+                                })
+                            : undefined
+                        }
+                      >
+                        <Td>
+                          <div className="flex items-center gap-2">
+                            <span>{el.name}</span>
+                            <span className="rounded-sm bg-mineshaft-700 px-1.5 py-0.5 text-xs text-mineshaft-400">
+                              Gateway v{el.isV1 ? "1" : "2"}
+                            </span>
+                          </div>
+                        </Td>
+                        {showPoolsTab && (
                           <Td>
-                            <div className="flex items-center gap-2">
-                              <span>{el.name}</span>
-                              <span className="rounded-sm bg-mineshaft-700 px-1.5 py-0.5 text-xs text-mineshaft-400">
-                                Gateway v{el.isV1 ? "1" : "2"}
-                              </span>
-                            </div>
-                          </Td>
-                          {showPoolsTab && (
-                            <Td>
-                              {(gatewayPoolMap.get(el.id) ?? []).length > 0 ? (
-                                <div className="flex flex-wrap gap-1">
-                                  {(gatewayPoolMap.get(el.id) ?? []).map((poolName) => (
-                                    <span
-                                      key={poolName}
-                                      className="rounded-sm bg-info/15 px-1.5 py-0.5 text-xs text-info"
-                                    >
-                                      {poolName}
-                                    </span>
-                                  ))}
-                                </div>
-                              ) : (
-                                <span className="text-mineshaft-400">&mdash;</span>
-                              )}
-                            </Td>
-                          )}
-                          <Td>
-                            {!el.isV1 && el.connectedResourcesCount > 0 ? (
-                              <span className="text-mineshaft-200">
-                                {el.connectedResourcesCount} resource
-                                {el.connectedResourcesCount !== 1 ? "s" : ""}
-                              </span>
+                            {(gatewayPoolMap.get(el.id) ?? []).length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {(gatewayPoolMap.get(el.id) ?? []).map((poolName) => (
+                                  <span
+                                    key={poolName}
+                                    className="rounded-sm bg-info/15 px-1.5 py-0.5 text-xs text-info"
+                                  >
+                                    {poolName}
+                                  </span>
+                                ))}
+                              </div>
                             ) : (
-                              <span className="text-mineshaft-400">—</span>
+                              <span className="text-mineshaft-400">&mdash;</span>
                             )}
                           </Td>
-                          <Td>
-                            <GatewayHealthStatus
-                              heartbeat={"heartbeat" in el ? el.heartbeat : null}
-                              heartbeatTTL={"heartbeatTTL" in el ? el.heartbeatTTL : null}
-                            />
-                          </Td>
-                          <Td className="w-5" onClick={(e) => e.stopPropagation()}>
-                            <Tooltip className="max-w-sm text-center" content="Options">
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <IconButton
-                                    ariaLabel="Options"
-                                    colorSchema="secondary"
-                                    className="w-6"
-                                    variant="plain"
-                                  >
-                                    <FontAwesomeIcon icon={faEllipsisV} />
-                                  </IconButton>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
+                        )}
+                        <Td>
+                          {!el.isV1 && el.connectedResourcesCount > 0 ? (
+                            <span className="text-mineshaft-200">
+                              {el.connectedResourcesCount} resource
+                              {el.connectedResourcesCount !== 1 ? "s" : ""}
+                            </span>
+                          ) : (
+                            <span className="text-mineshaft-400">—</span>
+                          )}
+                        </Td>
+                        <Td>
+                          <GatewayHealthStatus
+                            heartbeat={"heartbeat" in el ? el.heartbeat : null}
+                            heartbeatTTL={"heartbeatTTL" in el ? el.heartbeatTTL : null}
+                          />
+                        </Td>
+                        <Td className="w-5" onClick={(e) => e.stopPropagation()}>
+                          <Tooltip className="max-w-sm text-center" content="Options">
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <IconButton
+                                  ariaLabel="Options"
+                                  colorSchema="secondary"
+                                  className="w-6"
+                                  variant="plain"
+                                >
+                                  <FontAwesomeIcon icon={faEllipsisV} />
+                                </IconButton>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                  icon={<FontAwesomeIcon icon={faCopy} />}
+                                  onClick={() => navigator.clipboard.writeText(el.id)}
+                                >
+                                  Copy ID
+                                </DropdownMenuItem>
+                                {!el.isV1 && (!!el.heartbeat || !!el.heartbeatTTL) && (
                                   <DropdownMenuItem
-                                    icon={<FontAwesomeIcon icon={faCopy} />}
-                                    onClick={() => navigator.clipboard.writeText(el.id)}
+                                    icon={<FontAwesomeIcon icon={faHeartPulse} />}
+                                    onClick={() => handleTriggerHealthCheck(el.id)}
                                   >
-                                    Copy ID
+                                    Trigger Health Check
                                   </DropdownMenuItem>
-                                  {!el.isV1 && (!!el.heartbeat || !!el.heartbeatTTL) && (
-                                    <DropdownMenuItem
-                                      icon={<FontAwesomeIcon icon={faHeartPulse} />}
-                                      onClick={() => handleTriggerHealthCheck(el.id)}
-                                    >
-                                      Trigger Health Check
-                                    </DropdownMenuItem>
-                                  )}
-                                  {el.isV1 && (
-                                    <OrgPermissionCan
-                                      I={OrgGatewayPermissionActions.EditGateways}
-                                      a={OrgPermissionSubjects.Gateway}
-                                    >
-                                      {(isAllowed: boolean) => (
-                                        <DropdownMenuItem
-                                          isDisabled={!isAllowed}
-                                          icon={<FontAwesomeIcon icon={faEdit} />}
-                                          onClick={() => handlePopUpOpen("editDetails", el)}
-                                        >
-                                          Edit Details
-                                        </DropdownMenuItem>
-                                      )}
-                                    </OrgPermissionCan>
-                                  )}
+                                )}
+                                {el.isV1 && (
                                   <OrgPermissionCan
-                                    I={OrgGatewayPermissionActions.DeleteGateways}
+                                    I={OrgGatewayPermissionActions.EditGateways}
                                     a={OrgPermissionSubjects.Gateway}
                                   >
                                     {(isAllowed: boolean) => (
                                       <DropdownMenuItem
                                         isDisabled={!isAllowed}
-                                        icon={<FontAwesomeIcon icon={faTrash} />}
-                                        className="text-red"
-                                        onClick={() => handlePopUpOpen("deleteGateway", el)}
+                                        icon={<FontAwesomeIcon icon={faEdit} />}
+                                        onClick={() => handlePopUpOpen("editDetails", el)}
                                       >
-                                        Delete Gateway
+                                        Edit Details
                                       </DropdownMenuItem>
                                     )}
                                   </OrgPermissionCan>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            </Tooltip>
-                          </Td>
-                        </Tr>
-                      );
-                    })}
-                  </TBody>
-                </Table>
-                <Modal
-                  isOpen={popUp.editDetails.isOpen}
-                  onOpenChange={(isOpen) => handlePopUpToggle("editDetails", isOpen)}
-                >
-                  <ModalContent title="Edit Gateway">
-                    <EditGatewayDetailsModal
-                      gatewayDetails={popUp.editDetails.data}
-                      onClose={() => handlePopUpToggle("editDetails")}
-                    />
-                  </ModalContent>
-                </Modal>
-                {!isGatewaysLoading && !filteredGateway?.length && (
-                  <EmptyState
-                    title={
-                      gateways?.length
-                        ? "No Gateways match search..."
-                        : "No Gateways have been configured"
-                    }
-                    icon={gateways?.length ? faSearch : faDoorClosed}
+                                )}
+                                <OrgPermissionCan
+                                  I={OrgGatewayPermissionActions.DeleteGateways}
+                                  a={OrgPermissionSubjects.Gateway}
+                                >
+                                  {(isAllowed: boolean) => (
+                                    <DropdownMenuItem
+                                      isDisabled={!isAllowed}
+                                      icon={<FontAwesomeIcon icon={faTrash} />}
+                                      className="text-red"
+                                      onClick={() => handlePopUpOpen("deleteGateway", el)}
+                                    >
+                                      Delete Gateway
+                                    </DropdownMenuItem>
+                                  )}
+                                </OrgPermissionCan>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </Tooltip>
+                        </Td>
+                      </Tr>
+                    );
+                  })}
+                </TBody>
+              </Table>
+              <Modal
+                isOpen={popUp.editDetails.isOpen}
+                onOpenChange={(isOpen) => handlePopUpToggle("editDetails", isOpen)}
+              >
+                <ModalContent title="Edit Gateway">
+                  <EditGatewayDetailsModal
+                    gatewayDetails={popUp.editDetails.data}
+                    onClose={() => handlePopUpToggle("editDetails")}
                   />
-                )}
-                <DeleteActionModal
-                  isOpen={popUp.deleteGateway.isOpen}
-                  title={`Are you sure you want to delete gateway ${(popUp?.deleteGateway?.data as { name: string })?.name || ""}?`}
-                  onChange={(isOpen) => handlePopUpToggle("deleteGateway", isOpen)}
-                  deleteKey="confirm"
-                  onDeleteApproved={() => handleDeleteGateway()}
+                </ModalContent>
+              </Modal>
+              {!isGatewaysLoading && !filteredGateway?.length && (
+                <EmptyState
+                  title={
+                    gateways?.length
+                      ? "No Gateways match search..."
+                      : "No Gateways have been configured"
+                  }
+                  icon={gateways?.length ? faSearch : faDoorClosed}
                 />
-                <GatewayDeployModal
-                  isOpen={popUp.deployGateway.isOpen}
-                  onOpenChange={(isOpen) => handlePopUpToggle("deployGateway", isOpen)}
-                />
-              </TableContainer>
-            </div>
-          </>
-        )}
+              )}
+              <DeleteActionModal
+                isOpen={popUp.deleteGateway.isOpen}
+                title={`Are you sure you want to delete gateway ${(popUp?.deleteGateway?.data as { name: string })?.name || ""}?`}
+                onChange={(isOpen) => handlePopUpToggle("deleteGateway", isOpen)}
+                deleteKey="confirm"
+                onDeleteApproved={() => handleDeleteGateway()}
+              />
+              <GatewayDeployModal
+                isOpen={popUp.deployGateway.isOpen}
+                onOpenChange={(isOpen) => handlePopUpToggle("deployGateway", isOpen)}
+              />
+            </TableContainer>
+          )}
+        </CardContent>
         <CreateGatewayPoolModal
           isOpen={popUp.createPool.isOpen}
           onToggle={(isOpen) => handlePopUpToggle("createPool", isOpen)}
         />
-      </div>
+      </Card>
     );
   },
   { action: OrgGatewayPermissionActions.ListGateways, subject: OrgPermissionSubjects.Gateway }

--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/GatewayPoolsContent.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/GatewayPoolsContent.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { faEllipsisV, faMagnifyingGlass, faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faEllipsisV, faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
@@ -13,7 +13,6 @@ import {
   DropdownMenuTrigger,
   EmptyState,
   IconButton,
-  Input,
   Table,
   TableContainer,
   TableSkeleton,
@@ -33,10 +32,13 @@ import { PoolConnectedResourcesDrawer } from "./PoolConnectedResourcesDrawer";
 import { PoolDetailSheet } from "./PoolDetailSheet";
 import { PoolHealthBadge } from "./PoolHealthBadge";
 
-export const GatewayPoolsContent = () => {
+type Props = {
+  search: string;
+};
+
+export const GatewayPoolsContent = ({ search }: Props) => {
   const { subscription } = useSubscription();
   const isEnterprise = subscription?.gatewayPool;
-  const [search, setSearch] = useState("");
   const [selectedPoolId, setSelectedPoolId] = useState<string | null>(null);
   const [resourcesPool, setResourcesPool] = useState<{ id: string; name: string } | null>(null);
   const { data: pools, isPending: isPoolsLoading } = useListGatewayPools({
@@ -71,9 +73,6 @@ export const GatewayPoolsContent = () => {
   if (!isEnterprise) {
     return (
       <div>
-        <p className="mb-4 text-sm text-mineshaft-400">
-          Pool gateways for high availability and automatic failover
-        </p>
         <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 p-8 text-center">
           <div className="mb-3 text-2xl">&#x1f6e1;&#xfe0f;</div>
           <h4 className="mb-2 text-lg font-medium text-mineshaft-100">Enterprise Feature</h4>
@@ -96,19 +95,7 @@ export const GatewayPoolsContent = () => {
 
   return (
     <div>
-      <p className="mb-4 text-sm text-mineshaft-400">
-        Pool gateways for high availability and automatic failover
-      </p>
-      <div className="flex gap-2">
-        <Input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-          placeholder="Search pool..."
-          className="flex-1"
-        />
-      </div>
-      <TableContainer className="mt-4">
+      <TableContainer>
         <Table>
           <THead>
             <Tr>

--- a/frontend/src/pages/organization/NetworkingPage/components/RelayTab/RelayTab.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/RelayTab/RelayTab.tsx
@@ -4,19 +4,17 @@ import {
   faDoorClosed,
   faEllipsisV,
   faInfoCircle,
-  faMagnifyingGlass,
-  faPlus,
   faSearch,
   faTrash
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { formatRelative } from "date-fns";
+import { PlusIcon, SearchIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
   DeleteActionModal,
   DropdownMenu,
   DropdownMenuContent,
@@ -24,7 +22,6 @@ import {
   DropdownMenuTrigger,
   EmptyState,
   IconButton,
-  Input,
   Table,
   TableContainer,
   TableSkeleton,
@@ -35,7 +32,19 @@ import {
   Tooltip,
   Tr
 } from "@app/components/v2";
-import { DocumentationLinkBadge } from "@app/components/v3";
+import {
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DocumentationLinkBadge,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization } from "@app/context";
 import {
@@ -120,35 +129,34 @@ export const RelayTab = withPermission(
     );
 
     return (
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-        <div className="mb-2 flex items-center justify-between">
-          <div className="flex grow items-center gap-x-2">
-            <h3 className="text-lg font-medium text-mineshaft-100">Relays</h3>
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>
+            Relays
             <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/gateways/relay-deployment" />
-            <div className="flex grow" />
-            <Button
-              variant="outline_bg"
-              leftIcon={<FontAwesomeIcon icon={faPlus} />}
-              onClick={() => handlePopUpOpen("deployRelay")}
-            >
+          </CardTitle>
+          <CardDescription>
+            Create and configure relays to securely access private network resources from Infisical
+          </CardDescription>
+          <CardAction>
+            <Button variant="org" onClick={() => handlePopUpOpen("deployRelay")}>
+              <PlusIcon />
               Create Relay
             </Button>
-          </div>
-        </div>
-        <p className="mb-4 text-sm text-mineshaft-400">
-          Create and configure relays to securely access private network resources from Infisical
-        </p>
-        <div>
-          <div className="flex gap-2">
-            <Input
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <InputGroup className="mb-4">
+            <InputGroupAddon align="inline-start">
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
               placeholder="Search relay..."
-              className="flex-1"
             />
-          </div>
-          <TableContainer className="mt-4">
+          </InputGroup>
+          <TableContainer>
             <Table>
               <THead>
                 <Tr>
@@ -170,7 +178,7 @@ export const RelayTab = withPermission(
               </THead>
               <TBody>
                 {isRelaysLoading && (
-                  <TableSkeleton innerKey="relay-table" columns={4} key="relay-table" />
+                  <TableSkeleton innerKey="relay-table" columns={5} key="relay-table" />
                 )}
                 {filteredRelays?.map((el) => (
                   <Tr
@@ -267,8 +275,8 @@ export const RelayTab = withPermission(
               onOpenChange={(isOpen) => handlePopUpToggle("deployRelay", isOpen)}
             />
           </TableContainer>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     );
   },
   { action: OrgRelayPermissionActions.ListRelays, subject: OrgPermissionSubjects.Relay }


### PR DESCRIPTION
## Context

Fixes #6837

The Networking page had a couple of layout-stability and design-system consistency issues:

1. **Gateway sub-tab layout shift.** Switching to "Gateway Pools" on plans without pool actions unmounted the "Create" button, collapsing the card header row and shifting all content below it.
2. **Older hand-rolled UI patterns.** Gateways and Relays used custom card shells, search inputs, and a manually styled gateway sub-tab toggle instead of the newer v3 primitives used elsewhere in the org experience.

This PR updates the Networking page to use existing v3 design-system patterns:

- Replaces the hand-rolled Gateways and Relays shells with `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardAction`, and `CardContent`, matching the structure used by the Secret Sharing tabs.
- Replaces the custom "All Gateways / Gateway Pools" button toggle with v3 `Tabs`, giving the control proper tab semantics and keyboard behavior.
- Moves gateway/pool search into a toolbar using v3 `InputGroup`, matching the tabs-left, search-right layout of the Machine Identities section under Access Control, with a minimum width so the search wraps instead of compressing on narrow screens.
- Lifts pool search state into `GatewayTab` so the toolbar owns the visible search control for each sub-tab.
- Fixes the Relay table loading skeleton to render the same number of columns as the table (5, not 4).
- Updates the gateway description copy from singular to plural.

Most of the `GatewayTab.tsx` line count is re-indentation from removing a wrapper fragment. Review with whitespace hidden to see the smaller underlying change.

## Deliberately out of scope

- The tables, dropdown menus, and modals inside these cards still use v2 components. Migrating those to v3 should be a separate, more focused pass.
- The Enterprise upgrade CTA keeps its current styling to stay consistent with the existing upgrade flow.
- App Connections has a similar hand-rolled toggle and could be aligned with v3 `Tabs` in a follow-up.

## Screenshots

**Before — switching sub-tabs shifts the layout:**

https://github.com/user-attachments/assets/40f71d1b-abef-49b1-a7f1-72dac87260c2

**After — header and toolbar stay stable:**

https://github.com/user-attachments/assets/4e007e50-c16f-4b7d-a8a2-4be260cd010c

*(Clips include Secret Sharing as an existing v3 surface for comparison.)*

**Card styling before / after:**

<img width="3366" height="2288" alt="infisical-networking-card-before" src="https://github.com/user-attachments/assets/ddd4d03a-6930-4ab5-a342-a518b9e43932" />

<img width="3366" height="2288" alt="infisical-networking-card-after" src="https://github.com/user-attachments/assets/00dd6e97-2b95-4062-b340-761df4bfaa34" />

## Steps to verify

1. Go to Org → Networking → Gateways.
2. Switch between "All Gateways" and "Gateway Pools"; the header and toolbar should remain stable while the content changes.
3. Search gateways and relays; filtering should continue to work. (Pool search requires a plan with `gatewayPool` enabled.)
4. Narrow the viewport below tablet width; the search input should wrap instead of compressing.
5. Focus the gateway sub-tab control and use arrow keys to move between tabs.
6. Switch between the Gateways and Relays top-level tabs; both sections should use the same card/header/search structure.

## Verification

- [x] `make reviewable-ui`
- [x] `git diff --check`
- [x] Tested locally on both the free tier (upsell panel state) and with `gatewayPool` enabled (pools table, search, and create flow)

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [x] Updated docs, if needed — N/A, no behavior change
- [x] Updated CLAUDE.md files, if needed — N/A, applies existing v3 patterns
- [x] Read the contributing guide
