### PR TITLE
feat: group certificate resources under a navigation section

### DIFF
--- a/docs/documentation/platform/pki/ca/acme-ca.mdx
+++ b/docs/documentation/platform/pki/ca/acme-ca.mdx
@@ -137,7 +137,7 @@ In the following steps, we explore how to connect Infisical to an ACME-compatibl
     <Step title="Register an ACME-compatible CA">
         <Tabs>
           <Tab title="Infisical UI">
-              To register an ACME-compatible CA, in **Certificate Manager** go to **Settings → Certificate Authorities**, scroll to External Certificate Authorities, and click **Create CA**.
+              To register an ACME-compatible CA, in **Certificate Manager** go to **Certificate Authorities**, scroll to External Certificate Authorities, and click **Create CA**.
 
               Set the **CA Type** to **ACME** and fill out the following fields:
 

--- a/docs/documentation/platform/pki/ca/aws-acm-public-ca.mdx
+++ b/docs/documentation/platform/pki/ca/aws-acm-public-ca.mdx
@@ -75,7 +75,7 @@ Each certificate has a fixed 198-day validity and is generated and stored by AWS
   </Step>
 
   <Step title="Navigate to External Certificate Authorities">
-    In **Certificate Manager**, go to **Settings → Certificate Authorities** and scroll to the **External Certificate Authorities** section.
+    In **Certificate Manager**, go to **Certificate Authorities** and scroll to the **External Certificate Authorities** section.
   </Step>
 
   <Step title="Create the CA">

--- a/docs/documentation/platform/pki/ca/aws-pca.mdx
+++ b/docs/documentation/platform/pki/ca/aws-pca.mdx
@@ -83,7 +83,7 @@ See the [AWS Connection](/integrations/app-connections/aws) page for full setup 
   </Step>
 
   <Step title="Navigate to External Certificate Authorities">
-    In **Certificate Manager**, go to **Settings → Certificate Authorities** and scroll to the **External Certificate Authorities** section.
+    In **Certificate Manager**, go to **Certificate Authorities** and scroll to the **External Certificate Authorities** section.
   </Step>
 
   <Step title="Create New AWS PCA Certificate Authority">

--- a/docs/documentation/platform/pki/ca/azure-adcs.mdx
+++ b/docs/documentation/platform/pki/ca/azure-adcs.mdx
@@ -26,7 +26,7 @@ Infisical supports two ways to use AD CS: as an **External CA** for direct certi
 
     <Steps>
       <Step title="Navigate to External Certificate Authorities">
-        In **Certificate Manager**, go to **Settings → Certificate Authorities** and scroll to the **External Certificate Authorities** section.
+        In **Certificate Manager**, go to **Certificate Authorities** and scroll to the **External Certificate Authorities** section.
       </Step>
 
       <Step title="Create New Azure ADCS Certificate Authority">
@@ -37,7 +37,7 @@ Infisical supports two ways to use AD CS: as an **External CA** for direct certi
       </Step>
 
       <Step title="Create a Certificate Profile">
-        Go to **Certificate Manager → Settings → Certificate Profiles** and create a new profile:
+        Go to **Certificate Manager → Certificate Profiles** and create a new profile:
         - **Certificate Authority**: Select your ADCS CA
         - **Certificate Policy**: Select a policy
         - **Certificate Template**: Select from dynamically loaded ADCS templates

--- a/docs/documentation/platform/pki/ca/digicert-direct.mdx
+++ b/docs/documentation/platform/pki/ca/digicert-direct.mdx
@@ -22,7 +22,7 @@ Infisical can issue OV and EV TLS certificates directly from [DigiCert CertCentr
         Follow the [DigiCert App Connection guide](/integrations/app-connections/digicert) to store your CertCentral API key in Infisical.
       </Step>
       <Step title="Create the External CA">
-        In **Certificate Manager**, go to **Settings → Certificate Authorities**, click **Create CA** in the External Certificate Authorities section, choose **DigiCert CertCentral** as the type, and fill out the form:
+        In **Certificate Manager**, go to **Certificate Authorities**, click **Create CA** in the External Certificate Authorities section, choose **DigiCert CertCentral** as the type, and fill out the form:
 
         - **App Connection** — the DigiCert connection you created
         - **Organization** — the CertCentral organization that should appear on issued certificates

--- a/docs/documentation/platform/pki/ca/godaddy.mdx
+++ b/docs/documentation/platform/pki/ca/godaddy.mdx
@@ -19,7 +19,7 @@ Infisical can issue Domain Validated (DV) TLS certificates directly from [GoDadd
 
 ## Set up the certificate policy
 
-GoDaddy needs a **server-certificate policy that uses RSA**. The built-in `TLS Server Certificate` preset allows both ECDSA and RSA, so you can start from it and select RSA, or create a custom policy in **Settings → Certificate Policies → Create Policy**. Either way, configure:
+GoDaddy needs a **server-certificate policy that uses RSA**. The built-in `TLS Server Certificate` preset allows both ECDSA and RSA, so you can start from it and select RSA, or create a custom policy in **Certificate Policies → Create Policy**. Either way, configure:
 
 - **Key algorithm:** RSA 2048 (RSA 3072/4096 also work), not ECDSA (the preset selects ECDSA by default)
 - **Signature algorithm:** RSA-SHA256
@@ -38,7 +38,7 @@ Then create a [certificate profile](/documentation/platform/pki/settings/profile
         Follow the [GoDaddy App Connection guide](/integrations/app-connections/godaddy) to store your GoDaddy API key and secret in Infisical.
       </Step>
       <Step title="Create the External CA">
-        In **Certificate Manager**, go to **Settings → Certificate Authorities**, click **Create CA** in the External Certificate Authorities section, choose **GoDaddy** as the type, and fill out the form:
+        In **Certificate Manager**, go to **Certificate Authorities**, click **Create CA** in the External Certificate Authorities section, choose **GoDaddy** as the type, and fill out the form:
 
         - **App Connection**: the GoDaddy connection you created
         - **Product**: `DV SSL`

--- a/docs/documentation/platform/pki/ca/venafi-tpp.mdx
+++ b/docs/documentation/platform/pki/ca/venafi-tpp.mdx
@@ -15,7 +15,7 @@ Issue and manage certificates using a self-hosted Venafi Trust Protection Platfo
 
 <Steps>
   <Step title="Navigate to External Certificate Authorities">
-    In **Certificate Manager**, go to **Settings → Certificate Authorities** and scroll to the **External Certificate Authorities** section.
+    In **Certificate Manager**, go to **Certificate Authorities** and scroll to the **External Certificate Authorities** section.
   </Step>
   <Step title="Create New Venafi TPP CA">
     Click **Create CA** and configure:

--- a/docs/documentation/platform/pki/ca/venafi.mdx
+++ b/docs/documentation/platform/pki/ca/venafi.mdx
@@ -51,7 +51,7 @@ sequenceDiagram
   <Tab title="Infisical UI">
     <Steps>
       <Step title="Create an Intermediate CA">
-        If you haven't already, in **Certificate Manager** go to **Settings → Certificate Authorities** and click **Create CA** in the Internal Certificate Authorities section.
+        If you haven't already, in **Certificate Manager** go to **Certificate Authorities** and click **Create CA** in the Internal Certificate Authorities section.
 
         Set the **CA Type** to **Intermediate** and fill out the details for the intermediate CA (Common Name, Organization, Key Algorithm, etc.).
       </Step>

--- a/docs/documentation/platform/pki/guides/applications/k8s-cert-manager.mdx
+++ b/docs/documentation/platform/pki/guides/applications/k8s-cert-manager.mdx
@@ -268,7 +268,7 @@ helm upgrade trust-manager jetstack/trust-manager \
 
 **2. Create a CA certificate secret**
 
-Download the CA certificate chain from **Certificate Manager → Settings → Certificate Authorities** (select your CA → Download CA Certificate Chain), then create:
+Download the CA certificate chain from **Certificate Manager → Certificate Authorities** (select your CA → Download CA Certificate Chain), then create:
 
 ```yaml infisical-ca-cert.yaml
 apiVersion: v1

--- a/docs/documentation/platform/pki/quick-starts/issue-first-certificate.mdx
+++ b/docs/documentation/platform/pki/quick-starts/issue-first-certificate.mdx
@@ -14,7 +14,7 @@ Issue a TLS certificate from your own private CA in about 10 minutes. You'll set
 
 <Steps>
   <Step title="Create a Certificate Authority">
-    Go to **Certificate Manager → Settings → Certificate Authorities** and click **Create**.
+    Go to **Certificate Manager → Certificate Authorities** and click **Create**.
     
     | Field | Value |
     |-------|-------|
@@ -25,7 +25,7 @@ Issue a TLS certificate from your own private CA in about 10 minutes. You'll set
     [Learn more about CAs →](/documentation/platform/pki/ca/overview)
   </Step>
   <Step title="Create a Certificate Policy">
-    Go to **Settings → Certificate Policies** and click **Create**.
+    Go to **Certificate Policies** and click **Create**.
     
     | Field | Value |
     |-------|-------|
@@ -37,7 +37,7 @@ Issue a TLS certificate from your own private CA in about 10 minutes. You'll set
     [Learn more about policies →](/documentation/platform/pki/settings/policies)
   </Step>
   <Step title="Create a Certificate Profile">
-    Go to **Settings → Certificate Profiles** and click **Create**.
+    Go to **Certificate Profiles** and click **Create**.
     
     | Field | Value |
     |-------|-------|

--- a/docs/documentation/platform/pki/quick-starts/sign-first-code.mdx
+++ b/docs/documentation/platform/pki/quick-starts/sign-first-code.mdx
@@ -16,7 +16,7 @@ Sign a Java JAR file using Infisical-managed keys in about 10 minutes. You'll is
 
 <Steps>
   <Step title="Issue a Code Signing Certificate">
-    First, issue a certificate for code signing. Go to **Certificate Manager → Settings → Certificate Policies** and click **Create**.
+    First, issue a certificate for code signing. Go to **Certificate Manager → Certificate Policies** and click **Create**.
     
     | Field | Value |
     |-------|-------|

--- a/docs/documentation/platform/pki/settings/policies.mdx
+++ b/docs/documentation/platform/pki/settings/policies.mdx
@@ -18,7 +18,7 @@ This enforcement happens automatically — teams don't need to know the policy d
 
 ## Create a Certificate Policy
 
-Navigate to **Certificate Manager → Settings → Certificate Policies** and click **Create**.
+Navigate to **Certificate Manager → Certificate Policies** and click **Create**.
 
 ### Policy Presets
 

--- a/docs/documentation/platform/pki/settings/profiles.mdx
+++ b/docs/documentation/platform/pki/settings/profiles.mdx
@@ -22,7 +22,7 @@ Profiles solve a common problem: you want consistency across certificates withou
 
 ## Create a Certificate Profile
 
-Navigate to **Certificate Manager → Settings → Certificate Profiles** and click **Create Profile**.
+Navigate to **Certificate Manager → Certificate Profiles** and click **Create Profile**.
 
 ### Configuration
 

--- a/frontend/src/const/routes.ts
+++ b/frontend/src/const/routes.ts
@@ -327,9 +327,17 @@ export const ROUTE_PATHS = Object.freeze({
       "/organizations/$orgId/projects/cert-manager/$projectId/ca/$caId",
       "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/ca/$caId"
     ),
+    CertificateProfilesPage: setRoute(
+      "/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles",
+      "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/"
+    ),
     CertificateProfileDetailsByIDPage: setRoute(
       "/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles/$profileId",
       "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId"
+    ),
+    CertificatePoliciesPage: setRoute(
+      "/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies",
+      "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/"
     ),
     CertificatePolicyDetailsByIDPage: setRoute(
       "/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies/$policyId",

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
@@ -2,10 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useLocation } from "@tanstack/react-router";
 import {
   Bell,
+  FileBadge,
   FileKey,
   FileText,
   GitCompare,
   Inbox,
+  Landmark,
   LayoutDashboard,
   PenTool,
   Search,
@@ -140,6 +142,32 @@ export const CertManagerNav = ({
     }
   ];
 
+  const certificateResourcesItems: NavItem[] = [
+    {
+      label: "Certificate Authorities",
+      icon: Landmark,
+      pathSuffix: "certificate-authorities",
+      activeMatch: (pathname, search) =>
+        /\/ca\//.test(pathname) && !isApplicationSourcedDetail(pathname, search)
+    },
+    {
+      label: "Certificate Policies",
+      icon: Shield,
+      pathSuffix: "certificate-policies",
+      exactPath: true,
+      activeMatch: (pathname, search) =>
+        /\/certificate-policies\//.test(pathname) && !isApplicationSourcedDetail(pathname, search)
+    },
+    {
+      label: "Certificate Profiles",
+      icon: FileBadge,
+      pathSuffix: "certificate-profiles",
+      exactPath: true,
+      activeMatch: (pathname, search) =>
+        /\/certificate-profiles\//.test(pathname) && !isApplicationSourcedDetail(pathname, search)
+    }
+  ];
+
   const legacyItems: NavItem[] = [
     { label: "Alerts", icon: Bell, pathSuffix: "alerting", hidden: !hasLegacyAlerts },
     {
@@ -166,13 +194,7 @@ export const CertManagerNav = ({
       activeMatch: /\/access-management|\/groups\/|\/identities\/|\/members\/|\/roles\//
     },
     { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
-    {
-      label: "Settings",
-      icon: Settings,
-      pathSuffix: "settings",
-      activeMatch: (pathname, search) =>
-        detailPathRegex.test(pathname) && !isApplicationSourcedDetail(pathname, search)
-    }
+    { label: "Settings", icon: Settings, pathSuffix: "settings" }
   ];
 
   const generalItemsForRole = isCertManagerAdmin
@@ -192,6 +214,11 @@ export const CertManagerNav = ({
       <SidebarCollapsibleGroup label="Code Signing">
         <ProjectNavList items={codeSigningItems} onSubmenuOpen={onSubmenuOpen} />
       </SidebarCollapsibleGroup>
+      {isCertManagerAdmin ? (
+        <SidebarCollapsibleGroup label="Certificate Resources">
+          <ProjectNavList items={certificateResourcesItems} onSubmenuOpen={onSubmenuOpen} />
+        </SidebarCollapsibleGroup>
+      ) : null}
       {isCertManagerAdmin && hasAnyLegacy ? (
         <SidebarCollapsibleGroup label="Legacy" defaultOpen={false}>
           <ProjectNavList items={legacyItems} onSubmenuOpen={onSubmenuOpen} />

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
@@ -152,7 +152,7 @@ export const CertManagerNav = ({
     },
     {
       label: "Certificate Policies",
-      icon: Shield,
+      icon: ShieldCheck,
       pathSuffix: "certificate-policies",
       exactPath: true,
       activeMatch: (pathname, search) =>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
@@ -32,7 +32,8 @@ export const ProjectNavLink = ({
     }
     return item.activeMatch.test(pathname);
   })();
-  const pathMatch = pathname.startsWith(fullPath) || activeMatchResult;
+  const pathMatch =
+    (item.exactPath ? pathname === fullPath : pathname.startsWith(fullPath)) || activeMatchResult;
   const isActive = item.search
     ? pathMatch &&
       Object.entries(item.search).every(([key, value]) => {

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/types.ts
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/types.ts
@@ -42,6 +42,7 @@ export type NavItem = {
   search?: Record<string, string>;
   /** When true, this item is also active when the path matches but search keys are absent from the URL */
   isDefaultSearch?: boolean;
+  exactPath?: boolean;
 };
 
 export type OrgNavItem = {

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
@@ -477,9 +477,8 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
         <span>
           No certificate profiles exist yet. Create one in{" "}
           <Link
-            to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+            to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
             params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-            search={{ selectedTab: "certificate-profiles" }}
             className="text-primary underline hover:text-primary/80"
           >
             Certificate Profiles

--- a/frontend/src/pages/cert-manager/ApplicationsPage/components/ConfigureProfilesModal.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationsPage/components/ConfigureProfilesModal.tsx
@@ -110,12 +110,11 @@ export const ConfigureProfilesModal = ({ application, isOpen, onOpenChange }: Pr
             <p className="mt-3 text-xs text-yellow-500">
               No certificate profiles available.{" "}
               <Link
-                to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
                 params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-                search={{ selectedTab: "certificate-profiles" }}
                 className="underline hover:text-yellow-400"
               >
-                Create one in Settings
+                Create one in Certificate Profiles
               </Link>
             </p>
           )}

--- a/frontend/src/pages/cert-manager/ApplicationsPage/components/PkiApplicationModal.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationsPage/components/PkiApplicationModal.tsx
@@ -183,12 +183,11 @@ export const PkiApplicationModal = ({ popUp, handlePopUpToggle }: Props) => {
                     Select the profiles this application can issue certificates from.{" "}
                     {!profilesLoading && !profileOptions.length && (
                       <Link
-                        to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                        to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
                         params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-                        search={{ selectedTab: "certificate-profiles" }}
                         className="underline hover:text-yellow-400"
                       >
-                        Create one in Settings
+                        Create one in Certificate Profiles
                       </Link>
                     )}
                   </FieldDescription>

--- a/frontend/src/pages/cert-manager/CertAuthDetailsByIDPage/CertAuthDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/CertAuthDetailsByIDPage/CertAuthDetailsByIDPage.tsx
@@ -95,12 +95,11 @@ const Page = () => {
 
     handlePopUpClose("deleteCa");
     navigate({
-      to: "/organizations/$orgId/projects/cert-manager/$projectId/settings",
+      to: "/organizations/$orgId/projects/cert-manager/$projectId/certificate-authorities",
       params: {
         orgId: currentOrg.id,
         projectId
-      },
-      search: { selectedTab: "certificate-authorities" }
+      }
     });
   };
 
@@ -135,12 +134,11 @@ const Page = () => {
                   </Link>
                 ) : (
                   <Link
-                    to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                    to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-authorities"
                     params={{
                       orgId: currentOrg.id,
                       projectId
                     }}
-                    search={{ selectedTab: "certificate-authorities" }}
                     className="mb-4 flex items-center gap-x-2 text-sm text-mineshaft-400"
                   >
                     <FontAwesomeIcon icon={faChevronLeft} />

--- a/frontend/src/pages/cert-manager/CertificatePoliciesPage/CertificatePoliciesPage.tsx
+++ b/frontend/src/pages/cert-manager/CertificatePoliciesPage/CertificatePoliciesPage.tsx
@@ -1,0 +1,35 @@
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+
+import { ProjectPermissionCan } from "@app/components/permissions";
+import { PageHeader } from "@app/components/v2";
+import { ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionCertificatePolicyActions } from "@app/context/ProjectPermissionContext/types";
+import { ProjectType } from "@app/hooks/api/projects/types";
+
+import { CertificatePoliciesTab } from "../PoliciesPage/components";
+
+export const CertificatePoliciesPage = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="mx-auto flex h-full flex-col justify-between bg-bunker-800 text-white">
+      <Helmet>
+        <title>{t("common.head-title", { title: "Certificate Policies" })}</title>
+      </Helmet>
+      <div className="mx-auto mb-6 w-full max-w-8xl">
+        <PageHeader
+          scope={ProjectType.CertificateManager}
+          title="Certificate Policies"
+          description="Rules that define what certificates can look like, how they can be used, and how long they stay valid."
+        />
+        <ProjectPermissionCan
+          renderGuardBanner
+          I={ProjectPermissionCertificatePolicyActions.Read}
+          a={ProjectPermissionSub.CertificatePolicies}
+        >
+          <CertificatePoliciesTab />
+        </ProjectPermissionCan>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/cert-manager/CertificatePoliciesPage/route.tsx
+++ b/frontend/src/pages/cert-manager/CertificatePoliciesPage/route.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { CertificatePoliciesPage } from "./CertificatePoliciesPage";
+
+export const Route = createFileRoute(
+  "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/"
+)({
+  component: CertificatePoliciesPage,
+  beforeLoad: ({ context }) => {
+    return {
+      breadcrumbs: [
+        ...context.breadcrumbs,
+        {
+          label: "Certificate Policies"
+        }
+      ]
+    };
+  }
+});

--- a/frontend/src/pages/cert-manager/CertificatePolicyDetailsByIDPage/CertificatePolicyDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/CertificatePolicyDetailsByIDPage/CertificatePolicyDetailsByIDPage.tsx
@@ -75,12 +75,11 @@ const Page = () => {
 
       setIsDeleteModalOpen(false);
       navigate({
-        to: "/organizations/$orgId/projects/cert-manager/$projectId/settings",
+        to: "/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies",
         params: {
           orgId: currentOrg.id,
           projectId
-        },
-        search: { selectedTab: "certificate-policies" }
+        }
       });
     } catch (error) {
       createNotification({
@@ -119,12 +118,11 @@ const Page = () => {
                   </Link>
                 ) : (
                   <Link
-                    to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                    to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies"
                     params={{
                       orgId: currentOrg.id,
                       projectId
                     }}
-                    search={{ selectedTab: "certificate-policies" }}
                     className="mb-4 flex items-center gap-x-2 text-sm text-mineshaft-400"
                   >
                     <FontAwesomeIcon icon={faChevronLeft} />

--- a/frontend/src/pages/cert-manager/CertificatePolicyDetailsByIDPage/route.tsx
+++ b/frontend/src/pages/cert-manager/CertificatePolicyDetailsByIDPage/route.tsx
@@ -23,12 +23,11 @@ export const Route = createFileRoute(
         {
           label: "Certificate Policies",
           link: linkOptions({
-            to: "/organizations/$orgId/projects/cert-manager/$projectId/settings",
+            to: "/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies",
             params: {
               orgId: params.orgId,
               projectId: params.projectId
-            },
-            search: { selectedTab: "certificate-policies" }
+            }
           })
         }
       ]

--- a/frontend/src/pages/cert-manager/CertificateProfileDetailsByIDPage/CertificateProfileDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/CertificateProfileDetailsByIDPage/CertificateProfileDetailsByIDPage.tsx
@@ -59,12 +59,11 @@ const Page = () => {
     }
 
     navigate({
-      to: "/organizations/$orgId/projects/cert-manager/$projectId/settings",
+      to: "/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles",
       params: {
         orgId: currentOrg.id,
         projectId
-      },
-      search: { selectedTab: "certificate-profiles" }
+      }
     });
   };
 
@@ -114,12 +113,11 @@ const Page = () => {
                   </Link>
                 ) : (
                   <Link
-                    to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                    to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
                     params={{
                       orgId: currentOrg.id,
                       projectId
                     }}
-                    search={{ selectedTab: "certificate-profiles" }}
                     className="mb-4 flex items-center gap-x-2 text-sm text-mineshaft-400"
                   >
                     <FontAwesomeIcon icon={faChevronLeft} />

--- a/frontend/src/pages/cert-manager/CertificateProfileDetailsByIDPage/route.tsx
+++ b/frontend/src/pages/cert-manager/CertificateProfileDetailsByIDPage/route.tsx
@@ -21,12 +21,11 @@ export const Route = createFileRoute(
         {
           label: "Certificate Profiles",
           link: linkOptions({
-            to: "/organizations/$orgId/projects/cert-manager/$projectId/settings",
+            to: "/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles",
             params: {
               orgId: params.orgId,
               projectId: params.projectId
-            },
-            search: { selectedTab: "certificate-profiles" }
+            }
           })
         }
       ]

--- a/frontend/src/pages/cert-manager/CertificateProfilesPage/CertificateProfilesPage.tsx
+++ b/frontend/src/pages/cert-manager/CertificateProfilesPage/CertificateProfilesPage.tsx
@@ -1,0 +1,35 @@
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+
+import { ProjectPermissionCan } from "@app/components/permissions";
+import { PageHeader } from "@app/components/v2";
+import { ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionCertificateProfileActions } from "@app/context/ProjectPermissionContext/types";
+import { ProjectType } from "@app/hooks/api/projects/types";
+
+import { CertificateProfilesTab } from "../PoliciesPage/components";
+
+export const CertificateProfilesPage = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="mx-auto flex h-full flex-col justify-between bg-bunker-800 text-white">
+      <Helmet>
+        <title>{t("common.head-title", { title: "Certificate Profiles" })}</title>
+      </Helmet>
+      <div className="mx-auto mb-6 w-full max-w-8xl">
+        <PageHeader
+          scope={ProjectType.CertificateManager}
+          title="Certificate Profiles"
+          description="Reusable presets that pair a certificate authority with a policy to issue certificates."
+        />
+        <ProjectPermissionCan
+          renderGuardBanner
+          I={ProjectPermissionCertificateProfileActions.Read}
+          a={ProjectPermissionSub.CertificateProfiles}
+        >
+          <CertificateProfilesTab />
+        </ProjectPermissionCan>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/cert-manager/CertificateProfilesPage/route.tsx
+++ b/frontend/src/pages/cert-manager/CertificateProfilesPage/route.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { CertificateProfilesPage } from "./CertificateProfilesPage";
+
+export const Route = createFileRoute(
+  "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/"
+)({
+  component: CertificateProfilesPage,
+  beforeLoad: ({ context }) => {
+    return {
+      breadcrumbs: [
+        ...context.breadcrumbs,
+        {
+          label: "Certificate Profiles"
+        }
+      ]
+    };
+  }
+});

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
@@ -1177,9 +1177,8 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
                             <p className="-mt-2 mb-4 text-xs text-yellow-500">
                               No certificate authorities available.{" "}
                               <Link
-                                to="/organizations/$orgId/projects/cert-manager/$projectId/settings"
+                                to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-authorities"
                                 params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-                                search={{ selectedTab: "certificate-authorities" }}
                                 className="underline hover:text-yellow-400"
                               >
                                 Create one in Certificate Authorities

--- a/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
@@ -3,16 +3,10 @@ import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
 import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
-import {
-  ProjectPermissionAppConnectionActions,
-  ProjectPermissionCertificatePolicyActions,
-  ProjectPermissionCertificateProfileActions
-} from "@app/context/ProjectPermissionContext/types";
+import { ProjectPermissionSub } from "@app/context";
+import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
-import { CaSection, ExternalCaSection } from "../CertificateAuthoritiesPage/components";
-import { CertificatePoliciesTab, CertificateProfilesTab } from "../PoliciesPage/components";
 import { AppConnectionsTab } from "./components/AppConnectionsTab";
 import { CertificateCleanupTab } from "./components/CertificateCleanupTab";
 
@@ -20,7 +14,7 @@ export const SettingsPage = () => {
   const { orgId, projectId } = useParams({ strict: false });
   const search = useSearch({ strict: false }) as { selectedTab?: string };
   const navigate = useNavigate();
-  const activeTab = search.selectedTab ?? "certificate-profiles";
+  const activeTab = search.selectedTab ?? "app-connections";
 
   return (
     <div className="flex h-full w-full justify-center bg-bunker-800 text-white">
@@ -31,7 +25,7 @@ export const SettingsPage = () => {
         <PageHeader
           scope={ProjectType.CertificateManager}
           title="Settings"
-          description="Configure certificate authorities, profiles, policies, app connections, and cleanup rules."
+          description="Configure app connections and cleanup rules."
         />
 
         <Tabs
@@ -45,15 +39,6 @@ export const SettingsPage = () => {
           }
         >
           <TabList>
-            <Tab variant="project" value="certificate-profiles">
-              Certificate Profiles
-            </Tab>
-            <Tab variant="project" value="certificate-policies">
-              Certificate Policies
-            </Tab>
-            <Tab variant="project" value="certificate-authorities">
-              Certificate Authorities
-            </Tab>
             <Tab variant="project" value="app-connections">
               App Connections
             </Tab>
@@ -61,37 +46,6 @@ export const SettingsPage = () => {
               Cleanup
             </Tab>
           </TabList>
-
-          <TabPanel value="certificate-authorities">
-            <ProjectPermissionCan
-              renderGuardBanner
-              I={ProjectPermissionActions.Read}
-              a={ProjectPermissionSub.CertificateAuthorities}
-            >
-              <CaSection />
-              <ExternalCaSection />
-            </ProjectPermissionCan>
-          </TabPanel>
-
-          <TabPanel value="certificate-profiles">
-            <ProjectPermissionCan
-              renderGuardBanner
-              I={ProjectPermissionCertificateProfileActions.Read}
-              a={ProjectPermissionSub.CertificateProfiles}
-            >
-              <CertificateProfilesTab />
-            </ProjectPermissionCan>
-          </TabPanel>
-
-          <TabPanel value="certificate-policies">
-            <ProjectPermissionCan
-              renderGuardBanner
-              I={ProjectPermissionCertificatePolicyActions.Read}
-              a={ProjectPermissionSub.CertificatePolicies}
-            >
-              <CertificatePoliciesTab />
-            </ProjectPermissionCan>
-          </TabPanel>
 
           <TabPanel value="app-connections">
             <ProjectPermissionCan

--- a/frontend/src/pages/cert-manager/SettingsPage/route.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/route.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { SettingsPage } from "./SettingsPage";
 
 const settingsPageSearchSchema = z.object({
-  selectedTab: z.string().optional().default("certificate-profiles")
+  selectedTab: z.string().optional().default("app-connections")
 });
 
 export const Route = createFileRoute(

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -195,6 +195,8 @@ import { Route as certManagerIntegrationsListPageRouteImport } from './pages/cer
 import { Route as certManagerDiscoveryPageRouteImport } from './pages/cert-manager/DiscoveryPage/route'
 import { Route as certManagerCodeSigningPageRouteImport } from './pages/cert-manager/CodeSigningPage/route'
 import { Route as certManagerPkiTemplateListPageRouteImport } from './pages/cert-manager/PkiTemplateListPage/route'
+import { Route as certManagerCertificateProfilesPageRouteImport } from './pages/cert-manager/CertificateProfilesPage/route'
+import { Route as certManagerCertificatePoliciesPageRouteImport } from './pages/cert-manager/CertificatePoliciesPage/route'
 import { Route as certManagerApprovalsPageRouteImport } from './pages/cert-manager/ApprovalsPage/route'
 import { Route as certManagerApplicationsPageRouteImport } from './pages/cert-manager/ApplicationsPage/route'
 import { Route as secretScanningSecretScanningDataSourceByIdPageRouteImport } from './pages/secret-scanning/SecretScanningDataSourceByIdPage/route'
@@ -404,6 +406,14 @@ const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManager
 const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesImport =
   createFileRoute(
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates',
+  )()
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesImport =
+  createFileRoute(
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles',
+  )()
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesImport =
+  createFileRoute(
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies',
   )()
 const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsImport =
   createFileRoute(
@@ -1342,6 +1352,24 @@ const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManager
     } as any,
   )
 
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute =
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesImport.update(
+    {
+      id: '/certificate-profiles',
+      path: '/certificate-profiles',
+      getParentRoute: () => certManagerLayoutRoute,
+    } as any,
+  )
+
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute =
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesImport.update(
+    {
+      id: '/certificate-policies',
+      path: '/certificate-policies',
+      getParentRoute: () => certManagerLayoutRoute,
+    } as any,
+  )
+
 const projectAuditLogsPageRouteCertManagerRoute =
   projectAuditLogsPageRouteCertManagerImport.update({
     id: '/audit-logs',
@@ -1869,16 +1897,18 @@ const certManagerCertificateDetailsByIDPageRouteRoute =
 
 const certManagerCertificateProfileDetailsByIDPageRouteRoute =
   certManagerCertificateProfileDetailsByIDPageRouteImport.update({
-    id: '/certificate-profiles/$profileId',
-    path: '/certificate-profiles/$profileId',
-    getParentRoute: () => certManagerLayoutRoute,
+    id: '/$profileId',
+    path: '/$profileId',
+    getParentRoute: () =>
+      AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute,
   } as any)
 
 const certManagerCertificatePolicyDetailsByIDPageRouteRoute =
   certManagerCertificatePolicyDetailsByIDPageRouteImport.update({
-    id: '/certificate-policies/$policyId',
-    path: '/certificate-policies/$policyId',
-    getParentRoute: () => certManagerLayoutRoute,
+    id: '/$policyId',
+    path: '/$policyId',
+    getParentRoute: () =>
+      AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute,
   } as any)
 
 const certManagerCertAuthDetailsByIDPageRouteRoute =
@@ -2008,6 +2038,22 @@ const certManagerPkiTemplateListPageRouteRoute =
     path: '/',
     getParentRoute: () =>
       AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRoute,
+  } as any)
+
+const certManagerCertificateProfilesPageRouteRoute =
+  certManagerCertificateProfilesPageRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () =>
+      AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute,
+  } as any)
+
+const certManagerCertificatePoliciesPageRouteRoute =
+  certManagerCertificatePoliciesPageRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () =>
+      AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute,
   } as any)
 
 const certManagerApprovalsPageRouteRoute =
@@ -3701,6 +3747,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof projectAuditLogsPageRouteCertManagerImport
       parentRoute: typeof certManagerLayoutImport
     }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies'
+      path: '/certificate-policies'
+      fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies'
+      preLoaderRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesImport
+      parentRoute: typeof certManagerLayoutImport
+    }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles'
+      path: '/certificate-profiles'
+      fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles'
+      preLoaderRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesImport
+      parentRoute: typeof certManagerLayoutImport
+    }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates'
       path: '/certificate-templates'
@@ -3883,6 +3943,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof certManagerApprovalsPageRouteImport
       parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsImport
     }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/'
+      path: '/'
+      fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies/'
+      preLoaderRoute: typeof certManagerCertificatePoliciesPageRouteImport
+      parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesImport
+    }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/'
+      path: '/'
+      fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles/'
+      preLoaderRoute: typeof certManagerCertificateProfilesPageRouteImport
+      parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesImport
+    }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates/': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates/'
       path: '/'
@@ -4004,17 +4078,17 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/$policyId': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/$policyId'
-      path: '/certificate-policies/$policyId'
+      path: '/$policyId'
       fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies/$policyId'
       preLoaderRoute: typeof certManagerCertificatePolicyDetailsByIDPageRouteImport
-      parentRoute: typeof certManagerLayoutImport
+      parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesImport
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId'
-      path: '/certificate-profiles/$profileId'
+      path: '/$profileId'
       fullPath: '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles/$profileId'
       preLoaderRoute: typeof certManagerCertificateProfileDetailsByIDPageRouteImport
-      parentRoute: typeof certManagerLayoutImport
+      parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesImport
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificates/$certificateId': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificates/$certificateId'
@@ -5074,6 +5148,42 @@ const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManager
     AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRouteChildren,
   )
 
+interface AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteChildren {
+  certManagerCertificatePoliciesPageRouteRoute: typeof certManagerCertificatePoliciesPageRouteRoute
+  certManagerCertificatePolicyDetailsByIDPageRouteRoute: typeof certManagerCertificatePolicyDetailsByIDPageRouteRoute
+}
+
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteChildren: AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteChildren =
+  {
+    certManagerCertificatePoliciesPageRouteRoute:
+      certManagerCertificatePoliciesPageRouteRoute,
+    certManagerCertificatePolicyDetailsByIDPageRouteRoute:
+      certManagerCertificatePolicyDetailsByIDPageRouteRoute,
+  }
+
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteWithChildren =
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute._addFileChildren(
+    AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteChildren,
+  )
+
+interface AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteChildren {
+  certManagerCertificateProfilesPageRouteRoute: typeof certManagerCertificateProfilesPageRouteRoute
+  certManagerCertificateProfileDetailsByIDPageRouteRoute: typeof certManagerCertificateProfileDetailsByIDPageRouteRoute
+}
+
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteChildren: AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteChildren =
+  {
+    certManagerCertificateProfilesPageRouteRoute:
+      certManagerCertificateProfilesPageRouteRoute,
+    certManagerCertificateProfileDetailsByIDPageRouteRoute:
+      certManagerCertificateProfileDetailsByIDPageRouteRoute,
+  }
+
+const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteWithChildren =
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute._addFileChildren(
+    AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteChildren,
+  )
+
 interface AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRouteChildren {
   certManagerPkiTemplateListPageRouteRoute: typeof certManagerPkiTemplateListPageRouteRoute
 }
@@ -5176,14 +5286,14 @@ interface certManagerLayoutRouteChildren {
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApplicationsRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApplicationsRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRouteWithChildren
   projectAuditLogsPageRouteCertManagerRoute: typeof projectAuditLogsPageRouteCertManagerRoute
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteWithChildren
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCodeSigningRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCodeSigningRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutDiscoveryRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutDiscoveryRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutIntegrationsRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutIntegrationsRouteWithChildren
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutSubscribersRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutSubscribersRouteWithChildren
   certManagerCertAuthDetailsByIDPageRouteRoute: typeof certManagerCertAuthDetailsByIDPageRouteRoute
-  certManagerCertificatePolicyDetailsByIDPageRouteRoute: typeof certManagerCertificatePolicyDetailsByIDPageRouteRoute
-  certManagerCertificateProfileDetailsByIDPageRouteRoute: typeof certManagerCertificateProfileDetailsByIDPageRouteRoute
   certManagerCertificateDetailsByIDPageRouteRoute: typeof certManagerCertificateDetailsByIDPageRouteRoute
   projectGroupDetailsByIDPageRouteCertManagerRoute: typeof projectGroupDetailsByIDPageRouteCertManagerRoute
   projectIdentityDetailsByIDPageRouteCertManagerRoute: typeof projectIdentityDetailsByIDPageRouteCertManagerRoute
@@ -5213,6 +5323,10 @@ const certManagerLayoutRouteChildren: certManagerLayoutRouteChildren = {
     AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRouteWithChildren,
   projectAuditLogsPageRouteCertManagerRoute:
     projectAuditLogsPageRouteCertManagerRoute,
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRoute:
+    AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteWithChildren,
+  AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRoute:
+    AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteWithChildren,
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRoute:
     AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRouteWithChildren,
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCodeSigningRoute:
@@ -5225,10 +5339,6 @@ const certManagerLayoutRouteChildren: certManagerLayoutRouteChildren = {
     AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutSubscribersRouteWithChildren,
   certManagerCertAuthDetailsByIDPageRouteRoute:
     certManagerCertAuthDetailsByIDPageRouteRoute,
-  certManagerCertificatePolicyDetailsByIDPageRouteRoute:
-    certManagerCertificatePolicyDetailsByIDPageRouteRoute,
-  certManagerCertificateProfileDetailsByIDPageRouteRoute:
-    certManagerCertificateProfileDetailsByIDPageRouteRoute,
   certManagerCertificateDetailsByIDPageRouteRoute:
     certManagerCertificateDetailsByIDPageRouteRoute,
   projectGroupDetailsByIDPageRouteCertManagerRoute:
@@ -6501,6 +6611,8 @@ export interface FileRoutesByFullPath {
   '/organizations/$orgId/projects/cert-manager/$projectId/applications': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApplicationsRouteWithChildren
   '/organizations/$orgId/projects/cert-manager/$projectId/approvals': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRouteWithChildren
   '/organizations/$orgId/projects/cert-manager/$projectId/audit-logs': typeof projectAuditLogsPageRouteCertManagerRoute
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteWithChildren
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteWithChildren
   '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRouteWithChildren
   '/organizations/$orgId/projects/cert-manager/$projectId/code-signing': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCodeSigningRouteWithChildren
   '/organizations/$orgId/projects/cert-manager/$projectId/discovery': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutDiscoveryRouteWithChildren
@@ -6527,6 +6639,8 @@ export interface FileRoutesByFullPath {
   '/organizations/$orgId/projects/ssh/$projectId/audit-logs': typeof projectAuditLogsPageRouteSshRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/applications/': typeof certManagerApplicationsPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/approvals/': typeof certManagerApprovalsPageRouteRoute
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies/': typeof certManagerCertificatePoliciesPageRouteRoute
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles/': typeof certManagerCertificateProfilesPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates/': typeof certManagerPkiTemplateListPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/code-signing/': typeof certManagerCodeSigningPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/discovery/': typeof certManagerDiscoveryPageRouteRoute
@@ -6803,6 +6917,8 @@ export interface FileRoutesByTo {
   '/organizations/$orgId/projects/ssh/$projectId/audit-logs': typeof projectAuditLogsPageRouteSshRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/applications': typeof certManagerApplicationsPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/approvals': typeof certManagerApprovalsPageRouteRoute
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies': typeof certManagerCertificatePoliciesPageRouteRoute
+  '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles': typeof certManagerCertificateProfilesPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates': typeof certManagerPkiTemplateListPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/code-signing': typeof certManagerCodeSigningPageRouteRoute
   '/organizations/$orgId/projects/cert-manager/$projectId/discovery': typeof certManagerDiscoveryPageRouteRoute
@@ -7084,6 +7200,8 @@ export interface FileRoutesById {
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/applications': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApplicationsRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutApprovalsRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/audit-logs': typeof projectAuditLogsPageRouteCertManagerRoute
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificatePoliciesRouteWithChildren
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateProfilesRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCertificateTemplatesRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/code-signing': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutCodeSigningRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/discovery': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdProjectsCertManagerProjectIdCertManagerLayoutDiscoveryRouteWithChildren
@@ -7110,6 +7228,8 @@ export interface FileRoutesById {
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/ssh/$projectId/_ssh-layout/audit-logs': typeof projectAuditLogsPageRouteSshRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/applications/': typeof certManagerApplicationsPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals/': typeof certManagerApprovalsPageRouteRoute
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/': typeof certManagerCertificatePoliciesPageRouteRoute
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/': typeof certManagerCertificateProfilesPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates/': typeof certManagerPkiTemplateListPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/code-signing/': typeof certManagerCodeSigningPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/discovery/': typeof certManagerDiscoveryPageRouteRoute
@@ -7386,6 +7506,8 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/projects/cert-manager/$projectId/applications'
     | '/organizations/$orgId/projects/cert-manager/$projectId/approvals'
     | '/organizations/$orgId/projects/cert-manager/$projectId/audit-logs'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles'
     | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates'
     | '/organizations/$orgId/projects/cert-manager/$projectId/code-signing'
     | '/organizations/$orgId/projects/cert-manager/$projectId/discovery'
@@ -7412,6 +7534,8 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/projects/ssh/$projectId/audit-logs'
     | '/organizations/$orgId/projects/cert-manager/$projectId/applications/'
     | '/organizations/$orgId/projects/cert-manager/$projectId/approvals/'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies/'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles/'
     | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates/'
     | '/organizations/$orgId/projects/cert-manager/$projectId/code-signing/'
     | '/organizations/$orgId/projects/cert-manager/$projectId/discovery/'
@@ -7687,6 +7811,8 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/projects/ssh/$projectId/audit-logs'
     | '/organizations/$orgId/projects/cert-manager/$projectId/applications'
     | '/organizations/$orgId/projects/cert-manager/$projectId/approvals'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-policies'
+    | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles'
     | '/organizations/$orgId/projects/cert-manager/$projectId/certificate-templates'
     | '/organizations/$orgId/projects/cert-manager/$projectId/code-signing'
     | '/organizations/$orgId/projects/cert-manager/$projectId/discovery'
@@ -7966,6 +8092,8 @@ export interface FileRouteTypes {
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/applications'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/audit-logs'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/code-signing'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/discovery'
@@ -7992,6 +8120,8 @@ export interface FileRouteTypes {
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/ssh/$projectId/_ssh-layout/audit-logs'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/applications/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals/'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/code-signing/'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/discovery/'
@@ -8718,14 +8848,14 @@ export const routeTree = rootRoute
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/applications",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/audit-logs",
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies",
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/code-signing",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/discovery",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/integrations",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/subscribers",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/ca/$caId",
-        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/$policyId",
-        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificates/$certificateId",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/groups/$groupId",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/identities/$identityId",
@@ -8968,6 +9098,22 @@ export const routeTree = rootRoute
       "filePath": "project/AuditLogsPage/route-cert-manager.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout"
     },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies": {
+      "filePath": "",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout",
+      "children": [
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/",
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/$policyId"
+      ]
+    },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles": {
+      "filePath": "",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout",
+      "children": [
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/",
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId"
+      ]
+    },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates": {
       "filePath": "",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout",
@@ -9196,6 +9342,14 @@ export const routeTree = rootRoute
       "filePath": "cert-manager/ApprovalsPage/route.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/approvals"
     },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/": {
+      "filePath": "cert-manager/CertificatePoliciesPage/route.tsx",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies"
+    },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/": {
+      "filePath": "cert-manager/CertificateProfilesPage/route.tsx",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles"
+    },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates/": {
       "filePath": "cert-manager/PkiTemplateListPage/route.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-templates"
@@ -9266,11 +9420,11 @@ export const routeTree = rootRoute
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies/$policyId": {
       "filePath": "cert-manager/CertificatePolicyDetailsByIDPage/route.tsx",
-      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout"
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-policies"
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles/$profileId": {
       "filePath": "cert-manager/CertificateProfileDetailsByIDPage/route.tsx",
-      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout"
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificate-profiles"
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects/cert-manager/$projectId/_cert-manager-layout/certificates/$certificateId": {
       "filePath": "cert-manager/CertificateDetailsByIDPage/route.tsx",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -304,14 +304,14 @@ const certManagerRoutes = route("/organizations/$orgId/projects/cert-manager/$pr
       route("/$approvalRequestId", "cert-manager/ApprovalRequestDetailPage/route.tsx")
     ]),
     route("/ca/$caId", "cert-manager/CertAuthDetailsByIDPage/route.tsx"),
-    route(
-      "/certificate-profiles/$profileId",
-      "cert-manager/CertificateProfileDetailsByIDPage/route.tsx"
-    ),
-    route(
-      "/certificate-policies/$policyId",
-      "cert-manager/CertificatePolicyDetailsByIDPage/route.tsx"
-    ),
+    route("/certificate-profiles", [
+      index("cert-manager/CertificateProfilesPage/route.tsx"),
+      route("/$profileId", "cert-manager/CertificateProfileDetailsByIDPage/route.tsx")
+    ]),
+    route("/certificate-policies", [
+      index("cert-manager/CertificatePoliciesPage/route.tsx"),
+      route("/$policyId", "cert-manager/CertificatePolicyDetailsByIDPage/route.tsx")
+    ]),
     route("/certificates/$certificateId", "cert-manager/CertificateDetailsByIDPage/route.tsx"),
     route("/pki-collections/$collectionId", "cert-manager/PkiCollectionDetailsByIDPage/routes.tsx"),
     route("/integrations", [


### PR DESCRIPTION
## Context

This PR relocates Certificate Authorities, Policies, and Profiles from the Certificate Manager Settings tabs into a dedicated "Certificate Resources" sidebar group, adding two new standalone pages and nesting their routes. Settings now retains only App Connections and Cleanup. All detail-page back links, redirects, breadcrumbs, and cross-links were repointed to the new routes.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)