### PR TITLE
fix: resolved the failing go parsing for no-verify

### DIFF
--- a/backend-go/cmd/infisical/main.go
+++ b/backend-go/cmd/infisical/main.go
@@ -28,7 +28,7 @@ func main() {
 	// Setup structured JSON logger with context enrichment (e.g. request ID).
 	logger := slog.New(logutil.NewContextHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: config.GetConfiguredSlogLevel(),
-	}))).With("from", "go-sidecar")
+	}))).With(slog.String("from", "go-sidecar"))
 	slog.SetDefault(logger)
 
 	// Load configuration.

--- a/backend-go/cmd/infisical/main.go
+++ b/backend-go/cmd/infisical/main.go
@@ -28,7 +28,7 @@ func main() {
 	// Setup structured JSON logger with context enrichment (e.g. request ID).
 	logger := slog.New(logutil.NewContextHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: config.GetConfiguredSlogLevel(),
-	})))
+	}))).With("from", "go-sidecar")
 	slog.SetDefault(logger)
 
 	// Load configuration.

--- a/backend-go/internal/database/pg/pg.go
+++ b/backend-go/internal/database/pg/pg.go
@@ -134,10 +134,42 @@ func openPool(ctx context.Context, connURI, dbRootCert string) (*pgxpool.Pool, e
 	return pool, nil
 }
 
-// parseSslConfig mirrors the Node.js parseSslConfig function.
-// It returns a potentially modified URI (sslmode stripped) and TLS config.
+// parseSslConfig mirrors the Node.js parseSslConfig function and additionally
+// normalizes the node-postgres-specific "no-verify" sslmode, which pgx/libpq
+// reject ("sslmode is invalid"). It returns a possibly modified URI and an
+// optional TLS config.
+//
+// sslmode is stripped from the URI whenever we configure TLS ourselves, because
+// pgx applies TLS through ConnConfig.TLSConfig rather than the URI.
+//   - dbRootCert set: trust that CA; verify the server cert only for verify-ca
+//     and verify-full, otherwise skip verification (InsecureSkipVerify).
+//   - dbRootCert empty + sslmode=no-verify: encrypt but skip verification,
+//     matching node-postgres semantics.
+//   - dbRootCert empty + any other sslmode: leave the URI untouched and let pgx
+//     configure TLS natively.
 func parseSslConfig(connURI, dbRootCert string) (string, *tls.Config, error) {
+	parsed, parseErr := url.Parse(connURI)
+	sslMode := ""
+	if parseErr == nil {
+		sslMode = parsed.Query().Get("sslmode")
+	}
+
+	stripSslMode := func() string {
+		if parseErr != nil {
+			return connURI
+		}
+		q := parsed.Query()
+		q.Del("sslmode")
+		parsed.RawQuery = q.Encode()
+		return parsed.String()
+	}
+
 	if dbRootCert == "" {
+		// pgx does not understand the node-postgres "no-verify" value. Translate
+		// it to an encrypted, unverified connection so pgx can parse the URI.
+		if strings.EqualFold(sslMode, "no-verify") {
+			return stripSslMode(), &tls.Config{InsecureSkipVerify: true}, nil
+		}
 		return connURI, nil, nil
 	}
 
@@ -157,19 +189,11 @@ func parseSslConfig(connURI, dbRootCert string) (string, *tls.Config, error) {
 	}
 
 	modifiedURI := connURI
+	if sslMode != "" && !strings.EqualFold(sslMode, "disable") {
+		modifiedURI = stripSslMode()
 
-	parsed, err := url.Parse(connURI)
-	if err == nil {
-		sslMode := parsed.Query().Get("sslmode")
-		if sslMode != "" && !strings.EqualFold(sslMode, "disable") {
-			q := parsed.Query()
-			q.Del("sslmode")
-			parsed.RawQuery = q.Encode()
-			modifiedURI = parsed.String()
-
-			if strings.EqualFold(sslMode, "verify-ca") || strings.EqualFold(sslMode, "verify-full") {
-				tlsCfg.InsecureSkipVerify = false
-			}
+		if strings.EqualFold(sslMode, "verify-ca") || strings.EqualFold(sslMode, "verify-full") {
+			tlsCfg.InsecureSkipVerify = false
 		}
 	}
 

--- a/backend-go/internal/database/pg/pg.go
+++ b/backend-go/internal/database/pg/pg.go
@@ -148,27 +148,13 @@ func openPool(ctx context.Context, connURI, dbRootCert string) (*pgxpool.Pool, e
 //   - dbRootCert empty + any other sslmode: leave the URI untouched and let pgx
 //     configure TLS natively.
 func parseSslConfig(connURI, dbRootCert string) (string, *tls.Config, error) {
-	parsed, parseErr := url.Parse(connURI)
-	sslMode := ""
-	if parseErr == nil {
-		sslMode = parsed.Query().Get("sslmode")
-	}
-
-	stripSslMode := func() string {
-		if parseErr != nil {
-			return connURI
-		}
-		q := parsed.Query()
-		q.Del("sslmode")
-		parsed.RawQuery = q.Encode()
-		return parsed.String()
-	}
+	sslMode := sslModeOf(connURI)
 
 	if dbRootCert == "" {
 		// pgx does not understand the node-postgres "no-verify" value. Translate
 		// it to an encrypted, unverified connection so pgx can parse the URI.
 		if strings.EqualFold(sslMode, "no-verify") {
-			return stripSslMode(), &tls.Config{InsecureSkipVerify: true}, nil
+			return stripSslMode(connURI), &tls.Config{InsecureSkipVerify: true}, nil
 		}
 		return connURI, nil, nil
 	}
@@ -190,7 +176,7 @@ func parseSslConfig(connURI, dbRootCert string) (string, *tls.Config, error) {
 
 	modifiedURI := connURI
 	if sslMode != "" && !strings.EqualFold(sslMode, "disable") {
-		modifiedURI = stripSslMode()
+		modifiedURI = stripSslMode(connURI)
 
 		if strings.EqualFold(sslMode, "verify-ca") || strings.EqualFold(sslMode, "verify-full") {
 			tlsCfg.InsecureSkipVerify = false
@@ -198,4 +184,28 @@ func parseSslConfig(connURI, dbRootCert string) (string, *tls.Config, error) {
 	}
 
 	return modifiedURI, tlsCfg, nil
+}
+
+// sslModeOf returns the sslmode query parameter of a connection URI, or "" if
+// the URI cannot be parsed or has no sslmode.
+func sslModeOf(connURI string) string {
+	parsed, err := url.Parse(connURI)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("sslmode")
+}
+
+// stripSslMode removes the sslmode query parameter from a connection URI. pgx
+// applies TLS via ConnConfig.TLSConfig rather than the URI, so once we build our
+// own tls.Config the param is redundant (and "no-verify" is invalid in pgx).
+func stripSslMode(connURI string) string {
+	parsed, err := url.Parse(connURI)
+	if err != nil {
+		return connURI
+	}
+	q := parsed.Query()
+	q.Del("sslmode")
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
 }

--- a/backend-go/internal/database/pg/pg_test.go
+++ b/backend-go/internal/database/pg/pg_test.go
@@ -1,0 +1,188 @@
+package pg
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// selfSignedCertBase64 generates a valid self-signed CA cert and returns it
+// base64-encoded, matching the DB_ROOT_CERT format.
+func selfSignedCertBase64(t *testing.T) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Unix(0, 0),
+		NotAfter:              time.Unix(0, 0).AddDate(10, 0, 0),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating cert: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return base64.StdEncoding.EncodeToString(pemBytes)
+}
+
+func sslModeParam(t *testing.T, uri string) string {
+	t.Helper()
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		t.Fatalf("parsing result URI %q: %v", uri, err)
+	}
+	return parsed.Query().Get("sslmode")
+}
+
+// This is the exact failing case from the bug report: sslmode=no-verify with no
+// root cert. pgx rejects "no-verify", so parseSslConfig must strip it.
+func TestParseSslConfig_NoVerifyWithoutRootCert(t *testing.T) {
+	uri := "postgres://infisical:secret@host.rds.amazonaws.com:5432/infisical?sslmode=no-verify"
+
+	modifiedURI, tlsCfg, err := parseSslConfig(uri, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := sslModeParam(t, modifiedURI); got != "" {
+		t.Fatalf("expected sslmode stripped, still present: %q (uri=%q)", got, modifiedURI)
+	}
+	if tlsCfg == nil {
+		t.Fatal("expected a TLS config for no-verify, got nil")
+	}
+	if !tlsCfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true for no-verify")
+	}
+}
+
+// Other valid libpq sslmodes are understood by pgx, so without a cert they must
+// be left untouched (no TLS config, URI unchanged).
+func TestParseSslConfig_OtherSslModeWithoutRootCert(t *testing.T) {
+	for _, mode := range []string{"require", "prefer", "disable", "verify-full"} {
+		uri := "postgres://u:p@host:5432/db?sslmode=" + mode
+
+		modifiedURI, tlsCfg, err := parseSslConfig(uri, "")
+		if err != nil {
+			t.Fatalf("mode %q: unexpected error: %v", mode, err)
+		}
+		if modifiedURI != uri {
+			t.Fatalf("mode %q: expected URI unchanged, got %q", mode, modifiedURI)
+		}
+		if tlsCfg != nil {
+			t.Fatalf("mode %q: expected nil TLS config", mode)
+		}
+	}
+}
+
+func TestParseSslConfig_NoSslModeNoRootCert(t *testing.T) {
+	uri := "postgres://u:p@host:5432/db"
+
+	modifiedURI, tlsCfg, err := parseSslConfig(uri, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if modifiedURI != uri {
+		t.Fatalf("expected URI unchanged, got %q", modifiedURI)
+	}
+	if tlsCfg != nil {
+		t.Fatal("expected nil TLS config")
+	}
+}
+
+// With a root cert, sslmode must be stripped and verification only enabled for
+// verify-ca / verify-full.
+func TestParseSslConfig_WithRootCert(t *testing.T) {
+	cert := selfSignedCertBase64(t)
+
+	cases := []struct {
+		sslMode        string
+		wantSkipVerify bool
+		wantStripped   bool
+	}{
+		{"no-verify", true, true},
+		{"require", true, true},
+		{"verify-ca", false, true},
+		{"verify-full", false, true},
+		{"disable", true, false}, // disable: cert provided but TLS not forced via stripping
+		{"", true, false},
+	}
+
+	for _, tc := range cases {
+		uri := "postgres://u:p@host:5432/db"
+		if tc.sslMode != "" {
+			uri += "?sslmode=" + tc.sslMode
+		}
+
+		modifiedURI, tlsCfg, err := parseSslConfig(uri, cert)
+		if err != nil {
+			t.Fatalf("mode %q: unexpected error: %v", tc.sslMode, err)
+		}
+		if tlsCfg == nil {
+			t.Fatalf("mode %q: expected TLS config when cert provided", tc.sslMode)
+		}
+		if tlsCfg.RootCAs == nil {
+			t.Fatalf("mode %q: expected RootCAs populated from cert", tc.sslMode)
+		}
+		if tlsCfg.InsecureSkipVerify != tc.wantSkipVerify {
+			t.Fatalf("mode %q: InsecureSkipVerify=%v, want %v", tc.sslMode, tlsCfg.InsecureSkipVerify, tc.wantSkipVerify)
+		}
+		if tc.wantStripped {
+			if strings.Contains(modifiedURI, "sslmode=") {
+				t.Fatalf("mode %q: expected sslmode stripped, got %q", tc.sslMode, modifiedURI)
+			}
+		} else if modifiedURI != uri {
+			t.Fatalf("mode %q: expected URI unchanged, got %q", tc.sslMode, modifiedURI)
+		}
+	}
+}
+
+func TestParseSslConfig_InvalidRootCert(t *testing.T) {
+	if _, _, err := parseSslConfig("postgres://u:p@host/db", "not-base64-!!!"); err == nil {
+		t.Fatal("expected error for invalid base64 cert")
+	}
+	if _, _, err := parseSslConfig("postgres://u:p@host/db", base64.StdEncoding.EncodeToString([]byte("not a pem"))); err == nil {
+		t.Fatal("expected error for non-PEM cert")
+	}
+}
+
+// End-to-end check against pgx itself: the raw no-verify URI must fail
+// ParseConfig (reproducing the bug), and the URI returned by parseSslConfig
+// must parse cleanly.
+func TestParseSslConfig_NoVerifyParsesWithPgx(t *testing.T) {
+	uri := "postgres://infisical:secret@host.rds.amazonaws.com:5432/infisical?sslmode=no-verify"
+
+	if _, err := pgxpool.ParseConfig(uri); err == nil {
+		t.Fatal("expected raw no-verify URI to fail pgx ParseConfig (bug repro)")
+	}
+
+	modifiedURI, _, err := parseSslConfig(uri, "")
+	if err != nil {
+		t.Fatalf("parseSslConfig error: %v", err)
+	}
+	if strings.Contains(modifiedURI, "no-verify") {
+		t.Fatalf("no-verify should be stripped before reaching pgx: %q", modifiedURI)
+	}
+	if _, err := pgxpool.ParseConfig(modifiedURI); err != nil {
+		t.Fatalf("fixed URI should parse with pgx, got: %v", err)
+	}
+}

--- a/backend/src/server/plugins/go-sidecar.ts
+++ b/backend/src/server/plugins/go-sidecar.ts
@@ -27,7 +27,7 @@ export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
   const startSidecar = () => {
     if (shuttingDown) return;
 
-    logger.info({ binaryPath }, "Starting Go sidecar");
+    logger.info({ binaryPath }, "go-sidecar: Starting Go sidecar");
 
     sidecar = spawn(binaryPath, [], {
       stdio: ["ignore", "inherit", "inherit"],
@@ -40,7 +40,7 @@ export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
     });
 
     sidecar.on("error", (err) => {
-      logger.error({ err }, "Go sidecar failed to start");
+      logger.error({ err }, "go-sidecar: Go sidecar failed to start");
     });
 
     sidecar.on("exit", (code, signal) => {
@@ -50,28 +50,28 @@ export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
       }
 
       if (shuttingDown) {
-        logger.info("Go sidecar stopped during shutdown");
+        logger.info("go-sidecar: Go sidecar stopped during shutdown");
         return;
       }
 
-      logger.error({ code, signal, restartCount }, "Go sidecar exited unexpectedly");
+      logger.error({ code, signal, restartCount }, "go-sidecar: Go sidecar exited unexpectedly");
 
       if (restartCount >= maxRestarts) {
-        logger.error({ maxRestarts }, "Go sidecar max restarts reached, giving up");
+        logger.error({ maxRestarts }, "go-sidecar: Go sidecar max restarts reached, giving up");
         return;
       }
 
       const delay = Math.min(baseDelayMs * 2 ** restartCount, maxDelayMs);
       restartCount += 1;
 
-      logger.info({ delayMs: delay, restartCount }, "Scheduling Go sidecar restart");
+      logger.info({ delayMs: delay, restartCount }, "go-sidecar: Scheduling Go sidecar restart");
       setTimeout(startSidecar, delay);
     });
 
     // Reset restart count after healthy running period
     healthTimer = setTimeout(() => {
       if (sidecar && !sidecar.killed) {
-        logger.info("Go sidecar healthy, resetting restart count");
+        logger.info("go-sidecar: Go sidecar healthy, resetting restart count");
         restartCount = 0;
       }
     }, healthyThresholdMs);
@@ -85,7 +85,7 @@ export const goSidecarPlugin = fp(async (server, opts: GoSidecarOpts) => {
       clearTimeout(healthTimer);
     }
     if (sidecar && !sidecar.killed) {
-      logger.info("Stopping Go sidecar");
+      logger.info("go-sidecar: Stopping Go sidecar");
       sidecar.kill();
     }
   });


### PR DESCRIPTION
## Context

Our database configuration had `no-verify` in it. This is something knexjs specific and for pgx our go postgres client uses something like libpq standard and `no-verify` doesn't exist there. This needs to be fixed by custom parsing logic to keep it compatibility 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)