### PR TITLE
feat(secret-reference): check for empty value on reference

### DIFF
--- a/backend/e2e-test/routes/v3/secret-reference.spec.ts
+++ b/backend/e2e-test/routes/v3/secret-reference.spec.ts
@@ -88,6 +88,59 @@ describe("Secret expansion", () => {
     await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
+  test("Local secret reference with empty value", async () => {
+    const secrets = [
+      {
+        environmentSlug: seedData1.environment.slug,
+        workspaceId: projectId,
+        secretPath: "/",
+        authToken: jwtAuthToken,
+        key: "EMPTY",
+        value: ""
+      },
+      {
+        environmentSlug: seedData1.environment.slug,
+        workspaceId: projectId,
+        secretPath: "/",
+        authToken: jwtAuthToken,
+        key: "TEST",
+        // eslint-disable-next-line
+        value: "hello ${EMPTY}"
+      }
+    ];
+
+    for (const secret of secrets) {
+      // eslint-disable-next-line no-await-in-loop
+      await createSecretV2(secret);
+    }
+
+    const expandedSecret = await getSecretByNameV2({
+      environmentSlug: seedData1.environment.slug,
+      workspaceId: projectId,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      key: "TEST"
+    });
+    expect(expandedSecret.secretValue).toBe("hello ");
+
+    const listSecrets = await getSecretsV2({
+      environmentSlug: seedData1.environment.slug,
+      workspaceId: projectId,
+      secretPath: "/",
+      authToken: jwtAuthToken
+    });
+    expect(listSecrets.secrets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          secretKey: "TEST",
+          secretValue: "hello "
+        })
+      ])
+    );
+
+    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
+  });
+
   test("Cross environment secret reference", async () => {
     const secrets = [
       {

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
@@ -247,12 +247,10 @@ export const expandSecretReferencesFactory = ({
             stack.push({ ...node, visitedSecrets: newVisitedSecrets });
           }
 
-          if (referencedSecretValue) {
-            expandedValue = expandedValue.replaceAll(
-              interpolationSyntax,
-              () => referencedSecretValue // prevents special characters from triggering replacement patterns
-            );
-          }
+          expandedValue = expandedValue.replaceAll(
+            interpolationSyntax,
+            () => referencedSecretValue // prevents special characters from triggering replacement patterns
+          );
         }
       }
     }


### PR DESCRIPTION
## Context
If a secret reference is empty, we should show the resolved value

## Screenshots

<img width="1443" height="401" alt="image" src="https://github.com/user-attachments/assets/e59ae501-8676-43e6-a494-4bc781e1e5ec" />


## Steps to verify the change
- create a secret reference 
- check that if you delete the referenced secret the resolved value still shows up


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)