### PR TITLE
fix(pki): preserve certificate subject attributes across ACME issuance and discovery

### DIFF
--- a/backend/src/ee/routes/v1/pki-installation-router.ts
+++ b/backend/src/ee/routes/v1/pki-installation-router.ts
@@ -102,7 +102,12 @@ export const registerPkiInstallationRouter = async (server: FastifyZodProvider) 
                 notAfter: z.date().nullable().optional(),
                 status: z.string().nullable().optional(),
                 friendlyName: z.string().nullable().optional(),
-                fingerprintSha256: z.string().nullable().optional()
+                fingerprintSha256: z.string().nullable().optional(),
+                subjectOrganization: z.string().nullable().optional(),
+                subjectOrganizationalUnit: z.string().nullable().optional(),
+                subjectCountry: z.string().nullable().optional(),
+                subjectState: z.string().nullable().optional(),
+                subjectLocality: z.string().nullable().optional()
               })
             )
             .optional()

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -1045,6 +1045,11 @@ export const pkiAcmeServiceFactory = ({
       csr,
       ttl: updatedCertificateRequest.validity?.ttl,
       enrollmentType: EnrollmentType.ACME,
+      organization: updatedCertificateRequest.organization || undefined,
+      organizationalUnit: updatedCertificateRequest.organizationalUnit || undefined,
+      country: updatedCertificateRequest.country || undefined,
+      state: updatedCertificateRequest.state || undefined,
+      locality: updatedCertificateRequest.locality || undefined,
       tx
     });
     const csrObj = new x509.Pkcs10CertificateRequest(csr);
@@ -1064,6 +1069,11 @@ export const pkiAcmeServiceFactory = ({
         extendedKeyUsages: updatedCertificateRequest.extendedKeyUsages?.map((usage) => usage.toString()) ?? [],
         certificateRequestId: certRequest.id,
         csr: csrPem,
+        organization: updatedCertificateRequest.organization,
+        organizationalUnit: updatedCertificateRequest.organizationalUnit,
+        country: updatedCertificateRequest.country,
+        state: updatedCertificateRequest.state,
+        locality: updatedCertificateRequest.locality,
         ...(applicationId && { applicationId })
       }
     };

--- a/backend/src/ee/services/pki-discovery/pki-certificate-installation-dal.ts
+++ b/backend/src/ee/services/pki-discovery/pki-certificate-installation-dal.ts
@@ -226,7 +226,12 @@ export const pkiCertificateInstallationDALFactory = (db: TDbClient) => {
           `${TableName.Certificate}.notAfter`,
           `${TableName.Certificate}.status`,
           `${TableName.Certificate}.friendlyName`,
-          `${TableName.Certificate}.fingerprintSha256`
+          `${TableName.Certificate}.fingerprintSha256`,
+          `${TableName.Certificate}.subjectOrganization`,
+          `${TableName.Certificate}.subjectOrganizationalUnit`,
+          `${TableName.Certificate}.subjectCountry`,
+          `${TableName.Certificate}.subjectState`,
+          `${TableName.Certificate}.subjectLocality`
         )
         .join(
           TableName.Certificate,

--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -25,6 +25,7 @@ import { TCloudflareConnection } from "@app/services/app-connection/cloudflare/c
 import { TDNSMadeEasyConnection } from "@app/services/app-connection/dns-made-easy/dns-made-easy-connection-types";
 import { TCertificateBodyDALFactory } from "@app/services/certificate/certificate-body-dal";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
+import { extractCertificateFields } from "@app/services/certificate/certificate-fns";
 import { TCertificateSecretDALFactory } from "@app/services/certificate/certificate-secret-dal";
 import {
   CertExtendedKeyUsage,
@@ -572,6 +573,8 @@ export const orderCertificate = async (
       })
     : { cipherTextBlob: undefined };
 
+  const parsedFields = extractCertificateFields(Buffer.from(leafCert));
+
   return (tx || certificateDAL).transaction(async (innerTx: Knex) => {
     const cert = await certificateDAL.create(
       {
@@ -590,7 +593,8 @@ export const orderCertificate = async (
         keyAlgorithm,
         signatureAlgorithm,
         projectId: ca.projectId,
-        renewedFromCertificateId: isRenewal && originalCertificateId ? originalCertificateId : null
+        renewedFromCertificateId: isRenewal && originalCertificateId ? originalCertificateId : null,
+        ...parsedFields
       },
       innerTx
     );

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -437,7 +437,12 @@ export const certificateIssuanceQueueFactory = ({
           const [, generatedCsr] = await acme.crypto.createCsr(
             {
               altNames: altNames ? altNames.map((san) => san.value) : [],
-              commonName: commonName || ""
+              commonName: commonName || "",
+              organization: organization || undefined,
+              organizationUnit: organizationalUnit || undefined,
+              country: country || undefined,
+              state: state || undefined,
+              locality: locality || undefined
             },
             skLeaf
           );


### PR DESCRIPTION
## Context

**1. ACME CSR generation drops subject attributes.**

When Infisical generates a CSR to send to an external ACME CA (no customer-supplied CSR), `acme.crypto.createCsr` was only receiving `commonName` and `altNames`. The `organization`, `organizationalUnit`, `country`, `state`, and `locality` fields were available in the queue job data but never forwarded. The external CA never saw them, so the signed certificate had no O/OU/C/ST/L in its subject. Fixed by passing all subject fields to `createCsr` (mapping `organizationalUnit` to the library's `organizationUnit` field name).

> *TL;DR: We had the subject data in hand but never put it in the CSR we sent to the external ACME CA. Now we do.*

**2. ACME-issued certificates stored without parsed subject fields.**

After the external ACME CA returns the signed certificate, `certificateDAL.create` was storing the encrypted cert blob but never calling `extractCertificateFields` to populate the DB columns (`subjectOrganization`, `subjectOrganizationalUnit`, etc.). This meant even if the CA honored the CSR subject, the DB columns stayed NULL. When v3 auto-renewal later reads from those columns to build the renewal CSR, it gets nothing -- the renewed cert loses all subject attributes. Fixed by calling `extractCertificateFields` on the returned PEM and spreading the parsed fields into the DB insert, matching how `signCertFromCa` and `issueCertFromCa` already do it.

> *TL;DR: External ACME CA returns a cert with OU, we store the blob but never parse the subject into DB columns. Auto-renewal reads those NULL columns and the renewed cert loses OU. Now we parse and store.*

**3. ACME finalize omits subject attributes from cert request and job data.**

When an ACME order is finalized for an external CA (non-approval path), `processCertificateIssuanceForOrder` was creating the certificate request record and queuing the issuance job without including subject attributes extracted from the CSR. The approval path already included them (lines 1249-1253) but the non-approval path did not. Fixed by adding `organization`, `organizationalUnit`, `country`, `state`, `locality` to both the `createCertificateRequest` call and the `certIssuanceJobData`.

> *TL;DR: The CSR had the subject data, but it was dropped in the handoff between ACME finalize and the issuance queue. Now it flows through.*

**4. Discovery installation query missing subject columns.**

The `findByIdWithCertificates` query in the installation DAL only selected `commonName`, `serialNumber`, `notBefore`, `notAfter`, `status`, `friendlyName`, `fingerprintSha256` when joining certificates. The subject attributes (`subjectOrganization`, `subjectOrganizationalUnit`, `subjectCountry`, `subjectState`, `subjectLocality`) are correctly parsed and stored during network scan discovery but were never returned to the API consumer. Fixed by adding the missing columns to the SELECT and updating the response schema.

> *TL;DR: Discovery scans correctly store subject data in the DB, but the installation detail API never included those columns in its query. Now it does.*

## Steps to verify the change

**Fix 1 + 3 (ACME CSR + finalize):**
1. Create a Cloudflare app connection and an external ACME CA (e.g. Let's Encrypt staging)
2. Create a certificate profile linked to the ACME CA, attach to an application, enable API enrollment
3. Issue a certificate with `organization`, `organizationalUnit`, `country`, `state`, `locality` in the attributes
4. Check the `certificate_requests` table -- subject fields should be populated (not NULL)
5. Note: Let's Encrypt strips subject attributes from DV certs, so the signed cert won't have OU. A corporate ACME server (like the customer's) would honor them.

**Fix 2 (ACME cert storage):**
1. After the cert from step 3 above is issued, check the `certificates` table
2. `fingerprintSha256`, `fingerprintSha1`, `isCA` should be populated (confirms `extractCertificateFields` ran)
3. With a CA that honors CSR subject (not LE), `subjectOrganization` etc. would also be populated

**Fix 4 (Discovery query):**
1. Run a network scan discovery that finds certificates with subject attributes
2. Hit `GET /api/v1/cert-manager/installations/:id`
3. Verify `subjectOrganization`, `subjectOrganizationalUnit`, `subjectCountry`, `subjectState`, `subjectLocality` are in the response

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)