### PR TITLE
improvement(overview): fix empty environments on overview page

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -124,6 +124,7 @@ import {
   useToggle
 } from "@app/hooks";
 import {
+  projectKeys,
   useCreateFolder,
   useCreateSecretBatch,
   useCreateSecretV3,
@@ -189,6 +190,7 @@ import {
   useSecretRotationOverview
 } from "@app/hooks/utils";
 import { RequestAccessModal } from "@app/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal";
+import { AddEnvironmentModal } from "@app/pages/secret-manager/SettingsPage/components/EnvironmentSection/AddEnvironmentModal";
 
 import { CreateDynamicSecretForm } from "../SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm";
 import { CreateSecretImportForm } from "../SecretDashboardPage/components/ActionBar/CreateSecretImportForm";
@@ -402,6 +404,9 @@ const OverviewPageContent = () => {
   }, []);
 
   const userAvailableEnvs = currentProject?.environments || [];
+  const isMoreEnvironmentsAllowed = subscription?.environmentLimit
+    ? userAvailableEnvs.length < subscription.environmentLimit
+    : true;
   const userAvailableDynamicSecretEnvs = userAvailableEnvs.filter((env) =>
     permission.can(
       ProjectPermissionDynamicSecretActions.CreateRootCredential,
@@ -554,19 +559,23 @@ const OverviewPageContent = () => {
       environments: (userAvailableEnvs || []).map(({ slug }) => slug)
     });
 
-  const importedSecretsFlat = useMemo(
-    () =>
-      secretImports?.flatMap(({ data }, index) =>
-        (data ?? []).map((item) => ({
+  const importedSecretsFlat = useMemo(() => {
+    if (!userAvailableEnvs.length) return [];
+
+    return (
+      secretImports?.flatMap(({ data }, index) => {
+        const sourceEnv = userAvailableEnvs[index]?.slug;
+        if (!sourceEnv) return [];
+
+        return (data ?? []).map((item) => ({
           environment: item.environment,
           secretPath: item.secretPath,
-          sourceEnv: userAvailableEnvs[index].slug,
+          sourceEnv,
           secrets: item.secrets
-        }))
-      ) ?? [],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [(secretImports || []).map((response) => response.data)]
-  );
+        }));
+      }) ?? []
+    );
+  }, [secretImports, userAvailableEnvs]);
 
   const isFilteredByResources = Object.values(filter).some(Boolean);
   const activeTagSlugs = useMemo(
@@ -813,7 +822,8 @@ const OverviewPageContent = () => {
     "confirmDisableBatchMode",
     "editHoneyToken",
     "revokeHoneyToken",
-    "viewHoneyTokenCredentials"
+    "viewHoneyTokenCredentials",
+    "createEnvironment"
   ] as const);
 
   const [detailsDrawerHoneyTokenId, setDetailsDrawerHoneyTokenId] = useState<string | null>(null);
@@ -2433,6 +2443,7 @@ const OverviewPageContent = () => {
   const isTableFiltered = isFilteredByResources;
 
   const tableView = (() => {
+    if (userAvailableEnvs.length === 0) return "no-environments" as const;
     if (isTagFilterEmpty) return "tag-filter-empty" as const;
     if (isTableEmpty) {
       const cannotCreate = permission.cannot(
@@ -2715,6 +2726,20 @@ const OverviewPageContent = () => {
                   </AlertTitle>
                 </Alert>
               ) : null)}
+            {tableView === "no-environments" && (
+              <EmptyResourceDisplay
+                variant="no-environments"
+                onAddEnvironment={() => {
+                  if (isMoreEnvironmentsAllowed) {
+                    handlePopUpOpen("createEnvironment");
+                  } else {
+                    handlePopUpOpen("upgradePlan", {
+                      text: "Your current plan does not include access to adding custom environments. To unlock this feature, please upgrade to Infisical Pro plan."
+                    });
+                  }
+                }}
+              />
+            )}
             {tableView === "tag-filter-empty" && <EmptyResourceDisplay isFiltered />}
             {tableView === "filter-empty" && (
               <EmptyResourceDisplay isFiltered={isTableFiltered || Boolean(searchFilter)} />
@@ -3524,6 +3549,15 @@ const OverviewPageContent = () => {
           text={popUp.upgradePlan.data?.text}
         />
       )}
+      <AddEnvironmentModal
+        isOpen={popUp.createEnvironment.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("createEnvironment", isOpen)}
+        onComplete={async () => {
+          await queryClient.refetchQueries({
+            queryKey: projectKeys.getProjectById(projectId)
+          });
+        }}
+      />
       <CreateSecretRotationV2Modal
         secretPath={secretPath}
         environments={userAvailableSecretRotationEnvs}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
@@ -2,9 +2,7 @@ import { FolderPlusIcon, LayersIcon, PlusIcon, SearchIcon } from "lucide-react";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
-  Badge,
   Button,
-  DocumentationLinkBadge,
   Empty,
   EmptyContent,
   EmptyDescription,

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EmptyResourceDisplay/EmptyResourceDisplay.tsx
@@ -1,12 +1,56 @@
-import { FolderPlusIcon, SearchIcon } from "lucide-react";
+import { FolderPlusIcon, LayersIcon, PlusIcon, SearchIcon } from "lucide-react";
 
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@app/components/v3";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import {
+  Badge,
+  Button,
+  DocumentationLinkBadge,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle
+} from "@app/components/v3";
+import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
 
 type Props = {
   isFiltered?: boolean;
+  variant?: "secrets" | "no-environments";
+  onAddEnvironment?: () => void;
 };
 
-export function EmptyResourceDisplay({ isFiltered }: Props) {
+export function EmptyResourceDisplay({ isFiltered, variant = "secrets", onAddEnvironment }: Props) {
+  if (variant === "no-environments") {
+    return (
+      <Empty className="border">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <LayersIcon />
+          </EmptyMedia>
+          <EmptyTitle>No environments yet</EmptyTitle>
+          <EmptyDescription>
+            Environments isolate secrets by stage. Add one to start managing secrets for this
+            project.
+          </EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <ProjectPermissionCan
+            I={ProjectPermissionActions.Create}
+            a={ProjectPermissionSub.Environments}
+          >
+            {(isAllowed) => (
+              <Button size="xs" isDisabled={!isAllowed} onClick={onAddEnvironment}>
+                <PlusIcon />
+                Add Environment
+              </Button>
+            )}
+          </ProjectPermissionCan>
+        </EmptyContent>
+      </Empty>
+    );
+  }
+
   const { title, description } = isFiltered
     ? {
         title: "No resources match your search",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ReplicateFolderFromBoard/ReplicateFolderFromBoard.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ReplicateFolderFromBoard/ReplicateFolderFromBoard.tsx
@@ -85,7 +85,7 @@ export const ReplicateFolderFromBoard = ({
   const { data: accessibleSecrets } = useGetAccessibleSecrets({
     projectId,
     secretPath: "/",
-    environment: selectedEnvSlug.slug,
+    environment: selectedEnvSlug?.slug,
     recursive: true,
     filterByAction: shouldIncludeValues
       ? ProjectPermissionSecretActions.ReadValue


### PR DESCRIPTION
## Context
When all environment are deleted, an error was happening on the overview page. 

## Screenshots

<img width="1223" height="472" alt="image" src="https://github.com/user-attachments/assets/231aec09-ac79-4a55-80e1-ced52cd8d455" />

## Steps to verify the change
- delete all environments
- check that an error does not happen anymore

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)