### PR TITLE
feat(dynamic-secret): make GCP IAM token OAuth scopes configurable

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -38,7 +38,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
       targetPrincipal: serviceAccountEmail,
       lifetime: ttl,
       delegates: [],
-      targetScopes: tokenScopes
+      targetScopes: [...new Set(tokenScopes)]
     });
 
     let tokenResponse: GetAccessTokenResponse | undefined;

--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -14,7 +14,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
     return providerInputs;
   };
 
-  const $getToken = async (serviceAccountEmail: string, ttl: number): Promise<string> => {
+  const $getToken = async (serviceAccountEmail: string, ttl: number, tokenScopes: string[]): Promise<string> => {
     const appCfg = getConfig();
     if (!appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL) {
       throw new InternalServerError({
@@ -38,7 +38,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
       targetPrincipal: serviceAccountEmail,
       lifetime: ttl,
       delegates: [],
-      targetScopes: ["https://www.googleapis.com/auth/iam", "https://www.googleapis.com/auth/cloud-platform"]
+      targetScopes: tokenScopes
     });
 
     let tokenResponse: GetAccessTokenResponse | undefined;
@@ -67,7 +67,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
   const validateConnection = async (inputs: unknown) => {
     const providerInputs = await validateProviderInputs(inputs);
     try {
-      await $getToken(providerInputs.serviceAccountEmail, 10);
+      await $getToken(providerInputs.serviceAccountEmail, 10, providerInputs.tokenScopes);
       return true;
     } catch (err) {
       const sanitizedErrorMessage = sanitizeString({
@@ -89,7 +89,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
       const now = Math.floor(Date.now() / 1000);
       const ttl = Math.max(Math.floor(expireAt / 1000) - now, 0);
 
-      const token = await $getToken(providerInputs.serviceAccountEmail, ttl);
+      const token = await $getToken(providerInputs.serviceAccountEmail, ttl, providerInputs.tokenScopes);
       const entityId = alphaNumericNanoId(32);
 
       return { entityId, data: { SERVICE_ACCOUNT_EMAIL: providerInputs.serviceAccountEmail, TOKEN: token } };

--- a/backend/src/ee/services/dynamic-secret/providers/models.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/models.ts
@@ -615,7 +615,12 @@ export const DynamicSecretTotpSchema = z.discriminatedUnion("configType", [
 ]);
 
 export const DynamicSecretGcpIamSchema = z.object({
-  serviceAccountEmail: z.string().email().trim().min(1, "Service account email required").max(128)
+  serviceAccountEmail: z.string().email().trim().min(1, "Service account email required").max(128),
+  tokenScopes: z
+    .array(z.string().trim().min(1))
+    .min(1, "At least one scope is required")
+    .default(["https://www.googleapis.com/auth/iam", "https://www.googleapis.com/auth/cloud-platform"])
+    .describe("OAuth scopes for the generated access token.")
 });
 
 export const DynamicSecretGithubSchema = z.object({

--- a/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
@@ -108,7 +108,7 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
        		The email tied to the service account created in earlier steps.
     	</ParamField>
     	<ParamField path="Token Scopes" type="string[]" default="https://www.googleapis.com/auth/iam, https://www.googleapis.com/auth/cloud-platform">
-       		The OAuth scopes granted to the generated access token. Defaults to the `iam` and `cloud-platform` scopes. Add scopes such as `https://www.googleapis.com/auth/drive.readonly` to access Google APIs outside `cloud-platform`'s coverage.
+       		The OAuth scopes granted to the generated access token. Defaults to `https://www.googleapis.com/auth/iam` and `https://www.googleapis.com/auth/cloud-platform` scopes. You can add additional scopes such as `https://www.googleapis.com/auth/drive`.
     	</ParamField>
   </Step>
   <Step title="Click `Submit`">

--- a/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
@@ -6,11 +6,17 @@ description: "Learn how to dynamically generate GCP service account tokens."
 The Infisical GCP IAM dynamic secret allows you to generate GCP service account tokens on demand based on service account permissions.
 
 <Warning>
-    GCP service account access tokens cannot be revoked. As such, revoking or regenerating a token does not invalidate the old one; it remains active until it expires.
+  GCP service account access tokens cannot be revoked. As such, revoking or
+  regenerating a token does not invalidate the old one; it remains active until
+  it expires.
 </Warning>
 
 <Note>
-    You must enable the [IAM API](https://console.cloud.google.com/apis/library/iam.googleapis.com) and [IAM Credentials API](https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com) in your GCP console as a prerequisite
+  You must enable the [IAM
+  API](https://console.cloud.google.com/apis/library/iam.googleapis.com) and
+  [IAM Credentials
+  API](https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com)
+  in your GCP console as a prerequisite
 </Note>
 
 <Accordion title="Self-Hosted Instance">
@@ -41,6 +47,7 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
             4. You can now use GCP integration with service account impersonation.
         </Step>
     </Steps>
+
 </Accordion>
 
 ## Create GCP Service Account
@@ -72,6 +79,7 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
 
         ![Service Account Page](/images/app-connections/gcp/service-account-grant-access.png)
     </Step>
+
 </Steps>
 
 ## Set up Dynamic Secrets with GCP IAM
@@ -99,6 +107,9 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
     	<ParamField path="Service Account Email" type="string" required>
        		The email tied to the service account created in earlier steps.
     	</ParamField>
+    	<ParamField path="Token Scopes" type="string[]" default="https://www.googleapis.com/auth/iam, https://www.googleapis.com/auth/cloud-platform">
+       		The OAuth scopes granted to the generated access token. Defaults to the `iam` and `cloud-platform` scopes. Add scopes such as `https://www.googleapis.com/auth/drive.readonly` to access Google APIs outside `cloud-platform`'s coverage.
+    	</ParamField>
   </Step>
   <Step title="Click `Submit`">
       After submitting the form, you will see a dynamic secret created in the dashboard.
@@ -123,6 +134,7 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
     	Once you click the `Submit` button, a new secret lease will be generated and the credentials from it will be shown to you.
 
     	![Dynamic Secret Lease](/images/platform/dynamic-secrets/dynamic-secret-gcp-iam-lease.png)
+
   </Step>
 </Steps>
 
@@ -141,5 +153,6 @@ To extend the life of the generated dynamic secret leases past its initial time 
 ![Lease Renew](/images/platform/dynamic-secrets/dynamic-secret-lease-renew.png)
 
 <Warning>
-	Lease renewals cannot exceed the maximum TTL set when configuring the dynamic secret
+  Lease renewals cannot exceed the maximum TTL set when configuring the dynamic
+  secret
 </Warning>

--- a/frontend/src/hooks/api/dynamicSecret/types.ts
+++ b/frontend/src/hooks/api/dynamicSecret/types.ts
@@ -414,6 +414,7 @@ export type TDynamicSecretProvider =
       type: DynamicSecretProviders.GcpIam;
       inputs: {
         serviceAccountEmail: string;
+        tokenScopes: string[];
       };
     }
   | {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
@@ -214,20 +214,33 @@ export const GcpIamInputForm = ({
                   >
                     <div className="space-y-2">
                       {fields.map((field, index) => (
-                        <div key={field.id} className="flex items-center space-x-2">
-                          <Input
-                            {...control.register(`provider.tokenScopes.${index}`)}
-                            placeholder="https://www.googleapis.com/auth/cloud-platform"
-                            className="grow"
-                          />
-                          <IconButton
-                            onClick={() => remove(index)}
-                            variant="outline_bg"
-                            ariaLabel="Remove scope"
-                          >
-                            <FontAwesomeIcon icon={faTrash} />
-                          </IconButton>
-                        </div>
+                        <Controller
+                          key={field.id}
+                          control={control}
+                          name={`provider.tokenScopes.${index}`}
+                          render={({ field: itemField, fieldState: { error: itemError } }) => (
+                            <FormControl
+                              isError={Boolean(itemError?.message)}
+                              errorText={itemError?.message}
+                              className="mb-0"
+                            >
+                              <div className="flex items-center space-x-2">
+                                <Input
+                                  {...itemField}
+                                  placeholder="https://www.googleapis.com/auth/cloud-platform"
+                                  className="grow"
+                                />
+                                <IconButton
+                                  onClick={() => remove(index)}
+                                  variant="outline_bg"
+                                  ariaLabel="Remove scope"
+                                >
+                                  <FontAwesomeIcon icon={faTrash} />
+                                </IconButton>
+                              </div>
+                            </FormControl>
+                          )}
+                        />
                       ))}
                       <Button variant="outline_bg" onClick={() => append("")} type="button">
                         Add Scope

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
@@ -1,10 +1,12 @@
-import { Controller, useForm } from "react-hook-form";
+import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
-import { Button, FilterableSelect, FormControl, Input } from "@app/components/v2";
+import { Button, FilterableSelect, FormControl, IconButton, Input } from "@app/components/v2";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
 import { ProjectEnv } from "@app/hooks/api/types";
@@ -25,7 +27,8 @@ const validateTTL = (val: string, ctx: z.RefinementCtx) => {
 const formSchema = z
   .object({
     provider: z.object({
-      serviceAccountEmail: z.string().email().trim().min(1, "Service account email required")
+      serviceAccountEmail: z.string().email().trim().min(1, "Service account email required"),
+      tokenScopes: z.array(z.string().trim().min(1)).min(1, "At least one scope is required")
     }),
     defaultTTL: z.string().superRefine(validateTTL),
     maxTTL: z
@@ -41,7 +44,7 @@ const formSchema = z
     path: ["maxTTL"],
     message: "Max TTL must be greater than or equal to Default TTL"
   });
-type TForm = z.infer<typeof formSchema>;
+type TForm = z.infer<typeof formSchema> & FieldValues;
 
 type Props = {
   onCompleted: () => void;
@@ -67,8 +70,19 @@ export const GcpIamInputForm = ({
   } = useForm<TForm>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      environment: isSingleEnvironmentMode && environments.length > 0 ? environments[0] : undefined
+      environment: isSingleEnvironmentMode && environments.length > 0 ? environments[0] : undefined,
+      provider: {
+        tokenScopes: [
+          "https://www.googleapis.com/auth/iam",
+          "https://www.googleapis.com/auth/cloud-platform"
+        ]
+      }
     }
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "provider.tokenScopes"
   });
 
   const createDynamicSecret = useCreateDynamicSecret();
@@ -184,6 +198,41 @@ export const GcpIamInputForm = ({
                     }
                   >
                     <Input placeholder="example@project.iam.gserviceaccount.com" {...field} />
+                  </FormControl>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="provider.tokenScopes"
+                render={({ fieldState: { error } }) => (
+                  <FormControl
+                    label="Token Scopes"
+                    isError={Boolean(error?.message)}
+                    errorText={error?.message}
+                    helperText="OAuth scopes granted to the generated access token. Scopes can only be narrowed after issuance, never widened."
+                  >
+                    <div className="space-y-2">
+                      {fields.map((field, index) => (
+                        <div key={field.id} className="flex items-center space-x-2">
+                          <Input
+                            {...control.register(`provider.tokenScopes.${index}`)}
+                            placeholder="https://www.googleapis.com/auth/cloud-platform"
+                            className="grow"
+                          />
+                          <IconButton
+                            onClick={() => remove(index)}
+                            variant="outline_bg"
+                            ariaLabel="Remove scope"
+                          >
+                            <FontAwesomeIcon icon={faTrash} />
+                          </IconButton>
+                        </div>
+                      ))}
+                      <Button variant="outline_bg" onClick={() => append("")} type="button">
+                        Add Scope
+                      </Button>
+                    </div>
                   </FormControl>
                 )}
               />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -210,41 +210,49 @@ export const GcpIamInputForm = ({
                     label="Token Scopes"
                     isError={Boolean(error?.message)}
                     errorText={error?.message}
-                    helperText="OAuth scopes granted to the generated access token. Scopes can only be narrowed after issuance, never widened."
                   >
-                    <div className="space-y-2">
+                    <div className="flex flex-col space-y-2">
                       {fields.map((field, index) => (
-                        <Controller
-                          key={field.id}
-                          control={control}
-                          name={`provider.tokenScopes.${index}`}
-                          render={({ field: itemField, fieldState: { error: itemError } }) => (
-                            <FormControl
-                              isError={Boolean(itemError?.message)}
-                              errorText={itemError?.message}
-                              className="mb-0"
-                            >
-                              <div className="flex items-center space-x-2">
-                                <Input
-                                  {...itemField}
-                                  placeholder="https://www.googleapis.com/auth/cloud-platform"
-                                  className="grow"
-                                />
-                                <IconButton
-                                  onClick={() => remove(index)}
-                                  variant="outline_bg"
-                                  ariaLabel="Remove scope"
+                        <div key={field.id} className="flex items-end space-x-2">
+                          <div className="grow">
+                            <Controller
+                              control={control}
+                              name={`provider.tokenScopes.${index}`}
+                              render={({ field: itemField, fieldState: { error: itemError } }) => (
+                                <FormControl
+                                  isError={Boolean(itemError?.message)}
+                                  errorText={itemError?.message}
+                                  className="mb-0 grow"
                                 >
-                                  <FontAwesomeIcon icon={faTrash} />
-                                </IconButton>
-                              </div>
-                            </FormControl>
-                          )}
-                        />
+                                  <Input
+                                    {...itemField}
+                                    placeholder="https://www.googleapis.com/auth/cloud-platform"
+                                  />
+                                </FormControl>
+                              )}
+                            />
+                          </div>
+                          <IconButton
+                            ariaLabel="Remove scope"
+                            className="bottom-0.5 h-9"
+                            variant="outline_bg"
+                            onClick={() => remove(index)}
+                          >
+                            <FontAwesomeIcon icon={faTrash} />
+                          </IconButton>
+                        </div>
                       ))}
-                      <Button variant="outline_bg" onClick={() => append("")} type="button">
-                        Add Scope
-                      </Button>
+                      <div>
+                        <Button
+                          leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                          size="xs"
+                          variant="outline_bg"
+                          onClick={() => append("")}
+                          type="button"
+                        >
+                          Add Scope
+                        </Button>
+                      </div>
                     </div>
                   </FormControl>
                 )}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
@@ -1,4 +1,4 @@
-import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,7 +28,9 @@ const formSchema = z
   .object({
     provider: z.object({
       serviceAccountEmail: z.string().email().trim().min(1, "Service account email required"),
-      tokenScopes: z.array(z.string().trim().min(1)).min(1, "At least one scope is required")
+      tokenScopes: z
+        .array(z.object({ value: z.string().trim().min(1, "Scope is required") }))
+        .min(1, "At least one scope is required")
     }),
     defaultTTL: z.string().superRefine(validateTTL),
     maxTTL: z
@@ -44,7 +46,7 @@ const formSchema = z
     path: ["maxTTL"],
     message: "Max TTL must be greater than or equal to Default TTL"
   });
-type TForm = z.infer<typeof formSchema> & FieldValues;
+type TForm = z.infer<typeof formSchema>;
 
 type Props = {
   onCompleted: () => void;
@@ -73,8 +75,8 @@ export const GcpIamInputForm = ({
       environment: isSingleEnvironmentMode && environments.length > 0 ? environments[0] : undefined,
       provider: {
         tokenScopes: [
-          "https://www.googleapis.com/auth/iam",
-          "https://www.googleapis.com/auth/cloud-platform"
+          { value: "https://www.googleapis.com/auth/iam" },
+          { value: "https://www.googleapis.com/auth/cloud-platform" }
         ]
       }
     }
@@ -100,7 +102,8 @@ export const GcpIamInputForm = ({
       provider: {
         type: DynamicSecretProviders.GcpIam,
         inputs: {
-          ...provider
+          ...provider,
+          tokenScopes: [...new Set(provider.tokenScopes.map((scope) => scope.value))]
         }
       },
       maxTTL,
@@ -217,7 +220,7 @@ export const GcpIamInputForm = ({
                           <div className="grow">
                             <Controller
                               control={control}
-                              name={`provider.tokenScopes.${index}`}
+                              name={`provider.tokenScopes.${index}.value`}
                               render={({ field: itemField, fieldState: { error: itemError } }) => (
                                 <FormControl
                                   isError={Boolean(itemError?.message)}
@@ -247,7 +250,7 @@ export const GcpIamInputForm = ({
                           leftIcon={<FontAwesomeIcon icon={faPlus} />}
                           size="xs"
                           variant="outline_bg"
-                          onClick={() => append("")}
+                          onClick={() => append({ value: "" })}
                           type="button"
                         >
                           Add Scope

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
@@ -1,11 +1,13 @@
-import { Controller, useForm } from "react-hook-form";
+import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input } from "@app/components/v2";
+import { Button, FormControl, IconButton, Input } from "@app/components/v2";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 
@@ -25,7 +27,8 @@ const validateTTL = (val: string, ctx: z.RefinementCtx) => {
 const formSchema = z
   .object({
     inputs: z.object({
-      serviceAccountEmail: z.string().email().trim().min(1, "Service account email required")
+      serviceAccountEmail: z.string().email().trim().min(1, "Service account email required"),
+      tokenScopes: z.array(z.string().trim().min(1)).min(1, "At least one scope is required")
     }),
     defaultTTL: z.string().superRefine(validateTTL),
     maxTTL: z
@@ -40,7 +43,7 @@ const formSchema = z
     path: ["maxTTL"],
     message: "Max TTL must be greater than or equal to Default TTL"
   });
-type TForm = z.infer<typeof formSchema>;
+type TForm = z.infer<typeof formSchema> & FieldValues;
 
 type Props = {
   onClose: () => void;
@@ -67,9 +70,18 @@ export const EditDynamicSecretGcpIamForm = ({
       maxTTL: dynamicSecret.maxTTL,
       newName: dynamicSecret.name,
       inputs: {
-        ...(dynamicSecret.inputs as TForm["inputs"])
+        ...(dynamicSecret.inputs as TForm["inputs"]),
+        tokenScopes: (dynamicSecret.inputs as TForm["inputs"]).tokenScopes ?? [
+          "https://www.googleapis.com/auth/iam",
+          "https://www.googleapis.com/auth/cloud-platform"
+        ]
       }
     }
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "inputs.tokenScopes"
   });
 
   const updateDynamicSecret = useUpdateDynamicSecret();
@@ -163,6 +175,41 @@ export const EditDynamicSecretGcpIamForm = ({
                   errorText={error?.message}
                 >
                   <Input {...field} />
+                </FormControl>
+              )}
+            />
+
+            <Controller
+              control={control}
+              name="inputs.tokenScopes"
+              render={({ fieldState: { error } }) => (
+                <FormControl
+                  label="Token Scopes"
+                  isError={Boolean(error?.message)}
+                  errorText={error?.message}
+                  helperText="OAuth scopes granted to the generated access token. Scopes can only be narrowed after issuance, never widened."
+                >
+                  <div className="space-y-2">
+                    {fields.map((field, index) => (
+                      <div key={field.id} className="flex items-center space-x-2">
+                        <Input
+                          {...control.register(`inputs.tokenScopes.${index}`)}
+                          placeholder="https://www.googleapis.com/auth/cloud-platform"
+                          className="grow"
+                        />
+                        <IconButton
+                          onClick={() => remove(index)}
+                          variant="outline_bg"
+                          ariaLabel="Remove scope"
+                        >
+                          <FontAwesomeIcon icon={faTrash} />
+                        </IconButton>
+                      </div>
+                    ))}
+                    <Button variant="outline_bg" onClick={() => append("")} type="button">
+                      Add Scope
+                    </Button>
+                  </div>
                 </FormControl>
               )}
             />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
@@ -1,4 +1,4 @@
-import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,7 +28,9 @@ const formSchema = z
   .object({
     inputs: z.object({
       serviceAccountEmail: z.string().email().trim().min(1, "Service account email required"),
-      tokenScopes: z.array(z.string().trim().min(1)).min(1, "At least one scope is required")
+      tokenScopes: z
+        .array(z.object({ value: z.string().trim().min(1, "Scope is required") }))
+        .min(1, "At least one scope is required")
     }),
     defaultTTL: z.string().superRefine(validateTTL),
     maxTTL: z
@@ -43,7 +45,7 @@ const formSchema = z
     path: ["maxTTL"],
     message: "Max TTL must be greater than or equal to Default TTL"
   });
-type TForm = z.infer<typeof formSchema> & FieldValues;
+type TForm = z.infer<typeof formSchema>;
 
 type Props = {
   onClose: () => void;
@@ -70,11 +72,14 @@ export const EditDynamicSecretGcpIamForm = ({
       maxTTL: dynamicSecret.maxTTL,
       newName: dynamicSecret.name,
       inputs: {
-        ...(dynamicSecret.inputs as TForm["inputs"]),
-        tokenScopes: (dynamicSecret.inputs as TForm["inputs"]).tokenScopes ?? [
-          "https://www.googleapis.com/auth/iam",
-          "https://www.googleapis.com/auth/cloud-platform"
-        ]
+        serviceAccountEmail: (dynamicSecret.inputs as { serviceAccountEmail: string })
+          .serviceAccountEmail,
+        tokenScopes: (
+          (dynamicSecret.inputs as { tokenScopes?: string[] }).tokenScopes ?? [
+            "https://www.googleapis.com/auth/iam",
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        ).map((value) => ({ value }))
       }
     }
   });
@@ -97,7 +102,10 @@ export const EditDynamicSecretGcpIamForm = ({
       data: {
         maxTTL: maxTTL || undefined,
         defaultTTL,
-        inputs,
+        inputs: {
+          ...inputs,
+          tokenScopes: [...new Set(inputs.tokenScopes.map((scope) => scope.value))]
+        },
         newName: newName === dynamicSecret.name ? undefined : newName
       }
     });
@@ -194,7 +202,7 @@ export const EditDynamicSecretGcpIamForm = ({
                         <div className="grow">
                           <Controller
                             control={control}
-                            name={`inputs.tokenScopes.${index}`}
+                            name={`inputs.tokenScopes.${index}.value`}
                             render={({ field: itemField, fieldState: { error: itemError } }) => (
                               <FormControl
                                 isError={Boolean(itemError?.message)}
@@ -224,7 +232,7 @@ export const EditDynamicSecretGcpIamForm = ({
                         leftIcon={<FontAwesomeIcon icon={faPlus} />}
                         size="xs"
                         variant="outline_bg"
-                        onClick={() => append("")}
+                        onClick={() => append({ value: "" })}
                         type="button"
                       >
                         Add Scope

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
@@ -191,20 +191,33 @@ export const EditDynamicSecretGcpIamForm = ({
                 >
                   <div className="space-y-2">
                     {fields.map((field, index) => (
-                      <div key={field.id} className="flex items-center space-x-2">
-                        <Input
-                          {...control.register(`inputs.tokenScopes.${index}`)}
-                          placeholder="https://www.googleapis.com/auth/cloud-platform"
-                          className="grow"
-                        />
-                        <IconButton
-                          onClick={() => remove(index)}
-                          variant="outline_bg"
-                          ariaLabel="Remove scope"
-                        >
-                          <FontAwesomeIcon icon={faTrash} />
-                        </IconButton>
-                      </div>
+                      <Controller
+                        key={field.id}
+                        control={control}
+                        name={`inputs.tokenScopes.${index}`}
+                        render={({ field: itemField, fieldState: { error: itemError } }) => (
+                          <FormControl
+                            isError={Boolean(itemError?.message)}
+                            errorText={itemError?.message}
+                            className="mb-0"
+                          >
+                            <div className="flex items-center space-x-2">
+                              <Input
+                                {...itemField}
+                                placeholder="https://www.googleapis.com/auth/cloud-platform"
+                                className="grow"
+                              />
+                              <IconButton
+                                onClick={() => remove(index)}
+                                variant="outline_bg"
+                                ariaLabel="Remove scope"
+                              >
+                                <FontAwesomeIcon icon={faTrash} />
+                              </IconButton>
+                            </div>
+                          </FormControl>
+                        )}
+                      />
                     ))}
                     <Button variant="outline_bg" onClick={() => append("")} type="button">
                       Add Scope

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
@@ -1,5 +1,5 @@
 import { Controller, FieldValues, useFieldArray, useForm } from "react-hook-form";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
@@ -187,41 +187,49 @@ export const EditDynamicSecretGcpIamForm = ({
                   label="Token Scopes"
                   isError={Boolean(error?.message)}
                   errorText={error?.message}
-                  helperText="OAuth scopes granted to the generated access token. Scopes can only be narrowed after issuance, never widened."
                 >
-                  <div className="space-y-2">
+                  <div className="flex flex-col space-y-2">
                     {fields.map((field, index) => (
-                      <Controller
-                        key={field.id}
-                        control={control}
-                        name={`inputs.tokenScopes.${index}`}
-                        render={({ field: itemField, fieldState: { error: itemError } }) => (
-                          <FormControl
-                            isError={Boolean(itemError?.message)}
-                            errorText={itemError?.message}
-                            className="mb-0"
-                          >
-                            <div className="flex items-center space-x-2">
-                              <Input
-                                {...itemField}
-                                placeholder="https://www.googleapis.com/auth/cloud-platform"
-                                className="grow"
-                              />
-                              <IconButton
-                                onClick={() => remove(index)}
-                                variant="outline_bg"
-                                ariaLabel="Remove scope"
+                      <div key={field.id} className="flex items-end space-x-2">
+                        <div className="grow">
+                          <Controller
+                            control={control}
+                            name={`inputs.tokenScopes.${index}`}
+                            render={({ field: itemField, fieldState: { error: itemError } }) => (
+                              <FormControl
+                                isError={Boolean(itemError?.message)}
+                                errorText={itemError?.message}
+                                className="mb-0 grow"
                               >
-                                <FontAwesomeIcon icon={faTrash} />
-                              </IconButton>
-                            </div>
-                          </FormControl>
-                        )}
-                      />
+                                <Input
+                                  {...itemField}
+                                  placeholder="https://www.googleapis.com/auth/cloud-platform"
+                                />
+                              </FormControl>
+                            )}
+                          />
+                        </div>
+                        <IconButton
+                          ariaLabel="Remove scope"
+                          className="bottom-0.5 h-9"
+                          variant="outline_bg"
+                          onClick={() => remove(index)}
+                        >
+                          <FontAwesomeIcon icon={faTrash} />
+                        </IconButton>
+                      </div>
                     ))}
-                    <Button variant="outline_bg" onClick={() => append("")} type="button">
-                      Add Scope
-                    </Button>
+                    <div>
+                      <Button
+                        leftIcon={<FontAwesomeIcon icon={faPlus} />}
+                        size="xs"
+                        variant="outline_bg"
+                        onClick={() => append("")}
+                        type="button"
+                      >
+                        Add Scope
+                      </Button>
+                    </div>
                   </div>
                 </FormControl>
               )}


### PR DESCRIPTION
<img width="1568" height="747" alt="Screenshot 2026-06-13 at 9 43 05 PM" src="https://github.com/user-attachments/assets/7c3123b5-9f41-4e15-b953-6ed93b166e60" />

## Context

The GCP IAM dynamic secret provider mints short-lived OAuth access tokens by having an Infisical-controlled service account impersonate a user-specified target service account (via google-auth-library's `Impersonated` client).

The OAuth scopes on the minted token were **hardcoded** to `iam` + `cloud-platform`, with no way to change them. As a result, tokens could not carry scopes like `https://www.googleapis.com/auth/drive.readonly`, so any Google API outside `cloud-platform`'s coverage (Drive, Sheets, etc.) failed. Because OAuth scopes can only be **narrowed** after issuance, never widened, this could not be worked around on the consuming side; the scope must be set at mint time, in the provider.

This PR adds a configurable `tokenScopes` input that **defaults to the current two scopes**, so existing leases are unaffected.

**Backward compatibility:** the Zod `.default([...iam, ...cloud-platform])` fills in the original scopes for any dynamic secret stored before this change, so existing leases mint identical tokens. Provider inputs are stored as an encrypted JSON blob (`encryptedInput`), not as table columns, so **no database migration is required**.

**Scope of change:** service-account impersonation path only (`targetScopes`). It does **not** add domain-wide delegation / user impersonation (`subject`), which would be a separate, larger change and is out of scope here.

### Changes
- **Backend** — added `tokenScopes` to `DynamicSecretGcpIamSchema` and threaded it through `$getToken` into the `Impersonated` client's `targetScopes`. The source JWT client's `cloud-platform` scope (which governs the impersonation API call, not the minted token) is unchanged.
- **Frontend** — added `tokenScopes` to the GCP IAM DTO and surfaced it in the create and edit forms as an add/remove list, mirroring the existing Kubernetes `audiences` field pattern.
- **Docs** — documented the new `Token Scopes` parameter.

## Steps to verify the change

1. Create a GCP IAM dynamic secret leaving Token Scopes at the defaults → lease mints a token as before.
2. Create one with `https://www.googleapis.com/auth/drive.readonly` added → minted token carries the Drive scope (verify via `https://oauth2.googleapis.com/tokeninfo?access_token=<token>`).
3. Edit an existing (pre-change) secret → scope list shows the two defaults; saving and generating a new lease works.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`.
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)