### PR TITLE
fix(pki): handle NetScaler cert sync race conditions when same certificate is used across multiple syncs

### DIFF
--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
@@ -154,8 +154,7 @@ const createOrUpdateCertKey = async (
     });
   } catch (changeError: unknown) {
     const isNotFound =
-      changeError instanceof AxiosError &&
-      (changeError.response?.data as { errorcode?: number })?.errorcode === 1540;
+      changeError instanceof AxiosError && (changeError.response?.data as { errorcode?: number })?.errorcode === 1540;
 
     if (!isNotFound) {
       throw changeError;

--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
@@ -176,6 +176,7 @@ const createOrUpdateCertKey = async (
       });
     } catch (addError: unknown) {
       if (addError instanceof AxiosError && addError.response?.status === 409) {
+        logger.info(`NetScaler certkey "${certKeyName}" already exists, treating as success`);
         return;
       }
       throw addError;

--- a/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/netscaler/netscaler-pki-sync-fns.ts
@@ -110,18 +110,6 @@ const saveNetScalerConfig = async (session: TNetScalerSession): Promise<void> =>
   });
 };
 
-const deleteFile = async (session: TNetScalerSession, filename: string): Promise<void> => {
-  try {
-    await session.makeRequest({
-      method: "DELETE",
-      url: `${session.baseUrl}/systemfile/${encodeURIComponent(filename)}?args=filelocation:${encodeURIComponent("/nsconfig/ssl")}`,
-      headers: session.headers
-    });
-  } catch {
-    // Ignore errors if file doesn't exist
-  }
-};
-
 const uploadFileToNetScaler = async (
   session: TNetScalerSession,
   filename: string,
@@ -129,40 +117,19 @@ const uploadFileToNetScaler = async (
 ): Promise<void> => {
   const contentBase64 = Buffer.from(fileContent).toString("base64");
 
-  try {
-    await session.makeRequest({
-      method: "POST",
-      url: `${session.baseUrl}/systemfile`,
-      data: {
-        systemfile: {
-          filename,
-          filelocation: "/nsconfig/ssl",
-          filecontent: contentBase64,
-          fileencoding: "BASE64"
-        }
-      },
-      headers: session.headers
-    });
-  } catch (error: unknown) {
-    if (error instanceof AxiosError && error.response?.status === 409) {
-      await deleteFile(session, filename);
-      await session.makeRequest({
-        method: "POST",
-        url: `${session.baseUrl}/systemfile`,
-        data: {
-          systemfile: {
-            filename,
-            filelocation: "/nsconfig/ssl",
-            filecontent: contentBase64,
-            fileencoding: "BASE64"
-          }
-        },
-        headers: session.headers
-      });
-      return;
-    }
-    throw error;
-  }
+  await session.makeRequest({
+    method: "POST",
+    url: `${session.baseUrl}/systemfile?override=yes`,
+    data: {
+      systemfile: {
+        filename,
+        filelocation: "/nsconfig/ssl",
+        filecontent: contentBase64,
+        fileencoding: "BASE64"
+      }
+    },
+    headers: session.headers
+  });
 };
 
 const createOrUpdateCertKey = async (
@@ -185,19 +152,34 @@ const createOrUpdateCertKey = async (
       },
       headers: session.headers
     });
-  } catch {
-    await session.makeRequest({
-      method: "POST",
-      url: `${session.baseUrl}/sslcertkey`,
-      data: {
-        sslcertkey: {
-          certkey: certKeyName,
-          cert: `/nsconfig/ssl/${certFilename}`,
-          key: `/nsconfig/ssl/${keyFilename}`
-        }
-      },
-      headers: session.headers
-    });
+  } catch (changeError: unknown) {
+    const isNotFound =
+      changeError instanceof AxiosError &&
+      (changeError.response?.data as { errorcode?: number })?.errorcode === 1540;
+
+    if (!isNotFound) {
+      throw changeError;
+    }
+
+    try {
+      await session.makeRequest({
+        method: "POST",
+        url: `${session.baseUrl}/sslcertkey`,
+        data: {
+          sslcertkey: {
+            certkey: certKeyName,
+            cert: `/nsconfig/ssl/${certFilename}`,
+            key: `/nsconfig/ssl/${keyFilename}`
+          }
+        },
+        headers: session.headers
+      });
+    } catch (addError: unknown) {
+      if (addError instanceof AxiosError && addError.response?.status === 409) {
+        return;
+      }
+      throw addError;
+    }
   }
 };
 


### PR DESCRIPTION
## Context

When multiple certificate syncs target the same NetScaler appliance with the same certificate (bound to different vServers), the second sync fails with "Resource already exists." The customer-reported RCA attributed this to NetScaler rejecting identical content on the CHANGE operation, but testing against a live NetScaler confirmed CHANGE actually succeeds with identical content (200 OK). The real root cause is race conditions when syncs run concurrently.

Three fixes, all in `netscaler-pki-sync-fns.ts`:

- **File upload**: replaced the delete-then-reupload pattern with `?override=yes`, which atomically overwrites. The old pattern created a window where the file didn't exist on disk, causing concurrent CHANGE operations to fail with errorcode 1647 ("Input file(s) not present"). Removed the now-unused `deleteFile` helper.
- **CHANGE error handling**: the catch-all `} catch {` was swallowing all errors (network, auth, file-not-found) and falling through to ADD unconditionally. Now only falls through on errorcode 1540 ("Certificate does not exist"), which is the only case where creating a new certkey is the right response.
- **ADD error handling**: when ADD returns HTTP 409 ("Resource already exists"), the certkey already exists with the correct name and files, so log and return successfully instead of throwing.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)