### PR TITLE
fix: spurious commit changes modal after bulk tagging secrets on over…

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -353,15 +353,19 @@ export const SecretEditTableRow = ({
   useEffect(() => {
     if (!isSingleEnvView || hasPendingChange) return;
 
+    const newTags = tags?.map((t) => ({ id: t.id, slug: t.slug })) ?? [];
+    if (!getFieldState("tags").isDirty) {
+      setValue("tags", newTags, { shouldDirty: false });
+    }
+    originalTagsRef.current = newTags;
     originalCommentRef.current = comment ?? "";
-    originalTagsRef.current = tags?.map((t) => ({ id: t.id, slug: t.slug })) ?? [];
     originalMetadataRef.current =
       secretMetadata?.map((m) => ({
         key: m.key,
         value: m.value,
         isEncrypted: m.isEncrypted ?? false
       })) ?? [];
-  }, [comment, tags, secretMetadata, isSingleEnvView, hasPendingChange]);
+  }, [comment, tags, secretMetadata, isSingleEnvView, hasPendingChange, setValue, getFieldState]);
 
   // Stable callbacks for child components to avoid resetting their debounce timers on re-render
   const handleCommentChange = useCallback(

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
@@ -92,22 +92,20 @@ export const SecretTagForm = ({
   const watchedTags = watch("tags");
   const debounceTimer = useRef<ReturnType<typeof setTimeout>>();
 
-  const initialTagsRef = useRef(tags?.map((tag) => ({ id: tag.id, slug: tag.slug })) ?? []);
+  const isInitialRenderRef = useRef(true);
 
   useEffect(() => {
     if (!isBatchMode) return () => {};
 
     if (debounceTimer.current) clearTimeout(debounceTimer.current);
 
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+      return () => {};
+    }
+
     debounceTimer.current = setTimeout(() => {
-      const normalized = watchedTags.map((t) => ({ id: t.value, slug: t.label }));
-      const initialIds = initialTagsRef.current.map((t) => t.id).sort();
-      const normalizedIds = normalized.map((t) => t.id).sort();
-      const hasChanged =
-        normalizedIds.length !== initialIds.length ||
-        normalizedIds.some((id, i) => id !== initialIds[i]);
-      if (!hasChanged) return;
-      onTagsChange?.(normalized);
+      onTagsChange?.(watchedTags.map((t) => ({ id: t.value, slug: t.label })));
     }, 500);
 
     return () => {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
@@ -92,21 +92,26 @@ export const SecretTagForm = ({
   const watchedTags = watch("tags");
   const debounceTimer = useRef<ReturnType<typeof setTimeout>>();
 
+  const initialTagsRef = useRef(tags?.map((tag) => ({ id: tag.id, slug: tag.slug })) ?? []);
+
   useEffect(() => {
     if (!isBatchMode) return () => {};
 
-    if (debounceTimer.current) {
-      clearTimeout(debounceTimer.current);
-    }
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
 
     debounceTimer.current = setTimeout(() => {
-      onTagsChange?.(watchedTags.map((t) => ({ id: t.value, slug: t.label })));
+      const normalized = watchedTags.map((t) => ({ id: t.value, slug: t.label }));
+      const initialIds = initialTagsRef.current.map((t) => t.id).sort();
+      const normalizedIds = normalized.map((t) => t.id).sort();
+      const hasChanged =
+        normalizedIds.length !== initialIds.length ||
+        normalizedIds.some((id, i) => id !== initialIds[i]);
+      if (!hasChanged) return;
+      onTagsChange?.(normalized);
     }, 500);
 
     return () => {
-      if (debounceTimer.current) {
-        clearTimeout(debounceTimer.current);
-      }
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
     };
   }, [isBatchMode, watchedTags, onTagsChange]);
 


### PR DESCRIPTION
## Context

Fixes #6854 .

After bulk-assigning tags to secrets on the Overview page, hovering over an affected secret and opening the View Tags popover immediately triggered a spurious "Commit Changes" modal showing the tag as removed. Committing would permanently delete the tag server-side.

Root cause: `SecretTagForm` fires `onTagsChange` via its debounce effect on mount even when the user hasn't changed anything. At mount time the form field still holds the pre-refetch stale tag list, while `originalTagsRef` has already updated to the fresh server tags. The auto-apply logic in `SecretEditTableRow` sees this as a dirty diff and calls `addPendingChange`, writing a false tag removal into the Zustand store.

Fix: sync the form field with fresh server tags when there is no pending user change (`SecretEditTableRow.tsx`), and guard the debounce emission in `SecretTagForm.tsx` so it only fires when the tag selection actually differs from the initial value at mount.

## Screenshots

Before

https://github.com/user-attachments/assets/51b7442f-7daa-49e1-90cc-279861c5eb13

After

https://github.com/user-attachments/assets/e09992ae-8fbd-4481-8f41-293b622ff34b

## Steps to verify

1. Create secrets and a tag in batch mode
2. Bulk assign the tag via the selection panel
3. Hover over an affected secret and open View Tags
4. Confirm the tag is visible and no "Commit Changes" modal appears
5. Make an intentional tag change via the popover and confirm it still commits correctly

## Type
- [x] Fix

## Checklist
- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide



