### PR TITLE
fix(secrets): respect personal overrides on imported secrets

### DIFF
--- a/backend/e2e-test/routes/v1/secret-import.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-import.spec.ts
@@ -812,6 +812,8 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
 // a personal override on a secret in the source folder must be respected when the
 // secret is read through an import (e.g. CLI export of a folder that imports it).
 describe("Secret import personal override testing", () => {
+  // Setup and teardown live in beforeAll so cleanup runs unconditionally, even if an
+  // assertion in the test below fails.
   beforeAll(async () => {
     const devImportFromStaging = await createSecretImport({
       authToken: jwtAuthToken,
@@ -822,18 +824,6 @@ describe("Secret import personal override testing", () => {
       importEnv: "staging"
     });
 
-    return async () => {
-      await deleteSecretImport({
-        id: devImportFromStaging.id,
-        workspaceId: seedData1.projectV3.id,
-        environmentSlug: seedData1.environment.slug,
-        secretPath: "/",
-        authToken: jwtAuthToken
-      });
-    };
-  });
-
-  test("Personal override on an imported secret is respected", async () => {
     // shared secret living in the imported (staging) folder
     await createSecretV2({
       environmentSlug: "staging",
@@ -855,6 +845,35 @@ describe("Secret import personal override testing", () => {
       type: SecretType.Personal
     });
 
+    return async () => {
+      await deleteSecretV2({
+        environmentSlug: "staging",
+        workspaceId: seedData1.projectV3.id,
+        secretPath: "/",
+        authToken: jwtAuthToken,
+        key: "OVERRIDE_KEY",
+        type: SecretType.Personal
+      });
+
+      await deleteSecretV2({
+        environmentSlug: "staging",
+        workspaceId: seedData1.projectV3.id,
+        secretPath: "/",
+        authToken: jwtAuthToken,
+        key: "OVERRIDE_KEY"
+      });
+
+      await deleteSecretImport({
+        id: devImportFromStaging.id,
+        workspaceId: seedData1.projectV3.id,
+        environmentSlug: seedData1.environment.slug,
+        secretPath: "/",
+        authToken: jwtAuthToken
+      });
+    };
+  });
+
+  test("Personal override on an imported secret is respected", async () => {
     // dev imports from staging; the personal override must surface through the import.
     // expandSecretReferences is disabled to mirror the CLI export scenario from the bug report.
     const listSecrets = await getSecretsV2({
@@ -872,22 +891,5 @@ describe("Secret import personal override testing", () => {
 
     expect(personalOverride).toBeDefined();
     expect(personalOverride?.secretValue).toBe("personal-value");
-
-    await deleteSecretV2({
-      environmentSlug: "staging",
-      workspaceId: seedData1.projectV3.id,
-      secretPath: "/",
-      authToken: jwtAuthToken,
-      key: "OVERRIDE_KEY",
-      type: SecretType.Personal
-    });
-
-    await deleteSecretV2({
-      environmentSlug: "staging",
-      workspaceId: seedData1.projectV3.id,
-      secretPath: "/",
-      authToken: jwtAuthToken,
-      key: "OVERRIDE_KEY"
-    });
   });
 });

--- a/backend/e2e-test/routes/v1/secret-import.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-import.spec.ts
@@ -2,6 +2,7 @@ import { createFolder, deleteFolder } from "e2e-test/testUtils/folders";
 import { createSecretImport, deleteSecretImport } from "e2e-test/testUtils/secret-imports";
 import { createSecretV2, deleteSecretV2, getSecretByNameV2, getSecretsV2 } from "e2e-test/testUtils/secrets";
 
+import { SecretType } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
 
 describe("Secret Import Router", async () => {
@@ -806,3 +807,87 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
     });
   }
 );
+
+// Regression test for personal overrides on imported secrets (issue #4842):
+// a personal override on a secret in the source folder must be respected when the
+// secret is read through an import (e.g. CLI export of a folder that imports it).
+describe("Secret import personal override testing", () => {
+  beforeAll(async () => {
+    const devImportFromStaging = await createSecretImport({
+      authToken: jwtAuthToken,
+      secretPath: "/",
+      environmentSlug: seedData1.environment.slug,
+      workspaceId: seedData1.projectV3.id,
+      importPath: "/",
+      importEnv: "staging"
+    });
+
+    return async () => {
+      await deleteSecretImport({
+        id: devImportFromStaging.id,
+        workspaceId: seedData1.projectV3.id,
+        environmentSlug: seedData1.environment.slug,
+        secretPath: "/",
+        authToken: jwtAuthToken
+      });
+    };
+  });
+
+  test("Personal override on an imported secret is respected", async () => {
+    // shared secret living in the imported (staging) folder
+    await createSecretV2({
+      environmentSlug: "staging",
+      workspaceId: seedData1.projectV3.id,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      key: "OVERRIDE_KEY",
+      value: "shared-value"
+    });
+
+    // personal override of that secret for the requesting user
+    await createSecretV2({
+      environmentSlug: "staging",
+      workspaceId: seedData1.projectV3.id,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      key: "OVERRIDE_KEY",
+      value: "personal-value",
+      type: SecretType.Personal
+    });
+
+    // dev imports from staging; the personal override must surface through the import.
+    // expandSecretReferences is disabled to mirror the CLI export scenario from the bug report.
+    const listSecrets = await getSecretsV2({
+      environmentSlug: seedData1.environment.slug,
+      workspaceId: seedData1.projectV3.id,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      expandSecretReferences: false
+    });
+
+    const importedSecrets = listSecrets.imports.flatMap((importGroup) => importGroup.secrets);
+    const personalOverride = importedSecrets.find(
+      (secret) => secret.secretKey === "OVERRIDE_KEY" && secret.type === SecretType.Personal
+    );
+
+    expect(personalOverride).toBeDefined();
+    expect(personalOverride?.secretValue).toBe("personal-value");
+
+    await deleteSecretV2({
+      environmentSlug: "staging",
+      workspaceId: seedData1.projectV3.id,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      key: "OVERRIDE_KEY",
+      type: SecretType.Personal
+    });
+
+    await deleteSecretV2({
+      environmentSlug: "staging",
+      workspaceId: seedData1.projectV3.id,
+      secretPath: "/",
+      authToken: jwtAuthToken,
+      key: "OVERRIDE_KEY"
+    });
+  });
+});

--- a/backend/e2e-test/testUtils/secrets.ts
+++ b/backend/e2e-test/testUtils/secrets.ts
@@ -4,6 +4,7 @@ type TRawSecret = {
   secretKey: string;
   secretValue: string;
   secretComment?: string;
+  type?: SecretType;
   version: number;
 };
 
@@ -46,6 +47,7 @@ export const deleteSecretV2 = async (dto: {
   secretPath: string;
   key: string;
   authToken: string;
+  type?: SecretType;
 }) => {
   const deleteSecRes = await testServer.inject({
     method: "DELETE",
@@ -56,7 +58,8 @@ export const deleteSecretV2 = async (dto: {
     body: {
       workspaceId: dto.workspaceId,
       environment: dto.environmentSlug,
-      secretPath: dto.secretPath
+      secretPath: dto.secretPath,
+      ...(dto.type ? { type: dto.type } : {})
     }
   });
   expect(deleteSecRes.statusCode).toBe(200);
@@ -98,6 +101,7 @@ export const getSecretsV2 = async (dto: {
   secretPath: string;
   authToken: string;
   recursive?: boolean;
+  expandSecretReferences?: boolean;
 }) => {
   const getSecretsResponse = await testServer.inject({
     method: "GET",
@@ -109,7 +113,7 @@ export const getSecretsV2 = async (dto: {
       workspaceId: dto.workspaceId,
       environment: dto.environmentSlug,
       secretPath: dto.secretPath,
-      expandSecretReferences: "true",
+      expandSecretReferences: String(dto.expandSecretReferences ?? true),
       include_imports: "true",
       recursive: String(dto.recursive || false)
     }

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -402,10 +402,15 @@ export const fnSecretsV2FromImports = async ({
   }
   /* eslint-enable */
   if (expandSecretReferences) {
+    // With IncludeAll, a shared secret and its personal override share the same key but are distinct
+    // secrets (the same way direct secrets are returned), so they must both survive de-duplication.
+    // Other behaviors resolve to a single effective value per key, so de-duplicate by key alone.
+    const includeAll = personalOverridesBehavior === PersonalOverridesBehavior.IncludeAll;
+    const getDedupeKey = (i: { key: string; type: string }) => (includeAll ? `${i.key}:${i.type}` : i.key);
     await Promise.allSettled(
       processedImports.map((processedImport) => {
         // eslint-disable-next-line
-        processedImport.secrets = unique(processedImport.secrets, (i) => i.key);
+        processedImport.secrets = unique(processedImport.secrets, getDedupeKey);
         return Promise.allSettled(
           processedImport.secrets.map(async (decryptedSecret, index) => {
             if (decryptedSecret.secretValueHidden) return;

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1576,7 +1576,12 @@ export const secretV2BridgeServiceFactory = ({
       secretDAL,
       folderDAL,
       secretImportDAL,
-      userId: expandPersonalOverrides ? actorId : undefined,
+      // Mirror direct secrets: always pass the actor so personal overrides on imported secrets can be
+      // resolved. Whether they are actually included is decided by personalOverridesBehavior inside
+      // fnSecretsV2FromImports. Gating on expandPersonalOverrides here caused imported personal overrides
+      // to be dropped for callers that include overrides without reference expansion (e.g. the v3 raw
+      // endpoint used by the CLI export), so imports returned the shared value instead of the override.
+      userId: actorId,
       personalOverridesBehavior,
       expandSecretReferences:
         secretImportReferencesBehavior === SecretImportReferencesBehavior.Relative


### PR DESCRIPTION
## Context

Closes #4842.

When a folder imports secrets from another folder and a source secret has a **personal override**, reading the importing folder returned the original (shared) value instead of the override. This is most visible with `infisical export` of a folder that imports secrets — the exported values ignored personal overrides on the imported secrets (and `--secret-overriding` had no effect on them). Direct (non-imported) overrides already worked.

Two issues in the secret v2 bridge caused this:

1. **`getSecrets` gated the actor on `expandPersonalOverrides`.** It passed `userId: expandPersonalOverrides ? actorId : undefined` into `fnSecretsV2FromImports`. The v3 raw endpoint (used by the CLI export) requests `personalOverridesBehavior: IncludeAll` but does not set `expandPersonalOverrides`, so personal secrets were never fetched for imports. Direct secrets always pass the actor and let `personalOverridesBehavior` decide inclusion, so imports now do the same.

2. **`fnSecretsV2FromImports` de-duplicated imported secrets by key.** A shared secret and its personal override share the same key but are distinct secrets (exactly as they are for direct secrets under `IncludeAll`), so the override was collapsed away. De-duplication now keys on `key + type` for `IncludeAll`, while keeping key-only de-duplication for the behaviors that resolve to a single effective value per key (`Priority`, default).

## Steps to verify the change

1. In a project, create a secret in `/staging` (e.g. `OVERRIDE_KEY=shared-value`).
2. Add a personal override for it (`OVERRIDE_KEY=personal-value`).
3. In `/dev`, add a secret import from `/staging`.
4. Read `/dev` with imports included (e.g. `infisical export --env=dev --path=/`, or `GET /api/v3/secrets/raw?...&include_imports=true`).
5. The imported `OVERRIDE_KEY` now exposes the personal override; before this change it only returned `shared-value`.

A new e2e regression test (`backend/e2e-test/routes/v1/secret-import.spec.ts`) covers this. Existing secret/import/reference e2e suites continue to pass.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
