### PR TITLE
feat(ui): refactor secrets buttons

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -17,6 +17,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   IconButton,
   Tooltip,
@@ -95,6 +97,7 @@ export function AddResourceButtons({
           </IconButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuLabel>NEW</DropdownMenuLabel>
           <ProjectPermissionCan
             I={ProjectPermissionActions.Create}
             a={ProjectPermissionSub.SecretFolders}
@@ -144,6 +147,8 @@ export function AddResourceButtons({
             </TooltipTrigger>
             <TooltipContent side="left">Access restricted</TooltipContent>
           </Tooltip>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>BULK</DropdownMenuLabel>
           <Tooltip open={!isSecretImportAvailable || !isSingleEnvSelected ? undefined : false}>
             <TooltipTrigger className="block w-full">
               <DropdownMenuItem
@@ -199,6 +204,12 @@ export function AddResourceButtons({
               </Tooltip>
             )}
           </ProjectPermissionCan>
+          {(hasVaultConnection || hasDopplerConnection) && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>IMPORT FROM</DropdownMenuLabel>
+            </>
+          )}
           {hasVaultConnection && (
             <ProjectPermissionCan
               I={ProjectPermissionActions.Create}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -154,7 +154,7 @@ export function AddResourceButtons({
                   </DropdownMenuItem>
                 </TooltipTrigger>
                 <TooltipContent side="left">
-                  {!isAllowed ? "Access Denied" : "Access restricted"}
+                  {!isAllowed ? "Access Restricted" : "Access restricted"}
                 </TooltipContent>
               </Tooltip>
             )}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -138,15 +138,27 @@ export function AddResourceButtons({
             </TooltipTrigger>
             <TooltipContent side="left">Access restricted</TooltipContent>
           </Tooltip>
-          <Tooltip open={!isHoneyTokenAvailable ? undefined : false}>
-            <TooltipTrigger className="block w-full">
-              <DropdownMenuItem onClick={onAddHoneyToken} isDisabled={!isHoneyTokenAvailable}>
-                <HexagonIcon className="text-yellow" />
-                Add Honey Token
-              </DropdownMenuItem>
-            </TooltipTrigger>
-            <TooltipContent side="left">Access restricted</TooltipContent>
-          </Tooltip>
+          <ProjectPermissionCan
+            I={ProjectPermissionActions.Create}
+            a={ProjectPermissionSub.HoneyTokens}
+          >
+            {(isAllowed) => (
+              <Tooltip open={!isHoneyTokenAvailable || !isAllowed ? undefined : false}>
+                <TooltipTrigger className="block w-full">
+                  <DropdownMenuItem
+                    onClick={onAddHoneyToken}
+                    isDisabled={!isHoneyTokenAvailable || !isAllowed}
+                  >
+                    <HexagonIcon className="text-yellow" />
+                    Add Honey Token
+                  </DropdownMenuItem>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  {!isAllowed ? "Access Denied" : "Access restricted"}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </ProjectPermissionCan>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>BULK</DropdownMenuLabel>
           <Tooltip open={!isSecretImportAvailable || !isSingleEnvSelected ? undefined : false}>


### PR DESCRIPTION
## Context

Refactored secrets buttons to be grouped by action rather than all-in-one.

Additionally, I also took the liberty to fix the honey token being selectable in the UI when the user lacked permissions to create honey tokens.

## Screenshots

<img width="614" height="1140" alt="image" src="https://github.com/user-attachments/assets/ce91dc04-c01e-44fe-b397-dfa3f4b5ae5d" />


## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)