### PR TITLE
fix(scim): make PUT /Groups schemas optional per RFC 7644 §3.4.2

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -507,7 +507,11 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
         groupId: z.string().trim()
       }),
       body: z.object({
-        schemas: z.array(z.string()),
+        // Optional per RFC 7644 §3.4.2 — the server can infer the resource schema
+        // from the endpoint on PUT, and unused here. Some IdPs (e.g. Authentik)
+        // omit it; PATCH /Groups already treats this field as optional for the
+        // same reason.
+        schemas: z.array(z.string()).optional(),
         id: z.string().trim(),
         displayName: z.string().trim(),
         members: z.array(


### PR DESCRIPTION
## Context

Fixes part of #6552 — the PUT /Groups endpoint rejects the request when the body has no `schemas` field.

Today the route requires `schemas` as an array. But RFC 7644 §3.4.2 says the server can figure out the schema from the URL, so clients like Authentik don't send it. The PATCH route on the same file already treats `schemas` as optional. This PR does the same for PUT.

Only changed one Zod field. Left the other three defects from #6552 alone — they each need their own PR.

## Type

- [x] Fix

## Steps to verify the change

Send a PUT to `/api/v1/scim/Groups/<groupId>` without `schemas`:

- Before: 422, `schemas Required`
- After: 200, group updated

Requests that still include `schemas` keep working as before.

## Checklist

- [x] Title follows conventional commit format
- [x] Tested locally with curl
- [ ] Updated docs (no docs change)
- [ ] Updated CLAUDE.md files (no change)
- [x] Read the contributing guide
