### PR TITLE
fix(scim): add ServiceProviderConfig endpoint per RFC 7644 §5

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -45,7 +45,49 @@ const ScimGroupSchema = z.object({
   })
 });
 
+// SCIM /ServiceProviderConfig response per RFC 7644 §5. Describes which SCIM
+// capabilities Infisical's implementation supports so clients (Authentik etc.)
+// can negotiate without trial-and-error. Static — recompute when the supported
+// feature set actually changes.
+const ScimServiceProviderConfig = {
+  schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+  documentationUri: "https://infisical.com/docs/documentation/platform/scim/overview",
+  patch: { supported: true },
+  bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
+  filter: { supported: true, maxResults: 200 },
+  changePassword: { supported: false },
+  sort: { supported: false },
+  etag: { supported: false },
+  authenticationSchemes: [
+    {
+      name: "OAuth Bearer Token",
+      description: "Authentication scheme using the OAuth Bearer Token Standard",
+      specUri: "http://www.rfc-editor.org/info/rfc6750",
+      type: "oauthbearertoken",
+      primary: true
+    }
+  ],
+  meta: {
+    resourceType: "ServiceProviderConfig",
+    location: "/api/v1/scim/ServiceProviderConfig"
+  }
+};
+
 export const registerScimRouter = async (server: FastifyZodProvider) => {
+  server.route({
+    url: "/ServiceProviderConfig",
+    method: "GET",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      response: {
+        200: z.any()
+      }
+    },
+    handler: async () => ScimServiceProviderConfig
+  });
+
   server.route({
     url: "/scim-tokens",
     method: "POST",


### PR DESCRIPTION
## Context

Fixes another defect from #6552 — `GET /api/v1/scim/ServiceProviderConfig` returns 404.

RFC 7644 §5 makes this endpoint mandatory. SCIM clients hit it to find out what the server supports (patch, bulk, filter, etag, etc.). Without it, Authentik and other clients can't figure out what operations to use and fall back to assumptions that don't match Infisical's actual surface.

Added a small static handler that returns the config. Values match what Infisical actually supports today: patch yes, filter yes, bulk/changePassword/sort/etag no, bearer token auth.

## Type

- [x] Fix

## Steps to verify the change

```
curl -H "Authorization: Bearer <scim_token>" \
  https://<host>/api/v1/scim/ServiceProviderConfig
```

Before: 404. After: 200 with the config JSON.

## Checklist

- [x] Title follows conventional commit format
- [x] Tested locally
- [ ] Updated docs (no docs change)
- [ ] Updated CLAUDE.md files (no change)
- [x] Read the contributing guide
