### PR TITLE
fix(signup): read user row from primary to avoid stale replica after deletion

### DIFF
--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -125,23 +125,33 @@ export const authSignupServiceFactory = ({
     await tokenService.validateEmailSignupToken(sanitizedEmail, code);
 
     // Only create (or recover) the user after the OTP has been verified.
-    let user = await userDAL.findOne({ username: sanitizedEmail });
-    if (!user) {
-      user = await userDAL.create({
-        authMethods: [AuthMethod.EMAIL],
-        username: sanitizedEmail,
-        email: sanitizedEmail,
-        isGhost: false,
-        isEmailVerified: true
-      });
-    } else if (!user.isAccepted) {
-      // Migration path: pre-user created by the old flow before this refactor.
-      await userDAL.updateById(user.id, { isEmailVerified: true });
-      user = { ...user, isEmailVerified: true };
-    } else {
+    // Run the lookup + create/update inside a transaction so the read hits
+    // the primary. If replication still hasn't caught up with the delete
+    // from a re-signup flow, the replica would return the old isAccepted=true
+    // row and we'd throw "Invalid or expired verification request" even
+    // though the OTP itself was valid. See #6034.
+    const user = await userDAL.transaction(async (tx) => {
+      const existing = await userDAL.findOne({ username: sanitizedEmail }, tx);
+      if (!existing) {
+        return userDAL.create(
+          {
+            authMethods: [AuthMethod.EMAIL],
+            username: sanitizedEmail,
+            email: sanitizedEmail,
+            isGhost: false,
+            isEmailVerified: true
+          },
+          tx
+        );
+      }
+      if (!existing.isAccepted) {
+        // Migration path: pre-user created by the old flow before this refactor.
+        await userDAL.updateById(existing.id, { isEmailVerified: true }, tx);
+        return { ...existing, isEmailVerified: true };
+      }
       // isAccepted guard should have been caught in beginEmailSignupProcess, but defend here too.
       throw new Error("Invalid or expired verification request");
-    }
+    });
 
     const appCfg = getConfig();
     const jwtToken = crypto.jwt().sign(

--- a/backend/src/services/auth/auth-signup-service.ts
+++ b/backend/src/services/auth/auth-signup-service.ts
@@ -76,8 +76,12 @@ export const authSignupServiceFactory = ({
       }
     }
 
-    // Case sensitive email resolution
-    const existingUser = await userDAL.findOne({ username: sanitizedEmail });
+    // Case sensitive email resolution.
+    // Use a transaction so the read hits the primary — replica lag right after
+    // a hard-delete of the previous account would otherwise return the stale
+    // row with isAccepted=true and silently send the "account exists" email
+    // instead of starting a fresh signup. See #6034.
+    const existingUser = await userDAL.transaction(async (tx) => userDAL.findOne({ username: sanitizedEmail }, tx));
     if (existingUser?.isAccepted) {
       // Send informational email for existing accounts instead of throwing error to prevent user enumeration vulnerability
       const appCfg = getConfig();


### PR DESCRIPTION
## Context

Fixes #6034 — after a user deletes their account and immediately signs up again with the same email, they get the "account already exists" email instead of the OTP, and password recovery doesn't work either.

The cause is replica lag. `beginEmailSignupProcess` calls `userDAL.findOne` without a tx, so it goes to the read replica. The delete happened on the primary, but the replica might still have the old row with `isAccepted=true`. The flow sees it and bails into the "existing account" branch.

Fix is small: wrap the lookup in `userDAL.transaction` so it hits the primary. Single-statement Postgres transactions don't cost more than a normal query, so the signup hot path is unchanged.

## Type

- [x] Fix

## Steps to verify the change

1. Sign up with email A and complete the flow.
2. Delete the account from Personal Settings.
3. Immediately sign up again with the same email A.
4. Before: "account already exists" email arrives, no OTP, password recovery fails.
5. After: fresh OTP arrives as expected.

## Checklist

- [x] Title follows conventional commit format
- [x] Tested locally
- [ ] Updated docs (no docs change)
- [ ] Updated CLAUDE.md files (no change)
- [x] Read the contributing guide
