### PR TITLE
feat: fixing shadow mismatches in go and nodejs

### DIFF
--- a/backend-go/internal/ee/services/license/types.go
+++ b/backend-go/internal/ee/services/license/types.go
@@ -24,6 +24,32 @@ type RateLimits struct {
 	SecretsLimit int `json:"secretsLimit"`
 }
 
+// IntOrBool handles JSON fields that can be either an integer or a boolean.
+// When the value is true, it unmarshals as 1. When false or missing, it unmarshals as 0.
+// auditLogsRetentionDays returns the number of days to retain audit logs or sometimes as true
+type IntOrBool int
+
+func (i *IntOrBool) UnmarshalJSON(data []byte) error {
+	var intVal int
+	if err := json.Unmarshal(data, &intVal); err == nil {
+		*i = IntOrBool(intVal)
+		return nil
+	}
+
+	var boolVal bool
+	if err := json.Unmarshal(data, &boolVal); err == nil {
+		if boolVal {
+			*i = 1
+		} else {
+			*i = 0
+		}
+		return nil
+	}
+
+	*i = 0
+	return nil
+}
+
 type FeatureSet struct {
 	ID                           *string    `json:"_id"`
 	Slug                         *string    `json:"slug"`
@@ -44,7 +70,7 @@ type FeatureSet struct {
 	CustomRateLimits             bool       `json:"customRateLimits"`
 	CustomAlerts                 bool       `json:"customAlerts"`
 	AuditLogs                    bool       `json:"auditLogs"`
-	AuditLogsRetentionDays       int        `json:"auditLogsRetentionDays"`
+	AuditLogsRetentionDays       IntOrBool  `json:"auditLogsRetentionDays"`
 	AuditLogStreams              bool       `json:"auditLogStreams"`
 	AuditLogStreamLimit          int        `json:"auditLogStreamLimit"`
 	GithubOrgSync                bool       `json:"githubOrgSync"`
@@ -58,8 +84,6 @@ type FeatureSet struct {
 	Groups                       bool       `json:"groups"`
 	SubOrganization              bool       `json:"subOrganization"`
 	Status                       *string    `json:"status"`
-	TrialEnd                     *string    `json:"trial_end"`
-	HasUsedTrial                 bool       `json:"has_used_trial"`
 	SecretApproval               bool       `json:"secretApproval"`
 	SecretRotation               bool       `json:"secretRotation"`
 	CaCrl                        bool       `json:"caCrl"`
@@ -88,10 +112,9 @@ func DefaultFeatures() FeatureSet {
 	return FeatureSet{
 		Tier:                   -1,
 		SecretVersioning:       true,
-		HasUsedTrial:           true,
 		AuditLogStreamLimit:    3,
-		AuditLogs:              true,
-		AuditLogsRetentionDays: 1,
+		AuditLogs:              false,
+		AuditLogsRetentionDays: 0,
 		RateLimits: RateLimits{
 			ReadLimit:    60,
 			WriteLimit:   200,

--- a/backend-go/internal/libs/fn/string.go
+++ b/backend-go/internal/libs/fn/string.go
@@ -1,0 +1,13 @@
+package fn
+
+// RemoveTrailingSlash removes the trailing slash from a string.
+// If the string is just "/", it returns "/" unchanged.
+func RemoveTrailingSlash(str string) string {
+	if str == "/" {
+		return str
+	}
+	if str != "" && str[len(str)-1] == '/' {
+		return str[:len(str)-1]
+	}
+	return str
+}

--- a/backend-go/internal/libs/fn/string_test.go
+++ b/backend-go/internal/libs/fn/string_test.go
@@ -1,0 +1,46 @@
+package fn
+
+import "testing"
+
+func TestRemoveTrailingSlash(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "root path stays unchanged",
+			input:    "/",
+			expected: "/",
+		},
+		{
+			name:     "path with trailing slash",
+			input:    "/itabus/",
+			expected: "/itabus",
+		},
+		{
+			name:     "path without trailing slash",
+			input:    "/itabus",
+			expected: "/itabus",
+		},
+		{
+			name:     "nested path with trailing slash",
+			input:    "/foo/bar/baz/",
+			expected: "/foo/bar/baz",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RemoveTrailingSlash(tt.input)
+			if result != tt.expected {
+				t.Errorf("RemoveTrailingSlash(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/backend-go/internal/libs/logutil/context_handler.go
+++ b/backend-go/internal/libs/logutil/context_handler.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/google/uuid"
+
 	"github.com/infisical/api/internal/libs/requestid"
+	"github.com/infisical/api/internal/services/auth"
 )
 
 // ContextHandler wraps an slog.Handler and enriches every log record
-// with values extracted from the context (e.g. request ID).
+// with values extracted from the context (e.g. request ID, identity info).
 type ContextHandler struct {
 	inner slog.Handler
 }
 
-// NewContextHandler returns a handler that automatically adds the request ID
-// (and any future context values) to every log record.
+// NewContextHandler returns a handler that automatically adds the request ID,
+// identity info (orgId, actorType, actorId), and any future context values to every log record.
 func NewContextHandler(inner slog.Handler) *ContextHandler {
 	return &ContextHandler{inner: inner}
 }
@@ -26,6 +29,17 @@ func (h *ContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
 func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error { //nolint:gocritic // slog.Handler interface requires value receiver
 	if reqID := requestid.FromContext(ctx); reqID != "" {
 		r.AddAttrs(slog.String("reqId", reqID))
+	}
+
+	// Add identity info if available (set by RequireAuth middleware)
+	if identity, err := auth.IdentityFromContext(ctx); err == nil && identity != nil {
+		if identity.OrgID != uuid.Nil {
+			r.AddAttrs(slog.String("orgId", identity.OrgID.String()))
+		}
+		r.AddAttrs(
+			slog.String("actorType", string(identity.Actor)),
+			slog.String("actorId", identity.ActorID.String()),
+		)
 	}
 
 	return h.inner.Handle(ctx, r)

--- a/backend-go/internal/server/api/platform_services.go
+++ b/backend-go/internal/server/api/platform_services.go
@@ -7,6 +7,7 @@ import (
 	"github.com/infisical/api/internal/ee/services/externalkms"
 	"github.com/infisical/api/internal/ee/services/license"
 	"github.com/infisical/api/internal/ee/services/ratelimit"
+	"github.com/infisical/api/internal/server/api/shared"
 	"github.com/infisical/api/internal/services/assumeprivilege"
 	"github.com/infisical/api/internal/services/auditlog"
 	"github.com/infisical/api/internal/services/auth/apiauth"
@@ -57,7 +58,7 @@ func newPlatformServices(ctx context.Context, infra *Infra) (*PlatformServices, 
 		PermissionService: permissionSvc,
 	})
 
-	apiAuthenticator := apiauth.NewApiAuthenticator(infra.Logger, infra.DB, infra.Config.AuthSecret, infra.KeyStore, assumePrivilegeSvc)
+	apiAuthenticator := apiauth.NewApiAuthenticator(infra.Logger, infra.DB, infra.Config.AuthSecret, infra.KeyStore, assumePrivilegeSvc, shared.NewErrorHandler(infra.Logger))
 
 	auditLogSvc := auditlog.NewService(ctx, infra.Logger, &auditlog.Deps{
 		Queue:  infra.Queue,

--- a/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
+++ b/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
@@ -220,7 +220,7 @@ func (h *Handler) GetSecretByNameV4(ctx context.Context, opts *GetSecretByNameV4
 	response, err := h.getSecretByName(ctx, &getSecretByNameInternalOpts{
 		ProjectID:              q.ProjectID,
 		Environment:            q.Environment,
-		SecretPath:             fn.ValueOr(q.SecretPath, "/"),
+		SecretPath:             fn.RemoveTrailingSlash(fn.ValueOr(q.SecretPath, "/")),
 		SecretName:             p.SecretName,
 		SecretType:             getSecretType(identity, secretType),
 		UserID:                 getUserID(identity),
@@ -271,7 +271,7 @@ func (h *Handler) GetSecretByNameRawV3(ctx context.Context, opts *GetSecretByNam
 	response, err := h.getSecretByName(ctx, &getSecretByNameInternalOpts{
 		ProjectID:              projectID,
 		Environment:            env,
-		SecretPath:             fn.ValueOr(q.SecretPath, "/"),
+		SecretPath:             fn.RemoveTrailingSlash(fn.ValueOr(q.SecretPath, "/")),
 		SecretName:             p.SecretName,
 		SecretType:             getSecretType(identity, secretType),
 		UserID:                 getUserID(identity),

--- a/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
+++ b/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
@@ -227,7 +227,7 @@ func (h *Handler) ListSecretsV4(ctx context.Context, opts *ListSecretsV4ServiceR
 	response, err := h.listSecrets(ctx, &listSecretsInternalOpts{
 		ProjectID:                 q.ProjectID,
 		Environment:               q.Environment,
-		SecretPath:                fn.ValueOr(q.SecretPath, "/"),
+		SecretPath:                fn.RemoveTrailingSlash(fn.ValueOr(q.SecretPath, "/")),
 		UserID:                    getUserID(identity),
 		Recursive:                 fn.ValueOr(q.Recursive, false),
 		ViewSecretValue:           fn.ValueOr(q.ViewSecretValue, true),
@@ -275,7 +275,7 @@ func (h *Handler) ListSecretsRawV3(ctx context.Context, opts *ListSecretsRawV3Se
 	response, err := h.listSecrets(ctx, &listSecretsInternalOpts{
 		ProjectID:                 projectID,
 		Environment:               env,
-		SecretPath:                fn.ValueOr(q.SecretPath, "/"),
+		SecretPath:                fn.RemoveTrailingSlash(fn.ValueOr(q.SecretPath, "/")),
 		UserID:                    getUserID(identity),
 		Recursive:                 fn.ValueOr(q.Recursive, false),
 		ViewSecretValue:           fn.ValueOr(q.ViewSecretValue, true),
@@ -328,8 +328,8 @@ func (h *Handler) buildSecretRaw(ps *secretsvc.ProcessedSecret, projectID string
 			Slug: tag.Slug,
 			Name: tag.Slug,
 		}
-		if tag.Color != "" {
-			t.Color = &tag.Color
+		if tag.Color.Valid {
+			t.Color = &tag.Color.V
 		}
 		tags = append(tags, t)
 	}
@@ -374,6 +374,14 @@ func (h *Handler) buildSecretRaw(ps *secretsvc.ProcessedSecret, projectID string
 		SkipMultilineEncoding: skipMultilineEncoding,
 		IsRotatedSecret:       isRotatedSecret,
 		RotationID:            rotationID,
+	}
+
+	if sec.ReminderNote.Valid {
+		raw.SecretReminderNote = &sec.ReminderNote.V
+	}
+	if sec.ReminderRepeatDays.Valid {
+		repeatDays := int(sec.ReminderRepeatDays.V)
+		raw.SecretReminderRepeatDays = &repeatDays
 	}
 
 	return raw

--- a/backend-go/internal/server/api/shared/errors.go
+++ b/backend-go/internal/server/api/shared/errors.go
@@ -90,6 +90,7 @@ func (h *ErrorHandler) writeHTTPError(ctx context.Context, w http.ResponseWriter
 			slog.String("name", httpErr.Name),
 			slog.Int("status", status),
 			slog.String("message", httpErr.Message),
+			slog.Any("cause", httpErr.Err),
 		)
 	}
 

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -79,14 +79,26 @@ func (s *Server) Listen(ctx context.Context, addr string, wg *sync.WaitGroup, er
 	})
 }
 
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
 func requestLogger(next http.Handler, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		next.ServeHTTP(w, r)
-		logger.InfoContext(r.Context(), "request",
+		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(recorder, r)
+		logger.InfoContext(r.Context(), "request completed",
 			slog.String("reqId", requestid.FromContext(r.Context())),
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
+			slog.Int("statusCode", recorder.statusCode),
 			slog.String("duration", time.Since(start).String()),
 			slog.String("remote", r.RemoteAddr),
 		)

--- a/backend-go/internal/services/auth/apiauth/authenticator.go
+++ b/backend-go/internal/services/auth/apiauth/authenticator.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +32,12 @@ type AssumePrivilegeVerifier interface {
 	VerifyAssumePrivilegeToken(ctx context.Context, opts *assumeprivilege.VerifyTokenOpts) (*auth.AssumedPrivilegeDetails, error)
 }
 
+// ErrorHandler handles HTTP error responses with proper logging.
+// This interface matches shared.ErrorHandler to avoid import cycles.
+type ErrorHandler interface {
+	HandleError(w http.ResponseWriter, r *http.Request, statusCode int, err error)
+}
+
 // ApiAuthenticator performs token validation for various auth methods.
 // It's an exact port of the Node.js inject-identity logic.
 type ApiAuthenticator struct {
@@ -39,13 +46,14 @@ type ApiAuthenticator struct {
 	keyStore        keystore.KeyStore
 	authSecret      []byte
 	assumePrivilege AssumePrivilegeVerifier
+	errorHandler    ErrorHandler
 }
 
 // NewApiAuthenticator creates an ApiAuthenticator with real validation backed by pg.DB.
 // keyStore can be nil for tests that don't need Redis-backed features.
 // assumePrivilege can be nil if assume privilege feature is not needed.
-func NewApiAuthenticator(logger *slog.Logger, db pg.DB, authSecret string, keyStore keystore.KeyStore, assumePrivilege AssumePrivilegeVerifier) *ApiAuthenticator {
-	return &ApiAuthenticator{logger: logger, db: db, authSecret: []byte(authSecret), keyStore: keyStore, assumePrivilege: assumePrivilege}
+func NewApiAuthenticator(logger *slog.Logger, db pg.DB, authSecret string, keyStore keystore.KeyStore, assumePrivilege AssumePrivilegeVerifier, errorHandler ErrorHandler) *ApiAuthenticator {
+	return &ApiAuthenticator{logger: logger, db: db, authSecret: []byte(authSecret), keyStore: keyStore, assumePrivilege: assumePrivilege, errorHandler: errorHandler}
 }
 
 // AssumePrivilege returns the assume privilege verifier.

--- a/backend-go/internal/services/auth/apiauth/require_auth.go
+++ b/backend-go/internal/services/auth/apiauth/require_auth.go
@@ -2,8 +2,6 @@ package apiauth
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"net"
 	"net/http"
 	"strings"
@@ -83,7 +81,7 @@ func (a *ApiAuthenticator) RequireAuth(opts ...AuthOption) func(http.Handler) ht
 
 			token := extractBearerToken(r)
 			if token == "" {
-				writeUnauthorized(w, "Missing authorization header")
+				a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Missing authorization header"))
 				return
 			}
 
@@ -96,7 +94,7 @@ func (a *ApiAuthenticator) RequireAuth(opts ...AuthOption) func(http.Handler) ht
 			switch classifiedMode {
 			case auth.AuthModeServiceToken:
 				if !cfg.allowedModes[ServiceTokenAuth] {
-					writeUnauthorized(w, "Authentication method not allowed for this endpoint")
+					a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Authentication method not allowed for this endpoint"))
 					return
 				}
 				identity, err = a.ValidateServiceToken(ctx, token)
@@ -104,7 +102,7 @@ func (a *ApiAuthenticator) RequireAuth(opts ...AuthOption) func(http.Handler) ht
 
 			case auth.AuthModeJWT:
 				if !cfg.allowedModes[JWTAuth] && !cfg.allowedModes[IdentityAccessTokenAuth] {
-					writeUnauthorized(w, "Authentication method not allowed for this endpoint")
+					a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Authentication method not allowed for this endpoint"))
 					return
 				}
 				var authMode auth.AuthMode
@@ -112,27 +110,22 @@ func (a *ApiAuthenticator) RequireAuth(opts ...AuthOption) func(http.Handler) ht
 				actualMode, _ = mapClassifiedMode(authMode)
 
 			default:
-				writeUnauthorized(w, "Unsupported authentication method")
+				a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Unsupported authentication method"))
 				return
 			}
 
 			if err != nil {
-				var httpErr *errutil.Error
-				if errors.As(err, &httpErr) {
-					writeUnauthorized(w, httpErr.Message)
-				} else {
-					writeUnauthorized(w, "Authentication failed")
-				}
+				a.errorHandler.HandleError(w, r, http.StatusUnauthorized, err)
 				return
 			}
 
 			if identity == nil {
-				writeUnauthorized(w, "Authentication failed")
+				a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Authentication failed"))
 				return
 			}
 
 			if !cfg.allowedModes[actualMode] {
-				writeUnauthorized(w, "Authentication method not allowed for this endpoint")
+				a.errorHandler.HandleError(w, r, http.StatusUnauthorized, errutil.Unauthorized("Authentication method not allowed for this endpoint"))
 				return
 			}
 
@@ -243,14 +236,4 @@ func mapClassifiedMode(mode auth.AuthMode) (AuthMode, bool) {
 	default:
 		return 0, false
 	}
-}
-
-// writeUnauthorized writes a 401 response with the error message.
-func writeUnauthorized(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusUnauthorized)
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"code":    "UnauthorizedError",
-		"message": message,
-	})
 }

--- a/backend-go/internal/services/secretmanager/secret/secret.go
+++ b/backend-go/internal/services/secretmanager/secret/secret.go
@@ -39,7 +39,7 @@ const (
 type SecretTag struct {
 	ID    uuid.UUID
 	Slug  string
-	Color string
+	Color sql.Null[string]
 }
 
 type SecretMetadata struct {
@@ -77,6 +77,8 @@ type Secret struct {
 	FolderID              uuid.UUID
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
+	ReminderNote          sql.Null[string]
+	ReminderRepeatDays    sql.Null[int32]
 
 	Tags                     []SecretTag
 	SecretMetadata           []SecretMetadata
@@ -274,6 +276,7 @@ func (s *Service) FindByFolderIds(
 			tag.id AS tag_id, tag.slug AS tag_slug, tag.color AS tag_color,
 			meta.id AS meta_id, meta.key AS meta_key, meta.value AS meta_value, meta."encryptedValue" AS meta_encrypted_value,
 			rotationMapping."rotationId",
+			reminder.message AS reminder_note, reminder."repeatDays" AS reminder_repeat_days,
 			recipient.id AS recipient_id, recipientUser.id AS recipient_user_id, recipientUser.username AS recipient_username, recipientUser.email AS recipient_email
 		FROM secrets_v2 secret
 		LEFT JOIN secret_v2_tag_junction tagJunction ON secret.id = tagJunction."secrets_v2Id"
@@ -358,6 +361,7 @@ func (s *Service) FindByKey(
 			tag.id AS tag_id, tag.slug AS tag_slug, tag.color AS tag_color,
 			meta.id AS meta_id, meta.key AS meta_key, meta.value AS meta_value, meta."encryptedValue" AS meta_encrypted_value,
 			rotationMapping."rotationId",
+			reminder.message AS reminder_note, reminder."repeatDays" AS reminder_repeat_days,
 			recipient.id AS recipient_id, recipientUser.id AS recipient_user_id, recipientUser.username AS recipient_username, recipientUser.email AS recipient_email
 		FROM secrets_v2 secret
 		LEFT JOIN secret_v2_tag_junction tagJunction ON secret.id = tagJunction."secrets_v2Id"
@@ -416,6 +420,8 @@ func scanSecretRow(row pgx.CollectableRow) (Secret, error) {
 		metaValue             sql.Null[string]
 		metaEncryptedValue    []byte
 		rotationID            sql.Null[uuid.UUID]
+		reminderNote          sql.Null[string]
+		reminderRepeatDays    sql.Null[int32]
 		recipientID           sql.Null[uuid.UUID]
 		recipientUserID       sql.Null[uuid.UUID]
 		recipientUsername     sql.Null[string]
@@ -428,6 +434,7 @@ func scanSecretRow(row pgx.CollectableRow) (Secret, error) {
 		&tagID, &tagSlug, &tagColor,
 		&metaID, &metaKey, &metaValue, &metaEncryptedValue,
 		&rotationID,
+		&reminderNote, &reminderRepeatDays,
 		&recipientID, &recipientUserID, &recipientUsername, &recipientEmail,
 	); err != nil {
 		return Secret{}, err
@@ -446,13 +453,15 @@ func scanSecretRow(row pgx.CollectableRow) (Secret, error) {
 		FolderID:              folderID,
 		CreatedAt:             createdAt,
 		UpdatedAt:             updatedAt,
+		ReminderNote:          reminderNote,
+		ReminderRepeatDays:    reminderRepeatDays,
 	}
 
 	if tagID.Valid {
 		secret.Tags = []SecretTag{{
 			ID:    tagID.V,
 			Slug:  tagSlug.V,
-			Color: tagColor.V,
+			Color: tagColor,
 		}}
 	}
 

--- a/backend-go/tests/infra/logger.go
+++ b/backend-go/tests/infra/logger.go
@@ -3,10 +3,51 @@
 package infra
 
 import (
+	"encoding/json"
+	"errors"
 	"log/slog"
+	"net/http"
+
+	"github.com/infisical/api/internal/libs/errutil"
 )
 
 // NopLogger returns a logger that discards all output.
 func NopLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
+}
+
+// NopErrorHandler implements apiauth.ErrorHandler for tests.
+// It writes error responses without logging.
+type NopErrorHandler struct{}
+
+// NewNopErrorHandler creates a NopErrorHandler for tests.
+func NewNopErrorHandler() *NopErrorHandler {
+	return &NopErrorHandler{}
+}
+
+// HandleError writes an error response without logging.
+func (h *NopErrorHandler) HandleError(w http.ResponseWriter, _ *http.Request, statusCode int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var httpErr *errutil.Error
+	if errors.As(err, &httpErr) {
+		status := httpErr.Status
+		if status == 0 {
+			status = statusCode
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"statusCode": status,
+			"error":      httpErr.Name,
+			"message":    httpErr.Message,
+		})
+		return
+	}
+
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"statusCode": statusCode,
+		"error":      "UnknownError",
+		"message":    err.Error(),
+	})
 }

--- a/backend-go/tests/infra/nodejs.go
+++ b/backend-go/tests/infra/nodejs.go
@@ -588,10 +588,12 @@ type SecretSeed struct {
 
 // CreateSecretOpts holds optional parameters for CreateSecret.
 type CreateSecretOpts struct {
-	Comment  string
-	Metadata []SecretMetadataEntry
-	TagIDs   []string
-	Type     string // "shared" or "personal", defaults to "shared"
+	Comment            string
+	Metadata           []SecretMetadataEntry
+	TagIDs             []string
+	Type               string // "shared" or "personal", defaults to "shared"
+	ReminderNote       string
+	ReminderRepeatDays *int
 }
 
 // CreateSecret creates a secret via the Node.js API.
@@ -602,12 +604,16 @@ func (n *NodeJSService) CreateSecret(t *testing.T, projectID, environment, secre
 	var comment string
 	var metadata []SecretMetadataEntry
 	var tagIDs []string
+	var reminderNote string
+	var reminderRepeatDays *int
 	secretType := "shared"
 
 	if opts != nil {
 		comment = opts.Comment
 		metadata = opts.Metadata
 		tagIDs = opts.TagIDs
+		reminderNote = opts.ReminderNote
+		reminderRepeatDays = opts.ReminderRepeatDays
 		if opts.Type != "" {
 			secretType = opts.Type
 		}
@@ -622,14 +628,16 @@ func (n *NodeJSService) CreateSecret(t *testing.T, projectID, environment, secre
 	r, err := n.client.R().
 		SetAuthToken(token).
 		SetBody(CreateSecretRequest{
-			ProjectID:      projectID,
-			Environment:    environment,
-			SecretPath:     secretPath,
-			SecretValue:    value,
-			SecretComment:  comment,
-			SecretMetadata: metadata,
-			Type:           secretType,
-			TagIDs:         tagIDs,
+			ProjectID:                projectID,
+			Environment:              environment,
+			SecretPath:               secretPath,
+			SecretValue:              value,
+			SecretComment:            comment,
+			SecretMetadata:           metadata,
+			Type:                     secretType,
+			TagIDs:                   tagIDs,
+			SecretReminderNote:       reminderNote,
+			SecretReminderRepeatDays: reminderRepeatDays,
 		}).
 		SetResult(&resp).
 		Post(fmt.Sprintf("/api/v4/secrets/%s", key))
@@ -921,24 +929,46 @@ type ServiceTokenSeed struct {
 	Token string
 }
 
+// CreateServiceTokenOpts contains options for creating a service token.
+type CreateServiceTokenOpts struct {
+	Scopes      []ServiceTokenScope
+	Permissions []string
+	ExpiresIn   *int
+}
+
 // CreateServiceToken creates a service token for a project.
-func (n *NodeJSService) CreateServiceToken(t *testing.T, projectID, environment string, expiresIn *int) *ServiceTokenSeed {
+func (n *NodeJSService) CreateServiceToken(t *testing.T, projectID string, opts *CreateServiceTokenOpts) *ServiceTokenSeed {
 	t.Helper()
+
+	scopes := []ServiceTokenScope{{Environment: "dev", SecretPath: "/"}}
+	permissions := []string{"read", "write"}
+
+	if opts != nil {
+		if len(opts.Scopes) > 0 {
+			scopes = opts.Scopes
+		}
+		if len(opts.Permissions) > 0 {
+			permissions = opts.Permissions
+		}
+	}
+
+	var expiresIn *int
+	if opts != nil {
+		expiresIn = opts.ExpiresIn
+	}
 
 	var resp CreateServiceTokenResponse
 	r, err := n.client.R().
 		SetAuthToken(n.userToken).
 		SetBody(CreateServiceTokenRequest{
-			Name:        "test-service-token-" + uuid.New().String()[:8],
-			WorkspaceID: projectID,
-			Scopes: []ServiceTokenScope{
-				{Environment: environment, SecretPath: "/"},
-			},
+			Name:         "test-service-token-" + uuid.New().String()[:8],
+			WorkspaceID:  projectID,
+			Scopes:       scopes,
 			EncryptedKey: "",
 			IV:           "",
 			Tag:          "",
 			ExpiresIn:    expiresIn,
-			Permissions:  []string{"read", "write"},
+			Permissions:  permissions,
 		}).
 		SetResult(&resp).
 		Post("/api/v2/service-token")

--- a/backend-go/tests/infra/nodejs_types.go
+++ b/backend-go/tests/infra/nodejs_types.go
@@ -178,14 +178,16 @@ type SecretMetadataEntry struct {
 
 // CreateSecretRequest is the request body for POST /api/v4/secrets/{key}.
 type CreateSecretRequest struct {
-	ProjectID      string                `json:"projectId"`
-	Environment    string                `json:"environment"`
-	SecretPath     string                `json:"secretPath"`
-	SecretValue    string                `json:"secretValue"`
-	SecretComment  string                `json:"secretComment,omitempty"`
-	SecretMetadata []SecretMetadataEntry `json:"secretMetadata,omitempty"`
-	Type           string                `json:"type"`
-	TagIDs         []string              `json:"tagIds,omitempty"`
+	ProjectID                string                `json:"projectId"`
+	Environment              string                `json:"environment"`
+	SecretPath               string                `json:"secretPath"`
+	SecretValue              string                `json:"secretValue"`
+	SecretComment            string                `json:"secretComment,omitempty"`
+	SecretMetadata           []SecretMetadataEntry `json:"secretMetadata,omitempty"`
+	Type                     string                `json:"type"`
+	TagIDs                   []string              `json:"tagIds,omitempty"`
+	SecretReminderNote       string                `json:"secretReminderNote,omitempty"`
+	SecretReminderRepeatDays *int                  `json:"secretReminderRepeatDays,omitempty"`
 }
 
 // CreateSecretResponse is the response from POST /api/v4/secrets/{key}.

--- a/backend-go/tests/platform/auth/apiauthenticator_test.go
+++ b/backend-go/tests/platform/auth/apiauthenticator_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 		MustStart()
 
 	memKeyStore = keystore.NewMemoryKeyStore()
-	authenticator = apiauth.NewApiAuthenticator(slog.Default(), stack.DB(), infra.AuthSecret, memKeyStore, nil)
+	authenticator = apiauth.NewApiAuthenticator(slog.Default(), stack.DB(), infra.AuthSecret, memKeyStore, nil, infra.NewNopErrorHandler())
 
 	code := m.Run()
 	stack.Stop()
@@ -554,7 +554,7 @@ func TestValidateServiceToken_Valid(t *testing.T) {
 		nodejs.DeleteProject(t, proj.ID)
 	})
 
-	st := nodejs.CreateServiceToken(t, proj.ID, "dev", nil)
+	st := nodejs.CreateServiceToken(t, proj.ID, nil)
 	t.Cleanup(func() {
 		nodejs.DeleteServiceToken(t, st.ID)
 	})
@@ -577,7 +577,7 @@ func TestValidateServiceToken_WrongSecret(t *testing.T) {
 		nodejs.DeleteProject(t, proj.ID)
 	})
 
-	st := nodejs.CreateServiceToken(t, proj.ID, "dev", nil)
+	st := nodejs.CreateServiceToken(t, proj.ID, nil)
 	t.Cleanup(func() {
 		nodejs.DeleteServiceToken(t, st.ID)
 	})
@@ -602,7 +602,7 @@ func TestValidateServiceToken_Expired(t *testing.T) {
 	})
 
 	expiresIn := 1
-	st := nodejs.CreateServiceToken(t, proj.ID, "dev", &expiresIn)
+	st := nodejs.CreateServiceToken(t, proj.ID, &infra.CreateServiceTokenOpts{ExpiresIn: &expiresIn})
 
 	time.Sleep(2 * time.Second)
 
@@ -1088,7 +1088,7 @@ func TestValidateServiceToken_ProjectNotFound(t *testing.T) {
 	projName := "test-st-projdel-" + uuid.New().String()[:8]
 	proj := nodejs.CreateProject(t, projName)
 
-	st := nodejs.CreateServiceToken(t, proj.ID, "dev", nil)
+	st := nodejs.CreateServiceToken(t, proj.ID, nil)
 
 	// Delete the project (this should cascade delete the service token too,
 	// but let's manually delete just the project row to simulate orphaned token)

--- a/backend-go/tests/secretmanager/secrets/get_secret_by_name_integration_test.go
+++ b/backend-go/tests/secretmanager/secrets/get_secret_by_name_integration_test.go
@@ -196,6 +196,63 @@ func TestGetSecretByName_WithMetadata(t *testing.T) {
 	assert.Equal(t, "platform-team", metadataMap["owner"])
 }
 
+func TestGetSecretByName_WithReminder(t *testing.T) {
+	nodejs := stack.NodeJS()
+
+	proj := nodejs.CreateProject(t, "get-reminder-test")
+	repeatDays := 30
+	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "REMINDER_SECRET", "reminder-value", &infra.CreateSecretOpts{
+		ReminderNote:       "Remember to rotate this secret",
+		ReminderRepeatDays: &repeatDays,
+	})
+
+	identity := nodejs.CreateIdentity(t, "get-reminder-identity")
+	nodejs.AddIdentityToProject(t, proj.ID, identity.ID, infra.Role("admin"))
+
+	result, err := getSecretByName(t, auth.ActorTypeIdentity, identity.ID, nodejs.OrgID(), "REMINDER_SECRET", &GetSecretByNameV4Params{
+		ProjectID:       proj.ID,
+		Environment:     proj.EnvSlug,
+		SecretPath:      new("/"),
+		ViewSecretValue: new(true),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "REMINDER_SECRET", result.Secret.SecretKey)
+	require.NotNil(t, result.Secret.SecretReminderNote, "secretReminderNote should be present")
+	assert.Equal(t, "Remember to rotate this secret", *result.Secret.SecretReminderNote)
+	require.NotNil(t, result.Secret.SecretReminderRepeatDays, "secretReminderRepeatDays should be present")
+	assert.Equal(t, 30, *result.Secret.SecretReminderRepeatDays)
+}
+
+func TestGetSecretByName_WithTagColor(t *testing.T) {
+	nodejs := stack.NodeJS()
+
+	proj := nodejs.CreateProject(t, "get-tag-color-test")
+
+	tag := nodejs.CreateTag(t, proj.ID, "important", "Important", "#ff0000")
+
+	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "TAGGED_SECRET", "tagged-value", &infra.CreateSecretOpts{
+		TagIDs: []string{tag.ID},
+	})
+
+	identity := nodejs.CreateIdentity(t, "get-tag-color-identity")
+	nodejs.AddIdentityToProject(t, proj.ID, identity.ID, infra.Role("admin"))
+
+	result, err := getSecretByName(t, auth.ActorTypeIdentity, identity.ID, nodejs.OrgID(), "TAGGED_SECRET", &GetSecretByNameV4Params{
+		ProjectID:       proj.ID,
+		Environment:     proj.EnvSlug,
+		SecretPath:      new("/"),
+		ViewSecretValue: new(true),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "TAGGED_SECRET", result.Secret.SecretKey)
+	require.Len(t, result.Secret.Tags, 1, "should have one tag")
+	assert.Equal(t, "important", result.Secret.Tags[0].Slug)
+	require.NotNil(t, result.Secret.Tags[0].Color, "tag color should be present")
+	assert.Equal(t, "#ff0000", *result.Secret.Tags[0].Color)
+}
+
 // =============================================================================
 // Expansion Without Imports Tests
 // =============================================================================

--- a/backend-go/tests/secretmanager/secrets/list_secrets_integration_test.go
+++ b/backend-go/tests/secretmanager/secrets/list_secrets_integration_test.go
@@ -671,6 +671,52 @@ func TestListSecrets_Metadata(t *testing.T) {
 	})
 }
 
+func TestListSecrets_Reminder(t *testing.T) {
+	nodejs := stack.NodeJS()
+
+	proj := nodejs.CreateProject(t, "reminder-list-test")
+
+	repeatDays := 7
+	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "SECRET_WITH_REMINDER", "reminder-value", &infra.CreateSecretOpts{
+		ReminderNote:       "Rotate weekly",
+		ReminderRepeatDays: &repeatDays,
+	})
+	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "SECRET_WITHOUT_REMINDER", "no-reminder-value", nil)
+
+	identity := nodejs.CreateIdentity(t, "reminder-list-identity")
+	nodejs.AddIdentityToProject(t, proj.ID, identity.ID, infra.Role("admin"))
+
+	result, err := listSecrets(t, auth.ActorTypeIdentity, identity.ID, nodejs.OrgID(), &ListSecretsV4Params{
+		ProjectID:       proj.ID,
+		Environment:     proj.EnvSlug,
+		SecretPath:      new("/"),
+		ViewSecretValue: new(true),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Secrets, 2)
+
+	var secretWithReminder, secretWithoutReminder *secret.SecretRaw
+	for i := range result.Secrets {
+		switch result.Secrets[i].SecretKey {
+		case "SECRET_WITH_REMINDER":
+			secretWithReminder = &result.Secrets[i]
+		case "SECRET_WITHOUT_REMINDER":
+			secretWithoutReminder = &result.Secrets[i]
+		}
+	}
+
+	require.NotNil(t, secretWithReminder)
+	require.NotNil(t, secretWithReminder.SecretReminderNote, "secretReminderNote should be present")
+	assert.Equal(t, "Rotate weekly", *secretWithReminder.SecretReminderNote)
+	require.NotNil(t, secretWithReminder.SecretReminderRepeatDays, "secretReminderRepeatDays should be present")
+	assert.Equal(t, 7, *secretWithReminder.SecretReminderRepeatDays)
+
+	require.NotNil(t, secretWithoutReminder)
+	assert.Nil(t, secretWithoutReminder.SecretReminderNote, "secretReminderNote should be nil for secret without reminder")
+	assert.Nil(t, secretWithoutReminder.SecretReminderRepeatDays, "secretReminderRepeatDays should be nil for secret without reminder")
+}
+
 func TestListSecrets_PersonalOverrides(t *testing.T) {
 	nodejs := stack.NodeJS()
 

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -149,9 +149,18 @@ export const fnSecretsFromImports = async ({
     ({ importPath, importEnv }) => !cyclicDetector.has(getImportUniqKey(importEnv.slug, importPath))
   );
 
+  // Deduplicate imports with same (env, path) within this batch
+  const seenInBatch = new Set<string>();
+  const uniqueImports = allowedImports.filter(({ importPath, importEnv }) => {
+    const key = getImportUniqKey(importEnv.slug, importPath);
+    if (seenInBatch.has(key)) return false;
+    seenInBatch.add(key);
+    return true;
+  });
+
   const importedFolders = (
     await folderDAL.findByManySecretPath(
-      allowedImports.map(({ importEnv, importPath }) => ({
+      uniqueImports.map(({ importEnv, importPath }) => ({
         envId: importEnv.id,
         secretPath: importPath
       }))
@@ -175,7 +184,7 @@ export const fnSecretsFromImports = async ({
 
   const importedSecretsGroupByFolderId = groupBy(importedSecrets, (i) => i.folderId);
 
-  allowedImports.forEach(({ importPath, importEnv }) => {
+  uniqueImports.forEach(({ importPath, importEnv }) => {
     cyclicDetector.add(getImportUniqKey(importEnv.slug, importPath));
   });
   // now we need to check recursively deeper imports made inside other imports
@@ -194,7 +203,7 @@ export const fnSecretsFromImports = async ({
   }
   const secretsFromdeeperImportGroupedByFolderId = groupBy(secretsFromDeeperImports, (i) => i.importFolderId);
 
-  const secrets = allowedImports.map(({ importPath, importEnv, id, folderId }, i) => {
+  const secrets = uniqueImports.map(({ importPath, importEnv, id, folderId }, i) => {
     const sourceImportFolder = importedFolderGroupBySourceImport?.[`${importEnv.id}-${importPath}`]?.[0];
     const folderDeeperImportSecrets =
       secretsFromdeeperImportGroupedByFolderId?.[sourceImportFolder?.id || ""]?.[0]?.secrets || [];
@@ -280,8 +289,17 @@ export const fnSecretsV2FromImports = async ({
 
     if (!sanitizedImports.length) continue;
 
+    // Deduplicate imports with same (env, path) within this batch
+    const seenInBatch = new Set<string>();
+    const uniqueImports = sanitizedImports.filter(({ importPath, importEnv }) => {
+      const key = getImportUniqKey(importEnv.slug, importPath);
+      if (seenInBatch.has(key)) return false;
+      seenInBatch.add(key);
+      return true;
+    });
+
     const importedFolders = await folderDAL.findByManySecretPath(
-      sanitizedImports.map(({ importEnv, importPath }) => ({
+      uniqueImports.map(({ importEnv, importPath }) => ({
         envId: importEnv.id,
         secretPath: importPath
       }))
@@ -338,7 +356,7 @@ export const fnSecretsV2FromImports = async ({
 
     const importedSecretsGroupByFolderId = groupBy(importedSecrets, (i) => i.folderId);
 
-    const processedBatchImports = await processReservedImports(sanitizedImports, secretImportDAL);
+    const processedBatchImports = await processReservedImports(uniqueImports, secretImportDAL);
 
     processedBatchImports.forEach(({ importPath, importEnv }) => {
       cyclicDetector.add(getImportUniqKey(importEnv.slug, importPath));

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -15,7 +15,6 @@ import {
   TFindOpt
 } from "@app/lib/knex";
 import { OrderByDirection } from "@app/lib/types";
-import { SecretsOrderBy } from "@app/services/secret/secret-types";
 import type { TFindSecretsByFolderIdsFilter } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 
 export const SecretServiceCacheKeys = {
@@ -684,10 +683,8 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
             void bd.whereNull(`${TableName.SecretRotationV2SecretMapping}.secretId`);
           }
         })
-        .orderBy(
-          filters?.orderBy === SecretsOrderBy.Name ? "key" : "id",
-          filters?.orderDirection ?? OrderByDirection.ASC
-        );
+        // Always order by key (name) to match the Go sidecar's ordering.
+        .orderBy("key", filters?.orderDirection ?? OrderByDirection.ASC);
 
       let secs: Awaited<typeof query>;
 
@@ -1086,6 +1083,11 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
           );
         })
         .leftJoin(TableName.ResourceMetadata, `${TableName.SecretV2}.id`, `${TableName.ResourceMetadata}.secretId`)
+        .leftJoin(
+          TableName.SecretRotationV2SecretMapping,
+          `${TableName.SecretV2}.id`,
+          `${TableName.SecretRotationV2SecretMapping}.secretId`
+        )
         .select(selectAllTableCols(TableName.SecretV2))
         .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
         .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
@@ -1096,12 +1098,19 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
           db.ref("value").withSchema(TableName.ResourceMetadata).as("metadataValue"),
           db.ref("encryptedValue").withSchema(TableName.ResourceMetadata).as("metadataEncryptedValue")
         )
-        .select(db.ref("projectId").withSchema(TableName.Environment).as("projectId"));
+        .select(db.ref("projectId").withSchema(TableName.Environment).as("projectId"))
+        .select(db.ref("rotationId").withSchema(TableName.SecretRotationV2SecretMapping));
 
       const docs = sqlNestRelationships({
         data: rawDocs,
         key: "id",
-        parentMapper: (el) => ({ _id: el.id, projectId: el.projectId, ...SecretsV2Schema.parse(el) }),
+        parentMapper: (el) => ({
+          _id: el.id,
+          projectId: el.projectId,
+          ...SecretsV2Schema.parse(el),
+          isRotatedSecret: Boolean(el.rotationId),
+          rotationId: el.rotationId
+        }),
         childrenMapper: [
           {
             key: "tagId",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,13 +3,15 @@ version: "3"
 services:
   backend:
     container_name: infisical-backend
+    build:
+      context: .
+      dockerfile: Dockerfile.standalone-infisical
     restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_started
-    image: infisical/infisical:latest # PIN THIS TO A SPECIFIC TAG
     pull_policy: always
     env_file: .env
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,15 +3,13 @@ version: "3"
 services:
   backend:
     container_name: infisical-backend
-    build:
-      context: .
-      dockerfile: Dockerfile.standalone-infisical
     restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_started
+    image: infisical/infisical:latest # PIN THIS TO A SPECIFIC TAG
     pull_policy: always
     env_file: .env
     ports:


### PR DESCRIPTION
## Context

This PR addresses some of the shadow mismatch that happened on testing. The following are the fixes made

**1. Trailing slash normalization** (`list_secrets.go`, `get_secret_by_name.go`)
- Apply `fn.RemoveTrailingSlash()` to `secretPath` in V3 and V4 handlers to match Node.js behavior

**2. Tag color empty string handling** (`secret.go`, `list_secrets.go`)
- Changed `SecretTag.Color` from `string` to `sql.Null[string]` to distinguish between NULL and empty string in database
- Updated response builder to only include color when valid

**3. Missing reminder fields** (`secret.go`, `list_secrets.go`)
- Added `ReminderNote` and `ReminderRepeatDays` fields to Secret struct
- Updated SQL queries to join with reminder table and scan these fields
- Added fields to response builder

### Shadow Error Fix (Node.js Backend)

**5. Import deduplication** (`secret-import-fns.ts`)
- Fixed duplicate imports with same `(env, path)` being processed multiple times
- Added deduplication in both `fnSecretsFromImports` and `fnSecretsV2FromImports`

### Centralized Auth Error Handling (Go Backend)

**6. ErrorHandler integration** (`authenticator.go`, `require_auth.go`)
- Added `ErrorHandler` interface to `ApiAuthenticator`
- Replaced direct `writeUnauthorized()` calls with `errorHandler.HandleError()` for proper logging
- Auth failures now log internal error cause for debugging

**7. Improved error logging** (`shared/errors.go`)
- Added `cause` field logging for 4xx errors (previously only logged for 5xx)

**8. Request logging** (`server.go`)
- Added status code to request completion logs via `statusRecorder` wrapper

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)