### PR TITLE
fix(kms): pass transaction handle to decryptInternalKmsKey instead of…

### DIFF
--- a/backend-go/internal/services/kms/kms.go
+++ b/backend-go/internal/services/kms/kms.go
@@ -248,7 +248,7 @@ func (s *Service) generateEncryptedKeyMaterial() ([]byte, error) {
 
 // decryptInternalKmsKey loads a KMS key record and decrypts its key material using the root key.
 // For internal KMS keys only. Returns error for external KMS keys.
-func (s *Service) decryptInternalKmsKey(ctx context.Context, kmsKeyID uuid.UUID) ([]byte, error) {
+func (s *Service) decryptInternalKmsKey(ctx context.Context, q pg.Querier, kmsKeyID uuid.UUID) ([]byte, error) {
 	query := `
 		SELECT
 			kmsKey.id,
@@ -261,7 +261,7 @@ func (s *Service) decryptInternalKmsKey(ctx context.Context, kmsKeyID uuid.UUID)
 		LEFT JOIN external_kms externalKms ON externalKms."kmsKeyId" = kmsKey.id
 		WHERE kmsKey.id = @kmsKeyID
 	`
-	row := s.db.Replica().QueryRow(ctx, query, pgx.NamedArgs{"kmsKeyID": kmsKeyID})
+	row := q.QueryRow(ctx, query, pgx.NamedArgs{"kmsKeyID": kmsKeyID})
 
 	var (
 		id                          uuid.UUID

--- a/backend-go/internal/services/kms/kms_org.go
+++ b/backend-go/internal/services/kms/kms_org.go
@@ -128,7 +128,7 @@ func (s *Service) ensureOrgDataKey(ctx context.Context, orgID uuid.UUID) (dataKe
 			return nil, fmt.Errorf("decrypting KMS key: %w", err)
 		}
 	} else {
-		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, org.KmsDefaultKeyID.V)
+		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, tx, org.KmsDefaultKeyID.V)
 		if err != nil {
 			return nil, err
 		}

--- a/backend-go/internal/services/kms/kms_project.go
+++ b/backend-go/internal/services/kms/kms_project.go
@@ -129,7 +129,7 @@ func (s *Service) ensureProjectDataKey(ctx context.Context, projectID string) (d
 			return nil, fmt.Errorf("decrypting KMS key: %w", err)
 		}
 	} else {
-		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, project.KmsSecretManagerKeyID.V)
+		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, tx, project.KmsSecretManagerKeyID.V)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Context
`decryptInternalKmsKey` in `backend-go/internal/services/kms/kms.go` hardcoded `s.db.Replica().QueryRow()` internally with no way to pass a transaction handle. Both of its callers — `ensureProjectDataKey` and `ensureOrgDataKey` — invoke it inside an open primary transaction after acquiring an advisory lock.

Under replication lag, a concurrent request that just created a KMS key on the primary will cause `decryptInternalKmsKey` to return `pgx.ErrNoRows` on the replica, producing a `Failed to find KMS key` error and a 500 for the user.

Fix adds a `q pg.Querier` parameter to `decryptInternalKmsKey` (matching the existing pattern of `findProjectKmsInfo` and `findOrgKmsInfo`) and passes `tx` at both call sites. 3 lines changed across 3 files.

Closes #6864

## Screenshots
N/A — no UI changes.

## Steps to verify the change
1. Two concurrent requests hit `getProjectDataKey` or `getOrgDataKey` for the same project/org for the first time
2. Under replication lag, the second request previously failed with `Failed to find KMS key`
3. With this fix, the second request reads from the primary transaction and succeeds

## Type
- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist
- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)