### PR TITLE
fix: run 5 processBucketEvents in parallel

### DIFF
--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -521,23 +521,27 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
     }
   };
 
+  const BUCKET_CONCURRENCY = 5;
+
   const processAggregatedEvents = async () => {
     if (!postHog) return;
 
     for (const eventType of POSTHOG_AGGREGATED_EVENTS) {
       let totalProcessed = 0;
-
       logger.info(`Starting bucket processing for ${eventType}`);
 
-      // Process each bucket sequentially to control memory usage
-      for (const bucketId of TELEMETRY_BUCKET_NAMES) {
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          const processed = await processBucketEvents(eventType, bucketId);
-          totalProcessed += processed;
-        } catch (error) {
-          logger.error(error, `Failed to process bucket ${bucketId} for ${eventType}`);
-        }
+      for (let i = 0; i < TELEMETRY_BUCKET_NAMES.length; i += BUCKET_CONCURRENCY) {
+        const batch = TELEMETRY_BUCKET_NAMES.slice(i, i + BUCKET_CONCURRENCY);
+        // eslint-disable-next-line no-await-in-loop
+        const results = await Promise.all(
+          batch.map((bucketId) =>
+            processBucketEvents(eventType, bucketId).catch((error) => {
+              logger.error(error, `Failed to process bucket ${bucketId} for ${eventType}`);
+              return 0;
+            })
+          )
+        );
+        totalProcessed += results.reduce((sum, n) => sum + n, 0);
       }
 
       logger.info(`Completed processing ${totalProcessed} total events for ${eventType}`);

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -534,12 +534,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
         const batch = TELEMETRY_BUCKET_NAMES.slice(i, i + BUCKET_CONCURRENCY);
         // eslint-disable-next-line no-await-in-loop
         const results = await Promise.all(
-          batch.map((bucketId) =>
-            processBucketEvents(eventType, bucketId).catch((error) => {
-              logger.error(error, `Failed to process bucket ${bucketId} for ${eventType}`);
-              return 0;
-            })
-          )
+          batch.map((bucketId) => processBucketEvents(eventType, bucketId))
         );
         totalProcessed += results.reduce((sum, n) => sum + n, 0);
       }

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -533,9 +533,7 @@ To opt into telemetry, you can set "TELEMETRY_ENABLED=true" within the environme
       for (let i = 0; i < TELEMETRY_BUCKET_NAMES.length; i += BUCKET_CONCURRENCY) {
         const batch = TELEMETRY_BUCKET_NAMES.slice(i, i + BUCKET_CONCURRENCY);
         // eslint-disable-next-line no-await-in-loop
-        const results = await Promise.all(
-          batch.map((bucketId) => processBucketEvents(eventType, bucketId))
-        );
+        const results = await Promise.all(batch.map((bucketId) => processBucketEvents(eventType, bucketId)));
         totalProcessed += results.reduce((sum, n) => sum + n, 0);
       }
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This will reduce the time it takes for the `telemetry-aggregated-events` to run.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)