### PR TITLE
fix(secret-import): propagate secrets nested beyond two import levels

### DIFF
--- a/backend/src/services/secret-import/secret-import-fns.test.ts
+++ b/backend/src/services/secret-import/secret-import-fns.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { SecretType } from "@app/db/schemas";
+
+import { fnSecretsV2FromImports } from "./secret-import-fns";
+
+type TFolder = { id: string; envId: string; path: string };
+type TImport = {
+  id: string;
+  folderId: string;
+  importPath: string;
+  isReplication?: boolean;
+  isReserved?: boolean;
+  importEnv: { id: string; slug: string; name: string };
+};
+type TSecret = { id: string; key: string; folderId: string };
+
+const ENV = { id: "env-id", slug: "dev", name: "Development" };
+
+// minimal decoration so the function's `.map` field accesses don't throw
+const decorateSecret = (secret: TSecret) => ({
+  ...secret,
+  type: SecretType.Shared,
+  tags: [] as { slug: string }[],
+  secretMetadata: [] as { key: string; value: string }[],
+  encryptedValue: Buffer.from("root-value"),
+  encryptedComment: Buffer.from(""),
+  skipMultilineEncoding: false
+});
+
+/**
+ * Builds DAL mocks that model a linear chain of folders where each folder
+ * imports the secrets of the previous one:
+ *
+ *   /level{N} imports /level{N-1} imports ... imports / (root)
+ *
+ * A single secret lives in the root folder. Resolving the imports of the
+ * deepest folder must surface that root secret regardless of chain length.
+ */
+const buildChain = (levels: number) => {
+  // folders[0] is root ("/"), folders[i] is "/level{i}"
+  const folders: TFolder[] = Array.from({ length: levels + 1 }, (_, i) => ({
+    id: `folder-${i}`,
+    envId: ENV.id,
+    path: i === 0 ? "/" : `/level${i}`
+  }));
+
+  // each folder (except root) imports the folder one level shallower
+  const imports: TImport[] = folders.slice(1).map((folder, i) => ({
+    id: `import-${i + 1}`,
+    folderId: folder.id,
+    importPath: folders[i].path,
+    importEnv: ENV
+  }));
+
+  const rootSecret: TSecret = { id: "secret-root", key: "ROOT_SECRET", folderId: folders[0].id };
+
+  const folderByEnvPath = new Map(folders.map((f) => [`${f.envId}-${f.path}`, f]));
+  const importsByFolderId = new Map<string, TImport[]>();
+  imports.forEach((imp) => {
+    const list = importsByFolderId.get(imp.folderId) ?? [];
+    list.push(imp);
+    importsByFolderId.set(imp.folderId, list);
+  });
+
+  const folderDAL = {
+    findByManySecretPath: vi.fn(async (query: { envId: string; secretPath: string }[]) =>
+      query.map(({ envId, secretPath }) => folderByEnvPath.get(`${envId}-${secretPath}`))
+    )
+  };
+
+  const secretDAL = {
+    find: vi.fn(async (filter: { $in: { folderId: string[] }; type: string }) => {
+      const folderIds = filter.$in.folderId;
+      return folderIds.includes(rootSecret.folderId) ? [decorateSecret(rootSecret)] : [];
+    }),
+    findByFolderIds: vi.fn(async () => [])
+  };
+
+  const secretImportDAL = {
+    findByFolderIds: vi.fn(async (folderIds: string[]) => folderIds.flatMap((id) => importsByFolderId.get(id) ?? [])),
+    findByIds: vi.fn(async () => [])
+  };
+
+  // the deepest folder's import list is the entry point
+  const deepestFolder = folders[levels];
+  const rootSecretImports = importsByFolderId.get(deepestFolder.id) ?? [];
+
+  return { folderDAL, secretDAL, secretImportDAL, rootSecretImports };
+};
+
+const run = (chain: ReturnType<typeof buildChain>) =>
+  fnSecretsV2FromImports({
+    secretImports: chain.rootSecretImports as never,
+    folderDAL: chain.folderDAL as never,
+    secretDAL: chain.secretDAL as never,
+    secretImportDAL: chain.secretImportDAL as never,
+    decryptor: (value) => (value ? value.toString() : ""),
+    viewSecretValue: true,
+    hasSecretAccess: () => true
+  });
+
+const flattenKeys = (processed: Awaited<ReturnType<typeof fnSecretsV2FromImports>>) =>
+  processed.flatMap((p) => p.secrets.map((s) => s.secretKey));
+
+describe("fnSecretsV2FromImports - nested import depth propagation", () => {
+  test("surfaces a root secret imported through one level", async () => {
+    const processed = await run(buildChain(1));
+    expect(flattenKeys(processed)).toContain("ROOT_SECRET");
+  });
+
+  test("surfaces a root secret imported through two levels", async () => {
+    const processed = await run(buildChain(2));
+    expect(flattenKeys(processed)).toContain("ROOT_SECRET");
+  });
+
+  test("surfaces a root secret imported through three levels", async () => {
+    const processed = await run(buildChain(3));
+    expect(flattenKeys(processed)).toContain("ROOT_SECRET");
+  });
+
+  test("surfaces a root secret imported through four levels", async () => {
+    const processed = await run(buildChain(4));
+    expect(flattenKeys(processed)).toContain("ROOT_SECRET");
+  });
+});

--- a/backend/src/services/secret-import/secret-import-fns.test.ts
+++ b/backend/src/services/secret-import/secret-import-fns.test.ts
@@ -22,7 +22,7 @@ const decorateSecret = (secret: TSecret) => ({
   ...secret,
   type: SecretType.Shared,
   tags: [] as { slug: string }[],
-  secretMetadata: [] as { key: string; value: string }[],
+  secretMetadata: [] as { key: string; value: string; encryptedValue?: Buffer | null }[],
   encryptedValue: Buffer.from("root-value"),
   encryptedComment: Buffer.from(""),
   skipMultilineEncoding: false

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -377,14 +377,10 @@ export const fnSecretsV2FromImports = async ({
           _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
         }));
 
-      if (deeperImportsGroupByFolderId?.[sourceImportFolder?.id || ""]) {
-        stack.push({
-          secretImports: deeperImportsGroupByFolderId[sourceImportFolder?.id || ""],
-          depth: depth + 1,
-          parentImportedSecrets: secretsWithDuplicate
-        });
-      }
-
+      // On the first iteration `secretsWithDuplicate` is the array stored on the top-level
+      // processed import; deeper iterations append into their ancestor's `parentImportedSecrets`,
+      // which is that same top-level array. Either way, secrets discovered at this level must
+      // land in the live array that ultimately reaches the caller.
       if (isFirstIteration) {
         processedImports.push({
           secretPath: importPath,
@@ -397,6 +393,17 @@ export const fnSecretsV2FromImports = async ({
         });
       } else {
         parentImportedSecrets.push(...secretsWithDuplicate);
+      }
+
+      // Pass the live array (the first-iteration array IS the top-level `secrets`; deeper ones
+      // forward their ancestor's array) down to deeper imports so secrets nested more than two
+      // levels deep keep accumulating into it instead of being dropped into a detached array.
+      if (deeperImportsGroupByFolderId?.[sourceImportFolder?.id || ""]) {
+        stack.push({
+          secretImports: deeperImportsGroupByFolderId[sourceImportFolder?.id || ""],
+          depth: depth + 1,
+          parentImportedSecrets: isFirstIteration ? secretsWithDuplicate : parentImportedSecrets
+        });
       }
     });
   }


### PR DESCRIPTION
## Context

Secret imports stopped propagating past the third folder level. With a chain where /level1 imports /, /level2 imports /level1, /level3 imports /level2, a secret defined at the root shows up in level1 and level2 but disappears at level3 and deeper (#2903).

The iterative resolver `fnSecretsV2FromImports` built each level's secrets into a fresh local array and passed that throwaway array down to deeper imports. On the first level that array is the same object stored on the top-level result, so one- and two-level imports worked. For deeper levels the array was spread-copied into its parent while still empty, then the deeper secrets were pushed into the now-detached local array, so they never reached the result.

Fix: merge each level's secrets into the live top-level array first, then forward that same array reference to deeper imports, so nested imports keep accumulating into it regardless of depth. No API/schema change.

## Steps to verify the change

Added a backend unit test (mocked DALs) that resolves a root secret through 1, 2, 3 and 4 import levels. Before the fix the 3- and 4-level cases fail ("expected [] to include 'ROOT_SECRET'"); after, all pass.

## Type

- [x] Fix

Closes #2903
