### PR TITLE
fix: replace 500 error with bad request due to bitbucket returning 429

### DIFF
--- a/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
@@ -34,6 +34,9 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
       params: z.object({
         connectionId: z.string().uuid()
       }),
+      querystring: z.object({
+        search: z.string().trim().optional()
+      }),
       response: {
         200: z.object({
           workspaces: z.object({ slug: z.string() }).array()
@@ -43,10 +46,11 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
       const {
-        params: { connectionId }
+        params: { connectionId },
+        query: { search }
       } = req;
 
-      const workspaces = await server.services.appConnection.bitbucket.listWorkspaces(connectionId, req.permission);
+      const workspaces = await server.services.appConnection.bitbucket.listWorkspaces(connectionId, req.permission, search);
 
       return { workspaces };
     }
@@ -64,7 +68,8 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
         connectionId: z.string().uuid()
       }),
       querystring: z.object({
-        workspaceSlug: z.string().min(1).max(255)
+        workspaceSlug: z.string().min(1).max(255),
+        search: z.string().trim().optional()
       }),
       response: {
         200: z.object({
@@ -76,12 +81,13 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
     handler: async (req) => {
       const {
         params: { connectionId },
-        query: { workspaceSlug }
+        query: { workspaceSlug, search }
       } = req;
 
       const repositories = await server.services.appConnection.bitbucket.listRepositories(
         { connectionId, workspaceSlug },
-        req.permission
+        req.permission,
+        search
       );
 
       return { repositories };

--- a/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
@@ -50,7 +50,11 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
         query: { search }
       } = req;
 
-      const workspaces = await server.services.appConnection.bitbucket.listWorkspaces(connectionId, req.permission, search);
+      const workspaces = await server.services.appConnection.bitbucket.listWorkspaces(
+        connectionId,
+        req.permission,
+        search
+      );
 
       return { workspaces };
     }

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -146,32 +146,15 @@ export const listBitbucketRepositories = async (
   const encodedSlug = encodeURIComponent(workspaceSlug);
 
   try {
+    const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}`);
+    baseUrl.searchParams.set("pagelen", String(BITBUCKET_PAGE_SIZE));
+    baseUrl.searchParams.set("sort", "slug");
     if (search) {
-      const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}`);
-      baseUrl.searchParams.set("pagelen", String(BITBUCKET_PAGE_SIZE));
-      baseUrl.searchParams.set("sort", "slug");
       baseUrl.searchParams.set("q", `name ~ "${search.replace(/"/g, "")}"`);
-
-      const { data } = await request.get<BitbucketPaginatedResponse<TBitbucketRepo>>(baseUrl.toString(), { headers });
-      return data.values;
     }
 
-    // Fetch repos per-project to avoid Bitbucket's 1,000-result pagination cap
-    const projects = await paginateBitbucketRequest<{ key: string }>(
-      `${IntegrationUrls.BITBUCKET_API_URL}/2.0/workspaces/${encodedSlug}/projects?pagelen=${BITBUCKET_PAGE_SIZE}`,
-      headers
-    );
-
-    const reposByProject = await Promise.all(
-      projects.map((project) =>
-        paginateBitbucketRequest<TBitbucketRepo>(
-          `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}?pagelen=${BITBUCKET_PAGE_SIZE}&sort=slug&q=project.key="${encodeURIComponent(project.key)}"`,
-          headers
-        )
-      )
-    );
-
-    return reposByProject.flat();
+    const { data } = await request.get<BitbucketPaginatedResponse<TBitbucketRepo>>(baseUrl.toString(), { headers });
+    return data.values;
   } catch (error) {
     return ensureBitbucketRateLimitNotExceeded(error);
   }

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -86,9 +86,9 @@ export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnectio
   let allWorkspaces: TBitbucketWorkspace[] = [];
 
   const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/user/workspaces`);
-  baseUrl.searchParams.set("pagelen", BITBUCKET_PAGE_SIZE);
+  baseUrl.searchParams.set("pagelen", BITBUCKET_PAGE_SIZE.toString());
   if (search) {
-    baseUrl.searchParams.set("q", `slug ~ "${search}"`);
+    baseUrl.searchParams.set("q", `slug ~ "${search.replace(/"/g, "")}"`);
   }
 
   const endpoint = baseUrl.toString();
@@ -150,7 +150,7 @@ export const listBitbucketRepositories = async (
       const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}`);
       baseUrl.searchParams.set("pagelen", String(BITBUCKET_PAGE_SIZE));
       baseUrl.searchParams.set("sort", "slug");
-      baseUrl.searchParams.set("q", `name ~ "${search}"`);
+      baseUrl.searchParams.set("q", `name ~ "${search.replace(/"/g, "")}"`);
 
       const { data } = await request.get<BitbucketPaginatedResponse<TBitbucketRepo>>(baseUrl.toString(), { headers });
       return data.values;

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -17,7 +17,7 @@ import {
 const ensureBitbucketRateLimitNotExceeded = (error: unknown) => {
   if (error instanceof AxiosError && error.response?.status === HttpStatusCode.TooManyRequests) {
     throw new BadRequestError({
-      message: "Request to Bitbucket was blocked due to rate limiting. Please try again later."
+      message: "Request to Bitbucket was blocked due to rate limiting. Bitbucket's rate limit window is 1 hour. Please try again later."
     });
   }
   throw error;

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -14,10 +14,11 @@ import {
   TBitbucketWorkspace
 } from "./bitbucket-connection-types";
 
-const ensureBitbucketRateLimitNotExceeded = (error: unknown) => {
+const ensureBitbucketRateLimitNotExceeded = (error: unknown): never => {
   if (error instanceof AxiosError && error.response?.status === HttpStatusCode.TooManyRequests) {
     throw new BadRequestError({
-      message: "Request to Bitbucket was blocked due to rate limiting. Bitbucket's rate limit window is 1 hour. Please try again later."
+      message:
+        "Request to Bitbucket was blocked due to rate limiting. Bitbucket's rate limit window is 1 hour. Please try again later."
     });
   }
   throw error;
@@ -159,7 +160,7 @@ export const listBitbucketRepositories = async (appConnection: TBitbucketConnect
 
     return reposByProject.flat();
   } catch (error) {
-    ensureBitbucketRateLimitNotExceeded(error);
+    return ensureBitbucketRateLimitNotExceeded(error);
   }
 };
 
@@ -185,12 +186,9 @@ export const listBitbucketEnvironments = async (
   try {
     while (hasNextPage && iterationCount < 10) {
       // eslint-disable-next-line no-await-in-loop
-      const { data }: { data: { values: TBitbucketEnvironment[]; next: string } } = await request.get(
-        environmentsUrl,
-        {
-          headers
-        }
-      );
+      const { data }: { data: { values: TBitbucketEnvironment[]; next: string } } = await request.get(environmentsUrl, {
+        headers
+      });
 
       if (data?.values.length > 0) {
         environments.push(...data.values);

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -14,6 +14,9 @@ import {
   TBitbucketWorkspace
 } from "./bitbucket-connection-types";
 
+const BITBUCKET_MAX_PAGES = 10;
+const BITBUCKET_PAGE_SIZE = 100;
+
 const ensureBitbucketRateLimitNotExceeded = (error: unknown): never => {
   if (error instanceof AxiosError && error.response?.status === HttpStatusCode.TooManyRequests) {
     throw new BadRequestError({
@@ -72,7 +75,7 @@ interface BitbucketWorkspacesResponse {
   next?: string;
 }
 
-export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnection) => {
+export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnection, search?: string) => {
   const { email, apiToken } = appConnection.credentials;
 
   const headers = {
@@ -81,21 +84,20 @@ export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnectio
   };
 
   let allWorkspaces: TBitbucketWorkspace[] = [];
-  let nextUrl: string | undefined = `${IntegrationUrls.BITBUCKET_API_URL}/2.0/user/workspaces?pagelen=100`;
-  let iterationCount = 0;
 
-  // Limit to 10 iterations, fetching at most 10 * 100 = 1000 workspaces
+  const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/user/workspaces`);
+  baseUrl.searchParams.set("pagelen", BITBUCKET_PAGE_SIZE);
+  if (search) {
+    baseUrl.searchParams.set("q", `slug ~ "${search}"`);
+  }
+
+  const endpoint = baseUrl.toString();
   try {
-    while (nextUrl && iterationCount < 10) {
-      // eslint-disable-next-line no-await-in-loop
-      const { data }: { data: BitbucketWorkspacesResponse } = await request.get<BitbucketWorkspacesResponse>(nextUrl, {
-        headers
-      });
+    const { data }: { data: BitbucketWorkspacesResponse } = await request.get<BitbucketWorkspacesResponse>(endpoint, {
+      headers
+    });
 
-      allWorkspaces = allWorkspaces.concat(data.values.map((membership) => ({ slug: membership.workspace.slug })));
-      nextUrl = data.next;
-      iterationCount += 1;
-    }
+    allWorkspaces = allWorkspaces.concat(data.values.map((membership) => ({ slug: membership.workspace.slug })));
   } catch (error) {
     ensureBitbucketRateLimitNotExceeded(error);
   }
@@ -107,9 +109,6 @@ interface BitbucketPaginatedResponse<T> {
   values: T[];
   next?: string;
 }
-
-const BITBUCKET_MAX_PAGES = 10;
-const BITBUCKET_PAGE_SIZE = 100;
 
 const paginateBitbucketRequest = async <T>(url: string, headers: Record<string, string>): Promise<T[]> => {
   let allItems: T[] = [];
@@ -132,7 +131,11 @@ const paginateBitbucketRequest = async <T>(url: string, headers: Record<string, 
   return allItems;
 };
 
-export const listBitbucketRepositories = async (appConnection: TBitbucketConnection, workspaceSlug: string) => {
+export const listBitbucketRepositories = async (
+  appConnection: TBitbucketConnection,
+  workspaceSlug: string,
+  search?: string
+) => {
   const { email, apiToken } = appConnection.credentials;
 
   const headers = {
@@ -143,6 +146,16 @@ export const listBitbucketRepositories = async (appConnection: TBitbucketConnect
   const encodedSlug = encodeURIComponent(workspaceSlug);
 
   try {
+    if (search) {
+      const baseUrl = new URL(`${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}`);
+      baseUrl.searchParams.set("pagelen", String(BITBUCKET_PAGE_SIZE));
+      baseUrl.searchParams.set("sort", "slug");
+      baseUrl.searchParams.set("q", `name ~ "${search}"`);
+
+      const { data } = await request.get<BitbucketPaginatedResponse<TBitbucketRepo>>(baseUrl.toString(), { headers });
+      return data.values;
+    }
+
     // Fetch repos per-project to avoid Bitbucket's 1,000-result pagination cap
     const projects = await paginateBitbucketRequest<{ key: string }>(
       `${IntegrationUrls.BITBUCKET_API_URL}/2.0/workspaces/${encodedSlug}/projects?pagelen=${BITBUCKET_PAGE_SIZE}`,
@@ -176,34 +189,8 @@ export const listBitbucketEnvironments = async (
     Accept: "application/json"
   };
 
-  const environments: TBitbucketEnvironment[] = [];
-  let hasNextPage = true;
-
-  let environmentsUrl = `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodeURIComponent(workspaceSlug)}/${encodeURIComponent(repositorySlug)}/environments?pagelen=100`;
-
-  let iterationCount = 0;
-  // Limit to 10 iterations, fetching at most 10 * 100 = 1000 environments
-  try {
-    while (hasNextPage && iterationCount < 10) {
-      // eslint-disable-next-line no-await-in-loop
-      const { data }: { data: { values: TBitbucketEnvironment[]; next: string } } = await request.get(environmentsUrl, {
-        headers
-      });
-
-      if (data?.values.length > 0) {
-        environments.push(...data.values);
-      }
-
-      if (data.next) {
-        environmentsUrl = data.next;
-      } else {
-        hasNextPage = false;
-      }
-      iterationCount += 1;
-    }
-  } catch (error) {
-    ensureBitbucketRateLimitNotExceeded(error);
-  }
-
-  return environments;
+  return paginateBitbucketRequest<TBitbucketEnvironment>(
+    `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodeURIComponent(workspaceSlug)}/${encodeURIComponent(repositorySlug)}/environments?pagelen=${BITBUCKET_PAGE_SIZE}`,
+    headers
+  );
 };

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from "axios";
+import { AxiosError, HttpStatusCode } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
@@ -13,6 +13,15 @@ import {
   TBitbucketRepo,
   TBitbucketWorkspace
 } from "./bitbucket-connection-types";
+
+const ensureBitbucketRateLimitNotExceeded = (error: unknown) => {
+  if (error instanceof AxiosError && error.response?.status === HttpStatusCode.TooManyRequests) {
+    throw new BadRequestError({
+      message: "Request to Bitbucket was blocked due to rate limiting. Please try again later."
+    });
+  }
+  throw error;
+};
 
 export const getBitbucketConnectionListItem = () => {
   return {
@@ -75,15 +84,19 @@ export const listBitbucketWorkspaces = async (appConnection: TBitbucketConnectio
   let iterationCount = 0;
 
   // Limit to 10 iterations, fetching at most 10 * 100 = 1000 workspaces
-  while (nextUrl && iterationCount < 10) {
-    // eslint-disable-next-line no-await-in-loop
-    const { data }: { data: BitbucketWorkspacesResponse } = await request.get<BitbucketWorkspacesResponse>(nextUrl, {
-      headers
-    });
+  try {
+    while (nextUrl && iterationCount < 10) {
+      // eslint-disable-next-line no-await-in-loop
+      const { data }: { data: BitbucketWorkspacesResponse } = await request.get<BitbucketWorkspacesResponse>(nextUrl, {
+        headers
+      });
 
-    allWorkspaces = allWorkspaces.concat(data.values.map((membership) => ({ slug: membership.workspace.slug })));
-    nextUrl = data.next;
-    iterationCount += 1;
+      allWorkspaces = allWorkspaces.concat(data.values.map((membership) => ({ slug: membership.workspace.slug })));
+      nextUrl = data.next;
+      iterationCount += 1;
+    }
+  } catch (error) {
+    ensureBitbucketRateLimitNotExceeded(error);
   }
 
   return allWorkspaces;
@@ -102,13 +115,17 @@ const paginateBitbucketRequest = async <T>(url: string, headers: Record<string, 
   let nextUrl: string | undefined = url;
   let iterationCount = 0;
 
-  while (nextUrl && iterationCount < BITBUCKET_MAX_PAGES) {
-    // eslint-disable-next-line no-await-in-loop
-    const { data }: { data: BitbucketPaginatedResponse<T> } = await request.get(nextUrl, { headers });
+  try {
+    while (nextUrl && iterationCount < BITBUCKET_MAX_PAGES) {
+      // eslint-disable-next-line no-await-in-loop
+      const { data }: { data: BitbucketPaginatedResponse<T> } = await request.get(nextUrl, { headers });
 
-    allItems = allItems.concat(data.values);
-    nextUrl = data.next;
-    iterationCount += 1;
+      allItems = allItems.concat(data.values);
+      nextUrl = data.next;
+      iterationCount += 1;
+    }
+  } catch (error) {
+    ensureBitbucketRateLimitNotExceeded(error);
   }
 
   return allItems;
@@ -124,22 +141,26 @@ export const listBitbucketRepositories = async (appConnection: TBitbucketConnect
 
   const encodedSlug = encodeURIComponent(workspaceSlug);
 
-  // Fetch repos per-project to avoid Bitbucket's 1,000-result pagination cap
-  const projects = await paginateBitbucketRequest<{ key: string }>(
-    `${IntegrationUrls.BITBUCKET_API_URL}/2.0/workspaces/${encodedSlug}/projects?pagelen=${BITBUCKET_PAGE_SIZE}`,
-    headers
-  );
+  try {
+    // Fetch repos per-project to avoid Bitbucket's 1,000-result pagination cap
+    const projects = await paginateBitbucketRequest<{ key: string }>(
+      `${IntegrationUrls.BITBUCKET_API_URL}/2.0/workspaces/${encodedSlug}/projects?pagelen=${BITBUCKET_PAGE_SIZE}`,
+      headers
+    );
 
-  const reposByProject = await Promise.all(
-    projects.map((project) =>
-      paginateBitbucketRequest<TBitbucketRepo>(
-        `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}?pagelen=${BITBUCKET_PAGE_SIZE}&sort=slug&q=project.key="${encodeURIComponent(project.key)}"`,
-        headers
+    const reposByProject = await Promise.all(
+      projects.map((project) =>
+        paginateBitbucketRequest<TBitbucketRepo>(
+          `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodedSlug}?pagelen=${BITBUCKET_PAGE_SIZE}&sort=slug&q=project.key="${encodeURIComponent(project.key)}"`,
+          headers
+        )
       )
-    )
-  );
+    );
 
-  return reposByProject.flat();
+    return reposByProject.flat();
+  } catch (error) {
+    ensureBitbucketRateLimitNotExceeded(error);
+  }
 };
 
 export const listBitbucketEnvironments = async (
@@ -161,22 +182,29 @@ export const listBitbucketEnvironments = async (
 
   let iterationCount = 0;
   // Limit to 10 iterations, fetching at most 10 * 100 = 1000 environments
-  while (hasNextPage && iterationCount < 10) {
-    // eslint-disable-next-line no-await-in-loop
-    const { data }: { data: { values: TBitbucketEnvironment[]; next: string } } = await request.get(environmentsUrl, {
-      headers
-    });
+  try {
+    while (hasNextPage && iterationCount < 10) {
+      // eslint-disable-next-line no-await-in-loop
+      const { data }: { data: { values: TBitbucketEnvironment[]; next: string } } = await request.get(
+        environmentsUrl,
+        {
+          headers
+        }
+      );
 
-    if (data?.values.length > 0) {
-      environments.push(...data.values);
-    }
+      if (data?.values.length > 0) {
+        environments.push(...data.values);
+      }
 
-    if (data.next) {
-      environmentsUrl = data.next;
-    } else {
-      hasNextPage = false;
+      if (data.next) {
+        environmentsUrl = data.next;
+      } else {
+        hasNextPage = false;
+      }
+      iterationCount += 1;
     }
-    iterationCount += 1;
+  } catch (error) {
+    ensureBitbucketRateLimitNotExceeded(error);
   }
 
   return environments;

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-fns.ts
@@ -172,6 +172,8 @@ export const listBitbucketEnvironments = async (
     Accept: "application/json"
   };
 
+  // We still need to paginate this one as it's the only endpoint we use that doesn't support searching
+  // https://developer.atlassian.com/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-environments-get
   return paginateBitbucketRequest<TBitbucketEnvironment>(
     `${IntegrationUrls.BITBUCKET_API_URL}/2.0/repositories/${encodeURIComponent(workspaceSlug)}/${encodeURIComponent(repositorySlug)}/environments?pagelen=${BITBUCKET_PAGE_SIZE}`,
     headers

--- a/backend/src/services/app-connection/bitbucket/bitbucket-connection-service.ts
+++ b/backend/src/services/app-connection/bitbucket/bitbucket-connection-service.ts
@@ -19,18 +19,19 @@ type TGetAppConnectionFunc = (
 ) => Promise<TBitbucketConnection>;
 
 export const bitbucketConnectionService = (getAppConnection: TGetAppConnectionFunc) => {
-  const listWorkspaces = async (connectionId: string, actor: OrgServiceActor) => {
+  const listWorkspaces = async (connectionId: string, actor: OrgServiceActor, search?: string) => {
     const appConnection = await getAppConnection(AppConnection.Bitbucket, connectionId, actor);
-    const workspaces = await listBitbucketWorkspaces(appConnection);
+    const workspaces = await listBitbucketWorkspaces(appConnection, search);
     return workspaces;
   };
 
   const listRepositories = async (
     { connectionId, workspaceSlug }: TGetBitbucketRepositoriesDTO,
-    actor: OrgServiceActor
+    actor: OrgServiceActor,
+    search?: string
   ) => {
     const appConnection = await getAppConnection(AppConnection.Bitbucket, connectionId, actor);
-    const repositories = await listBitbucketRepositories(appConnection, workspaceSlug);
+    const repositories = await listBitbucketRepositories(appConnection, workspaceSlug, search);
     return repositories;
   };
 

--- a/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/BitbucketDataSourceConfigFields.tsx
+++ b/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/BitbucketDataSourceConfigFields.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { MultiValue, SingleValue } from "react-select";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { FilterableSelect, FormControl, Select, SelectItem, Tooltip } from "@app/components/v2";
+import { useDebounce } from "@app/hooks";
 import {
   TBitbucketRepo,
   TBitbucketWorkspace,
@@ -28,16 +29,21 @@ export const BitbucketDataSourceConfigFields = () => {
     }
   >();
 
+  const [workspaceSearch, setWorkspaceSearch] = useState("");
+  const [debouncedWorkspaceSearch] = useDebounce(workspaceSearch, 300);
+
   const connectionId = useWatch({ control, name: "connection.id" });
   const isUpdate = Boolean(watch("id"));
 
   const selectedWorkspaceSlug = useWatch({ control, name: "config.workspaceSlug" });
 
   const { data: workspaces, isPending: areWorkspacesLoading } =
-    useBitbucketConnectionListWorkspaces(connectionId, { enabled: Boolean(connectionId) });
+    useBitbucketConnectionListWorkspaces(connectionId, debouncedWorkspaceSearch || undefined, {
+      enabled: Boolean(connectionId)
+    });
 
   const { data: repositories, isPending: areRepositoriesLoading } =
-    useBitbucketConnectionListRepositories(connectionId, selectedWorkspaceSlug, {
+    useBitbucketConnectionListRepositories(connectionId, selectedWorkspaceSlug, undefined, {
       enabled: Boolean(connectionId) && Boolean(selectedWorkspaceSlug)
     });
 
@@ -96,10 +102,17 @@ export const BitbucketDataSourceConfigFields = () => {
                   setValue("config.includeRepos", []);
                 }
               }}
+              onInputChange={(newValue) => setWorkspaceSearch(newValue)}
+              filterOption={null}
               options={workspaces}
-              placeholder="Select workspace..."
+              placeholder="Search for a workspace..."
               getOptionLabel={(option) => option.slug}
               getOptionValue={(option) => option.slug}
+              noOptionsMessage={({ inputValue }) =>
+                inputValue
+                  ? "No workspaces found matching your search."
+                  : "No workspaces found."
+              }
             />
           </FormControl>
         )}

--- a/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/BitbucketDataSourceConfigFields.tsx
+++ b/frontend/src/components/secret-scanning/forms/SecretScanningDataSourceConfigFields/BitbucketDataSourceConfigFields.tsx
@@ -109,9 +109,7 @@ export const BitbucketDataSourceConfigFields = () => {
               getOptionLabel={(option) => option.slug}
               getOptionValue={(option) => option.slug}
               noOptionsMessage={({ inputValue }) =>
-                inputValue
-                  ? "No workspaces found matching your search."
-                  : "No workspaces found."
+                inputValue ? "No workspaces found matching your search." : "No workspaces found."
               }
             />
           </FormControl>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/BitbucketSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/BitbucketSyncFields.tsx
@@ -43,9 +43,14 @@ export const BitbucketSyncFields = () => {
     });
 
   const { data: repositories = [], isPending: isRepositoriesLoading } =
-    useBitbucketConnectionListRepositories(connectionId, workspace ?? "", debouncedRepoSearch || undefined, {
-      enabled: Boolean(connectionId) && Boolean(workspace)
-    });
+    useBitbucketConnectionListRepositories(
+      connectionId,
+      workspace ?? "",
+      debouncedRepoSearch || undefined,
+      {
+        enabled: Boolean(connectionId) && Boolean(workspace)
+      }
+    );
 
   const { data: environments = [], isPending: isEnvironmentsLoading } =
     useBitbucketConnectionListEnvironments(connectionId, workspace ?? "", repository ?? "", {
@@ -86,9 +91,7 @@ export const BitbucketSyncFields = () => {
                 getOptionLabel={(option) => option.slug}
                 getOptionValue={(option) => option.slug}
                 noOptionsMessage={({ inputValue }) =>
-                  inputValue
-                    ? "No workspaces found matching your search."
-                    : "No workspaces found."
+                  inputValue ? "No workspaces found matching your search." : "No workspaces found."
                 }
               />
               <FieldError errors={[error]} />

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/BitbucketSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/BitbucketSyncFields.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { SingleValue } from "react-select";
 
@@ -10,6 +11,7 @@ import {
   FieldLabel,
   FilterableSelect
 } from "@app/components/v3";
+import { useDebounce } from "@app/hooks";
 import {
   TBitbucketEnvironment,
   TBitbucketRepo,
@@ -27,17 +29,21 @@ export const BitbucketSyncFields = () => {
     TSecretSyncForm & { destination: SecretSync.Bitbucket }
   >();
 
+  const [workspaceSearch, setWorkspaceSearch] = useState("");
+  const [debouncedWorkspaceSearch] = useDebounce(workspaceSearch, 300);
+  const [repoSearch, setRepoSearch] = useState("");
+  const [debouncedRepoSearch] = useDebounce(repoSearch, 300);
   const connectionId = useWatch({ name: "connection.id", control });
   const workspace = useWatch({ name: "destinationConfig.workspaceSlug", control });
   const repository = useWatch({ name: "destinationConfig.repositorySlug", control });
 
   const { data: workspaces = [], isPending: isWorkspacesLoading } =
-    useBitbucketConnectionListWorkspaces(connectionId, {
+    useBitbucketConnectionListWorkspaces(connectionId, debouncedWorkspaceSearch || undefined, {
       enabled: Boolean(connectionId)
     });
 
   const { data: repositories = [], isPending: isRepositoriesLoading } =
-    useBitbucketConnectionListRepositories(connectionId, workspace ?? "", {
+    useBitbucketConnectionListRepositories(connectionId, workspace ?? "", debouncedRepoSearch || undefined, {
       enabled: Boolean(connectionId) && Boolean(workspace)
     });
 
@@ -73,10 +79,17 @@ export const BitbucketSyncFields = () => {
                   setValue("destinationConfig.repositorySlug", "");
                   setValue("destinationConfig.environmentId", "");
                 }}
+                onInputChange={(newValue) => setWorkspaceSearch(newValue)}
+                filterOption={null}
                 options={workspaces}
-                placeholder="Select workspace..."
+                placeholder="Search for a workspace..."
                 getOptionLabel={(option) => option.slug}
                 getOptionValue={(option) => option.slug}
+                noOptionsMessage={({ inputValue }) =>
+                  inputValue
+                    ? "No workspaces found matching your search."
+                    : "No workspaces found."
+                }
               />
               <FieldError errors={[error]} />
             </FieldContent>
@@ -100,10 +113,17 @@ export const BitbucketSyncFields = () => {
                   onChange(v?.slug ?? "");
                   setValue("destinationConfig.environmentId", "");
                 }}
+                onInputChange={(newValue) => setRepoSearch(newValue)}
+                filterOption={null}
                 options={repositories}
-                placeholder="Select repository..."
+                placeholder="Search for a repository..."
                 getOptionLabel={(option) => option.full_name}
                 getOptionValue={(option) => option.slug}
+                noOptionsMessage={({ inputValue }) =>
+                  inputValue
+                    ? "No repositories found matching your search."
+                    : "No repositories found."
+                }
               />
               <FieldError errors={[error]} />
             </FieldContent>

--- a/frontend/src/hooks/api/appConnections/bitbucket/queries.tsx
+++ b/frontend/src/hooks/api/appConnections/bitbucket/queries.tsx
@@ -14,16 +14,17 @@ import {
 
 const bitbucketConnectionKeys = {
   all: [...appConnectionKeys.all, "bitbucket"] as const,
-  listRepos: (connectionId: string, workspaceSlug: string) =>
-    [...bitbucketConnectionKeys.all, "repos", connectionId, workspaceSlug] as const,
-  listWorkspaces: (connectionId: string) =>
-    [...bitbucketConnectionKeys.all, "workspaces", connectionId] as const,
+  listWorkspaces: (connectionId: string, search?: string) =>
+    [...bitbucketConnectionKeys.all, "workspaces", connectionId, { search }] as const,
+  listRepos: (connectionId: string, workspaceSlug: string, search?: string) =>
+    [...bitbucketConnectionKeys.all, "repos", connectionId, workspaceSlug, { search }] as const,
   listEnvironments: (connectionId: string, workspaceSlug: string, repoSlug: string) =>
     [...bitbucketConnectionKeys.all, "environments", connectionId, workspaceSlug, repoSlug] as const
 };
 
 export const useBitbucketConnectionListWorkspaces = (
   connectionId: string,
+  search?: string,
   options?: Omit<
     UseQueryOptions<
       TBitbucketWorkspace[],
@@ -35,10 +36,15 @@ export const useBitbucketConnectionListWorkspaces = (
   >
 ) => {
   return useQuery({
-    queryKey: bitbucketConnectionKeys.listWorkspaces(connectionId),
+    queryKey: bitbucketConnectionKeys.listWorkspaces(connectionId, search),
     queryFn: async () => {
+      const params = new URLSearchParams();
+      if (search) {
+        params.set("search", search);
+      }
+      const query = params.toString();
       const { data } = await apiRequest.get<TBitbucketConnectionListWorkspacesResponse>(
-        `/api/v1/app-connections/bitbucket/${connectionId}/workspaces`
+        `/api/v1/app-connections/bitbucket/${connectionId}/workspaces${query ? `?${query}` : ""}`
       );
 
       return data.workspaces;
@@ -50,6 +56,7 @@ export const useBitbucketConnectionListWorkspaces = (
 export const useBitbucketConnectionListRepositories = (
   connectionId: string,
   workspaceSlug: string,
+  search?: string,
   options?: Omit<
     UseQueryOptions<
       TBitbucketRepo[],
@@ -61,10 +68,14 @@ export const useBitbucketConnectionListRepositories = (
   >
 ) => {
   return useQuery({
-    queryKey: bitbucketConnectionKeys.listRepos(connectionId, workspaceSlug),
+    queryKey: bitbucketConnectionKeys.listRepos(connectionId, workspaceSlug, search),
     queryFn: async () => {
+      const params = new URLSearchParams({ workspaceSlug });
+      if (search) {
+        params.set("search", search);
+      }
       const { data } = await apiRequest.get<TBitbucketConnectionListRepositoriesResponse>(
-        `/api/v1/app-connections/bitbucket/${connectionId}/repositories?workspaceSlug=${encodeURIComponent(workspaceSlug)}`
+        `/api/v1/app-connections/bitbucket/${connectionId}/repositories?${params.toString()}`
       );
 
       return data.repositories;

--- a/frontend/src/hooks/api/appConnections/bitbucket/queries.tsx
+++ b/frontend/src/hooks/api/appConnections/bitbucket/queries.tsx
@@ -14,10 +14,10 @@ import {
 
 const bitbucketConnectionKeys = {
   all: [...appConnectionKeys.all, "bitbucket"] as const,
-  listWorkspaces: (connectionId: string, search?: string) =>
-    [...bitbucketConnectionKeys.all, "workspaces", connectionId, { search }] as const,
   listRepos: (connectionId: string, workspaceSlug: string, search?: string) =>
     [...bitbucketConnectionKeys.all, "repos", connectionId, workspaceSlug, { search }] as const,
+  listWorkspaces: (connectionId: string, search?: string) =>
+    [...bitbucketConnectionKeys.all, "workspaces", connectionId, { search }] as const,
   listEnvironments: (connectionId: string, workspaceSlug: string, repoSlug: string) =>
     [...bitbucketConnectionKeys.all, "environments", connectionId, workspaceSlug, repoSlug] as const
 };


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We had a customer complaining about bitbucket failing with 500 error. However, after investigation, it was failing because BitBucket was returning 429 errors. 

We, unfortunately, cannot give more details because BitBucket doesn't return more information: for example, how long to wait. Bitbucket rate limit windows are 1h long.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)