### PR TITLE
fix: fix react select component spread to not overwrite styling

### DIFF
--- a/frontend/src/components/v3/generic/ReactSelect/CreatableSelect.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/CreatableSelect.tsx
@@ -8,6 +8,7 @@ export const CreatableSelect = <T,>({
   isMulti,
   closeMenuOnSelect,
   isError,
+  components,
   ...props
 }: CreatableProps<T, boolean, GroupBase<T>> & { isError?: boolean }) => {
   return (
@@ -18,7 +19,7 @@ export const CreatableSelect = <T,>({
       unstyled
       data-slot="creatable-select"
       styles={selectStyles as any}
-      components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, Option }}
+      components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, Option, ...components }}
       classNames={(isError ? getSelectClassNames(isError) : selectClassNames) as any}
       {...props}
     />

--- a/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.tsx
@@ -11,6 +11,7 @@ export const FilterableSelect = <T,>({
   getGroupHeaderLabel = null,
   options = [],
   isError,
+  components,
   ...props
 }: Props<T, boolean, GroupBase<T>> & {
   groupBy?: string | null;
@@ -56,7 +57,7 @@ export const FilterableSelect = <T,>({
         MultiValueRemove,
         Option,
         Group,
-        ...props.components
+        ...components
       }}
       classNames={(isError ? getSelectClassNames(isError) : selectClassNames) as any}
       {...props}

--- a/frontend/src/components/v3/generic/ReactSelect/components.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/components.tsx
@@ -33,7 +33,7 @@ export const Option = <T,>({ isSelected, children, ...props }: OptionProps<T>) =
   <components.Option isSelected={isSelected} {...props}>
     <div className="flex cursor-pointer flex-row items-center justify-between">
       <p className="truncate">{children}</p>
-      {isSelected && <CheckIcon className="ml-2 size-4" />}
+      {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
     </div>
   </components.Option>
 );

--- a/frontend/src/components/v3/generic/ReactSelect/styles.ts
+++ b/frontend/src/components/v3/generic/ReactSelect/styles.ts
@@ -17,7 +17,8 @@ export const selectClassNames: ClassNamesConfig<unknown, boolean, GroupBase<unkn
     "gap-1 max-h-40 !pointer-events-auto !overflow-y-auto thin-scrollbar flex-wrap",
   multiValue: () => "bg-foreground/10 rounded px-1.5 py-0.5 gap-1 text-xs items-center",
   multiValueLabel: () => "text-foreground/85",
-  multiValueRemove: () => "[&>svg]:size-3 hover:text-danger text-muted cursor-pointer ml-0.5",
+  multiValueRemove: () =>
+    "shrink-0 [&>svg]:size-3 [&>svg]:shrink-0 hover:text-danger text-muted cursor-pointer ml-0.5",
   menu: () => "my-2 w-full rounded-[6px] border border-border bg-popover p-1 shadow-md",
   menuList: () => "max-h-48 text-sm overflow-y-auto thin-scrollbar",
   option: ({ isFocused }) =>
@@ -26,11 +27,11 @@ export const selectClassNames: ClassNamesConfig<unknown, boolean, GroupBase<unkn
       isFocused && "bg-foreground/5"
     ),
   dropdownIndicator: () =>
-    "opacity-50 p-1 hover:bg-foreground/10 cursor-pointer rounded-md [&>svg]:size-4",
+    "opacity-50 p-1 hover:bg-foreground/10 cursor-pointer rounded-md [&>svg]:size-4 [&>svg]:shrink-0",
   indicatorsContainer: () => "gap-1 flex items-center text-foreground",
   indicatorSeparator: () => "bg-accent/20",
   clearIndicator: () =>
-    "opacity-50 hover:opacity-100 hover:bg-foreground/10 cursor-pointer rounded-md p-1 text-danger [&>svg]:size-4",
+    "opacity-50 hover:opacity-100 hover:bg-foreground/10 cursor-pointer rounded-md p-1 text-danger [&>svg]:size-4 [&>svg]:shrink-0",
   noOptionsMessage: () => "text-muted p-2 text-sm",
   loadingMessage: () => "text-muted p-2 text-sm",
   group: () => "pb-1",


### PR DESCRIPTION
## Context

This PR corrects a prop spread that was accidentally overwriting styling. also added some shrink 0s which prevent svgs collapsing

## Screenshots

N/A

## Steps to verify the change

- you can see the props spread was overwriting the components
- and the

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)