### PR TITLE
feat: auto-create a personal org on sign-up from sso

### DIFF
--- a/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
+++ b/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
@@ -38,12 +38,13 @@ export const NoOrgPage = () => {
       try {
         organization = await createOrg({ name: PERSONAL_ORG_NAME });
       } catch {
-        // Nothing was created, so let the user create an org manually.
+        // Nothing was created, so reset both guards and let the user create an org manually.
         createNotification({
           text: "Couldn't create your organization automatically. Please create one below.",
           type: "error"
         });
         setFailed(true);
+        hasRun.current = false;
         sessionStorage.removeItem(CREATION_STARTED_KEY);
         return;
       }

--- a/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
+++ b/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
@@ -1,10 +1,53 @@
+import { useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "@tanstack/react-router";
 
+import { createNotification } from "@app/components/notifications";
 import { CreateOrgModal } from "@app/components/organization/CreateOrgModal";
+import { ContentLoader } from "@app/components/v2";
+import { useCreateOrg, useSelectOrganization } from "@app/hooks/api";
+
+const PERSONAL_ORG_NAME = "Personal Org";
 
 export const NoOrgPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const { mutateAsync: createOrg } = useCreateOrg({ invalidate: false });
+  const { mutateAsync: selectOrg } = useSelectOrganization();
+
+  // Guards against React strict-mode's double-invoke (and re-renders) creating two orgs.
+  const hasRun = useRef(false);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    const createPersonalOrg = async () => {
+      try {
+        const organization = await createOrg({ name: PERSONAL_ORG_NAME });
+
+        await selectOrg({ organizationId: organization.id });
+
+        localStorage.setItem("orgData.id", organization.id);
+
+        navigate({
+          to: "/organizations/$orgId/projects",
+          params: { orgId: organization.id }
+        });
+      } catch {
+        createNotification({
+          text: "Couldn't create your organization automatically. Please create one below.",
+          type: "error"
+        });
+        setFailed(true);
+      }
+    };
+
+    createPersonalOrg();
+  }, [createOrg, selectOrg, navigate]);
 
   return (
     <>
@@ -13,7 +56,11 @@ export const NoOrgPage = () => {
         <link rel="icon" href="/infisical.ico" />
       </Helmet>
       <div className="min-h-screen bg-bunker-800">
-        <CreateOrgModal isOpen logoutOnClose />
+        {failed ? (
+          <CreateOrgModal isOpen logoutOnClose />
+        ) : (
+          <ContentLoader text="Setting up your organization..." />
+        )}
       </div>
     </>
   );

--- a/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
+++ b/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
@@ -1,18 +1,23 @@
 import { useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
 import { CreateOrgModal } from "@app/components/organization/CreateOrgModal";
 import { ContentLoader } from "@app/components/v2";
-import { useCreateOrg, useSelectOrganization } from "@app/hooks/api";
+import { organizationKeys, useCreateOrg, useSelectOrganization } from "@app/hooks/api";
 
 const PERSONAL_ORG_NAME = "Personal Org";
+// A useRef gate resets on a full unmount/remount; this sessionStorage flag survives it, so an
+// interrupted-then-remounted page can't fire a second createOrg and leave a duplicate org behind.
+const CREATION_STARTED_KEY = "personalOrgCreationStarted";
 
 export const NoOrgPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: createOrg } = useCreateOrg({ invalidate: false });
   const { mutateAsync: selectOrg } = useSelectOrganization();
@@ -25,10 +30,25 @@ export const NoOrgPage = () => {
     if (hasRun.current) return;
     hasRun.current = true;
 
-    const createPersonalOrg = async () => {
-      try {
-        const organization = await createOrg({ name: PERSONAL_ORG_NAME });
+    if (sessionStorage.getItem(CREATION_STARTED_KEY)) return;
+    sessionStorage.setItem(CREATION_STARTED_KEY, "true");
 
+    const createPersonalOrg = async () => {
+      let organization;
+      try {
+        organization = await createOrg({ name: PERSONAL_ORG_NAME });
+      } catch {
+        // Nothing was created, so let the user create an org manually.
+        createNotification({
+          text: "Couldn't create your organization automatically. Please create one below.",
+          type: "error"
+        });
+        setFailed(true);
+        sessionStorage.removeItem(CREATION_STARTED_KEY);
+        return;
+      }
+
+      try {
         await selectOrg({ organizationId: organization.id });
 
         localStorage.setItem("orgData.id", organization.id);
@@ -38,16 +58,22 @@ export const NoOrgPage = () => {
           params: { orgId: organization.id }
         });
       } catch {
+        // The org was created but selecting it failed. Showing CreateOrgModal here would create a
+        // second, orphaned org, so refresh the cached org list and hand off to the org picker,
+        // which auto-selects the now-existing single org and finishes login.
         createNotification({
-          text: "Couldn't create your organization automatically. Please create one below.",
+          text: "Created your organization, but couldn't open it automatically. Redirecting...",
           type: "error"
         });
-        setFailed(true);
+        await queryClient.invalidateQueries({ queryKey: organizationKeys.getUserOrganizations });
+        navigate({ to: "/login/select-organization" });
+      } finally {
+        sessionStorage.removeItem(CREATION_STARTED_KEY);
       }
     };
 
     createPersonalOrg();
-  }, [createOrg, selectOrg, navigate]);
+  }, [createOrg, selectOrg, navigate, queryClient]);
 
   return (
     <>


### PR DESCRIPTION
## Context

This PR updates the sso sign-up flow to automatically create a personal org instead of requiring the user to enter a name

## Screenshots

N/A

## Steps to verify the change

- sign up / login in with sso on a fresh account

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)