### PR TITLE
improvement: move project templates to advanced and add external KMS shortcut to new project modal

### DIFF
--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -2,10 +2,11 @@ import { FC, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, Plus } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import z from "zod";
 
+import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import { Lottie } from "@app/components/v2";
@@ -29,6 +30,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
   TextArea,
@@ -49,6 +51,7 @@ import {
   getProjectHomePage,
   getProjectLottieIcon
 } from "@app/helpers/project";
+import { usePopUp } from "@app/hooks";
 import { useCreateWorkspace, useGetExternalKmsList, useGetUserProjects } from "@app/hooks/api";
 import { INTERNAL_KMS_KEY_ID } from "@app/hooks/api/kms/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
@@ -95,6 +98,8 @@ const PROJECT_TYPE_MENU_ITEMS = [
   }
 ];
 
+const ADD_EXTERNAL_KMS_OPTION = "__add-external-kms__";
+
 const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProjectFormProps) => {
   const navigate = useNavigate();
   const { currentOrg } = useOrganization();
@@ -103,11 +108,14 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
   const createWs = useCreateWorkspace();
   const { refetch: refetchWorkspaces } = useGetUserProjects();
   const { subscription } = useSubscription();
+  const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
 
   const canReadProjectTemplates = permission.can(
     OrgPermissionActions.Read,
     OrgPermissionSubjects.ProjectTemplates
   );
+
+  const canCreateKms = permission.can(OrgPermissionActions.Create, OrgPermissionSubjects.Kms);
 
   const {
     control,
@@ -139,6 +147,22 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
       console.log("Current form errors:", errors);
     }
   }, [errors]);
+
+  const handleAddExternalKms = () => {
+    if (subscription && !subscription.externalKms) {
+      handlePopUpOpen("upgradePlan", { isEnterpriseFeature: true });
+      return;
+    }
+
+    if (!currentOrg) return;
+
+    onOpenChange(false);
+    navigate({
+      to: "/organizations/$orgId/settings",
+      params: { orgId: currentOrg.id },
+      search: { selectedTab: "tab-org-encryption" }
+    });
+  };
 
   const onCreateProject = async ({
     name,
@@ -247,90 +271,131 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
             </Field>
           )}
         />
-        <Controller
-          control={control}
-          name="template"
-          render={({ field: { value, onChange } }) => (
-            <OrgPermissionCan
-              I={OrgPermissionActions.Read}
-              a={OrgPermissionSubjects.ProjectTemplates}
-            >
-              {(isAllowed) => (
-                <Field>
-                  <FieldLabel htmlFor="new-project-template">
-                    Project Template
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoIcon className="text-muted" />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-xs">
-                        <p>
-                          Create this project from a template to provision it with custom
-                          environments and roles.
-                        </p>
-                        {subscription && !subscription.projectTemplates && (
-                          <p className="pt-2">Project templates are a paid feature.</p>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  </FieldLabel>
-                  <Select
-                    value={value}
-                    onValueChange={onChange}
-                    disabled={!isAllowed || !subscription?.projectTemplates}
-                  >
-                    <SelectTrigger id="new-project-template" className="w-full">
-                      <SelectValue placeholder={InfisicalProjectTemplate.Default} />
-                    </SelectTrigger>
-                    <SelectContent position="popper">
-                      {projectTemplates.length
-                        ? projectTemplates.map((template) => (
-                            <SelectItem key={template.id} value={template.name}>
-                              {template.name}
-                            </SelectItem>
-                          ))
-                        : Object.values(InfisicalProjectTemplate).map((template) => (
-                            <SelectItem key={template} value={template}>
-                              {template}
-                            </SelectItem>
-                          ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              )}
-            </OrgPermissionCan>
-          )}
-        />
       </div>
       <Accordion type="single" collapsible variant="ghost">
         <AccordionItem value="advance-settings" className="border-b-0">
           <AccordionTrigger>Advanced Settings</AccordionTrigger>
           <AccordionContent>
-            <Controller
-              control={control}
-              name="kmsKeyId"
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="new-project-kms">KMS</FieldLabel>
-                  <Select value={value} onValueChange={onChange}>
-                    <SelectTrigger id="new-project-kms" className="w-full">
-                      <SelectValue placeholder="Default Infisical KMS" />
-                    </SelectTrigger>
-                    <SelectContent position="popper">
-                      <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
-                        Default Infisical KMS
-                      </SelectItem>
-                      {externalKmsList?.map((kms) => (
-                        <SelectItem value={kms.id} key={`kms-${kms.id}`}>
-                          {kms.name}
+            <div className="flex flex-col gap-4">
+              <Controller
+                control={control}
+                name="template"
+                render={({ field: { value, onChange } }) => (
+                  <OrgPermissionCan
+                    I={OrgPermissionActions.Read}
+                    a={OrgPermissionSubjects.ProjectTemplates}
+                  >
+                    {(isAllowed) => (
+                      <Field>
+                        <FieldLabel htmlFor="new-project-template">
+                          Project Template
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoIcon className="text-muted" />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-xs">
+                              <p>
+                                Create this project from a template to provision it with custom
+                                environments and roles.
+                              </p>
+                              {subscription && !subscription.projectTemplates && (
+                                <p className="pt-2">Project templates are a paid feature.</p>
+                              )}
+                            </TooltipContent>
+                          </Tooltip>
+                        </FieldLabel>
+                        <Select
+                          value={value}
+                          onValueChange={onChange}
+                          disabled={!isAllowed || !subscription?.projectTemplates}
+                        >
+                          <SelectTrigger id="new-project-template" className="w-full">
+                            <SelectValue placeholder={InfisicalProjectTemplate.Default} />
+                          </SelectTrigger>
+                          <SelectContent position="popper">
+                            {projectTemplates.length
+                              ? projectTemplates.map((template) => (
+                                  <SelectItem key={template.id} value={template.name}>
+                                    {template.name}
+                                  </SelectItem>
+                                ))
+                              : Object.values(InfisicalProjectTemplate).map((template) => (
+                                  <SelectItem key={template} value={template}>
+                                    {template}
+                                  </SelectItem>
+                                ))}
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </OrgPermissionCan>
+                )}
+              />
+              <Controller
+                control={control}
+                name="kmsKeyId"
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="new-project-kms">KMS</FieldLabel>
+                    <Select
+                      value={value}
+                      onValueChange={(kmsValue) => {
+                        if (kmsValue === ADD_EXTERNAL_KMS_OPTION) {
+                          handleAddExternalKms();
+                          return;
+                        }
+                        onChange(kmsValue);
+                      }}
+                    >
+                      <SelectTrigger id="new-project-kms" className="w-full">
+                        <SelectValue placeholder="Default Infisical KMS" />
+                      </SelectTrigger>
+                      <SelectContent position="popper">
+                        <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
+                          Default Infisical KMS
                         </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {error && <FieldError>{error.message}</FieldError>}
-                </Field>
-              )}
-            />
+                        {externalKmsList?.map((kms) => (
+                          <SelectItem value={kms.id} key={`kms-${kms.id}`}>
+                            {kms.name}
+                          </SelectItem>
+                        ))}
+                        <SelectSeparator />
+                        {!canCreateKms ? (
+                          <SelectItem value={ADD_EXTERNAL_KMS_OPTION} key="kms-add-external">
+                            <span className="flex items-center gap-2 text-accent">
+                              <Plus />
+                              Add external KMS
+                            </span>
+                          </SelectItem>
+                        ) : (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+                              <span tabIndex={0} className="block">
+                                <SelectItem
+                                  value={ADD_EXTERNAL_KMS_OPTION}
+                                  key="kms-add-external"
+                                  disabled
+                                >
+                                  <span className="flex items-center gap-2 text-accent">
+                                    <Plus />
+                                    Add external KMS
+                                  </span>
+                                </SelectItem>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="right">
+                              You do not have permission to add an external KMS.
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                      </SelectContent>
+                    </Select>
+                    {error && <FieldError>{error.message}</FieldError>}
+                  </Field>
+                )}
+              />
+            </div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>
@@ -344,6 +409,12 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
           Create Project
         </Button>
       </DialogFooter>
+      <UpgradePlanModal
+        isOpen={popUp.upgradePlan.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+        text="Your current plan does not include access to external KMS. To unlock this feature, please upgrade to Infisical Enterprise plan."
+        isEnterpriseFeature={popUp.upgradePlan.data?.isEnterpriseFeature}
+      />
     </form>
   );
 };

--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -360,7 +360,7 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
                           </SelectItem>
                         ))}
                         <SelectSeparator />
-                        {!canCreateKms ? (
+                        {canCreateKms ? (
                           <SelectItem value={ADD_EXTERNAL_KMS_OPTION} key="kms-add-external">
                             <span className="flex items-center gap-2 text-accent">
                               <Plus />

--- a/frontend/src/components/projects/NewProjectModal.tsx
+++ b/frontend/src/components/projects/NewProjectModal.tsx
@@ -115,7 +115,9 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
     OrgPermissionSubjects.ProjectTemplates
   );
 
+  const canReadKms = permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms);
   const canCreateKms = permission.can(OrgPermissionActions.Create, OrgPermissionSubjects.Kms);
+  const canAddExternalKms = canReadKms && canCreateKms;
 
   const {
     control,
@@ -139,7 +141,7 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
   });
 
   const { data: externalKmsList } = useGetExternalKmsList(currentOrg.id, {
-    enabled: permission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Kms)
+    enabled: canReadKms
   });
 
   useEffect(() => {
@@ -149,7 +151,7 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
   }, [errors]);
 
   const handleAddExternalKms = () => {
-    if (subscription && !subscription.externalKms) {
+    if (!subscription?.externalKms) {
       handlePopUpOpen("upgradePlan", { isEnterpriseFeature: true });
       return;
     }
@@ -360,7 +362,7 @@ const NewProjectForm = ({ onOpenChange, projectType: fixedProjectType }: NewProj
                           </SelectItem>
                         ))}
                         <SelectSeparator />
-                        {canCreateKms ? (
+                        {canAddExternalKms ? (
                           <SelectItem value={ADD_EXTERNAL_KMS_OPTION} key="kms-add-external">
                             <span className="flex items-center gap-2 text-accent">
                               <Plus />

--- a/frontend/src/components/v3/generic/Select/Select.tsx
+++ b/frontend/src/components/v3/generic/Select/Select.tsx
@@ -102,7 +102,7 @@ function SelectContent({
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md bg-popover text-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover text-foreground shadow-md duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className


### PR DESCRIPTION
## Context

This PR moves the project template select when creating a project to the advanced section and updates the kms select to have a create extrenal kms button that either prompts to upgrade or links to the org section to do so

also includes styling improvement to select content

## Screenshots

<img width="1732" height="1454" alt="CleanShot 2026-06-15 at 17 35 46@2x" src="https://github.com/user-attachments/assets/f2a36cd3-fd40-493f-b2aa-2feaafee5fb7" />

## Steps to verify the change

- create project and test form especially the create external kms option with and without license and permission

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)