### PR TITLE
docs(cli): add migration guide for Cloudsmith repository transition to artifacts-cli.infisical.com

### DIFF
--- a/docs/cli/cloudsmith-migration.mdx
+++ b/docs/cli/cloudsmith-migration.mdx
@@ -63,7 +63,7 @@ Remove the old Cloudsmith source first, then re-run the repository setup script 
     sed -i '/cloudsmith.*infisical/d' /etc/apk/repositories
 
     # Add new repository and install
-    wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sh
+    wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sudo sh
     apk update && apk add infisical
     ```
   </Tab>

--- a/docs/cli/cloudsmith-migration.mdx
+++ b/docs/cli/cloudsmith-migration.mdx
@@ -43,7 +43,7 @@ Remove the old Cloudsmith source first, then re-run the repository setup script 
 
     # Add new repository and install
     curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
-    sudo apt-get install -y infisical
+    sudo apt-get update && sudo apt-get install -y infisical
     ```
   </Tab>
   <Tab title="RHEL / CentOS / Fedora (yum/dnf)">
@@ -64,7 +64,7 @@ Remove the old Cloudsmith source first, then re-run the repository setup script 
 
     # Add new repository and install
     wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sh
-    apk add infisical
+    apk update && apk add infisical
     ```
   </Tab>
 </Tabs>

--- a/docs/cli/cloudsmith-migration.mdx
+++ b/docs/cli/cloudsmith-migration.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Cloudsmith Repository Migration'
+title: 'Migrate off Cloudsmith'
 description: 'The Infisical CLI Linux package repository has moved from Cloudsmith to artifacts-cli.infisical.com. Learn how to migrate your package manager configuration.'
 ---
 
 <Warning>
-  The Cloudsmith package repository is shutting down. Any machine still pointed at the Cloudsmith URL will fail to install or update the Infisical CLI after the cutoff date. Follow the steps below to migrate now.
+  The Cloudsmith package repository stops serving on **September 16, 2026**. Any machine still pointed at the Cloudsmith URL will fail to install or update the Infisical CLI after that date. Follow the steps below to migrate now.
 </Warning>
 
 ## What changed

--- a/docs/cli/cloudsmith-migration.mdx
+++ b/docs/cli/cloudsmith-migration.mdx
@@ -1,0 +1,118 @@
+---
+title: 'Cloudsmith Repository Migration'
+description: 'The Infisical CLI Linux package repository has moved from Cloudsmith to artifacts-cli.infisical.com. Learn how to migrate your package manager configuration.'
+---
+
+<Warning>
+  The Cloudsmith package repository is shutting down. Any machine still pointed at the Cloudsmith URL will fail to install or update the Infisical CLI after the cutoff date. Follow the steps below to migrate now.
+</Warning>
+
+## What changed
+
+The Infisical CLI Linux package repository has moved from Cloudsmith to our own host at `artifacts-cli.infisical.com` (Amazon S3 served via CloudFront). All current and historical releases are available on the new host, so pinned version installs continue to resolve without changes to the version number.
+
+## Who is affected
+
+Anyone who installed the CLI on Linux from the Cloudsmith `apt`, `yum`/`dnf`, or `apk` repository is affected. This includes:
+
+- CI pipelines that install the CLI at build time
+- Container images with the CLI baked in
+- Developer machines running Linux
+
+Homebrew (macOS) and Windows users are **not affected**.
+
+## Impact of not migrating
+
+| Package manager | Effect of a dead Cloudsmith source |
+|---|---|
+| apt (Debian/Ubuntu) | `apt-get update` fails entirely, blocking **all** package operations |
+| yum/dnf (RHEL/CentOS/Fedora) | Infisical repo warns but other repos still work |
+| apk (Alpine) | Infisical repo warns but other repos still work |
+
+We recommend migrating regardless of your package manager to avoid any disruption.
+
+## Migration steps
+
+Remove the old Cloudsmith source first, then re-run the repository setup script for your distribution.
+
+<Tabs>
+  <Tab title="Debian / Ubuntu (apt)">
+    ```bash
+    # Remove old Cloudsmith source
+    grep -rlE 'cloudsmith.*infisical' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f
+
+    # Add new repository and install
+    curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+    sudo apt-get install -y infisical
+    ```
+  </Tab>
+  <Tab title="RHEL / CentOS / Fedora (yum/dnf)">
+    ```bash
+    # Remove old Cloudsmith source
+    grep -rlE 'cloudsmith.*infisical' /etc/yum.repos.d/ 2>/dev/null | xargs -r sudo rm -f
+
+    # Add new repository and install
+    curl -1sLf 'https://artifacts-cli.infisical.com/setup.rpm.sh' | sudo -E bash
+    sudo yum install -y infisical
+    ```
+  </Tab>
+  <Tab title="Alpine (apk)">
+    Run as root:
+    ```bash
+    # Remove old Cloudsmith source
+    sed -i '/cloudsmith.*infisical/d' /etc/apk/repositories
+
+    # Add new repository and install
+    wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sh
+    apk add infisical
+    ```
+  </Tab>
+</Tabs>
+
+## Already on the new host but stuck on an older version?
+
+If you are on RHEL/CentOS/Fedora and your machine won't install the latest release, your repo config may be pointing at an outdated path from an earlier setup. Re-run the setup script to fix it, then refresh:
+
+```bash
+curl -1sLf 'https://artifacts-cli.infisical.com/setup.rpm.sh' | sudo -E bash
+sudo yum clean all && sudo yum makecache && sudo yum install -y infisical
+```
+
+<Note>
+  This version-pinning issue only affects RHEL/CentOS/Fedora (yum/dnf). Debian/Ubuntu and Alpine are not affected.
+</Note>
+
+## Verify the migration
+
+After running the setup script, confirm your package manager is pointing at the new host:
+
+<Tabs>
+  <Tab title="Debian / Ubuntu">
+    ```bash
+    grep -r 'infisical' /etc/apt/sources.list.d/
+    # Should show artifacts-cli.infisical.com, not cloudsmith.io
+    ```
+  </Tab>
+  <Tab title="RHEL / CentOS / Fedora">
+    ```bash
+    grep -r 'infisical' /etc/yum.repos.d/
+    # Should show artifacts-cli.infisical.com, not cloudsmith.io
+    ```
+  </Tab>
+  <Tab title="Alpine">
+    ```bash
+    grep 'infisical' /etc/apk/repositories
+    # Should show artifacts-cli.infisical.com, not cloudsmith.io
+    ```
+  </Tab>
+</Tabs>
+
+Then confirm the CLI installs or updates cleanly:
+
+```bash
+infisical --version
+```
+
+## Full installation instructions
+
+For a clean install from scratch, see the [CLI installation page](/cli/overview).

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -4,7 +4,7 @@ description: "Infisical's CLI is one of the best ways to manage environments and
 ---
 
 <Warning>
-  **Action required for Linux users.** The Infisical CLI Linux package repository has moved from Cloudsmith to `artifacts-cli.infisical.com`. The Cloudsmith repository is shutting down — machines still pointed at the old URL will fail to install or update. See the [migration guide](/cli/cloudsmith-migration) for step-by-step instructions.
+  **Action required for Linux users.** The Infisical CLI Linux package repository has moved from Cloudsmith to `artifacts-cli.infisical.com`. The Cloudsmith repository stops serving on **September 16, 2026**. Machines still pointed at the old URL will fail to install or update. See the [migration guide](/cli/cloudsmith-migration) for step-by-step instructions.
 </Warning>
 
 The Infisical CLI is a powerful command line tool that can be used to retrieve, modify, export and inject secrets into any process or application as environment variables.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -3,6 +3,10 @@ title: 'Install'
 description: "Infisical's CLI is one of the best ways to manage environments and secrets. Install it here"
 ---
 
+<Warning>
+  **Action required for Linux users.** The Infisical CLI Linux package repository has moved from Cloudsmith to `artifacts-cli.infisical.com`. The Cloudsmith repository is shutting down — machines still pointed at the old URL will fail to install or update. See the [migration guide](/cli/cloudsmith-migration) for step-by-step instructions.
+</Warning>
+
 The Infisical CLI is a powerful command line tool that can be used to retrieve, modify, export and inject secrets into any process or application as environment variables.
 You can use it across various environments, whether it's local development, CI/CD, staging, or production.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1043,7 +1043,8 @@
               },
               "cli/scanning-overview",
               "cli/project-config",
-              "cli/faq"
+              "cli/faq",
+              "cli/cloudsmith-migration"
             ]
           }
         ]


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This commit introduces a new document detailing the migration steps for users transitioning from the Cloudsmith package repository to the new Infisical repository. It includes instructions for various package managers (apt, yum/dnf, apk) and highlights the impact of not migrating. Additionally, a warning is added to the CLI installation overview to inform Linux users of the change.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)