### PR TITLE
improvement(signup): lead with full-width SSO buttons (GitHub first)

### DIFF
--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -15,10 +15,7 @@ import {
   CardHeader,
   CardTitle,
   FieldError,
-  Input,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
+  Input
 } from "@app/components/v3";
 import { useServerConfig } from "@app/context";
 import { preserveHubSpotUtk } from "@app/helpers/utmTracking";
@@ -79,6 +76,53 @@ export default function InitialSignupStep({
           </CardAction>
         </CardHeader>
         <CardContent>
+          <div className="flex w-full flex-col gap-2">
+            {shouldDisplaySignupMethod(LoginMethod.GITHUB) && (
+              <Button
+                aria-label="Continue with GitHub"
+                variant="project"
+                size="lg"
+                isFullWidth
+                onClick={() => handleSocialSignup(LoginMethod.GITHUB)}
+              >
+                <FontAwesomeIcon icon={faGithub} className="!size-4" />
+                Continue with GitHub
+              </Button>
+            )}
+            {shouldDisplaySignupMethod(LoginMethod.GOOGLE) && (
+              <Button
+                aria-label={t("signup.continue-with-google")}
+                variant="outline"
+                size="lg"
+                isFullWidth
+                onClick={() => handleSocialSignup(LoginMethod.GOOGLE)}
+              >
+                <FontAwesomeIcon icon={faGoogle} className="!size-4" />
+                {t("signup.continue-with-google")}
+              </Button>
+            )}
+            {shouldDisplaySignupMethod(LoginMethod.GITLAB) && (
+              <Button
+                aria-label="Continue with GitLab"
+                variant="outline"
+                size="lg"
+                isFullWidth
+                onClick={() => handleSocialSignup(LoginMethod.GITLAB)}
+              >
+                <FontAwesomeIcon icon={faGitlab} className="!size-4" />
+                Continue with GitLab
+              </Button>
+            )}
+          </div>
+          {(!config.enabledLoginMethods ||
+            (shouldDisplaySignupMethod(LoginMethod.EMAIL) &&
+              config.enabledLoginMethods.length > 1)) && (
+            <div className="my-4 flex w-full flex-row items-center py-2">
+              <div className="w-full border-t border-mineshaft-400/60" />
+              <span className="mx-2 text-xs text-mineshaft-400">or</span>
+              <div className="w-full border-t border-mineshaft-400/60" />
+            </div>
+          )}
           {shouldDisplaySignupMethod(LoginMethod.EMAIL) && (
             <>
               <div className="w-full">
@@ -98,7 +142,7 @@ export default function InitialSignupStep({
                 <Button
                   type="submit"
                   onClick={handleEmailSignup}
-                  variant="project"
+                  variant="outline"
                   size="lg"
                   isFullWidth
                   isDisabled={isPending}
@@ -109,71 +153,6 @@ export default function InitialSignupStep({
               </div>
             </>
           )}
-          {(!config.enabledLoginMethods ||
-            (shouldDisplaySignupMethod(LoginMethod.EMAIL) &&
-              config.enabledLoginMethods.length > 1)) && (
-            <div className="my-4 flex w-full flex-row items-center py-2">
-              <div className="w-full border-t border-mineshaft-400/60" />
-              <span className="mx-2 text-xs text-mineshaft-400">or</span>
-              <div className="w-full border-t border-mineshaft-400/60" />
-            </div>
-          )}
-          <div className="flex w-full gap-2">
-            {shouldDisplaySignupMethod(LoginMethod.GOOGLE) && (
-              <Tooltip disableHoverableContent>
-                <TooltipTrigger asChild>
-                  <div className="relative w-full">
-                    <Button
-                      aria-label={t("signup.continue-with-google")}
-                      variant="outline"
-                      size="lg"
-                      isFullWidth
-                      onClick={() => handleSocialSignup(LoginMethod.GOOGLE)}
-                    >
-                      <FontAwesomeIcon icon={faGoogle} className="!size-4" />
-                    </Button>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="top">{t("signup.continue-with-google")}</TooltipContent>
-              </Tooltip>
-            )}
-            {shouldDisplaySignupMethod(LoginMethod.GITHUB) && (
-              <Tooltip disableHoverableContent>
-                <TooltipTrigger asChild>
-                  <div className="relative w-full">
-                    <Button
-                      aria-label="Continue with GitHub"
-                      variant="outline"
-                      size="lg"
-                      isFullWidth
-                      onClick={() => handleSocialSignup(LoginMethod.GITHUB)}
-                    >
-                      <FontAwesomeIcon icon={faGithub} className="!size-4" />
-                    </Button>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="top">Continue with GitHub</TooltipContent>
-              </Tooltip>
-            )}
-            {shouldDisplaySignupMethod(LoginMethod.GITLAB) && (
-              <Tooltip disableHoverableContent>
-                <TooltipTrigger asChild>
-                  <div className="relative w-full">
-                    <Button
-                      aria-label="Continue with GitLab"
-                      variant="outline"
-                      size="lg"
-                      isFullWidth
-                      onClick={() => handleSocialSignup(LoginMethod.GITLAB)}
-                    >
-                      <FontAwesomeIcon icon={faGitlab} className="!size-4" />
-                    </Button>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="top">Continue with GitLab</TooltipContent>
-              </Tooltip>
-            )}
-          </div>
           <div className="mt-6 flex flex-row justify-center text-xs text-label">
             <Link to="/login">
               <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -163,43 +163,45 @@ export default function InitialSignupStep({
               </span>
             </Link>
           </div>
-          <a
-            href="https://infisical.com/talk-to-us?utm_source=signup&utm_medium=referral"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-6 flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-project/35 bg-project/5 px-4 py-3 transition-colors hover:border-project/40 hover:bg-project/10"
-          >
-            <span className="min-w-0 flex-1 text-xs text-foreground/75">
-              Have a complex company use case?{" "}
-              <span className="font-medium">
-                Get <span className="text-white/90">Enterprise grade</span> assistance
-              </span>
-            </span>
-            <CircleChevronRightIcon className="size-4.5 opacity-75" />
-          </a>
+          <p className="mt-4 text-center text-xs text-pretty text-label">
+            By signing up, you agree to our{" "}
+            <a
+              href="https://infisical.com/terms/cloud"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
+            >
+              Terms of Service
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://infisical.com/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
+            >
+              Privacy Policy
+            </a>
+            .
+          </p>
         </CardContent>
       </Card>
-      <p className="mt-4 w-full max-w-sm text-center text-xs text-pretty text-label">
-        By signing up, you agree to our{" "}
+      <div className="mt-6 w-full max-w-sm rounded-lg bg-background">
         <a
-          href="https://infisical.com/terms/cloud"
+          href="https://infisical.com/talk-to-us?utm_source=signup&utm_medium=referral"
           target="_blank"
           rel="noopener noreferrer"
-          className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
+          className="flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-project/35 bg-project/10 px-4 py-3 text-foreground transition-colors hover:border-project/40 hover:bg-project/15"
         >
-          Terms of Service
-        </a>{" "}
-        and{" "}
-        <a
-          href="https://infisical.com/privacy"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
-        >
-          Privacy Policy
+          <span className="min-w-0 flex-1 text-xs text-foreground/75">
+            Have a complex company use case?{" "}
+            <span className="font-medium">
+              Get <span className="text-white/90">Enterprise grade</span> assistance
+            </span>
+          </span>
+          <CircleChevronRightIcon className="size-4.5 opacity-75" />
         </a>
-        .
-      </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -163,27 +163,6 @@ export default function InitialSignupStep({
               </span>
             </Link>
           </div>
-          <p className="mt-4 text-center text-xs text-pretty text-label">
-            By signing up, you agree to our{" "}
-            <a
-              href="https://infisical.com/terms/cloud"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
-            >
-              Terms of Service
-            </a>{" "}
-            and{" "}
-            <a
-              href="https://infisical.com/privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
-            >
-              Privacy Policy
-            </a>
-            .
-          </p>
           <a
             href="https://infisical.com/talk-to-us?utm_source=signup&utm_medium=referral"
             target="_blank"
@@ -200,6 +179,27 @@ export default function InitialSignupStep({
           </a>
         </CardContent>
       </Card>
+      <p className="mt-4 w-full max-w-sm text-center text-xs text-pretty text-label">
+        By signing up, you agree to our{" "}
+        <a
+          href="https://infisical.com/terms/cloud"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
+        >
+          Terms of Service
+        </a>{" "}
+        and{" "}
+        <a
+          href="https://infisical.com/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cursor-pointer underline underline-offset-2 duration-200 hover:text-foreground hover:decoration-project/45"
+        >
+          Privacy Policy
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -42,6 +42,11 @@ export default function InitialSignupStep({
   const shouldDisplaySignupMethod = (method: LoginMethod) =>
     !config.enabledLoginMethods || config.enabledLoginMethods.includes(method);
 
+  const hasSsoSignupMethod =
+    shouldDisplaySignupMethod(LoginMethod.GITHUB) ||
+    shouldDisplaySignupMethod(LoginMethod.GOOGLE) ||
+    shouldDisplaySignupMethod(LoginMethod.GITLAB);
+
   const handleEmailSignup = async () => {
     const isValid = z.string().email().safeParse(email);
 
@@ -114,9 +119,7 @@ export default function InitialSignupStep({
               </Button>
             )}
           </div>
-          {(!config.enabledLoginMethods ||
-            (shouldDisplaySignupMethod(LoginMethod.EMAIL) &&
-              config.enabledLoginMethods.length > 1)) && (
+          {hasSsoSignupMethod && shouldDisplaySignupMethod(LoginMethod.EMAIL) && (
             <div className="my-4 flex w-full flex-row items-center py-2">
               <div className="w-full border-t border-mineshaft-400/60" />
               <span className="mx-2 text-xs text-mineshaft-400">or</span>


### PR DESCRIPTION
## Context

This PR updates the sign-up page to prioritize/emphasize full SSO buttons with minor revisions

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-06-16 at 16 42 01@2x" src="https://github.com/user-attachments/assets/a245fcc7-0960-479b-a3fd-54f83fe668d1" />

## Steps to verify the change

- navigate to sign-up page 🎉  


## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)