### PR TITLE
feat(pki): use org ID as ExternalID for cert manager AWS connections

### DIFF
--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -487,9 +487,9 @@ export const appConnectionServiceFactory = ({
       scope: OrganizationActionScope.Any
     });
 
-    if (projectId) {
-      const project = await projectDAL.findProjectById(projectId);
+    const project = projectId ? await projectDAL.findProjectById(projectId) : null;
 
+    if (projectId) {
       if (!project) throw new BadRequestError({ message: `Could not find project with ID ${projectId}` });
 
       const { permission } = await permissionService.getProjectPermission({
@@ -571,7 +571,8 @@ export const appConnectionServiceFactory = ({
         orgId: actor.orgId,
         projectId,
         version: 2,
-        gatewayId: validationGatewayId
+        gatewayId: validationGatewayId,
+        projectType: project?.type
       } as TAppConnectionConfig,
       gatewayService,
       gatewayV2Service,
@@ -850,6 +851,10 @@ export const appConnectionServiceFactory = ({
           } Connection with method ${getAppConnectionMethodName(method)}`
         });
 
+      const updateProject = appConnection.projectId
+        ? await projectDAL.findProjectById(appConnection.projectId)
+        : null;
+
       updatedCredentials = await validateAppConnectionCredentials(
         {
           app,
@@ -858,7 +863,8 @@ export const appConnectionServiceFactory = ({
           version: appConnection.version,
           credentials: credentialsToValidate,
           method,
-          gatewayId: validationGatewayId
+          gatewayId: validationGatewayId,
+          projectType: updateProject?.type
         } as TAppConnectionConfig,
         gatewayService,
         gatewayV2Service,
@@ -1151,9 +1157,13 @@ export const appConnectionServiceFactory = ({
         } Connection with ID ${connectionId} cannot be used to connect to ${APP_CONNECTION_NAME_MAP[app]}`
       });
 
+    const connectionProject = appConnection.projectId
+      ? await projectDAL.findProjectById(appConnection.projectId)
+      : null;
+
     const connection = await decryptAppConnection(appConnection, kmsService);
 
-    return connection as T;
+    return { ...connection, projectType: connectionProject?.type } as T;
   };
 
   const validateAppConnectionUsageById = async (

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -851,9 +851,7 @@ export const appConnectionServiceFactory = ({
           } Connection with method ${getAppConnectionMethodName(method)}`
         });
 
-      const updateProject = appConnection.projectId
-        ? await projectDAL.findProjectById(appConnection.projectId)
-        : null;
+      const updateProject = appConnection.projectId ? await projectDAL.findProjectById(appConnection.projectId) : null;
 
       updatedCredentials = await validateAppConnectionCredentials(
         {
@@ -1163,7 +1161,7 @@ export const appConnectionServiceFactory = ({
 
     const connection = await decryptAppConnection(appConnection, kmsService);
 
-    return { ...connection, projectType: connectionProject?.type } as T;
+    return { ...connection, projectType: connectionProject?.type } as unknown as T;
   };
 
   const validateAppConnectionUsageById = async (

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -135,7 +135,7 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
           logger.info(`AssumeRole with ExternalId failed, trying next candidate [roleArn=${credentials.roleArn}]`);
         }
       }
-      if (lastErr) throw lastErr;
+      if (lastErr) throw lastErr as Error;
 
       if (!assumeRes?.Credentials?.AccessKeyId || !assumeRes?.Credentials?.SecretAccessKey) {
         throw new BadRequestError({ message: "Failed to assume role - verify credentials and role configuration" });

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -102,22 +102,45 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
       });
 
       // v1 (legacy) always used orgId; v2+ uses projectId when available, orgId otherwise.
-      // Certificate Manager projects don't expose "project" to users, so always use orgId.
-      let externalId = orgId;
-      if ((version ?? 1) >= 2 && projectType !== ProjectType.CertificateManager) {
-        externalId = projectId ?? orgId;
+      // Certificate Manager projects try projectId first for backwards compatibility,
+      // then fall back to orgId (the recommended ExternalID for cert manager going forward).
+      const externalIds: string[] = [];
+      if ((version ?? 1) >= 2) {
+        if (projectType === ProjectType.CertificateManager) {
+          if (projectId) externalIds.push(projectId);
+          externalIds.push(orgId);
+        } else {
+          externalIds.push(projectId ?? orgId);
+        }
+      } else {
+        externalIds.push(orgId);
       }
 
-      const command = new AssumeRoleCommand({
-        RoleArn: credentials.roleArn,
-        RoleSessionName: `infisical-app-connection-${crypto.nativeCrypto.randomUUID()}`,
-        DurationSeconds: 900, // 15 mins
-        ExternalId: externalId
-      });
+      let assumeRes;
+      for (const externalId of externalIds) {
+        const command = new AssumeRoleCommand({
+          RoleArn: credentials.roleArn,
+          RoleSessionName: `infisical-app-connection-${crypto.nativeCrypto.randomUUID()}`,
+          DurationSeconds: 900, // 15 mins
+          ExternalId: externalId
+        });
 
-      const assumeRes = await client.send(command);
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          assumeRes = await client.send(command);
+          break;
+        } catch (err) {
+          if (externalId !== externalIds[externalIds.length - 1]) {
+            logger.info(
+              `AssumeRole with ExternalId failed, trying next candidate [roleArn=${credentials.roleArn}]`
+            );
+            continue;
+          }
+          throw err;
+        }
+      }
 
-      if (!assumeRes.Credentials?.AccessKeyId || !assumeRes.Credentials?.SecretAccessKey) {
+      if (!assumeRes?.Credentials?.AccessKeyId || !assumeRes?.Credentials?.SecretAccessKey) {
         throw new BadRequestError({ message: "Failed to assume role - verify credentials and role configuration" });
       }
 

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -2,12 +2,12 @@ import { AssumeRoleCommand, GetCallerIdentityCommand, STSClient, STSServiceExcep
 import { AxiosError } from "axios";
 import { z } from "zod";
 
+import { ProjectType } from "@app/db/schemas";
 import { CustomAWSHasher } from "@app/lib/aws/hashing";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
-import { ProjectType } from "@app/db/schemas";
 import { AppConnection, AWSRegion } from "@app/services/app-connection/app-connection-enums";
 import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { TAppConnectionRaw } from "@app/services/app-connection/app-connection-types";
@@ -103,10 +103,10 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
 
       // v1 (legacy) always used orgId; v2+ uses projectId when available, orgId otherwise.
       // Certificate Manager projects don't expose "project" to users, so always use orgId.
-      const externalId =
-        (version ?? 1) >= 2
-          ? (projectType === ProjectType.CertificateManager ? orgId : (projectId ?? orgId))
-          : orgId;
+      let externalId = orgId;
+      if ((version ?? 1) >= 2 && projectType !== ProjectType.CertificateManager) {
+        externalId = projectId ?? orgId;
+      }
 
       const command = new AssumeRoleCommand({
         RoleArn: credentials.roleArn,

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -7,6 +7,7 @@ import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { ProjectType } from "@app/db/schemas";
 import { AppConnection, AWSRegion } from "@app/services/app-connection/app-connection-enums";
 import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { TAppConnectionRaw } from "@app/services/app-connection/app-connection-types";
@@ -75,7 +76,7 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
   let secretAccessKey: string;
   let sessionToken: undefined | string;
 
-  const { method, credentials, orgId, projectId, version } = appConnection;
+  const { method, credentials, orgId, projectId, version, projectType } = appConnection;
 
   switch (method) {
     case AwsConnectionMethod.AssumeRole: {
@@ -101,7 +102,11 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
       });
 
       // v1 (legacy) always used orgId; v2+ uses projectId when available, orgId otherwise.
-      const externalId = (version ?? 1) >= 2 ? (projectId ?? orgId) : orgId;
+      // Certificate Manager projects don't expose "project" to users, so always use orgId.
+      const externalId =
+        (version ?? 1) >= 2
+          ? (projectType === ProjectType.CertificateManager ? orgId : (projectId ?? orgId))
+          : orgId;
 
       const command = new AssumeRoleCommand({
         RoleArn: credentials.roleArn,
@@ -142,7 +147,7 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
 };
 
 export const buildAwsConnectionConfig = (
-  connection: Pick<TAppConnectionRaw, "orgId" | "projectId" | "version" | "method">,
+  connection: Pick<TAppConnectionRaw, "orgId" | "projectId" | "version" | "method"> & { projectType?: string },
   credentials: TAwsConnectionConfig["credentials"]
 ): TAwsConnectionConfig =>
   ({
@@ -151,7 +156,8 @@ export const buildAwsConnectionConfig = (
     credentials,
     orgId: connection.orgId,
     projectId: connection.projectId,
-    version: connection.version
+    version: connection.version,
+    projectType: connection.projectType
   }) as TAwsConnectionConfig;
 
 export const validateAwsConnectionCredentials = async (appConnection: TAwsConnectionConfig) => {

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -117,28 +117,25 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
       }
 
       let assumeRes;
+      let lastErr: unknown;
       for (const externalId of externalIds) {
-        const command = new AssumeRoleCommand({
-          RoleArn: credentials.roleArn,
-          RoleSessionName: `infisical-app-connection-${crypto.nativeCrypto.randomUUID()}`,
-          DurationSeconds: 900, // 15 mins
-          ExternalId: externalId
-        });
-
         try {
+          const command = new AssumeRoleCommand({
+            RoleArn: credentials.roleArn,
+            RoleSessionName: `infisical-app-connection-${crypto.nativeCrypto.randomUUID()}`,
+            DurationSeconds: 900, // 15 mins
+            ExternalId: externalId
+          });
           // eslint-disable-next-line no-await-in-loop
           assumeRes = await client.send(command);
+          lastErr = undefined;
           break;
         } catch (err) {
-          if (externalId !== externalIds[externalIds.length - 1]) {
-            logger.info(
-              `AssumeRole with ExternalId failed, trying next candidate [roleArn=${credentials.roleArn}]`
-            );
-            continue;
-          }
-          throw err;
+          lastErr = err;
+          logger.info(`AssumeRole with ExternalId failed, trying next candidate [roleArn=${credentials.roleArn}]`);
         }
       }
+      if (lastErr) throw lastErr;
 
       if (!assumeRes?.Credentials?.AccessKeyId || !assumeRes?.Credentials?.SecretAccessKey) {
         throw new BadRequestError({ message: "Failed to assume role - verify credentials and role configuration" });

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -102,13 +102,13 @@ export const getAwsConnectionConfig = async (appConnection: TAwsConnectionConfig
       });
 
       // v1 (legacy) always used orgId; v2+ uses projectId when available, orgId otherwise.
-      // Certificate Manager projects try projectId first for backwards compatibility,
-      // then fall back to orgId (the recommended ExternalID for cert manager going forward).
+      // Certificate Manager connections try orgId first (the recommended ExternalID),
+      // then fall back to projectId for backwards compatibility with existing trust policies.
       const externalIds: string[] = [];
       if ((version ?? 1) >= 2) {
         if (projectType === ProjectType.CertificateManager) {
-          if (projectId) externalIds.push(projectId);
           externalIds.push(orgId);
+          if (projectId && projectId !== orgId) externalIds.push(projectId);
         } else {
           externalIds.push(projectId ?? orgId);
         }

--- a/backend/src/services/app-connection/aws/aws-connection-types.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-types.ts
@@ -21,4 +21,5 @@ export type TAwsConnectionConfig = DiscriminativePick<TAwsConnectionInput, "meth
   orgId: string;
   projectId?: string | null;
   version?: number;
+  projectType?: string;
 };

--- a/backend/src/services/pki-sync/pki-sync-queue.ts
+++ b/backend/src/services/pki-sync/pki-sync-queue.ts
@@ -435,6 +435,8 @@ export const pkiSyncQueueFactory = ({
         throw new Error(`App connection not found: ${connectionId}`);
       }
 
+      const project = appConnectionProjectId ? await projectDAL.findById(appConnectionProjectId) : null;
+
       const credentials = await decryptAppConnectionCredentials({
         orgId,
         encryptedCredentials: appConnection.encryptedCredentials,
@@ -446,7 +448,8 @@ export const pkiSyncQueueFactory = ({
         ...pkiSync,
         connection: {
           ...pkiSync.connection,
-          credentials
+          credentials,
+          projectType: project?.type
         }
       } as TPkiSyncWithCredentials;
 
@@ -739,6 +742,8 @@ export const pkiSyncQueueFactory = ({
         throw new Error(`App connection not found: ${connectionId}`);
       }
 
+      const removeProject = appConnectionProjectId ? await projectDAL.findById(appConnectionProjectId) : null;
+
       const credentials = await decryptAppConnectionCredentials({
         orgId,
         encryptedCredentials: appConnection.encryptedCredentials,
@@ -753,7 +758,8 @@ export const pkiSyncQueueFactory = ({
           ...pkiSync,
           connection: {
             ...pkiSync.connection,
-            credentials
+            credentials,
+            projectType: removeProject?.type
           }
         } as TPkiSyncWithCredentials,
         Object.keys(certificateMap),

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
@@ -20,7 +20,7 @@ Push certificates from your Application to AWS Certificate Manager (ACM). Certif
   - `acm:ListTagsForCertificate`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is created within Certificate Manager, use your **Organization ID** as the External ID in your AWS IAM role trust policy. You can find the Organization ID in your organization settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
@@ -20,7 +20,7 @@ Push certificates from your Application to AWS Certificate Manager (ACM). Certif
   - `acm:ListTagsForCertificate`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
@@ -19,6 +19,10 @@ Push certificates from your Application to AWS Certificate Manager (ACM). Certif
   - `acm:DeleteCertificate`
   - `acm:ListTagsForCertificate`
 
+<Tip>
+  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+</Tip>
+
 <Note>
   Certificates synced to ACM are stored as imported certificates, preserving both the certificate and private key.
 </Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-certificate-manager.mdx
@@ -20,7 +20,7 @@ Push certificates from your Application to AWS Certificate Manager (ACM). Certif
   - `acm:ListTagsForCertificate`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
@@ -17,7 +17,7 @@ Deploy certificates directly to your AWS Application Load Balancers (ALBs) and N
   - **ELB:** `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeListeners`, `elasticloadbalancing:DescribeListenerCertificates`, `elasticloadbalancing:AddListenerCertificates`, `elasticloadbalancing:RemoveListenerCertificates`, `elasticloadbalancing:ModifyListener`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 ## Create an ELB Sync

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
@@ -17,7 +17,7 @@ Deploy certificates directly to your AWS Application Load Balancers (ALBs) and N
   - **ELB:** `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeListeners`, `elasticloadbalancing:DescribeListenerCertificates`, `elasticloadbalancing:AddListenerCertificates`, `elasticloadbalancing:RemoveListenerCertificates`, `elasticloadbalancing:ModifyListener`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is created within Certificate Manager, use your **Organization ID** as the External ID in your AWS IAM role trust policy. You can find the Organization ID in your organization settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 ## Create an ELB Sync

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
@@ -16,6 +16,10 @@ Deploy certificates directly to your AWS Application Load Balancers (ALBs) and N
   - **ACM:** `acm:ListCertificates`, `acm:DescribeCertificate`, `acm:ImportCertificate`, `acm:DeleteCertificate`, `acm:ListTagsForCertificate`
   - **ELB:** `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeListeners`, `elasticloadbalancing:DescribeListenerCertificates`, `elasticloadbalancing:AddListenerCertificates`, `elasticloadbalancing:RemoveListenerCertificates`, `elasticloadbalancing:ModifyListener`
 
+<Tip>
+  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+</Tip>
+
 ## Create an ELB Sync
 
 <Tabs>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-elastic-load-balancer.mdx
@@ -17,7 +17,7 @@ Deploy certificates directly to your AWS Application Load Balancers (ALBs) and N
   - **ELB:** `elasticloadbalancing:DescribeLoadBalancers`, `elasticloadbalancing:DescribeListeners`, `elasticloadbalancing:DescribeListenerCertificates`, `elasticloadbalancing:AddListenerCertificates`, `elasticloadbalancing:RemoveListenerCertificates`, `elasticloadbalancing:ModifyListener`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 ## Create an ELB Sync

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
@@ -20,7 +20,7 @@ Store certificates in AWS Secrets Manager as JSON secrets for application retrie
   - `secretsmanager:ListSecrets`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
@@ -20,7 +20,7 @@ Store certificates in AWS Secrets Manager as JSON secrets for application retrie
   - `secretsmanager:ListSecrets`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can find the Project ID in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
@@ -20,7 +20,7 @@ Store certificates in AWS Secrets Manager as JSON secrets for application retrie
   - `secretsmanager:ListSecrets`
 
 <Tip>
-  If your AWS Connection uses the **Assume Role** method and is scoped to the project your Application belongs to, use the **Project ID** as the External ID in your AWS IAM role trust policy. You can copy the Project ID from the **Settings** page of your Certificate Manager project. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
+  If your AWS Connection uses the **Assume Role** method and is created within Certificate Manager, use your **Organization ID** as the External ID in your AWS IAM role trust policy. You can find the Organization ID in your organization settings. See the [AWS Connection docs](/integrations/app-connections/aws) for more details.
 </Tip>
 
 <Note>

--- a/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-syncs/aws-secrets-manager.mdx
@@ -19,6 +19,10 @@ Store certificates in AWS Secrets Manager as JSON secrets for application retrie
   - `secretsmanager:DeleteSecret`
   - `secretsmanager:ListSecrets`
 
+<Tip>
+  If your AWS Connection uses the **Assume Role** method, the External ID for connections created within a Certificate Manager Application is the **Project ID** of the project the Application belongs to. You can find this in your project settings. See the [AWS Connection docs](/integrations/app-connections/aws) for details on configuring the External ID in your IAM role trust policy.
+</Tip>
+
 <Note>
   Certificates are stored as JSON secrets with configurable field names for certificate, private key, and chain.
 </Note>

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -71,7 +71,7 @@ Infisical supports two methods for connecting to AWS.
                     This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
                     Infisical automatically sends the correct External ID based on the connection’s scope:
-                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project.
+                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. This includes connections created within **Certificate Manager Applications**, which are project-scoped -- use the Application’s Project ID.
                     - **Organization-scoped connections** use the **Organization ID** as the External ID.
 
                     <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -71,7 +71,7 @@ Infisical supports two methods for connecting to AWS.
                     This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
                     Infisical automatically sends the correct External ID based on the connection’s scope:
-                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. **Certificate Manager** connections use the **Organization ID** as the External ID instead, since Certificate Manager does not expose project-level scoping.
+                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. **Certificate Manager** connections use the **Organization ID** as the External ID.
                     - **Organization-scoped connections** use the **Organization ID** as the External ID.
 
                     <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -71,7 +71,7 @@ Infisical supports two methods for connecting to AWS.
                     This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
                     Infisical automatically sends the correct External ID based on the connection’s scope:
-                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. This includes connections created within **Certificate Manager Applications**, which are project-scoped -- use the Application’s Project ID.
+                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. This includes connections used by **Certificate Manager Applications** -- use the Project ID of the project containing the Application.
                     - **Organization-scoped connections** use the **Organization ID** as the External ID.
 
                     <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>

--- a/docs/integrations/app-connections/aws.mdx
+++ b/docs/integrations/app-connections/aws.mdx
@@ -71,7 +71,7 @@ Infisical supports two methods for connecting to AWS.
                     This precaution helps protect your AWS account against the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), a potential security vulnerability where Infisical could be tricked into performing actions on your behalf by an unauthorized actor.
 
                     Infisical automatically sends the correct External ID based on the connection’s scope:
-                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. This includes connections used by **Certificate Manager Applications** -- use the Project ID of the project containing the Application.
+                    - **Project-scoped connections** use the **Project ID** as the External ID, restricting role access to a single project. **Certificate Manager** connections use the **Organization ID** as the External ID instead, since Certificate Manager does not expose project-level scoping.
                     - **Organization-scoped connections** use the **Organization ID** as the External ID.
 
                     <strong>Always enable "Require external ID" when setting up the IAM Role, and use the ID that matches your connection’s scope.</strong>

--- a/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
@@ -1,11 +1,9 @@
 import { Helmet } from "react-helmet";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 
-import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
-import { Button } from "@app/components/v3";
-import { ProjectPermissionSub, useProject } from "@app/context";
+import { ProjectPermissionSub } from "@app/context";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -16,7 +14,6 @@ export const SettingsPage = () => {
   const { orgId, projectId } = useParams({ strict: false });
   const search = useSearch({ strict: false }) as { selectedTab?: string };
   const navigate = useNavigate();
-  const { currentProject } = useProject();
   const activeTab = search.selectedTab ?? "app-connections";
 
   return (
@@ -29,21 +26,7 @@ export const SettingsPage = () => {
           scope={ProjectType.CertificateManager}
           title="Settings"
           description="Configure app connections and cleanup rules."
-        >
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={() => {
-              navigator.clipboard.writeText(currentProject?.id || "");
-              createNotification({
-                text: "Copied project ID to clipboard",
-                type: "success"
-              });
-            }}
-          >
-            Copy Project ID
-          </Button>
-        </PageHeader>
+        />
 
         <Tabs
           value={activeTab}

--- a/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/SettingsPage.tsx
@@ -1,9 +1,11 @@
 import { Helmet } from "react-helmet";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 
+import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
-import { ProjectPermissionSub } from "@app/context";
+import { Button } from "@app/components/v3";
+import { ProjectPermissionSub, useProject } from "@app/context";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -14,6 +16,7 @@ export const SettingsPage = () => {
   const { orgId, projectId } = useParams({ strict: false });
   const search = useSearch({ strict: false }) as { selectedTab?: string };
   const navigate = useNavigate();
+  const { currentProject } = useProject();
   const activeTab = search.selectedTab ?? "app-connections";
 
   return (
@@ -26,7 +29,21 @@ export const SettingsPage = () => {
           scope={ProjectType.CertificateManager}
           title="Settings"
           description="Configure app connections and cleanup rules."
-        />
+        >
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={() => {
+              navigator.clipboard.writeText(currentProject?.id || "");
+              createNotification({
+                text: "Copied project ID to clipboard",
+                type: "success"
+              });
+            }}
+          >
+            Copy Project ID
+          </Button>
+        </PageHeader>
 
         <Tabs
           value={activeTab}


### PR DESCRIPTION
## Context

AWS app connections created within Certificate Manager were using the internal Project ID as the ExternalID for Assume Role, but Certificate Manager doesn't expose "projects" to users -- there was no way to discover or copy the Project ID from the UI. Users setting up IAM trust policies had no idea what value to put for ExternalID.

Now, when an app connection belongs to a Certificate Manager project, Infisical sends the Organization ID as the ExternalID instead. Organization ID is already visible and copyable from org settings.

- Added `projectType` to `TAwsConnectionConfig` and `buildAwsConnectionConfig`
- `getAwsConnectionConfig` checks `projectType === CertificateManager` and falls back to `orgId`
- `projectType` is threaded through from `pki-sync-queue.ts` (sync + remove handlers), `app-connection-service.ts` (create, update, connect-by-ID)
- Updated docs on AWS cert sync pages (ACM, ELB, Secrets Manager) and the AWS connection page

Access Key connections are unaffected (no ExternalID involved).

## Screenshots

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)