### PR TITLE
fix(secrets): remove personal overrides when moving secrets

### DIFF
--- a/backend/e2e-test/routes/v4/secret-move.spec.ts
+++ b/backend/e2e-test/routes/v4/secret-move.spec.ts
@@ -1,0 +1,97 @@
+import { SecretType } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+import { createFolder, deleteFolder } from "../../testUtils/folders";
+
+const createRawSecret = async (dto: { path: string; key: string; value: string; type?: SecretType }) => {
+  const res = await testServer.inject({
+    method: "POST",
+    url: `/api/v3/secrets/raw/${dto.key}`,
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    },
+    body: {
+      workspaceId: seedData1.projectV3.id,
+      environment: seedData1.environment.slug,
+      type: dto.type || SecretType.Shared,
+      secretPath: dto.path,
+      secretValue: dto.value
+    }
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json().secret as { id: string; secretKey: string };
+};
+
+// counts every secrets_v2 row (shared + personal overrides) for a given key in a folder
+const countSecretRows = async (folderId: string, key: string): Promise<number> => {
+  // @ts-expect-error testDb is injected as a global by the knex test environment
+  const rows = await globalThis.testDb("secrets_v2").where({ folderId, key });
+  return rows.length;
+};
+
+describe("Move secrets with personal overrides", async () => {
+  let destFolderId = "";
+  const destPath = "/move-personal-override-dest";
+
+  beforeAll(async () => {
+    const folder = await createFolder({
+      workspaceId: seedData1.projectV3.id,
+      environmentSlug: seedData1.environment.slug,
+      secretPath: "/",
+      name: "move-personal-override-dest",
+      authToken: jwtAuthToken
+    });
+    destFolderId = folder.id;
+  });
+
+  afterAll(async () => {
+    await deleteFolder({
+      workspaceId: seedData1.projectV3.id,
+      environmentSlug: seedData1.environment.slug,
+      secretPath: "/",
+      id: destFolderId,
+      authToken: jwtAuthToken
+    });
+  });
+
+  test("removes the personal override from the source folder after moving the shared secret", async () => {
+    const key = "MOVE_OVERRIDE_SEC";
+
+    await createRawSecret({ path: "/", key, value: "shared-value" });
+    await createRawSecret({ path: "/", key, value: "personal-value", type: SecretType.Personal });
+
+    // @ts-expect-error testDb is injected as a global by the knex test environment
+    const sharedRow = await globalThis
+      .testDb("secrets_v2")
+      .where({ key, type: SecretType.Shared })
+      .whereNull("userId")
+      .first();
+
+    const sourceFolderId = sharedRow.folderId as string;
+
+    // the source folder holds both the shared secret and the personal override
+    expect(await countSecretRows(sourceFolderId, key)).toBe(2);
+
+    const moveRes = await testServer.inject({
+      method: "POST",
+      url: `/api/v4/secrets/move`,
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      },
+      body: {
+        projectId: seedData1.projectV3.id,
+        sourceEnvironment: seedData1.environment.slug,
+        sourceSecretPath: "/",
+        destinationEnvironment: seedData1.environment.slug,
+        destinationSecretPath: destPath,
+        secretIds: [sharedRow.id]
+      }
+    });
+    expect(moveRes.statusCode).toBe(200);
+
+    // the source folder must retain neither the shared secret nor its orphaned personal override
+    expect(await countSecretRows(sourceFolderId, key)).toBe(0);
+    // the shared secret should now live in the destination folder
+    expect(await countSecretRows(destFolderId, key)).toBe(1);
+  });
+});

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -3410,6 +3410,21 @@ export const secretV2BridgeServiceFactory = ({
           tx
         );
 
+        // personal overrides are stored as separate rows keyed by (folderId, key, userId) with no
+        // foreign key back to their shared secret, so deleting the shared secrets above leaves them
+        // orphaned in the source folder. Remove them explicitly to mirror the shared -> personal
+        // cleanup that secretDAL.deleteMany performs for a regular secret deletion.
+        await secretDAL.delete(
+          {
+            $in: {
+              key: decryptedSourceSecrets.map(({ key }) => key)
+            },
+            type: SecretType.Personal,
+            folderId: sourceFolder.id
+          },
+          tx
+        );
+
         isSourceUpdated = true;
       }
 


### PR DESCRIPTION
## Context

`moveSecrets` (`backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts`) moves secrets between folders as a create-at-destination + delete-at-source operation. The source delete only removed the **shared** secret rows (by id), leaving **personal overrides** behind.

Personal overrides are stored as separate `secrets_v2` rows keyed by `(folderId, key, userId)` with no foreign key back to their shared secret, so deleting the shared rows orphaned them in the source folder — each override then referenced a shared secret that no longer existed there, causing inconsistent secret counts and stale data.

This was already handled everywhere else:
- Regular secret deletion removes personal overrides via `secretDAL.deleteMany` (it explicitly deletes personal rows when a shared key is deleted).
- The move path that goes through a secret approval policy also relies on that helper (`fnSecretBulkDelete` → `deleteMany`).

Only the direct-delete branch of `moveSecrets` bypassed it. This change deletes the matching personal overrides explicitly so all three paths behave consistently.

Fixes #4627

## Steps to verify the change

1. In a project with two environments/folders, create a shared secret `FOO` in the source folder.
2. As a user, set a personal override for `FOO` in that same source folder.
3. Move `FOO` to the destination folder (no approval policy on the source).
4. Before: the personal override row remains orphaned in the source folder. After: it is removed, matching the behavior of a regular delete.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
