### PR TITLE
fix: added serviceconfig scim endpoint, resovled duplicate user error

### DIFF
--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -1,0 +1,425 @@
+/* eslint-disable no-await-in-loop */
+import crypto from "node:crypto";
+
+import jwt from "jsonwebtoken";
+import { Knex } from "knex";
+
+import { AccessScope, TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+import { AuthTokenType } from "@app/services/auth/auth-type";
+
+import { cleanupEmailDomains, seedVerifiedEmailDomain } from "../../testUtils/email-domains";
+
+const ORG_ID = seedData1.organization.id;
+const TEST_DOMAIN = "scim-test.local";
+
+const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
+
+const createScimToken = async (db: Knex, orgId: string): Promise<string> => {
+  const [scimTokenData] = await db(TableName.ScimToken)
+    .insert({
+      orgId,
+      description: "test-scim-token",
+      ttlDays: 365
+    })
+    .returning("*");
+
+  const scimToken = jwt.sign(
+    {
+      scimTokenId: scimTokenData.id,
+      authTokenType: AuthTokenType.SCIM_TOKEN
+    },
+    process.env.AUTH_SECRET ?? "something-random"
+  );
+
+  return scimToken;
+};
+
+describe("SCIM v1 Router", () => {
+  let scimToken: string;
+  const createdUserIds: string[] = [];
+  const createdMembershipIds: string[] = [];
+
+  beforeAll(async () => {
+    const db = getDb();
+
+    // Setup verified email domain
+    await seedVerifiedEmailDomain(ORG_ID, TEST_DOMAIN, db);
+
+    // Setup SAML config to enable orgAuthMethod
+    await db(TableName.SamlConfig)
+      .insert({
+        orgId: ORG_ID,
+        authProvider: "okta-saml",
+        isActive: true,
+        encryptedSamlEntryPoint: Buffer.from("test"),
+        encryptedSamlIssuer: Buffer.from("test"),
+        encryptedSamlCertificate: Buffer.from("test")
+      })
+      .onConflict()
+      .ignore();
+
+    // Enable SCIM on the org
+    await db(TableName.Organization).where({ id: ORG_ID }).update({ scimEnabled: true });
+
+    // Create SCIM token
+    scimToken = await createScimToken(db, ORG_ID);
+  });
+
+  afterAll(async () => {
+    const db = getDb();
+
+    // Cleanup in reverse order of dependencies
+    if (createdUserIds.length > 0) {
+      await db(TableName.UserAliases).whereIn("userId", createdUserIds).del();
+    }
+    if (createdMembershipIds.length > 0) {
+      await db(TableName.MembershipRole).whereIn("membershipId", createdMembershipIds).del();
+      await db(TableName.Membership).whereIn("id", createdMembershipIds).del();
+    }
+    if (createdUserIds.length > 0) {
+      await db(TableName.UserEncryptionKey).whereIn("userId", createdUserIds).del();
+      await db(TableName.Users).whereIn("id", createdUserIds).del();
+    }
+
+    // Cleanup SCIM tokens
+    await db(TableName.ScimToken).where({ orgId: ORG_ID }).del();
+
+    // Disable SCIM and remove SAML config
+    await db(TableName.Organization).where({ id: ORG_ID }).update({ scimEnabled: false });
+    await db(TableName.SamlConfig).where({ orgId: ORG_ID }).del();
+    await cleanupEmailDomains(ORG_ID, db);
+  });
+
+  describe("GET /Users - Duplicate alias handling", () => {
+    test("should return unique users even when multiple aliases exist for the same user", async () => {
+      const db = getDb();
+
+      // Create test users with multiple duplicate aliases
+      const testUsers = [];
+      for (let i = 0; i < 3; i += 1) {
+        const [user] = await db(TableName.Users)
+          .insert({
+            email: `scim-test-${i}@${TEST_DOMAIN}`,
+            username: `scim-test-${i}@${TEST_DOMAIN}`,
+            isGhost: false,
+            isEmailVerified: true,
+            authMethods: ["email"]
+          })
+          .returning("*");
+        createdUserIds.push(user.id);
+
+        // Create org membership
+        const [membership] = await db(TableName.Membership)
+          .insert({
+            actorUserId: user.id,
+            scopeOrgId: ORG_ID,
+            scope: AccessScope.Organization,
+            isActive: true
+          })
+          .returning("*");
+        createdMembershipIds.push(membership.id);
+
+        // Create membership role
+        await db(TableName.MembershipRole).insert({
+          membershipId: membership.id,
+          role: "member"
+        });
+
+        // Create MULTIPLE duplicate SAML aliases for this user (simulating the bug scenario)
+        for (let j = 0; j < 3; j += 1) {
+          await db(TableName.UserAliases).insert({
+            userId: user.id,
+            orgId: ORG_ID,
+            aliasType: "saml",
+            externalId: `saml-ext-${i}-${j}-${crypto.randomUUID().slice(0, 8)}`
+          });
+        }
+
+        testUsers.push({ user, membership });
+      }
+
+      // Call GET /Users
+      const res = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(res.statusCode).toBe(200);
+      const payload = JSON.parse(res.payload);
+
+      // Extract the IDs of our test users from the response
+      const returnedIds = payload.Resources.map((r: { id: string }) => r.id);
+      const testMembershipIds = testUsers.map((t) => t.membership.id);
+
+      // Count how many times each test user appears
+      const testUserOccurrences = testMembershipIds.map(
+        (id) => returnedIds.filter((returnedId: string) => returnedId === id).length
+      );
+
+      // Each user should appear exactly once (not duplicated due to multiple aliases)
+      testUserOccurrences.forEach((count) => {
+        expect(count).toBe(1);
+      });
+
+      // totalResults should match Resources length (no inflation)
+      expect(payload.totalResults).toBe(payload.Resources.length);
+    });
+
+    test("should use the latest alias externalId for each user", async () => {
+      const db = getDb();
+
+      const [user] = await db(TableName.Users)
+        .insert({
+          email: `scim-latest-alias@${TEST_DOMAIN}`,
+          username: `scim-latest-alias@${TEST_DOMAIN}`,
+          isGhost: false,
+          isEmailVerified: true,
+          authMethods: ["email"]
+        })
+        .returning("*");
+      createdUserIds.push(user.id);
+
+      const [membership] = await db(TableName.Membership)
+        .insert({
+          actorUserId: user.id,
+          scopeOrgId: ORG_ID,
+          scope: AccessScope.Organization,
+          isActive: true
+        })
+        .returning("*");
+      createdMembershipIds.push(membership.id);
+
+      await db(TableName.MembershipRole).insert({
+        membershipId: membership.id,
+        role: "member"
+      });
+
+      // Create aliases with different timestamps - the LATEST one should be used
+      // Insert old one first, then wait a bit and insert new one
+      const oldExternalId = "old-external-id";
+      const latestExternalId = "latest-external-id";
+
+      await db(TableName.UserAliases).insert({
+        userId: user.id,
+        orgId: ORG_ID,
+        aliasType: "saml",
+        externalId: oldExternalId
+      });
+
+      // Small delay to ensure different createdAt timestamps
+      await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+
+      await db(TableName.UserAliases).insert({
+        userId: user.id,
+        orgId: ORG_ID,
+        aliasType: "saml",
+        externalId: latestExternalId
+      });
+
+      const res = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(res.statusCode).toBe(200);
+      const payload = JSON.parse(res.payload);
+
+      const testUser = payload.Resources.find((r: { id: string }) => r.id === membership.id);
+      expect(testUser).toBeDefined();
+      expect(testUser.userName).toBe(latestExternalId);
+    });
+  });
+
+  describe("GET /Users - Auth method alias type selection", () => {
+    test("should use SAML aliases when org has SAML configured", async () => {
+      const db = getDb();
+
+      const [user] = await db(TableName.Users)
+        .insert({
+          email: `scim-saml-type@${TEST_DOMAIN}`,
+          username: `scim-saml-type@${TEST_DOMAIN}`,
+          isGhost: false,
+          isEmailVerified: true,
+          authMethods: ["email"]
+        })
+        .returning("*");
+      createdUserIds.push(user.id);
+
+      const [membership] = await db(TableName.Membership)
+        .insert({
+          actorUserId: user.id,
+          scopeOrgId: ORG_ID,
+          scope: AccessScope.Organization,
+          isActive: true
+        })
+        .returning("*");
+      createdMembershipIds.push(membership.id);
+
+      await db(TableName.MembershipRole).insert({
+        membershipId: membership.id,
+        role: "member"
+      });
+
+      // Create both SAML and OIDC aliases
+      const samlExternalId = "saml-external-id";
+      const oidcExternalId = "oidc-external-id";
+
+      await db(TableName.UserAliases).insert({
+        userId: user.id,
+        orgId: ORG_ID,
+        aliasType: "saml",
+        externalId: samlExternalId
+      });
+
+      await db(TableName.UserAliases).insert({
+        userId: user.id,
+        orgId: ORG_ID,
+        aliasType: "oidc",
+        externalId: oidcExternalId
+      });
+
+      // With SAML configured (from beforeAll), should use SAML alias
+      const res = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(res.statusCode).toBe(200);
+      const payload = JSON.parse(res.payload);
+
+      const testUser = payload.Resources.find((r: { id: string }) => r.id === membership.id);
+      expect(testUser).toBeDefined();
+      expect(testUser.userName).toBe(samlExternalId);
+    });
+
+    test("should use OIDC aliases when org has OIDC configured", async () => {
+      const db = getDb();
+
+      // Switch from SAML to OIDC config
+      await db(TableName.SamlConfig).where({ orgId: ORG_ID }).del();
+      await db(TableName.OidcConfig)
+        .insert({
+          orgId: ORG_ID,
+          isActive: true,
+          configurationType: "discovery_url",
+          encryptedOidcClientId: Buffer.from("test"),
+          encryptedOidcClientSecret: Buffer.from("test"),
+          discoveryURL: "https://example.com/.well-known/openid-configuration"
+        })
+        .onConflict()
+        .ignore();
+
+      try {
+        const [user] = await db(TableName.Users)
+          .insert({
+            email: `scim-oidc-type@${TEST_DOMAIN}`,
+            username: `scim-oidc-type@${TEST_DOMAIN}`,
+            isGhost: false,
+            isEmailVerified: true,
+            authMethods: ["email"]
+          })
+          .returning("*");
+        createdUserIds.push(user.id);
+
+        const [membership] = await db(TableName.Membership)
+          .insert({
+            actorUserId: user.id,
+            scopeOrgId: ORG_ID,
+            scope: AccessScope.Organization,
+            isActive: true
+          })
+          .returning("*");
+        createdMembershipIds.push(membership.id);
+
+        await db(TableName.MembershipRole).insert({
+          membershipId: membership.id,
+          role: "member"
+        });
+
+        // Create both SAML and OIDC aliases
+        const samlExternalId = "saml-external-id-oidc-test";
+        const oidcExternalId = "oidc-external-id-oidc-test";
+
+        await db(TableName.UserAliases).insert({
+          userId: user.id,
+          orgId: ORG_ID,
+          aliasType: "saml",
+          externalId: samlExternalId
+        });
+
+        await db(TableName.UserAliases).insert({
+          userId: user.id,
+          orgId: ORG_ID,
+          aliasType: "oidc",
+          externalId: oidcExternalId
+        });
+
+        // With OIDC configured, should use OIDC alias
+        const res = await testServer.inject({
+          method: "GET",
+          url: "/api/v1/scim/Users",
+          headers: {
+            authorization: `Bearer ${scimToken}`
+          }
+        });
+
+        expect(res.statusCode).toBe(200);
+        const payload = JSON.parse(res.payload);
+
+        const testUser = payload.Resources.find((r: { id: string }) => r.id === membership.id);
+        expect(testUser).toBeDefined();
+        expect(testUser.userName).toBe(oidcExternalId);
+      } finally {
+        // Restore SAML config for other tests
+        await db(TableName.OidcConfig).where({ orgId: ORG_ID }).del();
+        await db(TableName.SamlConfig)
+          .insert({
+            orgId: ORG_ID,
+            authProvider: "okta-saml",
+            isActive: true,
+            encryptedSamlEntryPoint: Buffer.from("test"),
+            encryptedSamlIssuer: Buffer.from("test"),
+            encryptedSamlCertificate: Buffer.from("test")
+          })
+          .onConflict()
+          .ignore();
+      }
+    });
+  });
+
+  describe("GET /ServiceProviderConfig", () => {
+    test("should return valid ServiceProviderConfig per RFC 7643", async () => {
+      const res = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/ServiceProviderConfig",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(res.statusCode).toBe(200);
+      const payload = JSON.parse(res.payload);
+
+      expect(payload.schemas).toContain("urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig");
+      expect(payload.patch.supported).toBe(true);
+      expect(payload.filter.supported).toBe(true);
+      expect(payload.authenticationSchemes).toBeInstanceOf(Array);
+      expect(payload.authenticationSchemes.length).toBeGreaterThan(0);
+
+      // RFC 7643 §5: type should be one of oauth, oauth2, oauthbearertoken, httpbasic, httpdigest
+      const authScheme = payload.authenticationSchemes[0];
+      expect(["oauth", "oauth2", "oauthbearertoken", "httpbasic", "httpdigest"]).toContain(authScheme.type);
+      expect(authScheme.primary).toBe(true);
+    });
+  });
+});

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -397,6 +397,149 @@ describe("SCIM v1 Router", () => {
     });
   });
 
+  describe("GET /Users/:id - Single user lookup consistency", () => {
+    test("should return the same userName as GET /Users list endpoint", async () => {
+      const db = getDb();
+      const uniqueId = crypto.randomUUID().slice(0, 8);
+      const email = `scim-single-${uniqueId}@${TEST_DOMAIN}`;
+      const externalId = `ext-single-${uniqueId}`;
+
+      // Create user via SCIM API
+      const createRes = await testServer.inject({
+        method: "POST",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        },
+        body: {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: externalId,
+          name: {
+            givenName: "Test",
+            familyName: "User"
+          },
+          emails: [{ primary: true, value: email }],
+          active: true
+        }
+      });
+
+      expect(createRes.statusCode).toBe(200);
+      const createdUser = JSON.parse(createRes.payload);
+      const membershipId = createdUser.id;
+
+      // Track for cleanup
+      const [membership] = await db(TableName.Membership).where({ id: membershipId }).select("actorUserId");
+      if (membership?.actorUserId) {
+        createdUserIds.push(membership.actorUserId);
+      }
+      createdMembershipIds.push(membershipId);
+
+      // Get user from list endpoint
+      const listRes = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(listRes.statusCode).toBe(200);
+      const listPayload = JSON.parse(listRes.payload);
+      const userFromList = listPayload.Resources.find((r: { id: string }) => r.id === membershipId);
+      expect(userFromList).toBeDefined();
+
+      // Get same user from single-user endpoint
+      const singleRes = await testServer.inject({
+        method: "GET",
+        url: `/api/v1/scim/Users/${membershipId}`,
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(singleRes.statusCode).toBe(200);
+      const userFromSingle = JSON.parse(singleRes.payload);
+
+      // Both endpoints should return the same userName
+      expect(userFromSingle.userName).toBe(userFromList.userName);
+      expect(userFromSingle.userName).toBe(externalId);
+    });
+
+    test("should return consistent userName even with multiple aliases", async () => {
+      const db = getDb();
+      const uniqueId = crypto.randomUUID().slice(0, 8);
+      const email = `scim-multi-alias-${uniqueId}@${TEST_DOMAIN}`;
+      const externalId = `ext-multi-${uniqueId}`;
+
+      // Create user via SCIM API
+      const createRes = await testServer.inject({
+        method: "POST",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        },
+        body: {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: externalId,
+          name: {
+            givenName: "Multi",
+            familyName: "Alias"
+          },
+          emails: [{ primary: true, value: email }],
+          active: true
+        }
+      });
+
+      expect(createRes.statusCode).toBe(200);
+      const createdUser = JSON.parse(createRes.payload);
+      const membershipId = createdUser.id;
+
+      // Track for cleanup
+      const [membership] = await db(TableName.Membership).where({ id: membershipId }).select("actorUserId");
+      if (membership?.actorUserId) {
+        createdUserIds.push(membership.actorUserId);
+
+        // Add duplicate aliases directly to DB to simulate the bug scenario
+        const latestExternalId = `latest-${uniqueId}`;
+        await db(TableName.UserAliases).insert({
+          userId: membership.actorUserId,
+          orgId: ORG_ID,
+          aliasType: "saml",
+          externalId: latestExternalId
+        });
+      }
+      createdMembershipIds.push(membershipId);
+
+      // Get user from list endpoint
+      const listRes = await testServer.inject({
+        method: "GET",
+        url: "/api/v1/scim/Users",
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(listRes.statusCode).toBe(200);
+      const listPayload = JSON.parse(listRes.payload);
+      const userFromList = listPayload.Resources.find((r: { id: string }) => r.id === membershipId);
+
+      // Get same user from single-user endpoint
+      const singleRes = await testServer.inject({
+        method: "GET",
+        url: `/api/v1/scim/Users/${membershipId}`,
+        headers: {
+          authorization: `Bearer ${scimToken}`
+        }
+      });
+
+      expect(singleRes.statusCode).toBe(200);
+      const userFromSingle = JSON.parse(singleRes.payload);
+
+      // Both endpoints MUST return the same userName - this was the bug
+      expect(userFromSingle.userName).toBe(userFromList.userName);
+    });
+  });
+
   describe("GET /ServiceProviderConfig", () => {
     test("should return valid ServiceProviderConfig per RFC 7643", async () => {
       const res = await testServer.inject({

--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -184,6 +184,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
+    onRequest: verifyAuth([AuthMode.SCIM_TOKEN]),
     schema: {
       response: {
         200: z.object({

--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -176,6 +176,98 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
   });
 
   // SCIM server endpoints
+
+  // ServiceProviderConfig - SCIM 2.0 discovery endpoint (RFC 7643 Section 5)
+  server.route({
+    url: "/ServiceProviderConfig",
+    method: "GET",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      response: {
+        200: z.object({
+          schemas: z.array(z.string()),
+          documentationUri: z.string().optional(),
+          patch: z.object({
+            supported: z.boolean()
+          }),
+          bulk: z.object({
+            supported: z.boolean(),
+            maxOperations: z.number(),
+            maxPayloadSize: z.number()
+          }),
+          filter: z.object({
+            supported: z.boolean(),
+            maxResults: z.number()
+          }),
+          changePassword: z.object({
+            supported: z.boolean()
+          }),
+          sort: z.object({
+            supported: z.boolean()
+          }),
+          etag: z.object({
+            supported: z.boolean()
+          }),
+          authenticationSchemes: z.array(
+            z.object({
+              type: z.string(),
+              name: z.string(),
+              description: z.string(),
+              specUri: z.string().optional(),
+              documentationUri: z.string().optional(),
+              primary: z.boolean().optional()
+            })
+          ),
+          meta: z.object({
+            resourceType: z.string(),
+            location: z.string().optional()
+          })
+        })
+      }
+    },
+    handler: async () => {
+      return {
+        schemas: ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+        documentationUri: "https://infisical.com/docs/documentation/platform/scim/overview",
+        patch: {
+          supported: true
+        },
+        bulk: {
+          supported: false,
+          maxOperations: 0,
+          maxPayloadSize: 0
+        },
+        filter: {
+          supported: true,
+          maxResults: 100
+        },
+        changePassword: {
+          supported: false
+        },
+        sort: {
+          supported: false
+        },
+        etag: {
+          supported: false
+        },
+        authenticationSchemes: [
+          {
+            type: "oauthbearertoken",
+            name: "OAuth Bearer Token",
+            description: "Authentication scheme using a bearer token",
+            specUri: "https://www.rfc-editor.org/rfc/rfc6750",
+            primary: true
+          }
+        ],
+        meta: {
+          resourceType: "ServiceProviderConfig"
+        }
+      };
+    }
+  });
+
   server.route({
     url: "/Users",
     method: "GET",
@@ -304,7 +396,8 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
         orgMembershipId: z.string().trim()
       }),
       body: z.object({
-        schemas: z.array(z.string()),
+        // RFC 7644 §3.4.2: schemas can be inferred from the resource endpoint on PUT; some IdPs (e.g. Authentik) omit it.
+        schemas: z.array(z.string()).default(["urn:ietf:params:scim:schemas:core:2.0:User"]),
         userName: z.string().trim(),
         name: z
           .object({
@@ -507,7 +600,8 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
         groupId: z.string().trim()
       }),
       body: z.object({
-        schemas: z.array(z.string()),
+        // RFC 7644 §3.4.2: schemas can be inferred from the resource endpoint on PUT; some IdPs (e.g. Authentik) omit it.
+        schemas: z.array(z.string()).default(["urn:ietf:params:scim:schemas:core:2.0:Group"]),
         id: z.string().trim(),
         displayName: z.string().trim(),
         members: z.array(

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -300,7 +300,13 @@ export const scimServiceFactory = ({
     filter,
     orgId
   }) => {
-    const org = await requestMemoize(requestMemoKeys.orgFindById(orgId), () => orgDAL.findById(orgId));
+    const org = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
+
+    if (!org)
+      throw new ScimRequestError({
+        detail: "Organization not found",
+        status: 404
+      });
 
     if (!org.scimEnabled)
       throw new ScimRequestError({
@@ -313,7 +319,7 @@ export const scimServiceFactory = ({
       ...(limit && { limit })
     };
 
-    const users = await orgDAL.findMembershipWithScimFilter(orgId, filter, findOpts);
+    const users = await orgDAL.findMembershipWithScimFilter(orgId, filter, org.orgAuthMethod, findOpts);
 
     const scimUsers = users.map(
       ({ id, externalId, username, firstName, lastName, email, isActive, createdAt, updatedAt }) =>

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -352,29 +352,30 @@ export const scimServiceFactory = ({
   };
 
   const getScimUser: TScimServiceFactory["getScimUser"] = async ({ orgMembershipId, orgId }) => {
-    const [membership] = await orgDAL
-      .findMembership({
-        [`${TableName.Membership}.id` as "id"]: orgMembershipId,
-        [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: orgId,
-        [`${TableName.Membership}.scope` as "scope"]: AccessScope.Organization
-      })
-      .catch(() => {
-        throw new ScimRequestError({
-          detail: "User not found",
-          status: 404
-        });
+    const org = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
+
+    if (!org)
+      throw new ScimRequestError({
+        detail: "Organization not found",
+        status: 404
       });
+
+    if (!org.scimEnabled)
+      throw new ScimRequestError({
+        detail: "SCIM is disabled for the organization",
+        status: 403
+      });
+
+    // Use findMembershipWithScimFilter with the membershipId parameter
+    // This ensures we use the same alias-type and latest-alias selection as listScimUsers
+    const [membership] = await orgDAL.findMembershipWithScimFilter(orgId, undefined, org.orgAuthMethod, {
+      membershipId: orgMembershipId
+    });
 
     if (!membership)
       throw new ScimRequestError({
         detail: "User not found",
         status: 404
-      });
-
-    if (!membership.scimEnabled)
-      throw new ScimRequestError({
-        detail: "SCIM is disabled for the organization",
-        status: 403
       });
 
     await scimEventsDAL.create({

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -845,7 +845,7 @@ export const orgDALFactory = (db: TDbClient) => {
   > => {
     try {
       // Determine alias type from org auth method (default to saml for backwards compatibility)
-      const aliasType = orgAuthMethod === "oidc" ? "oidc" : "saml";
+      const aliasType = orgAuthMethod === OrgAuthMethod.OIDC ? OrgAuthMethod.OIDC : OrgAuthMethod.SAML;
 
       // Subquery to get only the latest alias per user for the org's auth method
       const latestAliasSubquery = (tx || db.replicaNode())(TableName.UserAliases)

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -829,9 +829,37 @@ export const orgDALFactory = (db: TDbClient) => {
   const findMembershipWithScimFilter = async (
     orgId: string,
     scimFilter: string | undefined,
+    orgAuthMethod: string | undefined,
     { offset, limit, sort, tx }: TFindOpt<TMemberships> = {}
-  ) => {
+  ): Promise<
+    (TMemberships & {
+      email: string | null;
+      isEmailVerified: boolean | null;
+      username: string;
+      firstName: string | null;
+      lastName: string | null;
+      scimEnabled: boolean | null;
+      defaultMembershipRole: string;
+      externalId: string | null;
+    })[]
+  > => {
     try {
+      // Determine alias type from org auth method (default to saml for backwards compatibility)
+      const aliasType = orgAuthMethod === "oidc" ? "oidc" : "saml";
+
+      // Subquery to get only the latest alias per user for the org's auth method
+      const latestAliasSubquery = (tx || db.replicaNode())(TableName.UserAliases)
+        .select(
+          `${TableName.UserAliases}.userId`,
+          `${TableName.UserAliases}.externalId`,
+          db.raw(
+            `ROW_NUMBER() OVER (PARTITION BY "${TableName.UserAliases}"."userId" ORDER BY "${TableName.UserAliases}"."createdAt" DESC) as rn`
+          )
+        )
+        .where(`${TableName.UserAliases}.orgId`, orgId)
+        .where(`${TableName.UserAliases}.aliasType`, aliasType)
+        .as("latest_alias");
+
       const query = (tx || db.replicaNode())(TableName.Membership)
         // eslint-disable-next-line
         .where(`${TableName.Membership}.scopeOrgId`, orgId)
@@ -844,7 +872,7 @@ export const orgDALFactory = (db: TDbClient) => {
                 case "active":
                   return `${TableName.Membership}.isActive`;
                 case "userName":
-                  return `${TableName.UserAliases}.externalId`;
+                  return "latest_alias.externalId";
                 case "name.givenName":
                   return `${TableName.Users}.firstName`;
                 case "name.familyName":
@@ -860,10 +888,12 @@ export const orgDALFactory = (db: TDbClient) => {
         .join(TableName.Users, `${TableName.Users}.id`, `${TableName.Membership}.actorUserId`)
         .join(TableName.Organization, `${TableName.Organization}.id`, `${TableName.Membership}.scopeOrgId`)
         .whereNull(`${TableName.Organization}.rootOrgId`)
-        .leftJoin(TableName.UserAliases, function joinUserAlias() {
-          this.on(`${TableName.UserAliases}.userId`, "=", `${TableName.Membership}.actorUserId`)
-            .andOn(`${TableName.UserAliases}.orgId`, "=", `${TableName.Membership}.scopeOrgId`)
-            .andOn(`${TableName.UserAliases}.aliasType`, "=", (tx || db).raw("?", ["saml"]));
+        .leftJoin(latestAliasSubquery, function joinLatestAlias() {
+          this.on("latest_alias.userId", "=", `${TableName.Membership}.actorUserId`).andOn(
+            "latest_alias.rn",
+            "=",
+            db.raw("1")
+          );
         })
         .select(
           selectAllTableCols(TableName.Membership),
@@ -874,7 +904,7 @@ export const orgDALFactory = (db: TDbClient) => {
           db.ref("lastName").withSchema(TableName.Users),
           db.ref("scimEnabled").withSchema(TableName.Organization),
           db.ref("defaultMembershipRole").withSchema(TableName.Organization),
-          db.ref("externalId").withSchema(TableName.UserAliases)
+          db.ref("externalId").withSchema("latest_alias")
         )
         .where({ isGhost: false });
 
@@ -884,6 +914,8 @@ export const orgDALFactory = (db: TDbClient) => {
         void query.orderBy(sort.map(([column, order, nulls]) => ({ column: column as string, order, nulls })));
       }
       const res = await query;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return res;
     } catch (error) {
       throw new DatabaseError({ error, name: "Find one" });

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -830,7 +830,7 @@ export const orgDALFactory = (db: TDbClient) => {
     orgId: string,
     scimFilter: string | undefined,
     orgAuthMethod: string | undefined,
-    { offset, limit, sort, tx }: TFindOpt<TMemberships> = {}
+    { offset, limit, sort, tx, membershipId }: TFindOpt<TMemberships> & { membershipId?: string } = {}
   ): Promise<
     (TMemberships & {
       email: string | null;
@@ -866,9 +866,16 @@ export const orgDALFactory = (db: TDbClient) => {
         .where(`${TableName.Membership}.scope`, AccessScope.Organization)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
         .where((qb) => {
+          // Direct membership ID filter (safe, parameterized)
+          if (membershipId) {
+            void qb.where(`${TableName.Membership}.id`, membershipId);
+          }
+          // SCIM filter parsing (for list queries from external IdPs)
           if (scimFilter) {
             void generateKnexQueryFromScim(qb, scimFilter, (attrPath) => {
               switch (attrPath) {
+                case "id":
+                  return `${TableName.Membership}.id`;
                 case "active":
                   return `${TableName.Membership}.isActive`;
                 case "userName":


### PR DESCRIPTION
## Context

This resolves ENG-5114 in which users reported following things
1. Requirement for the ServiceProviderConfig
2. Duplicate user listing with duplicate saml alias or oidc alias. This. is done by filtering user org configured alias method and also by selected latest  alias of the user.
3. Resolved optional field as schemas

## Screenshots



## Steps to verify the change

1. Added test to replicate the scenerio. It should pass
2. Configure saml/oidc and then scim. Then just duplicate the user aliases and this should avoid. This can be duplicate due to external id changing etc. 
3. The scim should continue working. 

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)