### PR TITLE
feat: this ensures only version under v1 can be made to release in github

### DIFF
--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -8,7 +8,7 @@ on:
         required: false
   push:
     tags:
-      - "v*.*.*"
+      - "v0.*.*"
       - "!*nightly*"
 
 jobs:

--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -2,9 +2,9 @@ name: Release standalone docker image
 on:
     push:
         tags:
-            - "v*.*.*"
-            - "v*.*.*-nightly-*"
-            - "v*.*.*-nightly-*.*"
+            - "v0.*.*"
+            - "v0.*.*-nightly-*"
+            - "v0.*.*-nightly-*.*"
 
 jobs:
     infisical-tests:


### PR DESCRIPTION
## Context

This maps the release workflow to only trigger for version that starts with v0.x.x.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)