### PR TITLE
fix(secret-rotation): planet scale authentication

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
@@ -38,6 +38,24 @@ const redactPasswords = (e: unknown, credentials: TSqlCredentialsRotationGenerat
   return redactedMessage;
 };
 
+const validateRotationUsernames = (
+  connectionUsername: string,
+  host: string,
+  rotationUsername1: string,
+  rotationUsername2: string
+) => {
+  const connectionRoleUsername = getRoleUsernameForHost(connectionUsername, host);
+  const rotationRoleUsername1 = getRoleUsernameForHost(rotationUsername1, host);
+  const rotationRoleUsername2 = getRoleUsernameForHost(rotationUsername2, host);
+
+  if (rotationRoleUsername1 === connectionRoleUsername || rotationRoleUsername2 === connectionRoleUsername) {
+    throw new BadRequestError({
+      message:
+        "Rotation username cannot be the same as the connection username. The connection credentials are used to execute rotation operations and changing their password would break the connection."
+    });
+  }
+};
+
 const ORACLE_PASSWORD_REQUIREMENTS = {
   ...DEFAULT_PASSWORD_REQUIREMENTS,
   length: 30
@@ -67,12 +85,7 @@ export const sqlCredentialsRotationFactory: TRotationFactory<
     secretsMapping
   } = secretRotation;
 
-  if (username1 === connection.credentials.username || username2 === connection.credentials.username) {
-    throw new BadRequestError({
-      message:
-        "Rotation username cannot be the same as the connection username. The connection credentials are used to execute rotation operations and changing their password would break the connection."
-    });
-  }
+  validateRotationUsernames(connection.credentials.username, connection.credentials.host, username1, username2);
 
   const defaultPasswordRequirement =
     connection.app === AppConnection.OracleDB ? ORACLE_PASSWORD_REQUIREMENTS : DEFAULT_PASSWORD_REQUIREMENTS;

--- a/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
@@ -129,9 +129,11 @@ export const sqlCredentialsRotationFactory: TRotationFactory<
   };
 
   const $executeQuery = async (tx: Knex, username: string, password: string) => {
+    const filteredUsername = getRoleUsernameForHost(username, connection.credentials.host);
+
     if (userProvidedRotationStatement) {
       const revokeStatement = handlebars.compile(userProvidedRotationStatement)({
-        username,
+        username: filteredUsername,
         password,
         database: connection.credentials.database
       });
@@ -140,7 +142,6 @@ export const sqlCredentialsRotationFactory: TRotationFactory<
         await tx.raw(query);
       }
     } else {
-      const filteredUsername = getRoleUsernameForHost(username, connection.credentials.host);
       await tx.raw(...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[connection.app]({ username: filteredUsername, password }));
     }
   };

--- a/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
@@ -139,7 +139,8 @@ export const sqlCredentialsRotationFactory: TRotationFactory<
         await tx.raw(query);
       }
     } else {
-      await tx.raw(...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[connection.app]({ username, password }));
+      const filteredUsername = username.substring(0, username.indexOf("."));
+      await tx.raw(...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[connection.app]({ username: filteredUsername, password }));
     }
   };
 

--- a/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/shared/sql-credentials/sql-credentials-rotation-fns.ts
@@ -13,6 +13,7 @@ import { BadRequestError } from "@app/lib/errors";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import {
   executeWithPotentialGateway,
+  getRoleUsernameForHost,
   SQL_CONNECTION_ALTER_LOGIN_STATEMENT
 } from "@app/services/app-connection/shared/sql";
 import { generatePasswordWithConstraints } from "@app/services/secret-validation-rule/secret-validation-rule-password-generator";
@@ -139,7 +140,7 @@ export const sqlCredentialsRotationFactory: TRotationFactory<
         await tx.raw(query);
       }
     } else {
-      const filteredUsername = username.substring(0, username.indexOf("."));
+      const filteredUsername = getRoleUsernameForHost(username, connection.credentials.host);
       await tx.raw(...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[connection.app]({ username: filteredUsername, password }));
     }
   };

--- a/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
+++ b/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
@@ -283,8 +283,10 @@ export const transferSqlConnectionCredentialsToPlatform = async (
   try {
     return await executeWithPotentialGateway(config, gatewayService, gatewayV2Service, (client) => {
       return client.transaction(async (tx) => {
+        const filteredUsername = credentials.username.substring(0, credentials.username.indexOf("."));
+
         await tx.raw(
-          ...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[app]({ username: credentials.username, password: newPassword })
+          ...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[app]({ username: filteredUsername, password: newPassword })
         );
         return callback({
           ...credentials,

--- a/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
+++ b/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
@@ -260,6 +260,20 @@ export const validateSqlConnectionCredentials = async (
   }
 };
 
+// PlanetScale requires the connection username in `<user>.<branch>` form so its proxy can route to
+// the correct branch, but the underlying DB role is just `<user>`. Strip the branch suffix for
+// role-level statements (ALTER USER / ALTER LOGIN). Only applies to PlanetScale hosts so that
+// legitimate dotted usernames on other providers are left untouched.
+const PLANETSCALE_HOST_SUFFIX = "psdb.cloud";
+
+export const getRoleUsernameForHost = (username: string, host: string) => {
+  const isPlanetScaleHost = host.toLowerCase().includes(PLANETSCALE_HOST_SUFFIX);
+  if (isPlanetScaleHost && username.includes(".")) {
+    return username.slice(0, username.indexOf("."));
+  }
+  return username;
+};
+
 export const SQL_CONNECTION_ALTER_LOGIN_STATEMENT: Record<
   TSqlCredentialsRotationWithConnection["connection"]["app"],
   (credentials: TSqlCredentialsRotationGeneratedCredentials[number]) => [string, Knex.RawBinding]
@@ -283,7 +297,7 @@ export const transferSqlConnectionCredentialsToPlatform = async (
   try {
     return await executeWithPotentialGateway(config, gatewayService, gatewayV2Service, (client) => {
       return client.transaction(async (tx) => {
-        const filteredUsername = credentials.username.substring(0, credentials.username.indexOf("."));
+        const filteredUsername = getRoleUsernameForHost(credentials.username, credentials.host);
 
         await tx.raw(
           ...SQL_CONNECTION_ALTER_LOGIN_STATEMENT[app]({ username: filteredUsername, password: newPassword })

--- a/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
+++ b/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
@@ -264,10 +264,10 @@ export const validateSqlConnectionCredentials = async (
 // the correct branch, but the underlying DB role is just `<user>`. Strip the branch suffix for
 // role-level statements (ALTER USER / ALTER LOGIN). Only applies to PlanetScale hosts so that
 // legitimate dotted usernames on other providers are left untouched.
-const PLANETSCALE_HOST_SUFFIX = "psdb.cloud";
+const PLANETSCALE_HOST_SUFFIX = ".psdb.cloud";
 
 export const getRoleUsernameForHost = (username: string, host: string) => {
-  const isPlanetScaleHost = host.toLowerCase().includes(PLANETSCALE_HOST_SUFFIX);
+  const isPlanetScaleHost = host.toLowerCase().endsWith(PLANETSCALE_HOST_SUFFIX);
   if (isPlanetScaleHost && username.includes(".")) {
     return username.slice(0, username.indexOf("."));
   }

--- a/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
@@ -59,6 +59,17 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
             - **Database Username 1** - the username of the first user that will be used for rotation.
             - **Database Username 2** - the username of the second user that will be used for rotation.
 
+        <Warning>
+            If your database is hosted on **PlanetScale**, you must include the branch id in the username using the format `username.branch_id`.
+
+            To find your branch id, use the [PlanetScale CLI](https://planetscale.com/docs/reference/planetscale-cli):
+
+            ```bash
+            pscale org switch <org-name>
+            pscale branch show <database> <branch-name> --format json
+            ```
+        </Warning>
+
         ![Rotation Advance Parameters](/images/secret-rotations-v2/postgres-credentials/postgres-credentials-advance-parameters.png)
 
             - **Rotation Statement** - the template string query to generate password for the rotated user.

--- a/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
@@ -60,9 +60,9 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
             - **Database Username 2** - the username of the second user that will be used for rotation.
 
         <Warning>
-            If your database is hosted on **PlanetScale**, you must include the branch id in the username using the format `username.branch_id`.
+            If your database is hosted on **PlanetScale**, you must include the branch ID in the username using the format `username.branch_id`.
 
-            To find your branch id, use the [PlanetScale CLI](https://planetscale.com/docs/reference/planetscale-cli):
+            To find your branch ID, use the [PlanetScale CLI](https://planetscale.com/docs/reference/planetscale-cli):
 
             ```bash
             pscale org switch <org-name>
@@ -72,7 +72,7 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
 
         ![Rotation Advance Parameters](/images/secret-rotations-v2/postgres-credentials/postgres-credentials-advance-parameters.png)
 
-            - **Rotation Statement** - the template string query to generate password for the rotated user.
+            - **Rotation Statement** - the template string query to generate a password for the rotated user.
             - **Password Requirements** - the requirements for the password of the MySQL users that will be created for the rotation.
 
         5. Specify the secret names that the active credentials should be mapped to. Then click **Next**.


### PR DESCRIPTION
## Context
Update the username parsing on alter table so we can also take into account planet scale users. Also updated the docs 

## Screenshots
<img width="562" height="684" alt="image" src="https://github.com/user-attachments/assets/90af0af9-ad83-4677-ab7b-da2ed42623a0" />



## Steps to verify the change
- Create a new postgresql app connection using planetscale (ask me for credentials)
- Create a new secret rotation for postgres
- follow the docs, and add the new users with the planetscale branch id at the end (eg. infisical_user.branch_id)
- check that the rotation is created 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)