### PR TITLE
chore: allow external account google cloud auth

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -1,10 +1,11 @@
-import { gaxios, Impersonated, JWT } from "google-auth-library";
+import { gaxios, Impersonated } from "google-auth-library";
 import { GetAccessTokenResponse } from "google-auth-library/build/src/auth/oauth2client";
 
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { buildGcpSourceCredential } from "@app/services/app-connection/gcp/gcp-connection-fns";
 
 import { DynamicSecretGcpIamSchema, TDynamicProviderFns } from "./models";
 
@@ -22,16 +23,7 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
       });
     }
 
-    const credJson = JSON.parse(appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL) as {
-      client_email: string;
-      private_key: string;
-    };
-
-    const sourceClient = new JWT({
-      email: credJson.client_email,
-      key: credJson.private_key,
-      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
-    });
+    const sourceClient = buildGcpSourceCredential(appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL);
 
     const impersonatedCredentials = new Impersonated({
       sourceClient,

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -794,7 +794,8 @@ export const overwriteSchema: {
     fields: [
       {
         key: "INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL",
-        description: "The GCP Service Account JSON credentials."
+        description:
+          'The GCP credentials JSON used as the impersonation source. Accepts either a service account key (type "service_account") or a workload identity federation config (type "external_account"). For external_account, the referenced credential source (file, URL, or metadata endpoint) must be reachable from the instance.'
       }
     ]
   },

--- a/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
+++ b/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
@@ -1,4 +1,4 @@
-import { gaxios, Impersonated, JWT } from "google-auth-library";
+import { ExternalAccountClient, gaxios, Impersonated, JWT } from "google-auth-library";
 import { GetAccessTokenResponse } from "google-auth-library/build/src/auth/oauth2client";
 
 import { getConfig } from "@app/lib/config/env";
@@ -27,6 +27,38 @@ export const getGcpConnectionListItem = () => {
   };
 };
 
+export const buildGcpSourceCredential = (credentialJson: string) => {
+  const scopes = ["https://www.googleapis.com/auth/cloud-platform"];
+
+  const credJson = JSON.parse(credentialJson) as {
+    type?: string;
+    client_email?: string;
+    private_key?: string;
+  };
+
+  if (credJson.type === "external_account") {
+    const externalClient = ExternalAccountClient.fromJSON({
+      ...credJson,
+      scopes
+    } as Parameters<typeof ExternalAccountClient.fromJSON>[0]);
+
+    if (!externalClient) {
+      throw new InternalServerError({
+        message:
+          "Failed to initialize GCP external account credentials. Verify the workload identity federation configuration."
+      });
+    }
+
+    return externalClient;
+  }
+
+  return new JWT({
+    email: credJson.client_email,
+    key: credJson.private_key,
+    scopes
+  });
+};
+
 export const getGcpConnectionAuthToken = async (appConnection: TGcpConnectionConfig) => {
   const appCfg = getConfig();
   if (!appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL) {
@@ -37,16 +69,7 @@ export const getGcpConnectionAuthToken = async (appConnection: TGcpConnectionCon
     });
   }
 
-  const credJson = JSON.parse(appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL) as {
-    client_email: string;
-    private_key: string;
-  };
-
-  const sourceClient = new JWT({
-    email: credJson.client_email,
-    key: credJson.private_key,
-    scopes: ["https://www.googleapis.com/auth/cloud-platform"]
-  });
+  const sourceClient = buildGcpSourceCredential(appCfg.INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL);
 
   const impersonatedCredentials = new Impersonated({
     sourceClient,

--- a/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
@@ -45,6 +45,18 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
             2. Set it as a string value for the `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` environment variable.
             3. Restart your Infisical instance to apply the changes.
             4. You can now use GCP integration with service account impersonation.
+
+            <Note>
+                Workload identity federation is also supported. Instead of a service account key, you may
+                set `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` to an `external_account` credential
+                configuration JSON (the file produced by `gcloud iam workload-identity-pools create-cred-config`).
+                Infisical detects the credential type from the `type` field automatically.
+
+                Because an `external_account` config does not contain a secret but instead references a
+                credential source (a mounted file, a URL, or a metadata endpoint), that source must be
+                reachable from the Infisical instance at runtime. The federated identity also needs the
+                `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
+            </Note>
         </Step>
     </Steps>
 

--- a/docs/integrations/app-connections/gcp.mdx
+++ b/docs/integrations/app-connections/gcp.mdx
@@ -43,6 +43,18 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
             2. Set it as a string value for the `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` environment variable.
             3. Restart your Infisical instance to apply the changes.
             4. You can now use GCP integration with service account impersonation.
+
+            <Note>
+                Workload identity federation is also supported. Instead of a service account key, you may
+                set `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` to an `external_account` credential
+                configuration JSON (the file produced by `gcloud iam workload-identity-pools create-cred-config`).
+                Infisical detects the credential type from the `type` field automatically.
+
+                Because an `external_account` config does not contain a secret but instead references a
+                credential source (a mounted file, a URL, or a metadata endpoint), that source must be
+                reachable from the Infisical instance at runtime. The federated identity also needs the
+                `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
+            </Note>
         </Step>
     </Steps>
 


### PR DESCRIPTION
## Context

- Allow using external account google cloud auth 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. A target service account (the one to impersonate), e.g. infisical-impersonated@PROJECT.iam.gserviceaccount.com.
  2. A workload identity pool + provider (OIDC is easiest locally).
  3. Grant the federated principal roles/iam.serviceAccountTokenCreator on that service account.
  4. Generate the cred-config JSON:
  gcloud iam workload-identity-pools create-cred-config \
    projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL/providers/PROVIDER \
    --service-account=infisical-impersonated@PROJECT.iam.gserviceaccount.com \
    --credential-source-file=/tmp/oidc-token.txt \
    --output-file=/tmp/gcp-external-account.json
  4. This produces a type: "external_account" JSON whose credential_source is a file (/tmp/oidc-token.txt) that must be readable by the instance at runtime.
  You populate that file with a valid OIDC token for the configured subject/audience.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)