### PR TITLE
feat(pam): add sessions, audit logs, and access control pages

### DIFF
--- a/backend/src/db/migrations/20260603030053_pam-revamp.ts
+++ b/backend/src/db/migrations/20260603030053_pam-revamp.ts
@@ -415,6 +415,18 @@ export async function up(knex: Knex): Promise<void> {
     t.string("selectedHost").nullable();
   });
 
+  // Backfill folderName on existing sessions from account -> folder join
+  await knex(TableName.PamSession)
+    .whereNull("folderName")
+    .whereNotNull("accountId")
+    .update({
+      folderName: knex(TableName.PamAccount)
+        .join(TableName.PamFolder, `${TableName.PamAccount}.folderId`, `${TableName.PamFolder}.id`)
+        .whereRaw(`${TableName.PamAccount}.id = ${TableName.PamSession}."accountId"`)
+        .select(`${TableName.PamFolder}.name`)
+        .first()
+    });
+
   // Re-encrypt session data from old project key to new consolidated project key
   const SESSION_KEY_LENGTH = 32;
   const AAD_LENGTH = 32;

--- a/backend/src/db/migrations/20260603030053_pam-revamp.ts
+++ b/backend/src/db/migrations/20260603030053_pam-revamp.ts
@@ -424,7 +424,7 @@ export async function up(knex: Knex): Promise<void> {
         .join(TableName.PamFolder, `${TableName.PamAccount}.folderId`, `${TableName.PamFolder}.id`)
         .whereRaw(`${TableName.PamAccount}.id = ${TableName.PamSession}."accountId"`)
         .select(`${TableName.PamFolder}.name`)
-        .first()
+        .first() as unknown as string
     });
 
   // Re-encrypt session data from old project key to new consolidated project key

--- a/backend/src/ee/routes/v1/pam-routers/pam-account-template-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-account-template-router.ts
@@ -17,7 +17,6 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 const SanitizedTemplateSchema = PamAccountTemplatesSchema.pick({
   id: true,
-  projectId: true,
   name: true,
   description: true,
   type: true,

--- a/backend/src/ee/routes/v1/pam-routers/pam-folder-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-folder-router.ts
@@ -12,7 +12,6 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 const SanitizedFolderSchema = PamFoldersSchema.pick({
   id: true,
-  projectId: true,
   name: true,
   description: true,
   createdAt: true,

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -139,12 +139,18 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
-      return server.services.pamSession.getSessionLogs(req.params.sessionId, req.query.offset, req.query.limit, {
-        actor: req.permission.type,
-        actorId: req.permission.id,
-        actorOrgId: req.permission.orgId,
-        actorAuthMethod: req.permission.authMethod
-      }) as Promise<TSessionLogsPage>;
+      const result = await server.services.pamSession.getSessionLogs(
+        req.params.sessionId,
+        req.query.offset,
+        req.query.limit,
+        {
+          actor: req.permission.type,
+          actorId: req.permission.id,
+          actorOrgId: req.permission.orgId,
+          actorAuthMethod: req.permission.authMethod
+        }
+      );
+      return result as TSessionLogsPage;
     }
   });
 

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -4,7 +4,7 @@ import z from "zod";
 import { PamSessionsSchema } from "@app/db/schemas";
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { PamAccountType, PamSessionStatus } from "@app/ee/services/pam/pam-enums";
-import { SessionLogsPageSchema } from "@app/ee/services/pam-session/pam-session-log-schemas";
+import { SessionLogsPageSchema, TSessionLogsPage } from "@app/ee/services/pam-session/pam-session-log-schemas";
 import { PamRecordingStorageBackend } from "@app/ee/services/pam-session-recording/pam-recording-enums";
 import { ApiDocsTags } from "@app/lib/api-docs/constants";
 import { BadRequestError } from "@app/lib/errors";
@@ -144,7 +144,7 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
         actorId: req.permission.id,
         actorOrgId: req.permission.orgId,
         actorAuthMethod: req.permission.authMethod
-      });
+      }) as Promise<TSessionLogsPage>;
     }
   });
 

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -3,7 +3,8 @@ import z from "zod";
 
 import { PamSessionsSchema } from "@app/db/schemas";
 import { EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
-import { PamAccountType } from "@app/ee/services/pam/pam-enums";
+import { PamAccountType, PamSessionStatus } from "@app/ee/services/pam/pam-enums";
+import { SessionLogsPageSchema } from "@app/ee/services/pam-session/pam-session-log-schemas";
 import { PamRecordingStorageBackend } from "@app/ee/services/pam-session-recording/pam-recording-enums";
 import { ApiDocsTags } from "@app/lib/api-docs/constants";
 import { BadRequestError } from "@app/lib/errors";
@@ -16,7 +17,6 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 const SanitizedSessionSchema = PamSessionsSchema.pick({
   id: true,
-  projectId: true,
   accountId: true,
   accountType: true,
   accountName: true,
@@ -34,6 +34,7 @@ const SanitizedSessionSchema = PamSessionsSchema.pick({
   accessMethod: true,
   reason: true,
   gatewayId: true,
+  resourceName: true,
   folderName: true,
   selectedHost: true
 }).extend({
@@ -59,7 +60,13 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
           .max(100)
           .default(20)
           .optional()
-          .describe("The number of records to return for pagination")
+          .describe("The number of records to return for pagination"),
+        search: z
+          .string()
+          .trim()
+          .optional()
+          .describe("Search by account name, actor name, actor email, or folder name"),
+        status: z.nativeEnum(PamSessionStatus).optional().describe("Filter by session status")
       }),
       response: {
         200: z.object({ sessions: SanitizedSessionSchema.array(), totalCount: z.number() })
@@ -75,7 +82,7 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
           actorOrgId: req.permission.orgId,
           actorAuthMethod: req.permission.authMethod
         },
-        { offset: req.query.offset, limit: req.query.limit }
+        { offset: req.query.offset, limit: req.query.limit, search: req.query.search, status: req.query.status }
       );
       return { sessions, totalCount };
     }
@@ -108,6 +115,36 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
         throw new BadRequestError({ message: "Session not found" });
       }
       return { session };
+    }
+  });
+
+  server.route({
+    method: "GET",
+    url: "/:sessionId/logs",
+    config: { rateLimit: readLimit },
+    schema: {
+      operationId: "getPamSessionLogs",
+      description: "Get paginated logs for a PAM session",
+      tags: [ApiDocsTags.PamSessions],
+      params: z.object({
+        sessionId: z.string().uuid().describe("The ID of the session")
+      }),
+      querystring: z.object({
+        offset: z.coerce.number().int().nonnegative().default(0),
+        limit: z.coerce.number().int().min(1).max(100).default(20)
+      }),
+      response: {
+        200: SessionLogsPageSchema
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      return server.services.pamSession.getSessionLogs(req.params.sessionId, req.query.offset, req.query.limit, {
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorOrgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod
+      });
     }
   });
 
@@ -201,6 +238,50 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
       }
 
       return { message: "Session ended" };
+    }
+  });
+
+  server.route({
+    method: "POST",
+    url: "/:sessionId/terminate",
+    config: { rateLimit: writeLimit },
+    schema: {
+      operationId: "terminatePamSession",
+      description: "Terminate an active PAM session",
+      tags: [ApiDocsTags.PamSessions],
+      params: z.object({
+        sessionId: z.string().uuid().describe("The ID of the session")
+      }),
+      response: {
+        200: z.object({ session: SanitizedSessionSchema })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { session, projectId, accountName } = await server.services.pamSession.terminateSession(
+        req.params.sessionId,
+        {
+          actor: req.permission.type,
+          actorId: req.permission.id,
+          actorOrgId: req.permission.orgId,
+          actorAuthMethod: req.permission.authMethod
+        }
+      );
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        projectId,
+        event: {
+          type: EventType.PAM_SESSION_TERMINATE,
+          metadata: {
+            sessionId: req.params.sessionId,
+            accountName
+          }
+        }
+      });
+
+      return { session };
     }
   });
 };

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -705,6 +705,7 @@ export enum EventType {
   PAM_SESSION_CREDENTIALS_GET = "pam-session-credentials-get",
   PAM_SESSION_START = "pam-session-start",
   PAM_SESSION_END = "pam-session-end",
+  PAM_SESSION_TERMINATE = "pam-session-terminate",
   PAM_SESSION_CHUNK_UPLOAD = "pam-session-chunk-upload",
   PAM_SESSION_UPLOAD_TOKEN_INVALID = "pam-session-upload-token-invalid",
   PAM_ACCOUNT_TEMPLATE_CREATE = "pam-account-template-create",
@@ -5747,6 +5748,14 @@ interface PamSessionEndEvent {
   };
 }
 
+interface PamSessionTerminateEvent {
+  type: EventType.PAM_SESSION_TERMINATE;
+  metadata: {
+    sessionId: string;
+    accountName: string;
+  };
+}
+
 interface PamSessionChunkUploadEvent {
   type: EventType.PAM_SESSION_CHUNK_UPLOAD;
   metadata: {
@@ -7540,6 +7549,7 @@ export type Event =
   | OrgRoleDeleteEvent
   | PamSessionStartEvent
   | PamSessionEndEvent
+  | PamSessionTerminateEvent
   | PamSessionChunkUploadEvent
   | PamSessionUploadTokenInvalidEvent
   | PamAccountTemplateCreateEvent

--- a/backend/src/ee/services/pam-session-recording/pam-recording-chunk-dal.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-chunk-dal.ts
@@ -16,6 +16,19 @@ export const pamSessionEventChunkDALFactory = (db: TDbClient) => {
       .select("*");
   };
 
+  const findBySessionIdPaginated = async (
+    sessionId: string,
+    { offset, limit }: { offset: number; limit: number },
+    tx?: Knex
+  ) => {
+    return (tx || db.replicaNode())(TableName.PamSessionEventChunk)
+      .where("sessionId", sessionId)
+      .orderBy("chunkIndex", "asc")
+      .offset(offset)
+      .limit(limit)
+      .select("*");
+  };
+
   const findByChunkIndex = async (sessionId: string, chunkIndex: number, tx?: Knex) => {
     return (tx || db.replicaNode())(TableName.PamSessionEventChunk).where({ sessionId, chunkIndex }).first();
   };
@@ -24,5 +37,5 @@ export const pamSessionEventChunkDALFactory = (db: TDbClient) => {
     await (tx || db)(TableName.PamSessionEventChunk).insert(data).onConflict(["sessionId", "chunkIndex"]).ignore();
   };
 
-  return { ...orm, findAllBySessionId, findByChunkIndex, insertIgnoreDuplicate };
+  return { ...orm, findAllBySessionId, findBySessionIdPaginated, findByChunkIndex, insertIgnoreDuplicate };
 };

--- a/backend/src/ee/services/pam-session/pam-session-dal.ts
+++ b/backend/src/ee/services/pam-session/pam-session-dal.ts
@@ -56,6 +56,15 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     return updated;
   };
 
+  const terminateSessionById = async (sessionId: string, tx?: Knex) => {
+    const [updated] = await (tx || db)(TableName.PamSession)
+      .where("id", sessionId)
+      .whereIn("status", [PamSessionStatus.Active, PamSessionStatus.Starting])
+      .update({ status: PamSessionStatus.Terminated, endedAt: new Date() })
+      .returning("*");
+    return updated;
+  };
+
   const activateSession = async (sessionId: string, tx?: Knex) => {
     const [updated] = await (tx || db)(TableName.PamSession)
       .where("id", sessionId)
@@ -83,13 +92,17 @@ export const pamSessionDALFactory = (db: TDbClient) => {
       viewSessionsAccountIds,
       userId,
       offset,
-      limit
+      limit,
+      search,
+      status
     }: {
       viewSessionsFolderIds: string[];
       viewSessionsAccountIds: string[];
       userId: string;
       offset?: number;
       limit?: number;
+      search?: string;
+      status?: string;
     },
     tx?: Knex
   ) => {
@@ -105,6 +118,21 @@ export const pamSessionDALFactory = (db: TDbClient) => {
           void top.orWhereIn(`${TableName.PamSession}.accountId`, viewSessionsAccountIds);
         }
       });
+
+    if (search) {
+      const term = `%${search}%`;
+      void baseQuery.where((qb) => {
+        void qb
+          .orWhereILike(`${TableName.PamSession}.accountName`, term)
+          .orWhereILike(`${TableName.PamSession}.actorName`, term)
+          .orWhereILike(`${TableName.PamSession}.actorEmail`, term)
+          .orWhereILike(`${TableName.PamSession}.folderName`, term);
+      });
+    }
+
+    if (status) {
+      void baseQuery.where(`${TableName.PamSession}.status`, status);
+    }
 
     const countQuery = baseQuery
       .clone()
@@ -134,6 +162,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     countActiveWebSessions,
     endExpiredWebSessions,
     endSessionById,
+    terminateSessionById,
     activateSession,
     findByProjectId,
     findAccessibleByProjectId

--- a/backend/src/ee/services/pam-session/pam-session-dal.ts
+++ b/backend/src/ee/services/pam-session/pam-session-dal.ts
@@ -2,6 +2,7 @@ import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
 import { TableName } from "@app/db/schemas";
+import { sanitizeSqlLikeString } from "@app/lib/fn";
 import { ormify, selectAllTableCols } from "@app/lib/knex";
 
 import { PamAccessMethod, PamSessionStatus } from "../pam/pam-enums";
@@ -120,7 +121,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
       });
 
     if (search) {
-      const term = `%${search}%`;
+      const term = `%${sanitizeSqlLikeString(search)}%`;
       void baseQuery.where((qb) => {
         void qb
           .orWhereILike(`${TableName.PamSession}.accountName`, term)

--- a/backend/src/ee/services/pam-session/pam-session-fns.ts
+++ b/backend/src/ee/services/pam-session/pam-session-fns.ts
@@ -1,0 +1,63 @@
+import { createDecipheriv, createHash } from "node:crypto";
+
+import { TPamSessionEventChunks } from "@app/db/schemas";
+import { logger } from "@app/lib/logger";
+
+import { PamRecordingStorageBackend } from "../pam-session-recording/pam-recording-enums";
+
+const PAM_RECORDING_AAD_VERSION = "v1";
+
+const buildChunkAad = (projectId: string, sessionId: string, chunkIndex: number, storageBackend: string): Buffer =>
+  createHash("sha256")
+    .update(`${projectId}|${sessionId}|${chunkIndex}|${storageBackend}|${PAM_RECORDING_AAD_VERSION}`)
+    .digest();
+
+const AUTH_TAG_LENGTH = 16;
+
+const decryptSingleChunk = (
+  chunk: TPamSessionEventChunks,
+  sessionKey: Buffer,
+  projectId: string,
+  sessionId: string
+): unknown[] => {
+  if (!chunk.encryptedEventsBlob) return [];
+
+  const aad = buildChunkAad(projectId, sessionId, chunk.chunkIndex, chunk.storageBackend);
+  const ciphertext = chunk.encryptedEventsBlob;
+
+  if (ciphertext.length < AUTH_TAG_LENGTH) return [];
+
+  const encrypted = ciphertext.subarray(0, ciphertext.length - AUTH_TAG_LENGTH);
+  const authTag = ciphertext.subarray(ciphertext.length - AUTH_TAG_LENGTH);
+
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", sessionKey, chunk.iv);
+    decipher.setAuthTag(authTag);
+    decipher.setAAD(aad);
+    const plaintext = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    const parsed: unknown = JSON.parse(plaintext.toString("utf-8"));
+    if (Array.isArray(parsed)) {
+      return parsed as unknown[];
+    }
+    return [];
+  } catch (err) {
+    logger.warn(
+      { sessionId, chunkIndex: chunk.chunkIndex, err },
+      `Failed to decrypt chunk [sessionId=${sessionId}] [chunkIndex=${chunk.chunkIndex}]`
+    );
+    return [];
+  }
+};
+
+export const decryptChunks = (
+  chunks: TPamSessionEventChunks[],
+  sessionKey: Buffer,
+  projectId: string,
+  sessionId: string
+): unknown[] => {
+  const decryptable = chunks.filter(
+    (c) => c.encryptedEventsBlob && c.storageBackend === PamRecordingStorageBackend.Postgres
+  );
+
+  return decryptable.flatMap((chunk) => decryptSingleChunk(chunk, sessionKey, projectId, sessionId));
+};

--- a/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
+++ b/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const SessionLogsPageSchema = z.object({
+  logs: z.array(z.unknown()),
+  hasMore: z.boolean(),
+  batchCount: z.number()
+});

--- a/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
+++ b/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
@@ -1,7 +1,42 @@
 import { z } from "zod";
 
+const CommandLogSchema = z.object({
+  input: z.string(),
+  output: z.string(),
+  timestamp: z.string()
+});
+
+const SessionEventSchema = z.object({
+  timestamp: z.string(),
+  eventType: z.enum(["input", "output", "resize", "error"]),
+  channelType: z.enum(["terminal", "exec", "sftp"]).optional(),
+  data: z.string(),
+  elapsedTime: z.number()
+});
+
+const HttpRequestEventSchema = z.object({
+  timestamp: z.string(),
+  requestId: z.string(),
+  eventType: z.literal("request"),
+  headers: z.record(z.array(z.string())),
+  method: z.string(),
+  url: z.string(),
+  body: z.string().optional()
+});
+
+const HttpResponseEventSchema = z.object({
+  timestamp: z.string(),
+  requestId: z.string(),
+  eventType: z.literal("response"),
+  headers: z.record(z.array(z.string())),
+  status: z.string(),
+  body: z.string().optional()
+});
+
+const SessionLogSchema = z.union([CommandLogSchema, SessionEventSchema, HttpRequestEventSchema, HttpResponseEventSchema]);
+
 export const SessionLogsPageSchema = z.object({
-  logs: z.array(z.unknown()),
+  logs: z.array(SessionLogSchema),
   hasMore: z.boolean(),
   batchCount: z.number()
 });

--- a/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
+++ b/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
@@ -45,3 +45,5 @@ export const SessionLogsPageSchema = z.object({
   hasMore: z.boolean(),
   batchCount: z.number()
 });
+
+export type TSessionLogsPage = z.infer<typeof SessionLogsPageSchema>;

--- a/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
+++ b/backend/src/ee/services/pam-session/pam-session-log-schemas.ts
@@ -33,7 +33,12 @@ const HttpResponseEventSchema = z.object({
   body: z.string().optional()
 });
 
-const SessionLogSchema = z.union([CommandLogSchema, SessionEventSchema, HttpRequestEventSchema, HttpResponseEventSchema]);
+const SessionLogSchema = z.union([
+  CommandLogSchema,
+  SessionEventSchema,
+  HttpRequestEventSchema,
+  HttpResponseEventSchema
+]);
 
 export const SessionLogsPageSchema = z.object({
   logs: z.array(SessionLogSchema),

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -24,19 +24,28 @@ import { TPamAccountDALFactory } from "../pam-account/pam-account-dal";
 import { extractGatewayTarget, parseInternalMetadata } from "../pam-account/pam-account-schemas";
 import { PamTemplateAccessPolicySchema } from "../pam-account-template/pam-account-template-schemas";
 import { TPamFolderDALFactory } from "../pam-folder/pam-folder-dal";
+import { TPamSessionEventChunkDALFactory } from "../pam-session-recording/pam-recording-chunk-dal";
 import { PamRecordingStorageBackend } from "../pam-session-recording/pam-recording-enums";
-import { generateSessionRecordingSecrets } from "../pam-session-recording/pam-recording-secrets";
+import { decryptSessionKey, generateSessionRecordingSecrets } from "../pam-session-recording/pam-recording-secrets";
 import { ResourcePermissionPamResourceActions } from "../permission/resource-permission";
 import { DEFAULT_SESSION_DURATION_MS } from "./pam-session-constants";
 import { TPamSessionDALFactory } from "./pam-session-dal";
 import { TPamSessionExpirationServiceFactory } from "./pam-session-expiration-queue";
+import { decryptChunks } from "./pam-session-fns";
 
 type TPamSessionServiceFactoryDep = {
   pamSessionDAL: Pick<
     TPamSessionDALFactory,
-    "findAccessibleByProjectId" | "findById" | "findOne" | "create" | "endSessionById" | "updateById"
+    | "findAccessibleByProjectId"
+    | "findById"
+    | "findOne"
+    | "create"
+    | "endSessionById"
+    | "terminateSessionById"
+    | "updateById"
   >;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails" | "findOne">;
+  pamSessionEventChunkDAL: Pick<TPamSessionEventChunkDALFactory, "findBySessionIdPaginated">;
   pamFolderDAL: Pick<TPamFolderDALFactory, "findOne">;
   membershipDAL: Pick<TMembershipDALFactory, "findResourceMembershipsForActor">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "find">;
@@ -53,6 +62,7 @@ export type TPamSessionServiceFactory = ReturnType<typeof pamSessionServiceFacto
 export const pamSessionServiceFactory = ({
   pamSessionDAL,
   pamAccountDAL,
+  pamSessionEventChunkDAL,
   pamFolderDAL,
   membershipDAL,
   membershipRoleDAL,
@@ -79,7 +89,7 @@ export const pamSessionServiceFactory = ({
   const listSessions = async (
     projectId: string,
     ctx: TActorContext,
-    pagination?: { offset?: number; limit?: number }
+    pagination?: { offset?: number; limit?: number; search?: string; status?: string }
   ) => {
     await verifyProductMembership(permissionService, projectId, ctx);
 
@@ -384,11 +394,90 @@ export const pamSessionServiceFactory = ({
     };
   };
 
+  // TODO: when CLI sessions are supported, send a GatewayProxyProtocol.PamSessionCancellation ALPN signal to drop the gateway connection
+  const terminateSession = async (sessionId: string, ctx: TActorContext) => {
+    const session = await pamSessionDAL.findById(sessionId);
+    if (!session) {
+      throw new NotFoundError({ message: "Session not found" });
+    }
+
+    if (session.status !== PamSessionStatus.Active && session.status !== PamSessionStatus.Starting) {
+      throw new BadRequestError({ message: "Session is not active" });
+    }
+
+    if (!session.accountId) {
+      throw new BadRequestError({ message: "Session has no linked account" });
+    }
+
+    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+    await checkAccount(
+      session.accountId,
+      account?.folderId,
+      session.projectId,
+      ResourcePermissionPamResourceActions.TerminateSessions,
+      ctx
+    );
+
+    const updated = await pamSessionDAL.terminateSessionById(sessionId);
+    if (!updated) {
+      throw new BadRequestError({ message: "Session could not be terminated" });
+    }
+
+    return { session: updated, projectId: session.projectId, accountName: session.accountName };
+  };
+
+  const getSessionLogs = async (sessionId: string, offset: number, limit: number, ctx: TActorContext) => {
+    const session = await pamSessionDAL.findById(sessionId);
+    if (!session) {
+      throw new NotFoundError({ message: "Session not found" });
+    }
+
+    if (!session.accountId) {
+      return { logs: [], hasMore: false, batchCount: 0 };
+    }
+
+    const isOwnSession = session.userId === ctx.actorId;
+    if (!isOwnSession) {
+      const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+      await checkAccount(
+        session.accountId,
+        account?.folderId,
+        session.projectId,
+        ResourcePermissionPamResourceActions.ViewSessions,
+        ctx
+      );
+    }
+
+    if (!session.encryptedSessionKey) {
+      return { logs: [], hasMore: false, batchCount: 0 };
+    }
+
+    const sessionKey = await decryptSessionKey({
+      projectId: session.projectId,
+      sessionId,
+      encryptedSessionKey: session.encryptedSessionKey,
+      kmsService
+    });
+
+    const chunks = await pamSessionEventChunkDAL.findBySessionIdPaginated(sessionId, {
+      offset,
+      limit: limit + 1
+    });
+
+    const hasMore = chunks.length > limit;
+    const pageChunks = hasMore ? chunks.slice(0, limit) : chunks;
+    const logs = pageChunks.length > 0 ? decryptChunks(pageChunks, sessionKey, session.projectId, sessionId) : [];
+
+    return { logs, hasMore, batchCount: pageChunks.length };
+  };
+
   return {
     access,
     listSessions,
     getSessionById,
     getSessionCredentials,
-    endSessionFromGateway
+    getSessionLogs,
+    endSessionFromGateway,
+    terminateSession
   };
 };

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -1,3 +1,5 @@
+import net from "net";
+
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -5,6 +7,9 @@ import { createSshCert, createSshKeyPair } from "@app/ee/services/ssh/ssh-certif
 import { SshCertType } from "@app/ee/services/ssh/ssh-certificate-authority-types";
 import { SshCertKeyAlgorithm } from "@app/ee/services/ssh-certificate/ssh-certificate-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { GatewayProxyProtocol } from "@app/lib/gateway/types";
+import { createGatewayConnection, createRelayConnection } from "@app/lib/gateway-v2/gateway-v2";
+import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -394,7 +399,6 @@ export const pamSessionServiceFactory = ({
     };
   };
 
-  // TODO: when CLI sessions are supported, send a GatewayProxyProtocol.PamSessionCancellation ALPN signal to drop the gateway connection
   const terminateSession = async (sessionId: string, ctx: TActorContext) => {
     const session = await pamSessionDAL.findById(sessionId);
     if (!session) {
@@ -421,6 +425,49 @@ export const pamSessionServiceFactory = ({
     const updated = await pamSessionDAL.terminateSessionById(sessionId);
     if (!updated) {
       throw new BadRequestError({ message: "Session could not be terminated" });
+    }
+
+    if (session.gatewayId) {
+      void (async () => {
+        let relayConn: net.Socket | null = null;
+        try {
+          const user = await userDAL.findById(ctx.actorId);
+          const certs = await gatewayV2Service.getPAMConnectionDetails({
+            gatewayId: session.gatewayId!,
+            sessionId,
+            accountType: session.accountType as PamAccountType,
+            host: "0.0.0.0",
+            port: 0,
+            actorMetadata: { id: ctx.actorId, type: ActorType.USER, name: user?.email ?? "" }
+          });
+          if (!certs) {
+            logger.error(
+              { sessionId, gatewayId: session.gatewayId },
+              `Failed to get gateway [gatewayId=${session.gatewayId}] connection details for PAM session [sessionId=${sessionId}] termination`
+            );
+            return;
+          }
+          relayConn = await createRelayConnection({
+            relayHost: certs.relayHost,
+            clientCertificate: certs.relay.clientCertificate,
+            clientPrivateKey: certs.relay.clientPrivateKey,
+            serverCertificateChain: certs.relay.serverCertificateChain
+          });
+          const cancelConn = await createGatewayConnection(
+            relayConn,
+            certs.gateway,
+            GatewayProxyProtocol.PamSessionCancellation
+          );
+          cancelConn.end();
+        } catch (err) {
+          logger.error(
+            { sessionId, err },
+            `Session [sessionId=${sessionId}] termination ALPN signal failed (best-effort)`
+          );
+        } finally {
+          relayConn?.destroy();
+        }
+      })();
     }
 
     return { session: updated, projectId: session.projectId, accountName: session.accountName };

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -118,17 +118,14 @@ export const pamSessionServiceFactory = ({
     const session = await pamSessionDAL.findById(sessionId);
     if (!session || !session.accountId) return null;
 
-    const isOwnSession = session.userId === ctx.actorId;
-    if (!isOwnSession) {
-      const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
-      await checkAccount(
-        session.accountId,
-        account?.folderId,
-        session.projectId,
-        ResourcePermissionPamResourceActions.ViewSessions,
-        ctx
-      );
-    }
+    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+    await checkAccount(
+      session.accountId,
+      account?.folderId,
+      session.projectId,
+      ResourcePermissionPamResourceActions.ViewSessions,
+      ctx
+    );
 
     return session;
   };
@@ -483,17 +480,14 @@ export const pamSessionServiceFactory = ({
       return { logs: [], hasMore: false, batchCount: 0 };
     }
 
-    const isOwnSession = session.userId === ctx.actorId;
-    if (!isOwnSession) {
-      const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
-      await checkAccount(
-        session.accountId,
-        account?.folderId,
-        session.projectId,
-        ResourcePermissionPamResourceActions.ViewSessions,
-        ctx
-      );
-    }
+    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+    await checkAccount(
+      session.accountId,
+      account?.folderId,
+      session.projectId,
+      ResourcePermissionPamResourceActions.ViewSessions,
+      ctx
+    );
 
     if (!session.encryptedSessionKey) {
       return { logs: [], hasMore: false, batchCount: 0 };

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1777,6 +1777,7 @@ export const registerRoutes = async (
   const pamSessionService = pamSessionServiceFactory({
     pamSessionDAL,
     pamAccountDAL,
+    pamSessionEventChunkDAL,
     pamFolderDAL,
     membershipDAL,
     membershipRoleDAL,

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -310,6 +310,7 @@ export const eventToNameMap: { [K in EventType]: string } = {
 
   [EventType.PAM_SESSION_START]: "Start PAM Session",
   [EventType.PAM_SESSION_END]: "End PAM Session",
+  [EventType.PAM_SESSION_TERMINATE]: "Terminate PAM Session",
   [EventType.PAM_ACCOUNT_TEMPLATE_CREATE]: "Create PAM Account Template",
   [EventType.PAM_ACCOUNT_TEMPLATE_UPDATE]: "Update PAM Account Template",
   [EventType.PAM_ACCOUNT_TEMPLATE_DELETE]: "Delete PAM Account Template",
@@ -475,6 +476,7 @@ export const projectToEventsMap: Partial<Record<ProjectType, EventType[]>> = {
     ...sharedProjectEvents,
     EventType.PAM_SESSION_START,
     EventType.PAM_SESSION_END,
+    EventType.PAM_SESSION_TERMINATE,
     EventType.PAM_ACCOUNT_TEMPLATE_CREATE,
     EventType.PAM_ACCOUNT_TEMPLATE_UPDATE,
     EventType.PAM_ACCOUNT_TEMPLATE_DELETE,

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -302,6 +302,7 @@ export enum EventType {
 
   PAM_SESSION_START = "pam-session-start",
   PAM_SESSION_END = "pam-session-end",
+  PAM_SESSION_TERMINATE = "pam-session-terminate",
   PAM_ACCOUNT_TEMPLATE_CREATE = "pam-account-template-create",
   PAM_ACCOUNT_TEMPLATE_UPDATE = "pam-account-template-update",
   PAM_ACCOUNT_TEMPLATE_DELETE = "pam-account-template-delete",

--- a/frontend/src/hooks/api/pam/mutations.tsx
+++ b/frontend/src/hooks/api/pam/mutations.tsx
@@ -20,8 +20,8 @@ export const useCreatePamFolder = () => {
 
       return data.folder;
     },
-    onSuccess: ({ projectId }) => {
-      queryClient.invalidateQueries({ queryKey: pamKeys.listAccounts({ projectId }) });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pamKeys.account() });
     }
   });
 };
@@ -37,8 +37,8 @@ export const useUpdatePamFolder = () => {
 
       return data.folder;
     },
-    onSuccess: ({ projectId }) => {
-      queryClient.invalidateQueries({ queryKey: pamKeys.listAccounts({ projectId }) });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pamKeys.account() });
     }
   });
 };
@@ -53,8 +53,8 @@ export const useDeletePamFolder = () => {
 
       return data.folder;
     },
-    onSuccess: ({ projectId }) => {
-      queryClient.invalidateQueries({ queryKey: pamKeys.listAccounts({ projectId }) });
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pamKeys.account() });
     }
   });
 };
@@ -69,8 +69,8 @@ export const useTerminatePamSession = () => {
 
       return data.session;
     },
-    onSuccess: (_, { projectId, sessionId }) => {
-      queryClient.invalidateQueries({ queryKey: pamKeys.listSessions(projectId) });
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({ queryKey: pamKeys.session() });
       queryClient.invalidateQueries({ queryKey: pamKeys.getSession(sessionId) });
     }
   });

--- a/frontend/src/hooks/api/pam/queries.tsx
+++ b/frontend/src/hooks/api/pam/queries.tsx
@@ -40,7 +40,10 @@ export const pamKeys = {
   ],
   getAccount: (accountId: string) => [...pamKeys.account(), "get", accountId],
   getSession: (sessionId: string) => [...pamKeys.session(), "get", sessionId],
-  listSessions: (projectId: string) => [...pamKeys.session(), "list", projectId],
+  listSessions: (
+    projectId: string,
+    params?: { offset?: number; limit?: number; search?: string; status?: string }
+  ) => [...pamKeys.session(), "list", projectId, params],
   folderPermissions: (folderId: string) =>
     [...pamKeys.all, "folder-permissions", folderId] as const,
   accountPermissions: (accountId: string) =>
@@ -300,22 +303,24 @@ export const useGetPamSessionLogs = (sessionId: string, isActive: boolean, enabl
   return { logs, isLoading, hasMore, loadMore, isLoadingMore };
 };
 
+type TListPamSessionsResponse = {
+  sessions: TPamSession[];
+  totalCount: number;
+};
+
 export const useListPamSessions = (
   projectId: string,
-  options?: Omit<
-    UseQueryOptions<TPamSession[], unknown, TPamSession[], ReturnType<typeof pamKeys.listSessions>>,
-    "queryKey" | "queryFn"
-  >
+  params?: { offset?: number; limit?: number; search?: string; status?: string }
 ) => {
   return useQuery({
-    queryKey: pamKeys.listSessions(projectId),
+    queryKey: pamKeys.listSessions(projectId, params),
     queryFn: async () => {
-      const { data } = await apiRequest.get<{ sessions: TPamSession[] }>("/api/v1/pam/sessions", {
-        params: { projectId }
+      const { data } = await apiRequest.get<TListPamSessionsResponse>("/api/v1/pam/sessions", {
+        params: { projectId, ...params }
       });
 
-      return data.sessions;
+      return data;
     },
-    ...options
+    placeholderData: (prev) => prev
   });
 };

--- a/frontend/src/hooks/api/pam/queries.tsx
+++ b/frontend/src/hooks/api/pam/queries.tsx
@@ -321,6 +321,7 @@ export const useListPamSessions = (
 
       return data;
     },
+    refetchInterval: 30_000,
     placeholderData: (prev) => prev
   });
 };

--- a/frontend/src/hooks/api/pam/types/index.ts
+++ b/frontend/src/hooks/api/pam/types/index.ts
@@ -28,7 +28,6 @@ export type TPamAccount = {
   templateAccessPolicy: unknown;
   templateSettings: unknown;
   accountType: PamAccountType;
-  projectId: string;
   gatewayId: string | null;
   gatewayPoolId: string | null;
   recordingConnectionId: string | null;
@@ -39,7 +38,6 @@ export type TPamAccount = {
 
 export type TPamFolder = {
   id: string;
-  projectId: string;
   parentId?: string | null;
   name: string;
   description?: string | null;
@@ -49,7 +47,6 @@ export type TPamFolder = {
 
 export type TPamAccountTemplate = {
   id: string;
-  projectId: string;
   name: string;
   description?: string | null;
   accountType: PamAccountType;
@@ -105,12 +102,15 @@ export type TPamSessionAiInsights = {
 
 export type TPamSession = {
   id: string;
-  projectId: string;
   accountId?: string | null;
+  accountType?: PamAccountType | null;
   resourceId?: string | null;
   resourceType: PamResourceType;
   resourceName: string;
   accountName: string;
+  folderName?: string | null;
+  selectedHost?: string | null;
+  accessMethod?: string | null;
   userId?: string | null;
   actorName: string;
   actorEmail: string;
@@ -169,10 +169,9 @@ export type TListPamAccountsDTO = {
   search?: string;
 };
 
-export type TCreatePamFolderDTO = Pick<
-  TPamFolder,
-  "name" | "description" | "parentId" | "projectId"
->;
+export type TCreatePamFolderDTO = Pick<TPamFolder, "name" | "description" | "parentId"> & {
+  projectId: string;
+};
 
 export type TUpdatePamFolderDTO = Partial<Pick<TPamFolder, "name" | "description">> & {
   folderId: string;

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/PamNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/PamNav.tsx
@@ -1,4 +1,4 @@
-import { FileText, KeyRound, Shield } from "lucide-react";
+import { FileText, KeyRound, Shield, Video } from "lucide-react";
 
 import { SidebarCollapsibleGroup } from "@app/components/v3";
 
@@ -6,11 +6,10 @@ import { ProjectNavList } from "./ProjectNavLink";
 import type { NavItem, Submenu } from "./types";
 
 export const PamNav = ({ onSubmenuOpen }: { onSubmenuOpen: (submenu: Submenu) => void }) => {
-  const topItems: NavItem[] = [
-    { label: "Access", icon: KeyRound, pathSuffix: "access" }
-  ];
+  const topItems: NavItem[] = [{ label: "Access", icon: KeyRound, pathSuffix: "access" }];
 
   const monitorItems: NavItem[] = [
+    { label: "Sessions", icon: Video, pathSuffix: "sessions" },
     { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" }
   ];
 

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/PamNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/PamNav.tsx
@@ -1,9 +1,37 @@
-import { KeyRound } from "lucide-react";
+import { FileText, KeyRound, Shield } from "lucide-react";
+
+import { SidebarCollapsibleGroup } from "@app/components/v3";
 
 import { ProjectNavList } from "./ProjectNavLink";
 import type { NavItem, Submenu } from "./types";
 
 export const PamNav = ({ onSubmenuOpen }: { onSubmenuOpen: (submenu: Submenu) => void }) => {
-  const items: NavItem[] = [{ label: "Access", icon: KeyRound, pathSuffix: "access" }];
-  return <ProjectNavList items={items} onSubmenuOpen={onSubmenuOpen} />;
+  const topItems: NavItem[] = [
+    { label: "Access", icon: KeyRound, pathSuffix: "access" }
+  ];
+
+  const monitorItems: NavItem[] = [
+    { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" }
+  ];
+
+  const configureItems: NavItem[] = [
+    {
+      label: "Access Control",
+      icon: Shield,
+      pathSuffix: "access-management",
+      activeMatch: /\/access-management|\/groups\/|\/identities\/|\/members\/|\/roles\//
+    }
+  ];
+
+  return (
+    <>
+      <ProjectNavList items={topItems} onSubmenuOpen={onSubmenuOpen} />
+      <SidebarCollapsibleGroup label="Monitor">
+        <ProjectNavList items={monitorItems} onSubmenuOpen={onSubmenuOpen} />
+      </SidebarCollapsibleGroup>
+      <SidebarCollapsibleGroup label="Configure">
+        <ProjectNavList items={configureItems} onSubmenuOpen={onSubmenuOpen} />
+      </SidebarCollapsibleGroup>
+    </>
+  );
 };

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNav.tsx
@@ -84,6 +84,7 @@ export const ProjectNav = () => {
     if (isLegacyView || hasApplicationContext || isFromRootRequests || hasSignerContext)
       return null;
     if (isCertManager && (isOnAccessControl || pathname.includes("/discovery"))) return null;
+    if (currentProject.type === ProjectType.PAM) return null;
     if (isOnAccessControl) {
       if (currentProject.type === ProjectType.SecretManager)
         return SECRET_MANAGER_ACCESS_CONTROL_SUBMENU;

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -54,7 +54,7 @@ const PAM_ROLES = [
   {
     slug: "admin",
     name: "Admin",
-    description: "Full administrative access over Access Management"
+    description: "Full administrative access over Privileged Access Manager"
   },
   {
     slug: "member",
@@ -81,7 +81,7 @@ const PRODUCT_DEFINITIONS: ProductDefinition[] = [
   { type: ProjectType.KMS, name: "KMS", isSingleton: false },
   { type: ProjectType.SSH, name: "SSH", isSingleton: false },
   { type: ProjectType.SecretScanning, name: "Secret Scanning", isSingleton: false },
-  { type: ProjectType.PAM, name: "Access Management", isSingleton: false, roles: PAM_ROLES },
+  { type: ProjectType.PAM, name: "Privileged Access Manager", isSingleton: true, roles: PAM_ROLES },
   { type: ProjectType.AI, name: "AI", isSingleton: false }
 ];
 

--- a/frontend/src/pages/pam/PamAccessControlPage/PamAccessControlPage.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/PamAccessControlPage.tsx
@@ -1,0 +1,73 @@
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+
+import { PageHeader } from "@app/components/v2";
+import { Badge, Tabs, TabsContent, TabsList, TabsTrigger } from "@app/components/v3";
+import { useOrganization, useProject } from "@app/context";
+import { useGetWorkspaceUsers, useListWorkspaceGroups } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
+
+import { GroupsTab } from "./components/GroupsTab";
+import { MembersTab } from "./components/MembersTab";
+
+enum PamAccessControlTab {
+  Members = "members",
+  Groups = "groups"
+}
+
+export const PamAccessControlPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { currentOrg } = useOrganization();
+  const { currentProject } = useProject();
+
+  const selectedTab =
+    useSearch({
+      strict: false,
+      select: (el) => (el as { selectedTab?: string })?.selectedTab
+    }) || PamAccessControlTab.Members;
+
+  const { data: members = [] } = useGetWorkspaceUsers(currentProject.id);
+  const { data: groups = [] } = useListWorkspaceGroups(currentProject.id);
+
+  const updateTab = (tab: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigate as any)({
+      to: "/organizations/$orgId/pam/access-management",
+      search: { selectedTab: tab },
+      params: { orgId: currentOrg.id }
+    });
+  };
+
+  return (
+    <div className="mx-auto mb-6 w-full max-w-8xl">
+      <Helmet>
+        <title>{t("common.head-title", { title: "Access Control" })}</title>
+      </Helmet>
+      <PageHeader
+        scope={ProjectType.PAM}
+        title="Access Control"
+        description="Manage members, groups, and roles for the PAM product."
+      />
+      <Tabs value={selectedTab} onValueChange={updateTab}>
+        <TabsList variant="pam">
+          <TabsTrigger value={PamAccessControlTab.Members}>
+            Members
+            <Badge variant="pam">{members.length}</Badge>
+          </TabsTrigger>
+          <TabsTrigger value={PamAccessControlTab.Groups}>
+            Groups
+            <Badge variant="pam">{groups.length}</Badge>
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value={PamAccessControlTab.Members}>
+          <MembersTab />
+        </TabsContent>
+        <TabsContent value={PamAccessControlTab.Groups}>
+          <GroupsTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
@@ -30,12 +30,12 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full access to all sections including settings, templates, and access control."
+    description: "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",
     label: "Member",
-    description: "Can only view Access page."
+    description: "Access limited to assigned folders and accounts."
   }
 ];
 

--- a/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
@@ -1,0 +1,183 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
+import { useOrganization, useProject } from "@app/context";
+import {
+  useAddGroupToWorkspace,
+  useGetOrganizationGroups,
+  useListWorkspaceGroups
+} from "@app/hooks/api";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const ROLE_OPTIONS = [
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Full access to all sections including settings, templates, and access control."
+  },
+  {
+    value: "member",
+    label: "Member",
+    description: "Can only view Access page."
+  }
+];
+
+export const AddGroupModal = ({ isOpen, onOpenChange }: Props) => {
+  const { currentProject } = useProject();
+  const { currentOrg } = useOrganization();
+  const navigate = useNavigate();
+  const { mutateAsync: addGroup, isPending } = useAddGroupToWorkspace();
+
+  const [selectedGroup, setSelectedGroup] = useState<{ id: string; name: string } | null>(null);
+  const [selectedRole, setSelectedRole] = useState("member");
+
+  const { data: orgGroups } = useGetOrganizationGroups(currentOrg.id);
+  const { data: projectGroups } = useListWorkspaceGroups(currentProject.id, currentProject.type);
+
+  const availableGroups = useMemo(() => {
+    const assignedIds = new Set(projectGroups?.map((g) => g.group.id));
+    return (orgGroups || []).filter(({ id }) => !assignedIds.has(id));
+  }, [orgGroups, projectGroups]);
+
+  const handleClose = () => {
+    setSelectedGroup(null);
+    setSelectedRole("member");
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedGroup) return;
+
+    try {
+      await addGroup({
+        projectId: currentProject.id,
+        projectType: currentProject.type,
+        groupId: selectedGroup.id,
+        role: selectedRole
+      });
+      createNotification({ text: "Group added to project", type: "success" });
+      handleClose();
+    } catch {
+      createNotification({ text: "Failed to add group", type: "error" });
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-visible sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add Group</DialogTitle>
+          <DialogDescription>Add an existing organization group to this project.</DialogDescription>
+        </DialogHeader>
+
+        {availableGroups.length ? (
+          <div className="flex flex-col gap-5">
+            <Field>
+              <FieldLabel>
+                Group <span className="text-product-pam">*</span>
+              </FieldLabel>
+              <FilterableSelect
+                value={selectedGroup}
+                onChange={(val) => setSelectedGroup(val as { id: string; name: string } | null)}
+                getOptionValue={(option) => option.id}
+                getOptionLabel={(option) => option.name}
+                options={availableGroups}
+                placeholder="Select group..."
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel>
+                Product role <span className="text-product-pam">*</span>
+              </FieldLabel>
+              <div className="flex flex-col gap-2">
+                {ROLE_OPTIONS.map((option) => {
+                  const isSelected = selectedRole === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setSelectedRole(option.value)}
+                      className={`flex items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                        isSelected
+                          ? "border-product-pam/40 bg-product-pam/5"
+                          : "border-border bg-container hover:bg-container-hover"
+                      }`}
+                    >
+                      <div
+                        className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+                          isSelected ? "border-product-pam bg-product-pam" : "border-muted"
+                        }`}
+                      >
+                        {isSelected && <div className="size-1.5 rounded-full bg-white" />}
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">{option.label}</p>
+                        <p className="text-xs text-muted">{option.description}</p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </Field>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted">
+              All organization groups are already added to this project. Create a new group at the
+              organization level first.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="self-end"
+              onClick={() => {
+                handleClose();
+                navigate({
+                  to: "/organizations/$orgId/access-management" as never,
+                  params: { orgId: currentOrg.id } as never,
+                  search: { selectedTab: "groups" } as never
+                });
+              }}
+            >
+              Go to organization groups
+            </Button>
+          </div>
+        )}
+
+        {availableGroups.length > 0 && (
+          <DialogFooter>
+            <Button variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="pam"
+              isDisabled={!selectedGroup}
+              isPending={isPending}
+              onClick={handleSubmit}
+            >
+              Add Group
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
@@ -72,7 +72,7 @@ export const AddGroupModal = ({ isOpen, onOpenChange }: Props) => {
         groupId: selectedGroup.id,
         role: selectedRole
       });
-      createNotification({ text: "Group added to project", type: "success" });
+      createNotification({ text: "Group added", type: "success" });
       handleClose();
     } catch {
       createNotification({ text: "Failed to add group", type: "error" });
@@ -84,7 +84,7 @@ export const AddGroupModal = ({ isOpen, onOpenChange }: Props) => {
       <DialogContent className="overflow-visible sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Add Group</DialogTitle>
-          <DialogDescription>Add an existing organization group to this project.</DialogDescription>
+          <DialogDescription>Add an existing organization group.</DialogDescription>
         </DialogHeader>
 
         {availableGroups.length ? (
@@ -141,8 +141,8 @@ export const AddGroupModal = ({ isOpen, onOpenChange }: Props) => {
         ) : (
           <div className="flex flex-col gap-4">
             <p className="text-sm text-muted">
-              All organization groups are already added to this project. Create a new group at the
-              organization level first.
+              All organization groups have already been added. Create a new group at the organization
+              level first.
             </p>
             <Button
               variant="outline"

--- a/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/AddGroupModal.tsx
@@ -30,7 +30,8 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full administrative access: manage accounts, account templates, settings, and access control."
+    description:
+      "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",
@@ -141,8 +142,8 @@ export const AddGroupModal = ({ isOpen, onOpenChange }: Props) => {
         ) : (
           <div className="flex flex-col gap-4">
             <p className="text-sm text-muted">
-              All organization groups have already been added. Create a new group at the organization
-              level first.
+              All organization groups have already been added. Create a new group at the
+              organization level first.
             </p>
             <Button
               variant="outline"

--- a/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
@@ -27,12 +27,12 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full access to all sections including settings, templates, and access control."
+    description: "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",
     label: "Member",
-    description: "Can only view Access page."
+    description: "Access limited to assigned folders and accounts."
   }
 ];
 

--- a/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
@@ -27,7 +27,8 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full administrative access: manage accounts, account templates, settings, and access control."
+    description:
+      "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",

--- a/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/GroupDetailSheet.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { format } from "date-fns";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import {
+  Badge,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useUpdateGroupWorkspaceRole } from "@app/hooks/api";
+import { TGroupMembership } from "@app/hooks/api/groups/types";
+
+type Props = {
+  group: TGroupMembership | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const ROLE_OPTIONS = [
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Full access to all sections including settings, templates, and access control."
+  },
+  {
+    value: "member",
+    label: "Member",
+    description: "Can only view Access page."
+  }
+];
+
+export const GroupDetailSheet = ({ group, isOpen, onOpenChange }: Props) => {
+  const { currentProject } = useProject();
+  const updateRole = useUpdateGroupWorkspaceRole();
+
+  const currentRole = group?.roles?.[0]?.role ?? "member";
+  const [selectedRole, setSelectedRole] = useState<string>(currentRole);
+
+  useEffect(() => {
+    if (group) {
+      setSelectedRole(group.roles?.[0]?.role ?? "member");
+    }
+  }, [group]);
+
+  if (!group) return null;
+
+  const hasChanges = selectedRole !== currentRole;
+
+  const handleSave = async () => {
+    try {
+      await updateRole.mutateAsync({
+        projectId: currentProject.id,
+        projectType: currentProject.type,
+        groupId: group.group.id,
+        roles: [{ role: selectedRole, isTemporary: false }]
+      });
+      createNotification({ text: "Group role updated", type: "success" });
+      onOpenChange(false);
+    } catch {
+      createNotification({ text: "Failed to update group role", type: "error" });
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>Group Details</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6">
+          <div className="flex flex-col items-start gap-3">
+            <div>
+              <h3 className="text-lg font-semibold">{group.group.name}</h3>
+              <p className="font-mono text-sm text-muted">{group.group.slug}</p>
+            </div>
+            <Badge variant={currentRole === "admin" ? "pam" : "neutral"}>
+              {formatProjectRoleName(currentRole, group.roles?.[0]?.customRoleName)}
+            </Badge>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <p className="text-xs font-medium tracking-wider text-muted uppercase">Added</p>
+            <p className="mt-1 text-sm">
+              {group.createdAt ? format(new Date(group.createdAt), "MMM d, yyyy") : "-"}
+            </p>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <p className="mb-3 text-xs font-medium tracking-wider text-muted uppercase">
+              Product Role
+            </p>
+            <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Groups}>
+              {(isAllowed) => (
+                <div className="flex flex-col gap-2">
+                  {ROLE_OPTIONS.map((option) => {
+                    const isSelected = selectedRole === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        disabled={!isAllowed}
+                        onClick={() => setSelectedRole(option.value)}
+                        className={`flex items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                          isSelected
+                            ? "border-product-pam/40 bg-product-pam/5"
+                            : "border-border bg-container hover:bg-container-hover"
+                        } ${!isAllowed ? "cursor-not-allowed opacity-50" : ""}`}
+                      >
+                        <div
+                          className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+                            isSelected ? "border-product-pam bg-product-pam" : "border-muted"
+                          }`}
+                        >
+                          {isSelected && <div className="size-1.5 rounded-full bg-white" />}
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium">{option.label}</p>
+                          <p className="text-xs text-muted">{option.description}</p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </ProjectPermissionCan>
+          </div>
+        </div>
+
+        <SheetFooter className="flex-row justify-end gap-2 border-t border-border px-6 py-4">
+          <Button
+            variant="outline"
+            size="sm"
+            isDisabled={!hasChanges}
+            onClick={() => setSelectedRole(currentRole)}
+          >
+            Reset
+          </Button>
+          <Button
+            variant="pam"
+            size="sm"
+            isDisabled={!hasChanges}
+            isPending={updateRole.isPending}
+            onClick={handleSave}
+          >
+            Save
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/GroupsTab.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/GroupsTab.tsx
@@ -63,7 +63,7 @@ export const GroupsTab = () => {
         projectId: currentProject.id,
         groupId: groupToRemove.group.id
       });
-      createNotification({ text: "Group removed from project", type: "success" });
+      createNotification({ text: "Group removed", type: "success" });
     } catch {
       createNotification({ text: "Failed to remove group", type: "error" });
     } finally {
@@ -177,7 +177,7 @@ export const GroupsTab = () => {
                               }}
                             >
                               <Trash2Icon className="mr-2 size-4" />
-                              Remove from project
+                              Remove
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -206,7 +206,7 @@ export const GroupsTab = () => {
         onChange={(isOpen) => {
           if (!isOpen) setGroupToRemove(null);
         }}
-        title={`Remove ${groupToRemove?.group.name ?? "group"} from the project?`}
+        title={`Remove ${groupToRemove?.group.name ?? "group"}?`}
         deleteKey="remove"
         buttonText="Remove"
         onDeleteApproved={handleDeleteGroup}

--- a/frontend/src/pages/pam/PamAccessControlPage/components/GroupsTab.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/GroupsTab.tsx
@@ -1,0 +1,216 @@
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import { MoreHorizontalIcon, Plus, SearchIcon, Trash2Icon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import { DeleteActionModal } from "@app/components/v2";
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  IconButton,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useDeleteGroupFromWorkspace, useListWorkspaceGroups } from "@app/hooks/api";
+import { TGroupMembership } from "@app/hooks/api/groups/types";
+
+import { AddGroupModal } from "./AddGroupModal";
+import { GroupDetailSheet } from "./GroupDetailSheet";
+
+export const GroupsTab = () => {
+  const { currentProject } = useProject();
+  const [search, setSearch] = useState("");
+  const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
+  const [selectedGroup, setSelectedGroup] = useState<TGroupMembership | null>(null);
+  const [groupToRemove, setGroupToRemove] = useState<TGroupMembership | null>(null);
+
+  const { data: groups = [], isPending } = useListWorkspaceGroups(currentProject.id);
+  const deleteGroup = useDeleteGroupFromWorkspace();
+
+  const filteredGroups = useMemo(
+    () =>
+      groups.filter(
+        ({ group }) =>
+          group.name.toLowerCase().includes(search.toLowerCase()) ||
+          group.slug.toLowerCase().includes(search.toLowerCase())
+      ),
+    [groups, search]
+  );
+
+  const handleDeleteGroup = async () => {
+    if (!groupToRemove) return;
+    try {
+      await deleteGroup.mutateAsync({
+        projectId: currentProject.id,
+        groupId: groupToRemove.group.id
+      });
+      createNotification({ text: "Group removed from project", type: "success" });
+    } catch {
+      createNotification({ text: "Failed to remove group", type: "error" });
+    } finally {
+      setGroupToRemove(null);
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-sm text-muted">
+          {filteredGroups.length} group{filteredGroups.length !== 1 ? "s" : ""}
+        </p>
+        <ProjectPermissionCan I={ProjectPermissionActions.Create} a={ProjectPermissionSub.Groups}>
+          {(isAllowed) => (
+            <Button
+              variant="pam"
+              size="sm"
+              isDisabled={!isAllowed}
+              onClick={() => setIsAddGroupOpen(true)}
+            >
+              <Plus className="mr-1 size-4" />
+              Add Group
+            </Button>
+          )}
+        </ProjectPermissionCan>
+      </div>
+      <div className="mb-4">
+        <InputGroup>
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search groups..."
+          />
+        </InputGroup>
+      </div>
+      {!isPending && filteredGroups.length === 0 ? (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>{search ? "No groups match your search" : "No groups found"}</EmptyTitle>
+            <EmptyDescription>
+              {search ? "Try a different search term." : "Add groups to manage access."}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Group</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Added</TableHead>
+              <TableHead className="w-5" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isPending &&
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={`skeleton-${i + 1}`}>
+                  <TableCell>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-20" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-16" />
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              ))}
+            {filteredGroups.map((membership) => {
+              const { id, group, roles, createdAt } = membership;
+              const primaryRole = roles?.[0]?.role ?? "member";
+              return (
+                <TableRow key={id} onClick={() => setSelectedGroup(membership)}>
+                  <TableCell className="font-medium">{group.name}</TableCell>
+                  <TableCell>
+                    <Badge variant={primaryRole === "admin" ? "pam" : "neutral"}>
+                      {formatProjectRoleName(primaryRole, roles?.[0]?.customRoleName)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted">
+                    {createdAt ? format(new Date(createdAt), "MMM d, yyyy") : "-"}
+                  </TableCell>
+                  <TableCell>
+                    <ProjectPermissionCan
+                      I={ProjectPermissionActions.Delete}
+                      a={ProjectPermissionSub.Groups}
+                    >
+                      {(isAllowed) => (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <IconButton
+                              variant="outline"
+                              size="sm"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <MoreHorizontalIcon className="size-4" />
+                            </IconButton>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              isDisabled={!isAllowed}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setGroupToRemove(membership);
+                              }}
+                            >
+                              <Trash2Icon className="mr-2 size-4" />
+                              Remove from project
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </ProjectPermissionCan>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      <AddGroupModal isOpen={isAddGroupOpen} onOpenChange={setIsAddGroupOpen} />
+
+      <GroupDetailSheet
+        group={selectedGroup}
+        isOpen={!!selectedGroup}
+        onOpenChange={(open) => {
+          if (!open) setSelectedGroup(null);
+        }}
+      />
+
+      <DeleteActionModal
+        isOpen={!!groupToRemove}
+        onChange={(isOpen) => {
+          if (!isOpen) setGroupToRemove(null);
+        }}
+        title={`Remove ${groupToRemove?.group.name ?? "group"} from the project?`}
+        deleteKey="remove"
+        buttonText="Remove"
+        onDeleteApproved={handleDeleteGroup}
+      />
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -30,12 +30,12 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full access to all sections including settings, templates, and access control."
+    description: "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",
     label: "Member",
-    description: "Can only view Access page."
+    description: "Access limited to assigned folders and accounts."
   }
 ];
 

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -30,7 +30,8 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full administrative access: manage accounts, account templates, settings, and access control."
+    description:
+      "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from "react";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  CreatableSelect,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
+import {
+  OrgPermissionActions,
+  OrgPermissionSubjects,
+  useOrganization,
+  useOrgPermission,
+  useProject
+} from "@app/context";
+import { useAddUserToWsNonE2EE, useGetOrgUsers, useGetWorkspaceUsers } from "@app/hooks/api";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type SelectOption = {
+  label: string;
+  value: string;
+  isNewInvitee?: boolean;
+};
+
+const ROLE_OPTIONS = [
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Full access to all sections including settings, templates, and access control."
+  },
+  {
+    value: "member",
+    label: "Member",
+    description: "Can only view Access page."
+  }
+];
+
+export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
+  const { currentProject } = useProject();
+  const { currentOrg } = useOrganization();
+  const { permission: orgPermission } = useOrgPermission();
+  const { mutateAsync: addUser, isPending } = useAddUserToWsNonE2EE();
+
+  const [selectedUsers, setSelectedUsers] = useState<SelectOption[]>([]);
+  const [selectedRole, setSelectedRole] = useState("member");
+
+  const { data: members } = useGetWorkspaceUsers(currentProject.id);
+  const { data: orgUsers } = useGetOrgUsers(currentOrg.id);
+
+  const canInviteNewMembers = orgPermission.can(
+    OrgPermissionActions.Create,
+    OrgPermissionSubjects.Member
+  );
+
+  const availableUsers = useMemo(() => {
+    const wsUsernames = new Set(members?.map((m) => m.user.username));
+    return (orgUsers || [])
+      .filter(({ user: u }) => !wsUsernames.has(u.username))
+      .map(({ id, inviteEmail, user: { firstName, lastName, email } }) => ({
+        value: id,
+        label:
+          firstName && lastName
+            ? `${firstName} ${lastName}`
+            : firstName || lastName || email || inviteEmail
+      }));
+  }, [orgUsers, members]);
+
+  const handleClose = () => {
+    setSelectedUsers([]);
+    setSelectedRole("member");
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedUsers.length) return;
+
+    const existingMembers = selectedUsers.filter((u) => !u.isNewInvitee);
+    const newInvitees = selectedUsers.filter((u) => u.isNewInvitee).map((u) => u.value);
+
+    const existingUsernames = existingMembers
+      .map((selection) => {
+        const orgUser = orgUsers?.find((ou) => ou.id === selection.value);
+        return orgUser?.user.username || orgUser?.user.email;
+      })
+      .filter(Boolean) as string[];
+
+    try {
+      await addUser({
+        usernames: [...existingUsernames, ...newInvitees],
+        orgId: currentOrg.id,
+        projectId: currentProject.id,
+        projectType: currentProject.type,
+        roleSlugs: [selectedRole]
+      });
+      createNotification({
+        text: `Successfully added ${selectedUsers.length === 1 ? "member" : "members"}`,
+        type: "success"
+      });
+      handleClose();
+    } catch {
+      createNotification({ text: "Failed to add member", type: "error" });
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-visible sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add Member</DialogTitle>
+          <DialogDescription>
+            Users will receive an email with instructions to gain access.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5">
+          <Field>
+            <FieldLabel>
+              Users <span className="text-product-pam">*</span>
+            </FieldLabel>
+            {canInviteNewMembers ? (
+              <CreatableSelect
+                /* eslint-disable-next-line react/no-unstable-nested-components */
+                noOptionsMessage={() => (
+                  <>
+                    {availableUsers.length === 0 && (
+                      <p>All organization members are already assigned to this project.</p>
+                    )}
+                    <p>Invite new users to your organization by typing out their email address.</p>
+                  </>
+                )}
+                onCreateOption={(inputValue) =>
+                  setSelectedUsers((prev) => [
+                    ...prev,
+                    { label: inputValue, value: inputValue, isNewInvitee: true }
+                  ])
+                }
+                formatCreateLabel={(inputValue) => `Invite "${inputValue}"`}
+                isValidNewOption={(input) =>
+                  Boolean(input) &&
+                  z.string().email().safeParse(input).success &&
+                  !orgUsers
+                    ?.flatMap(({ user }) => [user.email, user.username].filter(Boolean))
+                    .includes(input)
+                }
+                placeholder="Add one or more users..."
+                isMulti
+                options={availableUsers}
+                value={selectedUsers}
+                onChange={(val) => setSelectedUsers(val as SelectOption[])}
+              />
+            ) : (
+              <FilterableSelect
+                placeholder="Add one or more users..."
+                isMulti
+                options={availableUsers}
+                value={selectedUsers}
+                onChange={(val) => setSelectedUsers(val as SelectOption[])}
+              />
+            )}
+          </Field>
+
+          <Field>
+            <FieldLabel>
+              Product role <span className="text-product-pam">*</span>
+            </FieldLabel>
+            <div className="flex flex-col gap-2">
+              {ROLE_OPTIONS.map((option) => {
+                const isSelected = selectedRole === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setSelectedRole(option.value)}
+                    className={`flex items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                      isSelected
+                        ? "border-product-pam/40 bg-product-pam/5"
+                        : "border-border bg-container hover:bg-container-hover"
+                    }`}
+                  >
+                    <div
+                      className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+                        isSelected ? "border-product-pam bg-product-pam" : "border-muted"
+                      }`}
+                    >
+                      {isSelected && <div className="size-1.5 rounded-full bg-white" />}
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium">{option.label}</p>
+                      <p className="text-xs text-muted">{option.description}</p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="pam"
+            isDisabled={!selectedUsers.length}
+            isPending={isPending}
+            onClick={handleSubmit}
+          >
+            Add {selectedUsers.length > 1 ? "Members" : "Member"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -1,10 +1,8 @@
 import { useMemo, useState } from "react";
-import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
   Button,
-  CreatableSelect,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -15,13 +13,7 @@ import {
   FieldLabel,
   FilterableSelect
 } from "@app/components/v3";
-import {
-  OrgPermissionActions,
-  OrgPermissionSubjects,
-  useOrganization,
-  useOrgPermission,
-  useProject
-} from "@app/context";
+import { useOrganization, useProject } from "@app/context";
 import { useAddUserToWsNonE2EE, useGetOrgUsers, useGetWorkspaceUsers } from "@app/hooks/api";
 
 type Props = {
@@ -32,7 +24,6 @@ type Props = {
 type SelectOption = {
   label: string;
   value: string;
-  isNewInvitee?: boolean;
 };
 
 const ROLE_OPTIONS = [
@@ -51,7 +42,6 @@ const ROLE_OPTIONS = [
 export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
   const { currentProject } = useProject();
   const { currentOrg } = useOrganization();
-  const { permission: orgPermission } = useOrgPermission();
   const { mutateAsync: addUser, isPending } = useAddUserToWsNonE2EE();
 
   const [selectedUsers, setSelectedUsers] = useState<SelectOption[]>([]);
@@ -59,11 +49,6 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
 
   const { data: members } = useGetWorkspaceUsers(currentProject.id);
   const { data: orgUsers } = useGetOrgUsers(currentOrg.id);
-
-  const canInviteNewMembers = orgPermission.can(
-    OrgPermissionActions.Create,
-    OrgPermissionSubjects.Member
-  );
 
   const availableUsers = useMemo(() => {
     const wsUsernames = new Set(members?.map((m) => m.user.username));
@@ -87,10 +72,7 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
   const handleSubmit = async () => {
     if (!selectedUsers.length) return;
 
-    const existingMembers = selectedUsers.filter((u) => !u.isNewInvitee);
-    const newInvitees = selectedUsers.filter((u) => u.isNewInvitee).map((u) => u.value);
-
-    const existingUsernames = existingMembers
+    const usernames = selectedUsers
       .map((selection) => {
         const orgUser = orgUsers?.find((ou) => ou.id === selection.value);
         return orgUser?.user.username || orgUser?.user.email;
@@ -99,7 +81,7 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
 
     try {
       await addUser({
-        usernames: [...existingUsernames, ...newInvitees],
+        usernames,
         orgId: currentOrg.id,
         projectId: currentProject.id,
         projectType: currentProject.type,
@@ -120,9 +102,7 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
       <DialogContent className="overflow-visible sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Add Member</DialogTitle>
-          <DialogDescription>
-            Users will receive an email with instructions to gain access.
-          </DialogDescription>
+          <DialogDescription>Add existing organization members.</DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-5">
@@ -130,46 +110,14 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
             <FieldLabel>
               Users <span className="text-product-pam">*</span>
             </FieldLabel>
-            {canInviteNewMembers ? (
-              <CreatableSelect
-                /* eslint-disable-next-line react/no-unstable-nested-components */
-                noOptionsMessage={() => (
-                  <>
-                    {availableUsers.length === 0 && (
-                      <p>All organization members are already assigned to this project.</p>
-                    )}
-                    <p>Invite new users to your organization by typing out their email address.</p>
-                  </>
-                )}
-                onCreateOption={(inputValue) =>
-                  setSelectedUsers((prev) => [
-                    ...prev,
-                    { label: inputValue, value: inputValue, isNewInvitee: true }
-                  ])
-                }
-                formatCreateLabel={(inputValue) => `Invite "${inputValue}"`}
-                isValidNewOption={(input) =>
-                  Boolean(input) &&
-                  z.string().email().safeParse(input).success &&
-                  !orgUsers
-                    ?.flatMap(({ user }) => [user.email, user.username].filter(Boolean))
-                    .includes(input)
-                }
-                placeholder="Add one or more users..."
-                isMulti
-                options={availableUsers}
-                value={selectedUsers}
-                onChange={(val) => setSelectedUsers(val as SelectOption[])}
-              />
-            ) : (
-              <FilterableSelect
-                placeholder="Add one or more users..."
-                isMulti
-                options={availableUsers}
-                value={selectedUsers}
-                onChange={(val) => setSelectedUsers(val as SelectOption[])}
-              />
-            )}
+            <FilterableSelect
+              placeholder="Select one or more users..."
+              isMulti
+              options={availableUsers}
+              value={selectedUsers}
+              onChange={(val) => setSelectedUsers(val as SelectOption[])}
+              noOptionsMessage={() => "All organization members have already been added."}
+            />
           </Field>
 
           <Field>

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
@@ -26,12 +26,12 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full access to all sections including settings, templates, and access control."
+    description: "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",
     label: "Member",
-    description: "Can only view Access page."
+    description: "Access limited to assigned folders and accounts."
   }
 ];
 

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
@@ -100,7 +100,7 @@ export const MemberDetailSheet = ({ member, isOpen, onOpenChange }: Props) => {
             </p>
             {isSelf ? (
               <p className="text-sm text-muted">
-                You cannot modify your own membership. Ask a project admin to make changes.
+                You cannot modify your own membership. Ask an admin to make changes.
               </p>
             ) : (
               <ProjectPermissionCan

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
@@ -26,7 +26,8 @@ const ROLE_OPTIONS = [
   {
     value: "admin",
     label: "Admin",
-    description: "Full administrative access: manage accounts, account templates, settings, and access control."
+    description:
+      "Full administrative access: manage accounts, account templates, settings, and access control."
   },
   {
     value: "member",

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MemberDetailSheet.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import {
+  Badge,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
+import { ProjectPermissionActions, ProjectPermissionSub, useProject, useUser } from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useUpdateUserWorkspaceRole } from "@app/hooks/api";
+import { TWorkspaceUser } from "@app/hooks/api/users/types";
+
+type Props = {
+  member: TWorkspaceUser | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const ROLE_OPTIONS = [
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Full access to all sections including settings, templates, and access control."
+  },
+  {
+    value: "member",
+    label: "Member",
+    description: "Can only view Access page."
+  }
+];
+
+export const MemberDetailSheet = ({ member, isOpen, onOpenChange }: Props) => {
+  const { currentProject } = useProject();
+  const { user } = useUser();
+  const updateRole = useUpdateUserWorkspaceRole();
+
+  const currentRole = member?.roles?.[0]?.role ?? "member";
+  const [selectedRole, setSelectedRole] = useState<string>(currentRole);
+
+  useEffect(() => {
+    if (member) {
+      setSelectedRole(member.roles?.[0]?.role ?? "member");
+    }
+  }, [member]);
+
+  if (!member) return null;
+
+  const isSelf = member.user.id === user?.id;
+
+  const displayName =
+    member.user.firstName || member.user.lastName
+      ? `${member.user.firstName ?? ""} ${member.user.lastName ?? ""}`.trim()
+      : member.user.username;
+
+  const hasChanges = selectedRole !== currentRole;
+
+  const handleSave = async () => {
+    try {
+      await updateRole.mutateAsync({
+        projectId: currentProject.id,
+        membershipId: member.id,
+        roles: [{ role: selectedRole, isTemporary: false }]
+      });
+      createNotification({ text: "Role updated", type: "success" });
+      onOpenChange(false);
+    } catch {
+      createNotification({ text: "Failed to update role", type: "error" });
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>Member Details</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6">
+          <div className="flex flex-col items-start gap-3">
+            <div>
+              <h3 className="text-lg font-semibold">{displayName}</h3>
+              <p className="font-mono text-sm text-muted">
+                {member.user.email || member.inviteEmail}
+              </p>
+            </div>
+            <Badge variant={currentRole === "admin" ? "pam" : "neutral"}>
+              {formatProjectRoleName(currentRole, member.roles?.[0]?.customRoleName)}
+            </Badge>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <p className="mb-3 text-xs font-medium tracking-wider text-muted uppercase">
+              Product Role
+            </p>
+            {isSelf ? (
+              <p className="text-sm text-muted">
+                You cannot modify your own membership. Ask a project admin to make changes.
+              </p>
+            ) : (
+              <ProjectPermissionCan
+                I={ProjectPermissionActions.Edit}
+                a={ProjectPermissionSub.Member}
+              >
+                {(isAllowed) => (
+                  <div className="flex flex-col gap-2">
+                    {ROLE_OPTIONS.map((option) => {
+                      const isSelected = selectedRole === option.value;
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          disabled={!isAllowed}
+                          onClick={() => setSelectedRole(option.value)}
+                          className={`flex items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                            isSelected
+                              ? "border-product-pam/40 bg-product-pam/5"
+                              : "border-border bg-container hover:bg-container-hover"
+                          } ${!isAllowed ? "cursor-not-allowed opacity-50" : ""}`}
+                        >
+                          <div
+                            className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${
+                              isSelected ? "border-product-pam bg-product-pam" : "border-muted"
+                            }`}
+                          >
+                            {isSelected && <div className="size-1.5 rounded-full bg-white" />}
+                          </div>
+                          <div>
+                            <p className="text-sm font-medium">{option.label}</p>
+                            <p className="text-xs text-muted">{option.description}</p>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </ProjectPermissionCan>
+            )}
+          </div>
+        </div>
+
+        {!isSelf && (
+          <SheetFooter className="flex-row justify-end gap-2 border-t border-border px-6 py-4">
+            <Button
+              variant="outline"
+              size="sm"
+              isDisabled={!hasChanges}
+              onClick={() => setSelectedRole(currentRole)}
+            >
+              Reset
+            </Button>
+            <Button
+              variant="pam"
+              size="sm"
+              isDisabled={!hasChanges}
+              isPending={updateRole.isPending}
+              onClick={handleSave}
+            >
+              Save
+            </Button>
+          </SheetFooter>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
@@ -230,7 +230,7 @@ export const MembersTab = () => {
         onChange={(isOpen) => {
           if (!isOpen) setMemberToRemove(null);
         }}
-        title={`Remove ${memberToRemove ? getDisplayName(memberToRemove) : "member"} from the project?`}
+        title={`Remove ${memberToRemove ? getDisplayName(memberToRemove) : "member"}?`}
         deleteKey="remove"
         buttonText="Remove"
         onDeleteApproved={handleRemoveMember}

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from "react";
+import { MoreHorizontalIcon, Plus, SearchIcon, UserXIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
+import { DeleteActionModal } from "@app/components/v2";
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  IconButton,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSub,
+  useOrganization,
+  useProject,
+  useUser
+} from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useDeleteUserFromWorkspace, useGetWorkspaceUsers } from "@app/hooks/api";
+import { TWorkspaceUser } from "@app/hooks/api/users/types";
+
+import { InviteMemberModal } from "./InviteMemberModal";
+import { MemberDetailSheet } from "./MemberDetailSheet";
+
+export const MembersTab = () => {
+  const { currentProject } = useProject();
+  const { currentOrg } = useOrganization();
+  const { user } = useUser();
+  const [search, setSearch] = useState("");
+  const [selectedMember, setSelectedMember] = useState<TWorkspaceUser | null>(null);
+  const [isInviteOpen, setIsInviteOpen] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState<TWorkspaceUser | null>(null);
+
+  const { data: members = [], isPending } = useGetWorkspaceUsers(currentProject.id);
+  const deleteMember = useDeleteUserFromWorkspace();
+
+  const filteredMembers = useMemo(
+    () =>
+      members.filter(
+        ({ user: u, inviteEmail }) =>
+          u?.firstName?.toLowerCase().includes(search.toLowerCase()) ||
+          u?.lastName?.toLowerCase().includes(search.toLowerCase()) ||
+          u?.email?.toLowerCase().includes(search.toLowerCase()) ||
+          inviteEmail?.toLowerCase().includes(search.toLowerCase())
+      ),
+    [members, search]
+  );
+
+  const handleRemoveMember = async () => {
+    if (!memberToRemove) return;
+    try {
+      await deleteMember.mutateAsync({
+        projectId: currentProject.id,
+        usernames: [memberToRemove.user.username],
+        orgId: currentOrg.id
+      });
+      createNotification({ text: "Member removed", type: "success" });
+    } catch {
+      createNotification({ text: "Failed to remove member", type: "error" });
+    } finally {
+      setMemberToRemove(null);
+    }
+  };
+
+  const getPrimaryRole = (member: TWorkspaceUser) => {
+    const role = member.roles?.[0];
+    if (!role) return "member";
+    return role.role;
+  };
+
+  const getDisplayName = (member: TWorkspaceUser) =>
+    member.user.firstName || member.user.lastName
+      ? `${member.user.firstName ?? ""} ${member.user.lastName ?? ""}`.trim()
+      : member.user.username || member.inviteEmail;
+
+  return (
+    <div className="mt-4">
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-sm text-muted">
+          {filteredMembers.length} member{filteredMembers.length !== 1 ? "s" : ""}
+        </p>
+        <ProjectPermissionCan I={ProjectPermissionActions.Create} a={ProjectPermissionSub.Member}>
+          {(isAllowed) => (
+            <Button
+              variant="pam"
+              size="sm"
+              isDisabled={!isAllowed}
+              onClick={() => setIsInviteOpen(true)}
+            >
+              <Plus className="mr-1 size-4" />
+              Invite Member
+            </Button>
+          )}
+        </ProjectPermissionCan>
+      </div>
+      <div className="mb-4">
+        <InputGroup>
+          <InputGroupAddon>
+            <SearchIcon />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search members..."
+          />
+        </InputGroup>
+      </div>
+      {!isPending && filteredMembers.length === 0 ? (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>{search ? "No members match your search" : "No members found"}</EmptyTitle>
+            <EmptyDescription>
+              {search ? "Try a different search term." : "Invite members to get started."}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Product Role</TableHead>
+              <TableHead className="w-5" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isPending &&
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={`skeleton-${i + 1}`}>
+                  <TableCell>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-20" />
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              ))}
+            {filteredMembers.map((member) => {
+              const role = getPrimaryRole(member);
+              const isSelf = member.user.id === user?.id;
+
+              return (
+                <TableRow key={member.id} onClick={() => setSelectedMember(member)}>
+                  <TableCell className="font-medium">{getDisplayName(member)}</TableCell>
+                  <TableCell className="font-mono text-sm text-muted">
+                    {member.user.email || member.inviteEmail}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={role === "admin" ? "pam" : "neutral"}>
+                      {formatProjectRoleName(role, member.roles?.[0]?.customRoleName)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {!isSelf && (
+                      <ProjectPermissionCan
+                        I={ProjectPermissionActions.Delete}
+                        a={ProjectPermissionSub.Member}
+                      >
+                        {(isAllowed) => (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <IconButton
+                                variant="outline"
+                                size="sm"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreHorizontalIcon className="size-4" />
+                              </IconButton>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                isDisabled={!isAllowed}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setMemberToRemove(member);
+                                }}
+                              >
+                                <UserXIcon className="mr-2 size-4" />
+                                Remove
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </ProjectPermissionCan>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      <MemberDetailSheet
+        member={selectedMember}
+        isOpen={!!selectedMember}
+        onOpenChange={(open) => {
+          if (!open) setSelectedMember(null);
+        }}
+      />
+
+      <InviteMemberModal isOpen={isInviteOpen} onOpenChange={setIsInviteOpen} />
+
+      <DeleteActionModal
+        isOpen={!!memberToRemove}
+        onChange={(isOpen) => {
+          if (!isOpen) setMemberToRemove(null);
+        }}
+        title={`Remove ${memberToRemove ? getDisplayName(memberToRemove) : "member"} from the project?`}
+        deleteKey="remove"
+        buttonText="Remove"
+        onDeleteApproved={handleRemoveMember}
+      />
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamAuditLogsPage/PamAuditLogsPage.tsx
+++ b/frontend/src/pages/pam/PamAuditLogsPage/PamAuditLogsPage.tsx
@@ -1,0 +1,26 @@
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+
+import { PageHeader } from "@app/components/v2";
+import { useProject } from "@app/context";
+import { ProjectType } from "@app/hooks/api/projects/types";
+import { LogsSection } from "@app/pages/organization/AuditLogsPage/components";
+
+export const PamAuditLogsPage = () => {
+  const { t } = useTranslation();
+  const { currentProject } = useProject();
+
+  return (
+    <div className="mx-auto mb-6 w-full max-w-8xl">
+      <Helmet>
+        <title>{t("common.head-title", { title: "Audit Logs" })}</title>
+      </Helmet>
+      <PageHeader
+        scope={ProjectType.PAM}
+        title="Audit Logs"
+        description="Audit logs for security and compliance teams to monitor information access."
+      />
+      <LogsSection pageView project={currentProject} />
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
@@ -30,16 +30,42 @@ import { useProject } from "@app/context";
 import {
   PAM_ACCOUNT_TYPE_MAP,
   PamAccountType,
+  PamResourcePermissionActions,
+  PamResourcePermissionSub,
   PamSessionStatus,
   useListPamSessions,
   useTerminatePamSession
 } from "@app/hooks/api/pam";
+import { usePamAccountPermission } from "@app/hooks/api/pam/queries";
 import { TPamSession } from "@app/hooks/api/pam/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 import { useDebounce } from "@app/hooks/useDebounce";
 
 import { SessionDetailSheet } from "./components/SessionDetailSheet";
 import { capitalize, formatDuration, STATUS_BADGE } from "./constants";
+
+const TerminateCell = ({
+  session,
+  onTerminate
+}: {
+  session: TPamSession;
+  onTerminate: (session: TPamSession, e?: React.MouseEvent) => void;
+}) => {
+  const { data: perm } = usePamAccountPermission(session.accountId ?? "");
+  const canTerminate = perm?.permission.can(
+    PamResourcePermissionActions.TerminateSessions,
+    PamResourcePermissionSub.PamResource
+  );
+
+  if (session.status !== PamSessionStatus.Active || !canTerminate) return null;
+
+  return (
+    <Button variant="danger" size="xs" onClick={(e) => onTerminate(session, e)}>
+      <SquareIcon className="mr-1 size-3" />
+      Terminate
+    </Button>
+  );
+};
 
 export const PamSessionsPage = () => {
   const { t } = useTranslation();
@@ -214,16 +240,7 @@ export const PamSessionsPage = () => {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    {session.status === PamSessionStatus.Active && (
-                      <Button
-                        variant="danger"
-                        size="xs"
-                        onClick={(e) => requestTerminate(session, e)}
-                      >
-                        <SquareIcon className="mr-1 size-3" />
-                        Terminate
-                      </Button>
-                    )}
+                    <TerminateCell session={session} onTerminate={requestTerminate} />
                   </TableCell>
                 </TableRow>
               );

--- a/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useState } from "react";
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+import { format } from "date-fns";
+import { SearchIcon, SquareIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { DeleteActionModal, PageHeader } from "@app/components/v2";
+import {
+  Badge,
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Pagination,
+  Skeleton,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
+import { useProject } from "@app/context";
+import {
+  PAM_ACCOUNT_TYPE_MAP,
+  PamAccountType,
+  PamSessionStatus,
+  useListPamSessions,
+  useTerminatePamSession
+} from "@app/hooks/api/pam";
+import { TPamSession } from "@app/hooks/api/pam/types";
+import { ProjectType } from "@app/hooks/api/projects/types";
+import { useDebounce } from "@app/hooks/useDebounce";
+
+import { SessionDetailSheet } from "./components/SessionDetailSheet";
+import { capitalize, formatDuration, STATUS_BADGE } from "./constants";
+
+export const PamSessionsPage = () => {
+  const { t } = useTranslation();
+  const { currentProject } = useProject();
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebounce(search);
+  const [activeOnly, setActiveOnly] = useState(false);
+  const [selectedSession, setSelectedSession] = useState<TPamSession | null>(null);
+  const [sessionToTerminate, setSessionToTerminate] = useState<TPamSession | null>(null);
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(20);
+
+  const offset = (page - 1) * perPage;
+
+  const { data, isPending } = useListPamSessions(currentProject.id, {
+    offset,
+    limit: perPage,
+    search: debouncedSearch || undefined,
+    status: activeOnly ? PamSessionStatus.Active : undefined
+  });
+  const sessions = data?.sessions ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const terminateSession = useTerminatePamSession();
+
+  useEffect(() => {
+    if (!selectedSession) return;
+    const fresh = sessions.find((s) => s.id === selectedSession.id);
+    if (fresh) {
+      setSelectedSession(fresh);
+    }
+  }, [sessions]);
+
+  const requestTerminate = (session: TPamSession, e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setSessionToTerminate(session);
+  };
+
+  const confirmTerminate = async () => {
+    if (!sessionToTerminate) return;
+    try {
+      await terminateSession.mutateAsync({
+        sessionId: sessionToTerminate.id,
+        projectId: currentProject.id
+      });
+      createNotification({ text: "Session terminated", type: "success" });
+      setSessionToTerminate(null);
+    } catch {
+      createNotification({ text: "Failed to terminate session", type: "error" });
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+    setPage(1);
+  };
+
+  const handleActiveOnlyChange = (checked: boolean) => {
+    setActiveOnly(checked);
+    setPage(1);
+  };
+
+  return (
+    <div className="mx-auto mb-6 w-full max-w-8xl">
+      <Helmet>
+        <title>{t("common.head-title", { title: "Sessions" })}</title>
+      </Helmet>
+      <PageHeader
+        scope={ProjectType.PAM}
+        title="Sessions"
+        description="Monitor and manage active and historical sessions."
+      />
+
+      <div className="mb-4 flex items-center gap-4">
+        <div className="flex-1">
+          <InputGroup>
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              value={search}
+              onChange={handleSearchChange}
+              placeholder="Search by account, user, or folder..."
+            />
+          </InputGroup>
+        </div>
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm text-muted">
+          <Switch checked={activeOnly} onCheckedChange={handleActiveOnlyChange} size="sm" />
+          Only show active sessions
+        </label>
+      </div>
+
+      {!isPending && sessions.length === 0 ? (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>
+              {search || activeOnly ? "No sessions match your filters" : "No sessions found"}
+            </EmptyTitle>
+            <EmptyDescription>
+              {search || activeOnly
+                ? "Try adjusting your search or filters."
+                : "Sessions will appear here when users connect to resources."}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Account</TableHead>
+              <TableHead>Folder</TableHead>
+              <TableHead>Started</TableHead>
+              <TableHead>Duration</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-5" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isPending &&
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={`skeleton-${i + 1}`}>
+                  {Array.from({ length: 7 }).map((__, j) => (
+                    <TableCell key={`cell-${j + 1}`}>
+                      <Skeleton className="h-4 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            {sessions.map((session) => {
+              const statusConfig = STATUS_BADGE[session.status];
+              const accountTypeDetails =
+                session.accountType && PAM_ACCOUNT_TYPE_MAP[session.accountType as PamAccountType];
+
+              return (
+                <TableRow key={session.id} onClick={() => setSelectedSession(session)}>
+                  <TableCell className="h-[50px]">{session.actorName}</TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      {accountTypeDetails && (
+                        <img
+                          src={`/images/integrations/${accountTypeDetails.image}`}
+                          alt={accountTypeDetails.name}
+                          className="size-5 shrink-0 rounded-sm"
+                        />
+                      )}
+                      <span className="text-sm">{session.accountName}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm">{session.folderName ?? "-"}</TableCell>
+                  <TableCell>
+                    {session.startedAt ? (
+                      <div className="flex flex-col">
+                        <span className="text-sm">
+                          {format(new Date(session.startedAt), "h:mm:ss a")}
+                        </span>
+                        <span className="text-xs text-muted">
+                          {format(new Date(session.startedAt), "M/d/yyyy")}
+                        </span>
+                      </div>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
+                  <TableCell className="text-sm">{formatDuration(session)}</TableCell>
+                  <TableCell>
+                    <Badge variant={statusConfig.variant}>
+                      {statusConfig.dot && (
+                        <span className="mr-1.5 inline-block size-1.5 rounded-full bg-product-pam" />
+                      )}
+                      {capitalize(session.status)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {session.status === PamSessionStatus.Active && (
+                      <Button
+                        variant="danger"
+                        size="xs"
+                        onClick={(e) => requestTerminate(session, e)}
+                      >
+                        <SquareIcon className="mr-1 size-3" />
+                        Terminate
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {totalCount > 0 && (
+        <Pagination
+          count={totalCount}
+          page={page}
+          perPage={perPage}
+          onChangePage={setPage}
+          onChangePerPage={(newPerPage) => {
+            setPerPage(newPerPage);
+            setPage(1);
+          }}
+        />
+      )}
+
+      <SessionDetailSheet
+        session={selectedSession}
+        isOpen={!!selectedSession}
+        onOpenChange={(open) => {
+          if (!open) setSelectedSession(null);
+        }}
+        onTerminate={requestTerminate}
+      />
+
+      <DeleteActionModal
+        isOpen={!!sessionToTerminate}
+        onChange={(open) => {
+          if (!open) setSessionToTerminate(null);
+        }}
+        title="Terminate Session"
+        subTitle="Are you sure you want to terminate this session? The user's connection will be immediately dropped."
+        deleteKey="terminate"
+        buttonText="Terminate"
+        onDeleteApproved={confirmTerminate}
+      />
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -117,11 +117,7 @@ const LogEntry = ({ log }: { log: TPamSessionLog }) => {
     );
   }
 
-  return (
-    <div className="border-b border-border px-4 py-3">
-      {content}
-    </div>
-  );
+  return <div className="border-b border-border px-4 py-3">{content}</div>;
 };
 
 const InfoRow = ({ label, value }: { label: string; value: string | null | undefined }) => (

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -19,9 +19,12 @@ import {
 import {
   PAM_ACCOUNT_TYPE_MAP,
   PamAccountType,
+  PamResourcePermissionActions,
+  PamResourcePermissionSub,
   PamSessionStatus,
   useGetPamSessionLogs
 } from "@app/hooks/api/pam";
+import { usePamAccountPermission } from "@app/hooks/api/pam/queries";
 import { TPamSession, TPamSessionLog } from "@app/hooks/api/pam/types";
 
 import { capitalize, formatDuration, STATUS_BADGE } from "../constants";
@@ -120,6 +123,12 @@ export const SessionDetailSheet = ({ session, isOpen, onOpenChange, onTerminate 
     setLogSearch("");
   }, [session?.id]);
 
+  const { data: accountPerm } = usePamAccountPermission(session?.accountId ?? "");
+  const canTerminate = accountPerm?.permission.can(
+    PamResourcePermissionActions.TerminateSessions,
+    PamResourcePermissionSub.PamResource
+  );
+
   const {
     logs,
     isLoading: isLogsLoading,
@@ -211,7 +220,7 @@ export const SessionDetailSheet = ({ session, isOpen, onOpenChange, onTerminate 
               <InfoRow label="Duration" value={formatDuration(session)} />
               <InfoRow label="IP Address" value={session.actorIp} />
               {session.reason && <InfoRow label="Reason" value={session.reason} />}
-              {session.status === PamSessionStatus.Active && (
+              {session.status === PamSessionStatus.Active && canTerminate && (
                 <Button variant="danger" size="sm" className="mt-2 w-full" onClick={handleTerminate}>
                   <SquareIcon className="mr-1.5 size-3.5" />
                   Terminate session

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import { ChevronRightIcon, ClipboardListIcon, SearchIcon, SquareIcon, TerminalIcon } from "lucide-react";
+
+import {
+  Badge,
+  Button,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Sheet,
+  SheetContent,
+  Skeleton,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger
+} from "@app/components/v3";
+import {
+  PAM_ACCOUNT_TYPE_MAP,
+  PamAccountType,
+  PamSessionStatus,
+  useGetPamSessionLogs
+} from "@app/hooks/api/pam";
+import { TPamSession, TPamSessionLog } from "@app/hooks/api/pam/types";
+
+import { capitalize, formatDuration, STATUS_BADGE } from "../constants";
+
+type Props = {
+  session: TPamSession | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTerminate: (session: TPamSession) => void;
+};
+
+const getLogText = (log: TPamSessionLog): string => {
+  if ("input" in log && "output" in log) {
+    return [log.input, log.output].filter(Boolean).join(" ");
+  }
+  if ("data" in log) {
+    return log.data;
+  }
+  if ("method" in log) {
+    return `${log.method} ${log.url}`;
+  }
+  if ("status" in log) {
+    return `Response ${log.status}`;
+  }
+  return "";
+};
+
+const DESTRUCTIVE_PREFIXES = ["DROP ", "DELETE ", "TRUNCATE ", "ALTER "];
+
+const isDestructiveQuery = (text: string): boolean => {
+  const upper = text.trimStart().toUpperCase();
+  return DESTRUCTIVE_PREFIXES.some((prefix) => upper.startsWith(prefix));
+};
+
+const LogEntry = ({ log }: { log: TPamSessionLog }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const text = getLogText(log);
+
+  const textRef = useCallback((node: HTMLParagraphElement | null) => {
+    if (node && !expanded) {
+      setOverflows(node.scrollWidth > node.clientWidth);
+    }
+  }, [expanded]);
+
+  if (!text) return null;
+
+  const destructive = isDestructiveQuery(text);
+  const toggleExpand = overflows ? () => setExpanded((prev) => !prev) : undefined;
+
+  return (
+    <div
+      className={`border-b border-border px-4 py-3 transition-colors hover:bg-white/[0.06] ${overflows ? "cursor-pointer" : "cursor-default"}`}
+      role={overflows ? "button" : undefined}
+      tabIndex={overflows ? 0 : undefined}
+      onClick={toggleExpand}
+      onKeyDown={
+        overflows
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") setExpanded((prev) => !prev);
+            }
+          : undefined
+      }
+    >
+      <p className="mb-1 text-xs text-muted">
+        {format(new Date(log.timestamp), "M/d/yyyy, h:mm:ss a")}
+      </p>
+      <div className="flex items-start gap-1.5">
+        {overflows && (
+          <ChevronRightIcon
+            className={`mt-0.5 size-3.5 shrink-0 text-muted transition-transform ${expanded ? "rotate-90" : ""}`}
+          />
+        )}
+        <p
+          ref={textRef}
+          className={`font-mono text-xs ${expanded ? "whitespace-pre-wrap break-all" : "truncate"} ${destructive ? "text-red-400" : ""}`}
+        >
+          {text}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const InfoRow = ({ label, value }: { label: string; value: string | null | undefined }) => (
+  <div>
+    <p className="text-xs font-medium tracking-wider text-muted uppercase">{label}</p>
+    <p className="mt-0.5 text-sm">{value || "-"}</p>
+  </div>
+);
+
+export const SessionDetailSheet = ({ session, isOpen, onOpenChange, onTerminate }: Props) => {
+  const [logSearch, setLogSearch] = useState("");
+
+  useEffect(() => {
+    setLogSearch("");
+  }, [session?.id]);
+
+  const {
+    logs,
+    isLoading: isLogsLoading,
+    hasMore,
+    loadMore,
+    isLoadingMore
+  } = useGetPamSessionLogs(
+    session?.id ?? "",
+    session?.status === PamSessionStatus.Active,
+    isOpen && !!session
+  );
+
+  const filteredLogs = useMemo(() => {
+    if (!logSearch.trim()) return logs;
+    const term = logSearch.trim().toLowerCase();
+    return logs.filter((log) => getLogText(log).toLowerCase().includes(term));
+  }, [logs, logSearch]);
+
+  if (!session) return null;
+
+  const statusConfig = STATUS_BADGE[session.status];
+  const accountTypeDetails =
+    session.accountType && PAM_ACCOUNT_TYPE_MAP[session.accountType as PamAccountType];
+  const shortId = session.id.slice(0, 8);
+
+  const handleTerminate = () => {
+    onTerminate(session);
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-5xl">
+        <div className="flex flex-1 overflow-hidden">
+          <div className="flex w-72 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border p-6">
+            <div className="flex size-12 items-center justify-center rounded-md bg-bunker-700">
+              {accountTypeDetails ? (
+                <img
+                  src={`/images/integrations/${accountTypeDetails.image}`}
+                  alt={accountTypeDetails.name}
+                  className="size-7 rounded-sm"
+                />
+              ) : (
+                <TerminalIcon className="size-6 text-muted" />
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div>
+                <h3 className="text-base font-semibold">
+                  Session · <span className="font-mono">{shortId}</span>
+                </h3>
+                <p className="text-xs text-muted">{session.actorName}</p>
+              </div>
+              <Badge variant={statusConfig.variant}>
+                {session.status === PamSessionStatus.Active && (
+                  <span className="mr-1.5 inline-block size-1.5 rounded-full bg-product-pam" />
+                )}
+                {capitalize(session.status)}
+              </Badge>
+            </div>
+
+            <div className="flex flex-col gap-4 border-t border-border pt-4">
+              <InfoRow
+                label="Account"
+                value={
+                  accountTypeDetails
+                    ? `${session.accountName} (${accountTypeDetails.name})`
+                    : session.accountName
+                }
+              />
+              <InfoRow label="Folder" value={session.folderName} />
+              <InfoRow label="Host" value={session.selectedHost ?? session.resourceName} />
+              <InfoRow
+                label="Started"
+                value={
+                  session.startedAt
+                    ? format(new Date(session.startedAt), "MMM d, yyyy HH:mm:ss")
+                    : null
+                }
+              />
+              <InfoRow
+                label="Ended"
+                value={
+                  session.endedAt
+                    ? format(new Date(session.endedAt), "MMM d, yyyy HH:mm:ss")
+                    : "Ongoing"
+                }
+              />
+              <InfoRow label="Duration" value={formatDuration(session)} />
+              <InfoRow label="IP Address" value={session.actorIp} />
+              {session.reason && <InfoRow label="Reason" value={session.reason} />}
+              {session.status === PamSessionStatus.Active && (
+                <Button variant="danger" size="sm" className="mt-2 w-full" onClick={handleTerminate}>
+                  <SquareIcon className="mr-1.5 size-3.5" />
+                  Terminate session
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <Tabs defaultValue="logs" className="flex flex-1 flex-col overflow-hidden">
+              <TabsList variant="pam" className="border-b border-border px-4 pt-4">
+                <TabsTrigger value="logs">
+                  <ClipboardListIcon className="mr-1.5 size-3.5" />
+                  Session Logs
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                value="logs"
+                className="flex flex-1 flex-col overflow-hidden p-4 data-[state=active]:mt-0"
+              >
+                <div className="mb-3">
+                  <InputGroup>
+                    <InputGroupAddon>
+                      <SearchIcon />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                      value={logSearch}
+                      onChange={(e) => setLogSearch(e.target.value)}
+                      placeholder="Search logs..."
+                    />
+                  </InputGroup>
+                </div>
+
+                <div className="flex-1 overflow-y-auto rounded-md border border-border bg-bunker-800">
+                  {isLogsLoading && (
+                    <div className="flex flex-col gap-2 p-4">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Skeleton key={`log-skeleton-${i + 1}`} className="h-4 w-full" />
+                      ))}
+                    </div>
+                  )}
+                  {!isLogsLoading && filteredLogs.length === 0 && (
+                    <div className="flex items-center justify-center p-8 text-sm text-muted">
+                      {logSearch
+                        ? "No logs match your search"
+                        : "No logs recorded for this session"}
+                    </div>
+                  )}
+                  {!isLogsLoading && filteredLogs.length > 0 && (
+                    <div>
+                      {filteredLogs.map((log, i) => (
+                        <LogEntry
+                          key={`log-${log.timestamp}-${i + 1}`}
+                          log={log}
+                        />
+                      ))}
+                      {hasMore && (
+                        <div className="flex justify-center p-3">
+                          <Button
+                            variant="outline"
+                            size="xs"
+                            isPending={isLoadingMore}
+                            onClick={loadMore}
+                          >
+                            Load more
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
-import { ChevronRightIcon, ClipboardListIcon, SearchIcon, SquareIcon, TerminalIcon } from "lucide-react";
+import {
+  ChevronRightIcon,
+  ClipboardListIcon,
+  SearchIcon,
+  SquareIcon,
+  TerminalIcon
+} from "lucide-react";
 
 import {
   Badge,
@@ -64,31 +70,22 @@ const LogEntry = ({ log }: { log: TPamSessionLog }) => {
   const [overflows, setOverflows] = useState(false);
   const text = getLogText(log);
 
-  const textRef = useCallback((node: HTMLParagraphElement | null) => {
-    if (node && !expanded) {
-      setOverflows(node.scrollWidth > node.clientWidth);
-    }
-  }, [expanded]);
+  const textRef = useCallback(
+    (node: HTMLParagraphElement | null) => {
+      if (node && !expanded) {
+        setOverflows(node.scrollWidth > node.clientWidth);
+      }
+    },
+    [expanded]
+  );
 
   if (!text) return null;
 
   const destructive = isDestructiveQuery(text);
   const toggleExpand = overflows ? () => setExpanded((prev) => !prev) : undefined;
 
-  return (
-    <div
-      className={`border-b border-border px-4 py-3 transition-colors hover:bg-white/[0.06] ${overflows ? "cursor-pointer" : "cursor-default"}`}
-      role={overflows ? "button" : undefined}
-      tabIndex={overflows ? 0 : undefined}
-      onClick={toggleExpand}
-      onKeyDown={
-        overflows
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") setExpanded((prev) => !prev);
-            }
-          : undefined
-      }
-    >
+  const content = (
+    <>
       <p className="mb-1 text-xs text-muted">
         {format(new Date(log.timestamp), "M/d/yyyy, h:mm:ss a")}
       </p>
@@ -100,11 +97,29 @@ const LogEntry = ({ log }: { log: TPamSessionLog }) => {
         )}
         <p
           ref={textRef}
-          className={`font-mono text-xs ${expanded ? "whitespace-pre-wrap break-all" : "truncate"} ${destructive ? "text-red-400" : ""}`}
+          className={`font-mono text-xs ${expanded ? "break-all whitespace-pre-wrap" : "truncate"} ${destructive ? "text-red-400" : ""}`}
         >
           {text}
         </p>
       </div>
+    </>
+  );
+
+  if (overflows) {
+    return (
+      <button
+        type="button"
+        className="w-full cursor-pointer border-b border-border px-4 py-3 text-left transition-colors hover:bg-white/[0.06]"
+        onClick={toggleExpand}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div className="border-b border-border px-4 py-3">
+      {content}
     </div>
   );
 };
@@ -221,7 +236,12 @@ export const SessionDetailSheet = ({ session, isOpen, onOpenChange, onTerminate 
               <InfoRow label="IP Address" value={session.actorIp} />
               {session.reason && <InfoRow label="Reason" value={session.reason} />}
               {session.status === PamSessionStatus.Active && canTerminate && (
-                <Button variant="danger" size="sm" className="mt-2 w-full" onClick={handleTerminate}>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  className="mt-2 w-full"
+                  onClick={handleTerminate}
+                >
                   <SquareIcon className="mr-1.5 size-3.5" />
                   Terminate session
                 </Button>
@@ -272,10 +292,7 @@ export const SessionDetailSheet = ({ session, isOpen, onOpenChange, onTerminate 
                   {!isLogsLoading && filteredLogs.length > 0 && (
                     <div>
                       {filteredLogs.map((log, i) => (
-                        <LogEntry
-                          key={`log-${log.timestamp}-${i + 1}`}
-                          log={log}
-                        />
+                        <LogEntry key={`log-${log.timestamp}-${i + 1}`} log={log} />
                       ))}
                       {hasMore && (
                         <div className="flex justify-center p-3">

--- a/frontend/src/pages/pam/PamSessionsPage/constants.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/constants.tsx
@@ -1,0 +1,37 @@
+import { PamSessionStatus } from "@app/hooks/api/pam";
+import { TPamSession } from "@app/hooks/api/pam/types";
+
+export const STATUS_BADGE: Record<
+  PamSessionStatus,
+  { variant: "pam" | "neutral" | "danger"; dot?: boolean }
+> = {
+  [PamSessionStatus.Starting]: { variant: "neutral" },
+  [PamSessionStatus.Active]: { variant: "pam", dot: true },
+  [PamSessionStatus.Ended]: { variant: "neutral" },
+  [PamSessionStatus.Terminated]: { variant: "danger" }
+};
+
+export const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+const formatCompactDuration = (ms: number) => {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+  return `${seconds}s`;
+};
+
+const getSessionEnd = (session: TPamSession) => {
+  if (session.status === PamSessionStatus.Active) return new Date();
+  return session.endedAt ? new Date(session.endedAt) : new Date();
+};
+
+export const formatDuration = (session: TPamSession) => {
+  const start = session.startedAt ? new Date(session.startedAt) : null;
+  if (!start) return "-";
+  return formatCompactDuration(getSessionEnd(session).getTime() - start.getTime());
+};

--- a/frontend/src/pages/pam/PamSessionsPage/route.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/route.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PamSessionsPage } from "./PamSessionsPage";
+
+export const Route = createFileRoute(
+  "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions"
+)({
+  component: PamSessionsPage,
+  beforeLoad: ({ context }) => {
+    return {
+      breadcrumbs: [
+        ...context.breadcrumbs,
+        {
+          label: "Sessions"
+        }
+      ]
+    };
+  }
+});

--- a/frontend/src/pages/project/AccessControlPage/route-pam.tsx
+++ b/frontend/src/pages/project/AccessControlPage/route-pam.tsx
@@ -2,20 +2,18 @@ import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
-import { ProjectAccessControlTabs } from "@app/types/project";
+import { PamAccessControlPage } from "@app/pages/pam/PamAccessControlPage/PamAccessControlPage";
 
-import { AccessControlPage } from "./AccessControlPage";
-
-const AccessControlPageQuerySchema = z.object({
-  selectedTab: z.nativeEnum(ProjectAccessControlTabs).catch(ProjectAccessControlTabs.Member),
+const PamAccessControlQuerySchema = z.object({
+  selectedTab: z.enum(["members", "groups"]).catch("members"),
   requesterEmail: z.string().catch("")
 });
 
 export const Route = createFileRoute(
   "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access-management"
 )({
-  component: AccessControlPage,
-  validateSearch: zodValidator(AccessControlPageQuerySchema),
+  component: PamAccessControlPage,
+  validateSearch: zodValidator(PamAccessControlQuerySchema),
   search: {
     middlewares: [stripSearchParams({ requesterEmail: "" })]
   },

--- a/frontend/src/pages/project/AuditLogsPage/route-pam.tsx
+++ b/frontend/src/pages/project/AuditLogsPage/route-pam.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { AuditLogsPage } from "./AuditLogsPage";
+import { PamAuditLogsPage } from "@app/pages/pam/PamAuditLogsPage/PamAuditLogsPage";
 
 export const Route = createFileRoute(
   "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/audit-logs"
 )({
-  component: AuditLogsPage,
+  component: PamAuditLogsPage,
   beforeLoad: ({ context }) => {
     return {
       breadcrumbs: [

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -81,6 +81,7 @@ import { Route as secretManagerRedirectsRedirectApprovalPageImport } from './pag
 import { Route as projectAuditLogsPageRoutePamImport } from './pages/project/AuditLogsPage/route-pam'
 import { Route as projectAccessControlPageRoutePamImport } from './pages/project/AccessControlPage/route-pam'
 import { Route as organizationSettingsPageOauthCallbackPageRouteImport } from './pages/organization/SettingsPage/OauthCallbackPage/route'
+import { Route as pamPamSessionsPageRouteImport } from './pages/pam/PamSessionsPage/route'
 import { Route as organizationNetworkingPageRelayDetailsByIDPageRouteImport } from './pages/organization/NetworkingPage/RelayDetailsByIDPage/route'
 import { Route as organizationNetworkingPageGatewayDetailsByIDPageRouteImport } from './pages/organization/NetworkingPage/GatewayDetailsByIDPage/route'
 import { Route as sshLayoutImport } from './pages/ssh/layout'
@@ -1051,6 +1052,12 @@ const organizationSettingsPageOauthCallbackPageRouteRoute =
     getParentRoute: () =>
       AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdSettingsRoute,
   } as any)
+
+const pamPamSessionsPageRouteRoute = pamPamSessionsPageRouteImport.update({
+  id: '/sessions',
+  path: '/sessions',
+  getParentRoute: () => pamLayoutRoute,
+} as any)
 
 const organizationNetworkingPageRelayDetailsByIDPageRouteRoute =
   organizationNetworkingPageRelayDetailsByIDPageRouteImport.update({
@@ -3149,6 +3156,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/organizations/$orgId/networking/relays/$relayId'
       preLoaderRoute: typeof organizationNetworkingPageRelayDetailsByIDPageRouteImport
       parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdNetworkingImport
+    }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions'
+      path: '/sessions'
+      fullPath: '/organizations/$orgId/pam/sessions'
+      preLoaderRoute: typeof pamPamSessionsPageRouteImport
+      parentRoute: typeof pamLayoutImport
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback': {
       id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback'
@@ -5615,6 +5629,7 @@ const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessR
   )
 
 interface pamLayoutRouteChildren {
+  pamPamSessionsPageRouteRoute: typeof pamPamSessionsPageRouteRoute
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRouteWithChildren
   projectAccessControlPageRoutePamRoute: typeof projectAccessControlPageRoutePamRoute
   projectAuditLogsPageRoutePamRoute: typeof projectAuditLogsPageRoutePamRoute
@@ -5625,6 +5640,7 @@ interface pamLayoutRouteChildren {
 }
 
 const pamLayoutRouteChildren: pamLayoutRouteChildren = {
+  pamPamSessionsPageRouteRoute: pamPamSessionsPageRouteRoute,
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRoute:
     AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRouteWithChildren,
   projectAccessControlPageRoutePamRoute: projectAccessControlPageRoutePamRoute,
@@ -6034,6 +6050,7 @@ export interface FileRoutesByFullPath {
   '/organization/app-connections/github/manifest/callback': typeof redirectsGithubManifestCallbackRedirectRoute
   '/organizations/$orgId/networking/gateways/$gatewayId': typeof organizationNetworkingPageGatewayDetailsByIDPageRouteRoute
   '/organizations/$orgId/networking/relays/$relayId': typeof organizationNetworkingPageRelayDetailsByIDPageRouteRoute
+  '/organizations/$orgId/pam/sessions': typeof pamPamSessionsPageRouteRoute
   '/organizations/$orgId/settings/oauth/callback': typeof organizationSettingsPageOauthCallbackPageRouteRoute
   '/organizations/$orgId/pam/access': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRouteWithChildren
   '/organizations/$orgId/pam/access-management': typeof projectAccessControlPageRoutePamRoute
@@ -6308,6 +6325,7 @@ export interface FileRoutesByTo {
   '/organization/app-connections/github/manifest/callback': typeof redirectsGithubManifestCallbackRedirectRoute
   '/organizations/$orgId/networking/gateways/$gatewayId': typeof organizationNetworkingPageGatewayDetailsByIDPageRouteRoute
   '/organizations/$orgId/networking/relays/$relayId': typeof organizationNetworkingPageRelayDetailsByIDPageRouteRoute
+  '/organizations/$orgId/pam/sessions': typeof pamPamSessionsPageRouteRoute
   '/organizations/$orgId/settings/oauth/callback': typeof organizationSettingsPageOauthCallbackPageRouteRoute
   '/organizations/$orgId/pam/access-management': typeof projectAccessControlPageRoutePamRoute
   '/organizations/$orgId/pam/audit-logs': typeof projectAuditLogsPageRoutePamRoute
@@ -6581,6 +6599,7 @@ export interface FileRoutesById {
   '/_authenticate/_inject-org-details/organization/app-connections/github/manifest/callback': typeof redirectsGithubManifestCallbackRedirectRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/gateways/$gatewayId': typeof organizationNetworkingPageGatewayDetailsByIDPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/relays/$relayId': typeof organizationNetworkingPageRelayDetailsByIDPageRouteRoute
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions': typeof pamPamSessionsPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback': typeof organizationSettingsPageOauthCallbackPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access': typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdPamPamLayoutAccessRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access-management': typeof projectAccessControlPageRoutePamRoute
@@ -6871,6 +6890,7 @@ export interface FileRouteTypes {
     | '/organization/app-connections/github/manifest/callback'
     | '/organizations/$orgId/networking/gateways/$gatewayId'
     | '/organizations/$orgId/networking/relays/$relayId'
+    | '/organizations/$orgId/pam/sessions'
     | '/organizations/$orgId/settings/oauth/callback'
     | '/organizations/$orgId/pam/access'
     | '/organizations/$orgId/pam/access-management'
@@ -7144,6 +7164,7 @@ export interface FileRouteTypes {
     | '/organization/app-connections/github/manifest/callback'
     | '/organizations/$orgId/networking/gateways/$gatewayId'
     | '/organizations/$orgId/networking/relays/$relayId'
+    | '/organizations/$orgId/pam/sessions'
     | '/organizations/$orgId/settings/oauth/callback'
     | '/organizations/$orgId/pam/access-management'
     | '/organizations/$orgId/pam/audit-logs'
@@ -7415,6 +7436,7 @@ export interface FileRouteTypes {
     | '/_authenticate/_inject-org-details/organization/app-connections/github/manifest/callback'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/gateways/$gatewayId'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/relays/$relayId'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access-management'
@@ -8076,6 +8098,7 @@ export const routeTree = rootRoute
       "filePath": "pam/layout.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam",
       "children": [
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/access-management",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/audit-logs",
@@ -8107,6 +8130,10 @@ export const routeTree = rootRoute
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking/relays/$relayId": {
       "filePath": "organization/NetworkingPage/RelayDetailsByIDPage/route.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/networking"
+    },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout/sessions": {
+      "filePath": "pam/PamSessionsPage/route.tsx",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/pam/_pam-layout"
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/settings/oauth/callback": {
       "filePath": "organization/SettingsPage/OauthCallbackPage/route.tsx",

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -396,6 +396,7 @@ const secretScanningRoutes = route("/organizations/$orgId/projects/secret-scanni
 const pamRoutes = route("/organizations/$orgId/pam", [
   layout("pam-layout", "pam/layout.tsx", [
     route("/access", [index("pam/PamAccessPage/route.tsx")]),
+    route("/sessions", "pam/PamSessionsPage/route.tsx"),
     route("/audit-logs", "project/AuditLogsPage/route-pam.tsx"),
 
     // Access Management


### PR DESCRIPTION
## Context

Add the new PAM revamp pages: Sessions (with logs, search, terminate, and detail sheet), Audit Logs, and Access Control (members and groups management).

## Type

- [x] Feature

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)