### PR TITLE
improvement: move oauth applications to org settings

### DIFF
--- a/docs/documentation/platform/oauth-applications.mdx
+++ b/docs/documentation/platform/oauth-applications.mdx
@@ -59,7 +59,7 @@ OAuth applications are managed at the organization level. You need permission to
 
 <Steps>
   <Step title="Open the OAuth Applications settings">
-    Head to **Organization Settings** and select the **OAuth Applications** tab.
+    Head to **Organization Settings** and open **OAuth Applications** from the sidebar.
   </Step>
   <Step title="Add an application">
     Press **Add OAuth application** and fill in the details:

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
@@ -17,8 +17,9 @@ export const OrgNav = () => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
-  // /settings, /sso and /networking all live under the settings submenu.
-  const isOnSettingsArea = /\/organizations\/[^/]+\/(settings|sso|networking)(\/|$)/.test(pathname);
+  // /settings, /sso, /networking and /oauth-applications all live under the settings submenu.
+  const isOnSettingsArea =
+    /\/organizations\/[^/]+\/(settings|sso|networking|oauth-applications)(\/|$)/.test(pathname);
   const [showSettings, setShowSettings] = useState(isOnSettingsArea);
 
   useEffect(() => {

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSubmenuView.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSubmenuView.tsx
@@ -44,7 +44,8 @@ export const OrgSettingsSubmenuView = ({ onBack }: { onBack: () => void }) => {
     {
       label: "OAuth Applications",
       icon: AppWindow,
-      pathSuffix: "oauth-applications"
+      pathSuffix: "oauth-applications",
+      hidden: isSubOrganization
     },
     {
       label: "Networking",

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSubmenuView.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSubmenuView.tsx
@@ -1,4 +1,5 @@
 import {
+  AppWindow,
   ChevronLeft,
   Cog,
   KeyRound,
@@ -39,6 +40,11 @@ export const OrgSettingsSubmenuView = ({ onBack }: { onBack: () => void }) => {
       icon: ShieldUser,
       pathSuffix: "sso",
       hidden: isSubOrganization
+    },
+    {
+      label: "OAuth Applications",
+      icon: AppWindow,
+      pathSuffix: "oauth-applications"
     },
     {
       label: "Networking",

--- a/frontend/src/pages/organization/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/organization/IntegrationsPage/IntegrationsPage.tsx
@@ -13,7 +13,6 @@ import {
 import { withPermission } from "@app/hoc";
 import { AppConnectionsTable } from "@app/pages/organization/AppConnections/AppConnectionsPage/components";
 import { ExternalMigrationsTab } from "@app/pages/organization/SettingsPage/components/ExternalMigrationsTab";
-import { OrgOauthClientsTab } from "@app/pages/organization/SettingsPage/components/OrgOauthClientsTab";
 import { OrgWorkflowIntegrationTab } from "@app/pages/organization/SettingsPage/components/OrgWorkflowIntegrationTab";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
@@ -61,8 +60,7 @@ export const IntegrationsPage = () => {
       key: "external-migrations",
       label: "External Migrations",
       component: ExternalMigrationsTab
-    },
-    { key: "oauth-applications", label: "OAuth Applications", component: OrgOauthClientsTab }
+    }
   ];
 
   const activeTab = tabs.some((tab) => tab.key === selectedTab)

--- a/frontend/src/pages/organization/IntegrationsPage/route.tsx
+++ b/frontend/src/pages/organization/IntegrationsPage/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
+import { createFileRoute, redirect, stripSearchParams } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
@@ -30,5 +30,15 @@ export const Route = createFileRoute(
         label: "Integrations"
       }
     ]
-  })
+  }),
+  beforeLoad: ({ params, search }) => {
+    // OAuth applications moved to a dedicated settings page; keep old deep links working.
+    if (search.selectedTab === "oauth-applications") {
+      throw redirect({
+        to: "/organizations/$orgId/oauth-applications",
+        params: { orgId: params.orgId }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    }
+  }
 });

--- a/frontend/src/pages/organization/OauthApplicationsPage/OauthApplicationsPage.tsx
+++ b/frontend/src/pages/organization/OauthApplicationsPage/OauthApplicationsPage.tsx
@@ -1,0 +1,29 @@
+import { Helmet } from "react-helmet";
+
+import { PageHeader } from "@app/components/v2";
+import { useOrganization } from "@app/context";
+import { OrgOauthClientsTab } from "@app/pages/organization/SettingsPage/components/OrgOauthClientsTab";
+
+export const OauthApplicationsPage = () => {
+  const { isSubOrganization } = useOrganization();
+
+  return (
+    <>
+      <Helmet>
+        <title>Infisical | OAuth Applications</title>
+        <link rel="icon" href="/infisical.ico" />
+        <meta property="og:image" content="/images/message.png" />
+      </Helmet>
+      <div className="flex w-full justify-center bg-bunker-800 text-white">
+        <div className="w-full max-w-8xl">
+          <PageHeader
+            scope={isSubOrganization ? "namespace" : "org"}
+            title="OAuth Applications"
+            description="Control how external platforms access Infisical on behalf of your users via OAuth 2.0."
+          />
+          <OrgOauthClientsTab />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/frontend/src/pages/organization/OauthApplicationsPage/route.tsx
+++ b/frontend/src/pages/organization/OauthApplicationsPage/route.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
+import { zodValidator } from "@tanstack/zod-adapter";
+import { z } from "zod";
+
+import { OauthApplicationsPage } from "./OauthApplicationsPage";
+
+// Tolerate a stray ?selectedTab carried over by old Settings/Integrations redirects, then strip it.
+const OauthApplicationsPageQuerySchema = z.object({
+  selectedTab: z.string().catch("")
+});
+
+export const Route = createFileRoute(
+  "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications"
+)({
+  component: OauthApplicationsPage,
+  validateSearch: zodValidator(OauthApplicationsPageQuerySchema),
+  search: {
+    middlewares: [stripSearchParams({ selectedTab: "" })]
+  },
+  context: () => ({
+    breadcrumbs: [
+      {
+        label: "OAuth Applications"
+      }
+    ]
+  })
+});

--- a/frontend/src/pages/organization/OauthApplicationsPage/route.tsx
+++ b/frontend/src/pages/organization/OauthApplicationsPage/route.tsx
@@ -1,6 +1,8 @@
-import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
+import { createFileRoute, redirect, stripSearchParams } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
+
+import { fetchOrganizationById, organizationKeys } from "@app/hooks/api/organization/queries";
 
 import { OauthApplicationsPage } from "./OauthApplicationsPage";
 
@@ -17,11 +19,26 @@ export const Route = createFileRoute(
   search: {
     middlewares: [stripSearchParams({ selectedTab: "" })]
   },
-  context: () => ({
-    breadcrumbs: [
-      {
-        label: "OAuth Applications"
-      }
-    ]
-  })
+  beforeLoad: async ({ context, params }) => {
+    const org = await context.queryClient.ensureQueryData({
+      queryKey: organizationKeys.getOrgById(context.organizationId),
+      queryFn: () => fetchOrganizationById(context.organizationId)
+    });
+
+    // OAuth applications are root-org only; sub-orgs must not reach this page via direct URL or moved-tab redirects.
+    if (org.rootOrgId && org.id !== org.rootOrgId) {
+      throw redirect({
+        to: "/organizations/$orgId/settings",
+        params: { orgId: params.orgId }
+      });
+    }
+
+    return {
+      breadcrumbs: [
+        {
+          label: "OAuth Applications"
+        }
+      ]
+    };
+  }
 });

--- a/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
@@ -101,7 +101,7 @@ export const OrgTabGroup = () => {
             >
               Audit Logs
             </Link>
-            , and workflow integrations, OAuth applications, and external migrations have moved to{" "}
+            , and workflow integrations and external migrations have moved to{" "}
             <Link
               to="/organizations/$orgId/integrations"
               params={{ orgId: currentOrg.id }}

--- a/frontend/src/pages/organization/SettingsPage/route.tsx
+++ b/frontend/src/pages/organization/SettingsPage/route.tsx
@@ -20,8 +20,8 @@ const MOVED_SETTINGS_TABS: Record<string, { to: string; selectedTab: string }> =
     selectedTab: "streams"
   },
   "oauth-applications": {
-    to: "/organizations/$orgId/integrations",
-    selectedTab: "oauth-applications"
+    to: "/organizations/$orgId/oauth-applications",
+    selectedTab: ""
   },
   "tab-external-migrations": {
     to: "/organizations/$orgId/integrations",

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -55,6 +55,7 @@ import { Route as organizationSecretSharingPageSecretSharingRedirectRouteImport 
 import { Route as adminResourceOverviewPageRouteImport } from './pages/admin/ResourceOverviewPage/route'
 import { Route as organizationSsoPageRouteImport } from './pages/organization/SsoPage/route'
 import { Route as organizationProjectsPageRouteImport } from './pages/organization/ProjectsPage/route'
+import { Route as organizationOauthApplicationsPageRouteImport } from './pages/organization/OauthApplicationsPage/route'
 import { Route as organizationIntegrationsPageRouteImport } from './pages/organization/IntegrationsPage/route'
 import { Route as organizationBillingPageRouteImport } from './pages/organization/BillingPage/route'
 import { Route as organizationAuditLogsPageRouteImport } from './pages/organization/AuditLogsPage/route'
@@ -793,6 +794,14 @@ const organizationProjectsPageRouteRoute =
   organizationProjectsPageRouteImport.update({
     id: '/projects',
     path: '/projects',
+    getParentRoute: () =>
+      AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdRoute,
+  } as any)
+
+const organizationOauthApplicationsPageRouteRoute =
+  organizationOauthApplicationsPageRouteImport.update({
+    id: '/oauth-applications',
+    path: '/oauth-applications',
     getParentRoute: () =>
       AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdRoute,
   } as any)
@@ -3182,6 +3191,13 @@ declare module '@tanstack/react-router' {
       path: '/integrations'
       fullPath: '/organizations/$orgId/integrations'
       preLoaderRoute: typeof organizationIntegrationsPageRouteImport
+      parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdImport
+    }
+    '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications': {
+      id: '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications'
+      path: '/oauth-applications'
+      fullPath: '/organizations/$orgId/oauth-applications'
+      preLoaderRoute: typeof organizationOauthApplicationsPageRouteImport
       parentRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdImport
     }
     '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects': {
@@ -6291,6 +6307,7 @@ interface AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdRouteChildren {
   organizationAuditLogsPageRouteRoute: typeof organizationAuditLogsPageRouteRoute
   organizationBillingPageRouteRoute: typeof organizationBillingPageRouteRoute
   organizationIntegrationsPageRouteRoute: typeof organizationIntegrationsPageRouteRoute
+  organizationOauthApplicationsPageRouteRoute: typeof organizationOauthApplicationsPageRouteRoute
   organizationProjectsPageRouteRoute: typeof organizationProjectsPageRouteRouteWithChildren
   organizationSsoPageRouteRoute: typeof organizationSsoPageRouteRoute
   AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdAppConnectionsRoute: typeof AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdAppConnectionsRouteWithChildren
@@ -6312,6 +6329,8 @@ const AuthenticateInjectOrgDetailsOrgLayoutOrganizationsOrgIdRouteChildren: Auth
     organizationBillingPageRouteRoute: organizationBillingPageRouteRoute,
     organizationIntegrationsPageRouteRoute:
       organizationIntegrationsPageRouteRoute,
+    organizationOauthApplicationsPageRouteRoute:
+      organizationOauthApplicationsPageRouteRoute,
     organizationProjectsPageRouteRoute:
       organizationProjectsPageRouteRouteWithChildren,
     organizationSsoPageRouteRoute: organizationSsoPageRouteRoute,
@@ -6588,6 +6607,7 @@ export interface FileRoutesByFullPath {
   '/organizations/$orgId/audit-logs': typeof organizationAuditLogsPageRouteRoute
   '/organizations/$orgId/billing': typeof organizationBillingPageRouteRoute
   '/organizations/$orgId/integrations': typeof organizationIntegrationsPageRouteRoute
+  '/organizations/$orgId/oauth-applications': typeof organizationOauthApplicationsPageRouteRoute
   '/organizations/$orgId/projects': typeof organizationProjectsPageRouteRouteWithChildren
   '/organizations/$orgId/sso': typeof organizationSsoPageRouteRoute
   '/admin/resources/overview': typeof adminResourceOverviewPageRouteRoute
@@ -6891,6 +6911,7 @@ export interface FileRoutesByTo {
   '/organizations/$orgId/audit-logs': typeof organizationAuditLogsPageRouteRoute
   '/organizations/$orgId/billing': typeof organizationBillingPageRouteRoute
   '/organizations/$orgId/integrations': typeof organizationIntegrationsPageRouteRoute
+  '/organizations/$orgId/oauth-applications': typeof organizationOauthApplicationsPageRouteRoute
   '/organizations/$orgId/projects': typeof organizationProjectsPageRouteRouteWithChildren
   '/organizations/$orgId/sso': typeof organizationSsoPageRouteRoute
   '/admin/resources/overview': typeof adminResourceOverviewPageRouteRoute
@@ -7176,6 +7197,7 @@ export interface FileRoutesById {
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/audit-logs': typeof organizationAuditLogsPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/billing': typeof organizationBillingPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/integrations': typeof organizationIntegrationsPageRouteRoute
+  '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications': typeof organizationOauthApplicationsPageRouteRoute
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects': typeof organizationProjectsPageRouteRouteWithChildren
   '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/sso': typeof organizationSsoPageRouteRoute
   '/_authenticate/_inject-org-details/admin/_admin-layout/resources/overview': typeof adminResourceOverviewPageRouteRoute
@@ -7492,6 +7514,7 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/audit-logs'
     | '/organizations/$orgId/billing'
     | '/organizations/$orgId/integrations'
+    | '/organizations/$orgId/oauth-applications'
     | '/organizations/$orgId/projects'
     | '/organizations/$orgId/sso'
     | '/admin/resources/overview'
@@ -7794,6 +7817,7 @@ export interface FileRouteTypes {
     | '/organizations/$orgId/audit-logs'
     | '/organizations/$orgId/billing'
     | '/organizations/$orgId/integrations'
+    | '/organizations/$orgId/oauth-applications'
     | '/organizations/$orgId/projects'
     | '/organizations/$orgId/sso'
     | '/admin/resources/overview'
@@ -8077,6 +8101,7 @@ export interface FileRouteTypes {
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/audit-logs'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/billing'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/integrations'
+    | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects'
     | '/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/sso'
     | '/_authenticate/_inject-org-details/admin/_admin-layout/resources/overview'
@@ -8632,6 +8657,7 @@ export const routeTree = rootRoute
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/audit-logs",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/billing",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/integrations",
+        "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/sso",
         "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/app-connections",
@@ -8659,6 +8685,10 @@ export const routeTree = rootRoute
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/integrations": {
       "filePath": "organization/IntegrationsPage/route.tsx",
+      "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId"
+    },
+    "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/oauth-applications": {
+      "filePath": "organization/OauthApplicationsPage/route.tsx",
       "parent": "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId"
     },
     "/_authenticate/_inject-org-details/_org-layout/organizations/$orgId/projects": {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -464,6 +464,7 @@ const organizationRoutes = route("/organizations/$orgId", [
   route("/identities/$identityId", "organization/IdentityDetailsByIDPage/route.tsx"),
   route("/integrations", "organization/IntegrationsPage/route.tsx"),
   route("/sso", "organization/SsoPage/route.tsx"),
+  route("/oauth-applications", "organization/OauthApplicationsPage/route.tsx"),
   route("/app-connections", [
     index("organization/AppConnections/AppConnectionsPage/route.tsx"),
     route(


### PR DESCRIPTION
## Context

This PR moves oauth applications to the org settings page

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-06-16 at 15 02 14@2x" src="https://github.com/user-attachments/assets/fc4598a5-c55e-481c-a3a5-f23031c39ffa" />

## Steps to verify the change

- test oauth application setup 

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)