### PR TITLE
improvement: add copy path button to overview page and adjust truncation logic and breakpoint

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,7 +52,7 @@
 }
 
 @theme {
-  --breakpoint-dashboard: 1100px;
+  --breakpoint-dashboard: 1400px;
 
   /* Fonts */
   --font-inter: "Inter", sans-serif;

--- a/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/AddResourceButtons/AddResourceButtons.tsx
@@ -97,7 +97,7 @@ export function AddResourceButtons({
           </IconButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuLabel>NEW</DropdownMenuLabel>
+          <DropdownMenuLabel>New</DropdownMenuLabel>
           <ProjectPermissionCan
             I={ProjectPermissionActions.Create}
             a={ProjectPermissionSub.SecretFolders}
@@ -160,7 +160,7 @@ export function AddResourceButtons({
             )}
           </ProjectPermissionCan>
           <DropdownMenuSeparator />
-          <DropdownMenuLabel>BULK</DropdownMenuLabel>
+          <DropdownMenuLabel>Bulk</DropdownMenuLabel>
           <Tooltip open={!isSecretImportAvailable || !isSingleEnvSelected ? undefined : false}>
             <TooltipTrigger className="block w-full">
               <DropdownMenuItem

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
@@ -357,9 +357,13 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
               size="xs"
               className="shrink-0"
               aria-label="Copy folder path"
-              onClick={() => {
-                navigator.clipboard.writeText(fullPath);
-                setIsCopied(true);
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(fullPath);
+                  setIsCopied(true);
+                } catch {
+                  // clipboard unavailable (denied or insecure context); keep the un-copied state
+                }
               }}
             >
               {isCopied ? <Check /> : <Copy />}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { FolderIcon, SlashIcon } from "lucide-react";
+import { Check, Copy, FolderIcon, SlashIcon } from "lucide-react";
 
 import {
   Breadcrumb,
@@ -13,8 +13,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger
+  DropdownMenuTrigger,
+  IconButton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
+import { useTimedReset } from "@app/hooks";
 
 type Props = {
   secretPath?: string;
@@ -46,6 +51,8 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
   });
 
   const folderPaths = useMemo(() => (secretPath || "").split("/").filter(Boolean), [secretPath]);
+
+  const [isCopied, , setIsCopied] = useTimedReset<boolean>({ initialState: false });
 
   const onFolderCrumbClick = useCallback(
     (index: number) => {
@@ -136,7 +143,12 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
       (sum, w) => sum + w + separatorWidth + GAP * 2,
       0
     );
-    const availableWidth = containerWidth - folderIconWidth - GAP;
+    // The copy-path button is a fixed-width sibling after the breadcrumb; subtract its
+    // footprint so the path collapses before it would collide with the button.
+    // v3 IconButton size="xs" => h-7 w-7 = 28px (border-box); GAP covers the gap before it.
+    const COPY_BUTTON_WIDTH = 28;
+    const copyButtonReserve = folderPaths.length > 0 ? COPY_BUTTON_WIDTH + GAP : 0;
+    const availableWidth = containerWidth - folderIconWidth - GAP - copyButtonReserve;
 
     // If everything fits, show all
     if (totalSegmentWidth <= availableWidth) {
@@ -203,8 +215,14 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
     ? folderPaths.slice(startCount, endCount > 0 ? folderPaths.length - endCount : undefined)
     : [];
 
+  // Canonical secret path (matches onFolderCrumbClick's "/"-prefixed format)
+  const fullPath = `/${folderPaths.join("/")}`;
+
   return (
-    <div ref={containerRef} className="relative min-w-0 flex-1 overflow-hidden">
+    <div
+      ref={containerRef}
+      className="relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
+    >
       {/* Hidden measurement container */}
       <div
         ref={measureContainerRef}
@@ -231,8 +249,8 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
         </span>
       </div>
 
-      {/* Visible breadcrumb */}
-      <Breadcrumb>
+      {/* Visible breadcrumb (shrinks/clips on its own so the copy button is never clipped) */}
+      <Breadcrumb className="min-w-0 overflow-hidden">
         <BreadcrumbList className="flex-nowrap">
           {/* Root folder icon */}
           <BreadcrumbItem onClick={() => onFolderCrumbClick(0)}>
@@ -329,6 +347,27 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
           })}
         </BreadcrumbList>
       </Breadcrumb>
+
+      {/* Copy current folder path (pinned outside the clip flow so it's always visible) */}
+      {folderPaths.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconButton
+              variant="ghost-muted"
+              size="xs"
+              className="shrink-0"
+              aria-label="Copy folder path"
+              onClick={() => {
+                navigator.clipboard.writeText(fullPath);
+                setIsCopied(true);
+              }}
+            >
+              {isCopied ? <Check /> : <Copy />}
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>{isCopied ? "Copied" : "Copy path"}</TooltipContent>
+        </Tooltip>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Context

This PR adds a copy path button to the secret overview page and updates the truncation and breakpoint for graceful handling of UI

## Screenshots

<img width="3456" height="1920" alt="CleanShot 2026-06-16 at 16 07 44@2x" src="https://github.com/user-attachments/assets/160a08dd-c709-4a03-bd8e-a803abcdb627" />

## Steps to verify the change

- test breakpoint/truncation logic with long path at various screen widths
- test copy

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)