### PR TITLE
fix(pki): mark subjectAltName critical for empty-subject certificates

### DIFF
--- a/backend/src/services/certificate-authority/certificate-authority-fns.test.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
 
-import { CertKeyAlgorithm } from "@app/services/certificate/certificate-types";
+import * as x509 from "@peculiar/x509";
+import { beforeAll, describe, expect, it } from "vitest";
 
-import { buildCrlDistributionPointUrls, signatureAlgorithmToAlgCfg } from "./certificate-authority-fns";
+import { CertKeyAlgorithm, TAltNameType } from "@app/services/certificate/certificate-types";
+
+import {
+  buildCrlDistributionPointUrls,
+  createSubjectAltNameExtension,
+  signatureAlgorithmToAlgCfg
+} from "./certificate-authority-fns";
 
 // Helper to access properties on the union return type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -235,5 +242,57 @@ describe("buildCrlDistributionPointUrls", () => {
   it("should include managed URL when disableManagedUrl is undefined", () => {
     const result = buildCrlDistributionPointUrls(managedUrl, null, undefined);
     expect(result).toEqual([managedUrl]);
+  });
+});
+
+describe("createSubjectAltNameExtension (RFC 5280 §4.1.2.6)", () => {
+  const sans = [{ type: TAltNameType.DNS, value: "svc.example" }];
+
+  it("marks the SAN extension critical when the subject DN is empty", () => {
+    const ext = createSubjectAltNameExtension(sans, "");
+    expect(ext.critical).toBe(true);
+  });
+
+  it("leaves the SAN extension non-critical when the subject DN is present", () => {
+    const ext = createSubjectAltNameExtension(sans, "CN=svc.example");
+    expect(ext.critical).toBe(false);
+  });
+});
+
+describe("issued leaf conforms to RFC 5280 §4.1.2.6", () => {
+  beforeAll(() => {
+    x509.cryptoProvider.set(webcrypto as Crypto);
+  });
+
+  const buildLeaf = async (subject: string) => {
+    const alg = { name: "ECDSA", namedCurve: "P-256", hash: "SHA-256" };
+    const keys = (await webcrypto.subtle.generateKey(alg, true, ["sign", "verify"])) as CryptoKeyPair;
+    const leaf = await x509.X509CertificateGenerator.create({
+      serialNumber: "01",
+      subject,
+      issuer: "CN=Test CA",
+      notBefore: new Date(),
+      notAfter: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      signingKey: keys.privateKey,
+      publicKey: keys.publicKey,
+      signingAlgorithm: alg,
+      extensions: [createSubjectAltNameExtension([{ type: TAltNameType.DNS, value: "svc.example" }], subject)]
+    });
+    // re-parse from PEM so we assert on the encoded DER, not the in-memory object
+    return new x509.X509Certificate(leaf.toString("pem"));
+  };
+
+  it("issues an empty-subject leaf with a CRITICAL subjectAltName", async () => {
+    const leaf = await buildLeaf("");
+    expect(leaf.subject).toBe("");
+    const san = leaf.getExtension(x509.SubjectAlternativeNameExtension);
+    expect(san?.critical).toBe(true);
+  });
+
+  it("issues a leaf carrying a subject DN with a non-critical subjectAltName", async () => {
+    const leaf = await buildLeaf("CN=svc.example");
+    expect(leaf.subject).toBe("CN=svc.example");
+    const san = leaf.getExtension(x509.SubjectAlternativeNameExtension);
+    expect(san?.critical).toBe(false);
   });
 });

--- a/backend/src/services/certificate-authority/certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-fns.ts
@@ -13,6 +13,7 @@ import {
   CertKeyAlgorithm,
   CertKeyUsage,
   CertStatus,
+  TAltNameMapping,
   TAltNameType
 } from "../certificate/certificate-types";
 import { DEFAULT_CRL_VALIDITY_DAYS } from "../certificate-common/certificate-constants";
@@ -58,6 +59,22 @@ export const createDistinguishedName = (parts: TDNParts) => {
   const name = new x509.Name(jsonName);
   return name.toString();
 };
+
+/**
+ * Build a Subject Alternative Name extension that honors RFC 5280 §4.1.2.6:
+ *
+ *   "If the subject field contains an empty sequence, then the issuing CA MUST
+ *    include a subjectAltName extension that is marked as critical."
+ *
+ * Standards-compliant ACME/EST/SCEP clients (Caddy/certmagic, certbot, lego,
+ * acme.sh) omit the Subject Common Name by default, producing an empty subject
+ * DN. In that case the SAN carries the only naming information and must be
+ * marked critical, otherwise RFC-conformant verifiers — notably Apple's Security
+ * framework on macOS/iOS — reject the leaf. The criticality is therefore derived
+ * from the resolved subject DN rather than hardcoded.
+ */
+export const createSubjectAltNameExtension = (altNames: TAltNameMapping[], subjectDn: string) =>
+  new x509.SubjectAlternativeNameExtension(altNames, !subjectDn);
 
 /**
  * Helper to get the last value of a DN attribute from an x509 Name object.

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.test.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.test.ts
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { webcrypto } from "node:crypto";
+
+import * as x509 from "@peculiar/x509";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { CaStatus } from "../certificate-authority-enums";
+import { internalCertificateAuthorityServiceFactory } from "./internal-certificate-authority-service";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({ SITE_URL: "https://test.infisical.com" })
+}));
+
+// Exercises signCertFromCa end to end with real signing — only the DAL/KMS
+// boundary is faked (identity KMS) — to lock in RFC 5280 §4.1.2.6: an empty
+// subject DN must yield a CRITICAL subjectAltName, and a present subject must not.
+describe("signCertFromCa — subjectAltName criticality (RFC 5280 §4.1.2.6)", () => {
+  const RSA_ALG = {
+    name: "RSASSA-PKCS1-v1_5",
+    hash: "SHA-256",
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1])
+  };
+
+  let service: ReturnType<typeof internalCertificateAuthorityServiceFactory>;
+  let csrWithoutCn: string;
+
+  const issue = (overrides: Record<string, unknown>) =>
+    service.signCertFromCa({ isInternal: true, caId: "ca-1", csr: csrWithoutCn, ttl: "1h", ...overrides } as any);
+
+  const getSanExtensions = (leaf: x509.X509Certificate) =>
+    leaf.extensions.filter((ext): ext is x509.SubjectAlternativeNameExtension => ext.type === "2.5.29.17");
+
+  beforeAll(async () => {
+    x509.cryptoProvider.set(webcrypto as Crypto);
+
+    // Real CA: self-signed cert + private key exported as DER PKCS8 (the form the
+    // CA-secret DAL stores and getCaCredentials imports).
+    const caKeys = (await webcrypto.subtle.generateKey(RSA_ALG, true, ["sign", "verify"])) as CryptoKeyPair;
+    const caCert = await x509.X509CertificateGenerator.createSelfSigned({
+      serialNumber: "01",
+      name: "CN=Test CA",
+      notBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      signingAlgorithm: RSA_ALG,
+      keys: caKeys,
+      extensions: [new x509.BasicConstraintsExtension(true, undefined, true)]
+    });
+    const caCertPem = caCert.toString("pem");
+    const caKeyDer = Buffer.from(await webcrypto.subtle.exportKey("pkcs8", caKeys.privateKey));
+
+    // A standards-compliant ACME CSR: no Common Name, SAN carries the only name.
+    const leafKeys = (await webcrypto.subtle.generateKey(RSA_ALG, true, ["sign", "verify"])) as CryptoKeyPair;
+    csrWithoutCn = (
+      await x509.Pkcs10CertificateRequestGenerator.create({
+        name: "",
+        keys: leafKeys,
+        signingAlgorithm: RSA_ALG,
+        extensions: [new x509.SubjectAlternativeNameExtension([{ type: "dns", value: "svc.example" }])]
+      })
+    ).toString("pem");
+
+    // Identity KMS: ciphertext === plaintext, so the real CA material round-trips.
+    const kmsService = {
+      decryptWithKmsKey: vi
+        .fn()
+        .mockResolvedValue(async ({ cipherTextBlob }: { cipherTextBlob: unknown }) =>
+          Buffer.isBuffer(cipherTextBlob) ? cipherTextBlob : Buffer.from(cipherTextBlob as string)
+        ),
+      encryptWithKmsKey: vi.fn().mockResolvedValue(async ({ plainText }: { plainText: Buffer }) => ({
+        cipherTextBlob: Buffer.from(plainText)
+      })),
+      generateKmsKey: vi.fn()
+    };
+
+    const ca = {
+      id: "ca-1",
+      projectId: "project-1",
+      status: CaStatus.ACTIVE,
+      enableDirectIssuance: true,
+      internalCa: {
+        id: "internal-ca-1",
+        activeCaCertId: "ca-cert-1",
+        keyAlgorithm: "RSA_2048",
+        notAfter: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+        crlDistributionPointUrls: null,
+        disableManagedCrlDistributionPointUrl: false
+      }
+    };
+
+    const deps = {
+      certificateAuthorityDAL: {
+        findByIdWithAssociatedCa: vi.fn().mockResolvedValue(ca),
+        findById: vi.fn().mockResolvedValue({ projectId: "project-1" })
+      },
+      certificateAuthorityCertDAL: {
+        findById: vi.fn().mockResolvedValue({
+          id: "ca-cert-1",
+          caId: "ca-1",
+          encryptedCertificate: caCertPem,
+          encryptedCertificateChain: Buffer.from(caCertPem)
+        })
+      },
+      certificateAuthoritySecretDAL: {
+        findOne: vi.fn().mockResolvedValue({ id: "ca-secret-1", encryptedPrivateKey: caKeyDer })
+      },
+      certificateAuthorityCrlDAL: { findOne: vi.fn().mockResolvedValue({ id: "crl-1" }) },
+      certificateDAL: {
+        create: vi.fn().mockResolvedValue({ id: "cert-1" }),
+        transaction: vi.fn().mockImplementation((cb: (tx: unknown) => unknown) => cb({}))
+      },
+      certificateBodyDAL: { create: vi.fn().mockResolvedValue({}) },
+      pkiCollectionItemDAL: { create: vi.fn() },
+      projectDAL: {
+        findOne: vi.fn().mockResolvedValue({ id: "project-1", orgId: "org-1", kmsCertificateKeyId: "kms-key-1" }),
+        updateById: vi.fn(),
+        transaction: vi.fn().mockImplementation((cb: (tx: unknown) => unknown) => cb({}))
+      },
+      kmsService,
+      usageMeteringService: { emitForProject: vi.fn() },
+      licenseService: { getPlan: vi.fn() }
+    };
+
+    service = internalCertificateAuthorityServiceFactory(deps as any);
+  });
+
+  it("issues an empty-subject leaf with a CRITICAL subjectAltName (default ACME path)", async () => {
+    // subjectOverride "" mirrors a CN-less CSR resolved through the profile flow.
+    const { certificate } = await issue({ subjectOverride: "" });
+
+    expect(certificate.subject).toBe("");
+    const sans = getSanExtensions(certificate);
+    expect(sans).toHaveLength(1); // exactly one SAN extension, never duplicated
+    expect(sans[0].critical).toBe(true);
+    expect(sans[0].names.items.map((n) => n.value)).toContain("svc.example");
+  });
+
+  it("issues a leaf carrying a subject DN with a non-critical subjectAltName", async () => {
+    const { certificate } = await issue({ subjectOverride: "CN=svc.example" });
+
+    expect(certificate.subject).toBe("CN=svc.example");
+    const sans = getSanExtensions(certificate);
+    expect(sans).toHaveLength(1);
+    expect(sans[0].critical).toBe(false);
+  });
+
+  it("emits a single SAN extension when altNames are passed explicitly (no duplicate)", async () => {
+    // Guards the historical double-push in the explicit-altNames branch.
+    const { certificate } = await issue({ subjectOverride: "", altNames: "svc.example" });
+
+    const sans = getSanExtensions(certificate);
+    expect(sans).toHaveLength(1);
+    expect(sans[0].critical).toBe(true);
+  });
+});

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -65,6 +65,7 @@ import {
   buildCrlDistributionPointUrls,
   createDistinguishedName,
   createSerialNumber,
+  createSubjectAltNameExtension,
   expandInternalCa,
   extractDnParts,
   getCaCertChain, // TODO: consider rename
@@ -1970,8 +1971,8 @@ export const internalCertificateAuthorityServiceFactory = ({
           return altNameType;
         });
 
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
-      extensions.push(altNamesExtension);
+      // RFC 5280 §4.1.2.6: SAN must be critical when the subject DN is empty.
+      extensions.push(createSubjectAltNameExtension(altNamesArray, csrObj.subject));
     }
 
     if (certificateTemplate) {
@@ -2424,9 +2425,6 @@ export const internalCertificateAuthorityServiceFactory = ({
           }
           return altNameType;
         });
-
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
-      extensions.push(altNamesExtension);
     } else {
       // attempt to read from CSR if altNames is not explicitly provided
       const sanExtension = csrObj.extensions.find((ext) => ext.type === "2.5.29.17");
@@ -2450,8 +2448,8 @@ export const internalCertificateAuthorityServiceFactory = ({
     }
 
     if (altNamesArray.length) {
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
-      extensions.push(altNamesExtension);
+      // RFC 5280 §4.1.2.6: SAN must be critical when the subject DN is empty.
+      extensions.push(createSubjectAltNameExtension(altNamesArray, subjectOverride || csrObj.subject));
     }
 
     if (certificateTemplate) {


### PR DESCRIPTION
## Context

Closes #6899.

The internal CA issued RFC 5280-invalid leaves on its CSR paths (ACME/EST/SCEP). When a CSR has no Common Name — the default for Caddy/certmagic, certbot, lego, acme.sh — the leaf got an **empty subject DN** with a **non-critical** `subjectAltName`. RFC 5280 §4.1.2.6 requires the SAN to be **critical** when the subject is empty; Apple's verifier (macOS/iOS) rejects the cert otherwise. `openssl`/curl/Go accept it (they read the SAN), which masked the bug.

Cause: `signCertFromCa` / `issueCertFromCa` built the SAN with the critical flag hardcoded `false`, with no empty-subject check. Same fix smallstep made in step-ca (smallstep/certificates#302, smallstep/crypto `a28955b`); Go's stdlib won't set it for you (golang/go#22249).

Fix: derive criticality from the resolved subject DN via a single helper, and apply it at both issuance sites. Also removes a duplicate `subjectAltName` push in the explicit-`altNames` branch of `signCertFromCa` (introduced in `e7a6f46`) that emitted the extension twice. Behavior is unchanged when the subject is non-empty.

```ts
export const createSubjectAltNameExtension = (altNames: TAltNameMapping[], subjectDn: string) =>
  new x509.SubjectAlternativeNameExtension(altNames, !subjectDn);
```

## Steps to verify the change

- `cd backend && npm run test:unit -- certificate-authority` — covers both the helper (empty subject ⇒ critical SAN; present ⇒ non-critical) and `signCertFromCa` end to end (real signing; asserts the issued leaf has an empty subject with a single, critical SAN, and a present subject with a non-critical SAN). Reverting the fix turns these red.
- Or issue via ACME with a CN-less CSR and inspect: `openssl x509 -noout -subject -ext subjectAltName` shows an empty subject with the SAN marked `critical`.

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
