### PR TITLE
fix(membership): correct inflated total count in user and identity list queries

### DIFF
--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -414,14 +414,17 @@ export const identityOrgDALFactory = (db: TDbClient) => {
     tx?: Knex
   ) => {
     try {
-      const searchQuery = (tx || db.replicaNode())(TableName.Membership)
-        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
-        .whereNotNull(`${TableName.Membership}.actorIdentityId`)
-        .where(`${TableName.Membership}.scopeOrgId`, orgId)
-        .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
-        .whereNull(`${TableName.Identity}.projectId`)
-        .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)
-        .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
+      const buildIdentitySearchBase = () =>
+        (tx || db.replicaNode())(TableName.Membership)
+          .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+          .whereNotNull(`${TableName.Membership}.actorIdentityId`)
+          .where(`${TableName.Membership}.scopeOrgId`, orgId)
+          .join(TableName.Identity, `${TableName.Identity}.id`, `${TableName.Membership}.actorIdentityId`)
+          .whereNull(`${TableName.Identity}.projectId`)
+          .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)
+          .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`);
+
+      const searchQuery = buildIdentitySearchBase()
         .orderBy(
           orderBy === OrgIdentityOrderBy.Role
             ? `${TableName.MembershipRole}.${orderBy}`
@@ -429,15 +432,24 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           orderDirection
         )
         .select(`${TableName.Membership}.id`)
-        .select<{ id: string; total_count: string }>(
-          db.raw(
-            `count(${TableName.Membership}."actorIdentityId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total_count`
-          )
-        )
         .as("searchedIdentities");
+
+      // the membership -> membership_roles join is one-to-many, so a window count over the joined
+      // rows counts role assignments instead of identities. Count distinct memberships separately.
+      const countQuery = buildIdentitySearchBase();
 
       if (searchFilter) {
         buildKnexFilterForSearchResource(searchQuery, searchFilter, (attr) => {
+          switch (attr) {
+            case "role":
+              return [`${TableName.Role}.slug`, `${TableName.MembershipRole}.role`];
+            case "name":
+              return `${TableName.Identity}.name`;
+            default:
+              throw new BadRequestError({ message: `Invalid ${String(attr)} provided` });
+          }
+        });
+        buildKnexFilterForSearchResource(countQuery, searchFilter, (attr) => {
           switch (attr) {
             case "role":
               return [`${TableName.Role}.slug`, `${TableName.MembershipRole}.role`];
@@ -452,6 +464,11 @@ export const identityOrgDALFactory = (db: TDbClient) => {
       if (limit) {
         void searchQuery.offset(offset).limit(limit);
       }
+
+      const [countResult] = (await countQuery.countDistinct(`${TableName.Membership}.id as count`)) as [
+        { count: string | number }?
+      ];
+      const totalCount = Number(countResult?.count ?? 0);
 
       type TSubquery = Awaited<typeof searchQuery>;
       const query = (tx || db.replicaNode())(TableName.Membership)
@@ -527,7 +544,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         )
         .select(
           db.ref("id").withSchema(TableName.Membership),
-          db.ref("total_count").withSchema("searchedIdentities"),
           db.ref("role").withSchema(TableName.MembershipRole),
           db.ref("customRoleId").withSchema(TableName.MembershipRole).as("roleId"),
           db.ref("scopeOrgId").withSchema(TableName.Membership).as("orgId"),
@@ -596,7 +612,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           hasDeleteProtection,
           role,
           roleId,
-          total_count,
           id,
           uaId,
           alicloudId,
@@ -619,7 +634,6 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           roleId,
           identityId: identityId as string,
           id,
-          total_count: total_count as string,
           orgId,
           createdAt,
           updatedAt,
@@ -668,7 +682,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         ]
       });
 
-      return { docs: formattedDocs, totalCount: Number(formattedDocs?.[0]?.total_count ?? 0) };
+      return { docs: formattedDocs, totalCount };
     } catch (error) {
       throw new DatabaseError({ error, name: "FindByOrgId" });
     }

--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -439,7 +439,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
       const countQuery = buildIdentitySearchBase();
 
       if (searchFilter) {
-        buildKnexFilterForSearchResource(searchQuery, searchFilter, (attr) => {
+        const getSearchFilterField = (attr: "name" | "role") => {
           switch (attr) {
             case "role":
               return [`${TableName.Role}.slug`, `${TableName.MembershipRole}.role`];
@@ -448,27 +448,14 @@ export const identityOrgDALFactory = (db: TDbClient) => {
             default:
               throw new BadRequestError({ message: `Invalid ${String(attr)} provided` });
           }
-        });
-        buildKnexFilterForSearchResource(countQuery, searchFilter, (attr) => {
-          switch (attr) {
-            case "role":
-              return [`${TableName.Role}.slug`, `${TableName.MembershipRole}.role`];
-            case "name":
-              return `${TableName.Identity}.name`;
-            default:
-              throw new BadRequestError({ message: `Invalid ${String(attr)} provided` });
-          }
-        });
+        };
+        buildKnexFilterForSearchResource(searchQuery, searchFilter, getSearchFilterField);
+        buildKnexFilterForSearchResource(countQuery, searchFilter, getSearchFilterField);
       }
 
       if (limit) {
         void searchQuery.offset(offset).limit(limit);
       }
-
-      const [countResult] = (await countQuery.countDistinct(`${TableName.Membership}.id as count`)) as [
-        { count: string | number }?
-      ];
-      const totalCount = Number(countResult?.count ?? 0);
 
       type TSubquery = Awaited<typeof searchQuery>;
       const query = (tx || db.replicaNode())(TableName.Membership)
@@ -596,7 +583,14 @@ export const identityOrgDALFactory = (db: TDbClient) => {
         );
       }
 
-      const docs = await query;
+      // the count and the paginated fetch are independent (they share only orgId), so run them
+      // concurrently instead of awaiting the count before building and executing the main query.
+      const [docs, countRows] = await Promise.all([
+        query,
+        countQuery.countDistinct(`${TableName.Membership}.id as count`)
+      ]);
+      const totalCount = Number((countRows as unknown as [{ count: string | number }?])[0]?.count ?? 0);
+
       const formattedDocs = sqlNestRelationships({
         data: docs,
         key: "id",

--- a/backend/src/services/membership-user/membership-user-dal.ts
+++ b/backend/src/services/membership-user/membership-user-dal.ts
@@ -149,12 +149,11 @@ export const membershipUserDALFactory = (db: TDbClient) => {
 
   const findUsers = async ({ scopeData, tx, filter }: TFindUserArg) => {
     try {
-      const paginatedUsers = (tx || db.replicaNode())(TableName.Membership)
+      const baseUserQuery = (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
         .join(TableName.Users, `${TableName.Users}.id`, `${TableName.Membership}.actorUserId`)
         .join(TableName.MembershipRole, `${TableName.Membership}.id`, `${TableName.MembershipRole}.membershipId`)
         .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
-        .distinct(`${TableName.Membership}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, scopeData.orgId)
         .where(`${TableName.Users}.isGhost`, false)
         .where((qb) => {
@@ -167,12 +166,9 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         });
 
-      if (filter.limit) void paginatedUsers.limit(filter.limit);
-      if (filter.offset) void paginatedUsers.offset(filter.offset);
-
       if (filter.username || filter.role) {
         buildKnexFilterForSearchResource(
-          paginatedUsers,
+          baseUserQuery,
           {
             username: filter.username!,
             role: filter.role!
@@ -189,6 +185,18 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         );
       }
+
+      // the membership -> membership_roles join is one-to-many, so counting joined rows (as the
+      // previous window function did) counts role assignments instead of users. Count distinct
+      // memberships before applying pagination to get the true number of matching users.
+      const [countResult] = (await baseUserQuery.clone().countDistinct(`${TableName.Membership}.id as count`)) as [
+        { count: string | number }?
+      ];
+      const totalCount = Number(countResult?.count ?? 0);
+
+      const paginatedUsers = baseUserQuery.clone().distinct(`${TableName.Membership}.id`);
+      if (filter.limit) void paginatedUsers.limit(filter.limit);
+      if (filter.offset) void paginatedUsers.offset(filter.offset);
 
       const docs = await (tx || db.replicaNode())(TableName.Membership)
         .whereNotNull(`${TableName.Membership}.actorUserId`)
@@ -223,11 +231,6 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           db.ref("firstName").withSchema(TableName.Users).as("userFirstName"),
           db.ref("lastName").withSchema(TableName.Users).as("userLastName"),
           db.ref("id").withSchema(TableName.Users).as("userId")
-        )
-        .select(
-          db.raw(
-            `count(${TableName.Membership}."actorUserId") OVER(PARTITION BY ${TableName.Membership}."scopeOrgId") as total`
-          )
         );
 
       const data = sqlNestRelationships({
@@ -277,7 +280,7 @@ export const membershipUserDALFactory = (db: TDbClient) => {
           }
         ]
       });
-      return { data, totalCount: Number((data?.[0] as unknown as { total: number })?.total ?? 0) };
+      return { data, totalCount };
     } catch (error) {
       throw new DatabaseError({ error, name: "MembershipfindUser" });
     }


### PR DESCRIPTION
## Context

Fixes #5885.

The "All users" / "All identities" list endpoints reported an inflated total count. Both DALs derived their total from a window function evaluated over a query that joins `membership_roles`:

```ts
count("Membership"."actorUserId") OVER (PARTITION BY "Membership"."scopeOrgId") as total
```

Since the membership → `membership_roles` join is one-to-many, a member with N role assignments produces N rows, so the window counted **role assignments**, not distinct members. For an org with 5 users where 2 have multiple roles, the count came back as 8 instead of 5. This throws off pagination math (page counts, "showing X of Y") in the UI.

Two queries were still affected:

- `membership-user-dal.ts` → `findUsers`
- `identity-org-dal.ts` → `searchIdentities`

PR #5850 already fixed the equivalent bug for the project identity membership list, and `membership-group-dal.ts` → `findGroups` was subsequently fixed the same way. This PR brings the remaining two siblings in line.

The fix replaces the window count with a separate `countDistinct("Membership"."id")` query over the same filtered set (before pagination is applied), exactly mirroring the pattern already used in `findGroups`. Pagination and result shape are unchanged.

## Steps to verify the change

1. In an org, give one or more users/identities multiple roles.
2. Open **Organization → Access Control → Users** (and **Identities**).
3. Before: the total/count shown is inflated by the number of extra role assignments.
4. After: the total reflects the actual number of distinct users/identities.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
