### PR TITLE
fix(project): allow spaces in All Projects search query

### DIFF
--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1162,13 +1162,10 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         orderBy: z.nativeEnum(SearchProjectSortBy).optional().default(SearchProjectSortBy.NAME),
         orderDirection: z.nativeEnum(SortDirection).optional().default(SortDirection.ASC),
         projectIds: z.string().trim().array().optional(),
-        name: z
-          .string()
-          .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
-          .optional()
+        // search term is matched with a parameterized, wildcard-escaped ILIKE in the DAL
+        // (sanitizeSqlLikeString), so it doesn't need an alphanumeric charset restriction —
+        // project names legitimately contain spaces and other characters.
+        name: z.string().trim().max(255).optional()
       }),
       response: {
         200: z.object({


### PR DESCRIPTION
## Context

Fixes #5813.

In **Organization → Projects → All Projects**, searching with a normal multi-word name fails. The `POST /api/v1/project/search` endpoint validated the `name` filter with a character validator that only permitted alphanumeric characters and hyphens:

```ts
name: z
  .string()
  .trim()
  .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
    message: "Invalid pattern: only alphanumeric characters, - are allowed."
  })
  .optional()
```

Project names legitimately contain spaces (and other characters), so a search like `My Project` is rejected with a validation error before it reaches the query.

The charset restriction was redundant as a safety measure: in the DAL the term is matched with a parameterized `whereILike` whose `%`/`_` wildcards are escaped via `sanitizeSqlLikeString`, so user input cannot break out of the LIKE pattern or inject SQL. This PR relaxes the filter to a trimmed string bounded at 255 characters — the same shape the identity search endpoint (`/api/v2/identities/search`) already uses for its `name` filter.

## Steps to verify the change

1. Create a project with a multi-word name, e.g. `My Project`.
2. Go to **Organization → Projects → All Projects**.
3. Search for `My Project` (with the space).
4. Before: request fails with a validation error / no results. After: the matching project is returned.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
