### PR TITLE
fix(secret-manager): skip initial onTagsChange on mount in batch mode tag form

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTagForm.tsx
@@ -91,9 +91,17 @@ export const SecretTagForm = ({
   // In batch mode, debounce tag changes to parent form
   const watchedTags = watch("tags");
   const debounceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const isFirstRun = useRef(true);
 
   useEffect(() => {
     if (!isBatchMode) return () => {};
+
+    // Skip the initial mount so we don't propagate the form's defaultValues back
+    // to the parent. Only actual user interactions should trigger onTagsChange.
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      return () => {};
+    }
 
     if (debounceTimer.current) {
       clearTimeout(debounceTimer.current);


### PR DESCRIPTION
## What

Fixes a data-loss bug (#6854) where opening the "View Tags" popover on a secret in batch mode could immediately trigger a spurious "Commit Changes" modal showing the tag as removed -- even though the user made no changes. Confirming that modal deleted the tag server-side.

## Root cause

`SecretTagForm` runs a debounced `useEffect` that calls `onTagsChange` whenever `watchedTags` changes. The effect also fires once on initial mount with whatever value `watch("tags")` returns at that moment.

In the bug scenario:
1. The user bulk-assigns a tag to several secrets.
2. React Query invalidates and refetches the secret rows. `originalTagsRef` in the parent row is updated to reflect the new tag.
3. But React Hook Form freezes `defaultValues` at mount time, so the row's `watchedTags` form field stays at `[]` (its value from before the bulk operation).
4. When the user opens the tag popover, `SecretTagForm` mounts and -- after 500 ms -- fires `onTagsChange([])`.
5. The parent's `handleTagsChange` calls `setValue("tags", [])`, triggering the batch auto-apply timer.
6. The timer compares `watchedTags = []` against `originalTagsRef = [{id, slug}]`, detects a diff, and creates a pending change showing the tag as removed.

## Fix

Add an `isFirstRun` ref in `SecretTagForm` and skip the first execution of the effect. Only actual user interactions in the tag picker should propagate to the parent -- not the initial form state on mount.

## Test plan

- [ ] Enable batch mode on the Secret Manager overview page
- [ ] Create a tag and bulk-assign it to one or more secrets
- [ ] Immediately open the "View Tags" popover on an affected secret -- no "Commit Changes" modal should appear
- [ ] Manually add or remove a tag inside the popover -- the pending change should appear as expected
- [ ] Confirm bulk-assigning tags with no pending changes still works correctly
