### PR TITLE
fix(keystore): use strconv.FormatInt instead of rune cast in intToString

### DIFF
--- a/backend-go/internal/keystore/memory.go
+++ b/backend-go/internal/keystore/memory.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -128,7 +129,7 @@ func (m *MemoryKeyStore) StreamAdd(_ context.Context, stream, id string, values 
 }
 
 func intToString(n int64) string {
-	return string(rune(n))
+	return strconv.FormatInt(n, 10)
 }
 
 func stringToInt(s string) int64 {


### PR DESCRIPTION
## What

Fixes a bug (#6643) where `IncrementBy` in the in-memory keystore silently persisted the wrong value for any input.

## Root cause

`intToString` used `string(rune(n))` to convert an integer to a string. In Go, `string(rune(n))` converts the integer to its Unicode code-point character, not its decimal representation. For example `string(rune(65))` returns `"A"`, not `"65"`. So `IncrementBy` would compute the correct new value (e.g. 5), return it from the function, but store `"E"` (U+0005... actually the control character at codepoint 5) in the map. The next call reads that back through `stringToInt`, which skips non-digit bytes and returns 0, so all subsequent increments start from 0 again.

## Fix

Replace `string(rune(n))` with `strconv.FormatInt(n, 10)`, which produces the correct decimal string.

## Test plan

- [ ] Verify the memory keystore `IncrementBy` returns incrementally correct values across multiple calls
- [ ] Existing integration tests in `tests/platform/` should continue to pass
