### PR TITLE
fix(kms): pass primary transaction to decryptInternalKmsKey to avoid replica lag

### DIFF
--- a/backend-go/internal/services/kms/kms.go
+++ b/backend-go/internal/services/kms/kms.go
@@ -248,7 +248,8 @@ func (s *Service) generateEncryptedKeyMaterial() ([]byte, error) {
 
 // decryptInternalKmsKey loads a KMS key record and decrypts its key material using the root key.
 // For internal KMS keys only. Returns error for external KMS keys.
-func (s *Service) decryptInternalKmsKey(ctx context.Context, kmsKeyID uuid.UUID) ([]byte, error) {
+// q must be the same connection/transaction used by the caller to avoid replica lag.
+func (s *Service) decryptInternalKmsKey(ctx context.Context, q pg.Querier, kmsKeyID uuid.UUID) ([]byte, error) {
 	query := `
 		SELECT
 			kmsKey.id,
@@ -261,7 +262,7 @@ func (s *Service) decryptInternalKmsKey(ctx context.Context, kmsKeyID uuid.UUID)
 		LEFT JOIN external_kms externalKms ON externalKms."kmsKeyId" = kmsKey.id
 		WHERE kmsKey.id = @kmsKeyID
 	`
-	row := s.db.Replica().QueryRow(ctx, query, pgx.NamedArgs{"kmsKeyID": kmsKeyID})
+	row := q.QueryRow(ctx, query, pgx.NamedArgs{"kmsKeyID": kmsKeyID})
 
 	var (
 		id                          uuid.UUID

--- a/backend-go/internal/services/kms/kms_org.go
+++ b/backend-go/internal/services/kms/kms_org.go
@@ -128,7 +128,7 @@ func (s *Service) ensureOrgDataKey(ctx context.Context, orgID uuid.UUID) (dataKe
 			return nil, fmt.Errorf("decrypting KMS key: %w", err)
 		}
 	} else {
-		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, org.KmsDefaultKeyID.V)
+		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, tx, org.KmsDefaultKeyID.V)
 		if err != nil {
 			return nil, err
 		}

--- a/backend-go/internal/services/kms/kms_project.go
+++ b/backend-go/internal/services/kms/kms_project.go
@@ -129,7 +129,7 @@ func (s *Service) ensureProjectDataKey(ctx context.Context, projectID string) (d
 			return nil, fmt.Errorf("decrypting KMS key: %w", err)
 		}
 	} else {
-		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, project.KmsSecretManagerKeyID.V)
+		kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, tx, project.KmsSecretManagerKeyID.V)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What

Fixes a race condition (#6864) where `decryptInternalKmsKey` reads from the replica inside an open primary transaction, causing intermittent 500 errors under replication lag.

## Root cause

Both `ensureProjectDataKey` and `ensureOrgDataKey` open a primary transaction and acquire advisory locks before re-checking whether a KMS key exists:

```go
project, err := s.findProjectKmsInfo(ctx, tx, projectID)  // correctly uses tx
```

`findProjectKmsInfo` and `findOrgKmsInfo` both accept a `pg.Querier` parameter and correctly receive the transaction. In the else branch (key already exists), however, the call to `decryptInternalKmsKey` hardcodes `s.db.Replica().QueryRow()` and was never given the same treatment:

```go
// before fix -- escapes the transaction
kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, project.KmsSecretManagerKeyID.V)
```

Under any replication lag, a concurrent request that just created the KMS key on the primary passes the `findProjectKmsInfo` check (read from the locked primary tx), then hits the replica in `decryptInternalKmsKey` and gets `pgx.ErrNoRows` -- producing a `Failed to find KMS key` 500.

## Fix

Add a `pg.Querier` parameter to `decryptInternalKmsKey`, matching the existing pattern from `findProjectKmsInfo` / `findOrgKmsInfo`. Both callers now pass their open primary transaction so all reads within the ensure function stay on the same connection.

```go
// after fix
kmsKeyMaterial, err = s.decryptInternalKmsKey(ctx, tx, project.KmsSecretManagerKeyID.V)
```

## Test plan

- [ ] Two concurrent requests for the same project/org data key on first use should not produce a 500 under replica lag
- [ ] Existing KMS integration tests in `tests/platform/kms/` should continue to pass
