### PR TITLE
feat(secret-sync): add Render workflow scope to secret sync

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3143,6 +3143,7 @@ export const SecretSyncs = {
     },
     RENDER: {
       serviceId: "The ID of the Render service to sync secrets to.",
+      workflowId: "The ID of the Render workflow to sync secrets to.",
       environmentGroupId: "The ID of the Render environment group to sync secrets to.",
       scope: "The Render scope that secrets should be synced to.",
       type: "The Render resource type to sync secrets to."

--- a/backend/src/server/routes/v1/app-connection-routers/render-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/render-connection-router.ts
@@ -79,4 +79,33 @@ export const registerRenderConnectionRouter = async (server: FastifyZodProvider)
       return groups;
     }
   });
+
+  server.route({
+    method: "GET",
+    url: `/:connectionId/workflows`,
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: "listRenderWorkflows",
+      params: z.object({
+        connectionId: z.string().uuid()
+      }),
+      response: {
+        200: z
+          .object({
+            id: z.string(),
+            name: z.string()
+          })
+          .array()
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const { connectionId } = req.params;
+      const workflows = await server.services.appConnection.render.listWorkflows(connectionId, req.permission);
+
+      return workflows;
+    }
+  });
 };

--- a/backend/src/services/app-connection/render/render-connection-fns.ts
+++ b/backend/src/services/app-connection/render/render-connection-fns.ts
@@ -10,10 +10,12 @@ import { RenderConnectionMethod } from "./render-connection-enums";
 import {
   TRawRenderEnvironmentGroup,
   TRawRenderService,
+  TRawRenderWorkflow,
   TRenderConnection,
   TRenderConnectionConfig,
   TRenderEnvironmentGroup,
-  TRenderService
+  TRenderService,
+  TRenderWorkflow
 } from "./render-connection-types";
 
 export const getRenderConnectionListItem = () => {
@@ -70,6 +72,53 @@ export const listRenderServices = async (appConnection: TRenderConnection): Prom
   }
 
   return services;
+};
+
+export const listRenderWorkflows = async (appConnection: TRenderConnection): Promise<TRenderWorkflow[]> => {
+  const {
+    credentials: { apiKey }
+  } = appConnection;
+
+  const workflows: TRenderWorkflow[] = [];
+  let hasMorePages = true;
+  const perPage = 100;
+  let cursor;
+  let maxIterations = 10;
+
+  while (hasMorePages) {
+    if (maxIterations <= 0) break;
+
+    const res: TRawRenderWorkflow[] = (
+      await request.get<TRawRenderWorkflow[]>(`${IntegrationUrls.RENDER_API_URL}/v1/workflows`, {
+        params: new URLSearchParams({
+          ...(cursor ? { cursor: String(cursor) } : {}),
+          limit: String(perPage)
+        }),
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+          "Accept-Encoding": "application/json"
+        }
+      })
+    ).data;
+
+    res.forEach((item) => {
+      workflows.push({
+        name: item.workflow.name,
+        id: item.workflow.id
+      });
+    });
+
+    if (res.length < perPage) {
+      hasMorePages = false;
+    } else {
+      cursor = res[res.length - 1].cursor;
+    }
+
+    maxIterations -= 1;
+  }
+
+  return workflows;
 };
 
 export const validateRenderConnectionCredentials = async (config: TRenderConnectionConfig) => {

--- a/backend/src/services/app-connection/render/render-connection-fns.ts
+++ b/backend/src/services/app-connection/render/render-connection-fns.ts
@@ -103,6 +103,7 @@ export const listRenderWorkflows = async (appConnection: TRenderConnection): Pro
     ).data;
 
     res.forEach((item) => {
+      if (!item.workflow) return;
       workflows.push({
         name: item.workflow.name,
         id: item.workflow.id

--- a/backend/src/services/app-connection/render/render-connection-service.ts
+++ b/backend/src/services/app-connection/render/render-connection-service.ts
@@ -2,7 +2,7 @@ import { logger } from "@app/lib/logger";
 import { OrgServiceActor } from "@app/lib/types";
 
 import { AppConnection } from "../app-connection-enums";
-import { listRenderEnvironmentGroups, listRenderServices } from "./render-connection-fns";
+import { listRenderEnvironmentGroups, listRenderServices, listRenderWorkflows } from "./render-connection-fns";
 import { TRenderConnection } from "./render-connection-types";
 
 type TGetAppConnectionFunc = (
@@ -36,8 +36,21 @@ export const renderConnectionService = (getAppConnection: TGetAppConnectionFunc)
     }
   };
 
+  const listWorkflows = async (connectionId: string, actor: OrgServiceActor) => {
+    const appConnection = await getAppConnection(AppConnection.Render, connectionId, actor);
+    try {
+      const workflows = await listRenderWorkflows(appConnection);
+
+      return workflows;
+    } catch (error) {
+      logger.error(error, "Failed to list workflows for Render connection");
+      return [];
+    }
+  };
+
   return {
     listServices,
-    listEnvironmentGroups
+    listEnvironmentGroups,
+    listWorkflows
   };
 };

--- a/backend/src/services/app-connection/render/render-connection-types.ts
+++ b/backend/src/services/app-connection/render/render-connection-types.ts
@@ -46,3 +46,22 @@ export type TRawRenderEnvironmentGroup = {
     name: string;
   };
 };
+
+export type TRenderWorkflow = {
+  name: string;
+  id: string;
+};
+
+export type TRawRenderWorkflow = {
+  cursor: string;
+  workflow: {
+    id: string;
+    name: string;
+  };
+};
+
+export type TRenderWorkflowDetail = {
+  id: string;
+  name: string;
+  envVars: { key: string; value: string }[];
+};

--- a/backend/src/services/secret-sync/render/render-sync-enums.ts
+++ b/backend/src/services/secret-sync/render/render-sync-enums.ts
@@ -1,6 +1,7 @@
 export enum RenderSyncScope {
   Service = "service",
-  EnvironmentGroup = "environment-group"
+  EnvironmentGroup = "environment-group",
+  Workflow = "workflow"
 }
 
 export enum RenderSyncType {

--- a/backend/src/services/secret-sync/render/render-sync-fns.ts
+++ b/backend/src/services/secret-sync/render/render-sync-fns.ts
@@ -102,16 +102,14 @@ async function getSecrets(input: { destination: TRenderSyncWithCredentials["dest
       const { workflowId } = input.destination;
       const res = await makeRequestWithRetry(() =>
         request.request<{
-          workflow: {
-            envVars: { key: string; value: string }[];
-          };
+          envVars: { key: string; value: string }[];
         }>({
           ...req,
           url: `/workflows/${workflowId}`
         })
       );
 
-      return (res.data.workflow.envVars ?? []).map((item) => ({
+      return (res.data.envVars ?? []).map((item) => ({
         key: item.key,
         value: item.value
       }));

--- a/backend/src/services/secret-sync/render/render-sync-fns.ts
+++ b/backend/src/services/secret-sync/render/render-sync-fns.ts
@@ -98,6 +98,24 @@ async function getSecrets(input: { destination: TRenderSyncWithCredentials["dest
         value: item.value
       }));
     }
+    case RenderSyncScope.Workflow: {
+      const { workflowId } = input.destination;
+      const res = await makeRequestWithRetry(() =>
+        request.request<{
+          workflow: {
+            envVars: { key: string; value: string }[];
+          };
+        }>({
+          ...req,
+          url: `/workflows/${workflowId}`
+        })
+      );
+
+      return (res.data.workflow.envVars ?? []).map((item) => ({
+        key: item.key,
+        value: item.value
+      }));
+    }
     default:
       throw new BadRequestError({ message: "Unknown render sync destination scope" });
   }
@@ -163,6 +181,19 @@ const batchUpdateEnvironmentSecrets = async (
           })
         );
       }
+      break;
+    }
+
+    case RenderSyncScope.Workflow: {
+      const { workflowId } = destinationConfig;
+      await makeRequestWithRetry(() =>
+        request.request({
+          ...req,
+          method: "PATCH",
+          url: `/workflows/${workflowId}`,
+          data: { envVars }
+        })
+      );
       break;
     }
 
@@ -266,6 +297,10 @@ const redeployService = async (secretSync: TRenderSyncWithCredentials) => {
       break;
     }
 
+    case RenderSyncScope.Workflow:
+      // Render workflows don't expose a deploy endpoint; auto-redeploy is a no-op for this scope.
+      break;
+
     default:
       throw new BadRequestError({ message: "Unknown render sync destination scope" });
   }
@@ -335,18 +370,22 @@ export const RenderSyncFns = {
 
   removeSecrets: async (secretSync: TRenderSyncWithCredentials, secretMap: TSecretMap) => {
     const renderSecrets = await getRenderEnvironmentSecrets(secretSync);
-    const finalEnvVars: Array<{ key: string; value: string }> = [];
 
-    for (const renderSecret of renderSecrets) {
-      if (renderSecret.key in secretMap) {
-        finalEnvVars.push({
-          key: renderSecret.key,
-          value: renderSecret.value
-        });
+    if (secretSync.destinationConfig.scope === RenderSyncScope.Workflow) {
+      // Workflows don't support per-key deletes; PATCH with the remaining env vars instead.
+      const remaining = renderSecrets.filter((s) => !(s.key in secretMap));
+      await batchUpdateEnvironmentSecrets(secretSync, remaining);
+    } else {
+      const toDelete: Array<{ key: string; value: string }> = [];
+
+      for (const renderSecret of renderSecrets) {
+        if (renderSecret.key in secretMap) {
+          toDelete.push({ key: renderSecret.key, value: renderSecret.value });
+        }
       }
-    }
 
-    await Promise.all(finalEnvVars.map((el) => deleteEnvironmentSecret(secretSync, el)));
+      await Promise.all(toDelete.map((el) => deleteEnvironmentSecret(secretSync, el)));
+    }
 
     if (secretSync.syncOptions.autoRedeployServices) {
       await redeployService(secretSync);

--- a/backend/src/services/secret-sync/render/render-sync-schemas.ts
+++ b/backend/src/services/secret-sync/render/render-sync-schemas.ts
@@ -26,6 +26,11 @@ const RenderSyncDestinationConfigSchema = z.discriminatedUnion("scope", [
       .min(1, "Environment Group ID is required")
       .describe(SecretSyncs.DESTINATION_CONFIG.RENDER.environmentGroupId),
     type: z.nativeEnum(RenderSyncType).describe(SecretSyncs.DESTINATION_CONFIG.RENDER.type)
+  }),
+  z.object({
+    scope: z.literal(RenderSyncScope.Workflow).describe(SecretSyncs.DESTINATION_CONFIG.RENDER.scope),
+    workflowId: z.string().min(1, "Workflow ID is required").describe(SecretSyncs.DESTINATION_CONFIG.RENDER.workflowId),
+    type: z.nativeEnum(RenderSyncType).describe(SecretSyncs.DESTINATION_CONFIG.RENDER.type)
   })
 ]);
 

--- a/backend/src/services/secret-sync/render/render-sync-schemas.ts
+++ b/backend/src/services/secret-sync/render/render-sync-schemas.ts
@@ -29,7 +29,11 @@ const RenderSyncDestinationConfigSchema = z.discriminatedUnion("scope", [
   }),
   z.object({
     scope: z.literal(RenderSyncScope.Workflow).describe(SecretSyncs.DESTINATION_CONFIG.RENDER.scope),
-    workflowId: z.string().min(1, "Workflow ID is required").describe(SecretSyncs.DESTINATION_CONFIG.RENDER.workflowId),
+    workflowId: z
+      .string()
+      .min(1, "Workflow ID is required")
+      .regex(/^[a-zA-Z0-9-]+$/, "Workflow ID may only contain alphanumeric characters and hyphens")
+      .describe(SecretSyncs.DESTINATION_CONFIG.RENDER.workflowId),
     type: z.nativeEnum(RenderSyncType).describe(SecretSyncs.DESTINATION_CONFIG.RENDER.type)
   })
 ]);


### PR DESCRIPTION
## What

Adds support for syncing secrets to Render **workflow** services.

Render workflows are a separate resource from regular services. They live under `/v1/workflows` (not `/v1/services`) and use a different env var API: env vars are read from `GET /v1/workflows/{id}` and written via `PATCH /v1/workflows/{id}`. The old `listRenderServices` call missed them entirely, so they never appeared in the Service selector.

## Changes

- New `workflow` scope in `RenderSyncScope`
- `listRenderWorkflows` function that pages through `GET /v1/workflows`
- New `GET /:connectionId/workflows` endpoint on the Render connection router so the UI can populate the workflow selector
- `getSecrets`, `syncSecrets`, and `removeSecrets` all handle the `workflow` scope:
  - reads use `GET /v1/workflows/{id}` + extract `workflow.envVars`
  - writes use `PATCH /v1/workflows/{id}` with the full `envVars` list (full replacement, no per-key deletes needed)
  - `autoRedeployServices` is a no-op for workflows since they have no deploy endpoint

Fixes #6409

## Checklist

- [x] I have read the contributing guide
- [x] My changes follow the project coding style
- [x] I have performed a self-review of my changes
- [ ] I added tests where applicable (no test coverage for connection fns in this area)
