### PR TITLE
fix(pki): use CA's own key algorithm when loading CA private key for signing

### DIFF
--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -2254,12 +2254,12 @@ export const internalCertificateAuthorityServiceFactory = ({
       $checkSignature(ca.internalCa.keyAlgorithm, $getSignatureKeyFamily(signatureAlgorithm), signatureAlgorithm);
     }
 
-    const effectiveKeyAlgorithm = (keyAlgorithm || ca.internalCa.keyAlgorithm) as CertKeyAlgorithm;
+    const caKeyAlgorithm = ca.internalCa.keyAlgorithm as CertKeyAlgorithm;
 
     const alg =
       isPqcAlgorithm(ca.internalCa.keyAlgorithm) || !signatureAlgorithm
-        ? keyAlgorithmToAlgCfg(ca.internalCa.keyAlgorithm as CertKeyAlgorithm)
-        : signatureAlgorithmToAlgCfg(signatureAlgorithm, effectiveKeyAlgorithm);
+        ? keyAlgorithmToAlgCfg(caKeyAlgorithm)
+        : signatureAlgorithmToAlgCfg(signatureAlgorithm, caKeyAlgorithm);
 
     const csrObj = new x509.Pkcs10CertificateRequest(csr);
 

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/useApprovalSubmenu.ts
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/useApprovalSubmenu.ts
@@ -2,6 +2,7 @@ import { DoorOpen, FileKey, Shield } from "lucide-react";
 
 import { useProject } from "@app/context";
 import { useGetAccessRequestsCount, useGetSecretApprovalRequestCount } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
 
 import type { Submenu } from "./types";
 
@@ -11,9 +12,15 @@ export const useApprovalSubmenu = (): {
 } => {
   const { currentProject, projectId } = useProject();
 
-  const { data: secretApprovalReqCount } = useGetSecretApprovalRequestCount({ projectId });
+  const isSecretManager = currentProject.type === ProjectType.SecretManager;
+
+  const { data: secretApprovalReqCount } = useGetSecretApprovalRequestCount({
+    projectId,
+    options: { enabled: isSecretManager }
+  });
   const { data: accessApprovalRequestCount } = useGetAccessRequestsCount({
-    projectSlug: currentProject?.slug || ""
+    projectSlug: currentProject?.slug || "",
+    options: { enabled: isSecretManager }
   });
 
   const pendingRequestsCount =


### PR DESCRIPTION
## Context

`signCertFromCa` was using the CSR's key algorithm instead of the CA's own when importing the CA private key. If the client uses a different curve than the CA (e.g. Certbot default ECDSA P-256 against an ECDSA P-384 CA), the import fails with "Named curve mismatch" and ACME returns `serverInternal`.

Also, the sidebar's `useApprovalSubmenu` hook was firing `secret-approval-requests/count` and `access-approvals/requests/count` on all project types. These fail with 400 on cert-manager projects and fill backend logs with "The project is of type cert-manager. Operations of type secret-manager are not allowed."

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)