### PR TITLE
fix(identity-tls-cert-auth): require an end-entity client certificate; document trusted-proxy header handling

### DIFF
--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -143,6 +143,22 @@ export const identityTlsCertAuthServiceFactory = ({
           }
         });
 
+      // Require an end-entity certificate issued by the configured CA, not the CA certificate
+      // itself. `.ca` covers certs marked CA:TRUE; the raw comparison also covers a self-signed CA
+      // that omits basic constraints.
+      const isClientCertACa = clientCertificateX509.ca || clientCertificateX509.raw.equals(caCertificateX509.raw);
+      if (isClientCertACa) {
+        throw new UnauthorizedError({
+          message: "Access denied: a CA certificate cannot be used as a client certificate.",
+          detail: {
+            reasonCode: "ca_certificate_not_allowed",
+            identityId: identity.id,
+            orgId: identity.orgId,
+            identityName: identity.name
+          }
+        });
+      }
+
       if (new Date(clientCertificateX509.validTo) < new Date()) {
         throw new UnauthorizedError({
           message: "Access denied: Certificate has expired.",

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -47,8 +47,9 @@ server {
     }
 
     # Identity TLS-cert auth: the client certificate is provided by the TLS-terminating upstream.
-    # Exact-match location takes priority over the regex /api block below.
-    location = /api/v1/auth/tls-cert-auth/login {
+    # Regex (matched before the /api block below) covers the optional trailing slash, since the
+    # backend treats /login and /login/ as the same route.
+    location ~ ^/api/v1/auth/tls-cert-auth/login/?$ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -46,12 +46,34 @@ server {
         proxy_cookie_path / "/; HttpOnly; SameSite=strict";
     }
 
+    # Identity TLS-cert auth: the client certificate is provided by the TLS-terminating upstream.
+    # Exact-match location takes priority over the regex /api block below.
+    location = /api/v1/auth/tls-cert-auth/login {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        # Cloud terminates mTLS at the upstream LB; for self-hosted nginx mTLS termination use
+        # $ssl_client_escaped_cert instead.
+        proxy_set_header X-Identity-Tls-Cert-Auth-Client-Cert $http_x_amzn_mtls_clientcert;
+
+        proxy_pass http://backend:4000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+    }
+
     location ~ ^/(api|secret-scanning/webhooks) {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
+
+        # This header is populated only by the dedicated TLS-cert-auth location above.
+        proxy_set_header X-Identity-Tls-Cert-Auth-Client-Cert "";
 
         proxy_pass http://backend:4000;
         proxy_redirect off;
@@ -96,7 +118,7 @@ server {
         proxy_set_header X-NginX-Proxy true;
 
         # specific for infisical cloud setup, needed for server-side mTLS
-        proxy_set_header X-SSL-Client-Cert $http_x_amzn_mtls_clientcert
+        proxy_set_header X-SSL-Client-Cert $http_x_amzn_mtls_clientcert;
 
         proxy_pass http://backend:4000;
         proxy_redirect off;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -52,12 +52,32 @@ server {
         proxy_cookie_path / "/; SameSite=strict";
     }
 
+    # Identity TLS-cert auth: the client certificate is provided by the TLS-terminating proxy.
+    # Exact-match location takes priority over the regex /api block below.
+    location = /api/v1/auth/tls-cert-auth/login {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_set_header X-Identity-Tls-Cert-Auth-Client-Cert $ssl_client_escaped_cert;
+
+        proxy_pass http://api;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; SameSite=strict";
+    }
+
     location ~ ^/(api|secret-scanning/webhooks) {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy true;
+
+        # This header is populated only by the dedicated TLS-cert-auth location above.
+        proxy_set_header X-Identity-Tls-Cert-Auth-Client-Cert "";
 
         proxy_pass http://api;
         proxy_redirect off;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -53,8 +53,9 @@ server {
     }
 
     # Identity TLS-cert auth: the client certificate is provided by the TLS-terminating proxy.
-    # Exact-match location takes priority over the regex /api block below.
-    location = /api/v1/auth/tls-cert-auth/login {
+    # Regex (matched before the /api block below) covers the optional trailing slash, since the
+    # backend treats /login and /login/ as the same route.
+    location ~ ^/api/v1/auth/tls-cert-auth/login/?$ {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
## Context

Identity TLS-certificate auth reads the client certificate for the
`/api/v1/auth/tls-cert-auth/login` route from a request header. That header is only meaningful when
it is populated by the mTLS-terminating edge from the verified handshake; the edge must be the sole
writer of it. This PR hardens what the backend accepts and documents the expected proxy behavior.

- **Proxy config** (`nginx/default.conf`, `nginx/default.dev.conf`) — included as a **reference
  example**, not as the cloud control: a dedicated location for the login route sets the
  client-certificate header from the TLS-terminating upstream
  (`$ssl_client_escaped_cert` for self-hosted nginx mTLS; `$http_x_amzn_mtls_clientcert` where the
  upstream is an mTLS LB), and the header is cleared on the other API routes so an inbound request
  cannot supply it. Also fixes a pre-existing missing semicolon in the EST `proxy_set_header`
  directive.
- **Backend** (`identity-tls-cert-auth-service.ts`): require an end-entity certificate issued by
  the configured CA. A CA certificate presented as the client certificate is rejected (covers both
  certs marked Basic Constraints `CA:TRUE` and a self-signed CA that omits that extension).

Behavior notes:
- This auth method expects an mTLS-terminating upstream (ALB, or self-hosted nginx with
  `ssl_verify_client`) that populates the client-certificate header. Deployments should confirm
  that upstream is in place; the source variable differs per topology (see the inline comment).
- Clients must present an end-entity certificate issued by the configured CA. A CA certificate used
  directly as the client certificate is no longer accepted.

## Screenshots

N/A

## Steps to verify the change

The backend behavior can be verified anywhere; the nginx steps apply to the dev stack and to
self-hosted nginx deployments (cloud relies on the LB instead).

1. Send a login request to `/api/v1/auth/tls-cert-auth/login` for that identity where no client
   certificate is provided by the upstream. The backend receives no certificate and returns
   `400 "Missing TLS certificate in header"`, confirming the header is sourced from the proxy and
   not from the inbound request.
2. In an mTLS-terminating environment (ALB or self-hosted nginx with `ssl_verify_client`), a client
   presenting a certificate issued by the configured CA authenticates and receives an access token
   (happy path unchanged).
3. Present a CA certificate as the client certificate. It is rejected with
   `401 "a CA certificate cannot be used as a client certificate"` (both for a CA marked `CA:TRUE`
   and a self-signed CA without that extension).
4. `eslint` is clean on the changed files. (Full `tsc --noEmit` was not run locally due to the
   type-check's memory ceiling in the container; the new `X509Certificate.ca` / `.raw` usages are
   typed in `@types/node`, and CI runs the full type-check.)

Verified manually against the running dev stack. An e2e test asserting (1) and (3) would be a good
follow-up.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the contributing guide