### PR TITLE
improvement: adjust toast positioning to center

### DIFF
--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -73,13 +73,13 @@ const NotificationBody = ({
     {(callToAction || copyActions) && (
       <div
         className={twMerge(
-          "mt-2 flex h-7 w-full flex-row items-end gap-2",
+          "mt-2 flex h-5 w-full flex-row items-end gap-2",
           callToAction ? "justify-between" : "justify-end"
         )}
       >
         {callToAction}
         {copyActions && (
-          <div className="flex h-7 flex-row items-center gap-2">
+          <div className="flex h-5 flex-row items-center gap-2">
             {copyActions.map((action) => (
               <div className="flex flex-row items-center gap-1.5" key={`copy-${action.name}`}>
                 {action.label && (

--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -73,13 +73,15 @@ const NotificationBody = ({
     {(callToAction || copyActions) && (
       <div
         className={twMerge(
-          "mt-2 flex h-5 w-full flex-row items-end gap-2",
-          callToAction ? "justify-between" : "justify-end"
+          "mt-2 flex w-full flex-row items-end gap-2",
+          callToAction ? "h-7 justify-between" : "h-5 justify-end"
         )}
       >
         {callToAction}
         {copyActions && (
-          <div className="flex h-5 flex-row items-center gap-2">
+          <div
+            className={twMerge("flex flex-row items-center gap-2", callToAction ? "h-7" : "h-5")}
+          >
             {copyActions.map((action) => (
               <div className="flex flex-row items-center gap-1.5" key={`copy-${action.name}`}>
                 {action.label && (

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -23,7 +23,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       toastOptions={{
         classNames: {
-          toast: "!pointer-events-auto !items-start !rounded-md !pl-5",
+          toast: "!pointer-events-auto !items-start !rounded-md !pl-5 !py-3",
           icon: "!mt-0.5",
           title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
           description: "!text-xs !text-foreground/75 whitespace-pre-line",

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -11,7 +11,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme="dark"
-      position="bottom-right"
+      position="bottom-center"
       closeButton
       className="toaster group"
       icons={{


### PR DESCRIPTION
## Context

This PR move the toast notification to position center bottom as it was overlapping with many of our sheets

## Screenshots

<img width="3406" height="1924" alt="CleanShot 2026-06-17 at 15 28 04@2x" src="https://github.com/user-attachments/assets/d4640d33-a173-4365-91a3-8856b3c1f748" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)