### PR TITLE
feat: add doc on projectSlug support in k8s operator

### DIFF
--- a/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
@@ -39,6 +39,9 @@ spec:
     - projectId: <your-project-id>
       environmentSlug: dev
       secretPath: /
+    - projectSlug: another-project
+      environmentSlug: dev
+      secretPath: /
 
   targets:
     - name: managed-secret
@@ -78,11 +81,14 @@ spec:
 
   | Field              | Required | Description                                                   |
   | ------------------ | -------- | ------------------------------------------------------------- |
-  | `projectId`        | Yes      | The Infisical project ID.                                     |
+  | `projectId`        | No       | The Infisical project ID.                                     |
+  | `projectSlug`      | No       | The Infisical project slug.                                   |
   | `environmentSlug`  | Yes      | The environment slug (e.g. `dev`, `staging`, `prod`).         |
   | `secretPath`       | Yes      | The path to the secrets. Root is `/`.                         |
   | `tagSlugs`         | No       | Filter secrets by tag slugs.                                  |
   | `recursive`        | No       | Whether to recursively fetch secrets from sub-folders. Defaults to `false`. |
+
+  <Note>You have to provide either `projectId` or `projectSlug`. If none or both are set, the CRD validation will fail.</Note>
 
   ```yaml
   sources:


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Add doc about the new `projectSlug` option for `InfisicalStaticSecret`'s sources.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)