### PR TITLE
fix(pki): enforce CA policy checks on certificate approval path

### DIFF
--- a/backend/src/services/certificate-common/certificate-csr-utils.ts
+++ b/backend/src/services/certificate-common/certificate-csr-utils.ts
@@ -84,9 +84,10 @@ export const extractCertificateRequestFromCSR = (csr: string): TCertificateReque
 
   const basicConstraintsExtension = csrObj.getExtension("2.5.29.19") as x509.BasicConstraintsExtension;
   if (basicConstraintsExtension) {
+    const parsedPathLength = basicConstraintsExtension.pathLength;
     certificateRequest.basicConstraints = {
       isCA: basicConstraintsExtension.ca,
-      pathLength: basicConstraintsExtension.pathLength
+      pathLength: parsedPathLength !== undefined && parsedPathLength >= 0 ? parsedPathLength : undefined
     };
   }
 

--- a/backend/src/services/certificate-v3/certificate-approval-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-approval-fns.ts
@@ -36,7 +36,7 @@ import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
 import { copyMetadataFromRequestToCertificate } from "@app/services/resource-metadata/resource-metadata-fns";
 
-import { CertExtendedKeyUsageType, CertKeyUsageType } from "../certificate-common/certificate-constants";
+import { CertExtendedKeyUsageType, CertKeyUsageType, CertPolicyState } from "../certificate-common/certificate-constants";
 import {
   calculateFinalRenewBeforeDays,
   extractCertificateFromBuffer,
@@ -367,10 +367,53 @@ export const certificateApprovalServiceFactory = (
 
     validateCaSupport(ca, "CSR signing");
 
+    const certPolicy = await certificatePolicyService.getPolicyById({
+      actor: undefined,
+      actorId: undefined,
+      actorAuthMethod: undefined,
+      actorOrgId: undefined,
+      policyId: profile.certificatePolicyId,
+      internal: true
+    });
+
+    if (!certPolicy) {
+      throw new NotFoundError({ message: "Certificate policy not found for this profile" });
+    }
+
+    validateAlgorithmCompatibility(ca, certPolicy);
+
+    const csrBasicConstraints = certRequest.basicConstraints as { isCA: boolean; pathLength?: number } | undefined;
+    const policyIsCAState: CertPolicyState =
+      (certPolicy.basicConstraints?.isCA as CertPolicyState) || CertPolicyState.DENIED;
+
+    if (csrBasicConstraints?.isCA && policyIsCAState === CertPolicyState.DENIED) {
+      throw new BadRequestError({
+        message:
+          "CA certificate issuance is not allowed by the current policy. The policy's CA:true basicConstraints must be set to 'allowed' or 'required'."
+      });
+    }
+
+    let effectiveBasicConstraints = csrBasicConstraints;
+    let effectivePathLength = csrBasicConstraints?.pathLength;
+
+    if (csrBasicConstraints?.isCA && policyIsCAState !== CertPolicyState.DENIED) {
+      const policyMaxPathLength = certPolicy.basicConstraints?.maxPathLength;
+      effectiveBasicConstraints = {
+        isCA: true,
+        pathLength: policyMaxPathLength
+      };
+      if (
+        policyMaxPathLength !== undefined &&
+        policyMaxPathLength !== null &&
+        policyMaxPathLength !== -1 &&
+        (csrBasicConstraints.pathLength === undefined || csrBasicConstraints.pathLength === null)
+      ) {
+        effectivePathLength = policyMaxPathLength;
+      }
+    }
+
     const { certificate, certificateChain, issuingCaCertificate, serialNumber, cert } =
       await certificateDAL.transaction(async (tx) => {
-        const csrBasicConstraints = certRequest.basicConstraints as { isCA: boolean; pathLength?: number } | undefined;
-
         const certResult = await internalCaService.signCertFromCa({
           isInternal: true,
           caId: ca.id,
@@ -382,8 +425,8 @@ export const certificateApprovalServiceFactory = (
           signatureAlgorithm: certRequest.signatureAlgorithm || undefined,
           keyAlgorithm: certRequest.keyAlgorithm || undefined,
           isFromProfile: true,
-          basicConstraints: csrBasicConstraints,
-          pathLength: csrBasicConstraints?.pathLength,
+          basicConstraints: effectiveBasicConstraints,
+          pathLength: effectivePathLength,
           tx
         });
 

--- a/backend/src/services/certificate-v3/certificate-approval-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-approval-fns.ts
@@ -36,7 +36,11 @@ import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
 import { copyMetadataFromRequestToCertificate } from "@app/services/resource-metadata/resource-metadata-fns";
 
-import { CertExtendedKeyUsageType, CertKeyUsageType, CertPolicyState } from "../certificate-common/certificate-constants";
+import {
+  CertExtendedKeyUsageType,
+  CertKeyUsageType,
+  CertPolicyState
+} from "../certificate-common/certificate-constants";
 import {
   calculateFinalRenewBeforeDays,
   extractCertificateFromBuffer,

--- a/backend/src/services/certificate-v3/certificate-approval-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-approval-fns.ts
@@ -398,7 +398,8 @@ export const certificateApprovalServiceFactory = (
     }
 
     let effectiveBasicConstraints = csrBasicConstraints;
-    let effectivePathLength = csrBasicConstraints?.pathLength;
+    const storedPathLength = csrBasicConstraints?.pathLength;
+    let effectivePathLength = storedPathLength !== undefined && storedPathLength >= 0 ? storedPathLength : undefined;
 
     if (csrBasicConstraints?.isCA && policyIsCAState !== CertPolicyState.DENIED) {
       const policyMaxPathLength = certPolicy.basicConstraints?.maxPathLength;

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1585,6 +1585,10 @@ export const certificateV3ServiceFactory = ({
       ? { isCA: true, pathLength: effectiveBasicConstraints?.pathLength }
       : effectiveBasicConstraints;
 
+    if (resolvedBasicConstraints) {
+      mappedCertificateRequest.basicConstraints = resolvedBasicConstraints;
+    }
+
     const validationResult = await certificatePolicyService.validateCertificateRequest(
       profile.certificatePolicyId,
       mappedCertificateRequest
@@ -1593,6 +1597,18 @@ export const certificateV3ServiceFactory = ({
     if (!validationResult.isValid) {
       throw new BadRequestError({
         message: `Certificate request validation failed: ${validationResult.errors.join(", ")}`
+      });
+    }
+
+    validateAlgorithmCompatibility(ca, policy);
+
+    const policyIsCAState: CertPolicyState =
+      (policy.basicConstraints?.isCA as CertPolicyState) || CertPolicyState.DENIED;
+
+    if (shouldIssueAsCA && policyIsCAState === CertPolicyState.DENIED) {
+      throw new BadRequestError({
+        message:
+          "CA certificate issuance is not allowed by this policy. The policy's CA:true basicConstraints must be set to 'allowed' or 'required'."
       });
     }
 
@@ -1722,20 +1738,8 @@ export const certificateV3ServiceFactory = ({
       };
     }
 
-    validateAlgorithmCompatibility(ca, policy);
-
     const effectiveSignatureAlgorithm = extractedSignatureAlgorithm;
     const effectiveKeyAlgorithm = extractedKeyAlgorithm;
-
-    const policyIsCAState: CertPolicyState =
-      (policy.basicConstraints?.isCA as CertPolicyState) || CertPolicyState.DENIED;
-
-    if (shouldIssueAsCA && policyIsCAState === CertPolicyState.DENIED) {
-      throw new BadRequestError({
-        message:
-          "CA certificate issuance is not allowed by this policy. The policy's CA:true basicConstraints must be set to 'allowed' or 'required'."
-      });
-    }
 
     // Transform policy basicConstraints to the format expected by the CA service
     const caBasicConstraints = shouldIssueAsCA


### PR DESCRIPTION
## Context

Fixes: https://linear.app/infisical/issue/PKI-268/ca-policy-bypass-on-certificate-approval-path

When an admin creates a certificate policy and sets "CA Certificate Property" to **Denied**, that's supposed to mean no CA certificates can be issued under that policy. On the direct signing path, this works. But when the request goes through an approval workflow (someone requests, someone else approves), the deny-CA check was never run. So a CA cert gets issued anyway, completely bypassing the policy.

The same gap existed for two other checks that only ran on the direct path:
- **Algorithm compatibility** (is the policy's allowed signature algorithm compatible with the CA's key type)
- **pathLength enforcement** (when the policy caps how deep a sub-CA chain can go, the approval path ignored the cap)

### How it worked

A CSR carrying `keyCertSign` in key usages but no explicit `basicConstraints` gets inferred as `isCA:true` internally (correct per RFC 5280). But the policy validator (`validateCertificateRequest`) was receiving the original request object without this inference, so it saw no CA request and let it through. The explicit deny-CA gate and the algorithm compatibility check both sat after the approval early-return, so they never ran when an approval policy was attached.

On approval, `$processCSRSigningRequest` signed the cert with zero policy re-validation.

### What we changed

**Moved validation before the approval fork** (`certificate-v3-service.ts`):
- Apply the resolved `basicConstraints` (with the keyCertSign inference) to the request object before calling `validateCertificateRequest`, so the policy validator sees the correct CA status
- Move `validateAlgorithmCompatibility` and the deny-CA check to before the approval early-return

**Added policy re-validation at approval time** (`certificate-approval-fns.ts`):
- `$processCSRSigningRequest` now loads the certificate policy and re-runs the deny-CA check and algorithm compatibility check
- Enforces the policy's `maxPathLength` on the stored request instead of trusting the attacker-influenced value

**Stripped negative pathLength from CSR extensions** (`certificate-csr-utils.ts`):
- A CSR with `pathlen:-1` in its BasicConstraints extension could bypass the policy's `maxPathLength` cap because -1 is used internally as an "unlimited" sentinel
- The CSR parser now treats negative pathLength values as unspecified

## Screenshots

<!-- Not applicable — backend-only change -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)