### PR TITLE
fix(acme): preserve all intermediates when storing external CA certificate chain

### DIFF
--- a/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
+++ b/backend/src/services/certificate-authority/acme/acme-certificate-authority-fns.ts
@@ -554,14 +554,14 @@ export const orderCertificate = async (
   }
   throwIfAcmeOrderAborted(abortSignal);
 
-  const [leafCert, parentCert] = acme.crypto.splitPemChain(pem);
+  const [leafCert, ...intermediates] = acme.crypto.splitPemChain(pem);
   const certObj = new x509.X509Certificate(leafCert);
 
   const { cipherTextBlob: encryptedCertificate } = await kmsEncryptor({
     plainText: Buffer.from(new Uint8Array(certObj.rawData))
   });
 
-  const certificateChainPem = parentCert.trim();
+  const certificateChainPem = intermediates.join("\n").trim();
 
   const { cipherTextBlob: encryptedCertificateChain } = await kmsEncryptor({
     plainText: Buffer.from(certificateChainPem)


### PR DESCRIPTION
## What

Fixes #6918.

`acme.crypto.splitPemChain(pem)` returns every certificate in the chain. The old destructure `const [leafCert, parentCert] = ...` only grabbed the first two and silently dropped the rest before the chain got encrypted and stored.

Let's Encrypt's new YE/YR series uses two intermediates. Without all of them in `encryptedCertificateChain`, clients that don't AIA-chase (Go's `crypto/tls`, cert-manager, most non-browser tooling) fail with `x509: certificate signed by unknown authority`.

Fix is two lines:

```ts
// before
const [leafCert, parentCert] = acme.crypto.splitPemChain(pem);
const certificateChainPem = parentCert.trim();

// after
const [leafCert, ...intermediates] = acme.crypto.splitPemChain(pem);
const certificateChainPem = intermediates.join("\n").trim();
```

Single-intermediate chains keep working since `[cert].join("\n")` equals `cert`.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (no unit test harness exists for ACME order issuance)
- [x] The change is limited to the affected code path
