### PR TITLE
fix(pam): validate gateway org ownership on resource and domain create/update

### DIFF
--- a/backend/src/ee/services/pam-domain/pam-domain-service.ts
+++ b/backend/src/ee/services/pam-domain/pam-domain-service.ts
@@ -45,6 +45,7 @@ export const pamDomainServiceFactory = ({
   pamResourceDAL,
   permissionService,
   kmsService,
+  gatewayV2DAL,
   gatewayV2Service,
   gatewayPoolService,
   resourceMetadataDAL
@@ -115,7 +116,12 @@ export const pamDomainServiceFactory = ({
       })
     );
 
-    if (gatewayPoolId) {
+    if (gatewayId) {
+      const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
+      if (!gateway) {
+        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+      }
+    } else if (gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
         poolId: gatewayPoolId,
         orgId: actor.orgId,
@@ -232,7 +238,12 @@ export const pamDomainServiceFactory = ({
       );
     }
 
-    if (gatewayPoolId && gatewayPoolId !== domain.gatewayPoolId) {
+    if (gatewayId && gatewayId !== domain.gatewayId) {
+      const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
+      if (!gateway) {
+        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+      }
+    } else if (gatewayPoolId && gatewayPoolId !== domain.gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
         poolId: gatewayPoolId,
         orgId: actor.orgId,

--- a/backend/src/ee/services/pam-domain/pam-domain-service.ts
+++ b/backend/src/ee/services/pam-domain/pam-domain-service.ts
@@ -1,6 +1,7 @@
 import { ForbiddenError, subject } from "@casl/ability";
 
-import { ActionProjectType, TPamDomains } from "@app/db/schemas";
+import { ActionProjectType, OrganizationActionScope, TPamDomains } from "@app/db/schemas";
+import { OrgPermissionGatewayActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
@@ -117,6 +118,19 @@ export const pamDomainServiceFactory = ({
     );
 
     if (gatewayId) {
+      const { permission: orgPermission } = await permissionService.getOrgPermission({
+        scope: OrganizationActionScope.Any,
+        actor: actor.type,
+        actorId: actor.id,
+        orgId: actor.orgId,
+        actorAuthMethod: actor.authMethod,
+        actorOrgId: actor.orgId
+      });
+      ForbiddenError.from(orgPermission).throwUnlessCan(
+        OrgPermissionGatewayActions.AttachGateways,
+        OrgPermissionSubjects.Gateway
+      );
+
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
         throw new NotFoundError({ message: "Gateway not found" });
@@ -239,6 +253,19 @@ export const pamDomainServiceFactory = ({
     }
 
     if (gatewayId && gatewayId !== domain.gatewayId) {
+      const { permission: orgPermission } = await permissionService.getOrgPermission({
+        scope: OrganizationActionScope.Any,
+        actor: actor.type,
+        actorId: actor.id,
+        orgId: actor.orgId,
+        actorAuthMethod: actor.authMethod,
+        actorOrgId: actor.orgId
+      });
+      ForbiddenError.from(orgPermission).throwUnlessCan(
+        OrgPermissionGatewayActions.AttachGateways,
+        OrgPermissionSubjects.Gateway
+      );
+
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
         throw new NotFoundError({ message: "Gateway not found" });

--- a/backend/src/ee/services/pam-domain/pam-domain-service.ts
+++ b/backend/src/ee/services/pam-domain/pam-domain-service.ts
@@ -119,7 +119,7 @@ export const pamDomainServiceFactory = ({
     if (gatewayId) {
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
-        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+        throw new NotFoundError({ message: "Gateway not found" });
       }
     } else if (gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
@@ -241,7 +241,7 @@ export const pamDomainServiceFactory = ({
     if (gatewayId && gatewayId !== domain.gatewayId) {
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
-        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+        throw new NotFoundError({ message: "Gateway not found" });
       }
     } else if (gatewayPoolId && gatewayPoolId !== domain.gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({

--- a/backend/src/ee/services/pam-domain/pam-domain-types.ts
+++ b/backend/src/ee/services/pam-domain/pam-domain-types.ts
@@ -67,7 +67,7 @@ export type TDeleteDomainDTO = {
 export type TPamDomainServiceFactoryDep = {
   pamDomainDAL: TPamDomainDALFactory;
   pamResourceDAL: Pick<TPamResourceDALFactory, "find" | "findById">;
-  permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
+  permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getOrgPermission">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "findOne">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;

--- a/backend/src/ee/services/pam-domain/pam-domain-types.ts
+++ b/backend/src/ee/services/pam-domain/pam-domain-types.ts
@@ -6,6 +6,7 @@ import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/res
 import { ResourceMetadataNonEncryptionSchema } from "@app/services/resource-metadata/resource-metadata-schema";
 
 import { TGatewayPoolServiceFactory } from "../gateway-pool/gateway-pool-service";
+import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
 import { TGatewayV2ServiceFactory } from "../gateway-v2/gateway-v2-service";
 import { TPamResourceDALFactory } from "../pam-resource/pam-resource-dal";
 import { TPostRotateContext } from "../pam-resource/pam-resource-types";
@@ -68,6 +69,7 @@ export type TPamDomainServiceFactoryDep = {
   pamResourceDAL: Pick<TPamResourceDALFactory, "find" | "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
+  gatewayV2DAL: Pick<TGatewayV2DALFactory, "findOne">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   gatewayPoolService: Pick<
     TGatewayPoolServiceFactory,

--- a/backend/src/ee/services/pam-resource/pam-resource-service.ts
+++ b/backend/src/ee/services/pam-resource/pam-resource-service.ts
@@ -1,7 +1,11 @@
 import { ForbiddenError, subject } from "@casl/ability";
 
 import { ActionProjectType, OrganizationActionScope, TPamResources } from "@app/db/schemas";
-import { OrgPermissionAppConnectionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import {
+  OrgPermissionAppConnectionActions,
+  OrgPermissionGatewayActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import {
   ProjectPermissionActions,
@@ -213,6 +217,19 @@ export const pamResourceServiceFactory = ({
     );
 
     if (gatewayId) {
+      const { permission: orgPermission } = await permissionService.getOrgPermission({
+        scope: OrganizationActionScope.Any,
+        actor: actor.type,
+        actorId: actor.id,
+        orgId: actor.orgId,
+        actorAuthMethod: actor.authMethod,
+        actorOrgId: actor.orgId
+      });
+      ForbiddenError.from(orgPermission).throwUnlessCan(
+        OrgPermissionGatewayActions.AttachGateways,
+        OrgPermissionSubjects.Gateway
+      );
+
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
         throw new NotFoundError({ message: "Gateway not found" });
@@ -372,6 +389,19 @@ export const pamResourceServiceFactory = ({
     }
 
     if (gatewayId && gatewayId !== resource.gatewayId) {
+      const { permission: orgPermission } = await permissionService.getOrgPermission({
+        scope: OrganizationActionScope.Any,
+        actor: actor.type,
+        actorId: actor.id,
+        orgId: actor.orgId,
+        actorAuthMethod: actor.authMethod,
+        actorOrgId: actor.orgId
+      });
+      ForbiddenError.from(orgPermission).throwUnlessCan(
+        OrgPermissionGatewayActions.AttachGateways,
+        OrgPermissionSubjects.Gateway
+      );
+
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
         throw new NotFoundError({ message: "Gateway not found" });

--- a/backend/src/ee/services/pam-resource/pam-resource-service.ts
+++ b/backend/src/ee/services/pam-resource/pam-resource-service.ts
@@ -215,7 +215,7 @@ export const pamResourceServiceFactory = ({
     if (gatewayId) {
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
-        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+        throw new NotFoundError({ message: "Gateway not found" });
       }
     } else if (gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
@@ -374,7 +374,7 @@ export const pamResourceServiceFactory = ({
     if (gatewayId && gatewayId !== resource.gatewayId) {
       const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
       if (!gateway) {
-        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+        throw new NotFoundError({ message: "Gateway not found" });
       }
     } else if (gatewayPoolId && gatewayPoolId !== resource.gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({

--- a/backend/src/ee/services/pam-resource/pam-resource-service.ts
+++ b/backend/src/ee/services/pam-resource/pam-resource-service.ts
@@ -24,6 +24,7 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
 
 import { TGatewayPoolServiceFactory } from "../gateway-pool/gateway-pool-service";
+import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
 import { TGatewayV2ServiceFactory } from "../gateway-v2/gateway-v2-service";
 import { TPamAccountDALFactory } from "../pam-account/pam-account-dal";
 import { PamAccountView } from "../pam-account/pam-account-enums";
@@ -61,6 +62,7 @@ type TPamResourceServiceFactoryDep = {
     TGatewayV2ServiceFactory,
     "getPAMConnectionDetails" | "getPlatformConnectionDetailsByGatewayId"
   >;
+  gatewayV2DAL: Pick<TGatewayV2DALFactory, "findOne">;
   gatewayPoolService: Pick<
     TGatewayPoolServiceFactory,
     "resolveEffectiveGatewayId" | "resolveAttachableGatewayFromPool"
@@ -82,6 +84,7 @@ export const pamResourceServiceFactory = ({
   pamAccountDAL,
   permissionService,
   kmsService,
+  gatewayV2DAL,
   gatewayV2Service,
   gatewayPoolService,
   resourceMetadataDAL,
@@ -209,7 +212,12 @@ export const pamResourceServiceFactory = ({
       })
     );
 
-    if (gatewayPoolId) {
+    if (gatewayId) {
+      const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
+      if (!gateway) {
+        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+      }
+    } else if (gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
         poolId: gatewayPoolId,
         orgId: actor.orgId,
@@ -363,7 +371,12 @@ export const pamResourceServiceFactory = ({
       );
     }
 
-    if (gatewayPoolId && gatewayPoolId !== resource.gatewayPoolId) {
+    if (gatewayId && gatewayId !== resource.gatewayId) {
+      const gateway = await gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId });
+      if (!gateway) {
+        throw new NotFoundError({ message: "Gateway not found or does not belong to this organization" });
+      }
+    } else if (gatewayPoolId && gatewayPoolId !== resource.gatewayPoolId) {
       await gatewayPoolService.resolveAttachableGatewayFromPool({
         poolId: gatewayPoolId,
         orgId: actor.orgId,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3427,6 +3427,7 @@ export const registerRoutes = async (
     pamAccountDAL,
     permissionService,
     kmsService,
+    gatewayV2DAL,
     gatewayV2Service,
     gatewayPoolService,
     resourceMetadataDAL,
@@ -3440,6 +3441,7 @@ export const registerRoutes = async (
     pamResourceDAL,
     permissionService,
     kmsService,
+    gatewayV2DAL,
     gatewayV2Service,
     gatewayPoolService,
     resourceMetadataDAL


### PR DESCRIPTION
## Context

Fixes: https://linear.app/infisical/issue/PAM-292/cross-org-gateway-attachment-in-pam-resources-and-domains

The direct `gatewayId` path in PAM resource and domain create/update never checked that the gateway belongs to the actor's org. A user in org A could pass org B's gateway ID and Infisical would accept it, try to use org B's gateway config, and route connections through org B's private network.

The pool path (`gatewayPoolId`) already had this check via `resolveAttachableGatewayFromPool`. Other features like dynamic secrets, app connections, PAM discovery, and PKI discovery also already validate `gatewayId` against the org. The PAM resource and domain services were the ones missing it.

### What changed

Added `gatewayV2DAL.findOne({ id: gatewayId, orgId: actor.orgId })` in PAM resource and domain services (create and update) before accepting a direct `gatewayId`. If the gateway doesn't exist or belongs to a different org, it throws a 404. Also added the `AttachGateways` RBAC check that every other direct-gateway consumer enforces. Same pattern used everywhere else.

## Screenshots

<!-- Not applicable — backend-only change -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)