### PR TITLE
fix(keystore): use strconv instead of rune conversion in memory IncrementBy

### DIFF
--- a/backend-go/internal/keystore/memory.go
+++ b/backend-go/internal/keystore/memory.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -128,28 +129,11 @@ func (m *MemoryKeyStore) StreamAdd(_ context.Context, stream, id string, values 
 }
 
 func intToString(n int64) string {
-	return string(rune(n))
+	return strconv.FormatInt(n, 10)
 }
 
 func stringToInt(s string) int64 {
-	if s == "" {
-		return 0
-	}
-	// Parse as integer string
-	var result int64
-	negative := false
-	start := 0
-	if s[0] == '-' {
-		negative = true
-		start = 1
-	}
-	for i := start; i < len(s); i++ {
-		if s[i] >= '0' && s[i] <= '9' {
-			result = result*10 + int64(s[i]-'0')
-		}
-	}
-	if negative {
-		return -result
-	}
-	return result
+	// invalid or empty values fall back to 0, matching the redis keystore's behaviour
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
 }

--- a/backend-go/internal/keystore/memory_test.go
+++ b/backend-go/internal/keystore/memory_test.go
@@ -1,0 +1,67 @@
+package keystore
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemoryKeyStore_IncrementBy(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("starts from zero on a missing key", func(t *testing.T) {
+		store := NewMemoryKeyStore()
+		got, err := store.IncrementBy(ctx, "counter", 5)
+		if err != nil {
+			t.Fatalf("IncrementBy returned error: %v", err)
+		}
+		if got != 5 {
+			t.Fatalf("IncrementBy = %d, want 5", got)
+		}
+	})
+
+	t.Run("accumulates across calls and persists the value", func(t *testing.T) {
+		store := NewMemoryKeyStore()
+		if _, err := store.IncrementBy(ctx, "counter", 65); err != nil {
+			t.Fatalf("IncrementBy returned error: %v", err)
+		}
+		got, err := store.IncrementBy(ctx, "counter", 2)
+		if err != nil {
+			t.Fatalf("IncrementBy returned error: %v", err)
+		}
+		if got != 67 {
+			t.Fatalf("IncrementBy = %d, want 67", got)
+		}
+
+		// reading the persisted value back must round-trip to the same integer,
+		// which the previous string(rune(n)) serialization broke (65 -> "A" -> 0).
+		raw, err := store.GetItem(ctx, "counter")
+		if err != nil {
+			t.Fatalf("GetItem returned error: %v", err)
+		}
+		if stringToInt(raw) != 67 {
+			t.Fatalf("persisted value = %q (parsed %d), want 67", raw, stringToInt(raw))
+		}
+	})
+
+	t.Run("supports decrement", func(t *testing.T) {
+		store := NewMemoryKeyStore()
+		if _, err := store.IncrementBy(ctx, "counter", 10); err != nil {
+			t.Fatalf("IncrementBy returned error: %v", err)
+		}
+		got, err := store.IncrementBy(ctx, "counter", -1)
+		if err != nil {
+			t.Fatalf("IncrementBy returned error: %v", err)
+		}
+		if got != 9 {
+			t.Fatalf("IncrementBy = %d, want 9", got)
+		}
+	})
+}
+
+func TestIntToString_RoundTrip(t *testing.T) {
+	for _, n := range []int64{0, 1, 9, 10, 65, 127, -1, -65, 1234567890} {
+		if got := stringToInt(intToString(n)); got != n {
+			t.Errorf("round-trip for %d failed: got %d (serialized %q)", n, got, intToString(n))
+		}
+	}
+}


### PR DESCRIPTION
## Context

Fixes #6643.

`MemoryKeyStore.IncrementBy` (the in-memory `KeyStore` used as a test/fallback double) was fully broken for numeric values. The integer was serialized with a rune conversion:

```go
func intToString(n int64) string {
    return string(rune(n))
}
```

`string(rune(n))` treats `n` as a Unicode code point, not as digits — `string(rune(65))` is `"A"`, not `"65"`. The downstream `stringToInt` parser only accepts `'0'`–`'9'`, so it read no digits and returned `0`. As a result, incrementing any stored integer and reading it back yielded `0` instead of the new value.

This swaps the hand-rolled helpers for `strconv.FormatInt` / `strconv.ParseInt`, which format and parse the decimal representation correctly. `stringToInt` keeps its "fall back to 0 on empty/invalid input" behavior (matching the redis keystore), now via `ParseInt`'s zero-on-error return.

## Steps to verify the change

`go test ./internal/keystore/...`

Added tests cover:
- increment from a missing key,
- accumulation across calls + value persistence (`65` then `+2` → `67`, read back as `67`),
- decrement (`-1`, as used by the auth rate limiter),
- `intToString`/`stringToInt` round-tripping across a range of values including `65` and `127`.

Against the old code the persistence/round-trip assertions fail (value comes back as `0`); with the fix they pass.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
