### PR TITLE
fix: update org settings pages titles to reflect the nav selection

### DIFF
--- a/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgTabGroup/OrgTabGroup.tsx
@@ -24,32 +24,50 @@ export const OrgTabGroup = () => {
   const { subscription } = useSubscription();
 
   const tabs = [
-    { name: "General", key: "tab-org-general", component: OrgGeneralTab },
+    {
+      name: "General",
+      key: "tab-org-general",
+      component: OrgGeneralTab,
+      description: isSubOrganization
+        ? "Update your sub-organization's name and other general settings."
+        : "Update your organization's name, incident contacts, and other general settings."
+    },
     {
       name: "Security",
       key: "tab-org-security",
       component: OrgSecurityTab,
+      description:
+        "Configure authentication requirements and access token limits for your organization.",
       isHidden: isSubOrganization
     },
     {
       name: "Encryption",
       key: "tab-org-encryption",
-      component: OrgEncryptionTab
+      component: OrgEncryptionTab,
+      description: `Configure the key management systems (KMS) used to encrypt your ${
+        isSubOrganization ? "sub-" : ""
+      }organization's data.`
     },
     {
       name: "Project Templates",
       key: "project-templates",
-      component: ProjectTemplatesTab
+      component: ProjectTemplatesTab,
+      description:
+        "Create reusable templates that standardize roles and environments for new projects."
     },
     {
       name: "Product Settings",
       key: "product-settings",
-      component: OrgProductSettingsTab
+      component: OrgProductSettingsTab,
+      description: `Configure product-specific defaults and features across your ${
+        isSubOrganization ? "sub-" : ""
+      }organization.`
     },
     {
       name: "Sub Organizations",
       key: "tab-sub-organizations",
       component: OrgSubOrgsTab,
+      description: "Create and manage sub-organizations to isolate teams, environments, and data.",
       isHidden: isSubOrganization,
       requiresFeature: !subscription?.subOrganization
     }
@@ -61,7 +79,8 @@ export const OrgTabGroup = () => {
     ? (visibleTabs.find((item) => item.key === search.selectedTab && !item.requiresFeature)?.key ??
       defaultTab)
     : defaultTab;
-  const selectedTabName = visibleTabs.find((item) => item.key === selectedTab)?.name;
+  const activeTab = visibleTabs.find((item) => item.key === selectedTab);
+  const selectedTabName = activeTab?.name;
   const settingsTitle = `${isSubOrganization ? "Sub-Organization" : "Organization"} Settings`;
   const pageTitle = selectedTabName ? `${selectedTabName} - ${settingsTitle}` : settingsTitle;
 
@@ -72,8 +91,11 @@ export const OrgTabGroup = () => {
       </Helmet>
       <PageHeader
         scope={isSubOrganization ? "namespace" : "org"}
-        description={`Configure ${isSubOrganization ? "sub-" : ""}organization-wide settings`}
-        title={settingsTitle}
+        description={
+          activeTab?.description ??
+          `Configure ${isSubOrganization ? "sub-" : ""}organization-wide settings`
+        }
+        title={selectedTabName ?? settingsTitle}
       >
         {isSubOrganization && (
           <Link
@@ -87,32 +109,34 @@ export const OrgTabGroup = () => {
           </Link>
         )}
       </PageHeader>
-      <Alert variant="info" className="mb-6">
-        <InfoIcon />
-        <AlertTitle>Some Settings Have Moved</AlertTitle>
-        <AlertDescription>
-          <p>
-            Audit log streams now live under{" "}
-            <Link
-              to="/organizations/$orgId/audit-logs"
-              params={{ orgId: currentOrg.id }}
-              search={{ selectedTab: "streams" }}
-              className="underline hover:opacity-80"
-            >
-              Audit Logs
-            </Link>
-            , and workflow integrations and external migrations have moved to{" "}
-            <Link
-              to="/organizations/$orgId/integrations"
-              params={{ orgId: currentOrg.id }}
-              className="underline hover:opacity-80"
-            >
-              Integrations
-            </Link>
-            .
-          </p>
-        </AlertDescription>
-      </Alert>
+      {selectedTab === "tab-org-general" && (
+        <Alert variant="info" className="mb-6">
+          <InfoIcon />
+          <AlertTitle>Some Settings Have Moved</AlertTitle>
+          <AlertDescription>
+            <p>
+              Audit log streams now live under{" "}
+              <Link
+                to="/organizations/$orgId/audit-logs"
+                params={{ orgId: currentOrg.id }}
+                search={{ selectedTab: "streams" }}
+                className="underline hover:opacity-80"
+              >
+                Audit Logs
+              </Link>
+              , and workflow integrations and external migrations have moved to{" "}
+              <Link
+                to="/organizations/$orgId/integrations"
+                params={{ orgId: currentOrg.id }}
+                className="underline hover:opacity-80"
+              >
+                Integrations
+              </Link>
+              .
+            </p>
+          </AlertDescription>
+        </Alert>
+      )}
       <Tabs orientation="vertical" value={selectedTab}>
         {visibleTabs
           .filter((tab) => !tab.requiresFeature)

--- a/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/ProjectTemplatesSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/ProjectTemplatesSection.tsx
@@ -29,10 +29,6 @@ export const ProjectTemplatesSection = () => {
         <EditProjectTemplateSection template={editTemplate} onBack={() => setEditTemplate(null)} />
       ) : (
         <div>
-          <p className="mb-6 font-inter text-bunker-300">
-            Create and configure templates with predefined roles and environments to streamline
-            project setup
-          </p>
           <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
               <div className="flex items-center gap-x-2">


### PR DESCRIPTION
## Context

This PR fixes several org settings pages that weren't properly updating the page title when navigating to them

## Screenshots

N/A

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)