### PR TITLE
improvement: restructure secrets management nav

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -240,7 +240,8 @@ export const accessApprovalRequestServiceFactory = ({
 
       const requesterFullName = `${requestedByUser.firstName} ${requestedByUser.lastName}`;
       const projectPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}`;
-      const approvalPath = `${projectPath}/approval`;
+      // Deep-link approvers straight to the Access Requests tab
+      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests`;
       const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
       await triggerWorkflowIntegrationNotification({
@@ -418,7 +419,8 @@ export const accessApprovalRequestServiceFactory = ({
       const requesterFullName = `${requestedByUser.firstName} ${requestedByUser.lastName}`;
       const editorFullName = `${editedByUser.firstName} ${editedByUser.lastName}`;
       const projectPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}`;
-      const approvalPath = `${projectPath}/approval`;
+      // Deep-link approvers straight to the Access Requests tab
+      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests`;
       const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
       await triggerWorkflowIntegrationNotification({
@@ -813,7 +815,8 @@ export const accessApprovalRequestServiceFactory = ({
               .map((appUser) => appUser.email)
               .filter((email): email is string => !!email);
 
-            const approvalPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval`;
+            // Deep-link approvers straight to the Access Requests tab
+            const approvalPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval?selectedTab=resource-requests`;
             const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
             await notificationService.createUserNotifications(

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNav.tsx
@@ -19,19 +19,16 @@ import {
   CERT_APPROVALS_SUBMENU,
   CERT_CERTIFICATES_SUBMENU,
   CERT_INTEGRATIONS_SUBMENU,
-  INTEGRATIONS_SUBMENU,
   MCP_SUBMENU,
   PAM_APPROVALS_SUBMENU,
   PAM_SETTINGS_SUBMENU,
   PROJECT_ACCESS_CONTROL_SUBMENU,
-  SECRET_MANAGER_ACCESS_CONTROL_SUBMENU,
   SECRET_SCANNING_SETTINGS_SUBMENU,
   SM_SETTINGS_SUBMENU
 } from "./submenus";
 import { ProjectSubmenuView } from "./SubmenuViews";
 import type { Submenu } from "./types";
 import { PROJECT_TYPE_PATH } from "./types";
-import { useApprovalSubmenu } from "./useApprovalSubmenu";
 
 const PROJECT_NAV_COMPONENT: Record<
   ProjectType,
@@ -59,8 +56,6 @@ export const ProjectNav = () => {
   );
   const isFromRootRequests = (locationSearch as { from?: string })?.from === "root-requests";
   const hasSignerContext = Boolean((locationSearch as { signerId?: string })?.signerId);
-  const { submenu: smApprovalsSubmenu, pendingRequestsCount: smPendingCount } =
-    useApprovalSubmenu();
   const intermediateAvailable = hasIntermediateProjectsView(currentProject.type);
   let projectLabel: string;
   if (intermediateAvailable) projectLabel = "Projects";
@@ -76,7 +71,6 @@ export const ProjectNav = () => {
     Boolean(pathname.match(/\/groups\/|\/identities\/|\/members\/|\/roles\//));
   const isOnIntegrations = pathname.includes("/integrations");
   const isOnProjectSettings = /\/settings(\/|\?|$)/.test(pathname);
-  const isOnApproval = pathname.includes("/approval");
   const isOnMcpOverview = currentProject.type === ProjectType.AI && pathname.includes("/overview");
   const isCertManager = currentProject.type === ProjectType.CertificateManager;
   const isOnCertPolicies = isCertManager && pathname.includes("/policies");
@@ -86,13 +80,9 @@ export const ProjectNav = () => {
     if (isLegacyView || hasApplicationContext || isFromRootRequests || hasSignerContext)
       return null;
     if (isCertManager && (isOnAccessControl || pathname.includes("/discovery"))) return null;
-    if (isOnAccessControl) {
-      if (currentProject.type === ProjectType.SecretManager)
-        return SECRET_MANAGER_ACCESS_CONTROL_SUBMENU;
+    // Secret manager renders access control as in-page tabs (no secondary submenu).
+    if (isOnAccessControl && currentProject.type !== ProjectType.SecretManager)
       return PROJECT_ACCESS_CONTROL_SUBMENU;
-    }
-    if (isOnIntegrations && currentProject.type === ProjectType.SecretManager)
-      return INTEGRATIONS_SUBMENU;
     if (isOnIntegrations && isCertManager) return CERT_INTEGRATIONS_SUBMENU;
     if (isOnProjectSettings && currentProject.type === ProjectType.SecretManager)
       return SM_SETTINGS_SUBMENU;
@@ -104,7 +94,6 @@ export const ProjectNav = () => {
     if (isOnCertApprovals) return CERT_APPROVALS_SUBMENU;
     if (currentProject.type === ProjectType.PAM && pathname.includes("/approvals"))
       return PAM_APPROVALS_SUBMENU;
-    if (isOnApproval && !isCertManager) return smApprovalsSubmenu;
     return null;
   };
 
@@ -114,19 +103,13 @@ export const ProjectNav = () => {
     setActiveSubmenu(getInitialProjectSubmenu());
   }, [pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Keep the active submenu in sync when badge data changes
-  useEffect(() => {
-    setActiveSubmenu((current) => {
-      if (current && current.pathSuffix === smApprovalsSubmenu.pathSuffix) {
-        return smApprovalsSubmenu;
-      }
-      return current;
-    });
-  }, [smPendingCount]); // eslint-disable-line react-hooks/exhaustive-deps
-
   const handleSubmenuOpen = (submenu: Submenu) => {
     setActiveSubmenu(submenu);
     const typePath = PROJECT_TYPE_PATH[currentProject.type];
+    // Already on this submenu's page (e.g. after collapsing via the "< back" button):
+    // re-navigating to the same URL would push a duplicate history entry, so just re-expand.
+    const submenuPath = `/organizations/${currentOrg.id}/projects/${typePath}/${currentProject.id}/${submenu.pathSuffix}`;
+    if (pathname === submenuPath || pathname.startsWith(`${submenuPath}/`)) return;
     navigate({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       to: `/organizations/$orgId/projects/${typePath}/$projectId/${submenu.pathSuffix}` as any,

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SecretManagerNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SecretManagerNav.tsx
@@ -1,13 +1,9 @@
-import { ActivityIcon, BookCheck, FileText, Plug, Settings, Shield } from "lucide-react";
+import { ActivityIcon, Blocks, BookCheck, FileText, Settings, Shield } from "lucide-react";
 
-import { ProjectIcon } from "@app/components/v3";
+import { ProjectIcon, SidebarCollapsibleGroup } from "@app/components/v3";
 
 import { ProjectNavList } from "./ProjectNavLink";
-import {
-  INTEGRATIONS_SUBMENU,
-  SECRET_MANAGER_ACCESS_CONTROL_SUBMENU,
-  SM_SETTINGS_SUBMENU
-} from "./submenus";
+import { SM_SETTINGS_SUBMENU } from "./submenus";
 import type { NavItem, Submenu } from "./types";
 import { useApprovalSubmenu } from "./useApprovalSubmenu";
 
@@ -16,9 +12,9 @@ export const SecretManagerNav = ({
 }: {
   onSubmenuOpen: (submenu: Submenu) => void;
 }) => {
-  const { submenu: approvalsSubmenu, pendingRequestsCount } = useApprovalSubmenu();
+  const { pendingRequestsCount } = useApprovalSubmenu();
 
-  const items: NavItem[] = [
+  const generalItems: NavItem[] = [
     {
       label: "Overview",
       icon: ProjectIcon,
@@ -29,30 +25,39 @@ export const SecretManagerNav = ({
       label: "Approvals",
       icon: BookCheck,
       pathSuffix: "approval",
-      badgeCount: pendingRequestsCount || undefined,
-      submenu: approvalsSubmenu
+      badgeCount: pendingRequestsCount || undefined
     },
     {
       label: "Integrations",
-      icon: Plug,
+      icon: Blocks,
       pathSuffix: "integrations",
-      submenu: INTEGRATIONS_SUBMENU
-    },
-    {
-      label: "Access Control",
-      icon: Shield,
-      pathSuffix: "access-management",
-      activeMatch: /\/groups\/|\/identities\/|\/members\/|\/roles\//,
-      submenu: SECRET_MANAGER_ACCESS_CONTROL_SUBMENU
+      // Keep highlighted on integration detail pages and the standalone app-connections page
+      activeMatch: /\/app-connections|\/integrations\//
     },
     {
       label: "Insights",
       icon: ActivityIcon,
       pathSuffix: "insights"
+    }
+  ];
+
+  const administrationItems: NavItem[] = [
+    {
+      label: "Access Control",
+      icon: Shield,
+      pathSuffix: "access-management",
+      activeMatch: /\/groups\/|\/identities\/|\/members\/|\/roles\//
     },
     { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
     { label: "Settings", icon: Settings, pathSuffix: "settings", submenu: SM_SETTINGS_SUBMENU }
   ];
 
-  return <ProjectNavList items={items} onSubmenuOpen={onSubmenuOpen} />;
+  return (
+    <>
+      <ProjectNavList items={generalItems} onSubmenuOpen={onSubmenuOpen} />
+      <SidebarCollapsibleGroup label="Administration">
+        <ProjectNavList items={administrationItems} onSubmenuOpen={onSubmenuOpen} />
+      </SidebarCollapsibleGroup>
+    </>
+  );
 };

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/submenus.ts
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/submenus.ts
@@ -1,10 +1,8 @@
 import {
   ArrowLeftRight,
-  Blocks,
   Cable,
   ClipboardList,
   Cog,
-  Container,
   FileCheck,
   FileKey,
   FileText,
@@ -45,14 +43,6 @@ export const PROJECT_ACCESS_CONTROL_SUBMENU: Submenu = {
   ]
 };
 
-export const SECRET_MANAGER_ACCESS_CONTROL_SUBMENU: Submenu = {
-  ...PROJECT_ACCESS_CONTROL_SUBMENU,
-  items: [
-    ...PROJECT_ACCESS_CONTROL_SUBMENU.items,
-    { label: "Service Tokens", icon: Key, tab: "service-tokens" }
-  ]
-};
-
 export const CERT_MANAGER_ACCESS_CONTROL_SUBMENU: Submenu = {
   title: "Access Control",
   pathSuffix: "access-management",
@@ -80,24 +70,6 @@ export const SM_SETTINGS_SUBMENU: Submenu = {
     { label: "Encryption", icon: Lock, tab: "tab-project-encryption" },
     { label: "Workflow Integrations", icon: Plug, tab: "tab-workflow-integrations" },
     { label: "Webhooks", icon: Cable, tab: "tab-project-webhooks" }
-  ]
-};
-
-export const INTEGRATIONS_SUBMENU: Submenu = {
-  title: "Integrations",
-  pathSuffix: "integrations",
-  defaultTab: "app-connections",
-  items: [
-    { label: "App Connections", icon: Cable, tab: "app-connections" },
-    {
-      label: "Secret Syncs",
-      icon: ArrowLeftRight,
-      tab: "secret-syncs",
-      activeMatch: /\/integrations\/secret-syncs\//
-    },
-    { label: "Framework Integrations", icon: Blocks, tab: "framework-integrations" },
-    { label: "Infrastructure Integrations", icon: Container, tab: "infrastructure-integrations" },
-    { label: "Native Integrations", icon: Plug, tab: "native-integrations" }
   ]
 };
 

--- a/frontend/src/pages/project/AccessControlPage/AccessControlPage.tsx
+++ b/frontend/src/pages/project/AccessControlPage/AccessControlPage.tsx
@@ -64,31 +64,41 @@ const Page = () => {
           </Link>
         </PageHeader>
         <Tabs
-          orientation={isCertManager ? "horizontal" : "vertical"}
+          orientation={isCertManager || isSecretManager ? "horizontal" : "vertical"}
           value={selectedTab}
           onValueChange={updateSelectedTab}
         >
-          {isCertManager && (
+          {(isCertManager || isSecretManager) && (
             <TabList>
               <Tab variant="project" value={ProjectAccessControlTabs.Member}>
                 Users
               </Tab>
-              <Tab variant="project" value={ProjectAccessControlTabs.Groups}>
-                Groups
-              </Tab>
               <Tab variant="project" value={ProjectAccessControlTabs.Identities}>
                 Machine Identities
               </Tab>
+              <Tab variant="project" value={ProjectAccessControlTabs.Groups}>
+                Groups
+              </Tab>
+              {isSecretManager && (
+                <Tab variant="project" value={ProjectAccessControlTabs.ServiceTokens}>
+                  Service Tokens
+                </Tab>
+              )}
+              {isSecretManager && (
+                <Tab variant="project" value={ProjectAccessControlTabs.Roles}>
+                  Roles
+                </Tab>
+              )}
             </TabList>
           )}
           <TabPanel value={ProjectAccessControlTabs.Member}>
             <MembersTab />
           </TabPanel>
-          <TabPanel value={ProjectAccessControlTabs.Groups}>
-            <GroupsTab />
-          </TabPanel>
           <TabPanel value={ProjectAccessControlTabs.Identities}>
             <IdentityTab />
+          </TabPanel>
+          <TabPanel value={ProjectAccessControlTabs.Groups}>
+            <GroupsTab />
           </TabPanel>
           {isSecretManager && (
             <TabPanel value={ProjectAccessControlTabs.ServiceTokens}>

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/IntegrationsListPage.tsx
@@ -1,11 +1,16 @@
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { PageHeader, TabPanel, Tabs } from "@app/components/v2";
+import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
 import { ROUTE_PATHS } from "@app/const/routes";
-import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSub,
+  useOrganization,
+  useProject
+} from "@app/context";
 import { ProjectPermissionSecretSyncActions } from "@app/context/ProjectPermissionContext/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
@@ -20,10 +25,21 @@ import {
 
 export const IntegrationsListPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { currentOrg } = useOrganization();
+  const { currentProject } = useProject();
 
   const { selectedTab } = useSearch({
     from: ROUTE_PATHS.SecretManager.IntegrationsListPage.id
   });
+
+  const updateSelectedTab = (tab: string) => {
+    navigate({
+      to: "/organizations/$orgId/projects/secret-management/$projectId/integrations",
+      params: { orgId: currentOrg.id, projectId: currentProject.id },
+      search: { selectedTab: tab as IntegrationsListPageTabs }
+    });
+  };
 
   return (
     <>
@@ -40,7 +56,24 @@ export const IntegrationsListPage = () => {
             title="Project Integrations"
             description="Manage integrations with third-party services."
           />
-          <Tabs orientation="vertical" value={selectedTab}>
+          <Tabs value={selectedTab} onValueChange={updateSelectedTab}>
+            <TabList>
+              <Tab variant="project" value={IntegrationsListPageTabs.AppConnections}>
+                App Connections
+              </Tab>
+              <Tab variant="project" value={IntegrationsListPageTabs.SecretSyncs}>
+                Secret Syncs
+              </Tab>
+              <Tab variant="project" value={IntegrationsListPageTabs.FrameworkIntegrations}>
+                Framework Integrations
+              </Tab>
+              <Tab variant="project" value={IntegrationsListPageTabs.InfrastructureIntegrations}>
+                Infrastructure Integrations
+              </Tab>
+              <Tab variant="project" value={IntegrationsListPageTabs.NativeIntegrations}>
+                Native Integrations
+              </Tab>
+            </TabList>
             <TabPanel value={IntegrationsListPageTabs.AppConnections}>
               <AppConnectionsTab />
             </TabPanel>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/SecretApprovalsPage.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/SecretApprovalsPage.tsx
@@ -1,10 +1,11 @@
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 
-import { PageHeader, TabPanel, Tabs } from "@app/components/v2";
+import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { Badge } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
-import { useProject } from "@app/context";
+import { useOrganization, useProject } from "@app/context";
 import { useGetAccessRequestsCount, useGetSecretApprovalRequestCount } from "@app/hooks/api";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -20,6 +21,8 @@ enum TabSection {
 
 export const SecretApprovalsPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { currentOrg } = useOrganization();
   const { currentProject, projectId } = useProject();
   const projectSlug = currentProject?.slug || "";
   const { data: secretApprovalReqCount } = useGetSecretApprovalRequestCount({
@@ -38,6 +41,14 @@ export const SecretApprovalsPage = () => {
 
   const selectedTab = searchTab || defaultTab;
 
+  const updateSelectedTab = (tab: string) => {
+    navigate({
+      to: "/organizations/$orgId/projects/secret-management/$projectId/approval",
+      params: { orgId: currentOrg.id, projectId },
+      search: (prev) => ({ ...prev, selectedTab: tab })
+    });
+  };
+
   return (
     <div>
       <Helmet>
@@ -51,7 +62,28 @@ export const SecretApprovalsPage = () => {
           title="Approval Workflows"
           description="Create approval policies for any modifications to secrets in sensitive environments and folders."
         />
-        <Tabs orientation="vertical" value={selectedTab}>
+        <Tabs value={selectedTab} onValueChange={updateSelectedTab}>
+          <TabList>
+            <Tab variant="project" value={TabSection.SecretApprovalRequests}>
+              Change Requests
+              {Boolean(secretApprovalReqCount?.open) && (
+                <Badge variant="warning" className="ml-2">
+                  {secretApprovalReqCount?.open}
+                </Badge>
+              )}
+            </Tab>
+            <Tab variant="project" value={TabSection.ResourceApprovalRequests}>
+              Access Requests
+              {Boolean(accessApprovalRequestCount?.pendingCount) && (
+                <Badge variant="warning" className="ml-2">
+                  {accessApprovalRequestCount?.pendingCount}
+                </Badge>
+              )}
+            </Tab>
+            <Tab variant="project" value={TabSection.Policies}>
+              Policies
+            </Tab>
+          </TabList>
           <TabPanel value={TabSection.SecretApprovalRequests}>
             <SecretApprovalRequest />
           </TabPanel>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/SecretApprovalsPage.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/SecretApprovalsPage.tsx
@@ -45,7 +45,9 @@ export const SecretApprovalsPage = () => {
     navigate({
       to: "/organizations/$orgId/projects/secret-management/$projectId/approval",
       params: { orgId: currentOrg.id, projectId },
-      search: (prev) => ({ ...prev, selectedTab: tab })
+      // Clear any open request detail when switching tabs so returning to
+      // Change Requests does not reopen a stale requestId.
+      search: { selectedTab: tab, requestId: "" }
     });
   };
 

--- a/frontend/src/pages/secret-manager/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/SettingsPage.tsx
@@ -24,27 +24,54 @@ export const SettingsPage = () => {
   });
 
   const tabs = [
-    { key: "tab-project-general", Component: ProjectGeneralTab },
-    { key: "tab-secret-general", Component: SecretSettingsTab },
     {
+      name: "General",
+      description: "Manage your project's name, audit log retention, and delete protection.",
+      key: "tab-project-general",
+      Component: ProjectGeneralTab
+    },
+    {
+      name: "Secrets Management",
+      description:
+        "Configure environments, secret tags, validation rules, and other secret behaviors.",
+      key: "tab-secret-general",
+      Component: SecretSettingsTab
+    },
+    {
+      name: "Encryption",
+      description: "Choose the Key Management System used to encrypt this project's data.",
       key: "tab-project-encryption",
       isHidden: currentProject?.version !== ProjectVersion.V3,
       Component: EncryptionTab
     },
-    { key: "tab-workflow-integrations", Component: WorkflowIntegrationTab },
-    { key: "tab-project-webhooks", Component: WebhooksTab }
+    {
+      name: "Workflow Integrations",
+      description: "Connect Slack and Microsoft Teams for approval and notification workflows.",
+      key: "tab-workflow-integrations",
+      Component: WorkflowIntegrationTab
+    },
+    {
+      name: "Webhooks",
+      description: "Manage webhooks that notify external services when your secrets change.",
+      key: "tab-project-webhooks",
+      Component: WebhooksTab
+    }
   ];
+
+  const activeTab = tabs.find((tab) => tab.key === selectedTab);
+  const baseTitle = t("settings.project.title");
+  const pageTitle = activeTab ? `${activeTab.name} - ${baseTitle}` : baseTitle;
 
   return (
     <div className="flex h-full w-full justify-center bg-bunker-800 text-white">
       <Helmet>
-        <title>{t("common.head-title", { title: t("settings.project.title") })}</title>
+        <title>{t("common.head-title", { title: pageTitle })}</title>
       </Helmet>
       <div className="w-full max-w-8xl">
         <PageHeader
           scope={ProjectType.SecretManager}
-          title="Project Settings"
-          description="Configure your secret manager's encryption, environments, webhooks and other configurations."
+          title={activeTab?.name ?? baseTitle}
+          description={activeTab?.description}
         >
           <Link
             to="/organizations/$orgId/settings"

--- a/frontend/src/pages/secret-manager/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/SettingsPage.tsx
@@ -58,7 +58,7 @@ export const SettingsPage = () => {
     }
   ];
 
-  const activeTab = tabs.find((tab) => tab.key === selectedTab);
+  const activeTab = tabs.find((tab) => !tab.isHidden && tab.key === selectedTab);
   const baseTitle = t("settings.project.title");
   const pageTitle = activeTab ? `${activeTab.name} - ${baseTitle}` : baseTitle;
 


### PR DESCRIPTION
## Context

This PR restructures the secrets management nav to be flatter and re-organized + settings page titles

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-06-18 at 11 47 03@2x" src="https://github.com/user-attachments/assets/f5db76a8-d86f-4ca5-a273-0c57794c64a6" />

<img width="3456" height="1922" alt="CleanShot 2026-06-18 at 11 47 07@2x" src="https://github.com/user-attachments/assets/8be19911-f9d8-4fdd-96fc-49d6a73cdbe6" />


## Steps to verify the change

- navigate around
- test links (secret approval,  app connection oauth redirect, etc.)

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)