### PR TITLE
feat: email sanitization in secret sharing and invite org

### DIFF
--- a/backend/src/server/routes/v1/invite-org-router.ts
+++ b/backend/src/server/routes/v1/invite-org-router.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 import { AccessScope, OrgMembershipRole } from "@app/db/schemas";
+import { unique } from "@app/lib/fn";
+import { sanitizeEmail } from "@app/lib/validator";
 import { inviteUserRateLimit, smtpRateLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -23,7 +25,7 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
           .email()
           .array()
           .max(100)
-          .refine((val) => val.every((el) => el === el.toLowerCase()), "Email must be lowercase"),
+          .transform((val) => unique(val.map((el) => sanitizeEmail(el)))),
         organizationId: z.string().trim(),
         organizationRoleSlug: z.string().default(OrgMembershipRole.Member)
       }),

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -22,6 +22,8 @@ import { SecretSharingType } from "@app/services/secret-sharing/secret-sharing-t
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { SanitizedSecretSharingSchema } from "../sanitizedSchemas";
+import { sanitizeEmail } from "@app/lib/validator";
+import { unique } from "@app/lib/fn";
 
 const ALLOWED_IMAGE_CONTENT_TYPES = ["image/png", "image/jpeg"];
 const MAX_IMAGE_SIZE = 1 * 1024 * 1024; // 1MB
@@ -289,8 +291,8 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
             .email()
             .array()
             .max(100)
+            .transform((val) => unique(val.map((el) => sanitizeEmail(el))))
             .optional()
-            .transform((val) => (val ? [...new Set(val)] : undefined))
             .describe(SECRET_SHARING.CREATE.authorizedEmails),
           allowExternalEmails: z.boolean().optional().describe(SECRET_SHARING.CREATE.allowExternalEmails)
         })

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -7,8 +7,10 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, SECRET_SHARING } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { unique } from "@app/lib/fn";
 import { ms } from "@app/lib/ms";
 import { SecretSharingAccessType } from "@app/lib/types";
+import { sanitizeEmail } from "@app/lib/validator";
 import {
   publicEndpointLimit,
   publicSecretShareCreationLimit,
@@ -22,8 +24,6 @@ import { SecretSharingType } from "@app/services/secret-sharing/secret-sharing-t
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { SanitizedSecretSharingSchema } from "../sanitizedSchemas";
-import { sanitizeEmail } from "@app/lib/validator";
-import { unique } from "@app/lib/fn";
 
 const ALLOWED_IMAGE_CONTENT_TYPES = ["image/png", "image/jpeg"];
 const MAX_IMAGE_SIZE = 1 * 1024 * 1024; // 1MB

--- a/backend/src/services/signer-membership/signer-membership-service.ts
+++ b/backend/src/services/signer-membership/signer-membership-service.ts
@@ -37,7 +37,7 @@ type TSignerMembershipServiceFactoryDep = {
   membershipDAL: Pick<TMembershipDALFactory, "create" | "findById" | "find" | "deleteById" | "transaction">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "create" | "find" | "delete" | "update">;
   permissionService: Pick<TPermissionServiceFactory, "getResourcePermission">;
-  userDAL: Pick<TUserDALFactory, "find" | "findByEmailsOrUsernames">;
+  userDAL: Pick<TUserDALFactory, "find">;
   identityDAL: Pick<TIdentityDALFactory, "find">;
   groupDAL: Pick<TGroupDALFactory, "find">;
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "find">;

--- a/backend/src/services/user/user-dal.ts
+++ b/backend/src/services/user/user-dal.ts
@@ -248,23 +248,6 @@ export const userDALFactory = (db: TDbClient) => {
     }
   };
 
-  const findByEmailsOrUsernames = async (
-    { emails, usernames }: { emails: string[]; usernames: string[] },
-    tx?: Knex
-  ) => {
-    if (!emails.length && !usernames.length) return [];
-    try {
-      return await (tx || db.replicaNode())(TableName.Users)
-        .where((qb) => {
-          if (emails.length) void qb.whereIn("email", emails);
-          if (usernames.length) void qb.orWhereIn("username", usernames);
-        })
-        .select(selectAllTableCols(TableName.Users));
-    } catch (error) {
-      throw new DatabaseError({ error, name: "Find users by emails or usernames" });
-    }
-  };
-
   return {
     ...userOrm,
     findUserEncKeyByUsername,
@@ -278,7 +261,6 @@ export const userDALFactory = (db: TDbClient) => {
     findOneUserAction,
     createUserAction,
     getUsersByFilter,
-    findAllMyAccounts,
-    findByEmailsOrUsernames
+    findAllMyAccounts
   };
 };


### PR DESCRIPTION
## Context

This PR resolves PLATFOR-461 in which the secret sharing and org invite makes the email  sanitized to lowercase and trimmed. This way it matches with the database as db stores them in this way always

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)