### PR TITLE
improvement(project-role): add endpoint to get project role by id

### DIFF
--- a/backend/src/ee/routes/v1/project-role-router.ts
+++ b/backend/src/ee/routes/v1/project-role-router.ts
@@ -354,7 +354,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        roleId: z.string().trim().uuid().describe("The ID of the role")
+        roleId: z.string().trim().uuid().describe(PROJECT_ROLE.GET_ROLE_BY_ID.roleId)
       }),
       response: {
         200: z.object({

--- a/backend/src/ee/routes/v1/project-role-router.ts
+++ b/backend/src/ee/routes/v1/project-role-router.ts
@@ -347,6 +347,12 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectRoles],
+      description: "Get a project role by ID",
+      security: [
+        {
+          bearerAuth: []
+        }
+      ],
       params: z.object({
         roleId: z.string().trim().describe(PROJECT_ROLE.GET_ROLE_BY_ID.roleId)
       }),

--- a/backend/src/ee/routes/v1/project-role-router.ts
+++ b/backend/src/ee/routes/v1/project-role-router.ts
@@ -340,6 +340,37 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "GET",
+    url: "/roles/:roleId",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      hide: false,
+      tags: [ApiDocsTags.ProjectRoles],
+      params: z.object({
+        roleId: z.string().trim().describe(PROJECT_ROLE.GET_ROLE_BY_ID.roleId)
+      }),
+      response: {
+        200: z.object({
+          role: SanitizedRoleSchema
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const role = await server.services.role.getProjectRoleById({
+        permission: req.permission,
+        selector: {
+          id: req.params.roleId
+        }
+      });
+
+      return { role: { ...role, projectId: role.projectId } };
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/:projectId/permissions",
     config: {
       rateLimit: readLimit

--- a/backend/src/ee/routes/v1/project-role-router.ts
+++ b/backend/src/ee/routes/v1/project-role-router.ts
@@ -354,7 +354,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        roleId: z.string().trim().describe(PROJECT_ROLE.GET_ROLE_BY_ID.roleId)
+        roleId: z.string().trim().uuid().describe("The ID of the role")
       }),
       response: {
         200: z.object({
@@ -371,7 +371,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         }
       });
 
-      return { role: { ...role, projectId: role.projectId } };
+      return { role };
     }
   });
 

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2444,6 +2444,9 @@ export const PROJECT_ROLE = {
     projectId: "The ID of the project.",
     roleSlug: "The slug of the role to get details."
   },
+  GET_ROLE_BY_ID: {
+    roleId: "The ID of the role to get."
+  },
   LIST: {
     projectSlug: "The slug of the project to list the roles of.",
     projectId: "The ID of the project."

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -23,6 +23,7 @@ import { TRoleDALFactory } from "./role-dal";
 import {
   TCreateRoleDTO,
   TDeleteRoleDTO,
+  TGetProjectRoleByIdDTO,
   TGetRoleByIdDTO,
   TGetRoleBySlugDTO,
   TGetUserPermissionDTO,
@@ -243,6 +244,35 @@ export const roleServiceFactory = ({
     return { ...role, [scope.key]: scope.value, permissions: unpackPermissions(role.permissions) };
   };
 
+  const getProjectRoleById = async (dto: TGetProjectRoleByIdDTO) => {
+    const { permission, selector } = dto;
+
+    const [role] = await roleDAL.find({ id: selector.id, $notNull: ["projectId"] }, { limit: 1 });
+    if (!role) {
+      throw new NotFoundError({ message: `Role with id ${selector.id} not found` });
+    }
+
+    // just forcing type safety
+    if (!role.projectId) {
+      throw new NotFoundError({ message: `Role with id ${selector.id} not found` });
+    }
+
+    const project = await projectDAL.findById(role.projectId);
+    if (!project || project.orgId !== permission.orgId) {
+      throw new NotFoundError({ message: `Role with id ${selector.id} not found` });
+    }
+
+    const scopeData = {
+      scope: AccessScope.Project,
+      orgId: permission.orgId,
+      projectId: role.projectId
+    } as const;
+
+    await scopeFactory[AccessScope.Project].onGetRoleByIdGuard({ permission, scopeData, selector });
+
+    return { ...role, projectId: role.projectId, permissions: unpackPermissions(role.permissions) };
+  };
+
   const getRoleBySlug = async (dto: TGetRoleBySlugDTO) => {
     const { scopeData, selector } = dto;
     const factory = scopeFactory[scopeData.scope];
@@ -339,6 +369,7 @@ export const roleServiceFactory = ({
     deleteRole,
     listRoles,
     getRoleById,
+    getProjectRoleById,
     getRoleBySlug,
     getUserPermission
   };

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -252,7 +252,6 @@ export const roleServiceFactory = ({
       throw new NotFoundError({ message: `Role with id ${selector.id} not found` });
     }
 
-    // just forcing type safety
     if (!role.projectId) {
       throw new NotFoundError({ message: `Role with id ${selector.id} not found` });
     }
@@ -268,9 +267,13 @@ export const roleServiceFactory = ({
       projectId: role.projectId
     } as const;
 
-    await scopeFactory[AccessScope.Project].onGetRoleByIdGuard({ permission, scopeData, selector });
+    const roleResult = await getRoleById({
+      permission,
+      scopeData,
+      selector: { id: role.id }
+    });
 
-    return { ...role, projectId: role.projectId, permissions: unpackPermissions(role.permissions) };
+    return { ...roleResult, projectId: scopeData.projectId };
   };
 
   const getRoleBySlug = async (dto: TGetRoleBySlugDTO) => {

--- a/backend/src/services/role/role-types.ts
+++ b/backend/src/services/role/role-types.ts
@@ -65,6 +65,13 @@ export type TGetRoleByIdDTO = {
   };
 };
 
+export type TGetProjectRoleByIdDTO = {
+  permission: OrgServiceActor;
+  selector: {
+    id: string;
+  };
+};
+
 export type TGetRoleBySlugDTO = {
   permission: OrgServiceActor;
   scopeData: AccessScopeData;

--- a/docs/api-reference/endpoints/project-roles/get-by-id.mdx
+++ b/docs/api-reference/endpoints/project-roles/get-by-id.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get By ID"
+openapi: "GET /api/v1/projects/roles/{roleId}"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1282,6 +1282,7 @@
                   "api-reference/endpoints/project-roles/update",
                   "api-reference/endpoints/project-roles/delete",
                   "api-reference/endpoints/project-roles/get-by-slug",
+                  "api-reference/endpoints/project-roles/get-by-id",
                   "api-reference/endpoints/project-roles/list",
                   {
                     "group": "Legacy",


### PR DESCRIPTION
## Context
Add a new endpoint to get project role by ID. This was added to support the project_role import using terraform  


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Create a new project role inside infisical 
- Use the following curl to get a project role: 
```
OCcurl -X GET "http://localhost:4000/api/v1/projects/roles/<ROLE_ID>" \
  -H "Authorization: Bearer <YOUR_TOKEN>" \
  -H "Content-Type: application/json"
```

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)