### PR TITLE
fix(billing): conditionally render download button for paid invoices

### DIFF
--- a/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
@@ -53,7 +53,7 @@ export const InvoicesTable = () => {
                   <Td>{paid ? "Paid" : "Not Paid"}</Td>
                   <Td>{formattedTotal}</Td>
                   <Td>
-                    {paid && (
+                    {invoice_pdf && (
                       <IconButton
                         onClick={async () => window.open(invoice_pdf)}
                         size="lg"

--- a/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
@@ -58,7 +58,7 @@ export const InvoicesTable = () => {
                         onClick={async () => window.open(invoice_pdf)}
                         size="lg"
                         variant="plain"
-                        ariaLabel="download receipt"
+                        ariaLabel="download invoice"
                       >
                         <FontAwesomeIcon icon={faDownload} />
                       </IconButton>

--- a/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
@@ -58,7 +58,7 @@ export const InvoicesTable = () => {
                         onClick={async () => window.open(invoice_pdf)}
                         size="lg"
                         variant="plain"
-                        ariaLabel="download invoice"
+                        ariaLabel="download receipt"
                       >
                         <FontAwesomeIcon icon={faDownload} />
                       </IconButton>

--- a/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingReceiptsTab/InvoicesTable.tsx
@@ -53,14 +53,16 @@ export const InvoicesTable = () => {
                   <Td>{paid ? "Paid" : "Not Paid"}</Td>
                   <Td>{formattedTotal}</Td>
                   <Td>
-                    <IconButton
-                      onClick={async () => window.open(invoice_pdf)}
-                      size="lg"
-                      variant="plain"
-                      ariaLabel="update"
-                    >
-                      <FontAwesomeIcon icon={faDownload} />
-                    </IconButton>
+                    {paid && (
+                      <IconButton
+                        onClick={async () => window.open(invoice_pdf)}
+                        size="lg"
+                        variant="plain"
+                        ariaLabel="download invoice"
+                      >
+                        <FontAwesomeIcon icon={faDownload} />
+                      </IconButton>
+                    )}
                   </Td>
                 </Tr>
               );


### PR DESCRIPTION
## Context

This change renders the download button only when there's an invoice PDF to be rendered.

## Steps to verify the change

- Check the invoices table

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)