### PR TITLE
improvement: migrate app connections UI to v3 components

### DIFF
--- a/docs/snippets/AppConnectionsBrowser.jsx
+++ b/docs/snippets/AppConnectionsBrowser.jsx
@@ -502,6 +502,70 @@ export const AppConnectionsBrowser = () => {
       description:
         "Learn how to connect Convex to manage and rotate access keys with Infisical.",
       category: "SaaS",
+    },
+    {
+      name: "Anthropic",
+      slug: "anthropic",
+      path: "/integrations/app-connections/anthropic",
+      description:
+        "Learn how to connect Anthropic to manage and rotate API keys with Infisical.",
+      category: "AI & LLM",
+    },
+    {
+      name: "Devin",
+      slug: "devin",
+      path: "/integrations/app-connections/devin",
+      description:
+        "Learn how to connect Devin to manage and rotate API keys with Infisical.",
+      category: "AI & LLM",
+    },
+    {
+      name: "DigiCert",
+      slug: "digicert",
+      path: "/integrations/app-connections/digicert",
+      description:
+        "Learn how to connect DigiCert to issue and manage certificates with Infisical.",
+      category: "Security",
+    },
+    {
+      name: "Venafi",
+      slug: "venafi",
+      path: "/integrations/app-connections/venafi",
+      description:
+        "Learn how to connect Venafi TLS Protect Cloud to manage certificates with Infisical.",
+      category: "Security",
+    },
+    {
+      name: "Venafi TPP",
+      slug: "venafi-tpp",
+      path: "/integrations/app-connections/venafi-tpp",
+      description:
+        "Learn how to connect Venafi Trust Protection Platform (TPP) to manage certificates with Infisical.",
+      category: "Security",
+    },
+    {
+      name: "F5 BIG-IP",
+      slug: "f5-big-ip",
+      path: "/integrations/app-connections/f5-big-ip",
+      description:
+        "Learn how to connect F5 BIG-IP to deploy and manage certificates with Infisical.",
+      category: "Networking & DNS",
+    },
+    {
+      name: "NetScaler",
+      slug: "netscaler",
+      path: "/integrations/app-connections/netscaler",
+      description:
+        "Learn how to connect NetScaler to deploy and manage certificates with Infisical.",
+      category: "Networking & DNS",
+    },
+    {
+      name: "GoDaddy",
+      slug: "godaddy",
+      path: "/integrations/app-connections/godaddy",
+      description:
+        "Learn how to connect GoDaddy to Infisical for ACME DNS validation.",
+      category: "Networking & DNS",
     }
   ].sort(function (a, b) {
     return a.name.toLowerCase().localeCompare(b.name.toLowerCase());

--- a/frontend/src/components/app-connections/AppConnectionOption.tsx
+++ b/frontend/src/components/app-connections/AppConnectionOption.tsx
@@ -3,8 +3,14 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CheckIcon } from "lucide-react";
 
-import { Tooltip } from "@app/components/v2";
-import { Badge, OrgIcon, SubOrgIcon } from "@app/components/v3";
+import {
+  Badge,
+  OrgIcon,
+  SubOrgIcon,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { TAvailableAppConnection } from "@app/hooks/api/appConnections";
 
@@ -32,20 +38,25 @@ export const AppConnectionOption = ({
           <>
             <p className="mr-auto truncate">{children}</p>
             {!props.data.projectId && (
-              <Tooltip
-                content={`This connection belongs to your ${isSubOrganization ? "sub-" : ""}organization.`}
-              >
-                {isSubOrganization ? (
-                  <Badge variant="sub-org">
-                    <SubOrgIcon />
-                    Sub-Organization
-                  </Badge>
-                ) : (
-                  <Badge variant="org">
-                    <OrgIcon />
-                    Organization
-                  </Badge>
-                )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    {isSubOrganization ? (
+                      <Badge variant="sub-org">
+                        <SubOrgIcon />
+                        Sub-Organization
+                      </Badge>
+                    ) : (
+                      <Badge variant="org">
+                        <OrgIcon />
+                        Organization
+                      </Badge>
+                    )}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  This connection belongs to your {isSubOrganization ? "sub-" : ""}organization.
+                </TooltipContent>
               </Tooltip>
             )}
             {isSelected && <CheckIcon className="ml-2 size-4" />}

--- a/frontend/src/helpers/appConnections.ts
+++ b/frontend/src/helpers/appConnections.ts
@@ -91,105 +91,450 @@ export const APP_CONNECTION_MAP: Record<
   {
     name: string;
     image: string;
+    category: string;
+    description: string;
     size?: number;
     icon?: IconDefinition;
     enterprise?: boolean;
     aliases?: string[];
   }
 > = {
-  [AppConnection.AWS]: { name: "AWS", image: "Amazon Web Services.png" },
-  [AppConnection.GitHub]: { name: "GitHub", image: "GitHub.png" },
+  [AppConnection.AWS]: {
+    name: "AWS",
+    image: "Amazon Web Services.png",
+    category: "AWS",
+    description: "Connect using IAM access keys or role assumption."
+  },
+  [AppConnection.GitHub]: {
+    name: "GitHub",
+    image: "GitHub.png",
+    category: "VERSION CONTROL",
+    description: "Authenticate via GitHub App, OAuth, or a personal access token."
+  },
   [AppConnection.GitHubRadar]: {
     name: "GitHub Radar",
     image: "GitHub.png",
-    icon: faBullseye
+    icon: faBullseye,
+    category: "SECURITY",
+    description: "GitHub App connection used for secret scanning."
   },
   [AppConnection.GCP]: {
     name: "GCP",
-    image: "Google Cloud Platform.png"
+    image: "Google Cloud Platform.png",
+    category: "GOOGLE CLOUD",
+    description: "Authenticate via service account impersonation."
   },
-  [AppConnection.AzureKeyVault]: { name: "Azure Key Vault", image: "Microsoft Azure.png" },
+  [AppConnection.AzureKeyVault]: {
+    name: "Azure Key Vault",
+    image: "Microsoft Azure.png",
+    category: "AZURE",
+    description: "Cloud-managed keys, secrets, and certificates."
+  },
   [AppConnection.AzureAppConfiguration]: {
     name: "Azure App Configuration",
-    image: "Microsoft Azure.png"
+    image: "Microsoft Azure.png",
+    category: "AZURE",
+    description: "Centralized application settings on Azure."
   },
   [AppConnection.AzureClientSecrets]: {
     name: "Azure Client Secrets",
-    image: "Microsoft Azure.png"
+    image: "Microsoft Azure.png",
+    category: "AZURE",
+    description: "Manage Entra ID application client secrets."
   },
-  [AppConnection.AzureDevOps]: { name: "Azure DevOps", image: "Microsoft Azure.png" },
-  [AppConnection.AzureADCS]: { name: "Azure ADCS", image: "Microsoft Azure.png" },
-  [AppConnection.AzureDNS]: { name: "Azure DNS", image: "Microsoft Azure.png" },
-  [AppConnection.Databricks]: { name: "Databricks", image: "Databricks.png" },
-  [AppConnection.Humanitec]: { name: "Humanitec", image: "Humanitec.png" },
-  [AppConnection.TerraformCloud]: { name: "Terraform Cloud", image: "Terraform Cloud.png" },
-  [AppConnection.Vercel]: { name: "Vercel", image: "Vercel.png" },
-  [AppConnection.Postgres]: { name: "PostgreSQL", image: "Postgres.png" },
-  [AppConnection.MsSql]: { name: "Microsoft SQL Server", image: "MsSql.png" },
-  [AppConnection.MySql]: { name: "MySQL", image: "MySql.png" },
-  [AppConnection.OracleDB]: { name: "OracleDB", image: "Oracle.png", enterprise: true },
-  [AppConnection.Camunda]: { name: "Camunda", image: "Camunda.png" },
-  [AppConnection.Windmill]: { name: "Windmill", image: "Windmill.png" },
-  [AppConnection.Auth0]: { name: "Auth0", image: "Auth0.png", size: 40 },
-  [AppConnection.HCVault]: { name: "Hashicorp Vault", image: "Vault.png", size: 65 },
-  [AppConnection.LDAP]: { name: "LDAP", image: "LDAP.png", size: 65 },
-  [AppConnection.TeamCity]: { name: "TeamCity", image: "TeamCity.png" },
-  [AppConnection.OCI]: { name: "OCI", image: "Oracle.png", enterprise: true },
-  [AppConnection.OnePass]: { name: "1Password", image: "1Password.png" },
-  [AppConnection.Heroku]: { name: "Heroku", image: "Heroku.png" },
-  [AppConnection.Render]: { name: "Render", image: "Render.png" },
-  [AppConnection.Flyio]: { name: "Fly.io", image: "Flyio.svg" },
-  [AppConnection.GitLab]: { name: "GitLab", image: "GitLab.png" },
-  [AppConnection.Cloudflare]: { name: "Cloudflare", image: "Cloudflare.png" },
-  [AppConnection.DNSMadeEasy]: { name: "DNS Made Easy", image: "DNSMadeEasy.svg", size: 120 },
-  [AppConnection.Zabbix]: { name: "Zabbix", image: "Zabbix.png" },
-  [AppConnection.Railway]: { name: "Railway", image: "Railway.png" },
-  [AppConnection.Bitbucket]: { name: "Bitbucket", image: "Bitbucket.png" },
-  [AppConnection.Checkly]: { name: "Checkly", image: "Checkly.png" },
-  [AppConnection.Supabase]: { name: "Supabase", image: "Supabase.png" },
+  [AppConnection.AzureDevOps]: {
+    name: "Azure DevOps",
+    image: "Microsoft Azure.png",
+    category: "AZURE",
+    description: "Pipeline and project access for Azure DevOps."
+  },
+  [AppConnection.AzureADCS]: {
+    name: "Azure ADCS",
+    image: "Microsoft Azure.png",
+    category: "CERTIFICATES",
+    description: "Issue certificates via Active Directory Certificate Services."
+  },
+  [AppConnection.AzureDNS]: {
+    name: "Azure DNS",
+    image: "Microsoft Azure.png",
+    category: "AZURE",
+    description: "Manage DNS zones and records on Azure."
+  },
+  [AppConnection.Databricks]: {
+    name: "Databricks",
+    image: "Databricks.png",
+    category: "DATA",
+    description: "Workspace access for jobs, notebooks, and secrets."
+  },
+  [AppConnection.Humanitec]: {
+    name: "Humanitec",
+    image: "Humanitec.png",
+    category: "PLATFORM",
+    description: "Platform orchestrator for application configuration."
+  },
+  [AppConnection.TerraformCloud]: {
+    name: "Terraform Cloud",
+    image: "Terraform Cloud.png",
+    category: "INFRASTRUCTURE",
+    description: "Manage variables across Terraform Cloud workspaces."
+  },
+  [AppConnection.Vercel]: {
+    name: "Vercel",
+    image: "Vercel.png",
+    category: "HOSTING",
+    description: "Project and environment access for Vercel."
+  },
+  [AppConnection.Postgres]: {
+    name: "PostgreSQL",
+    image: "Postgres.png",
+    category: "DATABASE",
+    description: "Connect to a PostgreSQL database."
+  },
+  [AppConnection.MsSql]: {
+    name: "Microsoft SQL Server",
+    image: "MsSql.png",
+    category: "DATABASE",
+    description: "Connect to a Microsoft SQL Server database."
+  },
+  [AppConnection.MySql]: {
+    name: "MySQL",
+    image: "MySql.png",
+    category: "DATABASE",
+    description: "Connect to a MySQL database."
+  },
+  [AppConnection.OracleDB]: {
+    name: "OracleDB",
+    image: "Oracle.png",
+    enterprise: true,
+    category: "DATABASE",
+    description: "Connect to an Oracle database."
+  },
+  [AppConnection.Camunda]: {
+    name: "Camunda",
+    image: "Camunda.png",
+    category: "PLATFORM",
+    description: "Cluster and client access for Camunda 8."
+  },
+  [AppConnection.Windmill]: {
+    name: "Windmill",
+    image: "Windmill.png",
+    category: "PLATFORM",
+    description: "Workspace access for Windmill scripts and flows."
+  },
+  [AppConnection.Auth0]: {
+    name: "Auth0",
+    image: "Auth0.png",
+    size: 40,
+    category: "IDENTITY",
+    description: "Manage an Auth0 tenant via client credentials."
+  },
+  [AppConnection.HCVault]: {
+    name: "Hashicorp Vault",
+    image: "Vault.png",
+    size: 65,
+    category: "SECRET MANAGER",
+    description: "Connect to a self-managed HashiCorp Vault."
+  },
+  [AppConnection.LDAP]: {
+    name: "LDAP",
+    image: "LDAP.png",
+    size: 65,
+    category: "IDENTITY",
+    description: "Bind to an LDAP directory server."
+  },
+  [AppConnection.TeamCity]: {
+    name: "TeamCity",
+    image: "TeamCity.png",
+    category: "CI/CD",
+    description: "Project and build access for JetBrains TeamCity."
+  },
+  [AppConnection.OCI]: {
+    name: "OCI",
+    image: "Oracle.png",
+    enterprise: true,
+    category: "ORACLE CLOUD",
+    description: "Authenticate to Oracle Cloud Infrastructure."
+  },
+  [AppConnection.OnePass]: {
+    name: "1Password",
+    image: "1Password.png",
+    category: "PASSWORD MANAGER",
+    description: "Read and manage items in 1Password vaults."
+  },
+  [AppConnection.Heroku]: {
+    name: "Heroku",
+    image: "Heroku.png",
+    category: "HOSTING",
+    description: "App and config var access for Heroku."
+  },
+  [AppConnection.Render]: {
+    name: "Render",
+    image: "Render.png",
+    category: "HOSTING",
+    description: "Service and environment access for Render."
+  },
+  [AppConnection.Flyio]: {
+    name: "Fly.io",
+    image: "Flyio.svg",
+    category: "HOSTING",
+    description: "App and secret access for Fly.io."
+  },
+  [AppConnection.GitLab]: {
+    name: "GitLab",
+    image: "GitLab.png",
+    category: "VERSION CONTROL",
+    description: "Authenticate via OAuth or an access token."
+  },
+  [AppConnection.Cloudflare]: {
+    name: "Cloudflare",
+    image: "Cloudflare.png",
+    category: "NETWORKING",
+    description: "Manage Cloudflare account resources via API token."
+  },
+  [AppConnection.DNSMadeEasy]: {
+    name: "DNS Made Easy",
+    image: "DNSMadeEasy.svg",
+    size: 120,
+    category: "DNS",
+    description: "Manage DNS records on DNS Made Easy."
+  },
+  [AppConnection.Zabbix]: {
+    name: "Zabbix",
+    image: "Zabbix.png",
+    category: "MONITORING",
+    description: "Monitoring and host access for Zabbix."
+  },
+  [AppConnection.Railway]: {
+    name: "Railway",
+    image: "Railway.png",
+    category: "HOSTING",
+    description: "Project and environment access for Railway."
+  },
+  [AppConnection.Bitbucket]: {
+    name: "Bitbucket",
+    image: "Bitbucket.png",
+    category: "VERSION CONTROL",
+    description: "Repository and workspace access for Bitbucket."
+  },
+  [AppConnection.Checkly]: {
+    name: "Checkly",
+    image: "Checkly.png",
+    category: "MONITORING",
+    description: "Synthetic monitoring access for Checkly."
+  },
+  [AppConnection.Supabase]: {
+    name: "Supabase",
+    image: "Supabase.png",
+    category: "PLATFORM",
+    description: "Project access for the Supabase platform."
+  },
   [AppConnection.DigitalOcean]: {
     name: "Digital Ocean",
-    image: "Digital Ocean.png"
+    image: "Digital Ocean.png",
+    category: "CLOUD",
+    description: "Account and resource access for DigitalOcean."
   },
   [AppConnection.Netlify]: {
     name: "Netlify",
-    image: "Netlify.png"
+    image: "Netlify.png",
+    category: "HOSTING",
+    description: "Site and environment access for Netlify."
   },
-  [AppConnection.Northflank]: { name: "Northflank", image: "Northflank.png" },
-  [AppConnection.Okta]: { name: "Okta", image: "Okta.png" },
-  [AppConnection.Redis]: { name: "Redis", image: "Redis.png" },
-  [AppConnection.MongoDB]: { name: "MongoDB", image: "MongoDB.png" },
+  [AppConnection.Northflank]: {
+    name: "Northflank",
+    image: "Northflank.png",
+    category: "HOSTING",
+    description: "Project and service access for Northflank."
+  },
+  [AppConnection.Okta]: {
+    name: "Okta",
+    image: "Okta.png",
+    category: "IDENTITY",
+    description: "Manage an Okta org via API token."
+  },
+  [AppConnection.Redis]: {
+    name: "Redis",
+    image: "Redis.png",
+    category: "DATABASE",
+    description: "Connect to a Redis instance."
+  },
+  [AppConnection.MongoDB]: {
+    name: "MongoDB",
+    image: "MongoDB.png",
+    category: "DATABASE",
+    description: "Connect to a MongoDB database."
+  },
   [AppConnection.LaravelForge]: {
     name: "Laravel Forge",
     image: "Laravel Forge.png",
-    size: 65
+    size: 65,
+    category: "HOSTING",
+    description: "Server and site access for Laravel Forge."
   },
-  [AppConnection.Chef]: { name: "Chef", image: "Chef.png", enterprise: true },
-  [AppConnection.OctopusDeploy]: { name: "Octopus Deploy", image: "Octopus Deploy.png" },
-  [AppConnection.SSH]: { name: "SSH", image: "SSH.png" },
-  [AppConnection.Dbt]: { name: "DBT", image: "DBT.png" },
-  [AppConnection.SMB]: { name: "SMB", image: "SMB.png", size: 50 },
-  [AppConnection.OpenRouter]: { name: "OpenRouter", image: "OpenRouter.png" },
-  [AppConnection.CircleCI]: { name: "CircleCI", image: "CircleCI.png" },
-  [AppConnection.AzureEntraId]: { name: "Azure Entra ID", image: "Microsoft Azure.png" },
-  [AppConnection.Venafi]: { name: "Venafi TLS Protect Cloud", image: "Venafi.png" },
-  [AppConnection.VenafiTpp]: { name: "Venafi TPP", image: "Venafi.png" },
-  [AppConnection.ExternalInfisical]: { name: "Infisical", image: "Infisical.png" },
-  [AppConnection.Doppler]: { name: "Doppler", image: "Doppler.png" },
-  [AppConnection.NetScaler]: { name: "NetScaler", image: "NetScaler.png" },
-  [AppConnection.Anthropic]: { name: "Anthropic", image: "Anthropic.png" },
-  [AppConnection.OVH]: { name: "OVH Cloud", image: "OVH.png" },
-  [AppConnection.Devin]: { name: "Devin", image: "Devin.png", size: 55 },
-  [AppConnection.Ona]: { name: "Ona", image: "Ona.png", aliases: ["gitpod"] },
-  [AppConnection.DigiCert]: { name: "DigiCert", image: "DigiCert.png" },
-  [AppConnection.GoDaddy]: { name: "GoDaddy", image: "GoDaddy.png" },
-  [AppConnection.TravisCI]: { name: "Travis CI", image: "Travis CI.png" },
-  [AppConnection.Salesforce]: { name: "Salesforce", image: "Salesforce.png" },
-  [AppConnection.Snowflake]: { name: "Snowflake", image: "Snowflake.png" },
-  [AppConnection.Datadog]: { name: "Datadog", image: "DatadogWhite.png" },
-  [AppConnection.F5BigIp]: { name: "F5 BIG-IP", image: "F5 BIG-IP.png" },
-  [AppConnection.Convex]: { name: "Convex", image: "Convex.png" }
+  [AppConnection.Chef]: {
+    name: "Chef",
+    image: "Chef.png",
+    enterprise: true,
+    category: "INFRASTRUCTURE",
+    description: "Node and data bag access for Chef Infra."
+  },
+  [AppConnection.OctopusDeploy]: {
+    name: "Octopus Deploy",
+    image: "Octopus Deploy.png",
+    category: "CI/CD",
+    description: "Project and deployment access for Octopus Deploy."
+  },
+  [AppConnection.SSH]: {
+    name: "SSH",
+    image: "SSH.png",
+    category: "INFRASTRUCTURE",
+    description: "Connect to a host over SSH."
+  },
+  [AppConnection.Dbt]: {
+    name: "DBT",
+    image: "DBT.png",
+    category: "DATA",
+    description: "Account and job access for dbt."
+  },
+  [AppConnection.SMB]: {
+    name: "SMB",
+    image: "SMB.png",
+    size: 50,
+    category: "STORAGE",
+    description: "Connect to an SMB/CIFS file share."
+  },
+  [AppConnection.OpenRouter]: {
+    name: "OpenRouter",
+    image: "OpenRouter.png",
+    category: "AI",
+    description: "Route requests across LLM providers."
+  },
+  [AppConnection.CircleCI]: {
+    name: "CircleCI",
+    image: "CircleCI.png",
+    category: "CI/CD",
+    description: "Project and pipeline access for CircleCI."
+  },
+  [AppConnection.AzureEntraId]: {
+    name: "Azure Entra ID",
+    image: "Microsoft Azure.png",
+    category: "IDENTITY",
+    description: "Manage users and groups in Entra ID."
+  },
+  [AppConnection.Venafi]: {
+    name: "Venafi TLS Protect Cloud",
+    image: "Venafi.png",
+    category: "CERTIFICATES",
+    description: "Issue and manage certificates via Venafi Cloud."
+  },
+  [AppConnection.VenafiTpp]: {
+    name: "Venafi TPP",
+    image: "Venafi.png",
+    category: "CERTIFICATES",
+    description: "Issue certificates via Venafi Trust Protection Platform."
+  },
+  [AppConnection.ExternalInfisical]: {
+    name: "Infisical",
+    image: "Infisical.png",
+    category: "SECRET MANAGER",
+    description: "Connect to another Infisical instance."
+  },
+  [AppConnection.Doppler]: {
+    name: "Doppler",
+    image: "Doppler.png",
+    category: "SECRET MANAGER",
+    description: "Project and config access for Doppler."
+  },
+  [AppConnection.NetScaler]: {
+    name: "NetScaler",
+    image: "NetScaler.png",
+    category: "NETWORKING",
+    description: "Manage a Citrix NetScaler appliance."
+  },
+  [AppConnection.Anthropic]: {
+    name: "Anthropic",
+    image: "Anthropic.png",
+    category: "AI",
+    description: "Manage Anthropic API access."
+  },
+  [AppConnection.OVH]: {
+    name: "OVH Cloud",
+    image: "OVH.png",
+    category: "CLOUD",
+    description: "Account and service access for OVHcloud."
+  },
+  [AppConnection.Devin]: {
+    name: "Devin",
+    image: "Devin.png",
+    size: 55,
+    category: "AI",
+    description: "Manage Devin API access."
+  },
+  [AppConnection.Ona]: {
+    name: "Ona",
+    image: "Ona.png",
+    aliases: ["gitpod"],
+    category: "PLATFORM",
+    description: "Workspace access for Ona (formerly Gitpod)."
+  },
+  [AppConnection.DigiCert]: {
+    name: "DigiCert",
+    image: "DigiCert.png",
+    category: "CERTIFICATES",
+    description: "Issue and manage certificates via DigiCert."
+  },
+  [AppConnection.GoDaddy]: {
+    name: "GoDaddy",
+    image: "GoDaddy.png",
+    category: "DNS",
+    description: "Manage DNS records on GoDaddy."
+  },
+  [AppConnection.TravisCI]: {
+    name: "Travis CI",
+    image: "Travis CI.png",
+    category: "CI/CD",
+    description: "Repository and build access for Travis CI."
+  },
+  [AppConnection.Salesforce]: {
+    name: "Salesforce",
+    image: "Salesforce.png",
+    category: "CRM",
+    description: "Org access via connected app client credentials."
+  },
+  [AppConnection.Snowflake]: {
+    name: "Snowflake",
+    image: "Snowflake.png",
+    category: "DATA",
+    description: "Connect to a Snowflake data warehouse."
+  },
+  [AppConnection.Datadog]: {
+    name: "Datadog",
+    image: "DatadogWhite.png",
+    category: "MONITORING",
+    description: "Metrics and monitoring access for Datadog."
+  },
+  [AppConnection.F5BigIp]: {
+    name: "F5 BIG-IP",
+    image: "F5 BIG-IP.png",
+    category: "NETWORKING",
+    description: "Manage an F5 BIG-IP appliance."
+  },
+  [AppConnection.Convex]: {
+    name: "Convex",
+    image: "Convex.png",
+    category: "PLATFORM",
+    description: "Project and deployment access for Convex."
+  }
 };
+
+export const POPULAR_APP_CONNECTIONS: AppConnection[] = [
+  AppConnection.AWS,
+  AppConnection.GitHub,
+  AppConnection.GCP,
+  AppConnection.AzureKeyVault,
+  AppConnection.Postgres,
+  AppConnection.Vercel
+];
 
 export const getAppConnectionMethodDetails = (method: TAppConnection["method"]) => {
   switch (method) {

--- a/frontend/src/pages/cert-manager/SettingsPage/components/AppConnectionsTab/AppConnectionRow.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/components/AppConnectionsTab/AppConnectionRow.tsx
@@ -17,7 +17,6 @@ import {
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Tooltip } from "@app/components/v2";
 import {
   Badge,
   DropdownMenu,
@@ -26,7 +25,10 @@ import {
   DropdownMenuTrigger,
   IconButton,
   TableCell,
-  TableRow
+  TableRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import { ProjectPermissionSub } from "@app/context";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
@@ -99,8 +101,11 @@ export const AppConnectionRow = ({
         <div className="flex items-center gap-1.5">
           <span className="truncate">{name}</span>
           {description && (
-            <Tooltip content={description}>
-              <InfoIcon className="text-accent" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="text-accent" />
+              </TooltipTrigger>
+              <TooltipContent>{description}</TooltipContent>
             </Tooltip>
           )}
         </div>
@@ -114,13 +119,18 @@ export const AppConnectionRow = ({
       <TableCell className="text-right">
         <div className="flex items-center justify-end gap-2">
           {isPlatformManagedCredentials && (
-            <Tooltip side="left" content="This connection's credentials are managed by Infisical.">
-              <div>
-                <Badge variant="info">
-                  <ServerIcon />
-                  Platform Managed
-                </Badge>
-              </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <Badge variant="info">
+                    <ServerIcon />
+                    Platform Managed
+                  </Badge>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                This connection&apos;s credentials are managed by Infisical.
+              </TooltipContent>
             </Tooltip>
           )}
           {appConnection.rotation && (

--- a/frontend/src/pages/cert-manager/SettingsPage/components/AppConnectionsTab/AppConnectionRow.tsx
+++ b/frontend/src/pages/cert-manager/SettingsPage/components/AppConnectionsTab/AppConnectionRow.tsx
@@ -35,7 +35,7 @@ import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermi
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { useToggle } from "@app/hooks";
 import { TAppConnection } from "@app/hooks/api/appConnections";
-import { CrededentialRotationStatusBadge } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CrededentialRotationBadge";
+import { CredentialRotationStatusBadge } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CredentialRotationBadge";
 
 type Props = {
   appConnection: TAppConnection;
@@ -134,7 +134,7 @@ export const AppConnectionRow = ({
             </Tooltip>
           )}
           {appConnection.rotation && (
-            <CrededentialRotationStatusBadge appConnection={appConnection} />
+            <CredentialRotationStatusBadge appConnection={appConnection} />
           )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
@@ -1,11 +1,28 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { AlertTriangleIcon, ArrowLeftIcon } from "lucide-react";
 
-import { Modal, ModalContent } from "@app/components/v2";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
 import { TAppConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 import { AppConnectionForm } from "./AppConnectionForm";
+import { AppConnectionHeader } from "./AppConnectionHeader";
 import { AppConnectionsSelect } from "./AppConnectionList";
 
 type Props = {
@@ -17,30 +34,6 @@ type Props = {
   onComplete?: (appConnection: TAppConnection) => void;
 };
 
-type ContentProps = {
-  onComplete: (appConnection: TAppConnection) => void;
-  projectId?: string;
-  projectType?: ProjectType;
-  app?: AppConnection;
-};
-
-const Content = ({ onComplete, projectId, projectType, app }: ContentProps) => {
-  const [selectedApp, setSelectedApp] = useState<AppConnection | null>(null);
-
-  if (app ?? selectedApp) {
-    return (
-      <AppConnectionForm
-        onComplete={onComplete}
-        onBack={app ? undefined : () => setSelectedApp(null)}
-        app={(app ?? selectedApp)!}
-        projectId={projectId}
-      />
-    );
-  }
-
-  return <AppConnectionsSelect onSelect={setSelectedApp} projectType={projectType} />;
-};
-
 export const AddAppConnectionModal = ({
   isOpen,
   onOpenChange,
@@ -49,23 +42,102 @@ export const AddAppConnectionModal = ({
   app,
   onComplete
 }: Props) => {
+  // When `app` is preset (inline create from another flow, or an OAuth reopen) we skip the provider
+  // select screen and go straight to that app's form. Otherwise the user picks a provider first.
+  const [selectedApp, setSelectedApp] = useState<AppConnection | null>(app ?? null);
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+
+  useEffect(() => {
+    setSelectedApp(app ?? null);
+  }, [app]);
+
+  const closeSheet = () => {
+    setSelectedApp(null);
+    onOpenChange(false);
+  };
+
+  const handleComplete = (appConnection: TAppConnection) => {
+    onComplete?.(appConnection);
+    closeSheet();
+  };
+
+  const handleSheetOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && selectedApp) {
+      // User has started configuring a connection — confirm before discarding.
+      setConfirmDiscardOpen(true);
+      return;
+    }
+    if (!nextOpen) setSelectedApp(null);
+    onOpenChange(nextOpen);
+  };
+
+  // Only offer "back to select" when the user navigated here from the select screen (no preset app).
+  const showBack = !app && Boolean(selectedApp);
+
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        className="max-w-2xl"
-        title="Add Connection"
-        subTitle="Select a third-party app to connect to."
-      >
-        <Content
-          projectId={projectId}
-          projectType={projectType}
-          app={app}
-          onComplete={(appConnection) => {
-            if (onComplete) onComplete(appConnection);
-            onOpenChange(false);
-          }}
-        />
-      </ModalContent>
-    </Modal>
+    <>
+      <Sheet open={isOpen} onOpenChange={handleSheetOpenChange}>
+        <SheetContent className="flex h-full max-h-full flex-col gap-y-0 sm:max-w-2xl">
+          <SheetHeader className="border-b">
+            {selectedApp ? (
+              <>
+                {showBack && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedApp(null)}
+                    className="mb-1 flex w-fit cursor-pointer items-center gap-1 text-xs text-muted transition-colors hover:text-foreground hover:underline"
+                  >
+                    <ArrowLeftIcon className="size-3" />
+                    Select Another App
+                  </button>
+                )}
+                <SheetTitle>
+                  <AppConnectionHeader app={selectedApp} isConnected={false} />
+                </SheetTitle>
+              </>
+            ) : (
+              <>
+                <SheetTitle>Add Connection</SheetTitle>
+                <SheetDescription>Select a third-party app to connect to.</SheetDescription>
+              </>
+            )}
+          </SheetHeader>
+          {selectedApp ? (
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+              <AppConnectionForm
+                app={selectedApp}
+                projectId={projectId}
+                onComplete={handleComplete}
+                onCancel={closeSheet}
+              />
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
+              <AppConnectionsSelect onSelect={setSelectedApp} projectType={projectType} />
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <AlertTriangleIcon />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Discard connection setup?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your progress configuring this connection will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
+            <AlertDialogAction variant="danger" onClick={closeSheet}>
+              Discard
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
@@ -47,9 +47,13 @@ export const AddAppConnectionModal = ({
   const [selectedApp, setSelectedApp] = useState<AppConnection | null>(app ?? null);
   const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
 
+  // Reset to the starting step whenever the sheet (re)opens: a preset `app` goes straight to its
+  // form, otherwise the provider picker. Keyed on `isOpen` so reopening with an unchanged preset
+  // `app` (inline create flows keep the modal mounted) still restores the form instead of falling
+  // back to the picker.
   useEffect(() => {
-    setSelectedApp(app ?? null);
-  }, [app]);
+    if (isOpen) setSelectedApp(app ?? null);
+  }, [isOpen, app]);
 
   const closeSheet = () => {
     setSelectedApp(null);
@@ -108,6 +112,9 @@ export const AddAppConnectionModal = ({
                 app={selectedApp}
                 projectId={projectId}
                 onComplete={handleComplete}
+                // Explicit Cancel is a deliberate abandon, so it closes immediately. Ambiguous
+                // dismissals (X / Escape / outside click) route through handleSheetOpenChange,
+                // which shows the discard confirmation.
                 onCancel={closeSheet}
               />
             </div>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/1PasswordConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/1PasswordConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { OnePassConnectionMethod, TOnePassConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const OnePassConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -66,31 +70,36 @@ export const OnePassConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.OnePass].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OnePassConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.OnePass].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OnePassConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,15 +107,26 @@ export const OnePassConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="The URL of the 1Password Connect Server instance to authenticate with."
-            >
-              <Input {...field} placeholder="https://1pass.example.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The URL of the 1Password Connect Server instance to authenticate with.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://1pass.example.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -114,36 +134,16 @@ export const OnePassConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to 1Password"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to 1Password"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AnthropicConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AnthropicConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TAnthropicConnection
 } from "@app/hooks/api/appConnections/types/anthropic-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const AnthropicConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,29 +71,34 @@ export const AnthropicConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Anthropic].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AnthropicConnectionMethod).map((method) => (
-                  <SelectItem value={method} key={method}>
-                    {getAppConnectionMethodDetails(method).name}
-                  </SelectItem>
-                ))}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Anthropic].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AnthropicConnectionMethod).map((method) => (
+                    <SelectItem value={method} key={method}>
+                      {getAppConnectionMethodDetails(method).name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -97,37 +106,26 @@ export const AnthropicConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-              tooltipText="The Anthropic API key used to authenticate with the Anthropic API."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">
+                API Key
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Anthropic API key used to authenticate with the Anthropic API.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Anthropic"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Anthropic"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { createNotification } from "@app/components/notifications";
-import { Button } from "@app/components/v2";
+import { Button } from "@app/components/v3";
 import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import {
   TAppConnection,
   useCreateAppConnection,
@@ -13,9 +14,9 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { DiscriminativePick } from "@app/types";
 
-import { AppConnectionHeader } from "../AppConnectionHeader";
 import { OnePassConnectionForm } from "./1PasswordConnectionForm";
 import { AnthropicConnectionForm } from "./AnthropicConnectionForm";
+import { AppConnectionFormProvider } from "./AppConnectionFormContext";
 import { Auth0ConnectionForm } from "./Auth0ConnectionForm";
 import { AwsConnectionForm } from "./AwsConnectionForm";
 import { AzureADCSConnectionForm } from "./AzureADCSConnectionForm";
@@ -108,35 +109,39 @@ const RotationConfirmation = ({
   onConfirm: () => void;
   onCancel: () => void;
   isSubmitting: boolean;
-}) => (
-  <div>
-    <div className="flex flex-col rounded-xs border border-l-2 border-mineshaft-600 border-l-primary bg-mineshaft-700/80 px-4 py-3">
-      <div className="mb-1 flex items-center text-sm">
-        <FontAwesomeIcon icon={faInfoCircle} size="sm" className="mr-1.5 text-primary" />
-        Automatic Credential Rotation
+}) => {
+  const scopeVariant = useScopeVariant();
+
+  return (
+    <div className="p-4">
+      <div className="flex flex-col rounded-xs border border-l-2 border-mineshaft-600 border-l-primary bg-mineshaft-700/80 px-4 py-3">
+        <div className="mb-1 flex items-center text-sm">
+          <FontAwesomeIcon icon={faInfoCircle} size="sm" className="mr-1.5 text-primary" />
+          Automatic Credential Rotation
+        </div>
+        <p className="bor mt-1 text-sm text-bunker-200">
+          Enabling automatic credential rotation will give Infisical full control over the lifecycle
+          of this credential. Infisical will automatically rotate the credential on the schedule you
+          configured and you will no longer be able to manage it manually. The original credential
+          provided will be revoked and replaced.
+        </p>
       </div>
-      <p className="bor mt-1 text-sm text-bunker-200">
-        Enabling automatic credential rotation will give Infisical full control over the lifecycle
-        of this credential. Infisical will automatically rotate the credential on the schedule you
-        configured and you will no longer be able to manage it manually. The original credential
-        provided will be revoked and replaced.
-      </p>
+      <div className="mt-4 flex gap-3">
+        <Button
+          onClick={onConfirm}
+          variant={scopeVariant}
+          isPending={isSubmitting}
+          isDisabled={isSubmitting}
+        >
+          I Understand
+        </Button>
+        <Button variant="outline" onClick={onCancel} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </div>
     </div>
-    <div className="mt-4 flex gap-4">
-      <Button
-        onClick={onConfirm}
-        colorSchema="secondary"
-        isLoading={isSubmitting}
-        isDisabled={isSubmitting}
-      >
-        I Understand
-      </Button>
-      <Button variant="plain" onClick={onCancel} colorSchema="secondary" isDisabled={isSubmitting}>
-        Cancel
-      </Button>
-    </div>
-  </div>
-);
+  );
+};
 
 type FormProps = {
   onComplete: (appConnection: TAppConnection) => void;
@@ -339,7 +344,15 @@ const CreateForm = ({ app, onComplete, projectId }: CreateFormProps) => {
           isSubmitting={isConfirmSubmitting}
         />
       )}
-      <div className={pendingFormData ? "hidden" : undefined}>{renderForm()}</div>
+      <div
+        className={
+          pendingFormData
+            ? "hidden"
+            : "flex flex-1 flex-col [&>form]:flex [&>form]:flex-1 [&>form]:flex-col [&>form]:px-4 [&>form]:pt-4"
+        }
+      >
+        {renderForm()}
+      </div>
     </>
   );
 };
@@ -578,31 +591,36 @@ const UpdateForm = ({ appConnection, onComplete }: UpdateFormProps) => {
           isSubmitting={isConfirmSubmitting}
         />
       )}
-      <div className={pendingFormData ? "hidden" : undefined}>{renderForm()}</div>
+      <div
+        className={
+          pendingFormData
+            ? "hidden"
+            : "flex flex-1 flex-col [&>form]:flex [&>form]:flex-1 [&>form]:flex-col [&>form]:px-4 [&>form]:pt-4"
+        }
+      >
+        {renderForm()}
+      </div>
     </>
   );
 };
 
-type Props = { onBack?: () => void; projectId?: string } & Pick<FormProps, "onComplete"> &
+type Props = { onCancel: () => void; projectId?: string } & Pick<FormProps, "onComplete"> &
   (
     | { app: AppConnection; appConnection?: undefined }
     | { app?: undefined; appConnection: TAppConnection }
   );
-export const AppConnectionForm = ({ onBack, projectId, ...props }: Props) => {
+export const AppConnectionForm = ({ onCancel, projectId, ...props }: Props) => {
   const { app, appConnection } = props;
 
+  const contextValue = useMemo(() => ({ onCancel }), [onCancel]);
+
   return (
-    <div>
-      <AppConnectionHeader
-        isConnected={Boolean(appConnection)}
-        app={appConnection?.app ?? app!}
-        onBack={onBack}
-      />
+    <AppConnectionFormProvider value={contextValue}>
       {appConnection ? (
         <UpdateForm {...props} appConnection={appConnection} />
       ) : (
         <CreateForm {...props} app={app} projectId={projectId} />
       )}
-    </div>
+    </AppConnectionFormProvider>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormContext.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+type AppConnectionFormContextValue = {
+  /**
+   * Closes the surrounding Sheet. Used by each provider form's Cancel button so the footer does not
+   * have to thread a prop through every form and the ~130 render sites in AppConnectionForm.
+   */
+  onCancel: () => void;
+};
+
+const AppConnectionFormContext = createContext<AppConnectionFormContextValue>({
+  onCancel: () => {}
+});
+
+export const AppConnectionFormProvider = AppConnectionFormContext.Provider;
+
+export const useAppConnectionForm = () => useContext(AppConnectionFormContext);

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormFooter.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormFooter.tsx
@@ -1,0 +1,45 @@
+import { useFormContext } from "react-hook-form";
+
+import { Button, SheetFooter } from "@app/components/v3";
+import { useScopeVariant } from "@app/hooks";
+
+import { useAppConnectionForm } from "./AppConnectionFormContext";
+
+type Props = {
+  submitLabel: string;
+  /** OR-ed with the default `isSubmitting || !isDirty` disabled logic. */
+  isDisabled?: boolean;
+  /**
+   * When true, the submit button does not require the form to be dirty. Used by forms that blank
+   * out secrets on edit and must allow re-submitting an unchanged form (e.g. OAuth reconnects).
+   */
+  allowPristineSubmit?: boolean;
+};
+
+export const AppConnectionFormFooter = ({
+  submitLabel,
+  isDisabled,
+  allowPristineSubmit
+}: Props) => {
+  const { onCancel } = useAppConnectionForm();
+  const {
+    formState: { isSubmitting, isDirty }
+  } = useFormContext();
+  const scopeVariant = useScopeVariant();
+
+  return (
+    <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
+      <Button
+        type="submit"
+        variant={scopeVariant}
+        isPending={isSubmitting}
+        isDisabled={isSubmitting || (!isDirty && !allowPristineSubmit) || isDisabled}
+      >
+        {submitLabel}
+      </Button>
+      <Button type="button" variant="outline" onClick={onCancel} isDisabled={isSubmitting}>
+        Cancel
+      </Button>
+    </SheetFooter>
+  );
+};

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/Auth0ConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/Auth0ConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { Auth0ConnectionMethod, TAuth0Connection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -54,11 +62,7 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,31 +72,36 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Auth0].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(Auth0ConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Auth0].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(Auth0ConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -100,13 +109,16 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Domain"
-            >
-              <Input {...field} placeholder="xxxxxxxxxxxx.xx.auth0.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="domain">Domain</FieldLabel>
+              <Input
+                id="domain"
+                {...field}
+                placeholder="xxxxxxxxxxxx.xx.auth0.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -114,13 +126,16 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client ID"
-            >
-              <Input {...field} placeholder="djfh67bpCZAw7HBCPoNml3CcYEUrU0os" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-id">Client ID</FieldLabel>
+              <Input
+                id="client-id"
+                {...field}
+                placeholder="djfh67bpCZAw7HBCPoNml3CcYEUrU0os"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -128,17 +143,11 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client Secret"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-secret">Client Secret</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -146,33 +155,31 @@ export const Auth0ConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Audience"
-              tooltipText="The unique identifier of the target API you want to access."
-            >
-              <Input {...field} placeholder="Your API identifier" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="audience">
+                Audience
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The unique identifier of the target API you want to access.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="audience"
+                {...field}
+                placeholder="Your API identifier"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Auth0"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Auth0"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AwsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AwsConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AwsConnectionMethod, TAwsConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -66,12 +74,7 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, watch } = form;
 
   const selectedMethod = watch("method");
 
@@ -83,32 +86,35 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AWS].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AwsConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AWS].name}. This field cannot be changed after
+                    creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AwsConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
+                      {getAppConnectionMethodDetails(method).name}
                       {method === AwsConnectionMethod.AssumeRole ? " (Recommended)" : ""}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         {selectedMethod === AwsConnectionMethod.AssumeRole ? (
@@ -118,18 +124,11 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Role ARN"
-                  className="group"
-                >
-                  <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                  />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel>Role ARN</FieldLabel>
+                  <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
@@ -137,27 +136,28 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="STS Endpoint URL"
-                  isOptional
-                  tooltipText={
-                    <div>
-                      <p>
+                <Field className="mb-4">
+                  <FieldLabel>
+                    STS Endpoint URL <span className="text-muted">(optional)</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-md">
                         Override the default AWS STS endpoint Infisical calls to assume the role.
                         Useful for VPC (PrivateLink), GovCloud, China, FIPS, or region-pinned
                         endpoints. Leave blank to use the default AWS STS endpoint.
-                      </p>
-                    </div>
-                  }
-                >
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
                     placeholder="https://sts.amazonaws.com"
                     value={value || ""}
                     onChange={(e) => onChange(e.target.value)}
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
@@ -168,17 +168,16 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Access Key ID"
-                >
+                <Field className="mb-4">
+                  <FieldLabel>Access Key ID</FieldLabel>
                   <Input
                     placeholder={"*".repeat(20)}
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
@@ -186,39 +185,16 @@ export const AwsConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Secret Access Key"
-                  className="group"
-                >
-                  <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                  />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel>Secret Access Key</FieldLabel>
+                  <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to AWS"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to AWS"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureADCSConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureADCSConnectionForm.tsx
@@ -1,27 +1,39 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { AzureADCSConnectionMethod, TAzureADCSConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -61,7 +73,7 @@ type FormData = z.infer<typeof formSchema>;
 
 export const AzureADCSConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [selectedTab, setSelectedTab] = useState("configuration");
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -80,12 +92,9 @@ export const AzureADCSConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty },
-    watch
-  } = form;
+  const { handleSubmit, control, watch } = form;
+
+  const scopeVariant = useScopeVariant();
 
   const sslEnabled = watch("credentials.adcsUrl")?.startsWith("https://") ?? false;
 
@@ -93,7 +102,7 @@ export const AzureADCSConnectionForm = ({ appConnection, onSubmit }: Props) => {
     <FormProvider {...form}>
       <form
         onSubmit={(e) => {
-          setSelectedTabIndex(0);
+          setSelectedTab("configuration");
           handleSubmit(onSubmit)(e);
         }}
       >
@@ -102,192 +111,145 @@ export const AzureADCSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureADCS].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureADCSConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.AzureADCS].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureADCSConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List
-            className={`-pb-1 ${selectedTabIndex === 1 ? "mb-3" : "mb-6"} w-full border-b-2 border-mineshaft-600`}
-          >
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              SSL ({sslEnabled ? "Enabled" : "Disabled"})
-            </Tab>
-          </Tab.List>
-          {selectedTabIndex === 1 && (
-            <div className="mb-2 text-xs text-mineshaft-300">
-              SSL configuration for HTTPS connections
-            </div>
-          )}
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="mb-4">
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="ssl">SSL ({sslEnabled ? "Enabled" : "Disabled"})</TabsTrigger>
+          </TabsList>
+          <TabsContent value="configuration">
+            <Controller
+              name="credentials.adcsUrl"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="adcs-url">ADCS URL</FieldLabel>
+                  <Input
+                    id="adcs-url"
+                    {...field}
+                    placeholder="https://your-adcs-server.com"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-2">
               <Controller
-                name="credentials.adcsUrl"
+                name="credentials.username"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="ADCS URL"
-                  >
-                    <Input {...field} placeholder="https://your-adcs-server.com" />
-                  </FormControl>
-                )}
-              />
-              <div className="grid grid-cols-2 gap-2">
-                <Controller
-                  name="credentials.username"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Username"
-                    >
-                      <Input {...field} placeholder="DOMAIN\\username or user@domain.com" />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Password"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-            </Tab.Panel>
-            <Tab.Panel>
-              <Controller
-                name="credentials.sslCertificate"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    className={sslEnabled ? "" : "opacity-50"}
-                    label="SSL Certificate"
-                    isOptional
-                  >
-                    <TextArea
-                      className="h-[3.6rem] resize-none!"
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="username">Username</FieldLabel>
+                    <Input
+                      id="username"
                       {...field}
-                      isDisabled={!sslEnabled}
-                      placeholder="-----BEGIN CERTIFICATE-----
-...
------END CERTIFICATE-----"
+                      placeholder="DOMAIN\\username or user@domain.com"
+                      isError={Boolean(error?.message)}
                     />
-                  </FormControl>
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
               <Controller
-                name="credentials.sslRejectUnauthorized"
+                name="credentials.password"
                 control={control}
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    className={sslEnabled ? "" : "opacity-50"}
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="ssl-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={sslEnabled ? value : false}
-                      onCheckedChange={onChange}
-                      isDisabled={!sslEnabled}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the ADCS server if it has a
-                              valid, trusted SSL certificate. Disable only in test environments with
-                              self-signed certificates.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="password">Password</FieldLabel>
+                    <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Azure ADCS"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="ssl">
+            <p className="mb-3 text-xs text-muted">SSL configuration for HTTPS connections</p>
+            <Controller
+              name="credentials.sslCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className={sslEnabled ? "mb-4" : "mb-4 opacity-50"}>
+                  <FieldLabel htmlFor="ssl-certificate">
+                    SSL Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="ssl-certificate"
+                    className="h-[3.6rem] resize-none!"
+                    {...field}
+                    disabled={!sslEnabled}
+                    isError={Boolean(error?.message)}
+                    placeholder="-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----"
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className={sslEnabled ? undefined : "opacity-50"}>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the ADCS server if it has a
+                        valid, trusted SSL certificate. Disable only in test environments with
+                        self-signed certificates.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      id="ssl-reject-unauthorized"
+                      variant={scopeVariant}
+                      checked={sslEnabled ? value : false}
+                      onCheckedChange={onChange}
+                      disabled={!sslEnabled}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Azure ADCS"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
@@ -3,15 +3,32 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import {
   AzureAppConfigurationConnectionMethod,
   TAzureAppConfigurationConnection,
@@ -20,6 +37,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureAppConfigurationFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -108,6 +126,7 @@ export const AzureAppConfigurationConnectionForm = ({
   projectId
 }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -129,6 +148,8 @@ export const AzureAppConfigurationConnectionForm = ({
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  const scopeVariant = useScopeVariant();
 
   const selectedMethod = watch("method");
 
@@ -182,39 +203,48 @@ export const AzureAppConfigurationConnectionForm = ({
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureAppConfiguration].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AzureAppConfiguration].name}. This field
+                    cannot be changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  id="method"
+                  className="w-full"
+                  isError={Boolean(error) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureAppConfigurationConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <FieldError>
+                {!isLoading && isMissingConfig
                   ? `Environment variables have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
                         : `See documentation to configure Azure ${methodDetails.name} Connections.`
                     }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureAppConfigurationConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
+                  : error?.message}
+              </FieldError>
+            </Field>
           )}
         />
 
@@ -222,22 +252,33 @@ export const AzureAppConfigurationConnectionForm = ({
           name="tenantId"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              tooltipText="The Azure Active Directory (Entra ID) Tenant ID."
-              isError={Boolean(error?.message)}
-              label="Tenant ID"
-              isOptional={selectedMethod === AzureAppConfigurationConnectionMethod.OAuth}
-              errorText={error?.message}
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="tenantId">
+                Tenant ID
+                {selectedMethod === AzureAppConfigurationConnectionMethod.OAuth && (
+                  <span className="text-muted"> (optional)</span>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Azure Active Directory (Entra ID) Tenant ID.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
                 {...field}
+                id="tenantId"
                 placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error)}
                 onChange={(e) => {
                   field.onChange(e.target.value);
                   setValue("credentials.tenantId", e.target.value);
                 }}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -248,51 +289,55 @@ export const AzureAppConfigurationConnectionForm = ({
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientSecret"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client Secret"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientSecret">Client Secret</FieldLabel>
                   <Input
                     {...field}
+                    id="credentials.clientSecret"
                     type="password"
                     placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={isSubmitting || (!isUpdate && !isDirty) || isMissingConfig || isRedirecting}
           >
             {isUpdate ? "Reconnect to Azure" : "Connect to Azure"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureClientSecretsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureClientSecretsConnectionForm.tsx
@@ -4,23 +4,33 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import {
   AzureClientSecretsConnectionMethod,
   TAzureClientSecretsConnection,
@@ -30,6 +40,7 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureClientSecretsFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -158,6 +169,7 @@ const getDefaultValues = (appConnection?: TAzureClientSecretsConnection): Partia
 
 export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -179,6 +191,8 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  const scopeVariant = useScopeVariant();
 
   const selectedMethod = watch("method");
 
@@ -226,39 +240,48 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureClientSecrets].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AzureClientSecrets].name}. This field cannot
+                    be changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  id="method"
+                  className="w-full"
+                  isError={Boolean(error) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureClientSecretsConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <FieldError>
+                {!isLoading && isMissingConfig
                   ? `Environment variables have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
                         : `See documentation to configure Azure ${methodDetails.name} Connections.`
                     }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureClientSecretsConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
+                  : error?.message}
+              </FieldError>
+            </Field>
           )}
         />
 
@@ -270,21 +293,28 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
           }
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              tooltipText="The Directory (tenant) ID."
-              isError={Boolean(error?.message)}
-              label="Tenant ID"
-              errorText={error?.message}
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="tenantId">
+                Tenant ID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">The Directory (tenant) ID.</TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
                 {...field}
+                id="tenantId"
                 placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error)}
                 onChange={(e) => {
                   field.onChange(e.target.value);
                   setValue("credentials.tenantId", e.target.value);
                 }}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -295,30 +325,33 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientSecret"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client Secret"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientSecret">Client Secret</FieldLabel>
                   <Input
                     {...field}
+                    id="credentials.clientSecret"
                     type="password"
                     placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
 
@@ -327,14 +360,28 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
                 name="credentials.clientSecretKeyId"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error?.message)}
-                    label="Client Secret Key ID"
-                    errorText={error?.message}
-                    tooltipText="The Key ID of the client secret provided above. Found in Azure Portal under App Registrations > Certificates & Secrets. Required so Infisical can revoke the original secret after rotation."
-                  >
-                    <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                      Client Secret Key ID
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          The Key ID of the client secret provided above. Found in Azure Portal
+                          under App Registrations &gt; Certificates &amp; Secrets. Required so
+                          Infisical can revoke the original secret after rotation.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="credentials.clientSecretKeyId"
+                      placeholder="00000000-0000-0000-0000-000000000000"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
             </CredentialRotationForm>
@@ -347,70 +394,68 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.certificateBody"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Certificate"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.certificateBody">Certificate</FieldLabel>
                   <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     placeholder="-----BEGIN CERTIFICATE-----..."
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.privateKey"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Private Key"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.privateKey">Private Key</FieldLabel>
                   <SecretInput
                     placeholder="-----BEGIN PRIVATE KEY-----..."
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={isSubmitting || (!isUpdate && !isDirty) || isMissingConfig || isRedirecting}
           >
             {isUpdate ? "Reconnect to Azure" : "Connect to Azure"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDNSConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDNSConnectionForm.tsx
@@ -1,21 +1,29 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TAzureDNSConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { AzureDNSConnectionMethod } from "@app/hooks/api/appConnections/types/azure-dns-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -61,11 +69,7 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -75,31 +79,36 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureDNS].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureDNSConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.AzureDNS].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureDNSConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -107,17 +116,17 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Tenant ID"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="tenant-id">Tenant ID</FieldLabel>
               <Input
+                id="tenant-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -125,17 +134,17 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client ID"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-id">Client ID</FieldLabel>
               <Input
+                id="client-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -143,18 +152,15 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client Secret"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-secret">Client Secret</FieldLabel>
               <SecretInput
                 placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -162,36 +168,22 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Subscription ID"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="subscription-id">Subscription ID</FieldLabel>
               <Input
+                id="subscription-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Azure DNS"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Azure DNS"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
@@ -4,15 +4,32 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import {
   AzureDevOpsConnectionMethod,
   TAzureDevOpsConnection,
@@ -21,6 +38,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureDevOpsFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -140,6 +158,7 @@ const getDefaultValues = (appConnection?: TAzureDevOpsConnection): Partial<FormD
 
 export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -161,6 +180,8 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
     formState: { isSubmitting, isDirty },
     setValue
   } = form;
+
+  const scopeVariant = useScopeVariant();
 
   const selectedMethod = watch("method");
 
@@ -207,39 +228,48 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureDevOps].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AzureDevOps].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  id="method"
+                  className="w-full"
+                  isError={Boolean(error) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureDevOpsConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <FieldError>
+                {!isLoading && isMissingConfig
                   ? `Environment variables have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
                         : `See documentation to configure Azure ${methodDetails.name} Connections.`
                     }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureDevOpsConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
+                  : error?.message}
+              </FieldError>
+            </Field>
           )}
         />
 
@@ -250,42 +280,60 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
               name="tenantId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="The Directory (tenant) ID."
-                  isError={Boolean(error?.message)}
-                  label="Tenant ID"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="tenantId">
+                    Tenant ID
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The Directory (tenant) ID.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
                     {...field}
+                    id="tenantId"
                     placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
                     onChange={(e) => {
                       field.onChange(e.target.value);
                       setValue("credentials.tenantId", e.target.value);
                     }}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="orgName"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="Your Azure DevOps organization name."
-                  isError={Boolean(error?.message)}
-                  label="Organization Name"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="orgName">
+                    Organization Name
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Your Azure DevOps organization name.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
                     {...field}
+                    id="orgName"
                     placeholder="myorganization"
+                    isError={Boolean(error)}
                     onChange={(e) => {
                       field.onChange(e.target.value);
                       setValue("credentials.orgName", e.target.value);
                     }}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
@@ -298,30 +346,33 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientSecret"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client Secret"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientSecret">Client Secret</FieldLabel>
                   <Input
                     {...field}
+                    id="credentials.clientSecret"
                     type="password"
                     placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
@@ -334,54 +385,76 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
               name="credentials.accessToken"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="Personal Access Token from Azure DevOps."
-                  isError={Boolean(error?.message)}
-                  label="Access Token"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.accessToken">
+                    Access Token
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Personal Access Token from Azure DevOps.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
                     {...field}
+                    id="credentials.accessToken"
                     type="password"
                     placeholder="Enter your Personal Access Token"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.orgName"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="Your Azure DevOps organization name."
-                  isError={Boolean(error?.message)}
-                  label="Organization Name"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="myorganization" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.orgName">
+                    Organization Name
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Your Azure DevOps organization name.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.orgName"
+                    placeholder="myorganization"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
 
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={isSubmitting || (!isUpdate && !isDirty) || isMissingConfig || isRedirecting}
           >
             {isUpdate ? "Reconnect to Azure" : "Connect to Azure"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
@@ -1,15 +1,33 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   AzureEntraIdConnectionMethod,
   TAzureEntraIdConnection
 } from "@app/hooks/api/appConnections/types/azure-entra-id-connection";
 
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -34,6 +52,7 @@ type Props = {
 
 export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -66,6 +85,8 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
     formState: { isSubmitting, isDirty }
   } = form;
 
+  const scopeVariant = useScopeVariant();
+
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -75,31 +96,36 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureEntraId].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureEntraIdConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AzureEntraId].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureEntraIdConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -107,14 +133,26 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="credentials.tenantId"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              tooltipText="The Azure Active Directory (Entra ID) Tenant ID."
-              isError={Boolean(error?.message)}
-              label="Tenant ID"
-              errorText={error?.message}
-            >
-              <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials.tenantId">
+                Tenant ID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Azure Active Directory (Entra ID) Tenant ID.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                {...field}
+                id="credentials.tenantId"
+                placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -122,14 +160,26 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="credentials.clientId"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              tooltipText="The Application (Client) ID of the Azure App Registration."
-              isError={Boolean(error?.message)}
-              label="Client ID"
-              errorText={error?.message}
-            >
-              <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials.clientId">
+                Client ID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Application (Client) ID of the Azure App Registration.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                {...field}
+                id="credentials.clientId"
+                placeholder="00000000-0000-0000-0000-000000000000"
+                isError={Boolean(error)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -137,34 +187,43 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="credentials.clientSecret"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              tooltipText="The client secret of the Azure App Registration."
-              isError={Boolean(error?.message)}
-              label="Client Secret"
-              errorText={error?.message}
-            >
-              <Input {...field} type="password" placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials.clientSecret">
+                Client Secret
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The client secret of the Azure App Registration.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                {...field}
+                id="credentials.clientSecret"
+                type="password"
+                placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
+                isError={Boolean(error)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
+            variant={scopeVariant}
+            isPending={isSubmitting}
             isDisabled={isSubmitting || (!isUpdate && !isDirty)}
           >
             {isUpdate ? "Reconnect to Azure" : "Connect to Azure"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button type="button" variant="outline" onClick={onCancel} isDisabled={isSubmitting}>
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureKeyVaultConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureKeyVaultConnectionForm.tsx
@@ -3,19 +3,27 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -28,6 +36,7 @@ import {
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import { useGetAppConnectionOption } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -37,6 +46,7 @@ import {
 
 import { AzureKeyVaultFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -169,6 +179,7 @@ const getDefaultValues = (appConnection?: TAzureKeyVaultConnection): Partial<For
 
 export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -190,6 +201,8 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
     watch,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  const scopeVariant = useScopeVariant();
 
   const selectedMethod = watch("method");
   const gatewayId = watch("gatewayId");
@@ -255,39 +268,48 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.AzureKeyVault].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.AzureKeyVault].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  id="method"
+                  className="w-full"
+                  isError={Boolean(error) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(AzureKeyVaultConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <FieldError>
+                {!isLoading && isMissingConfig
                   ? `Environment variables have not been configured. ${
                       isInfisicalCloud()
                         ? "Please contact Infisical."
                         : `See documentation to configure Azure ${methodDetails.name} Connections.`
                     }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(AzureKeyVaultConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
+                  : error?.message}
+              </FieldError>
+            </Field>
           )}
         />
 
@@ -297,23 +319,32 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -323,14 +354,26 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
             name="tenantId"
             control={control}
             render={({ field, fieldState: { error } }) => (
-              <FormControl
-                tooltipText="The Azure Active Directory (Entra ID) Tenant ID."
-                isError={Boolean(error?.message)}
-                label="Tenant ID"
-                errorText={error?.message}
-              >
-                <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel htmlFor="tenantId">
+                  Tenant ID
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">
+                      The Azure Active Directory (Entra ID) Tenant ID.
+                    </TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <Input
+                  {...field}
+                  id="tenantId"
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  isError={Boolean(error)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         )}
@@ -342,44 +385,59 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
               name="credentials.tenantId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="The Azure Active Directory (Entra ID) Tenant ID."
-                  isError={Boolean(error?.message)}
-                  label="Tenant ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.tenantId">
+                    Tenant ID
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The Azure Active Directory (Entra ID) Tenant ID.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.tenantId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientSecret"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client Secret"
-                  errorText={error?.message}
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientSecret">Client Secret</FieldLabel>
                   <Input
                     {...field}
+                    id="credentials.clientSecret"
                     type="password"
                     placeholder="~JzD8e6S.tH~w8XRaNnKcb7W1fM4rCns7FY"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <CredentialRotationForm>
@@ -387,14 +445,28 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
                 name="credentials.clientSecretKeyId"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    isError={Boolean(error?.message)}
-                    label="Client Secret Key ID"
-                    errorText={error?.message}
-                    tooltipText="The Key ID of the client secret provided above. Found in Azure Portal under App Registrations > Certificates & Secrets. Required so Infisical can revoke the original secret after rotation."
-                  >
-                    <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                      Client Secret Key ID
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          The Key ID of the client secret provided above. Found in Azure Portal
+                          under App Registrations &gt; Certificates &amp; Secrets. Required so
+                          Infisical can revoke the original secret after rotation.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="credentials.clientSecretKeyId"
+                      placeholder="00000000-0000-0000-0000-000000000000"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
             </CredentialRotationForm>
@@ -408,77 +480,104 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
               name="credentials.tenantId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="The Azure Active Directory (Entra ID) Tenant ID."
-                  isError={Boolean(error?.message)}
-                  label="Tenant ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.tenantId">
+                    Tenant ID
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The Azure Active Directory (Entra ID) Tenant ID.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.tenantId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.clientId"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Client ID"
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.clientId">Client ID</FieldLabel>
+                  <Input
+                    {...field}
+                    id="credentials.clientId"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.certificateBody"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Certificate"
-                  errorText={error?.message}
-                  tooltipText="The PEM-encoded public certificate uploaded to your Azure App Registration."
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.certificateBody">
+                    Certificate
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The PEM-encoded public certificate uploaded to your Azure App Registration.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     placeholder="-----BEGIN CERTIFICATE-----..."
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.privateKey"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  isError={Boolean(error?.message)}
-                  label="Private Key"
-                  errorText={error?.message}
-                  tooltipText="The PEM-encoded private key matching the certificate. The private key is never transmitted to Azure; it is only used locally to sign the client assertion."
-                >
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials.privateKey">
+                    Private Key
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The PEM-encoded private key matching the certificate. The private key is
+                        never transmitted to Azure; it is only used locally to sign the client
+                        assertion.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
                     value={value}
                     onChange={(e) => onChange(e.target.value)}
                     placeholder="-----BEGIN PRIVATE KEY-----..."
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
 
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={
               isSubmitting ||
               (!isUpdate && !isDirty && selectedMethod !== AzureKeyVaultConnectionMethod.OAuth) ||
@@ -488,12 +587,15 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
           >
             {isUpdate ? "Reconnect to Azure" : "Connect to Azure"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/BitbucketConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/BitbucketConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { BitbucketConnectionMethod, TBitbucketConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const BitbucketConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -66,31 +70,36 @@ export const BitbucketConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Bitbucket].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(BitbucketConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Bitbucket].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(BitbucketConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,9 +107,16 @@ export const BitbucketConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl errorText={error?.message} isError={Boolean(error?.message)} label="Email">
-              <Input {...field} placeholder="user@example.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="email">Email</FieldLabel>
+              <Input
+                id="email"
+                {...field}
+                placeholder="user@example.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -108,36 +124,16 @@ export const BitbucketConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Bitbucket"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Bitbucket"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CamundaConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CamundaConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { CamundaConnectionMethod, TCamundaConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const CamundaConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -66,31 +70,36 @@ export const CamundaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Camunda].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(CamundaConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Camunda].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(CamundaConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,13 +107,16 @@ export const CamundaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client ID"
-            >
-              <Input {...field} placeholder="YrBDnQYLevSe40PJ" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-id">Client ID</FieldLabel>
+              <Input
+                id="client-id"
+                {...field}
+                placeholder="YrBDnQYLevSe40PJ"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -112,36 +124,16 @@ export const CamundaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client Secret"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-secret">Client Secret</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Camunda"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Camunda"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChecklyConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChecklyConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TChecklyConnection
 } from "@app/hooks/api/appConnections/types/checkly-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const ChecklyConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const ChecklyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Checkly].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(ChecklyConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The type of token you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Checkly].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(ChecklyConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,37 +108,17 @@ export const ChecklyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key Value"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">API Key Value</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Checkly"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Checkly"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChefConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChefConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { ChefConnectionMethod, TChefConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -54,11 +62,7 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -69,49 +73,63 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Chef Server URL (optional)"
-              tooltipText="Will default to Chef Cloud if not specified."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="server-url">
+                Chef Server URL (optional)
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Will default to Chef Cloud if not specified.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="server-url"
                 placeholder="https://api.chef.io"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Chef].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(ChefConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Chef].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(ChefConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -120,18 +138,17 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Organization Short Name"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="org-name">Organization Short Name</FieldLabel>
               <Input
-                className="border border-mineshaft-500 bg-mineshaft-900"
+                id="org-name"
                 placeholder="your-org"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -139,18 +156,17 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="User Name"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="user-name">User Name</FieldLabel>
               <Input
-                className="border border-mineshaft-500 bg-mineshaft-900"
+                id="user-name"
                 placeholder="your-username"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -158,37 +174,26 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Private Key"
-              tooltipText="Your Chef user's private key (.pem file)"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:!border-primary-400/50 border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="private-key">
+                Private Key
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Your Chef user&apos;s private key (.pem file)
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Chef"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Chef"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CircleCIConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CircleCIConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { CircleCIConnectionMethod, TCircleCIConnection } from "@app/hooks/api/appConnections/types";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const CircleCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,20 +72,30 @@ export const CircleCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance Hostname"
-              isOptional
-              tooltipText="The host URL of your CircleCI instance. This is used to connect to your CircleCI instance. If not specified, the default value of 'circleci.com' will be used."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="host">
+                Instance Hostname <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The host URL of your CircleCI instance. This is used to connect to your CircleCI
+                    instance. If not specified, the default value of &apos;circleci.com&apos; will
+                    be used.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="host"
                 defaultValue="circleci.com"
                 placeholder="circleci.com"
                 value={value || ""}
                 onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -89,31 +103,36 @@ export const CircleCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.CircleCI].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(CircleCIConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.CircleCI].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(CircleCIConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -122,37 +141,27 @@ export const CircleCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-              tooltipText="Your CircleCI API Token. You can generate one from CircleCI User Settings > Personal API Tokens."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">
+                API Token
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Your CircleCI API Token. You can generate one from CircleCI User Settings &gt;
+                    Personal API Tokens.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to CircleCI"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to CircleCI"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CloudflareConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/CloudflareConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { CloudflareConnectionMethod, TCloudflareConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const CloudflareConnectionForm = ({ appConnection, onSubmit }: Props) => 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -66,31 +70,36 @@ export const CloudflareConnectionForm = ({ appConnection, onSubmit }: Props) => 
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Cloudflare].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(CloudflareConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Cloudflare].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(CloudflareConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,17 +107,17 @@ export const CloudflareConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Account ID"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="account-id">Account ID</FieldLabel>
               <Input
+                id="account-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="802fcff12d4340f8e22feb5dd1d6ecac"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -116,36 +125,16 @@ export const CloudflareConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Cloudflare"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Cloudflare"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ConvexConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ConvexConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { ConvexConnectionMethod, TConvexConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -59,11 +67,7 @@ export const ConvexConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -73,31 +77,36 @@ export const ConvexConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Convex].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(ConvexConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Convex].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(ConvexConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -105,17 +114,11 @@ export const ConvexConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="access-token">Access Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -123,35 +126,31 @@ export const ConvexConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              isOptional
-              tooltipClassName="max-w-sm"
-              tooltipText="Will default to https://api.convex.dev if not specified."
-            >
-              <Input {...field} placeholder="https://api.convex.dev" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Will default to https://api.convex.dev if not specified.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://api.convex.dev"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Convex"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Convex"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DNSMadeEasyConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DNSMadeEasyConnectionForm.tsx
@@ -1,21 +1,29 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TDNSMadeEasyConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { DNSMadeEasyConnectionMethod } from "@app/hooks/api/appConnections/types/dns-made-easy-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -57,11 +65,7 @@ export const DNSMadeEasyConnectionForm = ({ appConnection, onSubmit }: Props) =>
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -71,31 +75,36 @@ export const DNSMadeEasyConnectionForm = ({ appConnection, onSubmit }: Props) =>
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.DNSMadeEasy].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DNSMadeEasyConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.DNSMadeEasy].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DNSMadeEasyConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -103,17 +112,17 @@ export const DNSMadeEasyConnectionForm = ({ appConnection, onSubmit }: Props) =>
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">API Key</FieldLabel>
               <Input
+                id="api-key"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="af1b628f-3272-46aa-9cde-837d0c59155d"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -121,36 +130,16 @@ export const DNSMadeEasyConnectionForm = ({ appConnection, onSubmit }: Props) =>
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Secret Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="secret-key">Secret Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to DNS Made Easy"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to DNS Made Easy"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DatabricksConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DatabricksConnectionForm.tsx
@@ -1,16 +1,23 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -18,6 +25,7 @@ import {
   TDatabricksConnection
 } from "@app/hooks/api/appConnections/types/databricks-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -56,11 +64,7 @@ export const DatabricksConnectionForm = ({ appConnection, onSubmit }: Props) => 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -70,31 +74,36 @@ export const DatabricksConnectionForm = ({ appConnection, onSubmit }: Props) => 
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Databricks].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DatabricksConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Databricks].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DatabricksConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -102,13 +111,16 @@ export const DatabricksConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Workspace URL"
-            >
-              <Input {...field} placeholder="https://xxx-xxxxxxxx-xxx.cloud.databricks.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="workspace-url">Workspace URL</FieldLabel>
+              <Input
+                id="workspace-url"
+                {...field}
+                placeholder="https://xxx-xxxxxxxx-xxx.cloud.databricks.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -116,13 +128,16 @@ export const DatabricksConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client ID"
-            >
-              <Input {...field} placeholder="05810c8f-c44d-4bd0-a327-aab6dd77719b" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-id">Client ID</FieldLabel>
+              <Input
+                id="client-id"
+                {...field}
+                placeholder="05810c8f-c44d-4bd0-a327-aab6dd77719b"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -130,36 +145,16 @@ export const DatabricksConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client Secret"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="client-secret">Client Secret</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Databricks"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Databricks"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DatadogConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DatadogConnectionForm.tsx
@@ -1,14 +1,25 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, SecretInput } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   DatadogConnectionMethod,
   TDatadogConnection
 } from "@app/hooks/api/appConnections/types/datadog-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -47,11 +58,7 @@ export const DatadogConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -63,15 +70,26 @@ export const DatadogConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Datadog URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="The Datadog site URL to connect to (e.g., https://api.datadoghq.com)."
-            >
-              <Input {...field} placeholder="https://api.datadoghq.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="url">
+                Datadog URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Datadog site URL to connect to (e.g., https://api.datadoghq.com).
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="url"
+                {...field}
+                placeholder="https://api.datadoghq.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -79,17 +97,11 @@ export const DatadogConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">API Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -97,36 +109,16 @@ export const DatadogConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Application Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="application-key">Application Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Datadog"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Datadog"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DbtConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DbtConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { DbtConnectionMethod, TDbtConnection } from "@app/hooks/api/appConnections/types";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -58,11 +66,7 @@ export const DbtConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -74,17 +78,17 @@ export const DbtConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">Instance URL</FieldLabel>
               <Input
+                id="instance-url"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="https://bw255.us1.dbt.com"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -93,17 +97,17 @@ export const DbtConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Account ID"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="account-id">Account ID</FieldLabel>
               <Input
+                id="account-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="70471823527642"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -111,31 +115,36 @@ export const DbtConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Dbt].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DbtConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The type of token you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Dbt].name}. This field cannot be changed after
+                    creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DbtConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -143,37 +152,15 @@ export const DbtConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to DBT"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to DBT"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DevinConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DevinConnectionForm.tsx
@@ -1,19 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { DevinConnectionMethod, TDevinConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -54,11 +62,7 @@ export const DevinConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,29 +72,34 @@ export const DevinConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Devin].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DevinConnectionMethod).map((method) => (
-                  <SelectItem value={method} key={method}>
-                    {getAppConnectionMethodDetails(method).name}
-                  </SelectItem>
-                ))}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Devin].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DevinConnectionMethod).map((method) => (
+                    <SelectItem value={method} key={method}>
+                      {getAppConnectionMethodDetails(method).name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,37 +107,27 @@ export const DevinConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Service User API Key"
-              tooltipText="Generate a service-user credential with the ManageOrgSecrets permission from the Devin dashboard. The key starts with 'cog_'."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">
+                Service User API Key
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Generate a service-user credential with the ManageOrgSecrets permission from the
+                    Devin dashboard. The key starts with &apos;cog_&apos;.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput id="api-key" value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Devin"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Devin"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DigiCertConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DigiCertConnectionForm.tsx
@@ -1,15 +1,23 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -18,6 +26,7 @@ import {
   TDigiCertConnection
 } from "@app/hooks/api/appConnections/types/digicert-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -56,11 +65,7 @@ export const DigiCertConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -70,31 +75,36 @@ export const DigiCertConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.DigiCert].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DigiCertConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.DigiCert].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DigiCertConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -102,23 +112,30 @@ export const DigiCertConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="CertCentral Region"
-              tooltipText="Select the CertCentral tenant your API key was issued in. US and EU are independent — a US key cannot be used against EU and vice-versa."
-            >
-              <Select
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                <SelectItem value={DigiCertRegion.US}>US</SelectItem>
-                <SelectItem value={DigiCertRegion.EU}>EU</SelectItem>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="region">
+                CertCentral Region
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Select the CertCentral tenant your API key was issued in. US and EU are
+                    independent. A US key cannot be used against EU and vice-versa.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="region" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a region..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  <SelectItem value={DigiCertRegion.US}>US</SelectItem>
+                  <SelectItem value={DigiCertRegion.EU}>EU</SelectItem>
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -126,37 +143,21 @@ export const DigiCertConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="CertCentral API Key"
-              helperText="Generate an API key in CertCentral under Automation > API Keys."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">CertCentral API Key</FieldLabel>
+              <SecretInput id="api-key" value={value} onChange={(e) => onChange(e.target.value)} />
+              {!error && (
+                <FieldDescription>
+                  Generate an API key in CertCentral under Automation &gt; API Keys.
+                </FieldDescription>
+              )}
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to DigiCert"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to DigiCert"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DigitalOceanConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DigitalOceanConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TDigitalOceanConnection
 } from "@app/hooks/api/appConnections/types/digital-ocean";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const DigitalOceanConnectionForm = ({ appConnection, onSubmit }: Props) =
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const DigitalOceanConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.DigitalOcean].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DigitalOceanConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The type of token you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.DigitalOcean].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DigitalOceanConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,37 +108,20 @@ export const DigitalOceanConnectionForm = ({ appConnection, onSubmit }: Props) =
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key Value"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Key Value</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to DigitalOcean"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to DigitalOcean"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DopplerConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/DopplerConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TDopplerConnection
 } from "@app/hooks/api/appConnections/types/doppler-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const DopplerConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,29 +71,34 @@ export const DopplerConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Doppler].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(DopplerConnectionMethod).map((method) => (
-                  <SelectItem value={method} key={method}>
-                    {getAppConnectionMethodDetails(method).name}
-                  </SelectItem>
-                ))}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The type of token you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Doppler].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(DopplerConnectionMethod).map((method) => (
+                    <SelectItem value={method} key={method}>
+                      {getAppConnectionMethodDetails(method).name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -97,37 +106,20 @@ export const DopplerConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Doppler"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Doppler"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ExternalInfisicalConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ExternalInfisicalConnectionForm.tsx
@@ -1,16 +1,23 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import {
   ExternalInfisicalConnectionMethod,
@@ -18,6 +25,7 @@ import {
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -68,11 +76,7 @@ export const ExternalInfisicalConnectionForm = ({ appConnection, onSubmit }: Pro
         }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -82,31 +86,36 @@ export const ExternalInfisicalConnectionForm = ({ appConnection, onSubmit }: Pro
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.ExternalInfisical].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(ExternalInfisicalConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.ExternalInfisical].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(ExternalInfisicalConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -114,18 +123,28 @@ export const ExternalInfisicalConnectionForm = ({ appConnection, onSubmit }: Pro
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipText="The base URL of the external Infisical instance (e.g., https://app.infisical.com)"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The base URL of the external Infisical instance (e.g.,
+                    https://app.infisical.com)
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="instance-url"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="https://app.infisical.com"
+                isError={Boolean(error)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -133,18 +152,28 @@ export const ExternalInfisicalConnectionForm = ({ appConnection, onSubmit }: Pro
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Machine Identity Client ID"
-              tooltipText="The Client ID of the Machine Identity with Universal Auth configured on the external Infisical instance"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="machine-identity-client-id">
+                Machine Identity Client ID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Client ID of the Machine Identity with Universal Auth configured on the
+                    external Infisical instance
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="machine-identity-client-id"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="Enter Machine Identity Client ID"
+                isError={Boolean(error)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -152,36 +181,22 @@ export const ExternalInfisicalConnectionForm = ({ appConnection, onSubmit }: Pro
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Machine Identity Client Secret"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="machine-identity-client-secret">
+                Machine Identity Client Secret
+              </FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="machine-identity-client-secret"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Infisical"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Infisical"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/F5BigIpConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/F5BigIpConnectionForm.tsx
@@ -1,31 +1,43 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { OrgPermissionSubjects } from "@app/context";
 import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { F5BigIpConnectionMethod, TF5BigIpConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -77,7 +89,7 @@ type FormData = z.infer<typeof formSchema>;
 
 export const F5BigIpConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [selectedTab, setSelectedTab] = useState("configuration");
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -93,13 +105,8 @@ export const F5BigIpConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
+  const scopeVariant = useScopeVariant();
 
   const gatewayId = watch("gatewayId");
   const gatewayPoolId = watch("gatewayPoolId");
@@ -112,232 +119,207 @@ export const F5BigIpConnectionForm = ({ appConnection, onSubmit }: Props) => {
           I={OrgGatewayPermissionActions.AttachGateways}
           a={OrgPermissionSubjects.Gateway}
         >
-          {(isAllowed) => (
-            <FormControl label="Gateway">
-              <Tooltip
-                isDisabled={isAllowed}
-                content="Restricted access. You don't have permission to attach gateways to resources."
-              >
-                <div>
-                  <GatewayPicker
-                    isDisabled={!isAllowed}
-                    value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                    onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                      setValue("gatewayId", newGwId, { shouldDirty: true });
-                      setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                    }}
-                  />
-                </div>
-              </Tooltip>
-            </FormControl>
-          )}
+          {(isAllowed) => {
+            const picker = (
+              <GatewayPicker
+                isDisabled={!isAllowed}
+                value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                  setValue("gatewayId", newGwId, { shouldDirty: true });
+                  setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                }}
+              />
+            );
+
+            return (
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                {isAllowed ? (
+                  picker
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="block w-full cursor-not-allowed">{picker}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </Field>
+            );
+          }}
         </OrgPermissionCan>
         <Controller
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.F5BigIp].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(F5BigIpConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.F5BigIp].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(F5BigIpConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List className="mb-3 flex w-full gap-4 border-b border-mineshaft-600">
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              SSL
-            </Tab>
-          </Tab.List>
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
-              <div className="grid grid-cols-[1fr_auto] gap-2">
-                <Controller
-                  name="credentials.hostname"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Hostname"
-                    >
-                      <Input
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                        placeholder="e.g. bigip.example.com"
-                      />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.port"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Port"
-                      isOptional
-                    >
-                      <Input
-                        type="number"
-                        value={value ?? ""}
-                        onChange={(e) =>
-                          onChange(e.target.value ? Number(e.target.value) : undefined)
-                        }
-                        placeholder="443"
-                        className="w-24"
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <Controller
-                  name="credentials.username"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Username"
-                    >
-                      <Input
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                        placeholder="admin"
-                      />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Password"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-            </Tab.Panel>
-            <Tab.Panel>
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="mb-4">
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="ssl">SSL</TabsTrigger>
+          </TabsList>
+          <TabsContent value="configuration">
+            <div className="grid grid-cols-[1fr_auto] gap-2">
               <Controller
-                name="credentials.sslCertificate"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="SSL Certificate"
-                    isOptional
-                  >
-                    <TextArea
-                      className="h-[3.6rem] resize-none!"
-                      {...field}
-                      placeholder="-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
-                    />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.sslRejectUnauthorized"
+                name="credentials.hostname"
                 control={control}
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="ssl-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the F5 BIG-IP if it has a
-                              valid, trusted SSL certificate. Disable this for self-signed
-                              certificates or provide a CA certificate above.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="hostname">Hostname</FieldLabel>
+                    <Input
+                      id="hostname"
+                      value={value}
+                      onChange={(e) => onChange(e.target.value)}
+                      placeholder="e.g. bigip.example.com"
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to F5 BIG-IP"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+              <Controller
+                name="credentials.port"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="port">
+                      Port <span className="text-muted">(optional)</span>
+                    </FieldLabel>
+                    <Input
+                      id="port"
+                      type="number"
+                      value={value ?? ""}
+                      onChange={(e) =>
+                        onChange(e.target.value ? Number(e.target.value) : undefined)
+                      }
+                      placeholder="443"
+                      className="w-24"
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <Controller
+                name="credentials.username"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="username">Username</FieldLabel>
+                    <Input
+                      id="username"
+                      value={value}
+                      onChange={(e) => onChange(e.target.value)}
+                      placeholder="admin"
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+              <Controller
+                name="credentials.password"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="password">Password</FieldLabel>
+                    <SecretInput
+                      id="password"
+                      value={value}
+                      onChange={(e) => onChange(e.target.value)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="ssl">
+            <Controller
+              name="credentials.sslCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="ssl-certificate">
+                    SSL Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="ssl-certificate"
+                    className="h-[3.6rem] resize-none!"
+                    {...field}
+                    placeholder="-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the F5 BIG-IP if it has a valid,
+                        trusted SSL certificate. Disable this for self-signed certificates or
+                        provide a CA certificate above.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      id="ssl-reject-unauthorized"
+                      variant={scopeVariant}
+                      checked={value}
+                      onCheckedChange={onChange}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to F5 BIG-IP"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/FlyioConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/FlyioConnectionForm.tsx
@@ -1,19 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { FlyioConnectionMethod, TFlyioConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -54,11 +62,7 @@ export const FlyioConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,31 +72,36 @@ export const FlyioConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Flyio].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(FlyioConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Flyio].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(FlyioConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -100,36 +109,20 @@ export const FlyioConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="access-token">Access Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="access-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Fly.io"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Fly.io"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GcpConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GcpConnectionForm.tsx
@@ -2,25 +2,33 @@ import { Controller, FormProvider, useForm } from "react-hook-form";
 import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   IconButton,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { useToggle } from "@app/hooks";
 import { GcpConnectionMethod, TGcpConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -61,11 +69,7 @@ export const GcpConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const [isCopied, { timedToggle: toggleIsCopied }] = useToggle(false);
   const expectedAccountIdSuffix = currentOrg.id.split("-").slice(0, 2).join("-");
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -75,31 +79,36 @@ export const GcpConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.GCP].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(GcpConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.GCP].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(GcpConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -107,77 +116,62 @@ export const GcpConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Service Account Email"
-              className="group"
-              helperText={
-                <>
-                  <div>
+            <Field className="group mb-4">
+              <FieldLabel htmlFor="service-account-email">Service Account Email</FieldLabel>
+              <SecretInput
+                id="service-account-email"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+              />
+              {!error && (
+                <FieldDescription>
+                  <span className="block">
                     {`Service account ID must be suffixed with "${expectedAccountIdSuffix}"`}
-                    <Tooltip className="relative right-2" position="bottom" content="Copy">
-                      <IconButton
-                        variant="plain"
-                        ariaLabel="copy"
-                        onClick={() => {
-                          if (isCopied) {
-                            return;
-                          }
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <IconButton
+                          variant="ghost-muted"
+                          size="xs"
+                          aria-label="copy"
+                          onClick={() => {
+                            if (isCopied) {
+                              return;
+                            }
 
-                          navigator.clipboard.writeText(expectedAccountIdSuffix);
+                            navigator.clipboard.writeText(expectedAccountIdSuffix);
 
-                          createNotification({
-                            text: "Copied to clipboard",
-                            type: "info"
-                          });
+                            createNotification({
+                              text: "Copied to clipboard",
+                              type: "info"
+                            });
 
-                          toggleIsCopied(2000);
-                        }}
-                        className="hover:bg-bunker-100/10"
-                      >
-                        <FontAwesomeIcon
-                          icon={!isCopied ? faCopy : faCheck}
-                          size="sm"
-                          className="cursor-pointer"
-                        />
-                      </IconButton>
+                            toggleIsCopied(2000);
+                          }}
+                          className="ml-1"
+                        >
+                          <FontAwesomeIcon
+                            icon={!isCopied ? faCopy : faCheck}
+                            size="sm"
+                            className="cursor-pointer"
+                          />
+                        </IconButton>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">Copy</TooltipContent>
                     </Tooltip>
-                  </div>
-                  <div>
+                  </span>
+                  <span className="block">
                     Example:
                     <span className="ml-1">service-account-</span>
                     <span className="font-medium">{expectedAccountIdSuffix}</span>
                     <span>@my-project.iam.gserviceaccount.com</span>
-                  </div>
-                </>
-              }
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+                  </span>
+                </FieldDescription>
+              )}
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to GCP"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to GCP"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GenericAppConnectionFields.tsx
@@ -1,7 +1,14 @@
 import { useFormContext } from "react-hook-form";
 import { z } from "zod";
 
-import { FormControl, Input, TextArea } from "@app/components/v2";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  TextArea
+} from "@app/components/v3";
 import { slugSchema } from "@app/lib/schemas";
 
 export const rotationSchema = z.object({
@@ -38,27 +45,32 @@ export const GenericAppConnectionsFields = () => {
 
   return (
     <>
-      <FormControl
-        helperText="Name must be slug-friendly"
-        errorText={errors.name?.message}
-        isError={Boolean(errors.name?.message)}
-        label="Name"
-      >
-        <Input autoFocus placeholder="my-app-connection" {...register("name")} />
-      </FormControl>
-      <FormControl
-        errorText={errors.description?.message}
-        isError={Boolean(errors.description?.message)}
-        label="Description"
-        isOptional
-      >
+      <Field className="mb-4">
+        <FieldLabel htmlFor="app-connection-name">Name</FieldLabel>
+        <Input
+          id="app-connection-name"
+          autoFocus
+          placeholder="my-app-connection"
+          isError={Boolean(errors.name?.message)}
+          {...register("name")}
+        />
+        {!errors.name?.message && <FieldDescription>Must be slug-friendly.</FieldDescription>}
+        <FieldError errors={[errors.name]} />
+      </Field>
+      <Field className="mb-4">
+        <FieldLabel htmlFor="app-connection-description">
+          Description <span className="text-muted">(optional)</span>
+        </FieldLabel>
         <TextArea
-          className="resize-none!"
-          rows={1}
+          id="app-connection-description"
+          className="resize-none"
+          rows={2}
           placeholder="Connection description..."
+          isError={Boolean(errors.description?.message)}
           {...register("description")}
         />
-      </FormControl>
+        <FieldError errors={[errors.description]} />
+      </Field>
     </>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubAppSelector.tsx
@@ -1,27 +1,36 @@
 import { useLayoutEffect, useRef, useState } from "react";
-import { faGithub } from "@fortawesome/free-brands-svg-icons";
-import {
-  faArrowUpRightFromSquare,
-  faChevronLeft,
-  faCircleInfo,
-  faGear,
-  faPlus,
-  faTrash
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import slugify from "@sindresorhus/slugify";
+import {
+  ChevronLeftIcon,
+  ExternalLinkIcon,
+  GithubIcon,
+  InfoIcon,
+  PlusIcon,
+  SettingsIcon,
+  TrashIcon
+} from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
   Button,
-  FormControl,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldDescription,
+  FieldLabel,
   Input,
-  Modal,
-  ModalClose,
-  ModalContent,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
 import {
   Command,
   CommandGroup,
@@ -32,6 +41,7 @@ import { IconButton } from "@app/components/v3/generic/IconButton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3/generic/Tooltip";
 import { InstanceIcon, OrgIcon, ProjectIcon } from "@app/components/v3/platform/ScopeIcons";
 import { buildGitHubAppUrl, buildGitHubHostUrl } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { TGitHubApp, useDeleteGitHubApp } from "@app/hooks/api/gitHubApps";
 
 const SHARED_KEY = "__shared__";
@@ -82,6 +92,7 @@ export const GitHubAppSelector = ({
   const [newAppOrg, setNewAppOrg] = useState("");
   const containerRef = useRef<HTMLDivElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
+  const scopeVariant = useScopeVariant();
 
   // Toggling `mode` unmounts the focused button (e.g. "Create new GitHub App"). If focus dropped to
   // <body>, the Dialog's focus trap would yank it to the first field at the top of the modal and
@@ -152,9 +163,7 @@ export const GitHubAppSelector = ({
 
   // Non-interactive group label rendered between dropdown items.
   const renderPickerHeading = (label: string) => (
-    <div className="px-3 pt-2 pb-1 text-[10px] font-medium tracking-wide text-mineshaft-400">
-      {label}
-    </div>
+    <div className="px-3 pt-2 pb-1 text-[10px] font-medium tracking-wide text-muted">{label}</div>
   );
 
   const renderPickerItem = (app: TGitHubApp) => (
@@ -168,30 +177,25 @@ export const GitHubAppSelector = ({
 
     if (deleteTargetId === app.id) {
       return (
-        <div key={app.id} className="m-1 rounded-md border border-red-500/40 bg-red-500/5 p-3">
-          <div className="flex items-center gap-2 text-sm font-medium text-mineshaft-100">
-            <FontAwesomeIcon icon={faTrash} className="text-red-400" />
+        <div key={app.id} className="m-1 rounded-md border border-danger/40 bg-danger/5 p-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <TrashIcon className="size-4 text-danger" />
             <span>
               Delete <span className="font-mono">{app.name}</span>?
             </span>
           </div>
-          <p className="mt-1 text-xs leading-relaxed text-mineshaft-300">
+          <p className="mt-1 text-xs leading-relaxed text-accent">
             Removes it from Infisical and uninstalls it from GitHub. The app registration itself
             remains on GitHub until you delete it there.
           </p>
           <div className="mt-3 flex items-center justify-end gap-2">
-            <Button
-              variant="plain"
-              colorSchema="secondary"
-              size="xs"
-              onClick={() => setDeleteTargetId(null)}
-            >
+            <Button variant="ghost" size="xs" onClick={() => setDeleteTargetId(null)}>
               Cancel
             </Button>
             <Button
-              colorSchema="danger"
+              variant="danger"
               size="xs"
-              isLoading={deleteGitHubApp.isPending}
+              isPending={deleteGitHubApp.isPending}
               onClick={() => handleDelete(app)}
             >
               Delete
@@ -207,7 +211,7 @@ export const GitHubAppSelector = ({
         value={`${app.name} ${app.owner ?? ""} ${app.slug}`}
         className="group cursor-default"
       >
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-mineshaft-600">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-foreground/10">
           {app.projectId ? (
             <ProjectIcon className="size-4 text-project" />
           ) : (
@@ -215,8 +219,8 @@ export const GitHubAppSelector = ({
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate font-mono text-sm text-mineshaft-100">{app.name}</p>
-          <p className="truncate text-xs text-mineshaft-400">
+          <p className="truncate font-mono text-sm text-foreground">{app.name}</p>
+          <p className="truncate text-xs text-accent">
             {app.owner ? `${app.owner} · ` : ""}
             {app.connectionCount} connection{app.connectionCount === 1 ? "" : "s"}
           </p>
@@ -224,9 +228,10 @@ export const GitHubAppSelector = ({
         <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 data-[selected=true]:opacity-100">
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="cursor-pointer rounded p-1 text-mineshaft-300 hover:bg-mineshaft-600 hover:text-mineshaft-100"
+              <IconButton
+                variant="ghost-muted"
+                size="xs"
+                aria-label="Open on GitHub"
                 onClick={(e) => {
                   e.stopPropagation();
                   window.open(
@@ -236,8 +241,8 @@ export const GitHubAppSelector = ({
                   );
                 }}
               >
-                <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="text-xs" />
-              </button>
+                <ExternalLinkIcon />
+              </IconButton>
             </TooltipTrigger>
             <TooltipContent>Open on GitHub</TooltipContent>
           </Tooltip>
@@ -248,13 +253,9 @@ export const GitHubAppSelector = ({
                     needs a focusable wrapper to open on hover/focus. */}
                 {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
                 <span tabIndex={0}>
-                  <button
-                    type="button"
-                    disabled
-                    className="cursor-not-allowed rounded p-1 text-mineshaft-500"
-                  >
-                    <FontAwesomeIcon icon={faTrash} className="text-xs" />
-                  </button>
+                  <IconButton variant="ghost-muted" size="xs" aria-label="Delete app" isDisabled>
+                    <TrashIcon />
+                  </IconButton>
                 </span>
               </TooltipTrigger>
               <TooltipContent>
@@ -271,16 +272,18 @@ export const GitHubAppSelector = ({
           ) : (
             <Tooltip>
               <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  className="cursor-pointer rounded p-1 text-mineshaft-300 hover:bg-mineshaft-600 hover:text-red-400"
+                <IconButton
+                  variant="ghost-muted"
+                  size="xs"
+                  aria-label="Delete this app"
+                  className="hover:text-danger"
                   onClick={(e) => {
                     e.stopPropagation();
                     setDeleteTargetId(app.id);
                   }}
                 >
-                  <FontAwesomeIcon icon={faTrash} className="text-xs" />
-                </button>
+                  <TrashIcon />
+                </IconButton>
               </TooltipTrigger>
               <TooltipContent>Delete this app</TooltipContent>
             </Tooltip>
@@ -299,31 +302,30 @@ export const GitHubAppSelector = ({
             const app = apps.find((a) => getAppKey(a) === key);
             if (app) onChange(app);
           }}
-          isLoading={isLoading}
-          isDisabled={isLoading}
-          placeholder="Select a GitHub App"
-          containerClassName="min-w-0 flex-1"
-          className="w-full border border-mineshaft-500"
-          dropdownContainerClassName="max-w-none"
-          position="popper"
+          disabled={isLoading}
         >
-          {sharedApp && (
-            <>
-              {renderPickerHeading("INSTANCE")}
-              {renderPickerItem(sharedApp)}
-            </>
-          )}
-          {customApps.length > 0 && (
-            <>
-              {renderPickerHeading("PRIVATE")}
-              {customApps.map(renderPickerItem)}
-            </>
-          )}
-          {!sharedApp && customApps.length === 0 && !isLoading && (
-            <div className="px-4 py-6 text-center text-xs leading-relaxed text-mineshaft-400">
-              No GitHub Apps available yet. Use the gear button to create one.
-            </div>
-          )}
+          <SelectTrigger className="min-w-0 flex-1">
+            <SelectValue placeholder="Select a GitHub App" />
+          </SelectTrigger>
+          <SelectContent position="popper">
+            {sharedApp && (
+              <>
+                {renderPickerHeading("INSTANCE")}
+                {renderPickerItem(sharedApp)}
+              </>
+            )}
+            {customApps.length > 0 && (
+              <>
+                {renderPickerHeading("PRIVATE")}
+                {customApps.map(renderPickerItem)}
+              </>
+            )}
+            {!sharedApp && customApps.length === 0 && !isLoading && (
+              <div className="px-4 py-6 text-center text-xs leading-relaxed text-muted">
+                No GitHub Apps available yet. Use the gear button to create one.
+              </div>
+            )}
+          </SelectContent>
         </Select>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -331,122 +333,136 @@ export const GitHubAppSelector = ({
               variant="outline"
               aria-label="Manage GitHub Apps"
               onClick={() => setIsManageOpen(true)}
-              className="h-[38px] w-[38px] shrink-0 border-mineshaft-500 bg-mineshaft-900 text-mineshaft-200 hover:bg-mineshaft-700"
             >
-              <FontAwesomeIcon icon={faGear} />
+              <SettingsIcon />
             </IconButton>
           </TooltipTrigger>
           <TooltipContent>Manage GitHub Apps</TooltipContent>
         </Tooltip>
       </div>
 
-      <Modal isOpen={isManageOpen} onOpenChange={handleManageOpenChange}>
-        <ModalContent
-          title="Manage GitHub Apps"
-          subTitle="Create, inspect, and remove the GitHub Apps available to your connections."
+      <Dialog open={isManageOpen} onOpenChange={handleManageOpenChange}>
+        <DialogContent
           onOpenAutoFocus={(e) => {
             e.preventDefault();
             containerRef.current?.focus({ preventScroll: true });
           }}
+          className="max-w-xl"
         >
+          <DialogHeader>
+            <DialogTitle>Manage GitHub Apps</DialogTitle>
+            <DialogDescription>
+              Create, inspect, and remove the GitHub Apps available to your connections.
+            </DialogDescription>
+          </DialogHeader>
           <div
             ref={containerRef}
             tabIndex={-1}
-            className="overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 outline-none"
+            className="overflow-hidden rounded-md border border-border bg-container outline-none"
           >
             {mode === "create" ? (
               <div className="p-3">
-                <div className="mb-3 flex items-center gap-2 border-b border-mineshaft-600 pb-2 text-sm font-medium text-mineshaft-100">
-                  <button
-                    type="button"
-                    className="rounded p-1 text-mineshaft-300 hover:bg-mineshaft-600 hover:text-mineshaft-100"
+                <div className="mb-3 flex items-center gap-2 border-b border-border pb-2 text-sm font-medium text-foreground">
+                  <IconButton
+                    variant="ghost-muted"
+                    size="xs"
+                    aria-label="Back to list"
                     onClick={resetCreate}
                   >
-                    <FontAwesomeIcon icon={faChevronLeft} className="text-xs" />
-                  </button>
+                    <ChevronLeftIcon />
+                  </IconButton>
                   Create GitHub App
                 </div>
-                <FormControl
-                  label="App name"
-                  className="mb-1"
-                  helperText={
-                    <>
-                      {`${buildGitHubHostUrl(host).replace("https://", "")}/${
-                        instanceType === "server" ? "github-apps" : "apps"
-                      }/`}
-                      <span className="font-mono text-mineshaft-200">
-                        {GITHUB_APP_NAME_PREFIX}
-                        {newAppName.trim() ? slugify(newAppName, { lowercase: true }) : "your-app"}
-                      </span>
-                    </>
-                  }
-                >
+                <Field className="mb-1">
+                  <FieldLabel htmlFor="github-app-name">App name</FieldLabel>
                   <Input
+                    id="github-app-name"
                     ref={nameInputRef}
                     value={newAppName}
                     onChange={(e) => setNewAppName(e.target.value)}
                     placeholder="deploy-bot"
                     className="font-mono"
                   />
-                </FormControl>
-                <FormControl
-                  label="Organization"
-                  className="mt-3 mb-0"
-                  tooltipText="Enter a GitHub organization name to create the app under that organization. This is required if you want to install the app on repositories owned by the organization. Leave blank to create the app under your personal account."
-                >
+                  <FieldDescription>
+                    {`${buildGitHubHostUrl(host).replace("https://", "")}/${
+                      instanceType === "server" ? "github-apps" : "apps"
+                    }/`}
+                    <span className="font-mono text-foreground">
+                      {GITHUB_APP_NAME_PREFIX}
+                      {newAppName.trim() ? slugify(newAppName, { lowercase: true }) : "your-app"}
+                    </span>
+                  </FieldDescription>
+                </Field>
+                <Field className="mt-3 mb-0">
+                  <FieldLabel htmlFor="github-app-org">
+                    Organization
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Enter a GitHub organization name to create the app under that organization.
+                        This is required if you want to install the app on repositories owned by the
+                        organization. Leave blank to create the app under your personal account.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
+                    id="github-app-org"
                     value={newAppOrg}
                     onChange={(e) => setNewAppOrg(e.target.value)}
                     placeholder="Leave blank to create on your personal account"
                   />
-                </FormControl>
-                <div className="mt-3 flex items-start gap-2 rounded-md border border-mineshaft-500 bg-mineshaft-700/40 px-3 py-2.5 text-xs leading-relaxed text-mineshaft-300">
-                  <FontAwesomeIcon icon={faCircleInfo} className="mt-0.5 text-mineshaft-400" />
-                  <span>
-                    The app will be created on{" "}
-                    <span className="font-medium text-mineshaft-100">
-                      {buildGitHubHostUrl(host).replace("https://", "")}
-                    </span>
-                    {gatewayLabel ? (
-                      <>
-                        {" "}
-                        through the{" "}
-                        <span className="font-medium text-mineshaft-100">{gatewayLabel}</span>{" "}
-                        gateway
-                      </>
-                    ) : null}
-                    . You&apos;ll be redirected to complete the private app setup. GitHub fails the
-                    setup if you&apos;re signed out, so{" "}
-                    <a
-                      href={`${buildGitHubHostUrl(host)}/login`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-mineshaft-100 underline underline-offset-2 hover:text-primary"
-                    >
-                      sign in
-                    </a>{" "}
-                    first.
-                  </span>
-                </div>
+                </Field>
+                <Alert variant="info" className="mt-3">
+                  <InfoIcon />
+                  <AlertDescription>
+                    <p>
+                      The app will be created on{" "}
+                      <span className="font-medium text-foreground">
+                        {buildGitHubHostUrl(host).replace("https://", "")}
+                      </span>
+                      {gatewayLabel ? (
+                        <>
+                          {" "}
+                          through the{" "}
+                          <span className="font-medium text-foreground">{gatewayLabel}</span>{" "}
+                          gateway
+                        </>
+                      ) : null}
+                      . You&apos;ll be redirected to complete the private app setup. GitHub fails
+                      the setup if you&apos;re signed out, so{" "}
+                      <a
+                        href={`${buildGitHubHostUrl(host)}/login`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-2 hover:text-foreground"
+                      >
+                        sign in
+                      </a>{" "}
+                      first.
+                    </p>
+                  </AlertDescription>
+                </Alert>
                 <div className="mt-3 flex items-center justify-end gap-2">
-                  <Button variant="plain" colorSchema="secondary" size="xs" onClick={resetCreate}>
+                  <Button variant="ghost" size="sm" onClick={resetCreate}>
                     Cancel
                   </Button>
                   <Button
-                    colorSchema="secondary"
-                    size="xs"
+                    variant={scopeVariant}
+                    size="sm"
                     isDisabled={!newAppName.trim() || isCreating}
-                    isLoading={isCreating}
-                    leftIcon={<FontAwesomeIcon icon={faGithub} />}
+                    isPending={isCreating}
                     onClick={handleContinueCreate}
                   >
+                    <GithubIcon />
                     Continue on GitHub
                   </Button>
                 </div>
               </div>
             ) : (
               <>
-                <Command className="bg-transparent">
+                <Command className="h-auto bg-transparent">
                   <CommandList className="max-h-[360px]">
                     {sharedApp && (
                       <CommandGroup heading="INSTANCE">
@@ -454,14 +470,14 @@ export const GitHubAppSelector = ({
                           value={`instance server admin ${sharedApp.name}`}
                           className="group cursor-default"
                         >
-                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-mineshaft-600">
-                            <InstanceIcon className="size-4 text-mineshaft-200" />
+                          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm bg-foreground/10">
+                            <InstanceIcon className="size-4 text-foreground" />
                           </div>
                           <div className="min-w-0 flex-1">
-                            <p className="truncate font-mono text-sm text-mineshaft-100">
+                            <p className="truncate font-mono text-sm text-foreground">
                               {sharedApp.name}
                             </p>
-                            <p className="truncate text-xs text-mineshaft-400">
+                            <p className="truncate text-xs text-muted">
                               Server admin · {sharedApp.connectionCount} connection
                               {sharedApp.connectionCount === 1 ? "" : "s"}
                             </p>
@@ -469,9 +485,10 @@ export const GitHubAppSelector = ({
                           <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 data-[selected=true]:opacity-100">
                             <Tooltip>
                               <TooltipTrigger asChild>
-                                <button
-                                  type="button"
-                                  className="cursor-pointer rounded p-1 text-mineshaft-300 hover:bg-mineshaft-600 hover:text-mineshaft-100"
+                                <IconButton
+                                  variant="ghost-muted"
+                                  size="xs"
+                                  aria-label="Open on GitHub"
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     window.open(
@@ -485,11 +502,8 @@ export const GitHubAppSelector = ({
                                     );
                                   }}
                                 >
-                                  <FontAwesomeIcon
-                                    icon={faArrowUpRightFromSquare}
-                                    className="text-xs"
-                                  />
-                                </button>
+                                  <ExternalLinkIcon />
+                                </IconButton>
                               </TooltipTrigger>
                               <TooltipContent>Open on GitHub</TooltipContent>
                             </Tooltip>
@@ -502,7 +516,7 @@ export const GitHubAppSelector = ({
                         <span className="flex items-center gap-2">
                           PRIVATE
                           {customApps.length > 0 && (
-                            <span className="rounded-full bg-mineshaft-600 px-1.5 text-[10px] text-mineshaft-200">
+                            <span className="rounded-full bg-foreground/10 px-1.5 text-[10px] text-foreground">
                               {customApps.length}
                             </span>
                           )}
@@ -511,13 +525,11 @@ export const GitHubAppSelector = ({
                     >
                       {customApps.length === 0 && !isLoading ? (
                         <div className="flex flex-col items-center gap-2 px-4 py-6 text-center">
-                          <div className="flex h-12 w-12 items-center justify-center rounded-md bg-mineshaft-600 text-xl text-mineshaft-300">
-                            <FontAwesomeIcon icon={faGithub} />
+                          <div className="flex h-12 w-12 items-center justify-center rounded-md bg-foreground/10 text-accent">
+                            <GithubIcon className="size-6" />
                           </div>
-                          <p className="text-sm font-medium text-mineshaft-100">
-                            No private apps yet
-                          </p>
-                          <p className="max-w-[260px] text-xs leading-relaxed text-mineshaft-400">
+                          <p className="text-sm font-medium text-foreground">No private apps yet</p>
+                          <p className="max-w-[260px] text-xs leading-relaxed text-muted">
                             Create a dedicated GitHub App for tighter, per-team permission scoping.
                           </p>
                         </div>
@@ -532,27 +544,25 @@ export const GitHubAppSelector = ({
                 <button
                   type="button"
                   onClick={() => switchMode("create")}
-                  className="group flex w-full cursor-pointer items-center gap-2.5 border-t border-mineshaft-600 px-3 py-2.5 text-left hover:bg-foreground/5"
+                  className="group flex w-full cursor-pointer items-center gap-2.5 border-t border-border px-3 py-2.5 text-left hover:bg-foreground/5"
                 >
-                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm border border-mineshaft-500 text-mineshaft-200">
-                    <FontAwesomeIcon icon={faPlus} />
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-sm border border-border text-foreground">
+                    <PlusIcon className="size-4" />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-mineshaft-100">Create new GitHub App</p>
+                    <p className="text-sm font-medium text-foreground">Create new GitHub App</p>
                   </div>
                 </button>
               </>
             )}
           </div>
           <div className="mt-4 flex items-center justify-end">
-            <ModalClose asChild>
-              <Button colorSchema="secondary" variant="plain">
-                Close
-              </Button>
-            </ModalClose>
+            <DialogClose asChild>
+              <Button variant="outline">Close</Button>
+            </DialogClose>
           </div>
-        </ModalContent>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -12,14 +13,21 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { apiRequest } from "@app/config/request";
 import { useOrganization, useOrgPermission, useSubscription } from "@app/context";
@@ -39,6 +47,7 @@ import {
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import {
   GitHubConnectionMethod,
   TGitHubConnection,
@@ -50,6 +59,7 @@ import { gatewaysQueryKeys } from "@app/hooks/api/gateways/queries";
 import { TGitHubApp, useListGitHubApps } from "@app/hooks/api/gitHubApps";
 
 import { GitHubFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -112,6 +122,8 @@ type FormData = z.infer<typeof formSchema>;
 
 export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
+  const scopeVariant = useScopeVariant();
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [isEnterpriseEnabled, setIsEnterpriseEnabled] = useState(() =>
     Boolean(
@@ -432,20 +444,22 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
         <Accordion
           type="single"
           collapsible
+          variant="ghost"
           className="mb-4 w-full"
           value={isEnterpriseEnabled ? "enterprise-options" : ""}
           onValueChange={(value) => setIsEnterpriseEnabled(value === "enterprise-options")}
         >
-          <AccordionItem value="enterprise-options" className="data-[state=open]:border-none">
+          <AccordionItem value="enterprise-options">
             <AccordionTrigger className="h-fit flex-none pl-1 text-sm">
-              <div className="order-1 ml-3">GitHub Enterprise Options</div>
+              GitHub Enterprise Options
             </AccordionTrigger>
-            <AccordionContent childrenClassName="px-0">
+            <AccordionContent className="px-0">
               <Controller
                 name="credentials.instanceType"
                 control={control}
                 render={({ field }) => (
-                  <FormControl label="Instance Type">
+                  <Field className="mb-4">
+                    <FieldLabel>Instance Type</FieldLabel>
                     <Select
                       value={field.value}
                       onValueChange={(e) => {
@@ -455,16 +469,16 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
                           setValue("gatewayPoolId", null);
                         }
                       }}
-                      containerClassName="w-full"
-                      className="w-full border border-mineshaft-500"
-                      dropdownContainerClassName="max-w-none"
-                      placeholder="Enterprise Cloud"
-                      position="popper"
                     >
-                      <SelectItem value="cloud">Enterprise Cloud</SelectItem>
-                      <SelectItem value="server">Enterprise Server</SelectItem>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Enterprise Cloud" />
+                      </SelectTrigger>
+                      <SelectContent position="popper">
+                        <SelectItem value="cloud">Enterprise Cloud</SelectItem>
+                        <SelectItem value="server">Enterprise Server</SelectItem>
+                      </SelectContent>
                     </Select>
-                  </FormControl>
+                  </Field>
                 )}
               />
               <Controller
@@ -472,15 +486,19 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
                 control={control}
                 shouldUnregister
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Instance Hostname"
-                    isOptional={instanceType === "cloud"}
-                    isRequired={instanceType === "server"}
-                  >
-                    <Input {...field} placeholder="github.mycompany.com" />
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="github-host">
+                      Instance Hostname
+                      {instanceType === "cloud" && <span className="text-muted"> (optional)</span>}
+                    </FieldLabel>
+                    <Input
+                      id="github-host"
+                      {...field}
+                      placeholder="github.mycompany.com"
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
               {subscription.gateway && instanceType === "server" && (
@@ -489,26 +507,32 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
                   a={OrgPermissionSubjects.Gateway}
                 >
                   {(isAllowed) => (
-                    <FormControl label="Gateway">
-                      <Tooltip
-                        isDisabled={isAllowed}
-                        content="Restricted access. You don't have permission to attach gateways to resources."
-                      >
-                        <div>
-                          <GatewayPicker
-                            isDisabled={!isAllowed}
-                            value={{
-                              gatewayId: gatewayId ?? null,
-                              gatewayPoolId: gatewayPoolId ?? null
-                            }}
-                            onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                              setValue("gatewayId", newGwId, { shouldDirty: true });
-                              setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                            }}
-                          />
-                        </div>
+                    <Field className="mb-4">
+                      <FieldLabel>Gateway</FieldLabel>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div>
+                            <GatewayPicker
+                              isDisabled={!isAllowed}
+                              value={{
+                                gatewayId: gatewayId ?? null,
+                                gatewayPoolId: gatewayPoolId ?? null
+                              }}
+                              onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                                setValue("gatewayId", newGwId, { shouldDirty: true });
+                                setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                              }}
+                            />
+                          </div>
+                        </TooltipTrigger>
+                        {!isAllowed && (
+                          <TooltipContent>
+                            Restricted access. You don&apos;t have permission to attach gateways to
+                            resources.
+                          </TooltipContent>
+                        )}
                       </Tooltip>
-                    </FormControl>
+                    </Field>
                   )}
                 </OrgPermissionCan>
               )}
@@ -519,47 +543,62 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.GitHub].name
-              }. This field cannot be changed after creation.`}
-              errorText={getMethodErrorText(error)}
-              isError={Boolean(error?.message) || isMissingConfig || isCloudCustomHostUnsupported}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                containerClassName="w-full"
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(GitHubConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.GitHub].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  className="w-full"
+                  isError={
+                    Boolean(error?.message) || isMissingConfig || isCloudCustomHostUnsupported
+                  }
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(GitHubConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                       {method === GitHubConnectionMethod.App ? " (Recommended)" : ""}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError>{getMethodErrorText(error)}</FieldError>
+            </Field>
           )}
         />
         {selectedMethod === GitHubConnectionMethod.App && !isUpdate && (
-          <FormControl
-            label="GitHub App"
-            tooltipText={`Reuse an existing GitHub App from ${
-              // eslint-disable-next-line no-nested-ternary
-              projectId
-                ? canSeeOrgApps
-                  ? "this project or your organization"
-                  : "this project"
-                : "your organization"
-            }, or create a new one. Apps can be shared across multiple connections.`}
-          >
+          <Field className="mb-4">
+            <FieldLabel>
+              GitHub App
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-sm">
+                  Reuse an existing GitHub App from{" "}
+                  {/* eslint-disable-next-line no-nested-ternary */}
+                  {projectId
+                    ? canSeeOrgApps
+                      ? "this project or your organization"
+                      : "this project"
+                    : "your organization"}
+                  , or create a new one. Apps can be shared across multiple connections.
+                </TooltipContent>
+              </Tooltip>
+            </FieldLabel>
             <GitHubAppSelector
               apps={gitHubApps}
               isLoading={isGitHubAppsLoading}
@@ -572,7 +611,7 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
               isCreating={isRedirecting}
               projectId={projectId}
             />
-          </FormControl>
+          </Field>
         )}
         {selectedMethod === GitHubConnectionMethod.Pat && (
           <Controller
@@ -580,27 +619,19 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
             control={control}
             shouldUnregister
             render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Personal Access Token"
-              >
-                <SecretInput
-                  containerClassName="text-gray-400 group-focus-within:!border-primary-400/50 border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel>Personal Access Token</FieldLabel>
+                <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         )}
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={
               (!isUpdate && !isDirty && !isResumed) ||
               isSubmitting ||
@@ -612,12 +643,15 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
           >
             {getButtonText()}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubRadarConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubRadarConnectionForm.tsx
@@ -3,15 +3,31 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, ModalClose, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import {
   GitHubRadarConnectionMethod,
   TGitHubRadarConnection,
@@ -20,6 +36,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { GitHubRadarFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -39,6 +56,8 @@ type FormData = z.infer<typeof formSchema>;
 
 export const GitHubRadarConnectionForm = ({ appConnection, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
+  const scopeVariant = useScopeVariant();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -104,6 +123,17 @@ export const GitHubRadarConnectionForm = ({ appConnection, projectId }: Props) =
 
   const methodDetails = getAppConnectionMethodDetails(selectedMethod);
 
+  const getMethodErrorText = (fieldError?: { message?: string }) => {
+    if (!isLoading && isMissingConfig) {
+      return `Environment variables have not been configured. ${
+        isInfisicalCloud()
+          ? "Please contact Infisical."
+          : `See Docs to configure GitHub Radar ${methodDetails.name} Connections.`
+      }`;
+    }
+    return fieldError?.message;
+  };
+
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -112,58 +142,57 @@ export const GitHubRadarConnectionForm = ({ appConnection, projectId }: Props) =
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.GitHubRadar].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig
-                  ? `Environment variables have not been configured. ${
-                      isInfisicalCloud()
-                        ? "Please contact Infisical."
-                        : `See Docs to configure GitHub Radar ${methodDetails.name} Connections.`
-                    }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(GitHubRadarConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.GitHubRadar].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger
+                  className="w-full"
+                  isError={Boolean(error?.message) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(GitHubRadarConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError>{getMethodErrorText(error)}</FieldError>
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={isSubmitting || (!isUpdate && !isDirty) || isMissingConfig || isRedirecting}
           >
             {isUpdate ? "Reconnect to GitHub" : "Connect to GitHub"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitLabConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitLabConnectionForm.tsx
@@ -5,23 +5,33 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import { useGetAppConnectionOption } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { GitLabAccessTokenType } from "@app/hooks/api/appConnections/gitlab";
@@ -31,6 +41,7 @@ import {
 } from "@app/hooks/api/appConnections/types/gitlab-connection";
 
 import { GitLabFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -80,6 +91,8 @@ type FormData = z.infer<typeof formSchema>;
 
 export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
+  const scopeVariant = useScopeVariant();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const {
@@ -187,6 +200,17 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
 
   const methodDetails = getAppConnectionMethodDetails(selectedMethod);
 
+  const getMethodErrorText = (fieldError?: { message?: string }) => {
+    if (!isLoading && isMissingConfig && selectedMethod === GitLabConnectionMethod.OAuth) {
+      return `${
+        isInfisicalCloud()
+          ? "GitLab Oauth is not supported in Infisical Cloud."
+          : `Environment variables have not been configured. See Docs to configure GitLab ${methodDetails.name} Connections.`
+      }`;
+    }
+    return fieldError?.message;
+  };
+
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -196,18 +220,27 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
           name="credentials.instanceUrl"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              label="Self-hosted URL (optional)"
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              tooltipText="Will default to GitLab Cloud if not specified."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="gitlab-instance-url">
+                Self-hosted URL <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Will default to GitLab Cloud if not specified.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="gitlab-instance-url"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="https://gitlab.com"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -215,24 +248,22 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.GitLab].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig && selectedMethod === GitLabConnectionMethod.OAuth
-                  ? `${
-                      isInfisicalCloud()
-                        ? "GitLab Oauth is not supported in Infisical Cloud."
-                        : `Environment variables have not been configured. See Docs to configure GitLab ${methodDetails.name} Connections.`
-                    }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.GitLab].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Select
-                isDisabled={isUpdate}
+                disabled={isUpdate}
                 value={value}
                 onValueChange={(val) => {
                   onChange(val);
@@ -240,20 +271,24 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
                     setValue("credentials.code", "custom");
                   }
                 }}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
               >
-                {Object.values(GitLabConnectionMethod).map((method) => {
-                  return (
+                <SelectTrigger
+                  className="w-full"
+                  isError={Boolean(error?.message) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(GitLabConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                       {method === GitLabConnectionMethod.AccessToken ? " (Recommended)" : ""}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError>{getMethodErrorText(error)}</FieldError>
+            </Field>
           )}
         />
 
@@ -263,13 +298,10 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
               name="credentials.accessTokenType"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Access Token Type"
-                >
+                <Field className="mb-4">
+                  <FieldLabel>Access Token Type</FieldLabel>
                   <Select
-                    isDisabled={isUpdate}
+                    disabled={isUpdate}
                     value={value}
                     onValueChange={(val) => {
                       onChange(val);
@@ -277,49 +309,49 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
                         setValue("credentials.code", "custom");
                       }
                     }}
-                    className="w-full border border-mineshaft-500"
-                    position="popper"
-                    dropdownContainerClassName="max-w-none"
                   >
-                    {Object.values(GitLabAccessTokenType).map((method) => {
-                      return (
+                    <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                      <SelectValue placeholder="Select a type..." />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
+                      {Object.values(GitLabAccessTokenType).map((method) => (
                         <SelectItem value={method} key={method}>
                           {method.charAt(0).toUpperCase() + method.slice(1)} Access Token
                         </SelectItem>
-                      );
-                    })}
+                      ))}
+                    </SelectContent>
                   </Select>
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
               name="credentials.accessToken"
               control={control}
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  label="Access Token"
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  tooltipText="Your GitLab Access Token"
-                >
-                  <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
-                  />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="gitlab-access-token">
+                    Access Token
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">Your GitLab Access Token</TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
 
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={
               isSubmitting ||
               (!isUpdate && !isDirty) ||
@@ -333,12 +365,15 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
                 ? "Reconnect to GitLab"
                 : "Connect to GitLab"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GoDaddyConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GoDaddyConnectionForm.tsx
@@ -1,16 +1,24 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -18,6 +26,7 @@ import {
   TGoDaddyConnection
 } from "@app/hooks/api/appConnections/types/godaddy-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -56,11 +65,7 @@ export const GoDaddyConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -70,31 +75,36 @@ export const GoDaddyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.GoDaddy].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(GoDaddyConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.GoDaddy].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger id="method" className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(GoDaddyConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -102,14 +112,21 @@ export const GoDaddyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-              helperText="Generate an API key and secret at developer.godaddy.com under Keys."
-            >
-              <Input value={value} onChange={(e) => onChange(e.target.value)} />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">API Key</FieldLabel>
+              <Input
+                id="api-key"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error)}
+              />
+              {!error && (
+                <FieldDescription>
+                  Generate an API key and secret at developer.godaddy.com under Keys.
+                </FieldDescription>
+              )}
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -117,36 +134,20 @@ export const GoDaddyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Secret"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-secret">API Secret</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-secret"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to GoDaddy"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to GoDaddy"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HCVaultConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HCVaultConnectionForm.tsx
@@ -1,18 +1,24 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -23,6 +29,7 @@ import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/
 import { HCVaultConnectionMethod, THCVaultConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -80,13 +87,7 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const selectedMethod = watch("method");
   const gatewayId = watch("gatewayId");
@@ -102,32 +103,37 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.HCVault].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(HCVaultConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                      {method === HCVaultConnectionMethod.AppRole ? " (Recommended)" : ""}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.HCVault].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(HCVaultConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                        {method === HCVaultConnectionMethod.AppRole ? " (Recommended)" : ""}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         {subscription.gateway && (
@@ -136,23 +142,41 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
-                </Tooltip>
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                {isAllowed ? (
+                  <GatewayPicker
+                    isDisabled={!isAllowed}
+                    value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                    onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                      setValue("gatewayId", newGwId, { shouldDirty: true });
+                      setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                    }}
+                  />
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <GatewayPicker
+                          isDisabled={!isAllowed}
+                          value={{
+                            gatewayId: gatewayId ?? null,
+                            gatewayPoolId: gatewayPoolId ?? null
+                          }}
+                          onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                            setValue("gatewayId", newGwId, { shouldDirty: true });
+                            setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                          }}
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -161,15 +185,26 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="The URL at which your Hashicorp Vault instance is hosted."
-            >
-              <Input {...field} placeholder="https://vault.example.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-instance-url">
+                Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The URL at which your Hashicorp Vault instance is hosted.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="credentials-instance-url"
+                {...field}
+                placeholder="https://vault.example.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -177,16 +212,26 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Namespace"
-              isOptional
-              tooltipClassName="max-w-sm"
-              tooltipText="On self-hosted and enterprise clusters there may not be namespaces."
-            >
-              <Input {...field} placeholder="admin" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-namespace">
+                Namespace <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    On self-hosted and enterprise clusters there may not be namespaces.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="credentials-namespace"
+                {...field}
+                placeholder="admin"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         {selectedMethod === HCVaultConnectionMethod.AccessToken ? (
@@ -195,16 +240,11 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
             control={control}
             shouldUnregister
             render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Access Token"
-              >
-                <SecretInput
-                  {...field}
-                  containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel>Access Token</FieldLabel>
+                <SecretInput {...field} />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         ) : (
@@ -214,13 +254,16 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Role ID"
-                >
-                  <Input {...field} placeholder="00000000-0000-0000-0000-000000000000" />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials-role-id">Role ID</FieldLabel>
+                  <Input
+                    id="credentials-role-id"
+                    {...field}
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
@@ -228,37 +271,18 @@ export const HCVaultConnectionForm = ({ appConnection, onSubmit }: Props) => {
               control={control}
               shouldUnregister
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Secret ID"
-                >
-                  <SecretInput
-                    {...field}
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                  />
-                </FormControl>
+                <Field className="mb-4">
+                  <FieldLabel>Secret ID</FieldLabel>
+                  <SecretInput {...field} />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
           </>
         )}
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Hashicorp Vault"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Hashicorp Vault"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HerokuAppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HerokuAppConnectionForm.tsx
@@ -5,22 +5,32 @@ import crypto from "crypto";
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
   Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   APP_CONNECTION_MAP,
   getAppConnectionMethodDetails,
   useGetAppConnectionOauthReturnUrl
 } from "@app/helpers/appConnections";
 import { isInfisicalCloud } from "@app/helpers/platform";
+import { useScopeVariant } from "@app/hooks";
 import { useGetAppConnectionOption } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -28,6 +38,7 @@ import {
   THerokuConnection
 } from "@app/hooks/api/appConnections/types/heroku-connection";
 
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -60,6 +71,8 @@ type FormData = z.infer<typeof formSchema>;
 
 export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, projectId }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
+  const scopeVariant = useScopeVariant();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
   const returnUrl = useGetAppConnectionOauthReturnUrl();
@@ -156,6 +169,17 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
 
   const methodDetails = getAppConnectionMethodDetails(selectedMethod);
 
+  const getMethodErrorText = (fieldError?: { message?: string }) => {
+    if (!isLoading && isMissingConfig && selectedMethod === HerokuConnectionMethod.OAuth) {
+      return `Environment variables have not been configured. ${
+        isInfisicalCloud()
+          ? "Please contact Infisical."
+          : `See Docs to configure Heroku ${methodDetails.name} Connections.`
+      }`;
+    }
+    return fieldError?.message;
+  };
+
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
@@ -165,24 +189,22 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Heroku].name
-              }. This field cannot be changed after creation.`}
-              errorText={
-                !isLoading && isMissingConfig && selectedMethod === HerokuConnectionMethod.OAuth
-                  ? `Environment variables have not been configured. ${
-                      isInfisicalCloud()
-                        ? "Please contact Infisical."
-                        : `See Docs to configure Heroku ${methodDetails.name} Connections.`
-                    }`
-                  : error?.message
-              }
-              isError={Boolean(error?.message) || isMissingConfig}
-              label="Method"
-            >
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Heroku].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Select
-                isDisabled={isUpdate}
+                disabled={isUpdate}
                 value={value}
                 onValueChange={(val) => {
                   onChange(val);
@@ -190,20 +212,24 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
                     setValue("credentials.code", "custom");
                   }
                 }}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
               >
-                {Object.values(HerokuConnectionMethod).map((method) => {
-                  return (
+                <SelectTrigger
+                  className="w-full"
+                  isError={Boolean(error?.message) || isMissingConfig}
+                >
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(HerokuConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                       {method === HerokuConnectionMethod.AuthToken ? " (Recommended)" : ""}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError>{getMethodErrorText(error)}</FieldError>
+            </Field>
           )}
         />
 
@@ -212,29 +238,28 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
             name="credentials.authToken"
             control={control}
             render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                label="Auth Token"
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                tooltipText="Your Heroku Auth Token"
-              >
-                <SecretInput
-                  containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel htmlFor="heroku-auth-token">
+                  Auth Token
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">Your Heroku Auth Token</TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         )}
 
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting || isRedirecting}
+            variant={scopeVariant}
+            isPending={isSubmitting || isRedirecting}
             isDisabled={
               isSubmitting ||
               (!isUpdate && !isDirty) ||
@@ -248,12 +273,15 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
                 ? "Reconnect to Heroku"
                 : "Connect to Heroku"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            isDisabled={isSubmitting || isRedirecting}
+          >
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HumanitecConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HumanitecConnectionForm.tsx
@@ -1,19 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { HumanitecConnectionMethod, THumanitecConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -50,11 +58,7 @@ export const HumanitecConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -64,31 +68,36 @@ export const HumanitecConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Humanitec].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(HumanitecConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Humanitec].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(HumanitecConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -96,36 +105,16 @@ export const HumanitecConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Service API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>Service API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Humanitec"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Humanitec"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/LaravelForgeConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/LaravelForgeConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import {
   LaravelForgeConnectionMethod,
@@ -17,6 +24,7 @@ import {
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const LaravelForgeConnectionForm = ({ appConnection, onSubmit }: Props) =
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,31 +72,36 @@ export const LaravelForgeConnectionForm = ({ appConnection, onSubmit }: Props) =
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.LaravelForge].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(LaravelForgeConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.LaravelForge].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(LaravelForgeConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -100,36 +109,16 @@ export const LaravelForgeConnectionForm = ({ appConnection, onSubmit }: Props) =
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:!border-primary-400/50 border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Laravel Forge"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Laravel Forge"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/LdapConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/LdapConnectionForm.tsx
@@ -1,29 +1,40 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { OrgPermissionSubjects, useSubscription } from "@app/context";
 import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { DistinguishedNameRegex, UserPrincipalNameRegex } from "@app/helpers/string";
+import { useScopeVariant } from "@app/hooks";
 import {
   LdapConnectionMethod,
   LdapConnectionProvider,
@@ -31,6 +42,7 @@ import {
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -81,7 +93,7 @@ type FormData = z.infer<typeof formSchema>;
 
 export const LdapConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [selectedTab, setSelectedTab] = useState("configuration");
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -101,13 +113,8 @@ export const LdapConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    formState: { isSubmitting, isDirty },
-    watch
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
+  const scopeVariant = useScopeVariant();
 
   const selectedProvider = watch("credentials.provider");
   const sslEnabled = watch("credentials.url")?.startsWith("ldaps://") ?? false;
@@ -119,7 +126,7 @@ export const LdapConnectionForm = ({ appConnection, onSubmit }: Props) => {
     <FormProvider {...form}>
       <form
         onSubmit={(e) => {
-          setSelectedTabIndex(0);
+          setSelectedTab("configuration");
           handleSubmit(onSubmit)(e);
         }}
       >
@@ -130,23 +137,41 @@ export const LdapConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
-                </Tooltip>
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                {isAllowed ? (
+                  <GatewayPicker
+                    isDisabled={!isAllowed}
+                    value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                    onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                      setValue("gatewayId", newGwId, { shouldDirty: true });
+                      setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                    }}
+                  />
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <GatewayPicker
+                          isDisabled={!isAllowed}
+                          value={{
+                            gatewayId: gatewayId ?? null,
+                            gatewayPoolId: gatewayPoolId ?? null
+                          }}
+                          onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                            setValue("gatewayId", newGwId, { shouldDirty: true });
+                            setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                          }}
+                        />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -155,215 +180,172 @@ export const LdapConnectionForm = ({ appConnection, onSubmit }: Props) => {
             name="method"
             control={control}
             render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                tooltipText={`The method you would like to use to connect with ${
-                  APP_CONNECTION_MAP[AppConnection.LDAP].name
-                }. This field cannot be changed after creation.`}
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Method"
-              >
-                <Select
-                  isDisabled={isUpdate}
-                  value={value}
-                  onValueChange={(val) => onChange(val)}
-                  className="w-full border border-mineshaft-500"
-                  position="popper"
-                  dropdownContainerClassName="max-w-none"
-                >
-                  {Object.values(LdapConnectionMethod).map((method) => {
-                    return (
-                      <SelectItem value={method} key={method}>
-                        {getAppConnectionMethodDetails(method).name}
-                      </SelectItem>
-                    );
-                  })}
+              <Field className="mb-4">
+                <FieldLabel>
+                  Method
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">
+                      {`The method you would like to use to connect with ${
+                        APP_CONNECTION_MAP[AppConnection.LDAP].name
+                      }. This field cannot be changed after creation.`}
+                    </TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                  <SelectTrigger className="w-full" isError={Boolean(error)}>
+                    <SelectValue placeholder="Select a method..." />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    {Object.values(LdapConnectionMethod).map((method) => {
+                      return (
+                        <SelectItem value={method} key={method}>
+                          {getAppConnectionMethodDetails(method).name}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
                 </Select>
-              </FormControl>
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
           <Controller
             name="credentials.provider"
             control={control}
             render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="LDAP Provider"
-              >
-                <Select
-                  isDisabled={isUpdate}
-                  value={value}
-                  onValueChange={(val) => onChange(val)}
-                  className="w-full border border-mineshaft-500 capitalize"
-                  position="popper"
-                  dropdownContainerClassName="max-w-none"
-                >
-                  {Object.values(LdapConnectionProvider).map((provider) => {
-                    return (
-                      <SelectItem value={provider} className="capitalize" key={provider}>
-                        {provider.replace("-", " ")}
-                      </SelectItem>
-                    );
-                  })}
+              <Field className="mb-4">
+                <FieldLabel>LDAP Provider</FieldLabel>
+                <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                  <SelectTrigger className="w-full capitalize" isError={Boolean(error)}>
+                    <SelectValue placeholder="Select a provider..." />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    {Object.values(LdapConnectionProvider).map((provider) => {
+                      return (
+                        <SelectItem value={provider} className="capitalize" key={provider}>
+                          {provider.replace("-", " ")}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
                 </Select>
-              </FormControl>
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         </div>
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List
-            className={`-pb-1 ${selectedTabIndex === 1 ? "mb-3" : "mb-6"} w-full border-b-2 border-mineshaft-600`}
-          >
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              SSL ({sslEnabled ? "Enabled" : "Disabled"})
-            </Tab>
-          </Tab.List>
-          {selectedTabIndex === 1 && (
-            <div className="mb-2 text-xs text-mineshaft-300">Requires ldaps:// URL</div>
-          )}
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="mb-4">
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="ssl">SSL ({sslEnabled ? "Enabled" : "Disabled"})</TabsTrigger>
+          </TabsList>
+          <TabsContent value="configuration">
+            <Controller
+              name="credentials.url"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials-url">LDAP URL</FieldLabel>
+                  <Input
+                    id="credentials-url"
+                    {...field}
+                    placeholder="ldap://domain-or-ip:389"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-2">
               <Controller
-                name="credentials.url"
+                name="credentials.dn"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="LDAP URL"
-                  >
-                    <Input {...field} placeholder="ldap://domain-or-ip:389" />
-                  </FormControl>
-                )}
-              />
-              <div className="grid grid-cols-2 gap-2">
-                <Controller
-                  name="credentials.dn"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Binding DN/UPN"
-                    >
-                      <Input {...field} placeholder="CN=John,OU=Users,DC=example,DC=com" />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Binding Password"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-            </Tab.Panel>
-            <Tab.Panel>
-              <Controller
-                name="credentials.sslCertificate"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    className={sslEnabled ? "" : "opacity-50"}
-                    label="SSL Certificate"
-                    isOptional
-                  >
-                    <TextArea
-                      className="h-[3.6rem] resize-none!"
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials-dn">Binding DN/UPN</FieldLabel>
+                    <Input
+                      id="credentials-dn"
                       {...field}
-                      isDisabled={!sslEnabled}
+                      placeholder="CN=John,OU=Users,DC=example,DC=com"
+                      isError={Boolean(error?.message)}
                     />
-                  </FormControl>
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
               <Controller
-                name="credentials.sslRejectUnauthorized"
+                name="credentials.password"
                 control={control}
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    className={sslEnabled ? "" : "opacity-50"}
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="ssl-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={sslEnabled ? value : false}
-                      onCheckedChange={onChange}
-                      isDisabled={!sslEnabled}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the server if it has a
-                              valid, trusted SSL certificate.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel>Binding Password</FieldLabel>
+                    <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4 capitalize"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : `Connect to ${selectedProvider.replace("-", " ")}`}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="ssl">
+            <p className="mb-3 text-xs text-muted">Requires ldaps:// URL</p>
+            <Controller
+              name="credentials.sslCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className={sslEnabled ? "mb-4" : "mb-4 opacity-50"}>
+                  <FieldLabel htmlFor="ssl-certificate">
+                    SSL Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="ssl-certificate"
+                    className="h-[3.6rem] resize-none!"
+                    {...field}
+                    disabled={!sslEnabled}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className={sslEnabled ? undefined : "opacity-50"}>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the server if it has a valid,
+                        trusted SSL certificate.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      id="ssl-reject-unauthorized"
+                      variant={scopeVariant}
+                      checked={sslEnabled ? value : false}
+                      onCheckedChange={onChange}
+                      disabled={!sslEnabled}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
+        <AppConnectionFormFooter
+          submitLabel={
+            isUpdate
+              ? "Update Credentials"
+              : `Connect to ${selectedProvider
+                  .replace("-", " ")
+                  .replace(/\b\w/g, (char) => char.toUpperCase())}`
+          }
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MongoDBConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MongoDBConnectionForm.tsx
@@ -1,27 +1,39 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { MongoDBConnectionMethod, TMongoDBConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -58,6 +70,9 @@ const formSchema = z.discriminatedUnion("method", [
 
 type FormData = z.infer<typeof formSchema>;
 
+const CONFIGURATION_TAB = "configuration";
+const TLS_TAB = "tls";
+
 export const MongoDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -80,12 +95,8 @@ export const MongoDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    watch,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, watch, control } = form;
+  const scopeVariant = useScopeVariant();
 
   const tlsEnabled = watch("credentials.tlsEnabled");
 
@@ -97,229 +108,183 @@ export const MongoDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.MongoDB].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(MongoDBConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.MongoDB].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(MongoDBConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List className="-pb-1 mb-6 w-full border-b-2 border-mineshaft-600">
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              TLS ({tlsEnabled ? "Enabled" : "Disabled"})
-            </Tab>
-          </Tab.List>
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
-              <div className="mt-[0.675rem] flex items-start gap-2">
-                <Controller
-                  name="credentials.host"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      className="flex-1"
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Host"
-                    >
-                      <Input {...field} />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.database"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      className="flex-1"
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Database"
-                    >
-                      <Input {...field} />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.port"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      className="w-28"
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Port"
-                    >
-                      <Input type="number" {...field} />
-                    </FormControl>
-                  )}
-                />
-              </div>
-              <div className="mb-[0.675rem] flex items-start gap-2">
-                <Controller
-                  name="credentials.username"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Username"
-                      className="flex-1"
-                    >
-                      <Input {...field} />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Password"
-                      className="flex-1"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 w-full group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-            </Tab.Panel>
-            <Tab.Panel>
+        <Tabs
+          value={selectedTabIndex === 0 ? CONFIGURATION_TAB : TLS_TAB}
+          onValueChange={(val) => setSelectedTabIndex(val === CONFIGURATION_TAB ? 0 : 1)}
+          className="mb-4"
+        >
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value={CONFIGURATION_TAB}>Configuration</TabsTrigger>
+            <TabsTrigger value={TLS_TAB}>TLS ({tlsEnabled ? "Enabled" : "Disabled"})</TabsTrigger>
+          </TabsList>
+          <TabsContent value={CONFIGURATION_TAB}>
+            <div className="flex items-start gap-2">
               <Controller
-                name="credentials.tlsEnabled"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="tls-enabled"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                    >
-                      Enable TLS
-                    </Switch>
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.tlsCertificate"
+                name="credentials.host"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    className={tlsEnabled ? "" : "opacity-50"}
-                    label="TLS Certificate"
-                    isOptional
-                  >
-                    <TextArea className="h-14 resize-none!" {...field} isDisabled={!tlsEnabled} />
-                  </FormControl>
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="mongo-host">Host</FieldLabel>
+                    <Input id="mongo-host" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
               <Controller
-                name="credentials.tlsRejectUnauthorized"
+                name="credentials.database"
                 control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    className={tlsEnabled ? "" : "opacity-50"}
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="tls-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={tlsEnabled ? value : false}
-                      onCheckedChange={onChange}
-                      isDisabled={!tlsEnabled}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the server if it has a
-                              valid, trusted TLS certificate.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="mongo-database">Database</FieldLabel>
+                    <Input id="mongo-database" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
+              <Controller
+                name="credentials.port"
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="w-28">
+                    <FieldLabel htmlFor="mongo-port">Port</FieldLabel>
+                    <Input
+                      id="mongo-port"
+                      type="number"
+                      {...field}
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </div>
+            <div className="mt-4 flex items-start gap-2">
+              <Controller
+                name="credentials.username"
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="mongo-username">Username</FieldLabel>
+                    <Input id="mongo-username" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+              <Controller
+                name="credentials.password"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field className="flex-1">
+                    <FieldLabel>Password</FieldLabel>
+                    <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value={TLS_TAB}>
+            <Controller
+              name="credentials.tlsEnabled"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="tls-enabled">Enable TLS</Label>
+                    </FieldContent>
+                    <Switch
+                      id="tls-enabled"
+                      variant={scopeVariant}
+                      checked={value}
+                      onCheckedChange={onChange}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.tlsCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className={tlsEnabled ? "mb-4" : "mb-4 opacity-50"}>
+                  <FieldLabel htmlFor="tls-certificate">
+                    TLS Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="tls-certificate"
+                    className="h-14 resize-none"
+                    {...field}
+                    disabled={!tlsEnabled}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.tlsRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className={tlsEnabled ? undefined : "opacity-50"}>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="tls-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the server if it has a valid,
+                        trusted TLS certificate.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      id="tls-reject-unauthorized"
+                      variant={scopeVariant}
+                      checked={tlsEnabled ? value : false}
+                      onCheckedChange={onChange}
+                      disabled={!tlsEnabled}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
 
-        <div className="mt-6 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Database"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MsSqlConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MsSqlConnectionForm.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, ModalClose, Select, SelectItem, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -19,6 +32,7 @@ import {
 } from "@app/hooks/api/appConnections/types/mssql-connection";
 import { PlatformManagedConfirmationModal } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -73,13 +87,7 @@ export const MsSqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const { subscription } = useSubscription();
   const isPlatformManagedCredentials = appConnection?.isPlatformManagedCredentials ?? false;
@@ -110,23 +118,32 @@ export const MsSqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -134,31 +151,34 @@ export const MsSqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.MsSql].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(MsSqlConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.MsSql].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(MsSqlConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <SqlConnectionFields
@@ -169,23 +189,9 @@ export const MsSqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
         {isPlatformManagedCredentials ? (
           <PlatformManagedNoticeBanner />
         ) : (
-          <div className="mt-6 flex items-center">
-            <Button
-              className="mr-4"
-              size="sm"
-              type="submit"
-              colorSchema="secondary"
-              isLoading={isSubmitting}
-              isDisabled={isSubmitting || !isDirty}
-            >
-              {isUpdate ? "Update Credentials" : "Connect to Database"}
-            </Button>
-            <ModalClose asChild>
-              <Button colorSchema="secondary" variant="plain">
-                Cancel
-              </Button>
-            </ModalClose>
-          </div>
+          <AppConnectionFormFooter
+            submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+          />
         )}
       </form>
       <PlatformManagedConfirmationModal

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MySqlConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MySqlConnectionForm.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, ModalClose, Select, SelectItem, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -16,6 +29,7 @@ import { MySqlConnectionMethod, TMySqlConnection } from "@app/hooks/api/appConne
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { PlatformManagedConfirmationModal } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -70,13 +84,7 @@ export const MySqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const { subscription } = useSubscription();
   const isPlatformManagedCredentials = appConnection?.isPlatformManagedCredentials ?? false;
@@ -107,23 +115,32 @@ export const MySqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -131,31 +148,34 @@ export const MySqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.MySql].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(MySqlConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.MySql].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(MySqlConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <SqlConnectionFields
@@ -166,23 +186,9 @@ export const MySqlConnectionForm = ({ appConnection, onSubmit }: Props) => {
         {isPlatformManagedCredentials ? (
           <PlatformManagedNoticeBanner />
         ) : (
-          <div className="mt-6 flex items-center">
-            <Button
-              className="mr-4"
-              size="sm"
-              type="submit"
-              colorSchema="secondary"
-              isLoading={isSubmitting}
-              isDisabled={isSubmitting || !isDirty}
-            >
-              {isUpdate ? "Update Credentials" : "Connect to Database"}
-            </Button>
-            <ModalClose asChild>
-              <Button colorSchema="secondary" variant="plain">
-                Cancel
-              </Button>
-            </ModalClose>
-          </div>
+          <AppConnectionFormFooter
+            submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+          />
         )}
       </form>
       <PlatformManagedConfirmationModal

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NetScalerConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NetScalerConnectionForm.tsx
@@ -1,31 +1,43 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { OrgPermissionSubjects } from "@app/context";
 import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { NetScalerConnectionMethod, TNetScalerConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -77,7 +89,7 @@ type FormData = z.infer<typeof formSchema>;
 
 export const NetScalerConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [selectedTab, setSelectedTab] = useState("configuration");
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -93,13 +105,8 @@ export const NetScalerConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
+  const scopeVariant = useScopeVariant();
 
   const gatewayId = watch("gatewayId");
   const gatewayPoolId = watch("gatewayPoolId");
@@ -113,228 +120,203 @@ export const NetScalerConnectionForm = ({ appConnection, onSubmit }: Props) => {
           a={OrgPermissionSubjects.Gateway}
         >
           {(isAllowed) => (
-            <FormControl label="Gateway">
-              <Tooltip
-                isDisabled={isAllowed}
-                content="Restricted access. You don't have permission to attach gateways to resources."
-              >
-                <div>
-                  <GatewayPicker
-                    isDisabled={!isAllowed}
-                    value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                    onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                      setValue("gatewayId", newGwId, { shouldDirty: true });
-                      setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                    }}
-                  />
-                </div>
-              </Tooltip>
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>Gateway</FieldLabel>
+              {isAllowed ? (
+                <GatewayPicker
+                  isDisabled={!isAllowed}
+                  value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                  onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                    setValue("gatewayId", newGwId, { shouldDirty: true });
+                    setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                  }}
+                />
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Restricted access. You don&apos;t have permission to attach gateways to
+                    resources.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </Field>
           )}
         </OrgPermissionCan>
         <Controller
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.NetScaler].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(NetScalerConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.NetScaler].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(NetScalerConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List className="mb-3 flex w-full gap-4 border-b border-mineshaft-600">
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              SSL
-            </Tab>
-          </Tab.List>
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="mb-4">
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value="configuration">Configuration</TabsTrigger>
+            <TabsTrigger value="ssl">SSL</TabsTrigger>
+          </TabsList>
+          <TabsContent value="configuration">
+            <Controller
+              name="credentials.hostname"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials-hostname">Hostname</FieldLabel>
+                  <Input
+                    id="credentials-hostname"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder="e.g. ns.example.com"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-2">
               <Controller
-                name="credentials.hostname"
+                name="credentials.username"
                 control={control}
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Hostname"
-                  >
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials-username">Username</FieldLabel>
                     <Input
+                      id="credentials-username"
                       value={value}
                       onChange={(e) => onChange(e.target.value)}
-                      placeholder="e.g. ns.example.com"
+                      placeholder="nsroot"
+                      isError={Boolean(error?.message)}
                     />
-                  </FormControl>
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-              <div className="grid grid-cols-2 gap-2">
-                <Controller
-                  name="credentials.username"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Username"
-                    >
-                      <Input
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                        placeholder="nsroot"
-                      />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Password"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
               <Controller
-                name="credentials.port"
+                name="credentials.password"
                 control={control}
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Port"
-                    isOptional
-                  >
-                    <Input
-                      type="number"
-                      value={value ?? ""}
-                      onChange={(e) =>
-                        onChange(e.target.value ? Number(e.target.value) : undefined)
-                      }
-                      placeholder="443"
-                    />
-                  </FormControl>
+                  <Field className="mb-4">
+                    <FieldLabel>Password</FieldLabel>
+                    <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-            <Tab.Panel>
-              <Controller
-                name="credentials.sslCertificate"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
+            </div>
+            <Controller
+              name="credentials.port"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="credentials-port">
+                    Port <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <Input
+                    id="credentials-port"
+                    type="number"
+                    value={value ?? ""}
+                    onChange={(e) => onChange(e.target.value ? Number(e.target.value) : undefined)}
+                    placeholder="443"
                     isError={Boolean(error?.message)}
-                    label="SSL Certificate"
-                    isOptional
-                  >
-                    <TextArea
-                      className="h-[3.6rem] resize-none!"
-                      {...field}
-                      placeholder="-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
-                    />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.sslRejectUnauthorized"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+          <TabsContent value="ssl">
+            <Controller
+              name="credentials.sslCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="ssl-certificate">
+                    SSL Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="ssl-certificate"
+                    className="h-[3.6rem] resize-none!"
+                    {...field}
+                    placeholder="-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the NetScaler if it has a valid,
+                        trusted SSL certificate. Disable this for self-signed certificates or
+                        provide a CA certificate above.
+                      </FieldDescription>
+                    </FieldContent>
                     <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
                       id="ssl-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={value}
+                      variant={scopeVariant}
+                      checked={value}
                       onCheckedChange={onChange}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the NetScaler if it has a
-                              valid, trusted SSL certificate. Disable this for self-signed
-                              certificates or provide a CA certificate above.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
-                )}
-              />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to NetScaler"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to NetScaler"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NetlifyConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NetlifyConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TNetlifyConnection
 } from "@app/hooks/api/appConnections/types/netlify-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const NetlifyConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const NetlifyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The auth method you would like to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Netlify].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(NetlifyConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The auth method you would like to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Netlify].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(NetlifyConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,37 +108,17 @@ export const NetlifyConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Token Value"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>Access Token Value</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Netlify"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Netlify"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NorthflankConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/NorthflankConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TNorthflankConnection
 } from "@app/hooks/api/appConnections/types/northflank-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const NorthflankConnectionForm = ({ appConnection, onSubmit }: Props) => 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const NorthflankConnectionForm = ({ appConnection, onSubmit }: Props) => 
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Northflank].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(NorthflankConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.Northflank].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(NorthflankConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,16 @@ export const NorthflankConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Northflank"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Northflank"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OCIConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OCIConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { OCIConnectionMethod, TOCIConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -63,11 +71,7 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -77,31 +81,36 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.OCI].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OCIConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    {`The method you would like to use to connect with ${
+                      APP_CONNECTION_MAP[AppConnection.OCI].name
+                    }. This field cannot be changed after creation.`}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OCIConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -109,18 +118,28 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="User OCID"
-              tooltipClassName="max-w-sm"
-              tooltipText="The unique identifier (OCID) associated with your OCI user account. You can find this in your OCI console under Identity > Domains > [domain] > Users > [user]."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-user-ocid">
+                User OCID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The unique identifier (OCID) associated with your OCI user account. You can find
+                    this in your OCI console under Identity &gt; Domains &gt; [domain] &gt; Users
+                    &gt; [user].
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="credentials-user-ocid"
                 {...field}
                 placeholder="ocid1.user.oc1..************************************************************"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -128,18 +147,27 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Tenancy OCID"
-              tooltipClassName="max-w-sm"
-              tooltipText="The unique identifier (OCID) for your tenancy in Oracle Cloud. You can find this in your OCI console under Administration > Tenancy Details."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-tenancy-ocid">
+                Tenancy OCID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The unique identifier (OCID) for your tenancy in Oracle Cloud. You can find this
+                    in your OCI console under Administration &gt; Tenancy Details.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="credentials-tenancy-ocid"
                 {...field}
                 placeholder="ocid1.tenancy.oc1..************************************************************"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -147,15 +175,27 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Region"
-              tooltipClassName="max-w-sm"
-              tooltipText="The OCI region where your resources are located (e.g., us-ashburn-1, eu-frankfurt-1)."
-            >
-              <Input {...field} placeholder="us-ashburn-1" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-region">
+                Region
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The OCI region where your resources are located (e.g., us-ashburn-1,
+                    eu-frankfurt-1).
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="credentials-region"
+                {...field}
+                placeholder="us-ashburn-1"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -163,15 +203,27 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Fingerprint"
-              tooltipClassName="max-w-sm"
-              tooltipText="The fingerprint of the public key associated with your OCI API key. This is generated when you create an API key in your OCI user settings."
-            >
-              <Input {...field} placeholder="00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="credentials-fingerprint">
+                Fingerprint
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The fingerprint of the public key associated with your OCI API key. This is
+                    generated when you create an API key in your OCI user settings.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="credentials-fingerprint"
+                {...field}
+                placeholder="00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -179,36 +231,14 @@ export const OCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Private Key PEM"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>Private Key PEM</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to OCI"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to OCI"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OVHConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OVHConnectionForm.tsx
@@ -1,14 +1,26 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, SecretInput } from "@app/components/v2";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   OVHConnectionMethod,
   TOvhConnection
 } from "@app/hooks/api/appConnections/types/ovh-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -79,11 +91,7 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
         }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -101,18 +109,22 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Private Key (PEM)"
-              tooltipText="Paste the PEM-encoded private key issued by OVH OKMS, including the -----BEGIN/END PRIVATE KEY----- markers."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="private-key">
+                Private Key (PEM)
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Paste the PEM-encoded private key issued by OVH OKMS, including the
+                    -----BEGIN/END PRIVATE KEY----- markers.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -120,18 +132,22 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Certificate (PEM)"
-              tooltipText="Paste the PEM-encoded public certificate issued by OVH OKMS, including the -----BEGIN/END CERTIFICATE----- markers."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="certificate">
+                Certificate (PEM)
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Paste the PEM-encoded public certificate issued by OVH OKMS, including the
+                    -----BEGIN/END CERTIFICATE----- markers.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -139,14 +155,26 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="OKMS Domain"
-              tooltipText="The OKMS base URL, e.g. 'https://ca-east-bhs.okms.ovh.net'."
-            >
-              <Input {...field} placeholder="https://ca-east-bhs.okms.ovh.net" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="okms-domain">
+                OKMS Domain
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The OKMS base URL, e.g. &apos;https://ca-east-bhs.okms.ovh.net&apos;.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="okms-domain"
+                {...field}
+                placeholder="https://ca-east-bhs.okms.ovh.net"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -154,33 +182,24 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="OKMS ID"
-              helperText="Your OKMS instance identifier from the OVH Control Panel."
-            >
-              <Input {...field} placeholder="your-okms-instance-id" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="okms-id">OKMS ID</FieldLabel>
+              <Input
+                id="okms-id"
+                {...field}
+                placeholder="your-okms-instance-id"
+                isError={Boolean(error?.message)}
+              />
+              {!error && (
+                <FieldDescription>
+                  Your OKMS instance identifier from the OVH Control Panel.
+                </FieldDescription>
+              )}
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to OVH"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to OVH"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OctopusDeployConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OctopusDeployConnectionForm.tsx
@@ -1,16 +1,23 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import {
   OctopusDeployConnectionMethod,
@@ -18,6 +25,7 @@ import {
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -60,11 +68,7 @@ export const OctopusDeployConnectionForm = ({ appConnection, onSubmit }: Props) 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -74,31 +78,36 @@ export const OctopusDeployConnectionForm = ({ appConnection, onSubmit }: Props) 
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.OctopusDeploy].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OctopusDeployConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.OctopusDeploy].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OctopusDeployConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -106,15 +115,26 @@ export const OctopusDeployConnectionForm = ({ appConnection, onSubmit }: Props) 
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Octopus Deploy Instance URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="The URL of the Octopus Deploy Connect Server instance to authenticate with."
-            >
-              <Input {...field} placeholder="https://xxxx.octopus.app" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Octopus Deploy Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The URL of the Octopus Deploy Connect Server instance to authenticate with.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://xxxx.octopus.app"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -122,36 +142,16 @@ export const OctopusDeployConnectionForm = ({ appConnection, onSubmit }: Props) 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Octopus Deploy API Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">Octopus Deploy API Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Octopus Deploy"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Octopus Deploy"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OktaConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OktaConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { OktaConnectionMethod, TOktaConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -61,11 +69,7 @@ export const OktaConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -75,31 +79,36 @@ export const OktaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Okta].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OktaConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Okta].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OktaConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -107,13 +116,16 @@ export const OktaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-            >
-              <Input {...field} placeholder="https://example.okta.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">Instance URL</FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://example.okta.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -121,36 +133,16 @@ export const OktaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Okta"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Okta"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OnaConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OnaConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TOnaConnection
 } from "@app/hooks/api/appConnections/types/ona-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const OnaConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const OnaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Ona].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OnaConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Ona].name}. This field cannot be changed after
+                    creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OnaConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,14 @@ export const OnaConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Personal Access Token"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="personal-access-token">Personal Access Token</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Ona"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to Ona"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OpenRouterConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OpenRouterConnectionForm.tsx
@@ -1,19 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { OpenRouterConnectionMethod, TOpenRouterConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -50,11 +58,7 @@ export const OpenRouterConnectionForm = ({ appConnection, onSubmit }: Props) => 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -64,31 +68,36 @@ export const OpenRouterConnectionForm = ({ appConnection, onSubmit }: Props) => 
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.OpenRouter].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OpenRouterConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.OpenRouter].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OpenRouterConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -96,37 +105,26 @@ export const OpenRouterConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Provisioning API Key"
-              tooltipText="The OpenRouter Provisioning API key used to manage API keys."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">
+                Provisioning API Key
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The OpenRouter Provisioning API key used to manage API keys.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to OpenRouter"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to OpenRouter"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OracleDBConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OracleDBConnectionForm.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, ModalClose, Select, SelectItem, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -16,6 +29,7 @@ import { OracleDBConnectionMethod, TOracleDBConnection } from "@app/hooks/api/ap
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { PlatformManagedConfirmationModal } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -70,13 +84,7 @@ export const OracleDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const { subscription } = useSubscription();
   const isPlatformManagedCredentials = appConnection?.isPlatformManagedCredentials ?? false;
@@ -107,23 +115,32 @@ export const OracleDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -131,31 +148,34 @@ export const OracleDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.OracleDB].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(OracleDBConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.OracleDB].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OracleDBConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <SqlConnectionFields
@@ -166,23 +186,9 @@ export const OracleDBConnectionForm = ({ appConnection, onSubmit }: Props) => {
         {isPlatformManagedCredentials ? (
           <PlatformManagedNoticeBanner />
         ) : (
-          <div className="mt-6 flex items-center">
-            <Button
-              className="mr-4"
-              size="sm"
-              type="submit"
-              colorSchema="secondary"
-              isLoading={isSubmitting}
-              isDisabled={isSubmitting || !isDirty}
-            >
-              {isUpdate ? "Update Credentials" : "Connect to Database"}
-            </Button>
-            <ModalClose asChild>
-              <Button colorSchema="secondary" variant="plain">
-                Cancel
-              </Button>
-            </ModalClose>
-          </div>
+          <AppConnectionFormFooter
+            submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+          />
         )}
       </form>
       <PlatformManagedConfirmationModal

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/PostgresConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/PostgresConnectionForm.tsx
@@ -1,10 +1,23 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, ModalClose, Select, SelectItem, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -16,6 +29,7 @@ import { PostgresConnectionMethod, TPostgresConnection } from "@app/hooks/api/ap
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { PlatformManagedConfirmationModal } from "@app/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -70,13 +84,7 @@ export const PostgresConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const { subscription } = useSubscription();
   const isPlatformManagedCredentials = appConnection?.isPlatformManagedCredentials ?? false;
@@ -107,23 +115,32 @@ export const PostgresConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -131,31 +148,34 @@ export const PostgresConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Postgres].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(PostgresConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Postgres].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(PostgresConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <SqlConnectionFields
@@ -166,23 +186,9 @@ export const PostgresConnectionForm = ({ appConnection, onSubmit }: Props) => {
         {isPlatformManagedCredentials ? (
           <PlatformManagedNoticeBanner />
         ) : (
-          <div className="mt-6 flex items-center">
-            <Button
-              className="mr-4"
-              size="sm"
-              type="submit"
-              colorSchema="secondary"
-              isLoading={isSubmitting}
-              isDisabled={isSubmitting || !isDirty}
-            >
-              {isUpdate ? "Update Credentials" : "Connect to Database"}
-            </Button>
-            <ModalClose asChild>
-              <Button colorSchema="secondary" variant="plain">
-                Cancel
-              </Button>
-            </ModalClose>
-          </div>
+          <AppConnectionFormFooter
+            submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+          />
         )}
       </form>
       <PlatformManagedConfirmationModal

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RailwayConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RailwayConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TRailwayConnection
 } from "@app/hooks/api/appConnections/types/railway-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const RailwayConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const RailwayConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Railway].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(RailwayConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The type of token you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Railway].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(RailwayConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,16 @@ export const RailwayConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Value"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">Token Value</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Railway"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Railway"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RedisConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RedisConnectionForm.tsx
@@ -1,27 +1,39 @@
 import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
+  Label,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   TextArea,
-  Tooltip
-} from "@app/components/v2";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { RedisConnectionMethod, TRedisConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -57,6 +69,9 @@ const formSchema = z.discriminatedUnion("method", [
 
 type FormData = z.infer<typeof formSchema>;
 
+const CONFIGURATION_TAB = "configuration";
+const SSL_TAB = "ssl";
+
 export const RedisConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -78,12 +93,8 @@ export const RedisConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    watch,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, watch, control } = form;
+  const scopeVariant = useScopeVariant();
 
   const sslEnabled = watch("credentials.sslEnabled");
 
@@ -95,215 +106,172 @@ export const RedisConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Redis].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(RedisConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Redis].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(RedisConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}{" "}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-          <Tab.List className="-pb-1 mb-6 w-full border-b-2 border-mineshaft-600">
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              Configuration
-            </Tab>
-            <Tab
-              className={({ selected }) =>
-                `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                  selected
-                    ? "border-b-2 border-mineshaft-300 text-mineshaft-200"
-                    : "text-bunker-300"
-                }`
-              }
-            >
-              SSL ({sslEnabled ? "Enabled" : "Disabled"})
-            </Tab>
-          </Tab.List>
-          <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-            <Tab.Panel>
-              <div className="mt-[0.675rem] flex items-start gap-2">
-                <Controller
-                  name="credentials.host"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      className="flex-1"
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Host"
-                    >
-                      <Input {...field} />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.port"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      className="w-28"
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Port"
-                    >
-                      <Input type="number" {...field} />
-                    </FormControl>
-                  )}
-                />
-              </div>
-              <div className="mb-[0.675rem] flex items-start gap-2">
-                <Controller
-                  name="credentials.username"
-                  control={control}
-                  render={({ field, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Username"
-                      className="flex-1"
-                    >
-                      <Input {...field} />
-                    </FormControl>
-                  )}
-                />
-                <Controller
-                  name="credentials.password"
-                  control={control}
-                  render={({ field: { value, onChange }, fieldState: { error } }) => (
-                    <FormControl
-                      errorText={error?.message}
-                      isError={Boolean(error?.message)}
-                      label="Password"
-                      className="flex-1"
-                    >
-                      <SecretInput
-                        containerClassName="text-gray-400 w-full group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                        value={value}
-                        onChange={(e) => onChange(e.target.value)}
-                      />
-                    </FormControl>
-                  )}
-                />
-              </div>
-            </Tab.Panel>
-            <Tab.Panel>
+        <Tabs
+          value={selectedTabIndex === 0 ? CONFIGURATION_TAB : SSL_TAB}
+          onValueChange={(val) => setSelectedTabIndex(val === CONFIGURATION_TAB ? 0 : 1)}
+          className="mb-4"
+        >
+          <TabsList variant={scopeVariant}>
+            <TabsTrigger value={CONFIGURATION_TAB}>Configuration</TabsTrigger>
+            <TabsTrigger value={SSL_TAB}>SSL ({sslEnabled ? "Enabled" : "Disabled"})</TabsTrigger>
+          </TabsList>
+          <TabsContent value={CONFIGURATION_TAB}>
+            <div className="flex items-start gap-2">
               <Controller
-                name="credentials.sslEnabled"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="ssl-enabled"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                    >
-                      Enable SSL
-                    </Switch>
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.sslCertificate"
+                name="credentials.host"
                 control={control}
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    className={sslEnabled ? "" : "opacity-50"}
-                    label="SSL Certificate"
-                    isOptional
-                  >
-                    <TextArea className="h-14 resize-none!" {...field} isDisabled={!sslEnabled} />
-                  </FormControl>
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="redis-host">Host</FieldLabel>
+                    <Input id="redis-host" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
               <Controller
-                name="credentials.sslRejectUnauthorized"
+                name="credentials.port"
                 control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    className={sslEnabled ? "" : "opacity-50"}
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
-                    <Switch
-                      className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                      id="ssl-reject-unauthorized"
-                      thumbClassName="bg-mineshaft-800"
-                      isChecked={sslEnabled ? value : false}
-                      onCheckedChange={onChange}
-                      isDisabled={!sslEnabled}
-                    >
-                      <p className="w-38">
-                        Reject Unauthorized
-                        <Tooltip
-                          className="max-w-md"
-                          content={
-                            <p>
-                              If enabled, Infisical will only connect to the server if it has a
-                              valid, trusted SSL certificate.
-                            </p>
-                          }
-                        >
-                          <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                        </Tooltip>
-                      </p>
-                    </Switch>
-                  </FormControl>
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="w-28">
+                    <FieldLabel htmlFor="redis-port">Port</FieldLabel>
+                    <Input
+                      id="redis-port"
+                      type="number"
+                      {...field}
+                      isError={Boolean(error?.message)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
                 )}
               />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
+            </div>
+            <div className="mt-4 flex items-start gap-2">
+              <Controller
+                name="credentials.username"
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="redis-username">Username</FieldLabel>
+                    <Input id="redis-username" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+              <Controller
+                name="credentials.password"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field className="flex-1">
+                    <FieldLabel>Password</FieldLabel>
+                    <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value={SSL_TAB}>
+            <Controller
+              name="credentials.sslEnabled"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-enabled">Enable SSL</Label>
+                    </FieldContent>
+                    <Switch
+                      id="ssl-enabled"
+                      variant={scopeVariant}
+                      checked={value}
+                      onCheckedChange={onChange}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslCertificate"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className={sslEnabled ? "mb-4" : "mb-4 opacity-50"}>
+                  <FieldLabel htmlFor="ssl-certificate">
+                    SSL Certificate <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <TextArea
+                    id="ssl-certificate"
+                    className="h-14 resize-none"
+                    {...field}
+                    disabled={!sslEnabled}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.sslRejectUnauthorized"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className={sslEnabled ? undefined : "opacity-50"}>
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                      <FieldDescription>
+                        If enabled, Infisical will only connect to the server if it has a valid,
+                        trusted SSL certificate.
+                      </FieldDescription>
+                    </FieldContent>
+                    <Switch
+                      id="ssl-reject-unauthorized"
+                      variant={scopeVariant}
+                      checked={sslEnabled ? value : false}
+                      onCheckedChange={onChange}
+                      disabled={!sslEnabled}
+                    />
+                  </Field>
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </TabsContent>
+        </Tabs>
 
-        <div className="mt-6 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Database"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Database"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RenderConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/RenderConnectionForm.tsx
@@ -1,19 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { RenderConnectionMethod, TRenderConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -50,11 +58,7 @@ export const RenderConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -64,31 +68,36 @@ export const RenderConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Render].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(RenderConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Render].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)} id="method">
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(RenderConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -96,36 +105,16 @@ export const RenderConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-key">API Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Render"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Render"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SalesforceConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SalesforceConnectionForm.tsx
@@ -1,14 +1,25 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, SecretInput } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   SalesforceConnectionMethod,
   TSalesforceConnection
 } from "@app/hooks/api/appConnections/types/salesforce-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -47,11 +58,7 @@ export const SalesforceConnectionForm = ({ appConnection, onSubmit }: Props) => 
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -62,14 +69,26 @@ export const SalesforceConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipText="Your Salesforce My Domain URL (e.g. my-org.my.salesforce.com)."
-            >
-              <Input {...field} placeholder="my-org.my.salesforce.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Your Salesforce My Domain URL (e.g. my-org.my.salesforce.com).
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="my-org.my.salesforce.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -77,13 +96,16 @@ export const SalesforceConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Consumer Key"
-            >
-              <Input {...field} placeholder="3MVG9..." />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="consumer-key">Consumer Key</FieldLabel>
+              <Input
+                id="consumer-key"
+                {...field}
+                placeholder="3MVG9..."
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -91,36 +113,16 @@ export const SalesforceConnectionForm = ({ appConnection, onSubmit }: Props) => 
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Consumer Secret"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="consumer-secret">Consumer Secret</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Salesforce"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Salesforce"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SmbConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SmbConnectionForm.tsx
@@ -3,7 +3,16 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
-import { Button, FormControl, Input, ModalClose, SecretInput, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { OrgPermissionSubjects, useSubscription } from "@app/context";
 import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
@@ -18,6 +27,7 @@ import {
 import { SmbConnectionMethod, TSmbConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -106,13 +116,7 @@ export const SmbConnectionForm = ({ appConnection, onSubmit }: Props) => {
         }
   });
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    watch,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control, setValue, watch } = form;
 
   const gatewayId = watch("gatewayId");
   const gatewayPoolId = watch("gatewayPoolId");
@@ -127,123 +131,125 @@ export const SmbConnectionForm = ({ appConnection, onSubmit }: Props) => {
             I={OrgGatewayPermissionActions.AttachGateways}
             a={OrgPermissionSubjects.Gateway}
           >
-            {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
-                </Tooltip>
-              </FormControl>
-            )}
+            {(isAllowed) => {
+              const picker = (
+                <div>
+                  <GatewayPicker
+                    isDisabled={!isAllowed}
+                    value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                    onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                      setValue("gatewayId", newGwId, { shouldDirty: true });
+                      setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                    }}
+                  />
+                </div>
+              );
+
+              return (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="gateway">Gateway</FieldLabel>
+                  {isAllowed ? (
+                    picker
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>{picker}</TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Restricted access. You don&apos;t have permission to attach gateways to
+                        resources.
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </Field>
+              );
+            }}
           </OrgPermissionCan>
         )}
-        <div className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-          <Controller
-            name="credentials.host"
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
+        <Controller
+          name="credentials.host"
+          control={control}
+          render={({ field, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="host">Host</FieldLabel>
+              <Input
+                id="host"
+                {...field}
+                placeholder="Hostname or IP address of Windows server"
                 isError={Boolean(error?.message)}
-                label="Host"
-              >
-                <Input {...field} placeholder="Hostname or IP address of Windows server" />
-              </FormControl>
-            )}
-          />
-          <Controller
-            name="credentials.port"
-            control={control}
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
+              />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        <Controller
+          name="credentials.port"
+          control={control}
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="port">Port</FieldLabel>
+              <Input
+                id="port"
+                type="number"
+                value={value}
+                onChange={(e) => onChange(e.target.value ? Number(e.target.value) : 445)}
+                placeholder="445"
                 isError={Boolean(error?.message)}
-                label="Port"
-              >
-                <Input
-                  type="number"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value ? Number(e.target.value) : 445)}
-                  placeholder="445"
-                />
-              </FormControl>
-            )}
-          />
-          <Controller
-            name="credentials.domain"
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
+              />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        <Controller
+          name="credentials.domain"
+          control={control}
+          render={({ field, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="domain">
+                Domain <span className="text-muted">(optional)</span>
+              </FieldLabel>
+              <Input
+                id="domain"
+                {...field}
+                placeholder="e.g., MYDOMAIN (for domain-joined servers)"
                 isError={Boolean(error?.message)}
-                label="Domain"
-                isOptional
-              >
-                <Input {...field} placeholder="e.g., MYDOMAIN (for domain-joined servers)" />
-              </FormControl>
-            )}
-          />
-          <Controller
-            name="credentials.username"
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
+              />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        <Controller
+          name="credentials.username"
+          control={control}
+          render={({ field, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="username">Username</FieldLabel>
+              <Input
+                id="username"
+                {...field}
+                placeholder="Administrator"
                 isError={Boolean(error?.message)}
-                label="Username"
-              >
-                <Input {...field} placeholder="Administrator" />
-              </FormControl>
-            )}
-          />
-          <Controller
-            name="credentials.password"
-            control={control}
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Password"
-              >
-                <SecretInput
-                  containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
-            )}
-          />
-        </div>
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate
+              />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        <Controller
+          name="credentials.password"
+          control={control}
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="password">Password</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        <AppConnectionFormFooter
+          submitLabel={
+            isUpdate
               ? "Update Credentials"
-              : `Connect to ${APP_CONNECTION_MAP[AppConnection.SMB].name}`}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+              : `Connect to ${APP_CONNECTION_MAP[AppConnection.SMB].name}`
+          }
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SnowflakeConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SnowflakeConnectionForm.tsx
@@ -1,14 +1,25 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, SecretInput } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   SnowflakeConnectionMethod,
   TSnowflakeConnection
 } from "@app/hooks/api/appConnections/types/snowflake-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +63,7 @@ export const SnowflakeConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -68,14 +75,26 @@ export const SnowflakeConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Account"
-              tooltipText="Your Snowflake account identifier."
-            >
-              <Input value={value} onChange={(e) => onChange(e.target.value)} />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="account">
+                Account
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Your Snowflake account identifier.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="account"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -84,14 +103,26 @@ export const SnowflakeConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Username"
-              tooltipText="The login name used to authenticate with Snowflake."
-            >
-              <Input value={value} onChange={(e) => onChange(e.target.value)} />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="username">
+                Username
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The login name used to authenticate with Snowflake.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="username"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
@@ -100,38 +131,27 @@ export const SnowflakeConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Programmatic Access Token"
-              tooltipText="The Programmatic Access Token (PAT) used to authenticate with Snowflake."
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="password">
+                Programmatic Access Token
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The Programmatic Access Token (PAT) used to authenticate with Snowflake.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <SecretInput id="password" value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Snowflake"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Snowflake"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SshConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SshConnectionForm.tsx
@@ -1,18 +1,24 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { OrgPermissionSubjects, useSubscription } from "@app/context";
 import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
@@ -20,6 +26,7 @@ import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/
 import { SshConnectionMethod, TSshConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -92,13 +99,7 @@ export const SshConnectionForm = ({ appConnection, onSubmit }: Props) => {
         }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty },
-    watch,
-    setValue
-  } = form;
+  const { handleSubmit, control, watch, setValue } = form;
 
   const selectedMethod = watch("method");
   const gatewayId = watch("gatewayId");
@@ -138,23 +139,32 @@ export const SshConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -162,166 +172,163 @@ export const SshConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The authentication method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.SSH].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Authentication Method"
-            >
+            <Field className="mb-4">
+              <FieldLabel>
+                Authentication Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The authentication method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.SSH].name}. This field cannot be changed after
+                    creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Select
-                isDisabled={isUpdate}
+                disabled={isUpdate}
                 value={value}
                 onValueChange={(val) => handleMethodChange(val as SshConnectionMethod)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
               >
-                {Object.values(SshConnectionMethod).map((method) => {
-                  return (
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(SshConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-          <div className="grid grid-cols-2 gap-2">
-            <Controller
-              name="credentials.host"
-              control={control}
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Host"
-                >
-                  <Input {...field} placeholder="Hostname or IP address" />
-                </FormControl>
-              )}
-            />
-            <Controller
-              name="credentials.port"
-              control={control}
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  label="Port"
-                >
-                  <Input {...field} type="number" placeholder="22" />
-                </FormControl>
-              )}
-            />
-          </div>
+        <div className="grid grid-cols-2 gap-2">
           <Controller
-            name="credentials.username"
+            name="credentials.host"
             control={control}
             render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Username"
-              >
-                <Input {...field} placeholder="SSH username" />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel htmlFor="ssh-host">Host</FieldLabel>
+                <Input
+                  id="ssh-host"
+                  {...field}
+                  placeholder="Hostname or IP address"
+                  isError={Boolean(error?.message)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
-          {selectedMethod === SshConnectionMethod.Password ? (
-            <Controller
-              name="credentials.password"
-              control={control}
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
+          <Controller
+            name="credentials.port"
+            control={control}
+            render={({ field, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <FieldLabel htmlFor="ssh-port">Port</FieldLabel>
+                <Input
+                  id="ssh-port"
+                  {...field}
+                  type="number"
+                  placeholder="22"
                   isError={Boolean(error?.message)}
-                  label="Password"
-                >
+                />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        </div>
+        <Controller
+          name="credentials.username"
+          control={control}
+          render={({ field, fieldState: { error } }) => (
+            <Field className="mb-4">
+              <FieldLabel htmlFor="ssh-username">Username</FieldLabel>
+              <Input
+                id="ssh-username"
+                {...field}
+                placeholder="SSH username"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
+          )}
+        />
+        {selectedMethod === SshConnectionMethod.Password ? (
+          <Controller
+            name="credentials.password"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <FieldLabel>Password</FieldLabel>
+                <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        ) : (
+          <>
+            <Controller
+              name="credentials.privateKey"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel>Private Key</FieldLabel>
                   <SecretInput
-                    containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                    value={value}
-                    onChange={(e) => onChange(e.target.value)}
+                    value={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                    placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
-          ) : (
-            <>
-              <Controller
-                name="credentials.privateKey"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Private Key"
-                  >
-                    <SecretInput
-                      containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                      value={field.value}
-                      onChange={(e) => field.onChange(e.target.value)}
-                      placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"
-                    />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.passphrase"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Passphrase"
-                    isOptional
-                  >
-                    <SecretInput
-                      containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                      value={value ?? ""}
-                      onChange={(e) => onChange(e.target.value)}
-                    />
-                  </FormControl>
-                )}
-              />
-            </>
-          )}
-        </div>
+            <Controller
+              name="credentials.passphrase"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel>
+                    Passphrase <span className="text-muted">(optional)</span>
+                  </FieldLabel>
+                  <SecretInput value={value ?? ""} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </>
+        )}
         <Controller
           name="configuration.blockedUsers"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Blocked Users"
-              isOptional
-              tooltipText="A comma-separated list of usernames that are blocked from being used in operations like secret rotation (e.g., root,admin,ubuntu)."
-            >
-              <Input {...field} value={field.value ?? ""} placeholder="root,admin,ubuntu" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>
+                Blocked Users <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    A comma-separated list of usernames that are blocked from being used in
+                    operations like secret rotation (e.g., root,admin,ubuntu).
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                {...field}
+                value={field.value ?? ""}
+                placeholder="root,admin,ubuntu"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to SSH"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to SSH"} />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SupabaseConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/SupabaseConnectionForm.tsx
@@ -1,16 +1,23 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -18,6 +25,7 @@ import {
   TSupabaseConnection
 } from "@app/hooks/api/appConnections/types/supabase-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -55,11 +63,7 @@ export const SupabaseConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -70,51 +74,63 @@ export const SupabaseConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              isOptional
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="Will default to Supabase Cloud if not specified."
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Will default to Supabase Cloud if not specified.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <Input
+                id="instance-url"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder="https://api.supabase.com"
+                isError={Boolean(error?.message)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The type of token you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Supabase].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Token Type"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(SupabaseConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Token Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The type of token you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Supabase].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(SupabaseConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -122,37 +138,21 @@ export const SupabaseConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Key Value"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="access-key">Access Key Value</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="access-key"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
 
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Supabase"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Supabase"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TeamCityConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TeamCityConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TeamCityConnectionMethod, TTeamCityConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -52,11 +60,7 @@ export const TeamCityConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -66,31 +70,36 @@ export const TeamCityConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.TeamCity].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(TeamCityConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.TeamCity].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(TeamCityConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -98,15 +107,26 @@ export const TeamCityConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipClassName="max-w-sm"
-              tooltipText="The URL at which your TeamCity instance is hosted."
-            >
-              <Input {...field} placeholder="https://yourcompany.teamcity.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The URL at which your TeamCity instance is hosted.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://yourcompany.teamcity.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -114,36 +134,20 @@ export const TeamCityConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="access-token">Access Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="access-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to TeamCity"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to TeamCity"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TerraformCloudConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TerraformCloudConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import {
   TerraformCloudConnectionMethod,
@@ -17,6 +24,7 @@ import {
 } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const TerraformCloudConnectionForm = ({ appConnection, onSubmit }: Props)
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const TerraformCloudConnectionForm = ({ appConnection, onSubmit }: Props)
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.TerraformCloud].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(TerraformCloudConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.TerraformCloud].name}. This field cannot be
+                    changed after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(TerraformCloudConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,20 @@ export const TerraformCloudConnectionForm = ({ appConnection, onSubmit }: Props)
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Terraform Cloud"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Terraform Cloud"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TravisCIConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/TravisCIConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   TTravisCIConnection
 } from "@app/hooks/api/appConnections/types/travis-ci-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const TravisCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const TravisCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.TravisCI].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(TravisCIConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.TravisCI].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(TravisCIConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,20 @@ export const TravisCIConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Travis CI"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Travis CI"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TVenafiConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
@@ -19,6 +26,7 @@ import {
   VenafiRegion
 } from "@app/hooks/api/appConnections/types/venafi-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -59,11 +67,7 @@ export const VenafiConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -73,31 +77,34 @@ export const VenafiConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Venafi].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(VenafiConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Venafi].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(VenafiConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -105,26 +112,32 @@ export const VenafiConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Region"
-              tooltipClassName="max-w-sm"
-              tooltipText="The region of your Venafi TLS Protect Cloud instance."
-            >
-              <Select
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-              >
-                {Object.values(VenafiRegion).map((region) => (
-                  <SelectItem value={region} key={region}>
-                    {VENAFI_REGION_LABELS[region]}
-                  </SelectItem>
-                ))}
+            <Field className="mb-4">
+              <FieldLabel>
+                Region
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The region of your Venafi TLS Protect Cloud instance.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a region..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(VenafiRegion).map((region) => (
+                    <SelectItem value={region} key={region}>
+                      {VENAFI_REGION_LABELS[region]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -132,36 +145,17 @@ export const VenafiConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Key"
-            >
-              <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-              />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel>API Key</FieldLabel>
+              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || (isUpdate && !isDirty)}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Venafi"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Venafi"}
+          allowPristineSubmit={!isUpdate}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiTppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiTppConnectionForm.tsx
@@ -1,18 +1,26 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
+  SelectContent,
   SelectItem,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  SheetFooter,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
 import { useSubscription } from "@app/context";
 import {
@@ -20,9 +28,11 @@ import {
   OrgPermissionSubjects
 } from "@app/context/OrgPermissionContext/types";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { TVenafiTppConnection, VenafiTppConnectionMethod } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -57,6 +67,8 @@ type FormData = z.infer<typeof formSchema>;
 
 export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
+  const { onCancel } = useAppConnectionForm();
+  const scopeVariant = useScopeVariant();
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -96,31 +108,34 @@ export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.VenafiTpp].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(VenafiTppConnectionMethod).map((method) => {
-                  return (
+            <Field className="mb-4">
+              <FieldLabel>
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.VenafiTpp].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error?.message)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(VenafiTppConnectionMethod).map((method) => (
                     <SelectItem value={method} key={method}>
                       {getAppConnectionMethodDetails(method).name}
                     </SelectItem>
-                  );
-                })}
+                  ))}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         {subscription.gateway && (
@@ -129,23 +144,32 @@ export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
             a={OrgPermissionSubjects.Gateway}
           >
             {(isAllowed) => (
-              <FormControl label="Gateway">
-                <Tooltip
-                  isDisabled={isAllowed}
-                  content="Restricted access. You don't have permission to attach gateways to resources."
-                >
-                  <div>
-                    <GatewayPicker
-                      isDisabled={!isAllowed}
-                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
-                      onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
-                        setValue("gatewayId", newGwId, { shouldDirty: true });
-                        setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
-                      }}
-                    />
-                  </div>
+              <Field className="mb-4">
+                <FieldLabel>Gateway</FieldLabel>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {!isAllowed && (
+                    <TooltipContent>
+                      Restricted access. You don&apos;t have permission to attach gateways to
+                      resources.
+                    </TooltipContent>
+                  )}
                 </Tooltip>
-              </FormControl>
+              </Field>
             )}
           </OrgPermissionCan>
         )}
@@ -153,27 +177,42 @@ export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="credentials.tppUrl"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="TPP URL"
-            >
-              <Input {...field} placeholder="https://tpp.example.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="venafi-tpp-url">TPP URL</FieldLabel>
+              <Input
+                id="venafi-tpp-url"
+                {...field}
+                placeholder="https://tpp.example.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
           name="credentials.clientId"
           control={control}
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Client ID"
-              tooltipText="The OAuth Client ID registered in the Venafi TPP API Integration."
-            >
-              <Input {...field} placeholder="my-infisical-integration" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="venafi-client-id">
+                Client ID
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The OAuth Client ID registered in the Venafi TPP API Integration.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="venafi-client-id"
+                {...field}
+                placeholder="my-infisical-integration"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <div className="grid grid-cols-2 gap-2">
@@ -181,50 +220,43 @@ export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
             name="credentials.username"
             control={control}
             render={({ field, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Username"
-              >
-                <Input {...field} placeholder="admin@domain.com" />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel htmlFor="venafi-username">Username</FieldLabel>
+                <Input
+                  id="venafi-username"
+                  {...field}
+                  placeholder="admin@domain.com"
+                  isError={Boolean(error?.message)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
           <Controller
             name="credentials.password"
             control={control}
             render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                errorText={error?.message}
-                isError={Boolean(error?.message)}
-                label="Password"
-              >
-                <SecretInput
-                  containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                />
-              </FormControl>
+              <Field className="mb-4">
+                <FieldLabel>Password</FieldLabel>
+                <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                <FieldError errors={[error]} />
+              </Field>
             )}
           />
         </div>
-        <div className="mt-8 flex items-center">
+        <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
+            variant={scopeVariant}
+            isPending={isSubmitting}
             isDisabled={isSubmitting || !isDirty}
           >
             {isUpdate ? "Update Credentials" : "Connect to Venafi TPP"}
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+          <Button type="button" variant="outline" onClick={onCancel} isDisabled={isSubmitting}>
+            Cancel
+          </Button>
+        </SheetFooter>
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VercelConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VercelConnectionForm.tsx
@@ -1,15 +1,22 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
-  ModalClose,
+  Field,
+  FieldError,
+  FieldLabel,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
@@ -17,6 +24,7 @@ import {
   VercelConnectionMethod
 } from "@app/hooks/api/appConnections/types/vercel-connection";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -53,11 +61,7 @@ export const VercelConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -67,31 +71,36 @@ export const VercelConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Vercel].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(VercelConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Vercel].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(VercelConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -99,36 +108,20 @@ export const VercelConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="api-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Vercel"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Vercel"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/WindmillConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/WindmillConnectionForm.tsx
@@ -1,20 +1,28 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import {
-  Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   Input,
-  ModalClose,
   SecretInput,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TWindmillConnection, WindmillConnectionMethod } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -59,11 +67,7 @@ export const WindmillConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -73,31 +77,36 @@ export const WindmillConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Windmill].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(WindmillConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Windmill].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(WindmillConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -105,16 +114,26 @@ export const WindmillConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              isOptional
-              tooltipClassName="max-w-sm"
-              tooltipText="Will default to Windmill Cloud if not specified."
-            >
-              <Input {...field} placeholder="https://app.windmill.dev" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">
+                Instance URL <span className="text-muted">(optional)</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Will default to Windmill Cloud if not specified.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://app.windmill.dev"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -122,36 +141,20 @@ export const WindmillConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Access Token"
-            >
+            <Field className="mb-4">
+              <FieldLabel htmlFor="access-token">Access Token</FieldLabel>
               <SecretInput
-                containerClassName="text-gray-400 group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
+                id="access-token"
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
               />
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Windmill"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Windmill"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ZabbixConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ZabbixConnectionForm.tsx
@@ -1,12 +1,27 @@
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { Button, FormControl, Input, ModalClose, Select, SelectItem } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { TZabbixConnection, ZabbixConnectionMethod } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
+import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -44,11 +59,7 @@ export const ZabbixConnectionForm = ({ appConnection, onSubmit }: Props) => {
     }
   });
 
-  const {
-    handleSubmit,
-    control,
-    formState: { isSubmitting, isDirty }
-  } = form;
+  const { handleSubmit, control } = form;
 
   return (
     <FormProvider {...form}>
@@ -58,31 +69,36 @@ export const ZabbixConnectionForm = ({ appConnection, onSubmit }: Props) => {
           name="method"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              tooltipText={`The method you would like to use to connect with ${
-                APP_CONNECTION_MAP[AppConnection.Zabbix].name
-              }. This field cannot be changed after creation.`}
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Method"
-            >
-              <Select
-                isDisabled={isUpdate}
-                value={value}
-                onValueChange={(val) => onChange(val)}
-                className="w-full border border-mineshaft-500"
-                position="popper"
-                dropdownContainerClassName="max-w-none"
-              >
-                {Object.values(ZabbixConnectionMethod).map((method) => {
-                  return (
-                    <SelectItem value={method} key={method}>
-                      {getAppConnectionMethodDetails(method).name}{" "}
-                    </SelectItem>
-                  );
-                })}
+            <Field className="mb-4">
+              <FieldLabel htmlFor="method">
+                Method
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.Zabbix].name}. This field cannot be changed
+                    after creation.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(ZabbixConnectionMethod).map((method) => {
+                    return (
+                      <SelectItem value={method} key={method}>
+                        {getAppConnectionMethodDetails(method).name}{" "}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
               </Select>
-            </FormControl>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -90,13 +106,17 @@ export const ZabbixConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="API Token"
-            >
-              <Input {...field} type="password" placeholder="Enter your API Token" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="api-token">API Token</FieldLabel>
+              <Input
+                id="api-token"
+                {...field}
+                type="password"
+                placeholder="Enter your API Token"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
         <Controller
@@ -104,33 +124,21 @@ export const ZabbixConnectionForm = ({ appConnection, onSubmit }: Props) => {
           control={control}
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
-            <FormControl
-              errorText={error?.message}
-              isError={Boolean(error?.message)}
-              label="Instance URL"
-              tooltipClassName="max-w-sm"
-            >
-              <Input {...field} placeholder="https://your-zabbix-instance.com" />
-            </FormControl>
+            <Field className="mb-4">
+              <FieldLabel htmlFor="instance-url">Instance URL</FieldLabel>
+              <Input
+                id="instance-url"
+                {...field}
+                placeholder="https://your-zabbix-instance.com"
+                isError={Boolean(error?.message)}
+              />
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
-        <div className="mt-8 flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            {isUpdate ? "Update Credentials" : "Connect to Zabbix"}
-          </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to Zabbix"}
+        />
       </form>
     </FormProvider>
   );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CrededentialRotationBadge.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CrededentialRotationBadge.tsx
@@ -3,8 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { format, formatDistanceToNow } from "date-fns";
 import { PauseIcon, RefreshCwIcon, XIcon } from "lucide-react";
 
-import { Tooltip } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { TAppConnection } from "@app/hooks/api/appConnections";
 import { AppConnectionCredentialRotationStatus } from "@app/hooks/api/appConnections/types/root-connection-enums";
 
@@ -39,10 +38,14 @@ export const CrededentialRotationStatusBadge = ({ appConnection }: Props) => {
     }
 
     return (
-      <Tooltip
-        position="left"
-        className="max-w-sm select-text"
-        content={
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant="danger">
+            <XIcon />
+            Rotation Failed
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="max-w-sm select-text">
           <div className="flex flex-col gap-2 py-1 whitespace-normal">
             <div>
               <div className="mb-2 flex self-start text-red">
@@ -60,12 +63,7 @@ export const CrededentialRotationStatusBadge = ({ appConnection }: Props) => {
               </span>
             )}
           </div>
-        }
-      >
-        <Badge variant="danger">
-          <XIcon />
-          Rotation Failed
-        </Badge>
+        </TooltipContent>
       </Tooltip>
     );
   }
@@ -74,25 +72,22 @@ export const CrededentialRotationStatusBadge = ({ appConnection }: Props) => {
     (new Date(rotation.nextRotationAt).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24);
 
   return (
-    <Tooltip
-      className="max-w-lg"
-      content={
-        <>
-          <span>
-            Rotates on {format(rotation.nextRotationAt, "MM/dd/yyyy")} at{" "}
-            {format(rotation.nextRotationAt, "h:mm aa")}
-          </span>{" "}
-          <span className="text-mineshaft-300">(Local Time)</span>
-        </>
-      }
-      asChild
-    >
-      <Badge variant={daysToRotation >= 7 ? "info" : "warning"} className="capitalize">
-        <RefreshCwIcon />
-        {daysToRotation < 0
-          ? "Rotating"
-          : `Rotates ${formatDistanceToNow(rotation.nextRotationAt, { addSuffix: true })}`}
-      </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant={daysToRotation >= 7 ? "info" : "warning"} className="capitalize">
+          <RefreshCwIcon />
+          {daysToRotation < 0
+            ? "Rotating"
+            : `Rotates ${formatDistanceToNow(rotation.nextRotationAt, { addSuffix: true })}`}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-lg">
+        <span>
+          Rotates on {format(rotation.nextRotationAt, "MM/dd/yyyy")} at{" "}
+          {format(rotation.nextRotationAt, "h:mm aa")}
+        </span>{" "}
+        <span className="text-mineshaft-300">(Local Time)</span>
+      </TooltipContent>
     </Tooltip>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CredentialRotationBadge.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CredentialRotationBadge.tsx
@@ -11,7 +11,7 @@ type Props = {
   appConnection: TAppConnection;
 };
 
-export const CrededentialRotationStatusBadge = ({ appConnection }: Props) => {
+export const CredentialRotationStatusBadge = ({ appConnection }: Props) => {
   const { isAutoRotationEnabled, rotation } = appConnection;
 
   if (!rotation) {

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CredentialRotationForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/CredentialRotationForm.tsx
@@ -1,10 +1,24 @@
 import { ReactNode } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { format, setHours, setMinutes } from "date-fns";
+import { Info } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
-import { FormControl, Input, Switch } from "@app/components/v2";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  Label,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { getRotateAtLocal } from "@app/helpers/secretRotationsV2";
+import { useScopeVariant } from "@app/hooks";
 
 type Props = {
   children?: ReactNode;
@@ -12,6 +26,7 @@ type Props = {
 
 export const CredentialRotationForm = ({ children }: Props) => {
   const { control, watch } = useFormContext();
+  const scopeVariant = useScopeVariant();
 
   const isAutoRotationEnabled = watch("isAutoRotationEnabled");
   return (
@@ -21,25 +36,25 @@ export const CredentialRotationForm = ({ children }: Props) => {
           name="isAutoRotationEnabled"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              helperText={
-                value
-                  ? "App connection credentials will automatically be rotated when the rotation interval specified above as elapsed."
-                  : "App connection credentials will not be rotated automatically."
-              }
-              isError={Boolean(error?.message)}
-              errorText={error?.message}
-            >
-              <Switch
-                className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                id="platform-managed"
-                thumbClassName="bg-mineshaft-800"
-                isChecked={value}
-                onCheckedChange={onChange}
-              >
-                <p>Automatic Credential Rotation</p>
-              </Switch>
-            </FormControl>
+            <Field>
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <Label htmlFor="auto-rotation-enabled">Automatic Credential Rotation</Label>
+                  <FieldDescription>
+                    {value
+                      ? "App connection credentials will automatically be rotated when the rotation interval specified above as elapsed."
+                      : "App connection credentials will not be rotated automatically."}
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="auto-rotation-enabled"
+                  variant={scopeVariant}
+                  checked={value}
+                  onCheckedChange={onChange}
+                />
+              </Field>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
       </div>
@@ -47,24 +62,31 @@ export const CredentialRotationForm = ({ children }: Props) => {
       {isAutoRotationEnabled && (
         <>
           {children}
-          <div className="flex w-full items-center gap-2">
+          <div className="flex w-full items-start gap-2">
             <Controller
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  className="flex-1"
-                  tooltipText="How often Infisical will rotate the credentials of this connection."
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  label="Rotation Interval (In Days)"
-                >
+                <Field className="flex-1">
+                  <FieldLabel>
+                    Rotation Interval (In Days)
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        How often Infisical will rotate the credentials of this connection.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <Input
                     value={value}
                     type="number"
                     onChange={(e) => onChange(parseInt(e.target.value, 10))}
                     min={1}
                     placeholder="30"
+                    isError={Boolean(error)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
               control={control}
               name="rotation.rotationInterval"
@@ -72,13 +94,19 @@ export const CredentialRotationForm = ({ children }: Props) => {
             <Controller
               render={({ field: { value, onChange }, fieldState: { error } }) => {
                 return (
-                  <FormControl
-                    className="flex-1"
-                    tooltipText="The time of day at which Infisical will rotate the credentials of this connection."
-                    label="Rotate At (Local Time)"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
+                  <Field className="flex-1">
+                    <FieldLabel>
+                      Rotate At (Local Time)
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          The time of day at which Infisical will rotate the credentials of this
+                          connection.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
                     <Input
                       type="time"
                       value={format(getRotateAtLocal(value), "HH:mm")}
@@ -93,9 +121,11 @@ export const CredentialRotationForm = ({ children }: Props) => {
                           });
                         }
                       }}
-                      className="bg-mineshaft-700 text-white scheme-dark"
+                      className="scheme-dark"
+                      isError={Boolean(error)}
                     />
-                  </FormControl>
+                    <FieldError errors={[error]} />
+                  </Field>
                 );
               }}
               control={control}

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedConfirmationModal.tsx
@@ -1,5 +1,16 @@
-import { Button, Modal, ModalClose, ModalContent } from "@app/components/v2";
-import { NoticeBannerV2 } from "@app/components/v2/NoticeBannerV2/NoticeBannerV2";
+import { AlertTriangleIcon } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle
+} from "@app/components/v3";
 
 type Props = {
   isOpen: boolean;
@@ -9,35 +20,26 @@ type Props = {
 
 export const PlatformManagedConfirmationModal = ({ isOpen, onOpenChange, onConfirm }: Props) => {
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent className="max-w-2xl" title="Platform Managed Credentials">
-        <NoticeBannerV2 title="Are you sure you want have Infisical manage the credentials of this connection?">
-          <p className="my-1 text-sm text-mineshaft-300">
-            Once created, Infisical will update the password of this connection.
-          </p>
-          <p className="text-sm text-mineshaft-300">
-            You will not be able to access the updated password.
-          </p>
-        </NoticeBannerV2>
-        <div className="mt-4 flex gap-2">
-          <ModalClose asChild>
-            <Button
-              onClick={onConfirm}
-              className="mr-4"
-              size="sm"
-              type="submit"
-              colorSchema="secondary"
-            >
-              Grant Infisical Ownership
-            </Button>
-          </ModalClose>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
-              Cancel
-            </Button>
-          </ModalClose>
-        </div>
-      </ModalContent>
-    </Modal>
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia>
+            <AlertTriangleIcon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Platform Managed Credentials</AlertDialogTitle>
+          <AlertDialogDescription>
+            Once created, Infisical will update the password of this connection and you will no
+            longer be able to access it. Are you sure you want Infisical to manage the credentials
+            of this connection?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="warning" onClick={onConfirm}>
+            Grant Infisical Ownership
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedNoticeBanner.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/PlatformManagedNoticeBanner.tsx
@@ -1,9 +1,10 @@
-import { NoticeBannerV2 } from "@app/components/v2/NoticeBannerV2/NoticeBannerV2";
+import { Alert, AlertDescription, AlertTitle } from "@app/components/v3";
 
 export const PlatformManagedNoticeBanner = () => (
-  <NoticeBannerV2 title="Platform Managed Credentials">
-    <p className="text-sm text-bunker-300">
+  <Alert variant="warning" className="mb-4">
+    <AlertTitle>Platform Managed Credentials</AlertTitle>
+    <AlertDescription>
       This App Connection&#39;s credentials are managed by Infisical and cannot be updated.
-    </p>
-  </NoticeBannerV2>
+    </AlertDescription>
+  </Alert>
 );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/SqlConnectionFields.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/shared/SqlConnectionFields.tsx
@@ -1,10 +1,23 @@
 import { Dispatch, SetStateAction } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tab } from "@headlessui/react";
 
-import { FormControl, Input, SecretInput, Switch, TextArea, Tooltip } from "@app/components/v2";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  Label,
+  SecretInput,
+  Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  TextArea
+} from "@app/components/v3";
+import { useScopeVariant } from "@app/hooks";
 
 type Props = {
   isPlatformManagedCredentials: boolean;
@@ -12,225 +25,207 @@ type Props = {
   setSelectedTabIndex: Dispatch<SetStateAction<number>>;
 };
 
+const CONFIGURATION_TAB = "configuration";
+const SSL_TAB = "ssl";
+
 export const SqlConnectionFields = ({
   isPlatformManagedCredentials,
   setSelectedTabIndex,
   selectedTabIndex
 }: Props) => {
   const { control, watch } = useFormContext();
+  const scopeVariant = useScopeVariant();
 
   const sslEnabled = watch("credentials.sslEnabled");
   return (
     <>
-      <Tab.Group selectedIndex={selectedTabIndex} onChange={setSelectedTabIndex}>
-        <Tab.List className="-pb-1 mb-6 w-full border-b-2 border-mineshaft-600">
-          <Tab
-            className={({ selected }) =>
-              `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                selected ? "border-b-2 border-mineshaft-300 text-mineshaft-200" : "text-bunker-300"
-              }`
-            }
-          >
-            Configuration
-          </Tab>
-          <Tab
-            className={({ selected }) =>
-              `-mb-[0.14rem] px-4 py-2 text-sm font-medium whitespace-nowrap outline-hidden disabled:opacity-60 ${
-                selected ? "border-b-2 border-mineshaft-300 text-mineshaft-200" : "text-bunker-300"
-              }`
-            }
-          >
-            SSL ({sslEnabled ? "Enabled" : "Disabled"})
-          </Tab>
-        </Tab.List>
-        <Tab.Panels className="mb-4 rounded-sm border border-mineshaft-600 bg-mineshaft-700/70 p-3 pb-0">
-          <Tab.Panel>
-            <div className="mt-[0.675rem] flex items-start gap-2">
-              <Controller
-                name="credentials.host"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    className="flex-1"
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Host"
-                  >
-                    <Input {...field} isDisabled={isPlatformManagedCredentials} />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.database"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    className="flex-1"
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Database Name"
-                  >
-                    <Input {...field} isDisabled={isPlatformManagedCredentials} />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.port"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    className="w-28"
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Port"
-                  >
-                    <Input type="number" {...field} isDisabled={isPlatformManagedCredentials} />
-                  </FormControl>
-                )}
-              />
-            </div>
-            <div className="mb-[0.675rem] flex items-start gap-2">
-              <Controller
-                name="credentials.username"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Username"
-                    className="flex-1"
-                  >
-                    <Input {...field} isDisabled={isPlatformManagedCredentials} />
-                  </FormControl>
-                )}
-              />
-              <Controller
-                name="credentials.password"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    errorText={error?.message}
-                    isError={Boolean(error?.message)}
-                    label="Password"
-                    className="flex-1"
-                  >
-                    <SecretInput
-                      containerClassName="text-gray-400 w-full group-focus-within:border-primary-400/50! border border-mineshaft-500 bg-mineshaft-900 px-2.5 py-1.5"
-                      value={value}
-                      onChange={(e) => onChange(e.target.value)}
-                      isDisabled={isPlatformManagedCredentials}
-                    />
-                  </FormControl>
-                )}
-              />
-            </div>
-          </Tab.Panel>
-          <Tab.Panel>
+      <Tabs
+        value={selectedTabIndex === 0 ? CONFIGURATION_TAB : SSL_TAB}
+        onValueChange={(value) => setSelectedTabIndex(value === CONFIGURATION_TAB ? 0 : 1)}
+        className="mb-4"
+      >
+        <TabsList variant={scopeVariant}>
+          <TabsTrigger value={CONFIGURATION_TAB}>Configuration</TabsTrigger>
+          <TabsTrigger value={SSL_TAB}>SSL ({sslEnabled ? "Enabled" : "Disabled"})</TabsTrigger>
+        </TabsList>
+        <TabsContent value={CONFIGURATION_TAB}>
+          <div className="flex items-start gap-2">
             <Controller
-              name="credentials.sslEnabled"
-              control={control}
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-                  <Switch
-                    className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                    id="ssl-enabled"
-                    thumbClassName="bg-mineshaft-800"
-                    isChecked={value}
-                    onCheckedChange={onChange}
-                    isDisabled={isPlatformManagedCredentials}
-                  >
-                    Enable SSL
-                  </Switch>
-                </FormControl>
-              )}
-            />
-            <Controller
-              name="credentials.sslCertificate"
+              name="credentials.host"
               control={control}
               render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  errorText={error?.message}
-                  isError={Boolean(error?.message)}
-                  className={sslEnabled ? "" : "opacity-50"}
-                  label="SSL Certificate"
-                  isOptional
-                >
-                  <TextArea
-                    className="h-14 resize-none!"
+                <Field className="flex-1">
+                  <FieldLabel htmlFor="sql-host">Host</FieldLabel>
+                  <Input
+                    id="sql-host"
                     {...field}
-                    isDisabled={isPlatformManagedCredentials || !sslEnabled}
+                    disabled={isPlatformManagedCredentials}
+                    isError={Boolean(error?.message)}
                   />
-                </FormControl>
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
             <Controller
-              name="credentials.sslRejectUnauthorized"
+              name="credentials.database"
               control={control}
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  className={sslEnabled ? "" : "opacity-50"}
-                  isError={Boolean(error?.message)}
-                  errorText={error?.message}
-                >
-                  <Switch
-                    className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                    id="ssl-reject-unauthorized"
-                    thumbClassName="bg-mineshaft-800"
-                    isChecked={sslEnabled ? value : false}
-                    onCheckedChange={onChange}
-                    isDisabled={isPlatformManagedCredentials || !sslEnabled}
-                  >
-                    <p className="w-38">
-                      Reject Unauthorized
-                      <Tooltip
-                        className="max-w-md"
-                        content={
-                          <p>
-                            If enabled, Infisical will only connect to the server if it has a valid,
-                            trusted SSL certificate.
-                          </p>
-                        }
-                      >
-                        <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                      </Tooltip>
-                    </p>
-                  </Switch>
-                </FormControl>
+              render={({ field, fieldState: { error } }) => (
+                <Field className="flex-1">
+                  <FieldLabel htmlFor="sql-database">Database Name</FieldLabel>
+                  <Input
+                    id="sql-database"
+                    {...field}
+                    disabled={isPlatformManagedCredentials}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
               )}
             />
-          </Tab.Panel>
-        </Tab.Panels>
-      </Tab.Group>
+            <Controller
+              name="credentials.port"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="w-28">
+                  <FieldLabel htmlFor="sql-port">Port</FieldLabel>
+                  <Input
+                    id="sql-port"
+                    type="number"
+                    {...field}
+                    disabled={isPlatformManagedCredentials}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </div>
+          <div className="mt-4 flex items-start gap-2">
+            <Controller
+              name="credentials.username"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <Field className="flex-1">
+                  <FieldLabel htmlFor="sql-username">Username</FieldLabel>
+                  <Input
+                    id="sql-username"
+                    {...field}
+                    disabled={isPlatformManagedCredentials}
+                    isError={Boolean(error?.message)}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.password"
+              control={control}
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="flex-1">
+                  <FieldLabel>Password</FieldLabel>
+                  <SecretInput
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    isDisabled={isPlatformManagedCredentials}
+                  />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </div>
+        </TabsContent>
+        <TabsContent value={SSL_TAB}>
+          <Controller
+            name="credentials.sslEnabled"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <Label htmlFor="ssl-enabled">Enable SSL</Label>
+                  </FieldContent>
+                  <Switch
+                    id="ssl-enabled"
+                    variant={scopeVariant}
+                    checked={value}
+                    onCheckedChange={onChange}
+                    disabled={isPlatformManagedCredentials}
+                  />
+                </Field>
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+          <Controller
+            name="credentials.sslCertificate"
+            control={control}
+            render={({ field, fieldState: { error } }) => (
+              <Field className={sslEnabled ? "mb-4" : "mb-4 opacity-50"}>
+                <FieldLabel htmlFor="ssl-certificate">
+                  SSL Certificate <span className="text-muted">(optional)</span>
+                </FieldLabel>
+                <TextArea
+                  id="ssl-certificate"
+                  className="h-14 resize-none"
+                  {...field}
+                  disabled={isPlatformManagedCredentials || !sslEnabled}
+                  isError={Boolean(error?.message)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+          <Controller
+            name="credentials.sslRejectUnauthorized"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field className={sslEnabled ? undefined : "opacity-50"}>
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <Label htmlFor="ssl-reject-unauthorized">Reject Unauthorized</Label>
+                    <FieldDescription>
+                      If enabled, Infisical will only connect to the server if it has a valid,
+                      trusted SSL certificate.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    id="ssl-reject-unauthorized"
+                    variant={scopeVariant}
+                    checked={sslEnabled ? value : false}
+                    onCheckedChange={onChange}
+                    disabled={isPlatformManagedCredentials || !sslEnabled}
+                  />
+                </Field>
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        </TabsContent>
+      </Tabs>
       {!isPlatformManagedCredentials && (
         <Controller
           name="isPlatformManagedCredentials"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl isError={Boolean(error?.message)} errorText={error?.message}>
-              <Switch
-                className="bg-mineshaft-400/50 shadow-inner data-[state=checked]:bg-green/80"
-                id="platform-managed"
-                thumbClassName="bg-mineshaft-800"
-                isChecked={value}
-                onCheckedChange={onChange}
-                isDisabled={isPlatformManagedCredentials}
-              >
-                <p className="w-[13.6rem]">
-                  Platform Managed Credentials
-                  <Tooltip
-                    className="max-w-md"
-                    content={
-                      <p>
-                        If enabled, Infisical will manage the credentials of this App Connection by
-                        updating the password on creation.
-                      </p>
-                    }
-                  >
-                    <FontAwesomeIcon icon={faQuestionCircle} size="sm" className="ml-1" />
-                  </Tooltip>
-                </p>
-              </Switch>
-            </FormControl>
+            <Field>
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <Label htmlFor="platform-managed">Platform Managed Credentials</Label>
+                  <FieldDescription>
+                    If enabled, Infisical will manage the credentials of this App Connection by
+                    updating the password on creation.
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="platform-managed"
+                  variant={scopeVariant}
+                  checked={value}
+                  onCheckedChange={onChange}
+                  disabled={isPlatformManagedCredentials}
+                />
+              </Field>
+              <FieldError errors={[error]} />
+            </Field>
           )}
         />
       )}

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionHeader.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionHeader.tsx
@@ -7,24 +7,23 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 type Props = {
   app: AppConnection;
   isConnected: boolean;
-  onBack?: () => void;
 };
 
-export const AppConnectionHeader = ({ app, isConnected, onBack }: Props) => {
+export const AppConnectionHeader = ({ app, isConnected }: Props) => {
   const appDetails = APP_CONNECTION_MAP[app];
 
   return (
-    <div className="mb-4 flex w-full items-start gap-2 border-b border-mineshaft-500 pb-4">
-      <div className="relative">
+    <div className="flex w-full items-start gap-2">
+      <div className="relative flex h-10 w-10 items-center justify-center rounded-md bg-container">
         <img
           alt={`${appDetails.name} logo`}
           src={`/images/integrations/${appDetails.image}`}
-          className="h-12 w-12 rounded-md bg-bunker-500 object-contain p-2"
+          className="h-7 w-7 object-contain"
         />
         {appDetails.icon && (
           <FontAwesomeIcon
             icon={appDetails.icon}
-            className="absolute right-1 bottom-1 text-primary-700"
+            className="absolute right-0.5 bottom-0.5 text-primary-700"
           />
         )}
       </div>
@@ -35,19 +34,10 @@ export const AppConnectionHeader = ({ app, isConnected, onBack }: Props) => {
             href={`https://infisical.com/docs/integrations/app-connections/${app}`}
           />
         </div>
-        <p className="text-sm leading-4 text-mineshaft-400">
+        <p className="text-sm font-normal leading-4 text-mineshaft-400">
           {isConnected ? `${appDetails.name} Connection` : `Connect to ${appDetails.name}`}
         </p>
       </div>
-      {onBack && (
-        <button
-          type="button"
-          className="mt-1 ml-auto text-xs text-mineshaft-400 underline underline-offset-2 hover:text-mineshaft-300"
-          onClick={onBack}
-        >
-          Select another App
-        </button>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionHeader.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionHeader.tsx
@@ -34,7 +34,7 @@ export const AppConnectionHeader = ({ app, isConnected }: Props) => {
             href={`https://infisical.com/docs/integrations/app-connections/${app}`}
           />
         </div>
-        <p className="text-sm font-normal leading-4 text-mineshaft-400">
+        <p className="text-sm leading-4 font-normal text-mineshaft-400">
           {isConnected ? `${appDetails.name} Connection` : `Connect to ${appDetails.name}`}
         </p>
       </div>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
@@ -1,14 +1,24 @@
-import { useMemo } from "react";
-import { faInfoCircle, faMagnifyingGlass, faSearch } from "@fortawesome/free-solid-svg-icons";
+import { useMemo, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Loader2Icon, Search } from "lucide-react";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
-import { EmptyState, Input, Pagination, Spinner, Tooltip } from "@app/components/v2";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@app/components/v3";
 import { useSubscription } from "@app/context";
-import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
-import { usePagination, usePopUp, useResetPageHelper } from "@app/hooks";
+import { APP_CONNECTION_MAP, POPULAR_APP_CONNECTIONS } from "@app/helpers/appConnections";
+import { usePopUp } from "@app/hooks";
 import { useAppConnectionOptions } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
+import { TAppConnectionOption } from "@app/hooks/api/appConnections/types/app-options";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 type Props = {
@@ -16,160 +26,194 @@ type Props = {
   projectType?: ProjectType;
 };
 
+const ProviderCard = ({ app, onClick }: { app: AppConnection; onClick: () => void }) => {
+  const { name, image, category, description, icon } = APP_CONNECTION_MAP[app];
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex cursor-pointer flex-col gap-3 rounded-md border border-border bg-card p-4 text-left transition-colors hover:border-mineshaft-500 hover:bg-mineshaft-700/50"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="relative flex h-9 w-9 items-center justify-center rounded-md bg-mineshaft-700">
+          <img
+            src={`/images/integrations/${image}`}
+            alt={`${name} logo`}
+            className="h-6 w-6 object-contain"
+          />
+          {icon && (
+            <FontAwesomeIcon
+              icon={icon}
+              className="absolute -right-1 -bottom-1 text-primary-700"
+              size="sm"
+            />
+          )}
+        </div>
+        <span className="text-[10px] font-medium tracking-wider text-muted uppercase">
+          {category}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-semibold text-foreground">{name}</p>
+        <p className="text-xs leading-relaxed text-muted">{description}</p>
+      </div>
+    </button>
+  );
+};
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <p className="mb-3 text-[11px] font-medium tracking-wider text-muted uppercase">{children}</p>
+);
+
 export const AppConnectionsSelect = ({ onSelect, projectType }: Props) => {
   const { subscription } = useSubscription();
   const { isPending, data: appConnectionOptions } = useAppConnectionOptions(projectType);
-
   const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
+  const [search, setSearch] = useState("");
 
-  const { search, setSearch, setPage, page, perPage, setPerPage, offset } = usePagination("", {
-    initPerPage: 16
-  });
+  const handleSelect = (app: AppConnection) => {
+    if (APP_CONNECTION_MAP[app].enterprise && !subscription.enterpriseAppConnections) {
+      handlePopUpOpen("upgradePlan", { isEnterpriseFeature: true });
+      return;
+    }
+    onSelect(app);
+  };
+
+  const optionsByApp = useMemo(() => {
+    const map = new Map<AppConnection, TAppConnectionOption>();
+    appConnectionOptions?.forEach((option) => map.set(option.app, option));
+    return map;
+  }, [appConnectionOptions]);
 
   const filteredOptions = useMemo(() => {
-    const searchLower = search.trim().toLowerCase();
+    const query = search.trim().toLowerCase();
+    if (!query) return appConnectionOptions ?? [];
+
     return (
-      appConnectionOptions?.filter(({ name, app }) => {
-        const aliases = APP_CONNECTION_MAP[app]?.aliases ?? [];
+      appConnectionOptions?.filter(({ app, name }) => {
+        const entry = APP_CONNECTION_MAP[app];
+        const aliases = entry?.aliases ?? [];
         return (
-          name?.toLowerCase().includes(searchLower) ||
-          app.toLowerCase().includes(searchLower) ||
-          aliases.some((alias) => alias.toLowerCase().includes(searchLower))
+          name?.toLowerCase().includes(query) ||
+          entry?.name.toLowerCase().includes(query) ||
+          entry?.category.toLowerCase().includes(query) ||
+          app.toLowerCase().includes(query) ||
+          aliases.some((alias) => alias.toLowerCase().includes(query))
         );
       }) ?? []
     );
   }, [appConnectionOptions, search]);
 
-  useResetPageHelper({
-    totalCount: filteredOptions.length,
-    offset,
-    setPage
-  });
+  const popularOptions = useMemo(
+    () =>
+      POPULAR_APP_CONNECTIONS.map((app) => optionsByApp.get(app)).filter(
+        (option): option is TAppConnectionOption => Boolean(option)
+      ),
+    [optionsByApp]
+  );
+
+  const isSearching = search.trim().length > 0;
 
   if (isPending) {
     return (
-      <div className="flex h-full flex-col items-center justify-center py-2.5">
-        <Spinner size="lg" className="text-mineshaft-500" />
-        <p className="mt-4 text-sm text-mineshaft-400">Loading options...</p>
+      <div className="flex h-full flex-col items-center justify-center py-10">
+        <Loader2Icon className="size-8 animate-spin text-accent" />
+        <p className="mt-4 text-sm text-muted">Loading options...</p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <Input
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-        placeholder="Search options..."
-        className="bg-mineshaft-800 placeholder:text-mineshaft-400"
-      />
-      <div className="grid h-118 grid-cols-4 content-start gap-2">
-        {filteredOptions.slice(offset, perPage * page)?.map((option) => {
-          const {
-            image,
-            name,
-            size = 50,
-            enterprise = false,
-            icon
-          } = APP_CONNECTION_MAP[option.app];
-
-          return (
-            <button
-              key={option.app}
-              type="button"
-              onClick={() =>
-                enterprise && !subscription.enterpriseAppConnections
-                  ? handlePopUpOpen("upgradePlan", {
-                      isEnterpriseFeature: true
-                    })
-                  : onSelect(option.app)
-              }
-              className="group relative flex h-28 cursor-pointer flex-col items-center justify-center rounded-md border border-mineshaft-600 bg-mineshaft-700 p-4 duration-200 hover:bg-mineshaft-600"
-            >
-              {image && (
-                <img
-                  src={`/images/integrations/${image}`}
-                  style={{
-                    width: `${size}px`
-                  }}
-                  className="mt-auto"
-                  alt={`${name} logo`}
-                />
-              )}
-              {icon && (
-                <div className="relative">
-                  <FontAwesomeIcon
-                    className="absolute -right-1.5 -bottom-1.5 text-primary-700"
-                    size="xl"
-                    icon={icon}
-                  />
-                </div>
-              )}
-              <div className="mt-auto max-w-xs text-center text-xs font-medium text-gray-300 duration-200 group-hover:text-gray-200">
-                {name}
-              </div>
-            </button>
-          );
-        })}
-        {!filteredOptions?.length && (
-          <EmptyState
-            className="col-span-full mt-40"
-            title="No App Connections match search"
-            icon={faSearch}
-          />
-        )}
-      </div>
-      {Boolean(filteredOptions.length) && (
-        <Pagination
-          startAdornment={
-            <Tooltip
-              side="bottom"
-              className="max-w-sm py-4"
-              content={
-                <>
-                  <p className="mb-2">Infisical is constantly adding support for more services.</p>
-                  <p>
-                    {`If you don't see the third-party
-            service you're looking for,`}{" "}
-                    <a
-                      target="_blank"
-                      className="underline hover:text-mineshaft-300"
-                      href="https://infisical.com/slack"
-                      rel="noopener noreferrer"
-                    >
-                      let us know on Slack
-                    </a>{" "}
-                    or{" "}
-                    <a
-                      target="_blank"
-                      className="underline hover:text-mineshaft-300"
-                      href="https://github.com/Infisical/infisical/discussions"
-                      rel="noopener noreferrer"
-                    >
-                      make a request on GitHub
-                    </a>
-                    .
-                  </p>
-                </>
-              }
-            >
-              <div className="-ml-3 flex items-center gap-1.5 text-mineshaft-400">
-                <span className="text-xs">
-                  Don&#39;t see the third-party service you&#39;re looking for?
-                </span>
-                <FontAwesomeIcon size="xs" icon={faInfoCircle} />
-              </div>
-            </Tooltip>
-          }
-          count={filteredOptions.length}
-          page={page}
-          perPage={perPage}
-          onChangePage={setPage}
-          onChangePerPage={setPerPage}
-          perPageList={[16]}
+    <div className="flex flex-col gap-6">
+      <InputGroup>
+        <InputGroupAddon align="inline-start">
+          <Search />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search apps — AWS, GitHub, Postgres, Vault..."
         />
+      </InputGroup>
+
+      {isSearching ? (
+        <section>
+          {filteredOptions.length ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {filteredOptions.map((option) => (
+                <ProviderCard
+                  key={option.app}
+                  app={option.app}
+                  onClick={() => handleSelect(option.app)}
+                />
+              ))}
+            </div>
+          ) : (
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <Search />
+                </EmptyMedia>
+                <EmptyTitle>No matching apps</EmptyTitle>
+                <EmptyDescription>Try a different search term.</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
+        </section>
+      ) : (
+        <>
+          {popularOptions.length > 0 && (
+            <section>
+              <SectionLabel>Popular</SectionLabel>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {popularOptions.map((option) => (
+                  <ProviderCard
+                    key={option.app}
+                    app={option.app}
+                    onClick={() => handleSelect(option.app)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+          <section>
+            <SectionLabel>All apps</SectionLabel>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {(appConnectionOptions ?? []).map((option) => (
+                <ProviderCard
+                  key={option.app}
+                  app={option.app}
+                  onClick={() => handleSelect(option.app)}
+                />
+              ))}
+            </div>
+          </section>
+        </>
       )}
+
+      <p className="text-xs text-muted">
+        Don&apos;t see the app you&apos;re looking for?{" "}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://infisical.com/slack"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          Let us know on Slack
+        </a>{" "}
+        or{" "}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/Infisical/infisical/discussions"
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          request it on GitHub
+        </a>
+        .
+      </p>
+
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionList.tsx
@@ -133,7 +133,7 @@ export const AppConnectionsSelect = ({ onSelect, projectType }: Props) => {
         <InputGroupInput
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search apps — AWS, GitHub, Postgres, Vault..."
+          placeholder="Search apps (e.g. AWS, GitHub, Postgres, Vault)"
         />
       </InputGroup>
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionRow.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionRow.tsx
@@ -47,7 +47,7 @@ import { GitHubConnectionMethod, TAppConnection } from "@app/hooks/api/appConnec
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { useListGitHubApps } from "@app/hooks/api/gitHubApps";
 
-import { CrededentialRotationStatusBadge } from "./AppConnectionForm/shared/CrededentialRotationBadge";
+import { CredentialRotationStatusBadge } from "./AppConnectionForm/shared/CredentialRotationBadge";
 
 type Props = {
   appConnection: TAppConnection;
@@ -246,7 +246,7 @@ export const AppConnectionRow = ({
           )}
 
           {appConnection.rotation && (
-            <CrededentialRotationStatusBadge appConnection={appConnection} />
+            <CredentialRotationStatusBadge appConnection={appConnection} />
           )}
 
           <DropdownMenu>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionRow.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionRow.tsx
@@ -1,37 +1,38 @@
 import { useCallback } from "react";
 import { subject } from "@casl/ability";
-import {
-  faAsterisk,
-  faBuilding,
-  faCheck,
-  faCopy,
-  faEdit,
-  faEllipsisV,
-  faInfoCircle,
-  faPause,
-  faPlay,
-  faRotate,
-  faTable,
-  faTrash
-} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "@tanstack/react-router";
-import { ServerIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
+import {
+  AsteriskIcon,
+  CheckIcon,
+  CopyIcon,
+  Ellipsis,
+  InfoIcon,
+  PauseIcon,
+  PencilIcon,
+  PlayIcon,
+  RefreshCwIcon,
+  ServerIcon,
+  Trash2Icon
+} from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { VariablePermissionCan } from "@app/components/permissions";
 import {
+  Badge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   IconButton,
-  Td,
+  OrgIcon,
+  ProjectIcon,
+  TableCell,
+  TableRow,
   Tooltip,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { OrgPermissionSubjects, ProjectPermissionSub, useOrganization } from "@app/context";
 import { OrgPermissionAppConnectionActions } from "@app/context/OrgPermissionContext/types";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
@@ -129,11 +130,8 @@ export const AppConnectionRow = ({
     : null;
 
   return (
-    <Tr
-      className={twMerge("group h-12 transition-colors duration-100 hover:bg-mineshaft-700")}
-      key={`app-connection-${id}`}
-    >
-      <Td>
+    <TableRow className="group" key={`app-connection-${id}`}>
+      <TableCell>
         <div className="flex items-center gap-2">
           <div className="relative">
             <img
@@ -151,43 +149,47 @@ export const AppConnectionRow = ({
           </div>
           <span className="hidden lg:inline">{connectionDetails.name}</span>
         </div>
-      </Td>
-      <Td className="max-w-0 min-w-32!">
+      </TableCell>
+      <TableCell className="max-w-0 min-w-32!">
         <div className="flex w-full items-center">
           <p className="truncate">{name}</p>
           {description && (
-            <Tooltip content={description}>
-              <FontAwesomeIcon icon={faInfoCircle} className="ml-1 text-mineshaft-400" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InfoIcon className="ml-1 size-3.5 text-mineshaft-400" />
+              </TooltipTrigger>
+              <TooltipContent>{description}</TooltipContent>
             </Tooltip>
           )}
         </div>
-      </Td>
-      <Td className="max-w-0 min-w-32!">
+      </TableCell>
+      <TableCell className="max-w-0 min-w-32!">
         {gitHubAppUrl && linkedGitHubApp ? (
-          <Tooltip
-            content={
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                href={gitHubAppUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex items-center gap-1.5 text-mineshaft-100 underline-offset-2 hover:text-primary hover:underline"
+              >
+                <FontAwesomeIcon
+                  size="sm"
+                  className="text-mineshaft-300/75"
+                  icon={methodDetails.icon}
+                />
+                <span className="truncate underline">{methodDetails.name}</span>
+              </a>
+            </TooltipTrigger>
+            <TooltipContent>
               <div className="flex flex-col gap-0.5">
                 <span className="text-[10px] tracking-wider text-mineshaft-400 uppercase">
                   {methodDetails.name}
                 </span>
                 <span className="font-mono text-sm text-mineshaft-100">{linkedGitHubApp.slug}</span>
               </div>
-            }
-          >
-            <a
-              href={gitHubAppUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="inline-flex items-center gap-1.5 text-mineshaft-100 underline-offset-2 hover:text-primary hover:underline"
-            >
-              <FontAwesomeIcon
-                size="sm"
-                className="text-mineshaft-300/75"
-                icon={methodDetails.icon}
-              />
-              <span className="truncate underline">{methodDetails.name}</span>
-            </a>
+            </TooltipContent>
           </Tooltip>
         ) : (
           <p className="truncate">
@@ -199,9 +201,9 @@ export const AppConnectionRow = ({
             {methodDetails.name}
           </p>
         )}
-      </Td>
+      </TableCell>
       {!isProjectView && (
-        <Td className="max-w-0 min-w-32!">
+        <TableCell className="max-w-0 min-w-32!">
           {project ? (
             <Link
               // @ts-expect-error app-connections aren't in kms/ssh
@@ -212,37 +214,34 @@ export const AppConnectionRow = ({
               }}
               className="underline"
             >
-              <p className="truncate">
-                <FontAwesomeIcon
-                  size="sm"
-                  className="mr-1.5 text-mineshaft-300/75"
-                  icon={faTable}
-                />
+              <p className="flex items-center gap-1.5 truncate">
+                <ProjectIcon className="size-3.5 text-mineshaft-300/75" />
                 {project.name}
               </p>
             </Link>
           ) : (
-            <p className="truncate">
-              <FontAwesomeIcon
-                size="sm"
-                className="mr-1.5 text-mineshaft-300/75"
-                icon={faBuilding}
-              />
+            <p className="flex items-center gap-1.5 truncate">
+              <OrgIcon className="size-3.5 text-mineshaft-300/75" />
               Organization
             </p>
           )}
-        </Td>
+        </TableCell>
       )}
-      <Td>
+      <TableCell>
         <div className="flex items-center justify-end gap-2">
           {isPlatformManagedCredentials && (
-            <Tooltip side="left" content="This connection's credentials are managed by Infisical.">
-              <div>
-                <Badge variant="info">
-                  <ServerIcon />
-                  Platform Managed Credentials
-                </Badge>
-              </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <Badge variant="info">
+                    <ServerIcon />
+                    Platform Managed Credentials
+                  </Badge>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                This connection&apos;s credentials are managed by Infisical.
+              </TooltipContent>
             </Tooltip>
           )}
 
@@ -250,127 +249,80 @@ export const AppConnectionRow = ({
             <CrededentialRotationStatusBadge appConnection={appConnection} />
           )}
 
-          <Tooltip className="max-w-sm text-center" content="Options">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <IconButton
-                  ariaLabel="Options"
-                  colorSchema="secondary"
-                  className="w-6"
-                  variant="plain"
-                >
-                  <FontAwesomeIcon icon={faEllipsisV} />
-                </IconButton>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent sideOffset={2} align="end">
-                <DropdownMenuItem
-                  icon={<FontAwesomeIcon icon={isIdCopied ? faCheck : faCopy} />}
-                  onClick={() => handleCopyId()}
-                >
-                  Copy Connection ID
-                </DropdownMenuItem>
-                {(isProjectView || !project) && (
-                  <>
-                    <VariablePermissionCan
-                      type={isProjectView ? "project" : "org"}
-                      I={
-                        isProjectView
-                          ? ProjectPermissionAppConnectionActions.Edit
-                          : OrgPermissionAppConnectionActions.Edit
-                      }
-                      a={
-                        isProjectView
-                          ? subject(ProjectPermissionSub.AppConnections, {
-                              connectionId: id
-                            })
-                          : subject(OrgPermissionSubjects.AppConnections, {
-                              connectionId: id
-                            })
-                      }
-                    >
-                      {(isAllowed: boolean) => (
-                        <DropdownMenuItem
-                          isDisabled={!isAllowed}
-                          icon={<FontAwesomeIcon icon={faEdit} />}
-                          onClick={() => onEditDetails(appConnection)}
-                        >
-                          Edit Details
-                        </DropdownMenuItem>
-                      )}
-                    </VariablePermissionCan>
-                    <VariablePermissionCan
-                      type={isProjectView ? "project" : "org"}
-                      I={
-                        isProjectView
-                          ? ProjectPermissionAppConnectionActions.Edit
-                          : OrgPermissionAppConnectionActions.Edit
-                      }
-                      a={
-                        isProjectView
-                          ? subject(ProjectPermissionSub.AppConnections, {
-                              connectionId: id
-                            })
-                          : subject(OrgPermissionSubjects.AppConnections, {
-                              connectionId: id
-                            })
-                      }
-                    >
-                      {(isAllowed: boolean) => (
-                        <DropdownMenuItem
-                          isDisabled={!isAllowed}
-                          icon={<FontAwesomeIcon icon={faAsterisk} />}
-                          onClick={() => onEditCredentials(appConnection)}
-                        >
-                          {isPlatformManagedCredentials ? "View" : "Edit"} Credentials
-                        </DropdownMenuItem>
-                      )}
-                    </VariablePermissionCan>
-                    {appConnection.rotation && (
-                      <VariablePermissionCan
-                        type={isProjectView ? "project" : "org"}
-                        I={
-                          isProjectView
-                            ? ProjectPermissionAppConnectionActions.Edit
-                            : OrgPermissionAppConnectionActions.Edit
-                        }
-                        a={
-                          isProjectView
-                            ? subject(ProjectPermissionSub.AppConnections, {
-                                connectionId: id
-                              })
-                            : subject(OrgPermissionSubjects.AppConnections, {
-                                connectionId: id
-                              })
-                        }
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton aria-label="Options" variant="ghost" size="xs">
+                <Ellipsis />
+              </IconButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent sideOffset={2} align="end">
+              <DropdownMenuItem onClick={() => handleCopyId()}>
+                {isIdCopied ? <CheckIcon /> : <CopyIcon />}
+                Copy Connection ID
+              </DropdownMenuItem>
+              {(isProjectView || !project) && (
+                <>
+                  <VariablePermissionCan
+                    type={isProjectView ? "project" : "org"}
+                    I={
+                      isProjectView
+                        ? ProjectPermissionAppConnectionActions.Edit
+                        : OrgPermissionAppConnectionActions.Edit
+                    }
+                    a={
+                      isProjectView
+                        ? subject(ProjectPermissionSub.AppConnections, {
+                            connectionId: id
+                          })
+                        : subject(OrgPermissionSubjects.AppConnections, {
+                            connectionId: id
+                          })
+                    }
+                  >
+                    {(isAllowed: boolean) => (
+                      <DropdownMenuItem
+                        isDisabled={!isAllowed}
+                        onClick={() => onEditDetails(appConnection)}
                       >
-                        {(isAllowed: boolean) => (
-                          <>
-                            <DropdownMenuItem
-                              isDisabled={!isAllowed}
-                              icon={<FontAwesomeIcon icon={faRotate} />}
-                              onClick={() => onRotateCredentials(appConnection)}
-                            >
-                              Rotate Credentials
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              isDisabled={!isAllowed}
-                              icon={
-                                <FontAwesomeIcon icon={isAutoRotationEnabled ? faPause : faPlay} />
-                              }
-                              onClick={() => onToggleAutoRotation(appConnection)}
-                            >
-                              {isAutoRotationEnabled ? "Disable" : "Enable"} Auto-Rotation
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                      </VariablePermissionCan>
+                        <PencilIcon />
+                        Edit Details
+                      </DropdownMenuItem>
                     )}
+                  </VariablePermissionCan>
+                  <VariablePermissionCan
+                    type={isProjectView ? "project" : "org"}
+                    I={
+                      isProjectView
+                        ? ProjectPermissionAppConnectionActions.Edit
+                        : OrgPermissionAppConnectionActions.Edit
+                    }
+                    a={
+                      isProjectView
+                        ? subject(ProjectPermissionSub.AppConnections, {
+                            connectionId: id
+                          })
+                        : subject(OrgPermissionSubjects.AppConnections, {
+                            connectionId: id
+                          })
+                    }
+                  >
+                    {(isAllowed: boolean) => (
+                      <DropdownMenuItem
+                        isDisabled={!isAllowed}
+                        onClick={() => onEditCredentials(appConnection)}
+                      >
+                        <AsteriskIcon />
+                        {isPlatformManagedCredentials ? "View" : "Edit"} Credentials
+                      </DropdownMenuItem>
+                    )}
+                  </VariablePermissionCan>
+                  {appConnection.rotation && (
                     <VariablePermissionCan
                       type={isProjectView ? "project" : "org"}
                       I={
                         isProjectView
-                          ? ProjectPermissionAppConnectionActions.Delete
-                          : OrgPermissionAppConnectionActions.Delete
+                          ? ProjectPermissionAppConnectionActions.Edit
+                          : OrgPermissionAppConnectionActions.Edit
                       }
                       a={
                         isProjectView
@@ -383,22 +335,59 @@ export const AppConnectionRow = ({
                       }
                     >
                       {(isAllowed: boolean) => (
-                        <DropdownMenuItem
-                          isDisabled={!isAllowed}
-                          icon={<FontAwesomeIcon icon={faTrash} />}
-                          onClick={() => onDelete(appConnection)}
-                        >
-                          Delete Connection
-                        </DropdownMenuItem>
+                        <>
+                          <DropdownMenuItem
+                            isDisabled={!isAllowed}
+                            onClick={() => onRotateCredentials(appConnection)}
+                          >
+                            <RefreshCwIcon />
+                            Rotate Credentials
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            isDisabled={!isAllowed}
+                            onClick={() => onToggleAutoRotation(appConnection)}
+                          >
+                            {isAutoRotationEnabled ? <PauseIcon /> : <PlayIcon />}
+                            {isAutoRotationEnabled ? "Disable" : "Enable"} Auto-Rotation
+                          </DropdownMenuItem>
+                        </>
                       )}
                     </VariablePermissionCan>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </Tooltip>
+                  )}
+                  <VariablePermissionCan
+                    type={isProjectView ? "project" : "org"}
+                    I={
+                      isProjectView
+                        ? ProjectPermissionAppConnectionActions.Delete
+                        : OrgPermissionAppConnectionActions.Delete
+                    }
+                    a={
+                      isProjectView
+                        ? subject(ProjectPermissionSub.AppConnections, {
+                            connectionId: id
+                          })
+                        : subject(OrgPermissionSubjects.AppConnections, {
+                            connectionId: id
+                          })
+                    }
+                  >
+                    {(isAllowed: boolean) => (
+                      <DropdownMenuItem
+                        variant="danger"
+                        isDisabled={!isAllowed}
+                        onClick={() => onDelete(appConnection)}
+                      >
+                        <Trash2Icon />
+                        Delete Connection
+                      </DropdownMenuItem>
+                    )}
+                  </VariablePermissionCan>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
-      </Td>
-    </Tr>
+      </TableCell>
+    </TableRow>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionsTable.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionsTable.tsx
@@ -1,40 +1,44 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  faArrowDown,
-  faArrowUp,
-  faCheckCircle,
-  faFilter,
-  faMagnifyingGlass,
-  faPlug,
-  faPlus,
-  faSearch
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { ChevronDownIcon, FilterIcon, PlusIcon, SearchIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
 import { VariablePermissionCan } from "@app/components/permissions";
 import {
   Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DocumentationLinkBadge,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
-  EmptyState,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
   IconButton,
-  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   Pagination,
+  Skeleton,
   Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
-import { DocumentationLinkBadge } from "@app/components/v3";
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tabs,
+  TabsList,
+  TabsTrigger
+} from "@app/components/v3";
 import { OrgPermissionSubjects, ProjectPermissionSub } from "@app/context";
 import { OrgPermissionAppConnectionActions } from "@app/context/OrgPermissionContext/types";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
@@ -44,7 +48,7 @@ import {
   PreferenceKey,
   setUserTablePreference
 } from "@app/helpers/userTablePreferences";
-import { usePagination, usePopUp, useResetPageHelper } from "@app/hooks";
+import { usePagination, usePopUp, useResetPageHelper, useScopeVariant } from "@app/hooks";
 import {
   TAppConnection,
   useListAppConnections,
@@ -87,6 +91,7 @@ type Props = {
 export const AppConnectionsTable = ({ projectId, projectType }: Props) => {
   const isProjectView = Boolean(projectId);
   const isCertManagerView = projectType === ProjectType.CertificateManager;
+  const scopeVariant = useScopeVariant();
   const { isPending, data: appConnections = [] } = useListAppConnections(projectId);
   const rotateCredentials = useRotateAppConnectionCredentials();
   const updateAppConnection = useUpdateAppConnection();
@@ -217,11 +222,15 @@ export const AppConnectionsTable = ({ projectId, projectType }: Props) => {
     setOrderDirection(OrderByDirection.ASC);
   };
 
-  const getClassName = (col: AppConnectionsOrderBy) =>
-    twMerge("ml-2", orderBy === col ? "" : "opacity-30");
-
-  const getColSortIcon = (col: AppConnectionsOrderBy) =>
-    orderDirection === OrderByDirection.DESC && orderBy === col ? faArrowUp : faArrowDown;
+  const renderSortIcon = (col: AppConnectionsOrderBy) =>
+    orderBy === col ? (
+      <ChevronDownIcon
+        className={twMerge(
+          "ml-1 size-3.5 transition-transform",
+          orderDirection === OrderByDirection.DESC && "rotate-180"
+        )}
+      />
+    ) : null;
 
   const isTableFiltered = Boolean(filters.apps.length);
 
@@ -273,244 +282,232 @@ export const AppConnectionsTable = ({ projectId, projectType }: Props) => {
     );
   };
 
+  const visibleConnections = filteredAppConnections.slice(offset, perPage * page);
+
   return (
-    <div className="rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <div className="flex items-center gap-x-2">
-            <p className="text-xl font-medium text-mineshaft-100">App Connections</p>
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            App Connections
             <DocumentationLinkBadge href="https://infisical.com/docs/integrations/app-connections/overview" />
-          </div>
-          <p className="text-sm text-bunker-300">
+          </CardTitle>
+          <CardDescription>
             {isCertManagerView
               ? "Create and configure connections with third-party apps for your Applications and Signers."
               : `Create and configure connections with third-party apps for re-use across your project${
                   isProjectView ? "" : "s"
                 }.`}
-          </p>
-        </div>
-        <VariablePermissionCan
-          type={isProjectView ? "project" : "org"}
-          I={
-            isProjectView
-              ? ProjectPermissionAppConnectionActions.Create
-              : OrgPermissionAppConnectionActions.Create
-          }
-          a={
-            isProjectView
-              ? ProjectPermissionSub.AppConnections
-              : OrgPermissionSubjects.AppConnections
-          }
-        >
-          {(isAllowed) => (
-            <Button
-              colorSchema="secondary"
-              leftIcon={<FontAwesomeIcon icon={faPlus} />}
-              onClick={() => handlePopUpOpen("addConnection")}
-              isDisabled={!isAllowed}
+          </CardDescription>
+          <CardAction>
+            <VariablePermissionCan
+              type={isProjectView ? "project" : "org"}
+              I={
+                isProjectView
+                  ? ProjectPermissionAppConnectionActions.Create
+                  : OrgPermissionAppConnectionActions.Create
+              }
+              a={
+                isProjectView
+                  ? ProjectPermissionSub.AppConnections
+                  : OrgPermissionSubjects.AppConnections
+              }
             >
-              Add Connection
-            </Button>
-          )}
-        </VariablePermissionCan>
-      </div>
-      <div className="flex gap-2">
-        {!isProjectView && (
-          <div className="flex gap-x-0.5 rounded-md border border-mineshaft-600 bg-mineshaft-800 p-1">
-            <Button
-              variant="outline_bg"
-              onClick={() => {
-                setView(View.Scope);
-                localStorage.setItem(APP_CONNECTION_VIEW_STORAGE_KEY, View.Scope);
-              }}
-              size="xs"
-              className={`${
-                view === View.Scope ? "bg-mineshaft-500" : "bg-transparent"
-              } min-w-20 rounded border-none hover:bg-mineshaft-600`}
-            >
-              Organization
-            </Button>
-            <Button
-              variant="outline_bg"
-              onClick={() => {
-                setView(View.All);
-                localStorage.setItem(APP_CONNECTION_VIEW_STORAGE_KEY, View.All);
-              }}
-              size="xs"
-              className={`${
-                view === View.All ? "bg-mineshaft-500" : "bg-transparent"
-              } min-w-20 rounded border-none hover:bg-mineshaft-600`}
-            >
-              All
-            </Button>
-          </div>
-        )}
-        <Input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-          placeholder="Search connections..."
-          className="flex-1"
-        />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              ariaLabel="Filter Connections"
-              variant="plain"
-              size="sm"
-              className={twMerge(
-                "flex h-10 w-11 items-center justify-center overflow-hidden border border-mineshaft-600 bg-mineshaft-800 p-0 transition-all hover:border-primary/60 hover:bg-primary/10",
-                isTableFiltered && "border-primary/50 text-primary"
+              {(isAllowed) => (
+                <Button
+                  variant={scopeVariant}
+                  onClick={() => handlePopUpOpen("addConnection")}
+                  isDisabled={!isAllowed}
+                >
+                  <PlusIcon />
+                  Add Connection
+                </Button>
               )}
-            >
-              <FontAwesomeIcon icon={faFilter} />
-            </IconButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            sideOffset={2}
-            className="max-h-[70vh] thin-scrollbar overflow-y-auto"
-            align="end"
-          >
-            <DropdownMenuLabel>Filter by Apps</DropdownMenuLabel>
-            {appConnections.length ? (
-              [...new Set(appConnections.map(({ app }) => app))]
-                .sort((a, b) => {
-                  return a.toLowerCase().localeCompare(b.toLowerCase());
-                })
-                .map((app) => (
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setFilters((prev) => ({
-                        ...prev,
-                        apps: prev.apps.includes(app)
-                          ? prev.apps.filter((a) => a !== app)
-                          : [...prev.apps, app]
-                      }));
-                    }}
-                    key={app}
-                    icon={
-                      filters.apps.includes(app) && (
-                        <FontAwesomeIcon className="text-primary" icon={faCheckCircle} />
-                      )
-                    }
-                    iconPos="right"
-                  >
-                    <div className="flex items-center gap-2">
-                      <img
-                        alt={`${APP_CONNECTION_MAP[app].name} integration`}
-                        src={`/images/integrations/${APP_CONNECTION_MAP[app].image}`}
-                        className="h-4 w-4"
-                      />
-                      <span>{APP_CONNECTION_MAP[app].name}</span>
-                    </div>
-                  </DropdownMenuItem>
-                ))
-            ) : (
-              <DropdownMenuItem isDisabled>No Connections Configured</DropdownMenuItem>
+            </VariablePermissionCan>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            {!isProjectView && (
+              <Tabs
+                value={view}
+                onValueChange={(next) => {
+                  setView(next as View);
+                  localStorage.setItem(APP_CONNECTION_VIEW_STORAGE_KEY, next);
+                }}
+              >
+                <TabsList variant="filled">
+                  <TabsTrigger value={View.Scope}>Organization</TabsTrigger>
+                  <TabsTrigger value={View.All}>All</TabsTrigger>
+                </TabsList>
+              </Tabs>
             )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <TableContainer className="mt-4">
-        <Table>
-          <THead>
-            <Tr>
-              <Th className="w-1/4">
-                <div className="flex items-center">
-                  App
-                  <IconButton
-                    variant="plain"
-                    className={getClassName(AppConnectionsOrderBy.App)}
-                    ariaLabel="sort"
-                    onClick={() => handleSort(AppConnectionsOrderBy.App)}
-                  >
-                    <FontAwesomeIcon icon={getColSortIcon(AppConnectionsOrderBy.App)} />
-                  </IconButton>
-                </div>
-              </Th>
-              <Th className="w-1/3">
-                <div className="flex items-center">
-                  Name
-                  <IconButton
-                    variant="plain"
-                    className={getClassName(AppConnectionsOrderBy.Name)}
-                    ariaLabel="sort"
-                    onClick={() => handleSort(AppConnectionsOrderBy.Name)}
-                  >
-                    <FontAwesomeIcon icon={getColSortIcon(AppConnectionsOrderBy.Name)} />
-                  </IconButton>
-                </div>
-              </Th>
-              <Th>
-                <div className="flex items-center">
-                  Method
-                  <IconButton
-                    variant="plain"
-                    className={getClassName(AppConnectionsOrderBy.Method)}
-                    ariaLabel="sort"
-                    onClick={() => handleSort(AppConnectionsOrderBy.Method)}
-                  >
-                    <FontAwesomeIcon icon={getColSortIcon(AppConnectionsOrderBy.Method)} />
-                  </IconButton>
-                </div>
-              </Th>
-              {!isProjectView && (
-                <Th>
-                  <div className="flex items-center">
-                    Managed By
-                    <IconButton
-                      variant="plain"
-                      className={getClassName(AppConnectionsOrderBy.ManagedBy)}
-                      ariaLabel="sort"
-                      onClick={() => handleSort(AppConnectionsOrderBy.ManagedBy)}
-                    >
-                      <FontAwesomeIcon icon={getColSortIcon(AppConnectionsOrderBy.ManagedBy)} />
-                    </IconButton>
-                  </div>
-                </Th>
-              )}
-              <Th className="w-5" />
-            </Tr>
-          </THead>
-          <TBody>
-            {isPending && (
-              <TableSkeleton innerKey="app-connections-table" columns={4} key="app-connections" />
-            )}
-            {filteredAppConnections.slice(offset, perPage * page).map((connection) => (
-              <AppConnectionRow
-                appConnection={connection}
-                key={connection.id}
-                onDelete={handleDelete}
-                onEditCredentials={handleEditCredentials}
-                onEditDetails={handleEditDetails}
-                onRotateCredentials={handleRotateCredentials}
-                onToggleAutoRotation={handleToggleAutoRotation}
-                isProjectView={isProjectView}
+            <InputGroup className="flex-1">
+              <InputGroupAddon align="inline-start">
+                <SearchIcon />
+              </InputGroupAddon>
+              <InputGroupInput
+                placeholder="Search connections..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
               />
-            ))}
-          </TBody>
-        </Table>
-        {Boolean(filteredAppConnections.length) && (
-          <Pagination
-            count={filteredAppConnections.length}
-            page={page}
-            perPage={perPage}
-            onChangePage={setPage}
-            onChangePerPage={handlePerPageChange}
-          />
-        )}
-        {!isPending && !filteredAppConnections?.length && (
-          <EmptyState
-            title={
-              appConnections.length
-                ? "No App Connections match search..."
-                : "No App Connections have been configured"
-            }
-            icon={appConnections.length ? faSearch : faPlug}
-          />
-        )}
-      </TableContainer>
+            </InputGroup>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  aria-label="Filter Connections"
+                  variant={isTableFiltered ? scopeVariant : "outline"}
+                >
+                  <FilterIcon />
+                </IconButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                sideOffset={2}
+                className="max-h-[70vh] thin-scrollbar overflow-y-auto"
+                align="end"
+              >
+                <DropdownMenuLabel>Filter by Apps</DropdownMenuLabel>
+                {appConnections.length ? (
+                  [...new Set(appConnections.map(({ app }) => app))]
+                    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+                    .map((app) => (
+                      <DropdownMenuCheckboxItem
+                        key={app}
+                        checked={filters.apps.includes(app)}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setFilters((prev) => ({
+                            ...prev,
+                            apps: prev.apps.includes(app)
+                              ? prev.apps.filter((a) => a !== app)
+                              : [...prev.apps, app]
+                          }));
+                        }}
+                      >
+                        <div className="flex items-center gap-2">
+                          <img
+                            alt={`${APP_CONNECTION_MAP[app].name} integration`}
+                            src={`/images/integrations/${APP_CONNECTION_MAP[app].image}`}
+                            className="h-4 w-4"
+                          />
+                          <span>{APP_CONNECTION_MAP[app].name}</span>
+                        </div>
+                      </DropdownMenuCheckboxItem>
+                    ))
+                ) : (
+                  <DropdownMenuLabel className="font-normal text-mineshaft-400">
+                    No Connections Configured
+                  </DropdownMenuLabel>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="mt-4">
+            {!isPending && !filteredAppConnections.length ? (
+              <Empty className="border">
+                <EmptyHeader>
+                  <EmptyTitle>
+                    {appConnections.length
+                      ? "No App Connections match search"
+                      : "No App Connections have been configured"}
+                  </EmptyTitle>
+                  <EmptyDescription>
+                    {appConnections.length
+                      ? "Adjust your search or filters to view connections."
+                      : "Add a connection to a third-party app to get started."}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead
+                        className="w-1/4 cursor-pointer"
+                        onClick={() => handleSort(AppConnectionsOrderBy.App)}
+                      >
+                        App
+                        {renderSortIcon(AppConnectionsOrderBy.App)}
+                      </TableHead>
+                      <TableHead
+                        className="w-1/3 cursor-pointer"
+                        onClick={() => handleSort(AppConnectionsOrderBy.Name)}
+                      >
+                        Name
+                        {renderSortIcon(AppConnectionsOrderBy.Name)}
+                      </TableHead>
+                      <TableHead
+                        className="cursor-pointer"
+                        onClick={() => handleSort(AppConnectionsOrderBy.Method)}
+                      >
+                        Method
+                        {renderSortIcon(AppConnectionsOrderBy.Method)}
+                      </TableHead>
+                      {!isProjectView && (
+                        <TableHead
+                          className="cursor-pointer"
+                          onClick={() => handleSort(AppConnectionsOrderBy.ManagedBy)}
+                        >
+                          Managed By
+                          {renderSortIcon(AppConnectionsOrderBy.ManagedBy)}
+                        </TableHead>
+                      )}
+                      <TableHead className="w-5" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {isPending &&
+                      Array.from({ length: 10 }).map((_, i) => (
+                        <TableRow key={`skeleton-${i + 1}`}>
+                          <TableCell>
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                          {!isProjectView && (
+                            <TableCell>
+                              <Skeleton className="h-4 w-full" />
+                            </TableCell>
+                          )}
+                          <TableCell>
+                            <Skeleton className="h-4 w-4" />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    {!isPending &&
+                      visibleConnections.map((connection) => (
+                        <AppConnectionRow
+                          appConnection={connection}
+                          key={connection.id}
+                          onDelete={handleDelete}
+                          onEditCredentials={handleEditCredentials}
+                          onEditDetails={handleEditDetails}
+                          onRotateCredentials={handleRotateCredentials}
+                          onToggleAutoRotation={handleToggleAutoRotation}
+                          isProjectView={isProjectView}
+                        />
+                      ))}
+                  </TableBody>
+                </Table>
+                {!isPending && (
+                  <Pagination
+                    count={filteredAppConnections.length}
+                    page={page}
+                    perPage={perPage}
+                    onChangePage={setPage}
+                    onChangePerPage={handlePerPageChange}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
       <DeleteAppConnectionModal
         isOpen={popUp.deleteConnection.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("deleteConnection", isOpen)}
@@ -536,6 +533,6 @@ export const AppConnectionsTable = ({ projectId, projectType }: Props) => {
         projectId={projectId}
         projectType={projectType}
       />
-    </div>
+    </>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/DeleteAppConnectionModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/DeleteAppConnectionModal.tsx
@@ -1,6 +1,25 @@
+import { useEffect, useState } from "react";
+import { Trash2Icon } from "lucide-react";
+
 import { createNotification } from "@app/components/notifications";
-import { DeleteActionModal } from "@app/components/v2";
-import { NoticeBannerV2 } from "@app/components/v2/NoticeBannerV2/NoticeBannerV2";
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertTitle,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
 import { TAppConnection, useDeleteAppConnection } from "@app/hooks/api/appConnections";
 
@@ -12,12 +31,20 @@ type Props = {
 
 export const DeleteAppConnectionModal = ({ isOpen, onOpenChange, appConnection }: Props) => {
   const deleteAppConnection = useDeleteAppConnection();
+  const [inputData, setInputData] = useState("");
+
+  useEffect(() => {
+    setInputData("");
+  }, [isOpen]);
 
   if (!appConnection) return null;
 
   const { id: connectionId, name, app } = appConnection;
+  const isConfirmed = inputData === name;
 
   const handleDeleteAppConnection = async () => {
+    if (!isConfirmed) return;
+
     await deleteAppConnection.mutateAsync({
       connectionId,
       app
@@ -32,23 +59,55 @@ export const DeleteAppConnectionModal = ({ isOpen, onOpenChange, appConnection }
   };
 
   return (
-    <DeleteActionModal
-      isOpen={isOpen}
-      onChange={onOpenChange}
-      title={`Are you sure you want to delete ${name}?`}
-      deleteKey={name}
-      onDeleteApproved={handleDeleteAppConnection}
-    >
-      {appConnection.isPlatformManagedCredentials && (
-        <NoticeBannerV2 className="mt-3" title="Platform Managed Credentials">
-          <p className="text-sm text-bunker-300">
-            This App Connection&#39;s credentials are managed by Infisical.
-          </p>
-          <p className="mt-3 text-sm text-bunker-300">
-            By deleting this connection you may lose permanent access to the associated resource.
-          </p>
-        </NoticeBannerV2>
-      )}
-    </DeleteActionModal>
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia>
+            <Trash2Icon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Are you sure you want to delete {name}?</AlertDialogTitle>
+          <AlertDialogDescription>This action is irreversible.</AlertDialogDescription>
+        </AlertDialogHeader>
+        {appConnection.isPlatformManagedCredentials && (
+          <Alert variant="warning">
+            <AlertTitle>Platform Managed Credentials</AlertTitle>
+            <AlertDescription>
+              This App Connection&#39;s credentials are managed by Infisical. By deleting this
+              connection you may lose permanent access to the associated resource.
+            </AlertDescription>
+          </Alert>
+        )}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleDeleteAppConnection();
+          }}
+        >
+          <Field>
+            <FieldLabel>
+              Type <span className="font-bold">{name}</span> to confirm
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                value={inputData}
+                onChange={(e) => setInputData(e.target.value)}
+                placeholder={`Type ${name} here`}
+                autoComplete="off"
+              />
+            </FieldContent>
+          </Field>
+        </form>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="danger"
+            onClick={handleDeleteAppConnection}
+            disabled={!isConfirmed}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/DeleteAppConnectionModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/DeleteAppConnectionModal.tsx
@@ -6,7 +6,6 @@ import {
   Alert,
   AlertDescription,
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -15,6 +14,7 @@ import {
   AlertDialogMedia,
   AlertDialogTitle,
   AlertTitle,
+  Button,
   Field,
   FieldContent,
   FieldLabel,
@@ -43,19 +43,23 @@ export const DeleteAppConnectionModal = ({ isOpen, onOpenChange, appConnection }
   const isConfirmed = inputData === name;
 
   const handleDeleteAppConnection = async () => {
-    if (!isConfirmed) return;
+    if (!isConfirmed || deleteAppConnection.isPending) return;
 
-    await deleteAppConnection.mutateAsync({
-      connectionId,
-      app
-    });
+    try {
+      await deleteAppConnection.mutateAsync({
+        connectionId,
+        app
+      });
 
-    createNotification({
-      text: `Successfully removed ${APP_CONNECTION_MAP[app].name} connection`,
-      type: "success"
-    });
+      createNotification({
+        text: `Successfully removed ${APP_CONNECTION_MAP[app].name} connection`,
+        type: "success"
+      });
 
-    onOpenChange(false);
+      onOpenChange(false);
+    } catch {
+      // Error is handled by the mutation's onError handler
+    }
   };
 
   return (
@@ -99,13 +103,15 @@ export const DeleteAppConnectionModal = ({ isOpen, onOpenChange, appConnection }
         </form>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
+          <Button
             variant="danger"
+            size="sm"
+            isDisabled={!isConfirmed}
+            isPending={deleteAppConnection.isPending}
             onClick={handleDeleteAppConnection}
-            disabled={!isConfirmed}
           >
             Delete
-          </AlertDialogAction>
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/EditAppConnectionCredentialsModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/EditAppConnectionCredentialsModal.tsx
@@ -1,8 +1,8 @@
-import { Modal, ModalContent } from "@app/components/v2";
-import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@app/components/v3";
 import { TAppConnection } from "@app/hooks/api/appConnections";
 
 import { AppConnectionForm } from "./AppConnectionForm";
+import { AppConnectionHeader } from "./AppConnectionHeader";
 
 type Props = {
   isOpen: boolean;
@@ -18,16 +18,21 @@ export const EditAppConnectionCredentialsModal = ({
   if (!appConnection) return null;
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        className="max-w-2xl"
-        title="Edit Connection Credentials"
-        subTitle={`Update the credentials for this ${
-          appConnection ? APP_CONNECTION_MAP[appConnection.app].name : "App"
-        } Connection.`}
-      >
-        <AppConnectionForm onComplete={() => onOpenChange(false)} appConnection={appConnection} />
-      </ModalContent>
-    </Modal>
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent className="flex h-full max-h-full flex-col gap-y-0 sm:max-w-2xl">
+        <SheetHeader className="border-b">
+          <SheetTitle>
+            <AppConnectionHeader app={appConnection.app} isConnected />
+          </SheetTitle>
+        </SheetHeader>
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <AppConnectionForm
+            appConnection={appConnection}
+            onComplete={() => onOpenChange(false)}
+            onCancel={() => onOpenChange(false)}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/EditAppConnectionDetailsModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/EditAppConnectionDetailsModal.tsx
@@ -3,8 +3,17 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, Modal, ModalClose, ModalContent } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "@app/components/v3";
 import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
+import { useScopeVariant } from "@app/hooks";
 import { TAppConnection, useUpdateAppConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
@@ -26,6 +35,7 @@ type ContentProps = { appConnection: TAppConnection; onComplete: () => void };
 
 const Content = ({ appConnection, onComplete }: ContentProps) => {
   const updateAppConnection = useUpdateAppConnection();
+  const scopeVariant = useScopeVariant();
   const { name: appName } = APP_CONNECTION_MAP[appConnection.app];
 
   const form = useForm<FormData>({
@@ -58,22 +68,20 @@ const Content = ({ appConnection, onComplete }: ContentProps) => {
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <GenericAppConnectionsFields />
-        <div className="mt-8 flex items-center">
+        <div className="mt-8 flex items-center gap-3">
           <Button
-            className="mr-4"
-            size="sm"
             type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
+            variant={scopeVariant}
+            isPending={isSubmitting}
             isDisabled={isSubmitting || !isDirty}
           >
             Update Details
           </Button>
-          <ModalClose asChild>
-            <Button colorSchema="secondary" variant="plain">
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
               Cancel
             </Button>
-          </ModalClose>
+          </DialogClose>
         </div>
       </form>
     </FormProvider>
@@ -84,16 +92,16 @@ export const EditAppConnectionDetailsModal = ({ isOpen, onOpenChange, appConnect
   if (!appConnection) return null;
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        className="max-w-2xl"
-        title="Edit Connection Name"
-        subTitle={`Update the name for this ${
-          appConnection ? APP_CONNECTION_MAP[appConnection.app].name : "App"
-        } Connection.`}
-      >
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Connection Name</DialogTitle>
+          <DialogDescription>
+            Update the name for this {APP_CONNECTION_MAP[appConnection.app].name} Connection.
+          </DialogDescription>
+        </DialogHeader>
         <Content appConnection={appConnection} onComplete={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/organization/IntegrationsPage/IntegrationsPage.tsx
@@ -1,9 +1,9 @@
 import { Helmet } from "react-helmet";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { InfoIcon } from "lucide-react";
 
 import { PageHeader, Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { Alert, AlertTitle } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization } from "@app/context";
 import {
@@ -19,14 +19,12 @@ import { IntegrationsListPageTabs } from "@app/types/integrations";
 const AppConnectionsTab = withPermission(
   () => (
     <>
-      <div className="mb-4 flex w-full flex-col rounded-md border border-blue-500/50 bg-blue-500/30 px-4 py-2 text-sm text-blue-200">
-        <div className="flex items-center">
-          <FontAwesomeIcon icon={faInfoCircle} className="mr-2 mb-0.5 text-sm" />
-          <span className="text-sm text-blue-200">
-            App connections can also be created and managed independently in projects now.
-          </span>
-        </div>
-      </div>
+      <Alert variant="info" className="mb-4">
+        <InfoIcon />
+        <AlertTitle>
+          App connections can also be created and managed independently in projects now.
+        </AlertTitle>
+      </Alert>
       <AppConnectionsTable />
     </>
   ),


### PR DESCRIPTION
## Context

This PR migrates app connections UI to v3 components and updates the UI to match secret sync re-vamp styling

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-06-18 at 17 46 41@2x" src="https://github.com/user-attachments/assets/caee46a4-fb09-44b8-bcab-64e2b7ba4bab" />
<img width="3456" height="1922" alt="CleanShot 2026-06-18 at 17 46 44@2x" src="https://github.com/user-attachments/assets/0ce0d0b2-3939-4cf4-9cc3-0b43c4d3b75b" />
<img width="3456" height="1922" alt="CleanShot 2026-06-18 at 17 46 47@2x" src="https://github.com/user-attachments/assets/8116576c-bfb0-44db-8717-00c0d862da79" />

## Steps to verify the change

- check every from to validate no regressions
- check table and dropdown actions
- check one oauth flow end to end

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)