### PR TITLE
fix(scim): make schemas optional with default on POST /Users and POST /Groups

### DIFF
--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -329,7 +329,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       body: z.object({
-        schemas: z.array(z.string()),
+        schemas: z.array(z.string()).default(["urn:ietf:params:scim:schemas:core:2.0:User"]),
         userName: z.string().trim(),
         name: z
           .object({
@@ -503,7 +503,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     schema: {
       body: z.object({
-        schemas: z.array(z.string()),
+        schemas: z.array(z.string()).default(["urn:ietf:params:scim:schemas:core:2.0:Group"]),
         displayName: z.string().trim(),
         members: z
           .array(


### PR DESCRIPTION
POST /Users and POST /Groups rejected requests without an explicit `schemas` array with a 422. RFC 7644 does not require clients to include `schemas` on create requests (the endpoint already implies the resource type). PUT /Users and PUT /Groups already defaulted to the right URN; POST was left as required.

This applies the same `.default([...])` treatment to both POST endpoints so IdPs that omit `schemas` on create (e.g. Authentik) no longer get a 422.

No logic changes -- `schemas` is not used in any handler downstream; it is only a validation field.

Closes #6552 (remaining POST validation part after #6885).

## Checklist

- [x] Follows existing patterns (matches PUT /Users and PUT /Groups schema handling)
- [x] No DB or service-layer changes
- [x] Type-checked with `tsc --noEmit` -- no errors
