### PR TITLE
fix(scim): batch-fetch group members and fix totalResults in listScimGroups

### DIFF
--- a/backend/src/ee/services/group/group-dal.ts
+++ b/backend/src/ee/services/group/group-dal.ts
@@ -40,6 +40,19 @@ export const groupDALFactory = (db: TDbClient) => {
     }
   };
 
+  const countGroups = async (filter: TFindFilter<TGroups>, tx?: Knex): Promise<number> => {
+    try {
+      const result = await (tx || db.replicaNode())(TableName.Groups)
+        // eslint-disable-next-line
+        .where(buildFindFilter(filter))
+        .count<{ count: string }>({ count: "*" })
+        .first();
+      return Number(result?.count ?? 0);
+    } catch (err) {
+      throw new DatabaseError({ error: err, name: "Count groups" });
+    }
+  };
+
   const findByOrgId = async (orgId: string, tx?: Knex) => {
     try {
       // Return groups that have a membership in this org (native groups: group.orgId = orgId, or inherited: linked from root)
@@ -617,6 +630,7 @@ export const groupDALFactory = (db: TDbClient) => {
   return {
     ...groupOrm,
     findGroups,
+    countGroups,
     findByOrgId,
     listAvailableGroups,
     findAllGroupPossibleUsers,

--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -217,6 +217,38 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findGroupMembershipsByGroupIdsInOrg = async (groupIds: string[], orgId: string, tx?: Knex) => {
+    try {
+      const queryDb = tx || db.replicaNode();
+
+      const groupIdsVisibleInOrg = queryDb(TableName.Membership)
+        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Membership}.scopeOrgId`, orgId)
+        .whereNotNull(`${TableName.Membership}.actorGroupId`)
+        .select(`${TableName.Membership}.actorGroupId`);
+
+      const docs = await queryDb(TableName.UserGroupMembership)
+        .join(TableName.Groups, `${TableName.UserGroupMembership}.groupId`, `${TableName.Groups}.id`)
+        .join(TableName.Membership, `${TableName.UserGroupMembership}.userId`, `${TableName.Membership}.actorUserId`)
+        .join(TableName.Users, `${TableName.UserGroupMembership}.userId`, `${TableName.Users}.id`)
+        .whereIn(`${TableName.UserGroupMembership}.groupId`, groupIds)
+        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Membership}.scopeOrgId`, orgId)
+        .whereIn(`${TableName.UserGroupMembership}.groupId`, groupIdsVisibleInOrg)
+        .select(
+          db.ref("id").withSchema(TableName.UserGroupMembership),
+          db.ref("groupId").withSchema(TableName.UserGroupMembership),
+          db.ref("name").withSchema(TableName.Groups).as("groupName"),
+          db.ref("id").withSchema(TableName.Membership).as("orgMembershipId"),
+          db.ref("firstName").withSchema(TableName.Users).as("firstName"),
+          db.ref("lastName").withSchema(TableName.Users).as("lastName")
+        );
+      return docs;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find group memberships by group ids in org" });
+    }
+  };
+
   return {
     ...userGroupMembershipOrm,
     filterProjectsByUserMembership,
@@ -224,6 +256,7 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
     findGroupMembersNotInProject,
     deletePendingUserGroupMembershipsByUserIds,
     findGroupMembershipsByUserIdInOrg,
-    findGroupMembershipsByGroupIdInOrg
+    findGroupMembershipsByGroupIdInOrg,
+    findGroupMembershipsByGroupIdsInOrg
   };
 };

--- a/backend/src/ee/services/scim/scim-fns.ts
+++ b/backend/src/ee/services/scim/scim-fns.ts
@@ -84,18 +84,20 @@ export const buildScimUser = ({
 export const buildScimGroupList = ({
   scimGroups,
   startIndex,
-  limit
+  limit,
+  totalResults
 }: {
   scimGroups: TScimGroup[];
   startIndex: number;
   limit: number;
+  totalResults: number;
 }): TListScimGroups => {
   return {
     Resources: scimGroups,
     itemsPerPage: limit,
     schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
     startIndex,
-    totalResults: scimGroups.length
+    totalResults
   };
 };
 

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -105,6 +105,7 @@ type TScimServiceFactoryDep = {
     | "findAllGroupPossibleUsers"
     | "delete"
     | "findGroups"
+    | "countGroups"
     | "transaction"
     | "updateById"
     | "update"
@@ -120,6 +121,7 @@ type TScimServiceFactoryDep = {
     | "delete"
     | "findGroupMembershipsByUserIdInOrg"
     | "findGroupMembershipsByGroupIdInOrg"
+    | "findGroupMembershipsByGroupIdsInOrg"
   >;
   projectKeyDAL: Pick<TProjectKeyDALFactory, "find" | "findLatestProjectKey" | "insertMany" | "delete">;
   projectBotDAL: Pick<TProjectBotDALFactory, "findOne">;
@@ -919,18 +921,16 @@ export const scimServiceFactory = ({
         status: 403
       });
 
-    const groups = await groupDAL.findGroups(
-      {
-        ...(filter && parseScimFilter(filter)),
-        orgId
-      },
-      {
-        offset: startIndex - 1,
-        limit
-      }
-    );
+    const groupFilter = {
+      ...(filter && parseScimFilter(filter)),
+      orgId
+    };
 
-    const scimGroups: TScimGroup[] = [];
+    const [groups, totalResults] = await Promise.all([
+      groupDAL.findGroups(groupFilter, { offset: startIndex - 1, limit }),
+      groupDAL.countGroups(groupFilter)
+    ]);
+
     if (isMembersExcluded) {
       return buildScimGroupList({
         scimGroups: groups.map((group) =>
@@ -943,13 +943,26 @@ export const scimServiceFactory = ({
           })
         ),
         startIndex,
-        limit
+        limit,
+        totalResults
       });
     }
 
-    for await (const group of groups) {
-      const members = await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(group.id, orgId);
-      const scimGroup = buildScimGroup({
+    const groupIds = groups.map((g) => g.id);
+    const allMemberships = groupIds.length
+      ? await userGroupMembershipDAL.findGroupMembershipsByGroupIdsInOrg(groupIds, orgId)
+      : [];
+
+    const membersByGroupId = new Map<string, typeof allMemberships>();
+    for (const membership of allMemberships) {
+      const list = membersByGroupId.get(membership.groupId) ?? [];
+      list.push(membership);
+      membersByGroupId.set(membership.groupId, list);
+    }
+
+    const scimGroups: TScimGroup[] = groups.map((group) => {
+      const members = membersByGroupId.get(group.id) ?? [];
+      return buildScimGroup({
         groupId: group.id,
         name: group.name,
         members: members.map((member) => ({
@@ -959,8 +972,7 @@ export const scimServiceFactory = ({
         createdAt: group.createdAt,
         updatedAt: group.updatedAt
       });
-      scimGroups.push(scimGroup);
-    }
+    });
 
     await scimEventsDAL.create({
       orgId,
@@ -974,7 +986,8 @@ export const scimServiceFactory = ({
     return buildScimGroupList({
       scimGroups,
       startIndex,
-      limit
+      limit,
+      totalResults
     });
   };
 


### PR DESCRIPTION
## Problem

`listScimGroups` loaded group members with a separate DB query per group (N+1 pattern). For an org with 50 groups, listing groups triggered 51 queries. Under load this adds up and slows SCIM provisioning syncs noticeably.

A second bug: `buildScimGroupList` always set `totalResults` to the length of the current page instead of the total count across all pages. RFC 7644 §3.4.2 requires `totalResults` to be the total number of resources matching the query, not just the current page. Clients that rely on this to drive pagination or display counts get wrong numbers.

## Fix

- Added `findGroupMembershipsByGroupIdsInOrg` to `user-group-membership-dal.ts` - same join logic as the existing single-ID variant but accepts a `string[]` and uses `whereIn`. Fetches members for all groups in one query.
- Added `countGroups` to `group-dal.ts` - counts rows with the same filter used for `findGroups`, so `totalResults` reflects the true total rather than page size.
- `listScimGroups` now fires `findGroups` and `countGroups` in parallel (`Promise.all`), then builds a `Map<groupId, members[]>` in memory to populate each group without extra round-trips.
- `buildScimGroupList` now accepts an explicit `totalResults` parameter instead of computing it from `scimGroups.length`.

## Testing

Covered by existing SCIM integration test suite. The batch query path handles the empty-group list correctly (skips the query when `groupIds` is empty to avoid a `whereIn([])` no-op).
