### PR TITLE
fix(auth): promote invited users when OAuth login redirects via orgSlug

### DIFF
--- a/backend/src/services/auth/auth-login-service.ts
+++ b/backend/src/services/auth/auth-login-service.ts
@@ -1104,7 +1104,7 @@ export const authLoginServiceFactory = ({
           actorType: ActorType.USER,
           actorId: user.id,
           orgId: org.id,
-          status: OrgMembershipStatus.Accepted
+          acceptAnyStatus: true
         });
 
         if (orgMembership?.isActive) {


### PR DESCRIPTION
## Problem

When an OAuth provider redirects back to Infisical with an `orgSlug` parameter (used to direct the user into a specific organization), `oauth2Login` looks up the user's org membership to decide whether to set `orgId`. The lookup used `status: OrgMembershipStatus.Accepted`, which excludes users who have been invited but have not yet completed the invitation flow.

For those users:
- `orgMembership` comes back null
- `orgId` stays null
- `processProviderCallback` receives `organizationId: undefined`
- The `Invited -> Accepted` promotion at lines 338-347 never fires
- The user stays stuck with `status: Invited` after their first OAuth login

## Fix

Change the membership lookup to use `acceptAnyStatus: true` so invited users are included. This is consistent with how `selectOrganization` does the same check at line 1250.

The promotion code in `processProviderCallback` already filters by `status: OrgMembershipStatus.Invited`, so there is no risk of re-promoting users who are already `Accepted` - that update is a safe no-op.

## Testing

- Invite a user to an org, have them log in via OAuth (Google, GitHub, etc.) using a link that includes `?organizationSlug=<slug>`
- Before: user's membership stays `Invited` after login
- After: membership is promoted to `Accepted` on first OAuth login
