### PR TITLE
docs(kubernetes-operator): embed overview video on operator overview page

### DIFF
--- a/docs/integrations/platforms/kubernetes/overview.mdx
+++ b/docs/integrations/platforms/kubernetes/overview.mdx
@@ -16,6 +16,22 @@ It provides multiple Custom Resource Definitions (CRDs) which enable you to:
 When these CRDs are configured, the Infisical Operator will continuously monitor for changes and perform necessary updates to keep your Kubernetes secrets up to date.
 It can also automatically reload dependent Deployment resources whenever relevant secrets are updated.
 
+The short video below walks through how the Infisical Operator syncs secrets into your Kubernetes cluster.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/Nz15mAwIkYc"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  ></iframe>
+</div>
+
+<br />
+
 <Info>
   The operator supports two CRD API versions: **v1beta1** and **v1alpha1**. Use **v1beta1** for new installations; **v1alpha1** is legacy and will be deprecated soon.
 </Info>


### PR DESCRIPTION


## Context

Adds k8s operator video to the overview page.

## Screenshots
<img width="1144" height="1122" alt="Screenshot 2026-06-19 at 8 47 14 AM" src="https://github.com/user-attachments/assets/fc023d77-cb2d-48f0-bdc3-66b3838b6b0c" />

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x ] Docs
- [ ] Chore

## Checklist

- [ x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ x] Tested locally
- [ x] Updated docs (if needed)
- [ x] Updated CLAUDE.md files (if needed)
- [ x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)