### PR TITLE
fix(error-handler): enhance error logging for expected client errors

### DIFF
--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -71,10 +71,9 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
       error instanceof PermissionBoundaryError ||
       error instanceof ZodError ||
       error instanceof RateLimitError ||
-      error instanceof ScimRequestError ||
-      error instanceof CryptographyError ||
       error instanceof PolicyViolationError ||
-      error instanceof AcmeError ||
+      (error instanceof ScimRequestError && error.status < 500) ||
+      (error instanceof AcmeError && error.status < 500) ||
       error instanceof jwt.JsonWebTokenError;
 
     if (isExpectedClientError) {
@@ -86,7 +85,8 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
           errorName: error.name,
           errorMessage: error.message,
           route: req.routeOptions?.url,
-          method: req.method
+          method: req.method,
+          details: (error as { details?: unknown }).details
         },
         `client error: ${error.name}`
       );

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -60,7 +60,40 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
   });
 
   server.setErrorHandler((error: Error, req, res) => {
-    req.log.error(error);
+    // Expected client errors don't need stack traces. Log them without the Error object to
+    // avoid stack serialization; keep full-stack logging for unexpected / server errors.
+    const isExpectedClientError =
+      error instanceof BadRequestError ||
+      error instanceof NotFoundError ||
+      error instanceof UnauthorizedError ||
+      error instanceof ForbiddenError ||
+      error instanceof ForbiddenRequestError ||
+      error instanceof PermissionBoundaryError ||
+      error instanceof ZodError ||
+      error instanceof RateLimitError ||
+      error instanceof ScimRequestError ||
+      error instanceof CryptographyError ||
+      error instanceof PolicyViolationError ||
+      error instanceof AcmeError ||
+      error instanceof jwt.JsonWebTokenError;
+
+    if (isExpectedClientError) {
+      // Log structured fields (NOT the Error instance) so these stay searchable by name/route
+      // without serializing a stack
+      req.log.warn(
+        {
+          reqId: req.id,
+          errorName: error.name,
+          errorMessage: error.message,
+          route: req.routeOptions?.url,
+          method: req.method
+        },
+        `client error: ${error.name}`
+      );
+    } else {
+      req.log.error(error);
+    }
+
     if (appCfg.OTEL_TELEMETRY_COLLECTION_ENABLED) {
       const { method } = req;
       const route = req.routeOptions.url;


### PR DESCRIPTION
## Context

Expected client errors (4xx-class responses) are high-volume in production: auth failures, permission denials, validation errors, rate limits, etc. The global error handler was logging every one with req.log.error(error), which passes the full Error instance to Pino. That forces stack trace capture and serialization on each log line, allocating large strings that add unnecessary memory pressure and GC churn under load.

This change avoids that for known client-error types by logging only primitive structured fields (errorName, errorMessage, route, method) instead of the Error object. Unexpected / server errors still use req.log.error(error) with full stack traces for debugging.

Expected client error types: BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError, ForbiddenRequestError, PermissionBoundaryError, ZodError, RateLimitError, ScimRequestError, CryptographyError, PolicyViolationError, AcmeError, and jwt.JsonWebTokenError.

HTTP response behavior and OpenTelemetry error metrics are unchanged.
## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)