### PR TITLE
fix(secret-sync): fix personal tokens and sealed values on railway sync

### DIFF
--- a/backend/e2e-test/routes/v1/secret-folder.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-folder.spec.ts
@@ -36,6 +36,8 @@ const deleteFolder = async (dto: { path: string; id: string }) => {
 };
 
 describe("Secret Folder Router", async () => {
+  vi.setConfig({ testTimeout: 10_000 });
+
   test.each([
     { name: "folder1", path: "/" }, // one in root
     { name: "folder1", path: "/level1/level2" }, // then create a deep one creating intermediate ones

--- a/backend/e2e-test/routes/v2/secret-folder.spec.ts
+++ b/backend/e2e-test/routes/v2/secret-folder.spec.ts
@@ -341,7 +341,7 @@ describe("Secret Folder Move Router", async () => {
     expect(rootFolders.map((folder) => folder.name)).not.toContain("move-src");
 
     await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
-  });
+  }, 10_000);
 
   test("Move a folder to a different environment", async () => {
     const srcRoot = await createFolderInEnv({ path: "/", name: "move-cross", environment: sourceEnv });
@@ -369,7 +369,7 @@ describe("Secret Folder Move Router", async () => {
     );
     expect(movedFolder).toBeDefined();
     await deleteFolderInEnv({ path: "/", id: movedFolder!.id, environment: crossEnv, forceDelete: true });
-  });
+  }, 10_000);
 
   test("Moving a folder onto a path that already has a folder of the same name fails", async () => {
     const srcRoot = await createFolderInEnv({ path: "/", name: "move-conflict", environment: sourceEnv });
@@ -390,7 +390,7 @@ describe("Secret Folder Move Router", async () => {
 
     await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
     await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
-  });
+  }, 10_000);
 
   test("Blocks moving a folder whose subtree is governed by a source approval policy", async () => {
     // /policy-src/protected is covered by a source approval policy. Folders governed by a secret approval policy
@@ -428,7 +428,7 @@ describe("Secret Folder Move Router", async () => {
     await deleteSecretApprovalPolicy(policy.id);
     await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
     await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
-  });
+  }, 10_000);
 
   test("Blocks moving a folder when the destination path is governed by an approval policy", async () => {
     // /move-into-policy holds only static secrets and is freely movable, but the destination it would land at
@@ -462,5 +462,5 @@ describe("Secret Folder Move Router", async () => {
     await deleteSecretApprovalPolicy(policy.id);
     await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
     await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
-  });
+  }, 10_000);
 });

--- a/backend/src/services/app-connection/railway/railway-connection-constants.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-constants.ts
@@ -26,6 +26,7 @@ export enum RailwayDeploymentStatus {
 // selecting a deployment to redeploy.
 export const RAILWAY_NON_REDEPLOYABLE_STATUSES = new Set<string>([
   RailwayDeploymentStatus.Building,
+  RailwayDeploymentStatus.Deploying,
   RailwayDeploymentStatus.Queued,
   RailwayDeploymentStatus.Initializing,
   RailwayDeploymentStatus.Waiting,

--- a/backend/src/services/app-connection/railway/railway-connection-constants.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-constants.ts
@@ -3,3 +3,35 @@ export enum RailwayConnectionMethod {
   ProjectToken = "project-token",
   TeamToken = "team-token"
 }
+
+// Railway DeploymentStatus enum values (https://docs.railway.com/reference/public-api)
+export enum RailwayDeploymentStatus {
+  Building = "BUILDING",
+  Crashed = "CRASHED",
+  Deploying = "DEPLOYING",
+  Failed = "FAILED",
+  Initializing = "INITIALIZING",
+  NeedsApproval = "NEEDS_APPROVAL",
+  Queued = "QUEUED",
+  Removed = "REMOVED",
+  Removing = "REMOVING",
+  Skipped = "SKIPPED",
+  Sleeping = "SLEEPING",
+  Success = "SUCCESS",
+  Waiting = "WAITING"
+}
+
+// Deployments in these states have no build snapshot to replay, so Railway rejects
+// `deploymentRedeploy` with "Cannot redeploy without a snapshot". Skip them when
+// selecting a deployment to redeploy.
+export const RAILWAY_NON_REDEPLOYABLE_STATUSES = new Set<string>([
+  RailwayDeploymentStatus.Building,
+  RailwayDeploymentStatus.Queued,
+  RailwayDeploymentStatus.Initializing,
+  RailwayDeploymentStatus.Waiting,
+  RailwayDeploymentStatus.NeedsApproval,
+  RailwayDeploymentStatus.Skipped,
+  RailwayDeploymentStatus.Failed,
+  RailwayDeploymentStatus.Removed,
+  RailwayDeploymentStatus.Removing
+]);

--- a/backend/src/services/app-connection/railway/railway-connection-public-client.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-public-client.ts
@@ -178,8 +178,9 @@ class RailwayPublicClient {
         const projectPerWorkspace = await Promise.all(
           workspaces.me.workspaces.map(async (w) => {
             const projectsResponse = await this.send(
-              `{ workspace(workspaceId: "${w.id}") { projects { edges { node { id, name, services { edges { node { id, name } } } environments { edges { node { name, id } } } } } } } }`,
-              config
+              `query workspace($workspaceId: String!) { workspace(workspaceId: $workspaceId) { projects { edges { node { id, name, services { edges { node { id, name } } } environments { edges { node { name, id } } } } } } } }`,
+              config,
+              { workspaceId: w.id }
             );
 
             const projectsData = await RailwayWorkspaceProjectsListSchema.parseAsync(projectsResponse);

--- a/backend/src/services/app-connection/railway/railway-connection-public-client.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-public-client.ts
@@ -123,8 +123,8 @@ class RailwayPublicClient {
     config: RailwaySendReqOptions,
     variables: { input: { serviceId: string; environmentId: string }; first?: number }
   ) {
-    return this.send<TRailwayResponse<{ deployments: { edges: { node: { id: string } }[] } }>>(
-      `query deployments($input: DeploymentListInput!, $first: Int) { deployments(first: $first, input: $input) { edges { node { id } } } }`,
+    return this.send<TRailwayResponse<{ deployments: { edges: { node: { id: string; status: string } }[] } }>>(
+      `query deployments($input: DeploymentListInput!, $first: Int) { deployments(first: $first, input: $input) { edges { node { id status } } } }`,
       config,
       variables
     );

--- a/backend/src/services/app-connection/railway/railway-connection-public-client.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-public-client.ts
@@ -10,7 +10,8 @@ import {
   RailwayAccountWorkspaceListSchema,
   RailwayGetProjectsByProjectTokenSchema,
   RailwayGetSubscriptionTypeSchema,
-  RailwayProjectsListSchema
+  RailwayProjectsListSchema,
+  RailwayWorkspaceProjectsListSchema
 } from "./railway-connection-schemas";
 import { RailwayProject, TRailwayConnectionConfig, TRailwayResponse } from "./railway-connection-types";
 
@@ -107,7 +108,7 @@ class RailwayPublicClient {
   healthcheck(config: RailwaySendReqOptions) {
     switch (config.method) {
       case RailwayConnectionMethod.AccountToken:
-        return this.send(`{ me { teams { edges { node { id } } } } }`, config);
+        return this.send(`{ me { id } }`, config);
       case RailwayConnectionMethod.ProjectToken:
         return this.send(`{ projectToken { projectId environmentId project { id } } }`, config);
       case RailwayConnectionMethod.TeamToken:
@@ -169,21 +170,28 @@ class RailwayPublicClient {
       }
 
       case RailwayConnectionMethod.AccountToken: {
-        const res = await this.send(
-          `{ me { workspaces { id, name, team{ projects{ edges{ node{ id, name, services{ edges { node { name, id } } } environments { edges { node { name, id } } } } } } } } } }`,
-          config
+        const workspacesResponse = await this.send(`{ me { workspaces { id name } } }`, config);
+
+        const workspaces = await RailwayAccountWorkspaceListSchema.parseAsync(workspacesResponse);
+
+        const projectPerWorkspace = await Promise.all(
+          workspaces.me.workspaces.map(async (w) => {
+            const projectsResponse = await this.send(
+              `{ workspace(workspaceId: "${w.id}") { projects { edges { node { id, name, services { edges { node { id, name } } } environments { edges { node { name, id } } } } } } } }`,
+              config
+            );
+
+            const projectsData = await RailwayWorkspaceProjectsListSchema.parseAsync(projectsResponse);
+            return projectsData.workspace.projects.edges.map((p) => ({
+              id: p.node.id,
+              name: p.node.name,
+              environments: p.node.environments.edges.map((e) => e.node),
+              services: p.node.services.edges.map((s) => s.node)
+            }));
+          })
         );
 
-        const data = await RailwayAccountWorkspaceListSchema.parseAsync(res);
-
-        return data.me.workspaces.flatMap((w) =>
-          w.team.projects.edges.map((p) => ({
-            id: p.node.id,
-            name: p.node.name,
-            environments: p.node.environments.edges.map((e) => e.node),
-            services: p.node.services.edges.map((s) => s.node)
-          }))
-        );
+        return projectPerWorkspace.flat();
       }
 
       case RailwayConnectionMethod.ProjectToken: {

--- a/backend/src/services/app-connection/railway/railway-connection-public-client.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-public-client.ts
@@ -243,7 +243,7 @@ class RailwayPublicClient {
   async deleteVariable(
     config: RailwaySendReqOptions,
     variables: {
-      input: { projectId: string; environmentId: string; name: string; skipDeploys?: boolean; serviceId?: string };
+      input: { projectId: string; environmentId: string; name: string; serviceId?: string };
     }
   ) {
     await this.send<TRailwayResponse<{ variables: Record<string, string> }>>(

--- a/backend/src/services/app-connection/railway/railway-connection-public-client.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-public-client.ts
@@ -45,7 +45,7 @@ export function getRailwayRatelimiter(headers: AxiosResponse["headers"]): {
   const now = +new Date();
   const nextReset = +new Date(limitResetAt);
 
-  const remaining = Math.min(0, nextReset - now);
+  const remaining = Math.max(0, nextReset - now);
 
   const wait = () => {
     return new Promise<void>((res) => {
@@ -67,6 +67,7 @@ class RailwayPublicClient {
     this.client = createRequestClient({
       method: "POST",
       baseURL: IntegrationUrls.RAILWAY_API_URL,
+      timeout: 1000 * 60, // 60 seconds timeout
       headers: {
         "Content-Type": "application/json"
       }
@@ -223,7 +224,7 @@ class RailwayPublicClient {
     config: RailwaySendReqOptions,
     variables: { projectId: string; environmentId: string; serviceId?: string }
   ) {
-    const res = await this.send<TRailwayResponse<{ variables: Record<string, string> }>>(
+    const res = await this.send<TRailwayResponse<{ variables: Record<string, string | null> }>>(
       `query variables($projectId: String!, $environmentId: String!, $serviceId: String, $unrendered: Boolean) { variables( projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId, unrendered: $unrendered ) }`,
       config,
       { ...variables, unrendered: true }

--- a/backend/src/services/app-connection/railway/railway-connection-schemas.ts
+++ b/backend/src/services/app-connection/railway/railway-connection-schemas.ts
@@ -100,10 +100,17 @@ export const RailwayAccountWorkspaceListSchema = z.object({
     workspaces: z.array(
       z.object({
         id: z.string(),
-        name: z.string(),
-        team: RailwayProjectsListSchema
+        name: z.string()
       })
     )
+  })
+});
+
+export const RailwayWorkspaceProjectsListSchema = z.object({
+  workspace: z.object({
+    projects: z.object({
+      edges: z.array(RailwayProjectEdgeSchema)
+    })
   })
 });
 

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -56,8 +56,10 @@ export const RailwaySyncFns = {
   /**
    * Syncs secrets to Railway and redeploys the service if needed.
    *
-   * Gets existing Railway vars, merges with new secrets (keeping Railway vars if deletion is disabled),
-   * then replaces every variable with the new values, if variable is not in the secretMap, it is deleted.
+   * Upserts the Infisical-managed secrets with `replace: false` so existing Railway variables are
+   * never deleted implicitly. Sealed variables (value === null, unreadable by design) cannot be
+   * resubmitted, so a `replace: true` payload would silently wipe them — a data-loss bug. When
+   * deletion is enabled, drift is removed explicitly via per-key deletes that skip sealed variables.
    * If there's a service, triggers a redeploy to pick up the changes.
    */
   async syncSecrets(secretSync: TRailwaySyncWithCredentials, secretMap: TSecretMap) {
@@ -65,15 +67,9 @@ export const RailwaySyncFns = {
       const {
         syncOptions: { disableSecretDeletion }
       } = secretSync;
-      const railwaySecrets = await this.getSecrets(secretSync);
       const config = secretSync.destinationConfig;
 
-      const railwaySecretsMap = Object.fromEntries(
-        Object.entries(railwaySecrets).map(([key, secret]) => [key, secret.value])
-      );
       const secretMapMap = Object.fromEntries(Object.entries(secretMap).map(([key, secret]) => [key, secret.value]));
-
-      const toReplace = disableSecretDeletion ? { ...railwaySecretsMap, ...secretMapMap } : secretMapMap;
 
       const upserted = await RailwayPublicAPI.upsertCollection(secretSync.connection, {
         input: {
@@ -81,8 +77,8 @@ export const RailwaySyncFns = {
           environmentId: config.environmentId,
           serviceId: config.serviceId || undefined,
           skipDeploys: true,
-          variables: toReplace,
-          replace: true
+          variables: secretMapMap,
+          replace: false
         }
       });
 
@@ -90,6 +86,34 @@ export const RailwaySyncFns = {
         throw new SecretSyncError({
           message: "Failed to upsert secrets to Railway"
         });
+
+      // When deletion is enabled (full-mirror), remove only the variables Infisical no longer
+      // manages. Explicitly skip sealed variables (value === null) — they are unreadable and must
+      // never be deleted — and Railway system variables (RAILWAY_ prefix).
+      if (!disableSecretDeletion) {
+        const existingVariables = await RailwayPublicAPI.getVariables(secretSync.connection, {
+          projectId: config.projectId,
+          environmentId: config.environmentId,
+          serviceId: config.serviceId || undefined
+        });
+
+        const keysToDelete = Object.entries(existingVariables)
+          .filter(([key, value]) => value !== null && !key.startsWith("RAILWAY_") && !(key in secretMap))
+          .map(([key]) => key);
+
+        for (const name of keysToDelete) {
+          // eslint-disable-next-line no-await-in-loop
+          await RailwayPublicAPI.deleteVariable(secretSync.connection, {
+            input: {
+              projectId: config.projectId,
+              environmentId: config.environmentId,
+              serviceId: config.serviceId || undefined,
+              name,
+              skipDeploys: true
+            }
+          });
+        }
+      }
 
       if (!config.serviceId) return;
 
@@ -132,31 +156,32 @@ export const RailwaySyncFns = {
   },
 
   async removeSecrets(secretSync: TRailwaySyncWithCredentials, secretMap: TSecretMap) {
-    const existing = await this.getSecrets(secretSync);
     const config = secretSync.destinationConfig;
 
-    // Create a new variables object excluding secrets that exist in secretMap
-    const remainingVariables = Object.fromEntries(
-      Object.entries(existing)
-        .filter(([key]) => !(key in secretMap))
-        .map(([key, secret]) => [key, secret.value])
-    );
-
     try {
-      const upserted = await RailwayPublicAPI.upsertCollection(secretSync.connection, {
-        input: {
-          projectId: config.projectId,
-          environmentId: config.environmentId,
-          serviceId: config.serviceId || undefined,
-          skipDeploys: true,
-          variables: remainingVariables,
-          replace: true
-        }
+      const existingVariables = await RailwayPublicAPI.getVariables(secretSync.connection, {
+        projectId: config.projectId,
+        environmentId: config.environmentId,
+        serviceId: config.serviceId || undefined
       });
 
-      if (!upserted) {
-        throw new SecretSyncError({
-          message: "Failed to remove secrets from Railway"
+      // Delete only the Infisical-managed variables that exist in Railway. Per-key deletes (instead
+      // of a replace: true collection upsert) guarantee sealed variables (value === null) — which
+      // are unreadable and cannot be resubmitted — are never wiped.
+      const keysToDelete = Object.keys(existingVariables).filter(
+        (key) => key in secretMap && existingVariables[key] !== null
+      );
+
+      for (const name of keysToDelete) {
+        // eslint-disable-next-line no-await-in-loop
+        await RailwayPublicAPI.deleteVariable(secretSync.connection, {
+          input: {
+            projectId: config.projectId,
+            environmentId: config.environmentId,
+            serviceId: config.serviceId || undefined,
+            name,
+            skipDeploys: true
+          }
         });
       }
     } catch (error) {

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -33,7 +33,9 @@ export const RailwaySyncFns = {
         if (!matchesSchema(key, environment?.slug || "", keySchema)) continue;
 
         entries[key] = {
-          value
+          // Railway returns null for sealed/unrendered variables (unrendered: true);
+          // coalesce to "" so the value doesn't reach Buffer.from(null) during import.
+          value: value ?? ""
         };
       }
 
@@ -94,7 +96,7 @@ export const RailwaySyncFns = {
         first: 1
       });
 
-      const latestDeploymentId = latestDeployment?.deployments.edges[0].node.id;
+      const latestDeploymentId = latestDeployment?.deployments.edges[0]?.node.id;
 
       if (!latestDeploymentId)
         throw new SecretSyncError({

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
+import { logger } from "@app/lib/logger";
+import { RAILWAY_NON_REDEPLOYABLE_STATUSES } from "@app/services/app-connection/railway/railway-connection-constants";
 import { RailwayPublicAPI } from "@app/services/app-connection/railway/railway-connection-public-client";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
@@ -93,19 +95,25 @@ export const RailwaySyncFns = {
           serviceId: config.serviceId,
           environmentId: config.environmentId
         },
-        first: 1
+        first: 10
       });
 
-      const latestDeploymentId = latestDeployment?.deployments.edges[0]?.node.id;
+      const edges = latestDeployment?.deployments.edges ?? [];
 
-      if (!latestDeploymentId)
-        throw new SecretSyncError({
-          message: "Failed to get latest deployment from Railway"
-        });
+      // Only deployments with a build snapshot can be redeployed; deployments in states like
+      // BUILDING/FAILED/REMOVED have no snapshot and Railway rejects them with
+      // "Cannot redeploy without a snapshot". Pick the most recent redeployable deployment.
+      const redeployableDeploymentId = edges.find((edge) => !RAILWAY_NON_REDEPLOYABLE_STATUSES.has(edge.node.status))
+        ?.node.id;
+
+      // No redeployable deployment exists yet (e.g. service has never successfully deployed);
+      // the variables are already upserted, so skip the redeploy rather than failing the sync.
+      logger.info({ redeployableDeploymentId }, "Skipping redeploy. No redeployable deployment found.");
+      if (!redeployableDeploymentId) return;
 
       await RailwayPublicAPI.redeployDeployment(secretSync.connection, {
         input: {
-          deploymentId: latestDeploymentId
+          deploymentId: redeployableDeploymentId
         }
       });
     } catch (error) {

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -65,7 +65,7 @@ export const RailwaySyncFns = {
   async syncSecrets(secretSync: TRailwaySyncWithCredentials, secretMap: TSecretMap) {
     try {
       const {
-        syncOptions: { disableSecretDeletion }
+        syncOptions: { disableSecretDeletion, keySchema }
       } = secretSync;
       const config = secretSync.destinationConfig;
 
@@ -98,7 +98,13 @@ export const RailwaySyncFns = {
         });
 
         const keysToDelete = Object.entries(existingVariables)
-          .filter(([key, value]) => value !== null && !key.startsWith("RAILWAY_") && !(key in secretMap))
+          .filter(
+            ([key, value]) =>
+              value !== null &&
+              !key.startsWith("RAILWAY_") &&
+              matchesSchema(key, secretSync.environment?.slug || "", keySchema) &&
+              !(key in secretMap)
+          )
           .map(([key]) => key);
 
         for (const name of keysToDelete) {

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -34,10 +34,13 @@ export const RailwaySyncFns = {
         // eslint-disable-next-line no-continue
         if (!matchesSchema(key, environment?.slug || "", keySchema)) continue;
 
+        // Railway returns null for sealed/unrendered variables (unrendered: true). Skip them so we
+        // neither hit Buffer.from(null) during import nor overwrite the sealed value with "" on sync-back.
+        // eslint-disable-next-line no-continue
+        if (value === null) continue;
+
         entries[key] = {
-          // Railway returns null for sealed/unrendered variables (unrendered: true);
-          // coalesce to "" so the value doesn't reach Buffer.from(null) during import.
-          value: value ?? ""
+          value
         };
       }
 
@@ -108,8 +111,10 @@ export const RailwaySyncFns = {
 
       // No redeployable deployment exists yet (e.g. service has never successfully deployed);
       // the variables are already upserted, so skip the redeploy rather than failing the sync.
-      logger.info({ redeployableDeploymentId }, "Skipping redeploy. No redeployable deployment found.");
-      if (!redeployableDeploymentId) return;
+      if (!redeployableDeploymentId) {
+        logger.info({ redeployableDeploymentId }, "Skipping redeploy. No redeployable deployment found.");
+        return;
+      }
 
       await RailwayPublicAPI.redeployDeployment(secretSync.connection, {
         input: {

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -108,8 +108,7 @@ export const RailwaySyncFns = {
               projectId: config.projectId,
               environmentId: config.environmentId,
               serviceId: config.serviceId || undefined,
-              name,
-              skipDeploys: true
+              name
             }
           });
         }
@@ -179,8 +178,7 @@ export const RailwaySyncFns = {
             projectId: config.projectId,
             environmentId: config.environmentId,
             serviceId: config.serviceId || undefined,
-            name,
-            skipDeploys: true
+            name
           }
         });
       }


### PR DESCRIPTION
## Context
This PR fixes 3 bugs from railway secret sync. The first one is the creation of app connections using personal tokens, the second one is about checking the deployment status to avoid errors and the last one is about handling null values returned by railway. 

This also fixes: secrets-386 and secrets-306

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
### Bug 1: Personal tokens 
- Try to create an app connection using a personal token
- With this new app connection, try to create a secret sync
- check that you can list projects and teams (this was also not working before) 

### Bug 2: null argument error (you can run this with validation 1)
- In railway, create a secret that is sealed (do not forget to redeploy the service)
- create an app connection 
- create a secret sync and use the service that has this sealed variable 
- trigger the sync 
- check that no error happen 

### Bug 3: Distinguish regular deployments and cron services in Railway syncs
- Create a cron job in railway 
- try to make this in a invalid status (check `RAILWAY_NON_REDEPLOYABLE_STATUSES`)
- check that no error happen in this case.

### Validation 1: sealed values are not imported
For context: We should not interfer in sealed values, even if the user wants to delete it.
- create a railway service with a sealed value 
- create a sync 
- check that the sealed value is not imported 

### validation 2: value is not sealed at the import but it becomes sealed
- create a railway service without sealed values
- create a sync 
- check that the value is imported 
- On railway, change the variable to be a sealed one 
- delete this value (or modify it) inside infisical 
- check that this is not deleted inside railway

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)