### PR TITLE
chore: allow user invitation on SSO enforcement

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -881,7 +881,8 @@ export const registerRoutes = async (
     additionalPrivilegeDAL,
     projectAccessRequestDAL,
     applicationMembershipCleanupService,
-    approvalPolicyDAL
+    approvalPolicyDAL,
+    emailDomainDAL
   });
 
   const membershipIdentityService = membershipIdentityServiceFactory({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -882,7 +882,8 @@ export const registerRoutes = async (
     projectAccessRequestDAL,
     applicationMembershipCleanupService,
     approvalPolicyDAL,
-    emailDomainDAL
+    emailDomainDAL,
+    oidcConfigDAL
   });
 
   const membershipIdentityService = membershipIdentityServiceFactory({

--- a/backend/src/server/routes/v1/invite-org-router.ts
+++ b/backend/src/server/routes/v1/invite-org-router.ts
@@ -135,12 +135,18 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
       response: {
         200: z.object({
           message: z.string(),
-          token: z.string().optional()
+          token: z.string().optional(),
+          ssoRedirect: z
+            .object({
+              method: z.enum(["oidc", "saml"]),
+              orgSlug: z.string()
+            })
+            .optional()
         })
       }
     },
     handler: async (req) => {
-      const { token } = await server.services.org.verifyUserToOrg({
+      const { token, ssoRedirect } = await server.services.org.verifyUserToOrg({
         orgId: req.body.organizationId,
         code: req.body.code,
         email: req.body.email
@@ -148,7 +154,8 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
 
       return {
         message: "Successfully verified email",
-        token
+        token,
+        ssoRedirect
       };
     }
   });

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -8,6 +8,7 @@ import {
   TemporaryPermissionMode,
   TMembershipRolesInsert
 } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -78,6 +79,7 @@ type TMembershipUserServiceFactoryDep = {
     "cleanupActorApplicationMemberships"
   >;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "deleteUserStepApproversInProjects">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
 };
 
 export type TMembershipUserServiceFactory = ReturnType<typeof membershipUserServiceFactory>;
@@ -99,7 +101,8 @@ export const membershipUserServiceFactory = ({
   additionalPrivilegeDAL,
   projectAccessRequestDAL,
   applicationMembershipCleanupService,
-  approvalPolicyDAL
+  approvalPolicyDAL,
+  emailDomainDAL
 }: TMembershipUserServiceFactoryDep) => {
   const scopeFactory = {
     [AccessScope.Organization]: newOrgMembershipUserFactory({
@@ -110,7 +113,8 @@ export const membershipUserServiceFactory = ({
       tokenService,
       userDAL,
       userGroupMembershipDAL,
-      membershipUserDAL
+      membershipUserDAL,
+      emailDomainDAL
     }),
     [AccessScope.Project]: newProjectMembershipUserFactory({
       orgDAL,

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -11,6 +11,7 @@ import {
 import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
@@ -80,6 +81,7 @@ type TMembershipUserServiceFactoryDep = {
   >;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "deleteUserStepApproversInProjects">;
   emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
+  oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
 };
 
 export type TMembershipUserServiceFactory = ReturnType<typeof membershipUserServiceFactory>;
@@ -102,7 +104,8 @@ export const membershipUserServiceFactory = ({
   projectAccessRequestDAL,
   applicationMembershipCleanupService,
   approvalPolicyDAL,
-  emailDomainDAL
+  emailDomainDAL,
+  oidcConfigDAL
 }: TMembershipUserServiceFactoryDep) => {
   const scopeFactory = {
     [AccessScope.Organization]: newOrgMembershipUserFactory({
@@ -114,7 +117,8 @@ export const membershipUserServiceFactory = ({
       userDAL,
       userGroupMembershipDAL,
       membershipUserDAL,
-      emailDomainDAL
+      emailDomainDAL,
+      oidcConfigDAL
     }),
     [AccessScope.Project]: newProjectMembershipUserFactory({
       orgDAL,

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -1,6 +1,8 @@
 import { ForbiddenError } from "@casl/ability";
 
 import { AccessScope, OrganizationActionScope, OrgMembershipStatus } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
+import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
@@ -32,6 +34,7 @@ type TOrgMembershipUserScopeFactoryDep = {
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "delete">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   membershipUserDAL: Pick<TMembershipUserDALFactory, "find">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
 };
 
 export const newOrgMembershipUserFactory = ({
@@ -41,7 +44,8 @@ export const newOrgMembershipUserFactory = ({
   orgDAL,
   smtpService,
   licenseService,
-  membershipUserDAL
+  membershipUserDAL,
+  emailDomainDAL
 }: TOrgMembershipUserScopeFactoryDep): TMembershipUserScopeFactory => {
   const getScopeField: TMembershipUserScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Organization) {
@@ -101,10 +105,27 @@ export const newOrgMembershipUserFactory = ({
       orgDAL.findById(dto.permission.orgId)
     );
     if (org?.authEnforced) {
-      throw new ForbiddenRequestError({
-        name: "InviteUser",
-        message: "Failed to invite user due to org-level auth enforced for organization"
+      const verifiedDomains = await emailDomainDAL.find({
+        orgId: org.id,
+        status: EmailDomainStatus.Verified
       });
+      const verifiedDomainSet = new Set(verifiedDomains.map((el) => el.domain.toLowerCase().trim()));
+
+      const unverifiedEmails = newMembers
+        .map((member) => member.email)
+        .filter((email) => {
+          const emailDomain = email?.split("@")?.[1]?.toLowerCase().trim();
+          return !emailDomain || !verifiedDomainSet.has(emailDomain);
+        });
+
+      if (unverifiedEmails.length) {
+        throw new ForbiddenRequestError({
+          name: "InviteUser",
+          message: `Cannot invite ${unverifiedEmails.map((email) => email || "(no email)").join(", ")} because org-level authentication is enforced and ${
+            unverifiedEmails.length > 1 ? "their email domains are" : "their email domain is"
+          } not a verified domain for this organization. Invited users must be able to sign in through the configured SSO provider.`
+        });
+      }
     }
 
     if (org.rootOrgId) {

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -5,6 +5,7 @@ import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-doma
 import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { assertPermissionBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -12,6 +13,7 @@ import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, ForbiddenRequestError, InternalServerError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { matchesAllowedEmailDomain } from "@app/lib/validator";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
@@ -35,6 +37,7 @@ type TOrgMembershipUserScopeFactoryDep = {
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   membershipUserDAL: Pick<TMembershipUserDALFactory, "find">;
   emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
+  oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
 };
 
 export const newOrgMembershipUserFactory = ({
@@ -45,7 +48,8 @@ export const newOrgMembershipUserFactory = ({
   smtpService,
   licenseService,
   membershipUserDAL,
-  emailDomainDAL
+  emailDomainDAL,
+  oidcConfigDAL
 }: TOrgMembershipUserScopeFactoryDep): TMembershipUserScopeFactory => {
   const getScopeField: TMembershipUserScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Organization) {
@@ -125,6 +129,22 @@ export const newOrgMembershipUserFactory = ({
             unverifiedEmails.length > 1 ? "their email domains are" : "their email domain is"
           } not a verified domain for this organization. Invited users must be able to sign in through the configured SSO provider.`
         });
+      }
+
+      const oidcCfg = await oidcConfigDAL.findOne({ orgId: org.id, isActive: true });
+      if (oidcCfg?.allowedEmailDomains?.trim()) {
+        const disallowedEmails = newMembers
+          .map((member) => member.email)
+          .filter((email) => !email || !matchesAllowedEmailDomain(email, oidcCfg.allowedEmailDomains as string));
+
+        if (disallowedEmails.length) {
+          throw new ForbiddenRequestError({
+            name: "InviteUser",
+            message: `Cannot invite ${disallowedEmails.map((email) => email || "(no email)").join(", ")} because org-level authentication is enforced and ${
+              disallowedEmails.length > 1 ? "their email domains are" : "their email domain is"
+            } not permitted by the configured OIDC provider's allowed email domains. Invited users must be able to sign in through the configured SSO provider.`
+          });
+        }
       }
     }
 

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1038,18 +1038,27 @@ export const orgServiceFactory = ({
       isEmailVerified: true
     });
 
-    // If user already completed signup, they'll be promoted to Accepted
-    // when they authenticate via selectOrganization or processProviderCallback
-    if (user.isAccepted) {
-      return { user };
+    const membershipRole = await membershipRoleDAL.findOne({ membershipId: orgMembership.id });
+    const canBypassSsoEnforcement =
+      organization.bypassOrgAuthEnabled && membershipRole.role === OrgMembershipRole.Admin;
+    const isSsoEnforced = Boolean(organization.authEnforced) && !canBypassSsoEnforcement;
+    let ssoRedirect: { method: "oidc" | "saml"; orgSlug: string } | undefined;
+    if (isSsoEnforced && organization.slug) {
+      const oidcCfg = await oidcConfigDAL.findOne({ orgId, isActive: true });
+      if (oidcCfg) {
+        ssoRedirect = { method: "oidc", orgSlug: organization.slug };
+      } else {
+        const samlCfg = await samlConfigDAL.findOne({ orgId, isActive: true });
+        if (samlCfg) ssoRedirect = { method: "saml", orgSlug: organization.slug };
+      }
     }
 
-    const membershipRole = await membershipRoleDAL.findOne({ membershipId: orgMembership.id });
-    if (
-      organization.authEnforced &&
-      !(organization.bypassOrgAuthEnabled && membershipRole.role === OrgMembershipRole.Admin)
-    ) {
-      return { user };
+    if (user.isAccepted) {
+      return { user, ssoRedirect };
+    }
+
+    if (isSsoEnforced) {
+      return { user, ssoRedirect };
     }
 
     const appCfg = getConfig();

--- a/frontend/src/pages/auth/SignUpInvitePage/route.tsx
+++ b/frontend/src/pages/auth/SignUpInvitePage/route.tsx
@@ -41,18 +41,33 @@ export const Route = createFileRoute("/_restrict-login-signup/signupinvite")({
         organizationId
       });
 
-      if (!result.token) {
-        createNotification({
-          text: "Invitation accepted. Please login into your account",
-          type: "success"
-        });
-      }
-
       if (authData) {
         // Logged-in user — invitation accepted, go to the org
         throw redirect({
           to: "/login/select-organization",
           search: { org_id: organizationId }
+        });
+      }
+
+      if (!result.token && result.ssoRedirect) {
+        // SSO-enforced org — the invitee must authenticate via the org's IdP. Send them straight
+        // to the SSO login flow instead of the generic login screen.
+        const { method, orgSlug } = result.ssoRedirect as {
+          method: "oidc" | "saml";
+          orgSlug: string;
+        };
+        const ssoUrl =
+          method === "oidc"
+            ? `/api/v1/sso/oidc/login?orgSlug=${encodeURIComponent(orgSlug)}`
+            : `/api/v1/sso/redirect/saml2/organizations/${encodeURIComponent(orgSlug)}`;
+        window.location.assign(ssoUrl);
+        return { inviteEmail: email };
+      }
+
+      if (!result.token) {
+        createNotification({
+          text: "Invitation accepted. Please login into your account",
+          type: "success"
         });
       }
 

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -248,11 +249,23 @@ export const AddOrgMemberModal = ({
     }
 
     const usernames = emails.split(",").map((email) => email.trim());
-    const { data } = await addUsersMutateAsync({
-      organizationId: currentOrg?.id,
-      inviteeEmails: usernames,
-      organizationRoleSlug: organizationRole.slug
-    });
+
+    let data: Awaited<ReturnType<typeof addUsersMutateAsync>>["data"];
+    try {
+      ({ data } = await addUsersMutateAsync({
+        organizationId: currentOrg?.id,
+        inviteeEmails: usernames,
+        organizationRoleSlug: organizationRole.slug
+      }));
+    } catch (err) {
+      createNotification({
+        text:
+          (axios.isAxiosError(err) && (err.response?.data as { message?: string })?.message) ||
+          "Failed to invite users to the organization.",
+        type: "error"
+      });
+      return;
+    }
 
     await Promise.allSettled(
       targetProjects.map((el) =>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -93,14 +93,6 @@ export const OrgMembersSection = () => {
   const isEnterprise = subscription?.slug === SubscriptionPlanTypes.Enterprise;
 
   const handleAddMemberModal = () => {
-    if (currentOrg?.authEnforced) {
-      createNotification({
-        text: "You cannot manage users from Infisical when org-level auth is enforced for your organization",
-        type: "error"
-      });
-      return;
-    }
-
     if (!isMoreIdentitiesAllowed && !isEnterprise) {
       handlePopUpOpen("upgradePlan", {
         text: "You have reached the maximum number of members allowed on your current plan. Upgrade to Infisical Pro plan to add more members."


### PR DESCRIPTION
## Context

- Allow user invitation even on SSO enforcement.
- Pre creates the membership
- The SSO flows still untouched. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

- Register a verified domain
- Register a SSO provider - local SAML using SSOJet SAML 
- Turn enforce SSO ON
- Invite user
- Sign in user

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)