### PR TITLE
docs: rewrite Kubernetes Operator guide for v1beta1 CRDs

### DIFF
--- a/docs/documentation/guides/kubernetes-operator.mdx
+++ b/docs/documentation/guides/kubernetes-operator.mdx
@@ -1,239 +1,445 @@
 ---
 title: "Managing Secrets With Kubernetes Operator"
 sidebarTitle: "Kubernetes Operator"
-description: "How to use the Infisical Kubernetes Operator to Push Secrets, Pull Secrets, and Generate Dynamic Secrets within your clusters."
+description: "How to use the Infisical Kubernetes Operator to pull secrets, push secrets, and generate dynamic secrets within your clusters."
 ---
 
-Infisical's Kubernetes Operator provides a seamless, secure, and automated way to synchronize secrets between your Infisical instance and your Kubernetes clusters. The Operator's three Custom Resource Definitions (CRDs) make this possible. In this guide, we provide the necessary CRDs and configurations for your kubernetes cluster, but you can customize them to fit your use-case.
+The Infisical Kubernetes Operator synchronizes secrets between Infisical and your Kubernetes clusters using Custom Resource Definitions (CRDs). This guide walks through the current `v1beta1` workflow and keeps the `v1alpha1` push and dynamic-secret flows that do not yet have a `v1beta1` replacement.
 
-In this guide, we'll walk through how to:
+In this guide you will:
 
-1. **Install the Infisical Operator on your Kubernetes cluster**.
-2. **Configure Authentication using Kubernetes Service Accounts**.
-3. **Use Each of the three CRDs**.
-        - **InfisicalSecret** [Sync secrets from Infisical to Kubernetes]
-        - **InfisicalPushSecret** [Sync secrets from Kubernetes to Infisical]
-        - **InfisicalDynamicSecret** [Manage Dynamic Secrets and automatically create time-bound leases]
+1. **Install the operator** on your cluster.
+2. **Pull secrets** from Infisical into a Kubernetes Secret using the `v1beta1` CRDs: `InfisicalConnection`, `InfisicalAuth`, and `InfisicalStaticSecret`.
+3. **Consume** the synced secret in a workload and reload it automatically on change.
+4. **Push secrets** from Kubernetes to Infisical with `InfisicalPushSecret`.
+5. **Generate dynamic secrets** with `InfisicalDynamicSecret`.
+
+This guide uses [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth), the recommended method for authenticating the operator from inside a cluster: the operator presents short-lived service account tokens and stores no long-lived credential. If you want a simpler path for local testing or clusters that Infisical cannot reach, see [Use Universal Auth instead](#use-universal-auth-instead).
+
+<Note>
+  The `v1beta1` CRDs (`InfisicalConnection`, `InfisicalAuth`, `InfisicalStaticSecret`) replace the deprecated `v1alpha1` `InfisicalSecret`. `InfisicalPushSecret` and `InfisicalDynamicSecret` remain `v1alpha1` and are used as-is. See the [operator overview](/integrations/platforms/kubernetes/overview) for the full CRD reference and the [migration guide](/integrations/platforms/kubernetes/overview#migrating-from-v1alpha1-to-v1beta1).
+</Note>
 
 ## Prerequisites
 
-Before we begin, make sure your environment is ready
-1. Installed tools
-    - [helm](https://helm.sh/docs/intro/install/), [git](https://git-scm.com/downloads), [kubectl](https://kubernetes.io/docs/tasks/tools/)
-2. Kubernetes Cluster
-    - Ensure you have access to a running cluster and connect with kubectl
-3. PostgreSQL Cluster (for InfisicalDynamicSecret)
-    - Ensure you have a running database that you have access to
-4. Clone [infisical-guides-source-code](https://github.com/Infisical/infisical-guides-source-code) repository
-5. Access to an Infisical instance (cloud or self-hosted)
+- [helm](https://helm.sh/docs/intro/install/), [kubectl](https://kubernetes.io/docs/tasks/tools/), and access to a running Kubernetes cluster.
+- Access to an Infisical instance (Infisical Cloud or self-hosted).
+- A PostgreSQL database you can connect to, only if you want to follow the `InfisicalDynamicSecret` step.
 
-## Step-By-Step Guide
+## Step-by-step guide
+
 <Steps titleSize="h2">
+  <Step title="Install the operator">
+    Install the operator with Helm. It runs in your cluster and reconciles the CRDs you create.
 
-  <Step title="Install the Infisical Operator">
-
-The [Infisical Operator](https://infisical.com/docs/integrations/platforms/kubernetes/overview) runs inside your cluster and is responsible for handling secret synchronization events.
-
-```console
-helm repo add infisical-helm-charts 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/'
-helm repo update
-helm install infisical-operator infisical-helm-charts/secrets-operator
-```
-
-Verify the operator pod is running:
-
-```console
-kubectl get pods -n default
-```
-  </Step>
-  <Step title="Create a Machine Identity and Set Up a Project">
-
-The operator uses a [Machine Identity](https://infisical.com/docs/documentation/platform/identities/machine-identities) to authenticate with Infisical through the Kubernetes Auth Method
-1. Login to [Infisical](https://app.infisical.com/)
-2. Select **Organization Access** from the left navigational pane
-3. Create an Identity and give it a name and a role
-4. Once the Machine Identity is created, copy the **Identity ID** (will be used later)
-5. Select the created Machine Identity, and add a [Kubernetes Authentication Method](https://infisical.com/docs/documentation/platform/identities/kubernetes-auth). Use these configurations:
-    - **Allowed Service Account Names**: infisical-service-account, default
-    - **Allowed Namespaces**: default
-    - **Kubernetes Host URL** can be found by running ```kubectl cluster-info```
-    - **Token Reviewer JWT / CA Certificate**: We will be generating these two later and adding them in later, leave it blank for now
-6. Once the Machine Identity has been created, navigate back to **Overview**
-7. Now select **Add New Project**
-    - Add a **Project Name**, and select **Secrets Management** as the product type
-    - Add a description (Optional). 
-8. Once the Project is created, navigate into the Project to **Add Secrets**. You can add any key-value pair for this example, however if you want to use the InfisicalSecret CRD example provided in this demo, use the following configurations:
-    - **Key**: SMTP_HOST
-    - **Value**: smtp@gmail.com
-    - **Tags**: N/A (Not needed for this demonstration)
-    - **Environments**: Production
-9. Now lets navigate to the **Project Access** tab on the left hand navigation pane. 
-    - Add the machine identity we created, and give it Admin permissions (just for demonstration purposes)
-
-
-  </Step>
-  <Step title="Set Up RBAC, Service Accounts, and Create Tokens">
-
-Now we will be interacting with the local repository you cloned earlier. Make sure you are in the directory that contains the yaml configurations. Assuming you are in your root user directory: 
-
-```console 
-cd infisical-guides-source-code/kubernetes-operator-demo
-```
-
-1. Create the ```infisical-token-reviewer``` service account. This Manifest creates a **service account** that the Infisical Operator uses to authenticate with Kubernetes for token reviews. It allows Infisical to validate Kubernetes tokens securely during the Machine Identity authentication process. 
-```console 
-kubectl apply -f infisical-reviewer-service-account.yaml
-```
-2. Create the token for the reviewer service account. This Yaml defines a **service account token secret** linked to the reviewer account created above. It generates a JWT token that Infisical uses for the Kubernetes Auth Method in your Machine Identity configuration.
-```console 
-kubectl apply -f service-account-reviewer-token.yaml
-```
-3. This file binds the ```infisical-token-reviewer``` service account to the built-in ```system:auth-delegator``` ClusterRole. That role allows the service account to perform **token review** and **authentication delegation** requests on behalf of other service accounts - a key part of Kubernetes-based identity verification. Without this binding, the Infisical Operator wouldn't have permission to validate tokens. 
-```console 
-kubectl apply -f cluster-role-binding.yaml
-```
-4. Create the service account that will be used by the InfisicalSecret. This file creates a **dedicated service account** ```infisical-service-account``` that the Infisical Operator uses to access and sync secrets within your cluster. It operates as the Operator's working identity in your cluster, separate from the token reviewer. 
-```console 
-kubectl apply -f infisical-service-account.yaml
-```
-5. Create the token for the Infisical service account. This manifest defines a **token secret** for the ```infisical-service-account```. It allows the Infisical operator to authenticate against Infisical's API when syncing secrets. The token will then be manually patched and associated with the service account to make sure Kubernetes mains it persistently. 
-```console 
-kubectl apply -f infisical-service-account-token.yaml
-```
-6. Apply the patch to manually associate the token secret
-```console 
-kubectl patch serviceaccount infisical-service-account -p '{"secrets": [{"name": "infisical-service-account-token"}]}' -n default
-```
-7. Create the **JWT Token** and **Certificate** and add it to the **Machine Identity** we created under **Kubernetes Auth**. For the generated CA, navigate to the **Advanced** tab to paste the certificate:
-- JWT Command
-```console 
-kubectl get secret infisical-token-reviewer-token -n default -o jsonpath='{.data.token}' | base64 -d
-```
-
-- CA Command
-```console 
-kubectl get secret infisical-token-reviewer-token -n default -o jsonpath='{.data.ca\.crt}' | base64 -d
-```
-  </Step>
-  <Step title="Verify Service Accounts and Tokens">
-
-1. Check to see if the service accounts were created
-
-```console 
-kubectl get serviceaccount -n default | grep infisical
-```
-
-2. Verify the tokens were created and linked
-
-```console
-kubectl get secrets -n default | grep infisical
-```
-  </Step>
-  <Step title="Create the InfisicalSecret CRD">
-
-The [InfisicalSecret](https://infisical.com/docs/integrations/platforms/kubernetes/infisical-secret-crd) CRD tells the operator to sync secrets from Infisical to Kubernetes. By referencing your ```identityID```, ```projectSlug```, and ```envSlug```, this CRD tells the Infisical Operator which Infisical secrets to fetch and how to format them into a Kubernetes Secret. Make sure to edit the provided CRD to match your specific Machine Identity ID, Project ID, and which environment your secrets are being pulled from (default is prod).
-    - **Project Slug**: Can be found when you select your project and navigate to settings
-    - **Identity ID**: Can be found when you select your machine identity from your organization's access control
-
-1. After editing the ```example-infisical-secret-crd.yaml``` to contain your demo-specific values, apply the yaml in your cluster
-```console
-kubectl apply -f example-infisical-secret-crd.yaml
-```
-
-  </Step>
-  <Step title="Verify the InfisicalSecret Status">
-
-1. Check that the ```InfisicalSecret``` was created successfully
-```console
-kubectl get infisicalsecret -n default
-```
-2. Check that the operator created the ```managed-secret```
-```console
-kubectl get secret managed-secret -n default
-```
-3. View the secret contents (base64 encoded)
-```console
-kubectl get secret managed-secret -n default -o jsonpath='{.data}' | jq
-```
-  </Step>
-  <Step title="Deploy the Demo Application">
- 
-1. Deploy the nginx demo deployment that will use the managed secret. 
-```console
-kubectl apply -f demo-deployment.yaml
-```
-2. Wait 15-20 seconds and then verify the deployments
-```console
-kubectl get deployments
-kubectl get pods -l app=nginx
-```
-  </Step>
-  <Step title="Verify the Secret is Injected Into the Pod">
-
-1. Check that the environment variable is in the running pod. If everything was successful, at this point you should be able to see the secret populate in the kubernetes pod and have a successful **sync** from Infisical to Kubernetes.
-```console 
-kubectl exec -it $(kubectl get pod -l app=nginx -o jsonpath='{.items[0].metadata.name}') -- env | grep SMTP
-```
-  </Step>
-  <Step title="Create a Kubernetes Secret to Push Up to Infisical">
-
-Now that we have successfully synced secrets from Infisical to Kubernetes, lets explore how we can push **Kubernetes Secrets** to Infisical.
-
-    1. Either create a **Kubernetes Secret** via yaml, or use the one in the repository.
-```console
-kubectl apply -f source-secret.yaml
-```
-    2. Verify creation of the secret 
-```console
-kubectl get secret push-secret-demo -n default -o yaml
-```
-  </Step>
-  <Step title="Create the InfisicalPushSecret CRD">
-
-The [InfisicalPushSecret](https://infisical.com/docs/integrations/platforms/kubernetes/infisical-push-secret-crd) CRD tells the operator to sync secrets from Kubernetes to Infisical. Make sure you edit the CRD to include the specific **Project Slug**, and **Identity ID**. The other values present in ```example-push-secret.yaml``` should be configured based on the previously committed yaml configurations. 
-
-    1. Apply the InfisicalPushSecret CRD provided after making the necessary changes
-```console
-kubectl apply -f example-push-secret-crd.yaml
-```
-
-    2. Once your CRD has been configured, go back to your project within Infisical and check to see if your secrets have populated there. 
-
-![secrets dashboard](../../images/push-secret.png)
-
-  </Step>
-  <Step title="Create the InfisicalDynamicSecret CRD">
-
-The [InfisicalDynamicSecret](https://infisical.com/docs/integrations/platforms/kubernetes/infisical-dynamic-secret-crd) CRD allows you to sync dynamic secrets and create leases automatically in Kubernetes as native **Kubernetes Secret** resources Any Pod, Deployment, or other Kubernetes resource can make use of dynamic secrets from Infisical just like any other Kubernetes secret. 
-
-    1. Navigate to your Infisical **Project** and click on the dropdown next to **Add Secret**. From here you will select **Add Dynamic Secret**
-        - Select **SQL Database** as the service you would like to connect to.
-        - Select **PostegreSQL** as the database service. Enter in the connection details for your database, specifically the **Host**, **Port**, **User**, **Password**, and **Database Name**.
-        - For the **Secret Name**, if you want to use the same name as the one in the cloned **InfisicalDynamicSecret** CRD, use the name **dynamic-secret-lease**. Otherwise you will need to change the **dynamicSecret.secretName** config in the InfisicalDynamicSecret CRD to whatever you name the secret here.
-        - In the CA (SSL) section, make sure to upload the **CA Certificate** for your database.
-        - Finally, select **Prod** as the environment (we are keeping this configuration as part of the demonstration).
-
-![secrets dashboard dynamic](../../images/dynamic-secret.png)
-
-    2. Edit the ```dynamic-secret-crd``` with the proper machine **Identity ID**, **Project Slug**, **dynamicSecret.secretName** (same as the **Secret Name** you gave to the dynamic secret in Infisical), and managedSecretReference.secretName (name of the kubernetes secret that Infisical Operator will create/populate in the cluster).
-        - If you want to keep the **managedSecretReference.secretName** then you can leave it as **dynamic-secret-test**
-
-    3.  Once the changes have been saved, apply the yaml:
-
-    ```console
-    kubectl apply -f dynamic-secret-crd.yaml
+    ```bash
+    helm repo add infisical-helm-charts 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/'
+    helm repo update
+    helm install infisical-operator infisical-helm-charts/secrets-operator \
+      --namespace infisical-operator --create-namespace
     ```
 
-    4. After applying the CRD, you should notice that the dynamic secret lease has been created and synced with your cluster. Verify by running:
+    Confirm the controller is running and the CRDs are registered:
 
-```console
-kubectl get secret dynamic-secret-test -n default -o yaml
-```
+    ```bash
+    kubectl rollout status deploy -n infisical-operator
+    kubectl get crd | grep infisical
+    ```
 
-    5. Once the dynamic secret lease has been created, you should see that the secret has data that contains the lease credentials.
+    You should see `infisicalconnections`, `infisicalauths`, and `infisicalstaticsecrets` among the registered CRDs.
+  </Step>
 
-![dynamic secrets output](../../images/dynamic-secret-crd.png)
+  <Step title="Create a machine identity and a project">
+    The operator authenticates with a [machine identity](/documentation/platform/identities/machine-identities).
+
+    1. In Infisical, open **Access Control** (under Administration) and, on the **Machine Identities** tab, press **Create Organization Machine Identity**. New identities use Universal Auth by default; you will switch this one to Kubernetes Auth below.
+    2. Create a project (**Secrets Management**), then add the identity from the project's **Access Control** page, in the **Project Machine Identities** section, using **Add Machine Identity to Project** with a project role that can read secret values.
+    3. Add a secret to the project. This guide uses `SMTP_HOST` in the `dev` environment at path `/`.
+    4. From the identity's page, copy its **Identity ID**. You will need it shortly.
+  </Step>
+
+  <Step title="Define the connection to Infisical">
+    The `InfisicalConnection` CRD points the operator at your Infisical instance. It is referenced by `InfisicalAuth`, so you only define the address once.
+
+    ```yaml infisical-connection.yaml
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: lab-connection
+      namespace: default
+    spec:
+      address: https://app.infisical.com
+    ```
+
+    <Note>
+      For a self-hosted instance, set `address` to your instance URL (for example `https://infisical.your-domain.com`). To trust a private CA on the Infisical instance, configure `spec.tls.caCertificate`. See the [InfisicalConnection CRD](/integrations/platforms/kubernetes/infisical-connection-crd).
+    </Note>
+
+    ```bash
+    kubectl apply -f infisical-connection.yaml
+    ```
+  </Step>
+
+  <Step title="Create the reviewer service account">
+    With Kubernetes Auth, Infisical validates the operator's service account token through the cluster's TokenReview API. Create a service account for that review and bind it to `system:auth-delegator`. The `Secret` issues a long-lived reviewer token (the **Token Reviewer JWT**) that Infisical uses to call the API.
+
+    ```yaml infisical-service-account.yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: infisical-service-account
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: infisical-service-account-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+      - kind: ServiceAccount
+        name: infisical-service-account
+        namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: infisical-service-account-token
+      namespace: default
+      annotations:
+        kubernetes.io/service-account.name: infisical-service-account
+    type: kubernetes.io/service-account-token
+    ```
+
+    ```bash
+    kubectl apply -f infisical-service-account.yaml
+    ```
+  </Step>
+
+  <Step title="Configure Kubernetes Auth on the identity">
+    On the machine identity, open the **Authentication** section, remove the default Universal Auth method, and add **Kubernetes Auth**. Fill in:
+
+    - **Kubernetes Host / Base Kubernetes API URL**: the base URL of your API server, reachable from Infisical (see the reachability note below). You can usually get it from `kubectl cluster-info`.
+    - **Token Reviewer JWT**: the reviewer token from the previous step.
+
+      ```bash
+      kubectl get secret infisical-service-account-token -n default \
+        -o jsonpath='{.data.token}' | base64 -d
+      ```
+
+    - **CA Certificate**: the cluster's CA. Pasting it auto-enables **Verify TLS Certificate** so Infisical validates the API server over TLS. Keep verification on for production.
+
+      ```bash
+      kubectl get secret infisical-service-account-token -n default \
+        -o jsonpath='{.data.ca\.crt}' | base64 -d
+      ```
+
+    - **Allowed Namespaces**: `default`. Optionally set **Allowed Service Account Names** to `infisical-service-account`.
+
+    <Warning>
+      **Plan API server reachability.** The operator always connects outward to Infisical. In the default review mode (**Manual Token Reviewer JWT (API)**, without a gateway), **Infisical must connect inward** to your API server to run the TokenReview.
+
+      | Setup | Reachability approach |
+      | --- | --- |
+      | Managed cluster (EKS, GKE, AKS, OpenShift) | Use the API server's public or peered endpoint and supply its CA certificate with verification on. This is the production path. |
+      | No inbound access allowed | Set **Review Mode** to **Gateway as Reviewer**, so an in-cluster [Gateway](/documentation/platform/gateways/overview) performs the TokenReview locally. Gateway is an Enterprise feature. |
+      | Infisical Cloud + a local cluster (minikube, kind) | Expose the API server through a public hostname (for example an `ngrok` tunnel): a public host passes Infisical's host validation and is reachable for the TokenReview. Leave the CA certificate empty only for local testing, which disables TLS verification. |
+      | Self-hosted Infisical that routes to the cluster on a private IP | Set `ALLOW_INTERNAL_IP_CONNECTIONS=true` on the Infisical instance and use the API server's IP. When you save the auth method, Infisical otherwise rejects private IPs and always rejects the literal hostnames `localhost` and `host.docker.internal`. |
+
+      Infisical validates the **Kubernetes Host** when you save the auth method. When a CA certificate is supplied, it also verifies the API server hostname against the certificate's SAN, so the host must match a name the certificate is issued for.
+    </Warning>
+  </Step>
+
+  <Step title="Authenticate with InfisicalAuth">
+    Store the identity ID in a Secret, then create an `InfisicalAuth` that uses Kubernetes Auth. The operator mints short-lived tokens for `serviceAccountRef` and presents them to Infisical, so no long-lived credential is stored in the cluster.
+
+    ```bash
+    kubectl create secret generic kubernetes-credentials \
+      --from-literal=identityId="<your-machine-identity-id>"
+    ```
+
+    ```yaml infisical-auth.yaml
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: lab-auth
+      namespace: default
+    spec:
+      infisicalConnectionRef:
+        name: lab-connection
+        namespace: default
+      method: kubernetes
+      kubernetes:
+        identityIdRef:
+          name: kubernetes-credentials
+          namespace: default
+          key: identityId
+        serviceAccountRef:
+          name: infisical-service-account
+          namespace: default
+    ```
+
+    ```bash
+    kubectl apply -f infisical-auth.yaml
+    ```
+
+    Check that authentication is healthy:
+
+    ```bash
+    kubectl get infisicalauth lab-auth
+    ```
+
+    `READY` should be `True`. See the [InfisicalAuth CRD](/integrations/platforms/kubernetes/infisical-auth-crd) for every supported method and `serviceAccountTokenAudiences`.
+  </Step>
+
+  <Step title="Sync secrets with InfisicalStaticSecret">
+    The `InfisicalStaticSecret` CRD pulls secrets from one or more `sources` and writes them into one or more `targets` (a Kubernetes Secret or ConfigMap). Replace `projectId` and `environmentSlug` with your values.
+
+    ```yaml infisical-static-secret.yaml
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: lab-static-secret
+      namespace: default
+    spec:
+      infisicalAuthRef:
+        name: lab-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 30s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+
+    ```bash
+    kubectl apply -f infisical-static-secret.yaml
+    ```
+
+    Confirm the resources are healthy and the managed Secret was created:
+
+    ```bash
+    kubectl get infisicalconnection,infisicalauth,infisicalstaticsecret
+    kubectl get secret managed-secret -o jsonpath='{.data.SMTP_HOST}' | base64 -d
+    ```
+
+    `READY`/`SYNCED` should be `True`, and the managed Secret should contain your secret value.
+
+    <Tip>
+      `creationPolicy: Owner` sets an owner reference so the managed Secret is garbage-collected when you delete the `InfisicalStaticSecret`. Use `Orphan` to leave it in place. See the [InfisicalStaticSecret CRD](/integrations/platforms/kubernetes/infisical-static-secret-crd) for `tagSlugs`, `recursive`, `template`, `secretType`, and `ConfigMap` targets.
+    </Tip>
+  </Step>
+
+  <Step title="Consume the secret and reload on change">
+    Reference the managed Secret from a workload like any native Kubernetes Secret. Add the `secrets.infisical.com/auto-reload: "true"` annotation so the operator triggers a rolling restart when the secret changes.
+
+    ```yaml demo-deployment.yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: demo-app
+      labels:
+        app: demo-app
+      annotations:
+        secrets.infisical.com/auto-reload: "true"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: demo-app
+      template:
+        metadata:
+          labels:
+            app: demo-app
+        spec:
+          containers:
+            - name: app
+              image: nginx:1.27-alpine
+              envFrom:
+                - secretRef:
+                    name: managed-secret
+    ```
+
+    ```bash
+    kubectl apply -f demo-deployment.yaml
+    kubectl exec deploy/demo-app -- env | grep SMTP_HOST
+    ```
+
+    When you change the secret in Infisical, the operator updates the managed Secret on the next refresh and restarts the annotated workload so it picks up the new value.
   </Step>
 </Steps>
 
-**Congratulations! You successfully managed secrets with Kubernetes.**
+## Use Universal Auth instead
+
+[Universal Auth](/documentation/platform/identities/universal-auth) authenticates with a client ID and secret. It works on any cluster and requires no inbound access to your API server, which makes it the easiest option for local testing or for clusters Infisical cannot reach. The trade-off is that a long-lived credential is stored as a Kubernetes Secret, whereas Kubernetes Auth stores nothing long-lived.
+
+To use it, replace the reviewer service account, Kubernetes Auth, and `InfisicalAuth` steps above with the following, then continue from **Sync secrets with InfisicalStaticSecret**.
+
+<Steps>
+  <Step title="Get the identity's Universal Auth credentials">
+    New identities already use Universal Auth by default. Open the identity's **Universal Auth** method, copy its **Client ID**, and add a **Client Secret** in the **Client Secrets** section. The client secret is shown only once.
+  </Step>
+
+  <Step title="Store the credentials in the cluster">
+    ```bash
+    kubectl create secret generic universal-auth-credentials \
+      --from-literal=clientId="<your-machine-identity-client-id>" \
+      --from-literal=clientSecret="<your-machine-identity-client-secret>"
+    ```
+  </Step>
+
+  <Step title="Create the InfisicalAuth">
+    ```yaml infisical-auth-universal.yaml
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: lab-auth
+      namespace: default
+    spec:
+      infisicalConnectionRef:
+        name: lab-connection
+        namespace: default
+      method: universal
+      universal:
+        clientIdRef:
+          name: universal-auth-credentials
+          namespace: default
+          key: clientId
+        clientSecretRef:
+          name: universal-auth-credentials
+          namespace: default
+          key: clientSecret
+    ```
+
+    ```bash
+    kubectl apply -f infisical-auth-universal.yaml
+    ```
+
+    Because the resource is also named `lab-auth`, the `InfisicalStaticSecret` from the main flow references it without changes.
+  </Step>
+</Steps>
+
+## Push secrets to Infisical
+
+The `InfisicalPushSecret` CRD (`v1alpha1`) pushes a Kubernetes Secret's contents into Infisical and keeps them updated. It uses inline authentication and a `hostAPI` field rather than the `v1beta1` connection and auth resources.
+
+First create the Kubernetes Secret you want to push:
+
+```yaml source-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: push-secret-demo
+  namespace: default
+stringData:
+  PUSHED_KEY: example-value
+  ANOTHER_KEY: hello-from-k8s
+```
+
+```bash
+kubectl apply -f source-secret.yaml
+```
+
+Then create the `InfisicalPushSecret`. The identity must have permission to create secrets in the destination project. This example uses Kubernetes Auth; the `kubernetesAuth` block mirrors the `InfisicalAuth` you configured above.
+
+```yaml infisical-push-secret.yaml
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalPushSecret
+metadata:
+  name: lab-push
+  namespace: default
+spec:
+  resyncInterval: 1m
+  hostAPI: https://app.infisical.com/api
+  updatePolicy: Replace
+  deletionPolicy: Delete
+  destination:
+    projectId: <your-project-id>
+    environmentSlug: dev
+    secretsPath: /
+  push:
+    secret:
+      secretName: push-secret-demo
+      secretNamespace: default
+  authentication:
+    kubernetesAuth:
+      identityId: <your-machine-identity-id>
+      autoCreateServiceAccountToken: true
+      serviceAccountRef:
+        name: infisical-service-account
+        namespace: default
+```
+
+```bash
+kubectl apply -f infisical-push-secret.yaml
+```
+
+The keys from `push-secret-demo` appear in your project at the destination path. To push with Universal Auth instead, swap the `authentication` block for `universalAuth.credentialsRef` pointing at a credentials Secret. See the [InfisicalPushSecret CRD](/integrations/platforms/kubernetes/infisical-push-secret-crd) for `template`, `generators`, and every authentication method.
+
+<Note>
+  Self-hosted users set `hostAPI` to `https://your-domain.com/api`. The `v1alpha1` CRDs use `hostAPI` (with the `/api` suffix), unlike the `v1beta1` `InfisicalConnection.address`.
+</Note>
+
+## Generate dynamic secrets
+
+The `InfisicalDynamicSecret` CRD (`v1alpha1`) creates a dynamic secret lease and writes the generated credentials into a native Kubernetes Secret that your workloads consume like any other.
+
+1. In Infisical, create a [dynamic secret](/documentation/platform/dynamic-secrets/overview) (for example, a PostgreSQL dynamic secret) in your project. Note the dynamic secret name.
+2. Apply the CRD, pointing `dynamicSecret.secretName` at the dynamic secret and `managedSecretReference` at the Kubernetes Secret the operator should create.
+
+```yaml infisical-dynamic-secret.yaml
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalDynamicSecret
+metadata:
+  name: lab-dynamic-secret
+  namespace: default
+spec:
+  hostAPI: https://app.infisical.com/api
+  dynamicSecret:
+    secretName: <dynamic-secret-name>
+    projectId: <your-project-id>
+    secretsPath: /
+    environmentSlug: dev
+  leaseRevocationPolicy: Revoke
+  leaseTTL: 1m
+  managedSecretReference:
+    secretName: dynamic-secret-managed
+    secretNamespace: default
+  authentication:
+    kubernetesAuth:
+      identityId: <your-machine-identity-id>
+      autoCreateServiceAccountToken: true
+      serviceAccountRef:
+        name: infisical-service-account
+        namespace: default
+```
+
+```bash
+kubectl apply -f infisical-dynamic-secret.yaml
+kubectl get secret dynamic-secret-managed -o yaml
+```
+
+The managed Secret holds the leased credentials, and the operator renews and rotates the lease automatically. See the [InfisicalDynamicSecret CRD](/integrations/platforms/kubernetes/infisical-dynamic-secret-crd) for the full specification.
+
+## Cleanup
+
+```bash
+kubectl delete infisicalstaticsecret lab-static-secret
+kubectl delete infisicalpushsecret lab-push
+kubectl delete infisicaldynamicsecret lab-dynamic-secret
+kubectl delete infisicalauth lab-auth
+kubectl delete infisicalconnection lab-connection
+helm uninstall infisical-operator -n infisical-operator
+```
+
+<Note>
+  Managed Secrets created with `creationPolicy: Owner` are removed with their owning CRD. Secrets created with `Orphan`, the reviewer service account, and the operator's own namespace are not removed by `helm uninstall`.
+</Note>


### PR DESCRIPTION
## What

Rewrites the Kubernetes Operator guide for the current **v1beta1** CRD generation.

- Pull flow now uses `InfisicalConnection` + `InfisicalAuth` + `InfisicalStaticSecret` (replaces the deprecated `InfisicalSecret` + token-reviewer-JWT walkthrough).
- Leads with **Kubernetes Auth** (the recommended in-cluster method, no long-lived credential stored); documents **Universal Auth** as the simpler alternative for local testing or unreachable clusters.
- Keeps `InfisicalPushSecret` and `InfisicalDynamicSecret` on `v1alpha1` (no v1beta1 replacement yet).
- Adds a Kubernetes Auth reachability matrix (managed cluster, gateway, local + ngrok, self-hosted).
- Inlines the manifests so the guide is self-contained (no external demo-repo dependency).

## Validation

Run end-to-end on minikube against a self-hosted Infisical:

- Operator install (chart 0.11.2), all v1beta1 CRDs registered.
- `InfisicalConnection` / `InfisicalAuth` / `InfisicalStaticSecret` sync; Deployment consumption via `envFrom` + `auto-reload` redeploy.
- Both auth methods (Universal and Kubernetes), including the production **CA certificate + TLS-verify** token-review path.
- `InfisicalPushSecret` via both Universal and Kubernetes Auth.
- All YAML fields verified against the operator Go structs and the live CRD schemas; dashboard labels and nav verified against the frontend; internal links and anchors verified.

## Not yet validated (reviewer please note)

- `InfisicalDynamicSecret` section: schema-verified only, not run end-to-end.
- Dashboard click-throughs: verified against the shipping frontend code, not browser-tested.
