### PR TITLE
chore: allow user invitation when SSO enforce is enabled

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -881,7 +881,10 @@ export const registerRoutes = async (
     additionalPrivilegeDAL,
     projectAccessRequestDAL,
     applicationMembershipCleanupService,
-    approvalPolicyDAL
+    approvalPolicyDAL,
+    emailDomainDAL,
+    oidcConfigDAL,
+    samlConfigDAL
   });
 
   const membershipIdentityService = membershipIdentityServiceFactory({

--- a/backend/src/services/membership-user/membership-user-service.ts
+++ b/backend/src/services/membership-user/membership-user-service.ts
@@ -8,9 +8,12 @@ import {
   TemporaryPermissionMode,
   TMembershipRolesInsert
 } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
+import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
 import { ms } from "@app/lib/ms";
@@ -78,6 +81,9 @@ type TMembershipUserServiceFactoryDep = {
     "cleanupActorApplicationMemberships"
   >;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "deleteUserStepApproversInProjects">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
+  oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
+  samlConfigDAL: Pick<TSamlConfigDALFactory, "findOne">;
 };
 
 export type TMembershipUserServiceFactory = ReturnType<typeof membershipUserServiceFactory>;
@@ -99,7 +105,10 @@ export const membershipUserServiceFactory = ({
   additionalPrivilegeDAL,
   projectAccessRequestDAL,
   applicationMembershipCleanupService,
-  approvalPolicyDAL
+  approvalPolicyDAL,
+  emailDomainDAL,
+  oidcConfigDAL,
+  samlConfigDAL
 }: TMembershipUserServiceFactoryDep) => {
   const scopeFactory = {
     [AccessScope.Organization]: newOrgMembershipUserFactory({
@@ -110,7 +119,10 @@ export const membershipUserServiceFactory = ({
       tokenService,
       userDAL,
       userGroupMembershipDAL,
-      membershipUserDAL
+      membershipUserDAL,
+      emailDomainDAL,
+      oidcConfigDAL,
+      samlConfigDAL
     }),
     [AccessScope.Project]: newProjectMembershipUserFactory({
       orgDAL,

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -1,15 +1,20 @@
 import { ForbiddenError } from "@casl/ability";
 
 import { AccessScope, OrganizationActionScope, OrgMembershipStatus } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
+import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { assertPermissionBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
+import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, ForbiddenRequestError, InternalServerError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { matchesAllowedEmailDomain } from "@app/lib/validator";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
@@ -32,6 +37,9 @@ type TOrgMembershipUserScopeFactoryDep = {
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "delete">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   membershipUserDAL: Pick<TMembershipUserDALFactory, "find">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
+  oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
+  samlConfigDAL: Pick<TSamlConfigDALFactory, "findOne">;
 };
 
 export const newOrgMembershipUserFactory = ({
@@ -41,7 +49,10 @@ export const newOrgMembershipUserFactory = ({
   orgDAL,
   smtpService,
   licenseService,
-  membershipUserDAL
+  membershipUserDAL,
+  emailDomainDAL,
+  oidcConfigDAL,
+  samlConfigDAL
 }: TOrgMembershipUserScopeFactoryDep): TMembershipUserScopeFactory => {
   const getScopeField: TMembershipUserScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Organization) {
@@ -58,6 +69,25 @@ export const newOrgMembershipUserFactory = ({
   };
 
   const isCustomRole: TMembershipUserScopeFactory["isCustomRole"] = (role: string) => isCustomOrgRole(role);
+
+  const $getEnforcedSsoLoginUrl = async (orgId: string, orgSlug: string) => {
+    const appCfg = getConfig();
+
+    const [oidcConfig, samlConfig] = await Promise.all([
+      oidcConfigDAL.findOne({ orgId, isActive: true }).catch(() => null),
+      samlConfigDAL.findOne({ orgId, isActive: true }).catch(() => null)
+    ]);
+
+    if (oidcConfig) {
+      return `${appCfg.SITE_URL}/api/v1/sso/oidc/login?orgSlug=${encodeURIComponent(orgSlug)}`;
+    }
+    if (samlConfig) {
+      return `${appCfg.SITE_URL}/api/v1/sso/redirect/saml2/organizations/${encodeURIComponent(orgSlug)}`;
+    }
+    // LDAP is credential-based with no SSO redirect endpoint (and a safe fallback for any other
+    // enforced method) — send invitees to the login page to sign in with their org credentials.
+    return `${appCfg.SITE_URL}/login`;
+  };
 
   const onCreateMembershipUserGuard: TMembershipUserScopeFactory["onCreateMembershipUserGuard"] = async (
     dto,
@@ -101,10 +131,44 @@ export const newOrgMembershipUserFactory = ({
       orgDAL.findById(dto.permission.orgId)
     );
     if (org?.authEnforced) {
-      throw new ForbiddenRequestError({
-        name: "InviteUser",
-        message: "Failed to invite user due to org-level auth enforced for organization"
+      const invitedEmails = newMembers.map((el) => el.email).filter((email): email is string => Boolean(email));
+
+      // The invited address must belong to a verified org domain — anything else could never
+      // complete the enforced SSO login, leaving a dead invitation.
+      const verifiedDomains = await emailDomainDAL.find({
+        orgId: org.id,
+        status: EmailDomainStatus.Verified
       });
+      const verifiedDomainSet = new Set(verifiedDomains.map((el) => el.domain.toLowerCase().trim()));
+
+      const unverifiedEmails = invitedEmails.filter((email) => {
+        const emailDomain = email.split("@")?.[1]?.toLowerCase().trim();
+        return !emailDomain || !verifiedDomainSet.has(emailDomain);
+      });
+
+      if (unverifiedEmails.length) {
+        throw new ForbiddenRequestError({
+          name: "InviteUser",
+          message: `Failed to invite user(s) ${unverifiedEmails.join(
+            ", "
+          )} due to org-level auth being enforced. Only users with a verified organization email domain can be invited.`
+        });
+      }
+
+      const oidcConfig = await oidcConfigDAL.findOne({ orgId: org.id, isActive: true }).catch(() => null);
+      const oidcAllowedDomains = oidcConfig?.allowedEmailDomains?.trim();
+      if (oidcAllowedDomains) {
+        const disallowedEmails = invitedEmails.filter((email) => !matchesAllowedEmailDomain(email, oidcAllowedDomains));
+
+        if (disallowedEmails.length) {
+          throw new ForbiddenRequestError({
+            name: "InviteUser",
+            message: `Failed to invite user(s) ${disallowedEmails.join(
+              ", "
+            )} due to the organization's OIDC allowed email domain restrictions.`
+          });
+        }
+      }
     }
 
     if (org.rootOrgId) {
@@ -179,6 +243,23 @@ export const newOrgMembershipUserFactory = ({
           }
         });
       }
+    } else if (orgDetails.authEnforced) {
+      const ssoLoginUrl = await $getEnforcedSsoLoginUrl(orgDetails.id, orgDetails.slug);
+
+      const emails = newUsers.map((el) => el.email).filter((email): email is string => Boolean(email));
+      if (emails.length) {
+        await smtpService.sendMail({
+          template: SmtpTemplates.OrgInvite,
+          subjectLine: "Infisical organization invitation",
+          recipients: emails,
+          substitutions: {
+            inviterFirstName: actorDetails?.firstName,
+            inviterUsername: actorDetails?.email,
+            organizationName: orgDetails?.name,
+            callback_url: ssoLoginUrl
+          }
+        });
+      }
     } else if (isEmailLoginEnabled) {
       await Promise.allSettled(
         newUsers.map(async (el) => {
@@ -204,10 +285,9 @@ export const newOrgMembershipUserFactory = ({
                 inviterFirstName: actorDetails?.firstName,
                 inviterUsername: actorDetails?.email,
                 organizationName: orgDetails?.name,
-                email: el.email,
-                organizationId: orgDetails?.id.toString(),
-                token,
-                callback_url: `${appCfg.SITE_URL}/signupinvite`
+                callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+                  el.email
+                )}&organization_id=${dto.permission.orgId}`
               }
             });
           }

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -247,6 +247,16 @@ export const newOrgMembershipUserFactory = ({
       const ssoLoginUrl = await $getEnforcedSsoLoginUrl(orgDetails.id, orgDetails.slug);
 
       const emails = newUsers.map((el) => el.email).filter((email): email is string => Boolean(email));
+
+      if (!appCfg.isSmtpConfigured) {
+        emails.forEach((email) => {
+          signUpTokens.push({
+            email,
+            link: ssoLoginUrl
+          });
+        });
+      }
+
       await Promise.allSettled(
         emails.map((email) =>
           smtpService.sendMail({

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -247,19 +247,21 @@ export const newOrgMembershipUserFactory = ({
       const ssoLoginUrl = await $getEnforcedSsoLoginUrl(orgDetails.id, orgDetails.slug);
 
       const emails = newUsers.map((el) => el.email).filter((email): email is string => Boolean(email));
-      if (emails.length) {
-        await smtpService.sendMail({
-          template: SmtpTemplates.OrgInvite,
-          subjectLine: "Infisical organization invitation",
-          recipients: emails,
-          substitutions: {
-            inviterFirstName: actorDetails?.firstName,
-            inviterUsername: actorDetails?.email,
-            organizationName: orgDetails?.name,
-            callback_url: ssoLoginUrl
-          }
-        });
-      }
+      await Promise.allSettled(
+        emails.map((email) =>
+          smtpService.sendMail({
+            template: SmtpTemplates.OrgInvite,
+            subjectLine: "Infisical organization invitation",
+            recipients: [email],
+            substitutions: {
+              inviterFirstName: actorDetails?.firstName,
+              inviterUsername: actorDetails?.email,
+              organizationName: orgDetails?.name,
+              callback_url: ssoLoginUrl
+            }
+          })
+        )
+      );
     } else if (isEmailLoginEnabled) {
       await Promise.allSettled(
         newUsers.map(async (el) => {

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -915,6 +915,25 @@ export const orgServiceFactory = ({
     return membership;
   };
 
+  const $getEnforcedSsoLoginUrl = async (orgId: string, orgSlug: string) => {
+    const appCfg = getConfig();
+
+    const [oidcConfig, samlConfig] = await Promise.all([
+      oidcConfigDAL.findOne({ orgId, isActive: true }).catch(() => null),
+      samlConfigDAL.findOne({ orgId, isActive: true }).catch(() => null)
+    ]);
+
+    if (oidcConfig) {
+      return `${appCfg.SITE_URL}/api/v1/sso/oidc/login?orgSlug=${encodeURIComponent(orgSlug)}`;
+    }
+    if (samlConfig) {
+      return `${appCfg.SITE_URL}/api/v1/sso/redirect/saml2/organizations/${encodeURIComponent(orgSlug)}`;
+    }
+    // LDAP is credential-based with no SSO redirect endpoint (and a safe fallback for any other
+    // enforced method) — send invitees to the login page to sign in with their org credentials.
+    return `${appCfg.SITE_URL}/login`;
+  };
+
   const resendOrgMemberInvitation = async ({
     orgId,
     actorId,
@@ -949,6 +968,37 @@ export const orgServiceFactory = ({
       throw new BadRequestError({
         message: "Organization invitation already accepted"
       });
+    }
+
+    if (org?.authEnforced) {
+      const ssoLoginUrl = await $getEnforcedSsoLoginUrl(org.id, org.slug);
+
+      if (!appCfg.isSmtpConfigured) {
+        return {
+          signupToken: {
+            email: inviteeOrgMembership.email as string,
+            link: ssoLoginUrl
+          }
+        };
+      }
+
+      await smtpService.sendMail({
+        template: SmtpTemplates.OrgInvite,
+        subjectLine: "Infisical organization invitation",
+        recipients: [inviteeOrgMembership.email as string],
+        substitutions: {
+          inviterFirstName: invitingUser.firstName,
+          inviterUsername: invitingUser.email,
+          organizationName: org?.name,
+          callback_url: ssoLoginUrl
+        }
+      });
+
+      await membershipUserDAL.updateById(inviteeOrgMembership.id, {
+        lastInvitedAt: new Date()
+      });
+
+      return { signupToken: undefined };
     }
 
     const token = await tokenService.createTokenForUser({
@@ -1278,10 +1328,16 @@ export const orgServiceFactory = ({
     const invitedUsers = await orgMembershipDAL.findRecentInvitedMemberships();
     const appCfg = getConfig();
 
-    const orgCache: Record<string, { name: string; id: string } | undefined> = {};
+    const orgCache: Record<
+      string,
+      { name: string; id: string; slug: string; authEnforced?: boolean | null } | undefined
+    > = {};
     const notifiedUsers: string[] = [];
 
-    const resolvedInvites: { invitedUser: (typeof invitedUsers)[number]; org: { name: string; id: string } }[] = [];
+    const resolvedInvites: {
+      invitedUser: (typeof invitedUsers)[number];
+      org: { name: string; id: string; slug: string; authEnforced?: boolean | null };
+    }[] = [];
     for (const invitedUser of invitedUsers) {
       let org = orgCache[invitedUser.scopeOrgId];
       if (!org) {
@@ -1297,19 +1353,40 @@ export const orgServiceFactory = ({
       }
     }
 
+    const ssoLoginUrlByOrg = new Map<string, string>();
+    await Promise.all(
+      [...new Map(resolvedInvites.map(({ org }) => [org.id, org])).values()]
+        .filter((org) => org.authEnforced)
+        .map(async (org) => {
+          ssoLoginUrlByOrg.set(org.id, await $getEnforcedSsoLoginUrl(org.id, org.slug));
+        })
+    );
+
     const tokens = await tokenService.createTokensForUsers(
-      resolvedInvites.map(({ invitedUser, org }) => ({
-        type: TokenType.TOKEN_EMAIL_ORG_INVITATION,
-        userId: invitedUser.actorUserId as string,
-        orgId: org.id
-      }))
+      resolvedInvites
+        .filter(({ org }) => !org.authEnforced)
+        .map(({ invitedUser, org }) => ({
+          type: TokenType.TOKEN_EMAIL_ORG_INVITATION,
+          userId: invitedUser.actorUserId as string,
+          orgId: org.id
+        }))
     );
     const tokenByUserOrg = new Map(tokens.map((t) => [`${t.userId}:${t.orgId}`, t.token]));
 
     await Promise.all(
       resolvedInvites.map(async ({ invitedUser, org }) => {
-        const token = tokenByUserOrg.get(`${invitedUser.actorUserId}:${org.id}`);
-        if (!token) return;
+        let callbackUrl: string;
+        if (org.authEnforced) {
+          const ssoLoginUrl = ssoLoginUrlByOrg.get(org.id);
+          if (!ssoLoginUrl) return;
+          callbackUrl = ssoLoginUrl;
+        } else {
+          const token = tokenByUserOrg.get(`${invitedUser.actorUserId}:${org.id}`);
+          if (!token) return;
+          callbackUrl = `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+            invitedUser.inviteEmail as string
+          )}&organization_id=${org.id}`;
+        }
 
         await delayMs(Math.max(0, applyJitter(0, 2000)));
 
@@ -1320,9 +1397,7 @@ export const orgServiceFactory = ({
             recipients: [invitedUser.inviteEmail as string],
             substitutions: {
               organizationName: org.name,
-              callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
-                invitedUser.inviteEmail as string
-              )}&organization_id=${org.id}`
+              callback_url: callbackUrl
             }
           });
           notifiedUsers.push(invitedUser.id);

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -974,10 +974,9 @@ export const orgServiceFactory = ({
         inviterFirstName: invitingUser.firstName,
         inviterUsername: invitingUser.email,
         organizationName: org?.name,
-        email: inviteeOrgMembership.email,
-        organizationId: org?.id.toString(),
-        token,
-        callback_url: `${appCfg.SITE_URL}/signupinvite`
+        callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+          inviteeOrgMembership.email as string
+        )}&organization_id=${org?.id}`
       }
     });
 
@@ -1321,10 +1320,9 @@ export const orgServiceFactory = ({
             recipients: [invitedUser.inviteEmail as string],
             substitutions: {
               organizationName: org.name,
-              email: invitedUser.inviteEmail,
-              organizationId: org.id.toString(),
-              token,
-              callback_url: `${appCfg.SITE_URL}/signupinvite`
+              callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+                invitedUser.inviteEmail as string
+              )}&organization_id=${org.id}`
             }
           });
           notifiedUsers.push(invitedUser.id);

--- a/backend/src/services/smtp/emails/OrganizationInvitationTemplate.tsx
+++ b/backend/src/services/smtp/emails/OrganizationInvitationTemplate.tsx
@@ -6,13 +6,9 @@ import { BaseEmailWrapper, BaseEmailWrapperProps } from "./BaseEmailWrapper";
 import { BaseLink } from "./BaseLink";
 
 interface OrganizationInvitationTemplateProps extends Omit<BaseEmailWrapperProps, "preview" | "title"> {
-  metadata?: string;
   inviterFirstName?: string;
   inviterUsername?: string;
   organizationName: string;
-  email: string;
-  organizationId: string;
-  token: string;
   callback_url: string;
 }
 
@@ -20,11 +16,7 @@ export const OrganizationInvitationTemplate = ({
   organizationName,
   inviterFirstName,
   inviterUsername,
-  token,
   callback_url,
-  metadata,
-  email,
-  organizationId,
   siteUrl
 }: OrganizationInvitationTemplateProps) => {
   return (
@@ -54,11 +46,7 @@ export const OrganizationInvitationTemplate = ({
         </Text>
       </Section>
       <Section className="text-center">
-        <BaseButton
-          href={`${callback_url}?token=${token}${metadata ? `&metadata=${metadata}` : ""}&to=${encodeURIComponent(email)}&organization_id=${organizationId}`}
-        >
-          Accept Invite
-        </BaseButton>
+        <BaseButton href={callback_url}>Accept Invite</BaseButton>
       </Section>
       <Section className="mt-[24px] bg-gray-50 pt-[2px] pb-[16px] border border-solid border-gray-200 px-[24px] rounded-md text-gray-800">
         <Text className="mb-[0px]">
@@ -76,9 +64,7 @@ OrganizationInvitationTemplate.PreviewProps = {
   organizationName: "Example Organization",
   inviterFirstName: "Jane",
   inviterUsername: "jane@infisical.com",
-  email: "john@infisical.com",
   siteUrl: "https://infisical.com",
-  callback_url: "https://app.infisical.com",
-  token: "preview-token",
-  organizationId: "1ae1c2c7-8068-461c-b15e-421737868a6a"
+  callback_url:
+    "https://app.infisical.com/signupinvite?token=preview-token&to=john%40infisical.com&organization_id=1ae1c2c7-8068-461c-b15e-421737868a6a"
 } as OrganizationInvitationTemplateProps;

--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -928,10 +928,9 @@ export const superAdminServiceFactory = ({
             inviterFirstName: serverAdmin?.firstName,
             inviterUsername: serverAdmin?.email,
             organizationName: organization.name,
-            email: user.email,
-            organizationId: organization.id,
-            token,
-            callback_url: `${appCfg.SITE_URL}/signupinvite`
+            callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+              user.email
+            )}&organization_id=${organization.id}`
           }
         });
       })
@@ -1073,10 +1072,9 @@ export const superAdminServiceFactory = ({
         inviterFirstName: serverAdmin?.firstName,
         inviterUsername: serverAdmin?.email,
         organizationName: org?.name,
-        email: orgMembership.inviteEmail,
-        organizationId: orgMembership.scopeOrgId,
-        token,
-        callback_url: `${appCfg.SITE_URL}/signupinvite`
+        callback_url: `${appCfg.SITE_URL}/signupinvite?token=${token}&to=${encodeURIComponent(
+          orgMembership.inviteEmail
+        )}&organization_id=${orgMembership.scopeOrgId}`
       }
     });
 

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -93,14 +93,6 @@ export const OrgMembersSection = () => {
   const isEnterprise = subscription?.slug === SubscriptionPlanTypes.Enterprise;
 
   const handleAddMemberModal = () => {
-    if (currentOrg?.authEnforced) {
-      createNotification({
-        text: "You cannot manage users from Infisical when org-level auth is enforced for your organization",
-        type: "error"
-      });
-      return;
-    }
-
     if (!isMoreIdentitiesAllowed && !isEnterprise) {
       handlePopUpOpen("upgradePlan", {
         text: "You have reached the maximum number of members allowed on your current plan. Upgrade to Infisical Pro plan to add more members."


### PR DESCRIPTION
## Context

- Allow user invitation even on SSO enforcement.
- Pre creates the membership, so when a user sign up using SSO it keeps the user's pre defined role.
- Change invitation link to redirect to SSO sign in.
- The SSO flows still untouched.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

- Register a verified domain
- Register a SSO provider - local SAML using SSOJet SAML
- Turn enforce SSO ON
- Invite user
- Sign in user

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)