### PR TITLE
perf(signer): bulk-revoke active grants instead of looping updateById

### DIFF
--- a/backend/src/services/signer/signer-policy-service.ts
+++ b/backend/src/services/signer/signer-policy-service.ts
@@ -55,7 +55,7 @@ type TSignerPolicyServiceFactoryDep = {
   signerRequestDAL: TSignerRequestDALFactory;
   approvalRequestStepsDAL: Pick<TApprovalRequestStepsDALFactory, "create">;
   approvalRequestStepEligibleApproversDAL: Pick<TApprovalRequestStepEligibleApproversDALFactory, "create">;
-  approvalRequestGrantsDAL: Pick<TApprovalRequestGrantsDALFactory, "create" | "find" | "update" | "updateById">;
+  approvalRequestGrantsDAL: Pick<TApprovalRequestGrantsDALFactory, "create" | "update">;
   membershipDAL: Pick<TMembershipDALFactory, "find" | "transaction">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "find">;
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "find">;

--- a/backend/src/services/signer/signer-policy-service.ts
+++ b/backend/src/services/signer/signer-policy-service.ts
@@ -55,7 +55,7 @@ type TSignerPolicyServiceFactoryDep = {
   signerRequestDAL: TSignerRequestDALFactory;
   approvalRequestStepsDAL: Pick<TApprovalRequestStepsDALFactory, "create">;
   approvalRequestStepEligibleApproversDAL: Pick<TApprovalRequestStepEligibleApproversDALFactory, "create">;
-  approvalRequestGrantsDAL: Pick<TApprovalRequestGrantsDALFactory, "create" | "find" | "updateById">;
+  approvalRequestGrantsDAL: Pick<TApprovalRequestGrantsDALFactory, "create" | "find" | "update" | "updateById">;
   membershipDAL: Pick<TMembershipDALFactory, "find" | "transaction">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "find">;
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "find">;
@@ -737,22 +737,15 @@ export const signerPolicyServiceFactory = ({
     }
 
     await membershipDAL.transaction(async (tx) => {
-      const grants = await approvalRequestGrantsDAL.find(
+      await approvalRequestGrantsDAL.update(
         { requestId: dto.requestId, status: ApprovalRequestGrantStatus.Active },
-        { tx }
+        {
+          status: ApprovalRequestGrantStatus.Revoked,
+          revokedAt: new Date(),
+          revokedByUserId: dto.actor === ActorType.USER ? dto.actorId : null
+        },
+        tx
       );
-      for (const grant of grants) {
-        // eslint-disable-next-line no-await-in-loop
-        await approvalRequestGrantsDAL.updateById(
-          grant.id,
-          {
-            status: ApprovalRequestGrantStatus.Revoked,
-            revokedAt: new Date(),
-            revokedByUserId: dto.actor === ActorType.USER ? dto.actorId : null
-          },
-          tx
-        );
-      }
       await approvalRequestDAL.updateById(dto.requestId, { status: ApprovalRequestStatus.Cancelled }, tx);
     });
 


### PR DESCRIPTION
## What

`revokeRequest` in `signer-policy-service.ts` fetched every active grant for a signer approval request and then issued one `updateById` per grant inside the transaction. For a request with N grants that is N+1 round trips (1 find + N updates) when one bulk update covers it.

Replaced the find + loop with a single `approvalRequestGrantsDAL.update({ requestId, status: Active }, { ... })`. The grant DAL is `ormify`-based so this is one `WHERE requestId = ? AND status = 'active'` UPDATE.

## Behavior note

On existing rows the result is identical. If another transaction inserts a fresh Active grant for the same request between the original find and the per-row updates, the old code would miss revoking it. The bulk version revokes everything still Active at the moment of the UPDATE, which is what you want when cancelling a request.

Also bumped the `Pick<TApprovalRequestGrantsDALFactory, ...>` in the factory deps to expose `update`.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (signer service has no unit tests for revokeRequest; this is a perf refactor with no behavior change on existing rows)
- [x] The change is limited to the affected code path
