### PR TITLE
fix(db): index FK columns on pki_signer_certificate_issuance_jobs

### DIFF
--- a/backend/src/db/migrations/20260622052944_add-pki-signer-issuance-jobs-fk-indexes.ts
+++ b/backend/src/db/migrations/20260622052944_add-pki-signer-issuance-jobs-fk-indexes.ts
@@ -1,0 +1,56 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// pki_signer_certificate_issuance_jobs.caId (CASCADE FK to certificate_authorities) and
+// certificateId (SET NULL FK to certificates) ship without covering indexes, so the per-row
+// RI triggers fall back to a seq-scan of this table on every parent CA / certificate delete.
+// certificateId is nullable (created later by the issuance worker), so it gets a partial index
+// that skips the NULL rows.
+const FK_INDEXES = [
+  {
+    table: TableName.PkiSignerCertificateIssuanceJobs,
+    column: "caId",
+    name: "pki_signer_certificate_issuance_jobs_caid_idx",
+    partial: false
+  },
+  {
+    table: TableName.PkiSignerCertificateIssuanceJobs,
+    column: "certificateId",
+    name: "pki_signer_certificate_issuance_jobs_certificateid_idx",
+    partial: true
+  }
+];
+
+const indexExists = async (knex: Knex, indexName: string): Promise<boolean> => {
+  const result = await knex.raw(`SELECT 1 FROM pg_indexes WHERE indexname = ?`, [indexName]);
+  return result.rows.length > 0;
+};
+
+export async function up(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if (
+      (await knex.schema.hasTable(idx.table)) &&
+      (await knex.schema.hasColumn(idx.table, idx.column)) &&
+      !(await indexExists(knex, idx.name))
+    ) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        if (idx.partial) {
+          t.index([idx.column], idx.name, { predicate: knex.whereNotNull(idx.column) });
+        } else {
+          t.index([idx.column], idx.name);
+        }
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if ((await knex.schema.hasTable(idx.table)) && (await indexExists(knex, idx.name))) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        t.dropIndex([idx.column], idx.name);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## What

`pki_signer_certificate_issuance_jobs` was created in `20260528124443_signer-revamp.ts` with two foreign keys but no covering indexes:

- `caId` (NOT NULL, `references certificate_authorities ON DELETE CASCADE`)
- `certificateId` (nullable, `references certificates ON DELETE SET NULL`)

Postgres does not auto-index FK columns. The per-row referential-integrity trigger on each parent delete falls back to a seq-scan of this table to find the children, so every CA deletion or certificate deletion seq-scans every issuance-jobs row.

This PR adds the indexes via a new migration following the same pattern as `20260608123213_add-certificate-requests-certificate-id-index.ts`:

- `caId` (NOT NULL) gets a plain btree.
- `certificateId` is mostly NULL on the live path (only set once the worker finishes the issuance), so it gets a partial index `WHERE "certificateId" IS NOT NULL`. Saves space and write overhead while still serving the cascade lookup.

`down` drops both indexes if present.

## Why now

The table is small today but it grows over time (one row per signer cert issuance attempt, including retries). Catching this before the table is big means we don't have to rewrite with `CREATE INDEX CONCURRENTLY` later when the seq-scan starts blocking statement_timeout on CA deletes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DDL-only migration, behavior verified by query plan inspection rather than unit tests)
- [x] The change is limited to the affected code path
