### PR TITLE
perf(access-approval-policy): batch the per-env existence check

### DIFF
--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
@@ -149,7 +149,7 @@ export interface TAccessApprovalPolicyDALFactory
     | undefined
   >;
   findPolicyByEnvIdAndSecretPath: (
-    { envIds, secretPath }: { envIds: string[]; secretPath: string },
+    { envIds, secretPath, excludePolicyId }: { envIds: string[]; secretPath: string; excludePolicyId?: string },
     tx?: Knex
   ) => Promise<{
     name: string;
@@ -618,11 +618,11 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient): TAccessApprovalPo
   };
 
   const findPolicyByEnvIdAndSecretPath: TAccessApprovalPolicyDALFactory["findPolicyByEnvIdAndSecretPath"] = async (
-    { envIds, secretPath },
+    { envIds, secretPath, excludePolicyId },
     tx
   ) => {
     try {
-      const docs = await (tx || db.replicaNode())(TableName.AccessApprovalPolicy)
+      const query = (tx || db.replicaNode())(TableName.AccessApprovalPolicy)
         .join(
           TableName.AccessApprovalPolicyEnvironment,
           `${TableName.AccessApprovalPolicyEnvironment}.policyId`,
@@ -653,7 +653,11 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient): TAccessApprovalPo
             TableName.AccessApprovalPolicy
           )
         )
-        .whereNull(`${TableName.AccessApprovalPolicy}.deletedAt`)
+        .whereNull(`${TableName.AccessApprovalPolicy}.deletedAt`);
+      if (excludePolicyId) {
+        void query.whereNot(`${TableName.AccessApprovalPolicy}.id`, excludePolicyId);
+      }
+      const docs = await query
         .orderBy("deletedAt", "desc")
         .orderByRaw(`"deletedAt" IS NULL`)
         .select(selectAllTableCols(TableName.AccessApprovalPolicy))

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -62,25 +62,25 @@ export const accessApprovalPolicyServiceFactory = ({
   accessApprovalRequestReviewerDAL,
   projectMembershipDAL
 }: TAccessApprovalPolicyServiceFactoryDep): TAccessApprovalPolicyServiceFactory => {
-  const $policyExists = async ({
-    envId,
-    envIds,
+  const $assertNoConflictingPolicy = async ({
+    envs,
     secretPath,
-    policyId
+    excludePolicyId
   }: {
-    envId?: string;
-    envIds?: string[];
+    envs: { id: string; slug: string }[];
     secretPath: string;
-    policyId?: string;
+    excludePolicyId?: string;
   }) => {
-    if (!envId && !envIds) {
-      throw new BadRequestError({ message: "Must provide either envId or envIds" });
-    }
+    if (envs.length === 0) return;
     const policy = await accessApprovalPolicyDAL.findPolicyByEnvIdAndSecretPath({
       secretPath,
-      envIds: envId ? [envId] : (envIds as string[])
+      envIds: envs.map((e) => e.id)
     });
-    return policyId ? policy && policy.id !== policyId : Boolean(policy);
+    if (!policy || policy.id === excludePolicyId) return;
+    const conflictEnv = envs.find((e) => policy.environments?.some((pe) => pe.id === e.id)) ?? envs[0];
+    throw new BadRequestError({
+      message: `A policy for secret path '${secretPath}' already exists in environment '${conflictEnv.slug}'`
+    });
   };
 
   const verifyProjectUserMembership = async (userIds: string[], orgId: string, projectId: string) => {
@@ -155,14 +155,7 @@ export const accessApprovalPolicyServiceFactory = ({
       throw new NotFoundError({ message: `One or more environments not found: ${notFoundEnvs.join(", ")}` });
     }
 
-    for (const env of envs) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await $policyExists({ envId: env.id, secretPath })) {
-        throw new BadRequestError({
-          message: `A policy for secret path '${secretPath}' already exists in environment '${env.slug}'`
-        });
-      }
-    }
+    await $assertNoConflictingPolicy({ envs, secretPath });
 
     let approverUserIds = userApprovers;
     if (userApproverNames.length) {
@@ -383,20 +376,11 @@ export const accessApprovalPolicyServiceFactory = ({
       envs = await projectEnvDAL.find({ $in: { slug: environments }, projectId: accessApprovalPolicy.projectId });
     }
 
-    for (const env of envs) {
-      if (
-        // eslint-disable-next-line no-await-in-loop
-        await $policyExists({
-          envId: env.id,
-          secretPath: secretPath || accessApprovalPolicy.secretPath,
-          policyId: accessApprovalPolicy.id
-        })
-      ) {
-        throw new BadRequestError({
-          message: `A policy for secret path '${secretPath || accessApprovalPolicy.secretPath}' already exists in environment '${env.slug}'`
-        });
-      }
-    }
+    await $assertNoConflictingPolicy({
+      envs,
+      secretPath: secretPath || accessApprovalPolicy.secretPath,
+      excludePolicyId: accessApprovalPolicy.id
+    });
 
     const { permission } = await permissionService.getProjectPermission({
       actor,

--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-service.ts
@@ -74,9 +74,10 @@ export const accessApprovalPolicyServiceFactory = ({
     if (envs.length === 0) return;
     const policy = await accessApprovalPolicyDAL.findPolicyByEnvIdAndSecretPath({
       secretPath,
-      envIds: envs.map((e) => e.id)
+      envIds: envs.map((e) => e.id),
+      excludePolicyId
     });
-    if (!policy || policy.id === excludePolicyId) return;
+    if (!policy) return;
     const conflictEnv = envs.find((e) => policy.environments?.some((pe) => pe.id === e.id)) ?? envs[0];
     throw new BadRequestError({
       message: `A policy for secret path '${secretPath}' already exists in environment '${conflictEnv.slug}'`


### PR DESCRIPTION
## What

`createAccessApprovalPolicy` and `updateAccessApprovalPolicy` looped over the env list and called the DAL once per env to detect a conflicting policy for the same `secretPath`:

```ts
for (const env of envs) {
  // eslint-disable-next-line no-await-in-loop
  if (await $policyExists({ envId: env.id, secretPath })) {
    throw new BadRequestError({ ... });
  }
}
```

The DAL helper `findPolicyByEnvIdAndSecretPath` already accepts `envIds: string[]` and returns the conflicting policy with its `environments` array. The loop was N round trips when one query covers it.

This PR replaces the loop with a single batched call.

## Preserves behavior

When a conflict exists, the new code intersects `policy.environments` with the requested `envs` to identify the offending env, so the thrown error still names the same env slug as before. The update site keeps the existing self-exclusion via `excludePolicyId` (a policy is not allowed to conflict with itself).

Removes `$policyExists` since both call sites move to the new helper.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (no unit tests exist for this service path; the access-approval-policy DAL function being called was already used in batch form elsewhere)
- [x] The change is limited to the affected code path
