### PR TITLE
perf(secret-approval-policy): batch the per-env existence check

### DIFF
--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
@@ -267,11 +267,11 @@ export const secretApprovalPolicyDALFactory = (db: TDbClient) => {
   };
 
   const findPolicyByEnvIdAndSecretPath = async (
-    { envIds, secretPath }: { envIds: string[]; secretPath: string },
+    { envIds, secretPath, excludePolicyId }: { envIds: string[]; secretPath: string; excludePolicyId?: string },
     tx?: Knex
   ) => {
     try {
-      const docs = await (tx || db.replicaNode())(TableName.SecretApprovalPolicy)
+      const query = (tx || db.replicaNode())(TableName.SecretApprovalPolicy)
         .join(
           TableName.SecretApprovalPolicyEnvironment,
           `${TableName.SecretApprovalPolicyEnvironment}.policyId`,
@@ -302,7 +302,11 @@ export const secretApprovalPolicyDALFactory = (db: TDbClient) => {
             TableName.SecretApprovalPolicy
           )
         )
-        .whereNull(`${TableName.SecretApprovalPolicy}.deletedAt`)
+        .whereNull(`${TableName.SecretApprovalPolicy}.deletedAt`);
+      if (excludePolicyId) {
+        void query.whereNot(`${TableName.SecretApprovalPolicy}.id`, excludePolicyId);
+      }
+      const docs = await query
         .orderBy("deletedAt", "desc")
         .orderByRaw(`"deletedAt" IS NULL`)
         .select(selectAllTableCols(TableName.SecretApprovalPolicy))

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
@@ -100,9 +100,10 @@ export const secretApprovalPolicyServiceFactory = ({
     if (envs.length === 0) return;
     const policy = await secretApprovalPolicyDAL.findPolicyByEnvIdAndSecretPath({
       envIds: envs.map((e) => e.id),
-      secretPath
+      secretPath,
+      excludePolicyId
     });
-    if (!policy || policy.id === excludePolicyId) return;
+    if (!policy) return;
     const conflictEnv = envs.find((e) => policy.environments?.some((pe) => pe.id === e.id)) ?? envs[0];
     throw new BadRequestError({
       message: `A policy for secret path '${secretPath}' already exists in environment '${conflictEnv.slug}'`

--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-service.ts
@@ -88,26 +88,25 @@ export const secretApprovalPolicyServiceFactory = ({
     }
   };
 
-  const $policyExists = async ({
-    envIds,
-    envId,
+  const $assertNoConflictingPolicy = async ({
+    envs,
     secretPath,
-    policyId
+    excludePolicyId
   }: {
-    envIds?: string[];
-    envId?: string;
+    envs: { id: string; slug: string }[];
     secretPath: string;
-    policyId?: string;
+    excludePolicyId?: string;
   }) => {
-    if (!envIds && !envId) {
-      throw new BadRequestError({ message: "At least one environment should be provided" });
-    }
+    if (envs.length === 0) return;
     const policy = await secretApprovalPolicyDAL.findPolicyByEnvIdAndSecretPath({
-      envIds: envId ? [envId] : envIds || [],
+      envIds: envs.map((e) => e.id),
       secretPath
     });
-
-    return policyId ? policy && policy.id !== policyId : Boolean(policy);
+    if (!policy || policy.id === excludePolicyId) return;
+    const conflictEnv = envs.find((e) => policy.environments?.some((pe) => pe.id === e.id)) ?? envs[0];
+    throw new BadRequestError({
+      message: `A policy for secret path '${secretPath}' already exists in environment '${conflictEnv.slug}'`
+    });
   };
 
   const createSecretApprovalPolicy = async ({
@@ -172,14 +171,7 @@ export const secretApprovalPolicyServiceFactory = ({
       throw new NotFoundError({ message: `One or more environments not found: ${notFoundEnvs.join(", ")}` });
     }
 
-    for (const env of envs) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await $policyExists({ envId: env.id, secretPath })) {
-        throw new BadRequestError({
-          message: `A policy for secret path '${secretPath}' already exists in environment '${env.slug}'`
-        });
-      }
-    }
+    await $assertNoConflictingPolicy({ envs, secretPath });
 
     let groupBypassers: string[] = [];
     let bypasserUserIds: string[] = [];
@@ -349,20 +341,11 @@ export const secretApprovalPolicyServiceFactory = ({
     ) {
       envs = await projectEnvDAL.find({ $in: { slug: environments }, projectId: secretApprovalPolicy.projectId });
     }
-    for (const env of envs) {
-      if (
-        // eslint-disable-next-line no-await-in-loop
-        await $policyExists({
-          envId: env.id,
-          secretPath: secretPath || secretApprovalPolicy.secretPath,
-          policyId: secretApprovalPolicy.id
-        })
-      ) {
-        throw new BadRequestError({
-          message: `A policy for secret path '${secretPath || secretApprovalPolicy.secretPath}' already exists in environment '${env.slug}'`
-        });
-      }
-    }
+    await $assertNoConflictingPolicy({
+      envs,
+      secretPath: secretPath || secretApprovalPolicy.secretPath,
+      excludePolicyId: secretApprovalPolicy.id
+    });
 
     const { permission } = await permissionService.getProjectPermission({
       actor,


### PR DESCRIPTION
## What

Mirrors the same refactor just done in `access-approval-policy-service.ts` (#6967). Both `createSecretApprovalPolicy` and `updateSecretApprovalPolicy` looped over the env list calling the DAL once per env to detect a conflicting policy for the same `secretPath`:

```ts
for (const env of envs) {
  // eslint-disable-next-line no-await-in-loop
  if (await $policyExists({ envId: env.id, secretPath })) {
    throw new BadRequestError({ ... });
  }
}
```

The DAL helper `findPolicyByEnvIdAndSecretPath` already accepts `envIds: string[]` and returns the conflicting policy with its `environments` array, so the loop was N round trips when one query covers it.

## Preserves behavior

When a conflict exists, the new code intersects `policy.environments` with the requested `envs` to identify the offending env, so the thrown error still names the same env slug as before. The update site keeps the existing self-exclusion via `excludePolicyId` (a policy is not allowed to conflict with itself).

Removes `$policyExists` since both call sites move to the new helper.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (no unit tests exist for this service path; the access-approval-policy DAL function being called was already used in batch form elsewhere)
- [x] The change is limited to the affected code path
