### PR TITLE
feat(pam): add Kubernetes account support

### DIFF
--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -20,6 +20,7 @@ describe("buildPamAccountTypeMetadata", () => {
     expect(byType.get(PamAccountType.Postgres)?.supportsWebAccess).toBe(true);
     expect(byType.get(PamAccountType.SSH)?.supportsWebAccess).toBe(true);
     expect(byType.get(PamAccountType.MySQL)?.supportsWebAccess).toBe(false);
+    expect(byType.get(PamAccountType.Kubernetes)?.supportsWebAccess).toBe(false);
   });
 
   const fieldByKey = <T extends { key: string }>(fields: T[], key: string) => fields.find((f) => f.key === key);
@@ -106,6 +107,40 @@ describe("buildPamAccountTypeMetadata", () => {
     });
   });
 
+  test("derives Kubernetes connection and credential fields from the schema", () => {
+    const k8s = byType.get(PamAccountType.Kubernetes);
+    expect(k8s).toBeDefined();
+    expect(k8s?.name).toBe("Kubernetes");
+
+    expect(k8s?.connectionFields.map((f) => f.key)).toEqual(["url", "sslRejectUnauthorized", "sslCertificate"]);
+    expect(fieldByKey(k8s!.connectionFields, "url")).toMatchObject({ widget: "text", required: true });
+    expect(fieldByKey(k8s!.connectionFields, "sslRejectUnauthorized")).toMatchObject({
+      widget: "boolean",
+      required: true
+    });
+    expect(fieldByKey(k8s!.connectionFields, "sslCertificate")).toMatchObject({ widget: "textarea", required: false });
+
+    const authMethod = fieldByKey(k8s!.credentialFields, "authMethod");
+    expect(authMethod).toMatchObject({ widget: "select", required: true });
+    expect(authMethod?.options?.map((o) => o.value)).toEqual(["service-account-token", "gateway-kubernetes-auth"]);
+
+    expect(fieldByKey(k8s!.credentialFields, "serviceAccountToken")).toMatchObject({
+      widget: "textarea",
+      secret: true,
+      showWhen: { field: "authMethod", equals: "service-account-token" }
+    });
+    expect(fieldByKey(k8s!.credentialFields, "namespace")).toMatchObject({
+      widget: "text",
+      required: true,
+      showWhen: { field: "authMethod", equals: "gateway-kubernetes-auth" }
+    });
+    expect(fieldByKey(k8s!.credentialFields, "serviceAccountName")).toMatchObject({
+      widget: "text",
+      required: true,
+      showWhen: { field: "authMethod", equals: "gateway-kubernetes-auth" }
+    });
+  });
+
   test("flattens the SSH discriminated union into a select plus conditional variant fields", () => {
     const ssh = byType.get(PamAccountType.SSH);
     expect(ssh).toBeDefined();
@@ -137,6 +172,29 @@ describe("isCredentialConfigured", () => {
     expect(isCredentialConfigured(PamAccountType.Postgres, { username: "u", password: "p" })).toBe(true);
     expect(isCredentialConfigured(PamAccountType.Postgres, { username: "u", password: "  " })).toBe(false);
     expect(isCredentialConfigured(PamAccountType.MySQL, { username: "u" })).toBe(false);
+  });
+
+  test("Kubernetes credential depends on the auth method", () => {
+    expect(
+      isCredentialConfigured(PamAccountType.Kubernetes, {
+        authMethod: "service-account-token",
+        serviceAccountToken: "token123"
+      })
+    ).toBe(true);
+    expect(
+      isCredentialConfigured(PamAccountType.Kubernetes, {
+        authMethod: "service-account-token",
+        serviceAccountToken: ""
+      })
+    ).toBe(false);
+    expect(isCredentialConfigured(PamAccountType.Kubernetes, { authMethod: "service-account-token" })).toBe(false);
+    expect(
+      isCredentialConfigured(PamAccountType.Kubernetes, {
+        authMethod: "gateway-kubernetes-auth",
+        namespace: "default",
+        serviceAccountName: "my-sa"
+      })
+    ).toBe(true);
   });
 
   test("SSH credential depends on the auth method", () => {

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -158,7 +158,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
     credentials: z.discriminatedUnion("authMethod", [
       z.object({
         authMethod: z.literal("service-account-token"),
-        serviceAccountToken: z.string().trim().max(10000)
+        serviceAccountToken: z.string().trim().min(1).max(10000)
       }),
       z.object({
         authMethod: z.literal("gateway-kubernetes-auth"),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -141,6 +141,45 @@ export const ACCOUNT_TYPE_CONFIGS = {
       caPublicKey: z.string(),
       caKeyAlgorithm: z.string()
     })
+  },
+
+  [PamAccountType.Kubernetes]: {
+    name: "Kubernetes",
+    icon: "Kubernetes.png",
+    connectionDetails: z.object({
+      url: z.string().url().trim().max(500),
+      sslRejectUnauthorized: z.boolean(),
+      sslCertificate: z
+        .string()
+        .trim()
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    credentials: z.discriminatedUnion("authMethod", [
+      z.object({
+        authMethod: z.literal("service-account-token"),
+        serviceAccountToken: z.string().trim().max(10000)
+      }),
+      z.object({
+        authMethod: z.literal("gateway-kubernetes-auth"),
+        namespace: z.string().trim().min(1).max(63),
+        serviceAccountName: z.string().trim().min(1).max(253)
+      })
+    ]),
+    sanitizedCredentials: z.object({
+      authMethod: z.string().optional(),
+      namespace: z.string().optional(),
+      serviceAccountName: z.string().optional()
+    }),
+    ui: {
+      url: { label: "Kubernetes API URL" },
+      sslRejectUnauthorized: { label: "Reject Unauthorized" },
+      sslCertificate: { label: "SSL Certificate", widget: PamFieldWidget.Textarea },
+      authMethod: { label: "Auth Method" },
+      serviceAccountToken: { label: "Service Account Token", widget: PamFieldWidget.Textarea, secret: true },
+      namespace: { label: "Namespace" },
+      serviceAccountName: { label: "Service Account Name" }
+    }
   }
 } as const satisfies Partial<
   Record<
@@ -210,6 +249,14 @@ export const extractGatewayTarget = (
         host: (validated as { host: string; port: number }).host,
         port: (validated as { host: string; port: number }).port
       };
+    case PamAccountType.Kubernetes: {
+      const { url } = validated as { url: string };
+      const parsed = new URL(url);
+      return {
+        host: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : undefined
+      };
+    }
     default:
       throw new Error(`No gateway target extraction defined for account type '${accountType}'`);
   }

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -339,8 +339,11 @@ type TFieldUiHint = {
 };
 
 const humanizeKey = (key: string) => {
-  const spaced = key.replace(new RE2(/([A-Z])/g), " $1").trim();
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  const spaced = key.replace(new RE2(/([A-Z])/g), " $1").replace(/-/g, " ").trim();
+  return spaced
+    .split(" ")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
 };
 
 const unwrapField = (schema: z.ZodTypeAny): { base: z.ZodTypeAny; required: boolean } => {

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -252,10 +252,7 @@ export const extractGatewayTarget = (
     case PamAccountType.Kubernetes: {
       const { url } = validated as { url: string };
       const parsed = new URL(url);
-      return {
-        host: parsed.hostname,
-        port: parsed.port ? Number(parsed.port) : undefined
-      };
+      return { host: parsed.hostname };
     }
     default:
       throw new Error(`No gateway target extraction defined for account type '${accountType}'`);

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -339,7 +339,10 @@ type TFieldUiHint = {
 };
 
 const humanizeKey = (key: string) => {
-  const spaced = key.replace(new RE2(/([A-Z])/g), " $1").replace(/-/g, " ").trim();
+  const spaced = key
+    .replace(new RE2(/([A-Z])/g), " $1")
+    .replace(/-/g, " ")
+    .trim();
   return spaced
     .split(" ")
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -341,7 +341,7 @@ type TFieldUiHint = {
 const humanizeKey = (key: string) => {
   const spaced = key
     .replace(new RE2(/([A-Z])/g), " $1")
-    .replace(/-/g, " ")
+    .replace(new RE2(/-/g), " ")
     .trim();
   return spaced
     .split(" ")

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -381,12 +381,22 @@ export const pamSessionServiceFactory = ({
       throw new BadRequestError({ message: "Failed to obtain gateway connection details" });
     }
 
-    const metadata: Record<string, string> = {
-      username: rawCredentials.username as string
-    };
+    const metadata: Record<string, string> = {};
 
-    if (account.accountType === PamAccountType.Postgres || account.accountType === PamAccountType.MySQL) {
-      if (rawConnectionDetails.database) {
+    if (account.accountType === PamAccountType.Kubernetes) {
+      metadata.authMethod = rawCredentials.authMethod as string;
+      if (rawCredentials.namespace) {
+        metadata.namespace = rawCredentials.namespace as string;
+      }
+      if (rawCredentials.serviceAccountName) {
+        metadata.serviceAccountName = rawCredentials.serviceAccountName as string;
+      }
+    } else {
+      metadata.username = rawCredentials.username as string;
+      if (
+        (account.accountType === PamAccountType.Postgres || account.accountType === PamAccountType.MySQL) &&
+        rawConnectionDetails.database
+      ) {
         metadata.database = rawConnectionDetails.database as string;
       }
     }


### PR DESCRIPTION
## Context

Adds Kubernetes as a supported account type in the PAM revamp. Both auth methods from the old model are carried over:

- **Service Account Token** -- admin pastes a static K8s SA token, gateway injects it as a Bearer header
- **Gateway Kubernetes Auth** -- no secret stored, gateway uses its own pod SA token + K8s impersonation headers to act as the target service account (requires gateway deployed inside the cluster with impersonation RBAC)

The frontend is fully data-driven from `ACCOUNT_TYPE_CONFIGS` so no UI component changes are needed -- Kubernetes appears in the account type picker automatically with conditional form fields based on the selected auth method.

Companion CLI PR: Infisical/cli#273

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)