### PR TITLE
fix(billing): correct license server v2 customer portal behavior

### DIFF
--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -187,7 +187,11 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         returnPath: ReturnPathSchema
       }),
       response: {
-        200: z.object({ url: z.string() })
+        200: z.object({
+          outcome: z.enum(["checkout_created", "subscription_updated"]),
+          checkoutUrl: z.string().optional(),
+          subscriptionId: z.string().optional()
+        })
       }
     },
     onRequest: verifyAuth([AuthMode.JWT]),

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -430,12 +430,11 @@ export const licenseV2ServiceFactory = ({
       return { outcome: "subscription_updated" as const, subscriptionId: result.subscriptionId };
     }
 
-    // checkout_created (or the legacy { url } shape) means the customer must finish in Stripe Checkout.
-    const checkoutUrl = result.checkoutUrl ?? result.url;
-    if (!checkoutUrl) {
+    // checkout_created: the customer must finish in Stripe Checkout.
+    if (!result.checkoutUrl) {
       throw new InternalServerError({ message: "Checkout session did not return a URL" });
     }
-    return { outcome: "checkout_created" as const, checkoutUrl };
+    return { outcome: "checkout_created" as const, checkoutUrl: result.checkoutUrl };
   };
 
   const addPaymentMethod = async ({ orgId, actor, returnPath }: TAddBillingV2PaymentMethodDTO) => {

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { OrganizationActionScope, TableName } from "@app/db/schemas";
+import { OrganizationActionScope } from "@app/db/schemas";
 import { TEnvConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
@@ -332,7 +332,7 @@ export const licenseV2ServiceFactory = ({
 
     const members = await orgDAL.countAllOrgMembers(orgId);
     const identities = await identityOrgMembershipDAL.countAllOrgIdentities({
-      [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: orgId
+      scopeOrgId: orgId
     });
 
     // Plan caps come from the license server (a null limit means genuinely unlimited). Used counts

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -1,9 +1,10 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { OrganizationActionScope } from "@app/db/schemas";
+import { OrganizationActionScope, TableName } from "@app/db/schemas";
 import { TEnvConfig } from "@app/lib/config/env";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
+import { TIdentityOrgDALFactory } from "@app/services/identity/identity-org-dal";
 import { TLicenseClientFactory } from "@app/services/license-client";
 import {
   TCatalogProduct,
@@ -32,6 +33,7 @@ import {
 type TLicenseV2ServiceFactoryDep = {
   envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "countAllOrgMembers">;
+  identityOrgMembershipDAL: Pick<TIdentityOrgDALFactory, "countAllOrgIdentities">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   licenseClient: Pick<
     TLicenseClientFactory,
@@ -220,6 +222,7 @@ const buildCheckoutItems = (product: TCatalogProduct, cadence: "monthly" | "annu
 export const licenseV2ServiceFactory = ({
   envConfig,
   orgDAL,
+  identityOrgMembershipDAL,
   permissionService,
   licenseClient
 }: TLicenseV2ServiceFactoryDep) => {
@@ -328,6 +331,9 @@ export const licenseV2ServiceFactory = ({
     }
 
     const members = await orgDAL.countAllOrgMembers(orgId);
+    const identities = await identityOrgMembershipDAL.countAllOrgIdentities({
+      [`${TableName.Membership}.scopeOrgId` as "scopeOrgId"]: orgId
+    });
 
     // Plan caps come from the license server (a null limit means genuinely unlimited). Used counts
     // are overlaid here; a missing plan leaves limits unknown.
@@ -363,7 +369,7 @@ export const licenseV2ServiceFactory = ({
       usage: {
         members,
         memberLimit,
-        identities: 0,
+        identities,
         identityLimit
       },
       payment: null,

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -2,7 +2,7 @@ import { ForbiddenError } from "@casl/ability";
 
 import { OrganizationActionScope } from "@app/db/schemas";
 import { TEnvConfig } from "@app/lib/config/env";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { TIdentityOrgDALFactory } from "@app/services/identity/identity-org-dal";
 import { TLicenseClientFactory } from "@app/services/license-client";
@@ -425,8 +425,17 @@ export const licenseV2ServiceFactory = ({
       throw new BadRequestError({ message: "This product is not available for self-serve checkout" });
     }
 
-    const session = await licenseClient.createCheckout(orgId, { items, email, returnPath });
-    return { url: session.url };
+    const result = await licenseClient.createCheckout(orgId, { items, email, returnPath });
+    if (result.outcome === "subscription_updated") {
+      return { outcome: "subscription_updated" as const, subscriptionId: result.subscriptionId };
+    }
+
+    // checkout_created (or the legacy { url } shape) means the customer must finish in Stripe Checkout.
+    const checkoutUrl = result.checkoutUrl ?? result.url;
+    if (!checkoutUrl) {
+      throw new InternalServerError({ message: "Checkout session did not return a URL" });
+    }
+    return { outcome: "checkout_created" as const, checkoutUrl };
   };
 
   const addPaymentMethod = async ({ orgId, actor, returnPath }: TAddBillingV2PaymentMethodDTO) => {

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -37,7 +37,13 @@ type TLicenseV2ServiceFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   licenseClient: Pick<
     TLicenseClientFactory,
-    "getEntitlements" | "getCatalog" | "getSubscription" | "getCloudPlan" | "createCheckout" | "createPortal"
+    | "getEntitlements"
+    | "getCatalog"
+    | "getSubscription"
+    | "getCloudPlan"
+    | "getBillingProfile"
+    | "createCheckout"
+    | "createPortal"
   >;
 };
 
@@ -358,6 +364,29 @@ export const licenseV2ServiceFactory = ({
       }
     }
 
+    // Payment method, billing identity, and invoices come from the org's Stripe customer. A
+    // failure (or unconfigured backend) degrades to the empty state rather than failing the page.
+    let payment: BillingV2Overview["payment"] = null;
+    let billingDetails: BillingV2Overview["billingDetails"] = null;
+    let invoices: BillingV2Overview["invoices"] = [];
+    try {
+      const profile = await licenseClient.getBillingProfile(orgId);
+      if (profile) {
+        payment = profile.payment;
+        billingDetails = profile.billingDetails;
+        invoices = profile.invoices.map((invoice) => ({
+          id: invoice.id,
+          number: invoice.number,
+          date: formatDate(invoice.date) ?? "",
+          amount: centsToDollars(invoice.amount),
+          paid: invoice.paid,
+          pdfUrl: invoice.pdfUrl ?? ""
+        }));
+      }
+    } catch (error) {
+      logger.error(error, `billing-v2: failed to read billing profile [orgId=${orgId}]`);
+    }
+
     const overview: BillingV2Overview = {
       isCloud: true,
       mode: "self-serve",
@@ -372,9 +401,9 @@ export const licenseV2ServiceFactory = ({
         identities,
         identityLimit
       },
-      payment: null,
-      billingDetails: null,
-      invoices: [],
+      payment,
+      billingDetails,
+      invoices,
       entitlements: await buildEntitlements(orgId, subscription)
     };
 

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -240,10 +240,12 @@ export const licenseServiceFactory = ({
           // it non-fatal so a subscription read failure doesn't drop the org to the free fallback.
           try {
             const subscription = await licenseClient.getSubscription(rootOrgId);
-            const tiers = (subscription?.items ?? []).map((item) => item.plan.toLowerCase());
-            if (tiers.some((tier) => tier.includes("enterprise"))) {
+            const paidTiers = (subscription?.items ?? [])
+              .map((item) => item.plan.toLowerCase())
+              .filter((tier) => tier !== "free");
+            if (paidTiers.some((tier) => tier.includes("enterprise"))) {
               currentPlan.slug = "enterprise";
-            } else if (tiers.length > 0) {
+            } else if (paidTiers.length > 0) {
               currentPlan.slug = "pro";
             }
           } catch (error) {

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -67,7 +67,7 @@ type TLicenseServiceFactoryDep = {
   licenseDAL: TLicenseDALFactory;
   keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem">;
   projectDAL: TProjectDALFactory;
-  licenseClient?: Pick<TLicenseClientFactory, "getEntitlements">;
+  licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription">;
   licenseDualRead?: Pick<TDualReadServiceFactory, "compareInBackground">;
 };
 
@@ -234,6 +234,21 @@ export const licenseServiceFactory = ({
             throw new BadRequestError({ message: "License Server v2 entitlements are unavailable" });
           }
           currentPlan = projectV2ToFeatureSet(getDefaultOnPremFeatures(), entitlements);
+
+          // The entitlement projection only carries feature flags, so set the plan slug from the
+          // subscription tier; otherwise the org-level plan label can't reflect the real tier. Keep
+          // it non-fatal so a subscription read failure doesn't drop the org to the free fallback.
+          try {
+            const subscription = await licenseClient.getSubscription(rootOrgId);
+            const tiers = subscription?.items.map((item) => item.plan.toLowerCase()) ?? [];
+            if (tiers.some((tier) => tier.includes("enterprise"))) {
+              currentPlan.slug = "enterprise";
+            } else if (tiers.length > 0) {
+              currentPlan.slug = "pro";
+            }
+          } catch (error) {
+            logger.error(error, `getPlan: failed to resolve plan tier from subscription [orgId=${rootOrgId}]`);
+          }
         } else {
           const {
             data: { currentPlan: v1Plan }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -240,7 +240,7 @@ export const licenseServiceFactory = ({
           // it non-fatal so a subscription read failure doesn't drop the org to the free fallback.
           try {
             const subscription = await licenseClient.getSubscription(rootOrgId);
-            const tiers = subscription?.items.map((item) => item.plan.toLowerCase()) ?? [];
+            const tiers = (subscription?.items ?? []).map((item) => item.plan.toLowerCase());
             if (tiers.some((tier) => tier.includes("enterprise"))) {
               currentPlan.slug = "enterprise";
             } else if (tiers.length > 0) {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -834,6 +834,7 @@ export const registerRoutes = async (
   const licenseV2Service = licenseV2ServiceFactory({
     envConfig,
     orgDAL,
+    identityOrgMembershipDAL,
     permissionService,
     licenseClient
   });

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -1,12 +1,14 @@
 import jwt from "jsonwebtoken";
 
 import {
+  billingProfileResponseSchema,
   catalogResponseSchema,
   checkoutResultSchema,
   cloudPlanResponseSchema,
   entitlementsResponseSchema,
   sessionResponseSchema,
   subscriptionResponseSchema,
+  TBillingProfileResponse,
   TCatalogResponse,
   TCheckoutResult,
   TCloudPlanResponse,
@@ -22,6 +24,7 @@ const ENTITLEMENTS_PATH = "/v1/entitlements";
 const PRODUCTS_PATH = "/v1/products";
 const SUBSCRIPTION_PATH = "/v1/subscription";
 const CLOUD_PLAN_PATH = "/v1/cloud-plan";
+const BILLING_PROFILE_PATH = "/v1/billing/profile";
 const CHECKOUT_SESSION_PATH = "/v1/billing/checkout-session";
 const PORTAL_SESSION_PATH = "/v1/billing/portal-session";
 
@@ -119,6 +122,26 @@ export const licenseServerBackend = (serverUrl: string, signingKey: string): TLi
     }
     const body: unknown = await res.json();
     return cloudPlanResponseSchema.parse(body);
+  },
+
+  // The server returns 200 with everything empty when the org has no Stripe customer yet; a 404
+  // means the org has no license at all (same as /v1/subscription), so degrade to "no profile".
+  fetchBillingProfile: async (orgId: string): Promise<TBillingProfileResponse | null> => {
+    const url = new URL(BILLING_PROFILE_PATH, serverUrl);
+    url.searchParams.set("org_id", orgId);
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
+      redirect: "manual"
+    });
+    if (res.status === 404) {
+      return null;
+    }
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+    const body: unknown = await res.json();
+    return billingProfileResponseSchema.parse(body);
   },
 
   createCheckoutSession: async (orgId: string, payload: TCreateCheckoutPayload): Promise<TCheckoutResult> => {

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -2,11 +2,13 @@ import jwt from "jsonwebtoken";
 
 import {
   catalogResponseSchema,
+  checkoutResultSchema,
   cloudPlanResponseSchema,
   entitlementsResponseSchema,
   sessionResponseSchema,
   subscriptionResponseSchema,
   TCatalogResponse,
+  TCheckoutResult,
   TCloudPlanResponse,
   TCreateCheckoutPayload,
   TCreatePortalPayload,
@@ -119,7 +121,7 @@ export const licenseServerBackend = (serverUrl: string, signingKey: string): TLi
     return cloudPlanResponseSchema.parse(body);
   },
 
-  createCheckoutSession: async (orgId: string, payload: TCreateCheckoutPayload): Promise<TSessionResponse> => {
+  createCheckoutSession: async (orgId: string, payload: TCreateCheckoutPayload): Promise<TCheckoutResult> => {
     const url = new URL(CHECKOUT_SESSION_PATH, serverUrl);
     url.searchParams.set("org_id", orgId);
     const res = await fetch(url, {
@@ -132,7 +134,7 @@ export const licenseServerBackend = (serverUrl: string, signingKey: string): TLi
       throw new Error(`license server responded with ${res.status}`);
     }
     const body: unknown = await res.json();
-    return sessionResponseSchema.parse(body);
+    return checkoutResultSchema.parse(body);
   },
 
   createPortalSession: async (orgId: string, payload: TCreatePortalPayload): Promise<TSessionResponse> => {

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -109,6 +109,18 @@ export const sessionResponseSchema = z
   })
   .passthrough();
 
+// Checkout either needs the customer to complete a Stripe Checkout (checkout_created) or is applied
+// directly to an existing subscription (subscription_updated). `url` is the legacy shape, tolerated so
+// the cloud and license server can deploy in any order.
+export const checkoutResultSchema = z
+  .object({
+    outcome: z.enum(["checkout_created", "subscription_updated"]).optional(),
+    checkoutUrl: z.string().optional(),
+    subscriptionId: z.string().optional(),
+    url: z.string().optional()
+  })
+  .passthrough();
+
 // The cloud-plan FeatureSet carries plan caps; the server nulls a limit when it is effectively
 // unlimited. Used counts come back zeroed and are overlaid by this app, so we ignore them.
 export const cloudPlanResponseSchema = z
@@ -129,6 +141,7 @@ export type TCatalogResponse = z.infer<typeof catalogResponseSchema>;
 export type TSubscriptionItem = z.infer<typeof subscriptionItemSchema>;
 export type TSubscriptionResponse = z.infer<typeof subscriptionResponseSchema>;
 export type TSessionResponse = z.infer<typeof sessionResponseSchema>;
+export type TCheckoutResult = z.infer<typeof checkoutResultSchema>;
 export type TCloudPlanResponse = z.infer<typeof cloudPlanResponseSchema>;
 
 export type TCheckoutLineItem = {
@@ -153,6 +166,6 @@ export type TLicenseClientBackend = {
   fetchCatalog: () => Promise<TCatalogResponse>;
   fetchSubscription: (orgId: string) => Promise<TSubscriptionResponse | null>;
   fetchCloudPlan: (orgId: string) => Promise<TCloudPlanResponse | null>;
-  createCheckoutSession: (orgId: string, payload: TCreateCheckoutPayload) => Promise<TSessionResponse>;
+  createCheckoutSession: (orgId: string, payload: TCreateCheckoutPayload) => Promise<TCheckoutResult>;
   createPortalSession: (orgId: string, payload: TCreatePortalPayload) => Promise<TSessionResponse>;
 };

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -132,6 +132,44 @@ export const cloudPlanResponseSchema = z
   })
   .passthrough();
 
+// Billing profile: the org's Stripe payment method, billing identity, and recent invoices. Every
+// field is null/empty when the org has no Stripe customer yet (the server returns 200, not 404).
+// Invoice amounts are cents and dates are Unix seconds, matching /v1/subscription.
+const billingProfilePaymentSchema = z
+  .object({
+    brand: z.string(),
+    last4: z.string(),
+    expMonth: z.number(),
+    expYear: z.number()
+  })
+  .passthrough();
+
+const billingProfileDetailsSchema = z
+  .object({
+    name: z.string(),
+    email: z.string()
+  })
+  .passthrough();
+
+const billingProfileInvoiceSchema = z
+  .object({
+    id: z.string(),
+    number: z.string(),
+    date: z.number().nullish(),
+    amount: z.number(),
+    paid: z.boolean(),
+    pdfUrl: z.string().nullish()
+  })
+  .passthrough();
+
+export const billingProfileResponseSchema = z
+  .object({
+    payment: billingProfilePaymentSchema.nullable(),
+    billingDetails: billingProfileDetailsSchema.nullable(),
+    invoices: z.array(billingProfileInvoiceSchema).default([])
+  })
+  .passthrough();
+
 export type TEntitlementFeature = z.infer<typeof entitlementFeatureSchema>;
 export type TEntitlementsResponse = z.infer<typeof entitlementsResponseSchema>;
 export type TCatalogProduct = z.infer<typeof catalogProductSchema>;
@@ -141,6 +179,7 @@ export type TSubscriptionResponse = z.infer<typeof subscriptionResponseSchema>;
 export type TSessionResponse = z.infer<typeof sessionResponseSchema>;
 export type TCheckoutResult = z.infer<typeof checkoutResultSchema>;
 export type TCloudPlanResponse = z.infer<typeof cloudPlanResponseSchema>;
+export type TBillingProfileResponse = z.infer<typeof billingProfileResponseSchema>;
 
 export type TCheckoutLineItem = {
   productId: string;
@@ -164,6 +203,7 @@ export type TLicenseClientBackend = {
   fetchCatalog: () => Promise<TCatalogResponse>;
   fetchSubscription: (orgId: string) => Promise<TSubscriptionResponse | null>;
   fetchCloudPlan: (orgId: string) => Promise<TCloudPlanResponse | null>;
+  fetchBillingProfile: (orgId: string) => Promise<TBillingProfileResponse | null>;
   createCheckoutSession: (orgId: string, payload: TCreateCheckoutPayload) => Promise<TCheckoutResult>;
   createPortalSession: (orgId: string, payload: TCreatePortalPayload) => Promise<TSessionResponse>;
 };

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -110,14 +110,12 @@ export const sessionResponseSchema = z
   .passthrough();
 
 // Checkout either needs the customer to complete a Stripe Checkout (checkout_created) or is applied
-// directly to an existing subscription (subscription_updated). `url` is the legacy shape, tolerated so
-// the cloud and license server can deploy in any order.
+// directly to an existing subscription (subscription_updated).
 export const checkoutResultSchema = z
   .object({
-    outcome: z.enum(["checkout_created", "subscription_updated"]).optional(),
+    outcome: z.enum(["checkout_created", "subscription_updated"]),
     checkoutUrl: z.string().optional(),
-    subscriptionId: z.string().optional(),
-    url: z.string().optional()
+    subscriptionId: z.string().optional()
   })
   .passthrough();
 

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -79,6 +79,13 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     return backend.fetchCloudPlan(orgId);
   };
 
+  const getBillingProfile = async (orgId: string) => {
+    if (!backend) {
+      return null;
+    }
+    return backend.fetchBillingProfile(orgId);
+  };
+
   const createCheckout = async (orgId: string, payload: TCreateCheckoutPayload) => {
     if (!backend) {
       throw new Error("license client backend is not configured");
@@ -99,6 +106,7 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     getCatalog,
     getSubscription,
     getCloudPlan,
+    getBillingProfile,
     createCheckout,
     createPortal
   };

--- a/frontend/src/hooks/api/billingV2/mutations.tsx
+++ b/frontend/src/hooks/api/billingV2/mutations.tsx
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { apiRequest } from "@app/config/request";
 
 import {
+  BillingV2CheckoutResult,
   TAddBillingV2PaymentMethodDTO,
   TCreateBillingV2CheckoutSessionDTO,
   TCreateBillingV2PortalSessionDTO
@@ -32,14 +33,12 @@ export const useCreateBillingV2CheckoutSession = () => {
       email,
       returnPath
     }: TCreateBillingV2CheckoutSessionDTO) => {
-      const {
-        data: { url }
-      } = await apiRequest.post<{ url: string }>(
+      const { data } = await apiRequest.post<BillingV2CheckoutResult>(
         `/api/v1/organizations/${orgId}/billing/v2/checkout-session`,
         { productId, cadence, email, returnPath }
       );
 
-      return url;
+      return data;
     }
   });
 };

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -87,6 +87,12 @@ export type BillingV2Overview = {
   entitlements: Record<string, BillingV2Entitlement>;
 };
 
+export type BillingV2CheckoutResult = {
+  outcome: "checkout_created" | "subscription_updated";
+  checkoutUrl?: string;
+  subscriptionId?: string;
+};
+
 export type TCreateBillingV2PortalSessionDTO = {
   orgId: string;
   returnPath?: string;

--- a/frontend/src/hooks/api/subscriptions/fns.ts
+++ b/frontend/src/hooks/api/subscriptions/fns.ts
@@ -1,0 +1,17 @@
+import { SubscriptionPlan, SubscriptionPlanTypes } from "./types";
+
+// Derive the plan label from the real plan slug, not feature booleans. Inferring "Enterprise" from a
+// single entitled feature (e.g. groups) mislabels Pro orgs that bought an add-on granting it.
+export const getSubscriptionPlanLabel = (subscription: SubscriptionPlan, suffix = "") => {
+  const { slug } = subscription;
+  if (
+    slug === SubscriptionPlanTypes.Enterprise ||
+    slug === SubscriptionPlanTypes.OnPremEnterprise
+  ) {
+    return `Enterprise${suffix}`;
+  }
+  if (!slug || slug === SubscriptionPlanTypes.Starter) {
+    return `Free${suffix}`;
+  }
+  return `Pro${suffix}`;
+};

--- a/frontend/src/hooks/api/subscriptions/index.tsx
+++ b/frontend/src/hooks/api/subscriptions/index.tsx
@@ -1,1 +1,2 @@
+export { getSubscriptionPlanLabel } from "./fns";
 export { useGetOrgSubscription } from "./queries";

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -82,8 +82,9 @@ import {
 import { authKeys, selectOrganization } from "@app/hooks/api/auth/queries";
 import { MfaMethod } from "@app/hooks/api/auth/types";
 import { getAuthToken } from "@app/hooks/api/reactQuery";
+import { getSubscriptionPlanLabel } from "@app/hooks/api/subscriptions";
 import { SubscriptionPlanTypes } from "@app/hooks/api/subscriptions/types";
-import { Organization, SubscriptionPlan } from "@app/hooks/api/types";
+import { Organization } from "@app/hooks/api/types";
 import { AuthMethod } from "@app/hooks/api/users/types";
 import {
   ApplicationSelect,
@@ -96,12 +97,6 @@ import { ServerAdminsPanel } from "../ServerAdminsPanel/ServerAdminsPanel";
 import { NewSubOrganizationForm } from "./NewSubOrganizationForm";
 import { NotificationDropdown } from "./NotificationDropdown";
 import { VersionBadge } from "./VersionBadge";
-
-const getPlan = (subscription: SubscriptionPlan) => {
-  if (subscription.groups) return "Enterprise";
-  if (subscription.pitRecovery) return "Pro";
-  return "Free";
-};
 
 const getFormattedSupportEmailLink = (variables: {
   org_id: string;
@@ -619,7 +614,7 @@ export const Navbar = () => {
         </Tooltip>
       ) : (
         <Badge variant="info" className="mt-[3px] mr-3 hidden md:inline-flex">
-          {getPlan(subscription)}
+          {getSubscriptionPlanLabel(subscription)}
         </Badge>
       )}
       <VersionBadge />

--- a/frontend/src/layouts/OrganizationLayout/components/SidebarHeader/SidebarHeader.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/SidebarHeader/SidebarHeader.tsx
@@ -1,11 +1,5 @@
 import { useOrganization, useSubscription } from "@app/context";
-import { SubscriptionPlan } from "@app/hooks/api/types";
-
-const getPlan = (subscription: SubscriptionPlan) => {
-  if (subscription.groups) return "Enterprise Plan";
-  if (subscription.pitRecovery) return "Pro Plan";
-  return "Free Plan";
-};
+import { getSubscriptionPlanLabel } from "@app/hooks/api/subscriptions";
 
 export const SidebarHeader = () => {
   const { currentOrg } = useOrganization();
@@ -20,7 +14,9 @@ export const SidebarHeader = () => {
         <div className="max-w-36 truncate text-sm font-medium text-ellipsis capitalize">
           {currentOrg?.name}
         </div>
-        <div className="text-xs text-mineshaft-400">{getPlan(subscription)}</div>
+        <div className="text-xs text-mineshaft-400">
+          {getSubscriptionPlanLabel(subscription, " Plan")}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -94,14 +94,31 @@ export const BillingV2Page = () => {
 
   const redirectToCheckout = async (productId: string) => {
     try {
-      const url = await createCheckoutSession.mutateAsync({
+      const result = await createCheckoutSession.mutateAsync({
         orgId,
         productId,
         cadence,
         email: billingEmail,
         returnPath: window.location.pathname
       });
-      window.location.href = url;
+
+      // The product was added straight to the existing subscription; no Stripe redirect needed.
+      if (result.outcome === "subscription_updated") {
+        close();
+        createNotification({
+          type: "success",
+          text: "Product added to your subscription. It may take a moment to appear here."
+        });
+        refetch();
+        return;
+      }
+
+      if (result.checkoutUrl) {
+        window.location.href = result.checkoutUrl;
+        return;
+      }
+
+      createNotification({ type: "error", text: "Failed to start checkout." });
     } catch {
       createNotification({ type: "error", text: "Failed to start checkout." });
     }

--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -78,12 +78,6 @@ export const BillingV2Page = () => {
 
   const cadence = intervalToCadence(overview?.interval ?? null);
 
-  // New customers check out; existing subscribers add/manage products via the Stripe portal.
-  let sheetManageMode: "checkout" | "portal" = "portal";
-  if (overview?.subState === "no-subscription") {
-    sheetManageMode = "checkout";
-  }
-
   const close = () => setFlow(null);
 
   const redirectToPortal = async () => {
@@ -117,24 +111,19 @@ export const BillingV2Page = () => {
     redirectToPortal();
   };
 
-  // No subscription yet: send the customer to the product list to pick what they want, rather than
-  // pre-selecting a product for them.
-  const onGetStarted = () => {
-    document
-      .getElementById("billing-v2-products")
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
   const onUpgrade = (productId: string) => {
     setFlow({ type: "sheet", prodId: productId });
   };
 
+  // Owned products are managed in the Stripe portal; a product the org isn't entitled to yet always
+  // goes through checkout, even when a subscription already exists.
   const onSheetManage = async (productId: string) => {
-    if (sheetManageMode === "checkout") {
-      await redirectToCheckout(productId);
+    const isEntitled = Boolean(overview?.entitlements[productId]?.entitled);
+    if (isEntitled) {
+      await redirectToPortal();
       return;
     }
-    await redirectToPortal();
+    await redirectToCheckout(productId);
   };
 
   const onUpdatePayment = async () => {
@@ -192,7 +181,6 @@ export const BillingV2Page = () => {
               onUpdatePayment={onUpdatePayment}
               onEditDetails={onEditDetails}
               onContact={onContact}
-              onGetStarted={onGetStarted}
               onRetry={onRetry}
               canManageBilling={canManageBilling}
             />
@@ -206,7 +194,6 @@ export const BillingV2Page = () => {
           prod={catalogById(catalog, flow.prodId)}
           entitlement={overview?.entitlements[flow.prodId]}
           cadence={cadence}
-          manageMode={sheetManageMode}
           redirecting={sheetRedirecting}
           onClose={close}
           onManage={onSheetManage}

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from "react";
 import {
-  faArrowRight,
-  faBagShopping,
   faCalendar,
   faCircleExclamation,
   faCircleInfo,
@@ -189,31 +187,6 @@ const ErrorPanel = ({ onRetry }: ErrorPanelProps) => (
         <FontAwesomeIcon icon={faRotate} />
         Try again
       </Button>
-    </div>
-  </Card>
-);
-
-type GetStartedProps = {
-  onGetStarted: () => void;
-  canManage: boolean;
-};
-
-const GetStarted = ({ onGetStarted, canManage }: GetStartedProps) => (
-  <Card>
-    <div className="flex flex-col items-center gap-4 px-7 py-12 text-center">
-      <div className="flex size-[54px] items-center justify-center rounded-xl border border-org/25 bg-org/10 text-2xl text-org">
-        <FontAwesomeIcon icon={faBagShopping} />
-      </div>
-      <div className="text-lg font-semibold text-foreground">Start your subscription</div>
-      <div className="max-w-[42ch] text-sm text-mineshaft-300">
-        Pick the products your team needs and check out securely. You can change or cancel any time.
-      </div>
-      {canManage && (
-        <Button variant="org" size="lg" onClick={onGetStarted}>
-          Get started
-          <FontAwesomeIcon icon={faArrowRight} />
-        </Button>
-      )}
     </div>
   </Card>
 );
@@ -549,7 +522,6 @@ export type OverviewProps = {
   onUpdatePayment: () => void;
   onEditDetails: () => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
-  onGetStarted: () => void;
   onRetry: () => void;
   canManageBilling: boolean;
 };
@@ -563,7 +535,6 @@ export const Overview = ({
   onUpdatePayment,
   onEditDetails,
   onContact,
-  onGetStarted,
   onRetry,
   canManageBilling
 }: OverviewProps) => {
@@ -594,17 +565,14 @@ export const Overview = ({
           onUpdatePayment={onUpdatePayment}
           onManageSubscription={onManageSubscription}
         />
-        <GetStarted onGetStarted={onGetStarted} canManage={canManageBilling} />
         <UsageCard overview={overview} />
-        <div id="billing-v2-products">
-          <ProductsCard
-            overview={overview}
-            catalog={catalog}
-            readOnly={productsReadOnly}
-            onManage={onUpgrade}
-            onContact={onContact}
-          />
-        </div>
+        <ProductsCard
+          overview={overview}
+          catalog={catalog}
+          readOnly={productsReadOnly}
+          onManage={onUpgrade}
+          onContact={onContact}
+        />
       </div>
     );
   }

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -82,12 +82,14 @@ type PlansViewProps = {
   prod: BillingV2CatalogProduct;
   entitlement?: BillingV2Entitlement;
   cadence: BillingV2Cadence;
+  onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const PlansView = ({ prod, entitlement, cadence }: PlansViewProps) => {
+const PlansView = ({ prod, entitlement, cadence, onContact }: PlansViewProps) => {
   const hasEnterprise = !!prod.enterprise;
   const priceParts = proPriceParts(prod, cadence);
   const entitled = Boolean(entitlement?.entitled);
+  const selfServe = Boolean(prod.pro?.planKey);
 
   return (
     <>
@@ -110,18 +112,18 @@ const PlansView = ({ prod, entitlement, cadence }: PlansViewProps) => {
               <Badge variant="org">Self-serve</Badge>
             )}
           </div>
-          {priceParts ? (
+          {priceParts && (
             <div className="flex flex-wrap items-baseline gap-1.5">
               <span className="text-2xl font-semibold text-foreground">{priceParts.amount}</span>
               <span className="text-xs text-mineshaft-400">{priceParts.unit}</span>
             </div>
-          ) : null}
-          {prod.pro?.proFeature ? (
+          )}
+          {prod.pro?.proFeature && (
             <div className="text-xs text-mineshaft-300">{prod.pro.proFeature}</div>
-          ) : null}
+          )}
         </div>
 
-        {hasEnterprise && prod.enterprise ? (
+        {hasEnterprise && prod.enterprise && (
           <div className="flex flex-col gap-3.5 rounded-xl border border-border bg-card p-[18px]">
             <div className="flex items-center justify-between gap-2">
               <span className="text-[15px] font-semibold text-foreground">Enterprise</span>
@@ -131,11 +133,22 @@ const PlansView = ({ prod, entitlement, cadence }: PlansViewProps) => {
               <span className="text-2xl font-semibold text-foreground">Custom</span>
             </div>
             <div className="text-xs text-mineshaft-300">{prod.enterprise.feature}</div>
+            {selfServe && (
+              <Button
+                variant="info"
+                size="sm"
+                className="mt-auto self-start"
+                onClick={() => onContact(prod)}
+              >
+                Contact sales
+                <FontAwesomeIcon icon={faArrowRight} />
+              </Button>
+            )}
           </div>
-        ) : null}
+        )}
       </div>
 
-      {hasEnterprise && prod.compare ? (
+      {hasEnterprise && prod.compare && (
         <div>
           <div className="mb-3 text-xs font-semibold tracking-wide text-mineshaft-400 uppercase">
             Compare plans
@@ -159,9 +172,9 @@ const PlansView = ({ prod, entitlement, cadence }: PlansViewProps) => {
             </TableBody>
           </Table>
         </div>
-      ) : null}
+      )}
 
-      {!(hasEnterprise && prod.compare) && prod.includes ? (
+      {!(hasEnterprise && prod.compare) && prod.includes && (
         <div>
           <div className="mb-3 text-xs font-semibold tracking-wide text-mineshaft-400 uppercase">
             What&apos;s included
@@ -175,7 +188,7 @@ const PlansView = ({ prod, entitlement, cadence }: PlansViewProps) => {
             ))}
           </div>
         </div>
-      ) : null}
+      )}
     </>
   );
 };
@@ -185,7 +198,6 @@ type ProductSheetProps = {
   prod?: BillingV2CatalogProduct;
   entitlement?: BillingV2Entitlement;
   cadence: BillingV2Cadence;
-  manageMode: "checkout" | "portal";
   redirecting?: boolean;
   onClose: () => void;
   onManage: (prodId: string) => void;
@@ -197,7 +209,6 @@ export const ProductSheet = ({
   prod,
   entitlement,
   cadence,
-  manageMode,
   redirecting,
   onClose,
   onManage,
@@ -211,7 +222,7 @@ export const ProductSheet = ({
   const selfServe = Boolean(prod.pro?.planKey);
 
   let primaryCta = null;
-  if (entitled || (selfServe && manageMode === "portal")) {
+  if (entitled) {
     primaryCta = (
       <Button variant="org" onClick={() => onManage(prodId)} isPending={redirecting}>
         Manage in Stripe
@@ -261,15 +272,20 @@ export const ProductSheet = ({
           <div className="min-w-0 flex-1">
             <SheetTitle className="flex flex-wrap items-center gap-2 text-base">
               {prod.name}
-              {entitled ? <ActiveBadge /> : null}
-              {prod.addon ? <Badge variant="neutral">Add-on</Badge> : null}
+              {entitled && <ActiveBadge />}
+              {prod.addon && <Badge variant="neutral">Add-on</Badge>}
             </SheetTitle>
             <SheetDescription className="mt-1">{prod.tagline || prod.desc}</SheetDescription>
           </div>
         </SheetHeader>
 
         <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-5">
-          <PlansView prod={prod} entitlement={entitlement} cadence={cadence} />
+          <PlansView
+            prod={prod}
+            entitlement={entitlement}
+            cadence={cadence}
+            onContact={onContact}
+          />
         </div>
 
         <SheetFooter className="flex-row justify-end border-t">


### PR DESCRIPTION
## Context

Fixes a batch of issues found during License Server v2 gamma testing of the custom "Usage & Billing" Customer Portal. All changes are in this repo (the portal UI and its billing-v2 service); catalog data (pricing, per-plan feature lists, product ordering) is owned by the License Server and handled separately.

- **Checkout vs Stripe portal routing** is now decided per product by entitlement. An owned product opens the Stripe portal ("Manage in Stripe"); a not-yet-owned self-serve product goes through checkout ("Continue to Checkout"), even when the org already has a subscription. Previously any existing subscriber was sent to the Stripe portal for every product, so adding a new product never reached checkout.
- **Two-outcome checkout response**: the checkout endpoint now returns either `checkout_created` (redirect to Stripe) or `subscription_updated` (the product was added straight to the existing subscription). The UI redirects only for `checkout_created`; for `subscription_updated` it refreshes the overview and notifies in place instead of navigating to an empty URL. The client schema tolerates the legacy `{ url }` shape so the cloud and License Server can deploy in any order.
- **Top-right plan badge** is derived from the real plan slug instead of the `groups` feature flag, so a Pro org that holds an SSO/groups add-on is no longer mislabeled "Enterprise". Logic is shared via `getSubscriptionPlanLabel` so NavBar and SidebarHeader cannot drift.
- **Plan slug under v2 mode**: the entitlement projection only carries feature flags, so `getPlan` now sets the slug from the subscription tier (enterprise > pro), non-fatally. This also repairs other `subscription.slug` consumers (member-limit bypass, Pro custom-roles banner, etc.) that were silently treating every v2 org as having no tier.
- **Usage card** shows the real machine-identity count via `countAllOrgIdentities` (it was hardcoded to `0`). "Unlimited" remains only when a cap is genuinely absent.
- **Enterprise option** in the product sheet now exposes a working "Contact sales" button on the Enterprise card for products that also have a self-serve Pro tier (routes to talk-to-us).
- **Empty state**: removed the redundant "Get started" card whose button only scrolled to the product list already on screen.

## Screenshots

Behavioral/correctness changes, visible on the org Usage & Billing page (badge, usage counts, product sheet CTAs, checkout routing).

## Steps to verify the change

- As an org with an existing subscription, open a not-yet-owned product and confirm the CTA is "Continue to Checkout". When the License Server returns `subscription_updated`, the sheet closes, a success toast shows, and the overview refreshes with no Stripe redirect; when it returns `checkout_created`, it redirects to Stripe. An owned product still shows "Manage in Stripe".
- Open a product that has both Pro and Enterprise tiers and confirm the Enterprise card shows a working "Contact sales" button.
- Confirm the top-right badge reflects the actual plan (a Pro org with the groups feature no longer reads "Enterprise").
- Confirm the Usage card shows the real machine-identity count, and the empty "Get started" card is gone for orgs with no subscription.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the contributing guide
