### PR TITLE
fix: check all orgs before failing request

### DIFF
--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -110,7 +110,8 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
       return req.server.services.secretSharing.getSharedSecretById(
         req.params.id,
         req.permission?.orgId,
-        req.permission?.id
+        req.permission?.id,
+        req.permission?.type
       );
     }
   });
@@ -146,7 +147,8 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         sharedSecretId: req.params.id,
         password: req.body.password,
         orgId: req.permission?.orgId,
-        actorId: req.permission?.id
+        actorId: req.permission?.id,
+        actor: req.permission?.type
       });
 
       if (sharedSecret.orgId) {

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -679,7 +679,13 @@ export const secretSharingServiceFactory = ({
   };
 
   /** Gets password-less secret. validates all secret's requested (must be fresh). */
-  const accessSharedSecret = async ({ sharedSecretId, orgId, actorId, actor, password }: TGetActiveSharedSecretByIdDTO) => {
+  const accessSharedSecret = async ({
+    sharedSecretId,
+    orgId,
+    actorId,
+    actor,
+    password
+  }: TGetActiveSharedSecretByIdDTO) => {
     const result = await secretSharingDAL.transaction(async (tx) => {
       await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.AccessSharedSecret(sharedSecretId)]);
 

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError } from "@casl/ability";
 import { Knex } from "knex";
 
-import { OrganizationActionScope, TOrganizations, TSecretSharing } from "@app/db/schemas";
+import { OrganizationActionScope, OrgMembershipStatus, TOrganizations, TSecretSharing } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionSecretShareAction, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -113,11 +113,13 @@ export const secretSharingServiceFactory = ({
     if (!actorId) {
       throw new UnauthorizedError({ message: "Authentication required to view this secret" });
     }
-    const actorOrgs = await orgDAL.listOrganizationsWithSubOrgs({ actorId });
-    const accessibleOrgIds = new Set(
-      actorOrgs.flatMap((org) => [org.id, ...org.subOrganizations.map((s: { id: string }) => s.id)])
-    );
-    if (!accessibleOrgIds.has(secretOrgId)) {
+    const memberships = await orgDAL.findMembership({
+      actorUserId: actorId,
+      scopeOrgId: secretOrgId,
+      status: OrgMembershipStatus.Accepted,
+      isActive: true
+    });
+    if (memberships.length === 0) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
     }
   };

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError } from "@casl/ability";
 import { Knex } from "knex";
 
-import { OrganizationActionScope, OrgMembershipStatus, TOrganizations, TSecretSharing } from "@app/db/schemas";
+import { OrganizationActionScope, TOrganizations, TSecretSharing } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionSecretShareAction, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -107,19 +107,14 @@ export const secretSharingServiceFactory = ({
   const $hasExternalEmailAccess = (sharedSecret: TSecretSharing): boolean =>
     Boolean(sharedSecret.allowExternalEmails && sharedSecret.password);
 
-  // Verifies the actor has access to secretOrgId, accounting for sub-org membership.
-  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string, actorId?: string): Promise<void> => {
+  // Verifies the actor has access to secretOrgId by checking they share the same root org.
+  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string): Promise<void> => {
     if (secretOrgId === actorOrgId) return;
-    if (!actorId) {
-      throw new UnauthorizedError({ message: "Authentication required to view this secret" });
-    }
-    const memberships = await orgDAL.findMembership({
-      actorUserId: actorId,
-      scopeOrgId: secretOrgId,
-      status: OrgMembershipStatus.Accepted,
-      isActive: true
-    });
-    if (memberships.length === 0) {
+    const [actorRootOrg, secretRootOrg] = await Promise.all([
+      orgDAL.findRootOrgDetails(actorOrgId),
+      orgDAL.findRootOrgDetails(secretOrgId)
+    ]);
+    if (!actorRootOrg || !secretRootOrg || actorRootOrg.id !== secretRootOrg.id) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
     }
   };
@@ -620,7 +615,7 @@ export const secretSharingServiceFactory = ({
         throw new UnauthorizedError({ message: "Authentication required to view this secret" });
       }
       if (sharedSecret.orgId) {
-        await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
+        await $assertOrgAccess(sharedSecret.orgId, orgId);
       }
     }
 
@@ -692,7 +687,7 @@ export const secretSharingServiceFactory = ({
           throw new UnauthorizedError();
         }
         if (sharedSecret.orgId) {
-          await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
+          await $assertOrgAccess(sharedSecret.orgId, orgId);
         }
       }
 

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -107,8 +107,13 @@ export const secretSharingServiceFactory = ({
   const $hasExternalEmailAccess = (sharedSecret: TSecretSharing): boolean =>
     Boolean(sharedSecret.allowExternalEmails && sharedSecret.password);
 
-  // Verifies the actor has access to secretOrgId: same root org family AND active membership in secretOrgId.
-  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string, actorId?: string): Promise<void> => {
+  // Verifies the actor has access to secretOrgId: same root org family AND effective membership in secretOrgId.
+  const $assertOrgAccess = async (
+    secretOrgId: string,
+    actorOrgId: string,
+    actorId?: string,
+    actorType?: ActorType
+  ): Promise<void> => {
     if (secretOrgId === actorOrgId) return;
     const [actorRootOrg, secretRootOrg] = await Promise.all([
       orgDAL.findRootOrgDetails(actorOrgId),
@@ -117,16 +122,16 @@ export const secretSharingServiceFactory = ({
     if (!actorRootOrg || !secretRootOrg || actorRootOrg.id !== secretRootOrg.id) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
     }
-    if (!actorId) {
+    if (!actorId || !actorType) {
       throw new UnauthorizedError({ message: "Authentication required to view this secret" });
     }
-    const memberships = await orgDAL.findMembership({
-      actorUserId: actorId,
-      scopeOrgId: secretOrgId,
-      status: OrgMembershipStatus.Accepted,
-      isActive: true
+    const membership = await orgDAL.findEffectiveOrgMembership({
+      actorType,
+      actorId,
+      orgId: secretOrgId,
+      status: OrgMembershipStatus.Accepted
     });
-    if (memberships.length === 0) {
+    if (!membership || !membership.isActive) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
     }
   };
@@ -609,7 +614,7 @@ export const secretSharingServiceFactory = ({
 
   // Checks whether external (non-org) email access is available for this secret.
 
-  const getSharedSecretById = async (sharedSecretId: string, orgId?: string, actorId?: string) => {
+  const getSharedSecretById = async (sharedSecretId: string, orgId?: string, actorId?: string, actor?: ActorType) => {
     const sharedSecret = await secretSharingDAL.findOne({
       type: SecretSharingType.Share,
       identifier: Buffer.from(sharedSecretId, "base64url").toString("hex")
@@ -627,7 +632,7 @@ export const secretSharingServiceFactory = ({
         throw new UnauthorizedError({ message: "Authentication required to view this secret" });
       }
       if (sharedSecret.orgId) {
-        await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
+        await $assertOrgAccess(sharedSecret.orgId, orgId, actorId, actor);
       }
     }
 
@@ -674,7 +679,7 @@ export const secretSharingServiceFactory = ({
   };
 
   /** Gets password-less secret. validates all secret's requested (must be fresh). */
-  const accessSharedSecret = async ({ sharedSecretId, orgId, actorId, password }: TGetActiveSharedSecretByIdDTO) => {
+  const accessSharedSecret = async ({ sharedSecretId, orgId, actorId, actor, password }: TGetActiveSharedSecretByIdDTO) => {
     const result = await secretSharingDAL.transaction(async (tx) => {
       await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.AccessSharedSecret(sharedSecretId)]);
 
@@ -699,7 +704,7 @@ export const secretSharingServiceFactory = ({
           throw new UnauthorizedError();
         }
         if (sharedSecret.orgId) {
-          await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
+          await $assertOrgAccess(sharedSecret.orgId, orgId, actorId, actor);
         }
       }
 

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -113,9 +113,9 @@ export const secretSharingServiceFactory = ({
     if (!actorId) {
       throw new UnauthorizedError({ message: "Authentication required to view this secret" });
     }
-    const customerOrgs = await orgDAL.listOrganizationsWithSubOrgs({ actorId });
+    const actorOrgs = await orgDAL.listOrganizationsWithSubOrgs({ actorId });
     const accessibleOrgIds = new Set(
-      customerOrgs.flatMap((org) => [org.id, ...org.subOrganizations.map((s: { id: string }) => s.id)])
+      actorOrgs.flatMap((org) => [org.id, ...org.subOrganizations.map((s: { id: string }) => s.id)])
     );
     if (!accessibleOrgIds.has(secretOrgId)) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -107,6 +107,21 @@ export const secretSharingServiceFactory = ({
   const $hasExternalEmailAccess = (sharedSecret: TSecretSharing): boolean =>
     Boolean(sharedSecret.allowExternalEmails && sharedSecret.password);
 
+  // Verifies the actor has access to secretOrgId, accounting for sub-org membership.
+  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string, actorId?: string): Promise<void> => {
+    if (secretOrgId === actorOrgId) return;
+    if (!actorId) {
+      throw new UnauthorizedError({ message: "Authentication required to view this secret" });
+    }
+    const customerOrgs = await orgDAL.listOrganizationsWithSubOrgs({ actorId });
+    const accessibleOrgIds = new Set(
+      customerOrgs.flatMap((org) => [org.id, ...org.subOrganizations.map((s: { id: string }) => s.id)])
+    );
+    if (!accessibleOrgIds.has(secretOrgId)) {
+      throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
+    }
+  };
+
   const createSharedSecret = async ({
     actor,
     actorId,
@@ -602,8 +617,8 @@ export const secretSharingServiceFactory = ({
       if (!orgId) {
         throw new UnauthorizedError({ message: "Authentication required to view this secret" });
       }
-      if (sharedSecret.orgId && sharedSecret.orgId !== orgId) {
-        throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
+      if (sharedSecret.orgId) {
+        await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
       }
     }
 
@@ -670,12 +685,13 @@ export const secretSharingServiceFactory = ({
 
       const { accessType, expiresAt, expiresAfterViews } = sharedSecret;
 
-      if (accessType === SecretSharingAccessType.Organization && orgId === undefined) {
-        throw new UnauthorizedError();
-      }
-
-      if (accessType === SecretSharingAccessType.Organization && orgId !== sharedSecret.orgId) {
-        throw new ForbiddenRequestError();
+      if (accessType === SecretSharingAccessType.Organization) {
+        if (orgId === undefined) {
+          throw new UnauthorizedError();
+        }
+        if (sharedSecret.orgId) {
+          await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
+        }
       }
 
       const isAuthorizedUser = await $isAuthorizedEmailUser(sharedSecret, actorId);

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError } from "@casl/ability";
 import { Knex } from "knex";
 
-import { OrganizationActionScope, TOrganizations, TSecretSharing } from "@app/db/schemas";
+import { OrganizationActionScope, OrgMembershipStatus, TOrganizations, TSecretSharing } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionSecretShareAction, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -107,14 +107,26 @@ export const secretSharingServiceFactory = ({
   const $hasExternalEmailAccess = (sharedSecret: TSecretSharing): boolean =>
     Boolean(sharedSecret.allowExternalEmails && sharedSecret.password);
 
-  // Verifies the actor has access to secretOrgId by checking they share the same root org.
-  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string): Promise<void> => {
+  // Verifies the actor has access to secretOrgId: same root org family AND active membership in secretOrgId.
+  const $assertOrgAccess = async (secretOrgId: string, actorOrgId: string, actorId?: string): Promise<void> => {
     if (secretOrgId === actorOrgId) return;
     const [actorRootOrg, secretRootOrg] = await Promise.all([
       orgDAL.findRootOrgDetails(actorOrgId),
       orgDAL.findRootOrgDetails(secretOrgId)
     ]);
     if (!actorRootOrg || !secretRootOrg || actorRootOrg.id !== secretRootOrg.id) {
+      throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
+    }
+    if (!actorId) {
+      throw new UnauthorizedError({ message: "Authentication required to view this secret" });
+    }
+    const memberships = await orgDAL.findMembership({
+      actorUserId: actorId,
+      scopeOrgId: secretOrgId,
+      status: OrgMembershipStatus.Accepted,
+      isActive: true
+    });
+    if (memberships.length === 0) {
       throw new ForbiddenRequestError({ message: "You do not have access to this secret" });
     }
   };
@@ -615,7 +627,7 @@ export const secretSharingServiceFactory = ({
         throw new UnauthorizedError({ message: "Authentication required to view this secret" });
       }
       if (sharedSecret.orgId) {
-        await $assertOrgAccess(sharedSecret.orgId, orgId);
+        await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
       }
     }
 
@@ -687,7 +699,7 @@ export const secretSharingServiceFactory = ({
           throw new UnauthorizedError();
         }
         if (sharedSecret.orgId) {
-          await $assertOrgAccess(sharedSecret.orgId, orgId);
+          await $assertOrgAccess(sharedSecret.orgId, orgId, actorId);
         }
       }
 

--- a/backend/src/services/secret-sharing/secret-sharing-types.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-types.ts
@@ -38,6 +38,7 @@ export type TGetActiveSharedSecretByIdDTO = {
   sharedSecretId: string;
   orgId?: string;
   actorId?: string;
+  actor?: ActorType;
   password?: string;
 };
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

* Create a secret in a suborg
* Share secret with Org
* Open it in another account that has access to said root org and suborg and has root org selected at the time
* Secret opens normally

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)