### PR TITLE
feat(membership): get membership by project id and user id

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1100,6 +1100,10 @@ export const PROJECT_USERS = {
     membershipId: "The ID of the user's project membership.",
     username: "The username to get project membership of. Email is the default username."
   },
+  GET_USER_MEMBERSHIP_BY_USER_ID: {
+    projectId: "The ID of the project to get the membership from.",
+    userId: "The ID of the user to get the project membership of."
+  },
   UPDATE_USER_MEMBERSHIP: {
     projectId: "The ID of the project to update the membership for.",
     membershipId: "The ID of the membership to update.",

--- a/backend/src/server/routes/v1/project-membership-router.ts
+++ b/backend/src/server/routes/v1/project-membership-router.ts
@@ -154,6 +154,71 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
 
   server.route({
     method: "GET",
+    url: "/:projectId/user/:userId/membership",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: "getProjectMembershipByUserId",
+      tags: [ApiDocsTags.ProjectUsers],
+      description: "Return a project user's membership by user ID",
+      security: [
+        {
+          bearerAuth: []
+        }
+      ],
+      params: z.object({
+        projectId: z.string().min(1).uuid().trim().describe(PROJECT_USERS.GET_USER_MEMBERSHIP_BY_USER_ID.projectId),
+        userId: z.string().min(1).uuid().trim().describe(PROJECT_USERS.GET_USER_MEMBERSHIP_BY_USER_ID.userId)
+      }),
+      response: {
+        200: z.object({
+          membership: ProjectMembershipsSchema.extend({
+            user: SanitizedUserSchema,
+            roles: z.array(
+              z.object({
+                id: z.string(),
+                role: z.string(),
+                customRoleId: z.string().optional().nullable(),
+                customRoleName: z.string().optional().nullable(),
+                customRoleSlug: z.string().optional().nullable(),
+                isTemporary: z.boolean(),
+                temporaryMode: z.string().optional().nullable(),
+                temporaryRange: z.string().nullable().optional(),
+                temporaryAccessStartTime: z.date().nullable().optional(),
+                temporaryAccessEndTime: z.date().nullable().optional()
+              })
+            )
+          }).omit({ updatedAt: true })
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const membership = await server.services.membershipUser.getMembershipByUserId({
+        permission: req.permission,
+        scopeData: {
+          scope: AccessScope.Project,
+          orgId: req.permission.orgId,
+          projectId: req.params.projectId
+        },
+        selector: {
+          userId: req.params.userId
+        }
+      });
+
+      return {
+        membership: {
+          ...membership,
+          userId: req.params.userId,
+          projectId: req.params.projectId
+        }
+      };
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/:projectId/memberships/:membershipId/permissions/audit",
     config: {
       rateLimit: readLimit

--- a/backend/src/server/routes/v1/project-membership-router.ts
+++ b/backend/src/server/routes/v1/project-membership-router.ts
@@ -18,6 +18,24 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { SanitizedUserSchema } from "../sanitizedSchemas";
 
+const projectUserMembershipRoleSchema = z.object({
+  id: z.string(),
+  role: z.string(),
+  customRoleId: z.string().optional().nullable(),
+  customRoleName: z.string().optional().nullable(),
+  customRoleSlug: z.string().optional().nullable(),
+  isTemporary: z.boolean(),
+  temporaryMode: z.string().optional().nullable(),
+  temporaryRange: z.string().nullable().optional(),
+  temporaryAccessStartTime: z.date().nullable().optional(),
+  temporaryAccessEndTime: z.date().nullable().optional()
+});
+
+const projectUserMembershipSchema = ProjectMembershipsSchema.extend({
+  user: SanitizedUserSchema,
+  roles: z.array(projectUserMembershipRoleSchema)
+});
+
 export const registerProjectMembershipRouter = async (server: FastifyZodProvider) => {
   server.route({
     method: "GET",
@@ -39,25 +57,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }),
       response: {
         200: z.object({
-          memberships: ProjectMembershipsSchema.extend({
-            user: SanitizedUserSchema,
-            roles: z.array(
-              z.object({
-                id: z.string(),
-                role: z.string(),
-                customRoleId: z.string().optional().nullable(),
-                customRoleName: z.string().optional().nullable(),
-                customRoleSlug: z.string().optional().nullable(),
-                isTemporary: z.boolean(),
-                temporaryMode: z.string().optional().nullable(),
-                temporaryRange: z.string().nullable().optional(),
-                temporaryAccessStartTime: z.date().nullable().optional(),
-                temporaryAccessEndTime: z.date().nullable().optional()
-              })
-            )
-          })
-            .omit({ updatedAt: true })
-            .array()
+          memberships: projectUserMembershipSchema.omit({ updatedAt: true }).array()
         })
       }
     },
@@ -103,23 +103,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }),
       response: {
         200: z.object({
-          membership: ProjectMembershipsSchema.extend({
-            user: SanitizedUserSchema,
-            roles: z.array(
-              z.object({
-                id: z.string(),
-                role: z.string(),
-                customRoleId: z.string().optional().nullable(),
-                customRoleName: z.string().optional().nullable(),
-                customRoleSlug: z.string().optional().nullable(),
-                isTemporary: z.boolean(),
-                temporaryMode: z.string().optional().nullable(),
-                temporaryRange: z.string().nullable().optional(),
-                temporaryAccessStartTime: z.date().nullable().optional(),
-                temporaryAccessEndTime: z.date().nullable().optional()
-              })
-            )
-          }).omit({ updatedAt: true })
+          membership: projectUserMembershipSchema.omit({ updatedAt: true })
         })
       }
     },
@@ -173,23 +157,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }),
       response: {
         200: z.object({
-          membership: ProjectMembershipsSchema.extend({
-            user: SanitizedUserSchema,
-            roles: z.array(
-              z.object({
-                id: z.string(),
-                role: z.string(),
-                customRoleId: z.string().optional().nullable(),
-                customRoleName: z.string().optional().nullable(),
-                customRoleSlug: z.string().optional().nullable(),
-                isTemporary: z.boolean(),
-                temporaryMode: z.string().optional().nullable(),
-                temporaryRange: z.string().nullable().optional(),
-                temporaryAccessStartTime: z.date().nullable().optional(),
-                temporaryAccessEndTime: z.date().nullable().optional()
-              })
-            )
-          }).omit({ updatedAt: true })
+          membership: projectUserMembershipSchema.omit({ updatedAt: true })
         })
       }
     },
@@ -305,23 +273,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }),
       response: {
         200: z.object({
-          membership: ProjectMembershipsSchema.extend({
-            user: SanitizedUserSchema,
-            roles: z.array(
-              z.object({
-                id: z.string(),
-                role: z.string(),
-                customRoleId: z.string().optional().nullable(),
-                customRoleName: z.string().optional().nullable(),
-                customRoleSlug: z.string().optional().nullable(),
-                isTemporary: z.boolean(),
-                temporaryMode: z.string().optional().nullable(),
-                temporaryRange: z.string().nullable().optional(),
-                temporaryAccessStartTime: z.date().nullable().optional(),
-                temporaryAccessEndTime: z.date().nullable().optional()
-              })
-            )
-          }).omit({ createdAt: true, updatedAt: true })
+          membership: projectUserMembershipSchema.omit({ createdAt: true, updatedAt: true })
         })
       }
     },

--- a/docs/api-reference/endpoints/project-users/get-by-user-id.mdx
+++ b/docs/api-reference/endpoints/project-users/get-by-user-id.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get By User ID"
+openapi: "GET /api/v1/projects/{projectId}/user/{userId}/membership"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1202,6 +1202,7 @@
                   "api-reference/endpoints/project-users/remove-member-from-project",
                   "api-reference/endpoints/project-users/memberships",
                   "api-reference/endpoints/project-users/get-by-username",
+                  "api-reference/endpoints/project-users/get-by-user-id",
                   "api-reference/endpoints/project-users/update-membership",
                   {
                     "group": "Legacy",


### PR DESCRIPTION
## Context
Add new endpoint to allow terraform import using project id and user id (the pattern we are using there right now is by using ids)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)