### PR TITLE
docs: link upgrade tool from self-hosted upgrade guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Check out the [Quickstart Guides](https://infisical.com/docs/documentation/getti
 
 | Use Infisical Cloud                                                                                                                                     | Deploy Infisical on premise                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| The fastest and most reliable way to <br> get started with Infisical is signing up <br> for free to [Infisical Cloud](https://app.infisical.com/login). | <br> View all [deployment options](https://infisical.com/docs/self-hosting/overview) |
+| The fastest and most reliable way to <br> get started with Infisical is signing up <br> for free to [Infisical Cloud](https://app.infisical.com/login). | <br> View all [deployment options](https://infisical.com/docs/self-hosting/overview) <br><br> Already self-hosting? Plan version upgrades with the [Infisical Upgrade Tool](https://upgrade.infisical.com/). |
 
 ### Run Infisical locally
 

--- a/docs/self-hosting/deployment-options/linux-upgrade.mdx
+++ b/docs/self-hosting/deployment-options/linux-upgrade.mdx
@@ -3,6 +3,10 @@ title: "Upgrading"
 description: "How to upgrade Infisical deployment using linux package"
 ---
 
+<Tip>
+  Planning an upgrade? Use the [Infisical Upgrade Tool](https://upgrade.infisical.com/) to map out your upgrade path and review notable changes between your current and target versions.
+</Tip>
+
 This guide explains how to upgrade Infisical Linux package installations to newer versions. 
 The Infisical Linux package includes only the Infisical service component itself, as PostgreSQL and Redis databases are managed separately. 
 Upgrades for PostgreSQL and Redis are not covered in this guide as they depend on your specific database deployment method.

--- a/docs/self-hosting/guides/upgrading-infisical.mdx
+++ b/docs/self-hosting/guides/upgrading-infisical.mdx
@@ -5,6 +5,10 @@ description: "How to upgrade Infisical self-hosted instance"
 
 ---
 
+<Tip>
+  Planning an upgrade? Use the [Infisical Upgrade Tool](https://upgrade.infisical.com/) to map out your upgrade path and review notable changes between your current and target versions.
+</Tip>
+
 Keeping your Infisical instance up to date is key to making sure you receive the latest performance improvements, security patches, and feature updates. 
 We release updates approximately once a week, which may include new features, bug fixes, performance enhancements, and critical security patches.
 


### PR DESCRIPTION
## Context

We don't link the [Infisical Upgrade Tool](https://upgrade.infisical.com/) anywhere in the docs. This surfaces it where users go when planning an upgrade.

- Add a `<Tip>` linking the tool at the top of the self-hosted instance and Linux package upgrade guides
- Mention the tool in the README self-hosting cell

## Steps to verify the change

- Open the [self-hosted upgrade guide](https://infisical.com/docs/self-hosting/guides/upgrading-infisical) and Linux upgrade guide; the tool link appears at the top
- Confirm the README self-hosting cell links the tool

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)