### PR TITLE
improvement: revamp and revise secret management policies tab

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/ApprovalPolicyList.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/ApprovalPolicyList.tsx
@@ -1,40 +1,41 @@
 import { useMemo, useState } from "react";
-import {
-  faArrowDown,
-  faArrowUp,
-  faCheckCircle,
-  faFileShield,
-  faFilter,
-  faMagnifyingGlass,
-  faPlus,
-  faSearch
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ArrowDownIcon, ArrowUpIcon, FilterIcon, PlusIcon, SearchIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
   Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DocumentationLinkBadge,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
-  EmptyState,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
   IconButton,
-  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   Pagination,
+  Skeleton,
   Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
-import { DocumentationLinkBadge } from "@app/components/v3";
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
 import {
   ProjectPermissionSub,
   TProjectPermission,
@@ -61,6 +62,7 @@ import { Project, TAccessApprovalPolicy } from "@app/hooks/api/types";
 
 import { AccessPolicyForm } from "./components/AccessPolicyModal";
 import { ApprovalPolicyRow } from "./components/ApprovalPolicyRow";
+import { EnvironmentFilterSelect } from "./components/EnvironmentFilterSelect";
 import { RemoveApprovalPolicyModal } from "./components/RemoveApprovalPolicyModal";
 
 interface IProps {
@@ -220,8 +222,6 @@ export const ApprovalPolicyList = ({ projectId }: IProps) => {
     setPage
   });
 
-  const isTableFiltered = filters.type !== null || Boolean(filters.environmentIds.length);
-
   const handleSort = (column: PolicyOrderBy) => {
     if (column === orderBy) {
       toggleOrderDirection();
@@ -235,231 +235,217 @@ export const ApprovalPolicyList = ({ projectId }: IProps) => {
   const getClassName = (col: PolicyOrderBy) => twMerge("ml-2", orderBy === col ? "" : "opacity-30");
 
   const getColSortIcon = (col: PolicyOrderBy) =>
-    orderDirection === OrderByDirection.DESC && orderBy === col ? faArrowUp : faArrowDown;
+    orderDirection === OrderByDirection.DESC && orderBy === col ? (
+      <ArrowUpIcon />
+    ) : (
+      <ArrowDownIcon />
+    );
 
   return (
     <>
-      <div className="w-full rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <div className="flex items-center gap-x-2">
-              <p className="text-xl font-medium text-mineshaft-100">Policies</p>
-              <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/pr-workflows" />
-            </div>
-            <p className="text-sm text-bunker-300">
-              Implement granular policies for access requests and secrets management
-            </p>
-          </div>
-          <ProjectPermissionCan
-            I={ProjectPermissionActions.Create}
-            a={ProjectPermissionSub.SecretApproval}
-          >
-            {(isAllowed) => (
-              <Button
-                onClick={() => {
-                  if (subscription && !subscription?.secretApproval) {
-                    handlePopUpOpen("upgradePlan");
-                    return;
-                  }
-                  handlePopUpOpen("policyForm");
-                }}
-                colorSchema="secondary"
-                leftIcon={<FontAwesomeIcon icon={faPlus} />}
-                isDisabled={!isAllowed}
-              >
-                Create Policy
-              </Button>
-            )}
-          </ProjectPermissionCan>
-        </div>
-        <div className="mb-4 flex items-center gap-2">
-          <Input
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-            placeholder="Search policies by name, type, environment or secret path..."
-            className="flex-1"
-          />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <IconButton
-                ariaLabel="Filter findings"
-                variant="plain"
-                size="sm"
-                className={twMerge(
-                  "flex h-10 w-11 items-center justify-center overflow-hidden border border-mineshaft-600 bg-mineshaft-800 p-0 transition-all hover:border-primary/60 hover:bg-primary/10",
-                  isTableFiltered && "border-primary/50 text-primary"
-                )}
-              >
-                <FontAwesomeIcon icon={faFilter} />
-              </IconButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="max-h-[70vh] thin-scrollbar overflow-y-auto"
-              align="end"
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            Policies
+            <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/pr-workflows" />
+          </CardTitle>
+          <CardDescription>
+            Implement granular policies for access requests and secrets management
+          </CardDescription>
+          <CardAction>
+            <ProjectPermissionCan
+              I={ProjectPermissionActions.Create}
+              a={ProjectPermissionSub.SecretApproval}
             >
-              <DropdownMenuLabel>Policy Type</DropdownMenuLabel>
-              <DropdownMenuItem
-                onClick={() =>
-                  setFilters((prev) => ({
-                    ...prev,
-                    type: null
-                  }))
-                }
-                icon={!filters && <FontAwesomeIcon icon={faCheckCircle} />}
-                iconPos="right"
+              {(isAllowed) => (
+                <Button
+                  onClick={() => {
+                    if (subscription && !subscription?.secretApproval) {
+                      handlePopUpOpen("upgradePlan");
+                      return;
+                    }
+                    handlePopUpOpen("policyForm");
+                  }}
+                  variant="project"
+                  isDisabled={!isAllowed}
+                >
+                  <PlusIcon />
+                  Add Policy
+                </Button>
+              )}
+            </ProjectPermissionCan>
+          </CardAction>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex items-center gap-2">
+            <EnvironmentFilterSelect
+              environments={currentProject.environments}
+              selectedEnvironmentIds={filters.environmentIds}
+              onChange={(environmentIds) => setFilters((prev) => ({ ...prev, environmentIds }))}
+            />
+            <InputGroup className="flex-1">
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <InputGroupInput
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search policies by name, type, environment or secret path..."
+              />
+            </InputGroup>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  aria-label="Filter policies"
+                  variant={filters.type !== null ? "project" : "outline"}
+                >
+                  <FilterIcon />
+                </IconButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="max-h-[70vh] thin-scrollbar overflow-y-auto"
+                align="end"
               >
-                All
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() =>
-                  setFilters((prev) => ({
-                    ...prev,
-                    type: PolicyType.AccessPolicy
-                  }))
-                }
-                icon={
-                  filters.type === PolicyType.AccessPolicy && (
-                    <FontAwesomeIcon icon={faCheckCircle} />
-                  )
-                }
-                iconPos="right"
-              >
-                Access Policy
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() =>
-                  setFilters((prev) => ({
-                    ...prev,
-                    type: PolicyType.ChangePolicy
-                  }))
-                }
-                icon={
-                  filters.type === PolicyType.ChangePolicy && (
-                    <FontAwesomeIcon icon={faCheckCircle} />
-                  )
-                }
-                iconPos="right"
-              >
-                Change Policy
-              </DropdownMenuItem>
-              <DropdownMenuLabel>Environment</DropdownMenuLabel>
-              {currentProject.environments.map((env) => (
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.preventDefault();
+                <DropdownMenuLabel>Policy Type</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={filters.type ?? "all"}
+                  onValueChange={(value) =>
                     setFilters((prev) => ({
                       ...prev,
-                      environmentIds: prev.environmentIds.includes(env.id)
-                        ? prev.environmentIds.filter((i) => i !== env.id)
-                        : [...prev.environmentIds, env.id]
-                    }));
-                  }}
-                  key={env.id}
-                  icon={
-                    filters.environmentIds.includes(env.id) && (
-                      <FontAwesomeIcon className="text-primary" icon={faCheckCircle} />
-                    )
+                      type: value === "all" ? null : (value as PolicyType)
+                    }))
                   }
-                  iconPos="right"
                 >
-                  <span className="capitalize">{env.name}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-        <TableContainer>
-          <Table>
-            <THead>
-              <Tr>
-                <Th>
-                  <div className="flex items-center">
-                    Name
-                    <IconButton
-                      variant="plain"
-                      className={getClassName(PolicyOrderBy.Name)}
-                      ariaLabel="sort"
-                      onClick={() => handleSort(PolicyOrderBy.Name)}
-                    >
-                      <FontAwesomeIcon icon={getColSortIcon(PolicyOrderBy.Name)} />
-                    </IconButton>
-                  </div>
-                </Th>
-                <Th>
-                  <div className="flex items-center">
-                    Environment
-                    <IconButton
-                      variant="plain"
-                      className={getClassName(PolicyOrderBy.Environment)}
-                      ariaLabel="sort"
-                      onClick={() => handleSort(PolicyOrderBy.Environment)}
-                    >
-                      <FontAwesomeIcon icon={getColSortIcon(PolicyOrderBy.Environment)} />
-                    </IconButton>
-                  </div>
-                </Th>
-                <Th>
-                  <div className="flex items-center">
-                    Secret Path
-                    <IconButton
-                      variant="plain"
-                      className={getClassName(PolicyOrderBy.SecretPath)}
-                      ariaLabel="sort"
-                      onClick={() => handleSort(PolicyOrderBy.SecretPath)}
-                    >
-                      <FontAwesomeIcon icon={getColSortIcon(PolicyOrderBy.SecretPath)} />
-                    </IconButton>
-                  </div>
-                </Th>
-                <Th>
-                  <div className="flex items-center">
-                    Type
-                    <IconButton
-                      variant="plain"
-                      className={getClassName(PolicyOrderBy.Type)}
-                      ariaLabel="sort"
-                      onClick={() => handleSort(PolicyOrderBy.Type)}
-                    >
-                      <FontAwesomeIcon icon={getColSortIcon(PolicyOrderBy.Type)} />
-                    </IconButton>
-                  </div>
-                </Th>
-                <Th className="w-5" />
-              </Tr>
-            </THead>
-            <TBody>
-              {isPoliciesLoading && (
-                <TableSkeleton
-                  columns={5}
-                  innerKey="secret-policies"
-                  className="bg-mineshaft-700"
-                />
-              )}
-              {!isPoliciesLoading && !policies?.length && (
-                <Tr>
-                  <Td colSpan={5}>
-                    <EmptyState title="No Policies Found" icon={faFileShield} />
-                  </Td>
-                </Tr>
-              )}
-              {!!currentProject &&
-                filteredPolicies
-                  ?.slice(offset, perPage * page)
-                  .map((policy) => (
-                    <ApprovalPolicyRow
-                      policy={policy}
-                      key={policy.id}
-                      members={members}
-                      groups={groups}
-                      onEdit={() => handlePopUpOpen("policyForm", policy)}
-                      onDelete={() => handlePopUpOpen("deletePolicy", policy)}
-                    />
+                  <DropdownMenuRadioItem value="all">All Policies</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value={PolicyType.AccessPolicy}>
+                    Access Policy
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value={PolicyType.ChangePolicy}>
+                    Change Policy
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          {(isPoliciesLoading || filteredPolicies.length > 0) && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <div className="flex items-center">
+                      Name
+                      <IconButton
+                        variant="ghost-muted"
+                        size="xs"
+                        className={getClassName(PolicyOrderBy.Name)}
+                        aria-label="sort"
+                        onClick={() => handleSort(PolicyOrderBy.Name)}
+                      >
+                        {getColSortIcon(PolicyOrderBy.Name)}
+                      </IconButton>
+                    </div>
+                  </TableHead>
+                  <TableHead>
+                    <div className="flex items-center">
+                      Environment
+                      <IconButton
+                        variant="ghost-muted"
+                        size="xs"
+                        className={getClassName(PolicyOrderBy.Environment)}
+                        aria-label="sort"
+                        onClick={() => handleSort(PolicyOrderBy.Environment)}
+                      >
+                        {getColSortIcon(PolicyOrderBy.Environment)}
+                      </IconButton>
+                    </div>
+                  </TableHead>
+                  <TableHead>
+                    <div className="flex items-center">
+                      Secret Path
+                      <IconButton
+                        variant="ghost-muted"
+                        size="xs"
+                        className={getClassName(PolicyOrderBy.SecretPath)}
+                        aria-label="sort"
+                        onClick={() => handleSort(PolicyOrderBy.SecretPath)}
+                      >
+                        {getColSortIcon(PolicyOrderBy.SecretPath)}
+                      </IconButton>
+                    </div>
+                  </TableHead>
+                  <TableHead>
+                    <div className="flex items-center">
+                      Type
+                      <IconButton
+                        variant="ghost-muted"
+                        size="xs"
+                        className={getClassName(PolicyOrderBy.Type)}
+                        aria-label="sort"
+                        onClick={() => handleSort(PolicyOrderBy.Type)}
+                      >
+                        {getColSortIcon(PolicyOrderBy.Type)}
+                      </IconButton>
+                    </div>
+                  </TableHead>
+                  <TableHead className="w-5" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isPoliciesLoading &&
+                  Array.from({ length: 5 }).map((_, idx) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <TableRow key={`policy-skeleton-${idx}`}>
+                      <TableCell>
+                        <Skeleton className="h-5" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton className="h-5" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton className="h-5" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton className="h-5" />
+                      </TableCell>
+                      <TableCell>
+                        <Skeleton className="h-5" />
+                      </TableCell>
+                    </TableRow>
                   ))}
-            </TBody>
-          </Table>
+                {!isPoliciesLoading &&
+                  !!currentProject &&
+                  filteredPolicies
+                    ?.slice(offset, perPage * page)
+                    .map((policy) => (
+                      <ApprovalPolicyRow
+                        policy={policy}
+                        key={policy.id}
+                        members={members}
+                        groups={groups}
+                        onEdit={() => handlePopUpOpen("policyForm", policy)}
+                        onDelete={() => handlePopUpOpen("deletePolicy", policy)}
+                      />
+                    ))}
+              </TableBody>
+            </Table>
+          )}
+          {!isPoliciesLoading && !policies?.length && (
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyTitle>No Policies Found</EmptyTitle>
+                <EmptyDescription>
+                  Create a policy to require approval for secret changes and access requests.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
           {Boolean(!filteredPolicies.length && policies.length && !isPoliciesLoading) && (
-            <EmptyState title="No Policies Match Search" icon={faSearch} />
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyTitle>No Policies Match Search</EmptyTitle>
+                <EmptyDescription>Try adjusting your search or filters.</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           )}
           {Boolean(filteredPolicies.length) && (
             <Pagination
@@ -470,8 +456,8 @@ export const ApprovalPolicyList = ({ projectId }: IProps) => {
               onChangePerPage={handlePerPageChange}
             />
           )}
-        </TableContainer>
-      </div>
+        </CardContent>
+      </Card>
       <AccessPolicyForm
         projectId={currentProject.id}
         projectSlug={currentProject.slug}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -1,28 +1,48 @@
-import { RefObject, useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faGripVertical, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { GripVerticalIcon, InfoIcon, PlusIcon, Trash2Icon, TriangleAlertIcon } from "lucide-react";
 import ms from "ms";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
+  Badge,
   Button,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldTitle,
   FilterableSelect,
-  FormControl,
   IconButton,
   Input,
-  Modal,
-  ModalContent,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemGroup,
+  ItemMedia,
+  ItemSeparator,
+  SecretPathInput,
   Select,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   Switch,
-  Tag,
-  Tooltip
-} from "@app/components/v2";
-import { SecretPathInput } from "@app/components/v2/SecretPathInput";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import { getMemberLabel } from "@app/helpers/members";
 import { policyDetails } from "@app/helpers/policies";
@@ -44,6 +64,7 @@ import {
 import { EnforcementLevel, PolicyType } from "@app/hooks/api/policies/enums";
 import { TWorkspaceUser } from "@app/hooks/api/users/types";
 
+import { ApproverMultiValueLabel, ApproverOption, ApproverOptionData } from "./ApproverOption";
 import { PolicyMemberOption } from "./PolicyMemberOption";
 
 type Props = {
@@ -172,9 +193,8 @@ const Form = ({
   projectId,
   projectSlug,
   editValues,
-  modalContainer,
   isEditMode
-}: Props & { modalContainer: RefObject<HTMLDivElement>; isEditMode: boolean }) => {
+}: Props & { isEditMode: boolean }) => {
   const [draggedItem, setDraggedItem] = useState<number | null>(null);
   const [dragOverItem, setDragOverItem] = useState<number | null>(null);
   const {
@@ -182,7 +202,8 @@ const Form = ({
     handleSubmit,
     watch,
     resetField,
-    formState: { isSubmitting }
+    setValue,
+    formState: { isSubmitting, errors }
   } = useForm<TFormSchema>({
     resolver: zodResolver(formSchema),
     values: editValues
@@ -262,6 +283,8 @@ const Form = ({
 
   const enforcementLevel = watch("enforcementLevel");
 
+  const formUserApprovers = watch("userApprovers");
+  const formGroupApprovers = watch("groupApprovers");
   const formUserBypassers = watch("userBypassers");
   const formGroupBypassers = watch("groupBypassers");
   const formEnvironments = watch("environments");
@@ -392,6 +415,34 @@ const Form = ({
     [groups]
   );
 
+  const approverOptions = useMemo<ApproverOptionData[]>(
+    () => [...memberOptions, ...(groupOptions ?? [])],
+    [memberOptions, groupOptions]
+  );
+
+  const getApproverLabel = (option: ApproverOptionData) => {
+    if (option.type === ApproverType.Group) {
+      return groups?.find(({ group }) => group.id === option.id)?.group.name ?? option.id;
+    }
+    const member = members?.find((m) => m.user.id === option.id);
+    if (!member) return option.name || option.id;
+    return getMemberLabel(member);
+  };
+
+  const splitSelectedApprovers = (selected: readonly ApproverOptionData[]) => ({
+    users: selected
+      .filter((option) => option.type === ApproverType.User)
+      .map((option) => ({
+        type: ApproverType.User as const,
+        id: option.id,
+        name: option.name,
+        isOrgMembershipActive: option.isOrgMembershipActive
+      })),
+    groups: selected
+      .filter((option) => option.type === ApproverType.Group)
+      .map((option) => ({ type: ApproverType.Group as const, id: option.id }))
+  });
+
   const bypasserMemberOptions = useMemo(
     () =>
       members.map((member) => ({
@@ -440,150 +491,158 @@ const Form = ({
     setDragOverItem(null);
   };
 
+  const renderApproverSelect = (index: number) => (
+    <FilterableSelect
+      menuPosition="fixed"
+      menuPlacement="top"
+      isMulti
+      placeholder="Select members or groups..."
+      options={approverOptions}
+      components={{
+        Option: ApproverOption,
+        MultiValueLabel: ApproverMultiValueLabel
+      }}
+      getOptionValue={(option) => `${option.type}-${option.id}`}
+      getOptionLabel={getApproverLabel}
+      value={[
+        ...(watch(`sequenceApprovers.${index}.user`) ?? []),
+        ...(watch(`sequenceApprovers.${index}.group`) ?? [])
+      ]}
+      onChange={(newValue) => {
+        const { users, groups: selectedGroups } = splitSelectedApprovers(
+          newValue as ApproverOptionData[]
+        );
+        setValue(`sequenceApprovers.${index}.user`, users, { shouldValidate: true });
+        setValue(`sequenceApprovers.${index}.group`, selectedGroups, { shouldValidate: true });
+      }}
+    />
+  );
+
+  const renderMinApprovals = (index: number, inputClassName: string) => (
+    <Controller
+      control={control}
+      name={`sequenceApprovers.${index}.approvals` as const}
+      defaultValue={1}
+      render={({ field }) => (
+        <Input
+          {...field}
+          type="number"
+          min={1}
+          className={inputClassName}
+          onChange={(val) => field.onChange(parseInt(val.target.value, 10))}
+        />
+      )}
+    />
+  );
+
   return (
-    <div className="flex flex-col space-y-3">
-      <form onSubmit={handleSubmit(handleFormSubmit)}>
-        <div className="flex items-center gap-x-3">
-          <Controller
-            control={control}
-            name="policyType"
-            defaultValue={PolicyType.ChangePolicy}
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                label="Policy Type"
-                isRequired
-                isError={Boolean(error)}
-                tooltipText="Change policies govern secret changes within a given environment and secret path. Access policies allow underprivileged user to request access to environment/secret path."
-                errorText={error?.message}
-                className="flex-1"
-              >
+    <form
+      onSubmit={handleSubmit(handleFormSubmit)}
+      className="flex flex-1 flex-col gap-4 overflow-hidden"
+    >
+      <div className="flex thin-scrollbar flex-1 flex-col gap-4 overflow-y-auto p-4">
+        <Controller
+          control={control}
+          name="policyType"
+          defaultValue={PolicyType.ChangePolicy}
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>
+                Policy Type
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoIcon />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Change policies govern secret changes within a given environment and secret
+                    path. Access policies allow underprivileged user to request access to
+                    environment/secret path.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <FieldContent>
                 <Select
-                  isDisabled={isEditMode}
                   value={value}
                   onValueChange={(val) => {
                     onChange(val as PolicyType);
                     resetField("secretPath");
                   }}
-                  className="w-full border border-mineshaft-500"
+                  disabled={isEditMode}
                 >
-                  {Object.values(PolicyType).map((policyType) => {
-                    return (
+                  <SelectTrigger className="w-full" isError={Boolean(error)}>
+                    <SelectValue placeholder="Select policy type" />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    {Object.values(PolicyType).map((policyType) => (
                       <SelectItem value={policyType} key={`policy-type-${policyType}`}>
                         {policyDetails[policyType].name}
                       </SelectItem>
-                    );
-                  })}
+                    ))}
+                  </SelectContent>
                 </Select>
-              </FormControl>
-            )}
-          />
-          <Controller
-            control={control}
-            name="name"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                label="Policy Name"
-                isError={Boolean(error)}
-                errorText={error?.message}
-                className="min-w-0 flex-[2]"
-              >
-                <Input {...field} value={field.value || ""} />
-              </FormControl>
-            )}
-          />
-
-          {isAccessPolicyType && (
-            <Controller
-              control={control}
-              name="maxTimePeriod"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Max. Time Period"
-                  tooltipText="The maximum amount of time someone can request access for. Ex: 1h, 3w, 30d"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  className="w-36 shrink-0"
-                >
-                  <Input {...field} value={field.value || ""} placeholder="permanent" />
-                </FormControl>
-              )}
-            />
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
           )}
-
-          {isAccessPolicyType && (
-            <Controller
-              control={control}
-              name="requestExpirationTime"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Request Expiration"
-                  tooltipText="Time before unapproved requests expire. Ex: 1h, 3d, 72h"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  className="w-36 shrink-0"
-                >
-                  <Input {...field} value={field.value || ""} placeholder="never expires" />
-                </FormControl>
-              )}
-            />
-          )}
-
-          {!isAccessPolicyType && (
-            <Controller
-              control={control}
-              name="approvals"
-              defaultValue={1}
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Min. Approvals Required"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  className="shrink"
-                >
-                  <Input
-                    {...field}
-                    type="number"
-                    min={1}
-                    onChange={(el) => field.onChange(parseInt(el.target.value, 10))}
-                  />
-                </FormControl>
-              )}
-            />
-          )}
-        </div>
-        <div className="flex items-center gap-x-3">
-          <Controller
-            control={control}
-            name="secretPath"
-            defaultValue="/"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                tooltipText="Secret paths support glob patterns. Use * to match a single level and ** to match all nested levels. Example: /** matches all paths, /services/* matches immediate children."
-                label="Secret Path"
-                isRequired
-                isError={Boolean(error)}
-                errorText={error?.message}
-                className="flex-1"
-              >
-                <SecretPathInput
+        />
+        <Controller
+          control={control}
+          name="name"
+          render={({ field, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>Policy Name</FieldLabel>
+              <FieldContent>
+                <Input
                   {...field}
                   value={field.value || ""}
-                  environment={formEnvironments?.[0]?.slug || ""}
+                  placeholder="e.g. Production Approvals"
+                  isError={Boolean(error)}
                 />
-              </FormControl>
-            )}
-          />
-          <Controller
-            control={control}
-            name="environments"
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                label="Environments"
-                isRequired
-                isError={Boolean(error)}
-                errorText={error?.message}
-                className="flex-1"
-              >
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
+          )}
+        />
+        <Controller
+          control={control}
+          name="secretPath"
+          defaultValue="/"
+          render={({ field, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>
+                Secret Path
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <InfoIcon />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-sm">
+                    Secret paths support glob patterns. Use * to match a single level and ** to
+                    match all nested levels. Example: /** matches all paths, /services/* matches
+                    immediate children.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <FieldContent>
+                <SecretPathInput
+                  name={field.name}
+                  onBlur={field.onBlur}
+                  value={field.value || ""}
+                  onChange={field.onChange}
+                  environment={formEnvironments?.[0]?.slug || ""}
+                  isError={Boolean(error)}
+                />
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
+          )}
+        />
+        <Controller
+          control={control}
+          name="environments"
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>Environments</FieldLabel>
+              <FieldContent>
                 <FilterableSelect
                   value={value}
                   isMulti
@@ -592,141 +651,175 @@ const Form = ({
                   options={availableEnvironments}
                   getOptionValue={(option) => option.slug}
                   getOptionLabel={(option) => option.name}
+                  isError={Boolean(error)}
                 />
-              </FormControl>
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
+          )}
+        />
+        {isAccessPolicyType && (
+          <div className="flex items-start gap-x-3">
+            <Controller
+              control={control}
+              name="maxTimePeriod"
+              render={({ field, fieldState: { error } }) => (
+                <Field className="flex-1">
+                  <FieldLabel>
+                    Max. Time Period
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        The maximum amount of time someone can request access for. Ex: 1h, 3w, 30d
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <FieldContent>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="permanent"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </FieldContent>
+                </Field>
+              )}
+            />
+            <Controller
+              control={control}
+              name="requestExpirationTime"
+              render={({ field, fieldState: { error } }) => (
+                <Field className="flex-1">
+                  <FieldLabel>
+                    Request Expiration
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Time before unapproved requests expire. Ex: 1h, 3d, 72h
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <FieldContent>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="never expires"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </FieldContent>
+                </Field>
+              )}
+            />
+          </div>
+        )}
+        {!isAccessPolicyType && (
+          <Controller
+            control={control}
+            name="approvals"
+            defaultValue={1}
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel>Min. Approvals Required</FieldLabel>
+                <FieldContent>
+                  <Input
+                    {...field}
+                    type="number"
+                    min={1}
+                    isError={Boolean(error)}
+                    onChange={(el) => field.onChange(parseInt(el.target.value, 10))}
+                  />
+                  <FieldError errors={[error]} />
+                </FieldContent>
+              </Field>
             )}
           />
-        </div>
-        <div className="mb-2">
-          <p>Approvers</p>
-          <p className="font-inter text-xs text-mineshaft-300 opacity-90">
+        )}
+        <div>
+          <p className="text-sm font-medium text-foreground">Approvers</p>
+          <p className="text-xs text-muted">
             Select members or groups that are allowed to approve requests from this policy.
           </p>
         </div>
         {isAccessPolicyType ? (
           <>
-            <div className="max-h-64 thin-scrollbar space-y-2 overflow-y-auto rounded-sm border border-mineshaft-600 bg-mineshaft-900 p-2">
-              {sequenceApproversFieldArray.fields.map((el, index) => (
-                <div
-                  className={twMerge(
-                    "rounded-sm border border-mineshaft-500 bg-mineshaft-700 p-3 pb-0 shadow-inner",
-                    dragOverItem === index ? "border-2 border-blue-400" : "",
-                    draggedItem === index ? "opacity-50" : ""
-                  )}
-                  key={el.id}
-                  onDragOver={(e) => handleDragOver(e, index)}
-                  onDrop={handleDrop}
-                >
-                  <div className="mb-3 flex items-center justify-between">
-                    <Tag>Step {index + 1}</Tag>
-                    <div className="flex items-center gap-3">
-                      <div className="inline text-xs text-mineshaft-400">Min. Approvals</div>
-                      <div className="mr-2 w-20 border-r border-mineshaft-400 pr-3">
-                        <Controller
-                          control={control}
-                          name={`sequenceApprovers.${index}.approvals` as const}
-                          defaultValue={1}
-                          render={({ field }) => (
-                            <Input
-                              {...field}
-                              type="number"
-                              size="xs"
-                              min={1}
-                              onChange={(val) => field.onChange(parseInt(val.target.value, 10))}
-                            />
-                          )}
-                        />
-                      </div>
-                      <Tooltip content="Remove step">
-                        <IconButton
-                          ariaLabel="delete"
-                          variant="plain"
-                          onClick={() => sequenceApproversFieldArray.remove(index)}
-                          className="text-red-500 hover:text-gray-200"
-                        >
-                          <FontAwesomeIcon icon={faTrash} />
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip content="Drag to reorder permission">
-                        <div
-                          draggable
-                          onDragStart={(e) => handleDragStart(e, index)}
-                          onDragEnd={handleDragEnd}
-                          className="mr-2 cursor-move text-gray-400 hover:text-gray-200"
-                        >
-                          <FontAwesomeIcon icon={faGripVertical} />
+            {sequenceApproversFieldArray.fields.length === 1 ? (
+              <div className="flex items-start gap-3">
+                <Field className="min-w-0 flex-1">
+                  <FieldLabel>Approvers</FieldLabel>
+                  <FieldContent>{renderApproverSelect(0)}</FieldContent>
+                </Field>
+                <Field className="w-28">
+                  <FieldLabel>Min. Approvals</FieldLabel>
+                  <FieldContent>{renderMinApprovals(0, "h-9 w-full")}</FieldContent>
+                </Field>
+              </div>
+            ) : (
+              <ItemGroup className="max-h-[12rem] thin-scrollbar shrink-0 gap-0 overflow-y-auto rounded-lg border border-border bg-container">
+                {sequenceApproversFieldArray.fields.map((el, index) => (
+                  <Fragment key={el.id}>
+                    {index > 0 && <ItemSeparator className="m-0" />}
+                    <Item
+                      onDragOver={(e) => handleDragOver(e, index)}
+                      onDrop={handleDrop}
+                      className={twMerge(
+                        "rounded-none border-0",
+                        dragOverItem === index && "bg-container-hover",
+                        draggedItem === index && "opacity-50"
+                      )}
+                    >
+                      <ItemMedia>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div
+                              draggable
+                              onDragStart={(e) => handleDragStart(e, index)}
+                              onDragEnd={handleDragEnd}
+                              className="cursor-move text-muted hover:text-foreground"
+                            >
+                              <GripVerticalIcon className="size-4" />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>Drag to reorder</TooltipContent>
+                        </Tooltip>
+                        <Badge variant="neutral">Step {index + 1}</Badge>
+                      </ItemMedia>
+                      <ItemContent className="min-w-0">{renderApproverSelect(index)}</ItemContent>
+                      <ItemActions>
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-xs text-muted">Min</span>
+                          {renderMinApprovals(index, "h-8 w-14")}
                         </div>
-                      </Tooltip>
-                    </div>
-                  </div>
-                  <div className="flex gap-2">
-                    <Controller
-                      control={control}
-                      name={`sequenceApprovers.${index}.user` as const}
-                      render={({ field: { value, onChange }, fieldState: { error } }) => (
-                        <FormControl
-                          label="User Approvers"
-                          isError={Boolean(error)}
-                          errorText={error?.message}
-                          className="flex-1"
-                        >
-                          <FilterableSelect
-                            menuPortalTarget={modalContainer.current}
-                            menuPlacement="top"
-                            isMulti
-                            placeholder="Select members..."
-                            options={memberOptions}
-                            components={{ Option: PolicyMemberOption }}
-                            getOptionValue={(option) => option.id}
-                            getOptionLabel={(option) => {
-                              const member = members?.find((m) => m.user.id === option.id);
-
-                              if (!member)
-                                return ("name" in option && (option.name as string)) || option.id;
-
-                              return getMemberLabel(member);
-                            }}
-                            value={value}
-                            onChange={onChange}
-                          />
-                        </FormControl>
-                      )}
-                    />
-                    <Controller
-                      control={control}
-                      name={`sequenceApprovers.${index}.group` as const}
-                      render={({ field: { value, onChange }, fieldState: { error } }) => (
-                        <FormControl
-                          label="Group Approvers"
-                          isError={Boolean(error)}
-                          errorText={error?.message}
-                          className="flex-1"
-                        >
-                          <FilterableSelect
-                            menuPortalTarget={modalContainer.current}
-                            menuPlacement="top"
-                            isMulti
-                            placeholder="Select groups..."
-                            options={groupOptions}
-                            getOptionValue={(option) => option.id}
-                            getOptionLabel={(option) =>
-                              groups?.find(({ group }) => group.id === option.id)?.group.name ??
-                              option.id
-                            }
-                            value={value}
-                            onChange={onChange}
-                          />
-                        </FormControl>
-                      )}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-            <div className="my-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <IconButton
+                              aria-label="Remove step"
+                              variant="ghost"
+                              size="xs"
+                              onClick={() => sequenceApproversFieldArray.remove(index)}
+                              className="text-danger hover:text-danger"
+                            >
+                              <Trash2Icon />
+                            </IconButton>
+                          </TooltipTrigger>
+                          <TooltipContent>Remove step</TooltipContent>
+                        </Tooltip>
+                      </ItemActions>
+                    </Item>
+                  </Fragment>
+                ))}
+              </ItemGroup>
+            )}
+            <div>
               <Button
                 size="xs"
-                variant="outline_bg"
+                variant="outline"
+                type="button"
                 onClick={() =>
                   sequenceApproversFieldArray.append({
                     approvals: 1,
@@ -735,214 +828,175 @@ const Form = ({
                   })
                 }
               >
+                <PlusIcon />
                 Add Step
               </Button>
             </div>
           </>
         ) : (
-          <div className="flex gap-2">
-            <Controller
-              control={control}
-              name="userApprovers"
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  label="User Approvers"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  className="w-1/2"
-                >
-                  <FilterableSelect
-                    menuPlacement="top"
-                    isMulti
-                    placeholder="Select members..."
-                    components={{ Option: PolicyMemberOption }}
-                    options={memberOptions}
-                    getOptionValue={(option) => option.id}
-                    getOptionLabel={(option) => {
-                      const member = members?.find((m) => m.user.id === option.id);
-
-                      if (!member)
-                        return ("name" in option && (option.name as string)) || option.id;
-
-                      return getMemberLabel(member);
-                    }}
-                    value={value}
-                    onChange={onChange}
-                  />
-                </FormControl>
-              )}
-            />
-            <Controller
-              control={control}
-              name="groupApprovers"
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  label="Group Approvers"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  className="w-1/2"
-                >
-                  <FilterableSelect
-                    menuPlacement="top"
-                    isMulti
-                    placeholder="Select groups..."
-                    options={groupOptions}
-                    getOptionValue={(option) => option.id}
-                    getOptionLabel={(option) =>
-                      groups?.find(({ group }) => group.id === option.id)?.group.name ?? option.id
-                    }
-                    value={value}
-                    onChange={onChange}
-                  />
-                </FormControl>
-              )}
-            />
-          </div>
+          <Field>
+            <FieldLabel>Approvers</FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                menuPlacement="top"
+                isMulti
+                placeholder="Select members or groups..."
+                options={approverOptions}
+                components={{
+                  Option: ApproverOption,
+                  MultiValueLabel: ApproverMultiValueLabel
+                }}
+                getOptionValue={(option) => `${option.type}-${option.id}`}
+                getOptionLabel={getApproverLabel}
+                value={[...(formUserApprovers ?? []), ...(formGroupApprovers ?? [])]}
+                onChange={(newValue) => {
+                  const { users, groups: selectedGroups } = splitSelectedApprovers(
+                    newValue as ApproverOptionData[]
+                  );
+                  setValue("userApprovers", users, { shouldValidate: true });
+                  setValue("groupApprovers", selectedGroups, { shouldValidate: true });
+                }}
+                isError={Boolean(errors.userApprovers || errors.groupApprovers)}
+              />
+              <FieldError errors={[errors.userApprovers, errors.groupApprovers]} />
+            </FieldContent>
+          </Field>
         )}
         <Controller
           control={control}
           name="allowedSelfApprovals"
           defaultValue
-          render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl label="Self Approvals" isError={Boolean(error)} errorText={error?.message}>
+          render={({ field: { value, onChange } }) => (
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>Self Approvals</FieldTitle>
+                <FieldDescription>Allow approvers to review their own requests</FieldDescription>
+              </FieldContent>
               <Switch
                 id="self-approvals"
-                thumbClassName="bg-mineshaft-800"
-                isChecked={value}
+                variant="project"
+                checked={value}
                 onCheckedChange={onChange}
-              >
-                Allow approvers to review their own requests
-              </Switch>
-            </FormControl>
+              />
+            </Field>
           )}
         />
         <Controller
           control={control}
           name="enforcementLevel"
           defaultValue={EnforcementLevel.Hard}
-          render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <FormControl
-              label="Bypass Approvals"
-              isError={Boolean(error)}
-              errorText={error?.message}
-              className="mb-3"
-            >
+          render={({ field: { value, onChange } }) => (
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>Bypass Approvals</FieldTitle>
+                <FieldDescription>
+                  Allow certain users to bypass policy in break-glass situations
+                </FieldDescription>
+              </FieldContent>
               <Switch
                 id="bypass-approvals"
-                thumbClassName="bg-mineshaft-800"
-                isChecked={value === EnforcementLevel.Soft}
+                variant="project"
+                checked={value === EnforcementLevel.Soft}
                 onCheckedChange={(v) => onChange(v ? EnforcementLevel.Soft : EnforcementLevel.Hard)}
-              >
-                Allow certain users to bypass policy in break-glass situations
-              </Switch>
-            </FormControl>
+              />
+            </Field>
           )}
         />
         {enforcementLevel === EnforcementLevel.Soft && (
           <>
-            <div className="flex gap-2">
+            <div className="flex flex-col gap-4">
               <Controller
                 control={control}
                 name="userBypassers"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    label="User Bypassers"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                    className="mb-2 w-1/2"
-                  >
-                    <FilterableSelect
-                      menuPlacement="top"
-                      isMulti
-                      placeholder="Select members..."
-                      components={{ Option: PolicyMemberOption }}
-                      options={bypasserMemberOptions}
-                      getOptionValue={(option) => option.id}
-                      getOptionLabel={(option) => {
-                        const member = members?.find((m) => m.user.id === option.id);
+                  <Field>
+                    <FieldLabel>User Bypassers</FieldLabel>
+                    <FieldContent>
+                      <FilterableSelect
+                        menuPlacement="top"
+                        isMulti
+                        placeholder="Select members..."
+                        components={{ Option: PolicyMemberOption }}
+                        options={bypasserMemberOptions}
+                        getOptionValue={(option) => option.id}
+                        getOptionLabel={(option) => {
+                          const member = members?.find((m) => m.user.id === option.id);
 
-                        if (!member) return option.id;
+                          if (!member) return option.id;
 
-                        return getMemberLabel(member);
-                      }}
-                      value={value}
-                      onChange={onChange}
-                    />
-                  </FormControl>
+                          return getMemberLabel(member);
+                        }}
+                        value={value}
+                        onChange={onChange}
+                        isError={Boolean(error)}
+                      />
+                      <FieldError errors={[error]} />
+                    </FieldContent>
+                  </Field>
                 )}
               />
               <Controller
                 control={control}
                 name="groupBypassers"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    label="Group Bypassers"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                    className="mb-2 w-1/2"
-                  >
-                    <FilterableSelect
-                      menuPlacement="top"
-                      isMulti
-                      placeholder="Select groups..."
-                      options={bypasserGroupOptions}
-                      getOptionValue={(option) => option.id}
-                      getOptionLabel={(option) =>
-                        groups?.find(({ group }) => group.id === option.id)?.group.name ?? option.id
-                      }
-                      value={value}
-                      onChange={onChange}
-                    />
-                  </FormControl>
+                  <Field>
+                    <FieldLabel>Group Bypassers</FieldLabel>
+                    <FieldContent>
+                      <FilterableSelect
+                        menuPlacement="top"
+                        isMulti
+                        placeholder="Select groups..."
+                        options={bypasserGroupOptions}
+                        getOptionValue={(option) => option.id}
+                        getOptionLabel={(option) =>
+                          groups?.find(({ group }) => group.id === option.id)?.group.name ??
+                          option.id
+                        }
+                        value={value}
+                        onChange={onChange}
+                        isError={Boolean(error)}
+                      />
+                      <FieldError errors={[error]} />
+                    </FieldContent>
+                  </Field>
                 )}
               />
             </div>
 
             {bypasserCount <= 0 && (
-              <div className="mt-1 flex rounded-r border-l-2 border-l-red-500 bg-mineshaft-300/5 px-4 py-2.5 text-sm text-bunker-300">
-                Not selecting specific users or groups will allow anyone to bypass this policy.
-              </div>
+              <Alert variant="warning">
+                <TriangleAlertIcon />
+                <AlertDescription>
+                  Not selecting specific users or groups will allow anyone to bypass this policy.
+                </AlertDescription>
+              </Alert>
             )}
           </>
         )}
-        <div className="mt-8 flex items-center space-x-4">
-          <Button
-            type="submit"
-            colorSchema="secondary"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting}
-          >
-            Save
-          </Button>
-          <Button onClick={() => onToggle(false)} colorSchema="secondary" variant="plain">
-            Close
-          </Button>
-        </div>
-      </form>
-    </div>
+      </div>
+      <SheetFooter className="border-t">
+        <Button type="submit" variant="project" isPending={isSubmitting} isDisabled={isSubmitting}>
+          {isEditMode ? "Update Policy" : "Add Policy"}
+        </Button>
+        <Button onClick={() => onToggle(false)} variant="outline" type="button">
+          Close
+        </Button>
+      </SheetFooter>
+    </form>
   );
 };
 
 export const AccessPolicyForm = ({ isOpen, onToggle, editValues, ...props }: Props) => {
-  const modalContainer = useRef<HTMLDivElement>(null);
   const isEditMode = Boolean(editValues);
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onToggle}>
-      <ModalContent
-        className="max-w-3xl"
-        ref={modalContainer}
-        title={isEditMode ? "Edit Policy" : "Create Policy"}
-      >
-        <Form
-          {...props}
-          isOpen={isOpen}
-          onToggle={onToggle}
-          editValues={editValues}
-          modalContainer={modalContainer}
-          isEditMode={isEditMode}
-        />
-      </ModalContent>
-    </Modal>
+    <Sheet open={isOpen} onOpenChange={onToggle}>
+      <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-xl">
+        <SheetHeader className="border-b">
+          <SheetTitle>{isEditMode ? "Edit Policy" : "Add Policy"}</SheetTitle>
+        </SheetHeader>
+        <Form {...props} onToggle={onToggle} editValues={editValues} isEditMode={isEditMode} />
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -246,10 +246,10 @@ const Form = ({
                   ? {
                       user: [curr],
                       group: [],
-                      sequence: 1,
+                      sequence: curr.sequence,
                       approvals
                     }
-                  : { group: [curr], user: [], sequence: 1, approvals }
+                  : { group: [curr], user: [], sequence: curr.sequence, approvals }
               );
               return acc;
             },

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
@@ -1,34 +1,39 @@
 import { useMemo } from "react";
 import {
-  faClipboardCheck,
-  faEdit,
-  faEllipsisV,
-  faTrash,
-  faUser,
-  faUserGroup
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { BanIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
+  BanIcon,
+  ClipboardCheckIcon,
+  EllipsisVerticalIcon,
+  InfoIcon,
+  PencilIcon,
+  Trash2Icon,
+  UserIcon,
+  UsersIcon
+} from "lucide-react";
 
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
+  Badge,
+  Detail,
+  DetailLabel,
+  DetailValue,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  GenericFieldLabel,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
   IconButton,
-  Td,
+  TableCell,
+  TableRow,
   Tooltip,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { ProjectPermissionSub } from "@app/context";
 import { ProjectPermissionActions } from "@app/context/ProjectPermissionContext/types";
 import { getMemberLabel } from "@app/helpers/members";
 import { policyDetails } from "@app/helpers/policies";
-import { useToggle } from "@app/hooks";
 import { Approver } from "@app/hooks/api/accessApproval/types";
 import { TGroupMembership } from "@app/hooks/api/groups/types";
 import { EnforcementLevel, PolicyType } from "@app/hooks/api/policies/enums";
@@ -64,8 +69,6 @@ export const ApprovalPolicyRow = ({
   onEdit,
   onDelete
 }: Props) => {
-  const [isExpanded, setIsExpanded] = useToggle();
-
   const labels = useMemo(() => {
     const sortedSteps = policy.approvers?.sort((a, b) => (a?.sequence || 0) - (b?.sequence || 0));
     const entityInSameSequence = sortedSteps?.reduce(
@@ -106,39 +109,135 @@ export const ApprovalPolicyRow = ({
   const { variant, Icon } = policyDetails[policy.policyType];
 
   return (
-    <>
-      <Tr
-        isHoverable
-        isSelectable
-        role="button"
-        tabIndex={0}
-        onKeyDown={(evt) => {
-          if (evt.key === "Enter") setIsExpanded.toggle();
-        }}
-        onClick={() => setIsExpanded.toggle()}
-      >
-        <Td>{policy.name || <span className="text-mineshaft-400">Unnamed Policy</span>}</Td>
-        <Td>{policy.environments.map((env) => env.name).join(", ")}</Td>
-        <Td>{policy.secretPath || "*"}</Td>
-        <Td>
-          <Badge variant={variant}>
-            <Icon />
-            <span>{policyDetails[policy.policyType].name}</span>
-          </Badge>
-        </Td>
-        <Td>
+    <TableRow>
+      <TableCell>{policy.name || <span className="text-muted">Unnamed Policy</span>}</TableCell>
+      <TableCell>{policy.environments.map((env) => env.name).join(", ")}</TableCell>
+      <TableCell>{policy.secretPath || "*"}</TableCell>
+      <TableCell>
+        <Badge variant={variant}>
+          <Icon />
+          <span>{policyDetails[policy.policyType].name}</span>
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center justify-end gap-1">
+          <HoverCard openDelay={100}>
+            <HoverCardTrigger asChild>
+              <IconButton aria-label="View approvers" variant="ghost-muted" size="xs">
+                <InfoIcon />
+              </IconButton>
+            </HoverCardTrigger>
+            <HoverCardContent
+              align="end"
+              className="max-h-96 thin-scrollbar w-80 overflow-y-auto p-4"
+            >
+              <div className="mb-3 text-sm font-medium text-foreground">Approvers</div>
+              {labels && labels.length > 0 ? (
+                <div className="flex flex-col gap-4">
+                  {labels.map((el, index) => (
+                    <div
+                      key={`approval-list-${index + 1}`}
+                      className="flex flex-col gap-2.5 border-b border-border pb-4 last:border-0 last:pb-0"
+                    >
+                      {labels.length > 1 && (
+                        <Badge variant="neutral" className="w-fit">
+                          Step {index + 1}
+                        </Badge>
+                      )}
+                      <Detail>
+                        <DetailLabel className="flex items-center gap-1.5">
+                          <UserIcon className="size-3" />
+                          Users
+                        </DetailLabel>
+                        <DetailValue>
+                          {el.users.length ? (
+                            <div className="flex flex-row flex-wrap gap-x-1 gap-y-1">
+                              {el.users.map(({ member, approver }, idx) => {
+                                const isLast = idx === el.users.length - 1;
+
+                                if (!member) {
+                                  return (
+                                    <span key={approver.id} className="flex items-center gap-1">
+                                      <span className="flex items-center gap-1.5 opacity-40">
+                                        {approver.name || approver.id}
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <Badge variant="neutral">
+                                              <BanIcon />
+                                              Removed
+                                            </Badge>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            This user has been removed from the project.
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </span>
+                                      {!isLast && ","}
+                                    </span>
+                                  );
+                                }
+
+                                return member.user.isOrgMembershipActive ? (
+                                  <span key={member.id}>
+                                    {getMemberLabel(member)}
+                                    {!isLast && ","}
+                                  </span>
+                                ) : (
+                                  <span key={member.id} className="flex items-center gap-1">
+                                    <span className="flex items-center gap-1.5 opacity-40">
+                                      {getMemberLabel(member)}
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <Badge variant="neutral">
+                                            <BanIcon />
+                                            Inactive
+                                          </Badge>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          This user has been deactivated and no longer has an active
+                                          organization membership.
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    </span>
+                                    {!isLast && ","}
+                                  </span>
+                                );
+                              })}
+                            </div>
+                          ) : (
+                            <span className="text-muted">None</span>
+                          )}
+                        </DetailValue>
+                      </Detail>
+                      <Detail>
+                        <DetailLabel className="flex items-center gap-1.5">
+                          <UsersIcon className="size-3" />
+                          Groups
+                        </DetailLabel>
+                        <DetailValue>
+                          {el.groupLabels || <span className="text-muted">None</span>}
+                        </DetailValue>
+                      </Detail>
+                      <Detail>
+                        <DetailLabel className="flex items-center gap-1.5">
+                          <ClipboardCheckIcon className="size-3" />
+                          Approvals Required
+                        </DetailLabel>
+                        <DetailValue>{el.approvals}</DetailValue>
+                      </Detail>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-sm text-muted">No approvers configured.</span>
+              )}
+            </HoverCardContent>
+          </HoverCard>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild className="cursor-pointer rounded-lg">
-              <DropdownMenuTrigger asChild>
-                <IconButton
-                  ariaLabel="Options"
-                  colorSchema="secondary"
-                  className="w-6"
-                  variant="plain"
-                >
-                  <FontAwesomeIcon icon={faEllipsisV} />
-                </IconButton>
-              </DropdownMenuTrigger>
+            <DropdownMenuTrigger asChild>
+              <IconButton aria-label="Options" variant="ghost" size="xs">
+                <EllipsisVerticalIcon />
+              </IconButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent sideOffset={2} align="end" className="min-w-48 p-1">
               <ProjectPermissionCan
@@ -146,14 +245,8 @@ export const ApprovalPolicyRow = ({
                 a={ProjectPermissionSub.SecretApproval}
               >
                 {(isAllowed) => (
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onEdit();
-                    }}
-                    isDisabled={!isAllowed}
-                    icon={<FontAwesomeIcon icon={faEdit} />}
-                  >
+                  <DropdownMenuItem onClick={onEdit} isDisabled={!isAllowed}>
+                    <PencilIcon />
                     Edit Policy
                   </DropdownMenuItem>
                 )}
@@ -163,117 +256,16 @@ export const ApprovalPolicyRow = ({
                 a={ProjectPermissionSub.SecretApproval}
               >
                 {(isAllowed) => (
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDelete();
-                    }}
-                    isDisabled={!isAllowed}
-                    icon={<FontAwesomeIcon icon={faTrash} />}
-                  >
+                  <DropdownMenuItem variant="danger" onClick={onDelete} isDisabled={!isAllowed}>
+                    <Trash2Icon />
                     Delete Policy
                   </DropdownMenuItem>
                 )}
               </ProjectPermissionCan>
             </DropdownMenuContent>
           </DropdownMenu>
-        </Td>
-      </Tr>
-      <Tr>
-        <Td colSpan={6} className="border-none! p-0">
-          <div
-            className={`w-full overflow-hidden bg-mineshaft-900/75 transition-all duration-500 ease-in-out ${
-              isExpanded ? "max-h-104 thin-scrollbar overflow-y-auto! opacity-100" : "max-h-0"
-            }`}
-          >
-            <div className="p-4">
-              <div className="border-b-2 border-mineshaft-500 pb-2">Approvers</div>
-              {labels?.map((el, index) => (
-                <div key={`approval-list-${index + 1}`} className="flex">
-                  {labels.length > 1 && (
-                    <div className="flex w-12 flex-col items-center gap-2 pr-4">
-                      <div
-                        className={twMerge("grow border-mineshaft-600", index !== 0 && "border-r")}
-                      />
-                      {labels.length > 1 && (
-                        <Badge variant="neutral">
-                          <span>{index + 1}</span>
-                        </Badge>
-                      )}
-                      <div
-                        className={twMerge(
-                          "grow border-mineshaft-600",
-                          index < labels.length - 1 && "border-r"
-                        )}
-                      />
-                    </div>
-                  )}
-                  <div className="grid flex-1 grid-cols-5 border-b border-mineshaft-600 p-4">
-                    <GenericFieldLabel className="col-span-2" icon={faUser} label="Users">
-                      {Boolean(el.users.length) && (
-                        <div className="flex flex-row flex-wrap gap-2">
-                          {el.users.map(({ member, approver }, idx) => {
-                            if (!member) {
-                              return (
-                                <div className="flex items-center" key={approver.id}>
-                                  <span className="flex items-center gap-2 opacity-40">
-                                    {approver.name || approver.id}
-                                    <span className="text-xs">
-                                      <Tooltip content="This user has been removed from the project.">
-                                        <div>
-                                          <Badge variant="neutral">
-                                            <BanIcon />
-                                            Removed
-                                          </Badge>
-                                        </div>
-                                      </Tooltip>
-                                    </span>
-                                  </span>
-                                  {idx < el.users.length - 1 && ","}
-                                </div>
-                              );
-                            }
-
-                            return member.user.isOrgMembershipActive ? (
-                              <div className="flex items-center" key={member.id}>
-                                <span>{getMemberLabel(member)}</span>
-                                {idx < el.users.length - 1 && ","}
-                              </div>
-                            ) : (
-                              <div className="flex items-center" key={member.id}>
-                                <span className="flex items-center gap-2 opacity-40">
-                                  {getMemberLabel(member)}
-                                  <span className="text-xs">
-                                    <Tooltip content="This user has been deactivated and no longer has an active organization membership.">
-                                      <div>
-                                        <Badge variant="neutral">
-                                          <BanIcon />
-                                          Inactive
-                                        </Badge>
-                                      </div>
-                                    </Tooltip>
-                                  </span>
-                                </span>
-                                {idx < el.users.length - 1 && ","}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </GenericFieldLabel>
-                    <GenericFieldLabel className="col-span-2" icon={faUserGroup} label="Groups">
-                      {el.groupLabels}
-                    </GenericFieldLabel>
-                    <GenericFieldLabel icon={faClipboardCheck} label="Approvals Required">
-                      {el.approvals}
-                    </GenericFieldLabel>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </Td>
-      </Tr>
-    </>
+        </div>
+      </TableCell>
+    </TableRow>
   );
 };

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApprovalPolicyRow.tsx
@@ -108,11 +108,19 @@ export const ApprovalPolicyRow = ({
 
   const { variant, Icon } = policyDetails[policy.policyType];
 
+  const environmentNames = policy.environments.map((env) => env.name).join(", ");
+
   return (
     <TableRow>
-      <TableCell>{policy.name || <span className="text-muted">Unnamed Policy</span>}</TableCell>
-      <TableCell>{policy.environments.map((env) => env.name).join(", ")}</TableCell>
-      <TableCell>{policy.secretPath || "*"}</TableCell>
+      <TableCell isTruncatable className="w-1/3" title={policy.name || "Unnamed Policy"}>
+        {policy.name || <span className="text-muted">Unnamed Policy</span>}
+      </TableCell>
+      <TableCell isTruncatable className="w-1/3" title={environmentNames}>
+        {environmentNames}
+      </TableCell>
+      <TableCell isTruncatable className="w-1/3" title={policy.secretPath || "*"}>
+        {policy.secretPath || "*"}
+      </TableCell>
       <TableCell>
         <Badge variant={variant}>
           <Icon />

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApproverOption.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/ApproverOption.tsx
@@ -1,0 +1,63 @@
+import { components, MultiValueGenericProps, OptionProps } from "react-select";
+import { BanIcon, CheckIcon, UserIcon, UsersIcon } from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+import { Badge } from "@app/components/v3";
+import { ApproverType } from "@app/hooks/api/accessApproval/types";
+
+export type ApproverOptionData = {
+  id: string;
+  type: ApproverType;
+  name?: string;
+  isOrgMembershipActive?: boolean;
+};
+
+const TypeIcon = ({ type }: { type: ApproverType }) =>
+  type === ApproverType.Group ? (
+    <UsersIcon className="size-3.5 shrink-0 text-muted" />
+  ) : (
+    <UserIcon className="size-3.5 shrink-0 text-muted" />
+  );
+
+export const ApproverOption = ({
+  isSelected,
+  children,
+  ...props
+}: OptionProps<ApproverOptionData>) => {
+  const { type, isOrgMembershipActive } = props.data;
+  const isInactive = type === ApproverType.User && isOrgMembershipActive === false;
+
+  return (
+    <components.Option isSelected={isSelected} {...props}>
+      <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <TypeIcon type={type} />
+          <span className={twMerge("truncate", isInactive && "text-mineshaft-400")}>
+            {children}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {isInactive && (
+            <Badge variant="neutral">
+              <BanIcon />
+              Inactive
+            </Badge>
+          )}
+          {isSelected && <CheckIcon className="size-4 shrink-0" />}
+        </div>
+      </div>
+    </components.Option>
+  );
+};
+
+export const ApproverMultiValueLabel = (props: MultiValueGenericProps<ApproverOptionData>) => {
+  const { data, children } = props;
+  return (
+    <components.MultiValueLabel {...props}>
+      <span className="flex items-center gap-1.5">
+        <TypeIcon type={data.type} />
+        {children}
+      </span>
+    </components.MultiValueLabel>
+  );
+};

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/EnvironmentFilterSelect.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/EnvironmentFilterSelect.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
+
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+import { ProjectEnv } from "@app/hooks/api/types";
+
+type Props = {
+  environments: ProjectEnv[];
+  selectedEnvironmentIds: string[];
+  onChange: (environmentIds: string[]) => void;
+};
+
+export const EnvironmentFilterSelect = ({
+  environments,
+  selectedEnvironmentIds,
+  onChange
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+
+  const label =
+    environments.find((env) => env.id === selectedEnvironmentIds[0])?.name ?? "All Environments";
+
+  const handleSelectAll = () => onChange([]);
+
+  const handleToggleEnv = (environmentId: string) => {
+    onChange(selectedEnvironmentIds.includes(environmentId) ? [] : [environmentId]);
+  };
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={isOpen}
+          className="w-[200px] shrink-0 justify-between"
+        >
+          <span className="truncate">{label}</span>
+          <ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[240px] p-0">
+        <Command>
+          <CommandInput
+            value={inputValue}
+            onValueChange={setInputValue}
+            placeholder="Filter environments"
+          />
+          <CommandList>
+            <CommandEmpty>No environment found.</CommandEmpty>
+            {Boolean(environments.length) && !inputValue && (
+              <>
+                <CommandGroup>
+                  <CommandItem forceMount keywords={[]} onSelect={handleSelectAll}>
+                    <CheckIcon
+                      className={cn(
+                        "h-4 w-4",
+                        selectedEnvironmentIds.length ? "opacity-0" : "opacity-100"
+                      )}
+                    />
+                    All Environments
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+            <CommandGroup>
+              {environments.map((env) => (
+                <CommandItem
+                  key={env.id}
+                  value={env.id}
+                  onSelect={handleToggleEnv}
+                  keywords={[env.name, env.slug]}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "h-4 w-4 shrink-0",
+                      selectedEnvironmentIds.includes(env.id) ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  <span className="truncate">{env.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/PolicyMemberOption.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/PolicyMemberOption.tsx
@@ -1,7 +1,5 @@
 import { components, OptionProps } from "react-select";
-import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { BanIcon } from "lucide-react";
+import { BanIcon, CheckIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { Badge } from "@app/components/v3";
@@ -31,9 +29,7 @@ export const PolicyMemberOption = ({
             Inactive
           </Badge>
         )}
-        {isSelected && (
-          <FontAwesomeIcon className="ml-2 text-primary" icon={faCheckCircle} size="sm" />
-        )}
+        {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
       </div>
     </components.Option>
   );

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/RemoveApprovalPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/RemoveApprovalPolicyModal.tsx
@@ -51,31 +51,6 @@ export const RemoveApprovalPolicyModal = ({
   const isConfirmed = inputData === "remove";
   const isDeleting = deleteSecretApprovalPolicy.isPending || deleteAccessApprovalPolicy.isPending;
 
-  useEffect(() => {
-    setInputData("");
-  }, [isOpen]);
-
-  const handleDeletePolicy = async () => {
-    if (!isConfirmed) return;
-
-    if (policyType === PolicyType.ChangePolicy) {
-      await deleteSecretApprovalPolicy.mutateAsync({
-        projectId: currentProject.id,
-        id: policyId
-      });
-    } else {
-      await deleteAccessApprovalPolicy.mutateAsync({
-        projectSlug: currentProject.slug,
-        id: policyId
-      });
-    }
-    createNotification({
-      type: "success",
-      text: "Successfully deleted policy"
-    });
-    onOpenChange(false);
-  };
-
   const deleteSecretApprovalData = useGetSecretApprovalRequestCount({
     policyId,
     projectId: currentProject.id,
@@ -103,6 +78,31 @@ export const RemoveApprovalPolicyModal = ({
   }
 
   const hasOpenRequests = (openCount ?? 0) > 0;
+
+  useEffect(() => {
+    setInputData("");
+  }, [isOpen]);
+
+  const handleDeletePolicy = async () => {
+    if (!isConfirmed || isDeleting || isCheckingRequests) return;
+
+    if (policyType === PolicyType.ChangePolicy) {
+      await deleteSecretApprovalPolicy.mutateAsync({
+        projectId: currentProject.id,
+        id: policyId
+      });
+    } else {
+      await deleteAccessApprovalPolicy.mutateAsync({
+        projectSlug: currentProject.slug,
+        id: policyId
+      });
+    }
+    createNotification({
+      type: "success",
+      text: "Successfully deleted policy"
+    });
+    onOpenChange(false);
+  };
 
   return (
     <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
@@ -160,7 +160,7 @@ export const RemoveApprovalPolicyModal = ({
             variant="danger"
             onClick={handleDeletePolicy}
             isPending={isDeleting}
-            isDisabled={!isConfirmed || isDeleting}
+            isDisabled={!isConfirmed || isDeleting || isCheckingRequests}
           >
             Remove
           </Button>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/RemoveApprovalPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/RemoveApprovalPolicyModal.tsx
@@ -1,9 +1,25 @@
-import { faCheck, faWarning } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { twMerge } from "tailwind-merge";
+import { useEffect, useState } from "react";
+import { CheckIcon, LoaderCircleIcon, Trash2Icon, TriangleAlertIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import { DeleteActionModal, Spinner } from "@app/components/v2";
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertTitle,
+  Button,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import {
   useDeleteAccessApprovalPolicy,
@@ -26,19 +42,29 @@ export const RemoveApprovalPolicyModal = ({
   isOpen,
   onOpenChange
 }: Props) => {
-  const { mutateAsync: deleteSecretApprovalPolicy } = useDeleteSecretApprovalPolicy();
-  const { mutateAsync: deleteAccessApprovalPolicy } = useDeleteAccessApprovalPolicy();
+  const deleteSecretApprovalPolicy = useDeleteSecretApprovalPolicy();
+  const deleteAccessApprovalPolicy = useDeleteAccessApprovalPolicy();
 
   const { currentProject } = useProject();
 
+  const [inputData, setInputData] = useState("");
+  const isConfirmed = inputData === "remove";
+  const isDeleting = deleteSecretApprovalPolicy.isPending || deleteAccessApprovalPolicy.isPending;
+
+  useEffect(() => {
+    setInputData("");
+  }, [isOpen]);
+
   const handleDeletePolicy = async () => {
+    if (!isConfirmed) return;
+
     if (policyType === PolicyType.ChangePolicy) {
-      await deleteSecretApprovalPolicy({
+      await deleteSecretApprovalPolicy.mutateAsync({
         projectId: currentProject.id,
         id: policyId
       });
     } else {
-      await deleteAccessApprovalPolicy({
+      await deleteAccessApprovalPolicy.mutateAsync({
         projectSlug: currentProject.slug,
         id: policyId
       });
@@ -67,62 +93,79 @@ export const RemoveApprovalPolicyModal = ({
   });
 
   let openCount: number | undefined;
-  let isPending: boolean;
+  let isCheckingRequests: boolean;
   if (policyType === PolicyType.ChangePolicy) {
     openCount = deleteSecretApprovalData.data?.open;
-    isPending = deleteSecretApprovalData.isPending;
+    isCheckingRequests = deleteSecretApprovalData.isPending;
   } else {
     openCount = deleteAccessApprovalData.data?.pendingCount;
-    isPending = deleteAccessApprovalData.isPending;
+    isCheckingRequests = deleteAccessApprovalData.isPending;
   }
 
+  const hasOpenRequests = (openCount ?? 0) > 0;
+
   return (
-    <DeleteActionModal
-      isOpen={isOpen}
-      deleteKey="remove"
-      title="Do you want to remove this policy?"
-      onChange={onOpenChange}
-      onDeleteApproved={handleDeletePolicy}
-      isDisabled={isPending}
-    >
-      {isPending ? (
-        <div className="mt-4 flex w-full items-center gap-2 p-2">
-          <Spinner size="xs" className="text-mineshaft-600" />
-          <span className="text-sm text-mineshaft-400">Checking for open requests...</span>
-        </div>
-      ) : (
-        <div
-          className={twMerge(
-            "mt-4 flex w-full items-start gap-2 rounded-sm border p-2 text-sm",
-            (openCount ?? 0) > 0
-              ? "border-yellow/20 bg-yellow/10 text-yellow"
-              : "border-green/20 bg-green/10 text-green"
-          )}
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia>
+            <Trash2Icon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Do you want to remove this policy?</AlertDialogTitle>
+          <AlertDialogDescription>Removing this policy cannot be undone.</AlertDialogDescription>
+        </AlertDialogHeader>
+        {isCheckingRequests ? (
+          <div className="flex w-full items-center gap-2 p-2">
+            <LoaderCircleIcon className="size-4 animate-spin text-muted" />
+            <span className="text-sm text-muted">Checking for open requests...</span>
+          </div>
+        ) : (
+          <Alert variant={hasOpenRequests ? "warning" : "success"}>
+            {hasOpenRequests ? <TriangleAlertIcon /> : <CheckIcon />}
+            <AlertTitle>
+              {hasOpenRequests
+                ? `This policy has ${openCount} open request${(openCount ?? 0) > 1 ? "s" : ""}`
+                : "This policy has no open requests"}
+            </AlertTitle>
+            <AlertDescription>
+              {hasOpenRequests
+                ? "Removing this policy will close all open requests."
+                : "This policy is safe to remove."}
+            </AlertDescription>
+          </Alert>
+        )}
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleDeletePolicy();
+          }}
         >
-          {(openCount ?? 0) > 0 ? (
-            <>
-              <FontAwesomeIcon className="mt-1" icon={faWarning} />
-              <div className="flex flex-col">
-                <span>
-                  This policy has {openCount} open request
-                  {(openCount ?? 0) > 1 ? "s" : ""}
-                </span>
-                <p className="text-xs text-mineshaft-200">
-                  Removing this policy will close all open requests.
-                </p>
-              </div>
-            </>
-          ) : (
-            <>
-              <FontAwesomeIcon className="mt-1" icon={faCheck} />
-              <div className="flex flex-col">
-                <span>This policy has no open requests</span>
-                <p className="text-xs text-mineshaft-200">This policy is safe to remove.</p>
-              </div>
-            </>
-          )}
-        </div>
-      )}
-    </DeleteActionModal>
+          <Field>
+            <FieldLabel>
+              Type <span className="font-bold">remove</span> to confirm
+            </FieldLabel>
+            <FieldContent>
+              <Input
+                value={inputData}
+                onChange={(e) => setInputData(e.target.value)}
+                placeholder="Type remove here"
+                autoComplete="off"
+              />
+            </FieldContent>
+          </Field>
+        </form>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button
+            variant="danger"
+            onClick={handleDeletePolicy}
+            isPending={isDeleting}
+            isDisabled={!isConfirmed || isDeleting}
+          >
+            Remove
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };


### PR DESCRIPTION
## Context

This PR revamps the approvals policy tab including the table, modal and details display, including UX improvements in addition to v3 component migration

## Screenshots

<img width="3456" height="1922" alt="CleanShot 2026-06-22 at 18 40 59@2x" src="https://github.com/user-attachments/assets/726d5ff2-71dd-486b-8cde-04906b7ece17" />

<img width="3456" height="1922" alt="CleanShot 2026-06-22 at 18 41 02@2x" src="https://github.com/user-attachments/assets/de143fba-9d0f-4632-8107-200804dbf5bd" />

<img width="3456" height="1922" alt="CleanShot 2026-06-22 at 18 41 09@2x" src="https://github.com/user-attachments/assets/5a9f87bf-6666-4863-a51b-d2a561c6c339" />

## Steps to verify the change

- [ ] List renders in v3 (search, environment + type filters, column sort, pagination)
- [ ] Loading skeleton + empty states display correctly
- [ ] Create a Change Policy works
- [ ] Create an Access Policy works (steps: add / remove / drag / scroll)
- [ ] Approvers select handles users + groups together (icons)
- [ ] Row info hovercard shows approver details (both types with and without tests)
- [ ] Edit Policy works (test both types)
- [ ] Delete Policy works

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)