### PR TITLE
fix(pki): honor CA-issuance policy denial on certificate renewal

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2553,6 +2553,8 @@ export const certificateV3ServiceFactory = ({
             signatureAlgorithm: originalSignatureAlgorithm,
             keyAlgorithm: originalKeyAlgorithm,
             isFromProfile: true,
+            basicConstraints: originalCert.isCA ? { isCA: true, pathLength: originalCert.pathLength } : undefined,
+            pathLength: originalCert.pathLength ?? undefined,
             organization: originalCert.subjectOrganization || undefined,
             ou: originalCert.subjectOrganizationalUnit || undefined,
             country: originalCert.subjectCountry || undefined,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2471,7 +2471,10 @@ export const certificateV3ServiceFactory = ({
           ttl
         },
         signatureAlgorithm: originalCert.signatureAlgorithm || undefined,
-        keyAlgorithm: originalCert.keyAlgorithm || undefined
+        keyAlgorithm: originalCert.keyAlgorithm || undefined,
+        basicConstraints: originalCert.isCA
+          ? { isCA: true, pathLength: originalCert.pathLength ?? undefined }
+          : undefined
       };
 
       let validationResult: { isValid: boolean; errors: string[] } = { isValid: true, errors: [] };


### PR DESCRIPTION
Fixes #6971.

## What

The renewal path in `certificateV3Service` runs the same `certificatePolicyService.validateCertificateRequest` that direct issuance runs, but the `certificateRequest` it builds (`certificate-v3-service.ts:2457-2475`) never populated `basicConstraints` from the original certificate. `validateRequestAgainstPolicy` gates its CA-related checks on `request.basicConstraints?.isCA === true`, so the check was always falsy on renewal. A policy that denied CA issuance was silently bypassed when renewing an existing CA certificate.

Repro from the issue:

1. Create a policy with CA issuance allowed.
2. Issue a CA cert under that policy.
3. Tighten the policy to deny CA issuance.
4. Renew the existing CA cert → succeeds. The renewal still issues a CA-flagged certificate even though the active policy denies it.

The same denial fires correctly on the two other issuance paths (`certificate-v3-service.ts:1290` for direct issuance, `certificate-approval-fns.ts:393` for the approval flow), so renewal was the lone gap.

## Fix

Carry `originalCert.isCA` and `originalCert.pathLength` into the renewal `certificateRequest`. The policy's deny / allow / require + pathLength checks then run on renewal exactly the way they run on issuance.

## Not in this PR

The reporter also suggested extracting the three near-identical inline CA checks into a single shared helper so the next issuance path can't miss it. That is a sensible follow-up, but is out of scope here — keeping the fix minimal so it can land as a targeted patch.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (no existing unit tests on this service path; the policy check itself is already covered by the issuance path tests)
- [x] The change is limited to the affected code path
