### PR TITLE
fix(approval-review): block no access users

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -28,6 +28,7 @@ import { NotificationType } from "../../../services/notification/notification-ty
 import { TAccessApprovalPolicyApproverDALFactory } from "../access-approval-policy/access-approval-policy-approver-dal";
 import { TAccessApprovalPolicyDALFactory } from "../access-approval-policy/access-approval-policy-dal";
 import { TGroupDALFactory } from "../group/group-dal";
+import { flattenActiveRolesFromMemberships } from "../permission/permission-service";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import {
   ProjectPermissionApprovalRequestActions,
@@ -597,7 +598,7 @@ export const accessApprovalRequestServiceFactory = ({
         })
       : undefined;
 
-    const { hasRole } = await permissionService.getProjectPermission({
+    const { hasRole, memberships } = await permissionService.getProjectPermission({
       actor,
       actorId,
       projectId: accessApprovalRequest.projectId,
@@ -606,8 +607,14 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
-    // If the user has no access to the project, they are not authorized to review the request, even with a break-glass approval.
-    if (hasRole(ProjectMembershipRole.NoAccess)) {
+    // A user whose only active project role is NoAccess is not authorized to review the request,
+    // even with a break-glass approval. If they also hold another active role (e.g. via a group),
+    // allow the review to proceed.
+    const activeRoles = flattenActiveRolesFromMemberships(memberships, ProjectMembershipRole.Custom);
+    const hasOnlyNoAccessRole =
+      activeRoles.length > 0 && activeRoles.every((r) => r.role === ProjectMembershipRole.NoAccess);
+
+    if (hasOnlyNoAccessRole) {
       throw new ForbiddenRequestError({ message: "You are not authorized to review this request" });
     }
 

--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -621,6 +621,16 @@ export const accessApprovalRequestServiceFactory = ({
 
     const isSelfRejection = isSelfApproval && status === ApprovalStatus.REJECTED;
 
+    const isBypasser = policy.bypassers.some((bypasser) => bypasser.userId === actorId);
+
+    // Self-approval is blocked when the policy disallows it, unless this is a soft-enforcement break-glass approval and the user is on the bypasser list.
+    // this does not work for policies where all bypassers are allowed to self-approve.
+    if (isSelfApproval && status === ApprovalStatus.APPROVED && !policy.allowedSelfApprovals && !isBypasser) {
+      throw new BadRequestError({
+        message: "Failed to review access approval request. Users are not authorized to review their own request."
+      });
+    }
+
     // users can always reject (cancel) their own requests
     if (!isSelfRejection) {
       // If user is (not an approver OR cant self approve) AND can't bypass policy
@@ -636,6 +646,11 @@ export const accessApprovalRequestServiceFactory = ({
       accessApprovalRequest.requestedByUserId !== actorId && // The request wasn't made by the current user
       !isApprover // The request isn't performed by an assigned approver
     ) {
+      throw new ForbiddenRequestError({ message: "You are not authorized to approve this request" });
+    }
+
+    // If the user has no access to the project, they are not authorized to approve the request, even with a break-glass approval.
+    if (hasRole(ProjectMembershipRole.NoAccess)) {
       throw new ForbiddenRequestError({ message: "You are not authorized to approve this request" });
     }
 

--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -606,6 +606,11 @@ export const accessApprovalRequestServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
+    // If the user has no access to the project, they are not authorized to review the request, even with a break-glass approval.
+    if (hasRole(ProjectMembershipRole.NoAccess)) {
+      throw new ForbiddenRequestError({ message: "You are not authorized to review this request" });
+    }
+
     const isSelfApproval = actorId === accessApprovalRequest.requestedByUserId;
     const isSoftEnforcement = policy.enforcementLevel === EnforcementLevel.Soft;
     const canBypass = !policy.bypassers.length || policy.bypassers.some((bypasser) => bypasser.userId === actorId);
@@ -646,11 +651,6 @@ export const accessApprovalRequestServiceFactory = ({
       accessApprovalRequest.requestedByUserId !== actorId && // The request wasn't made by the current user
       !isApprover // The request isn't performed by an assigned approver
     ) {
-      throw new ForbiddenRequestError({ message: "You are not authorized to approve this request" });
-    }
-
-    // If the user has no access to the project, they are not authorized to approve the request, even with a break-glass approval.
-    if (hasRole(ProjectMembershipRole.NoAccess)) {
       throw new ForbiddenRequestError({ message: "You are not authorized to approve this request" });
     }
 

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -216,7 +216,7 @@ const isActiveRole = <U extends { isTemporary?: boolean; temporaryAccessEndTime?
   !role.isTemporary ||
   Boolean(role.isTemporary && role.temporaryAccessEndTime && new Date() < role.temporaryAccessEndTime);
 
-const flattenActiveRolesFromMemberships = <T extends string>(
+export const flattenActiveRolesFromMemberships = <T extends string>(
   memberships: MembershipWithRoles[],
   customRoleValue: T
 ): { role: string; permissions?: unknown }[] => {

--- a/docs/documentation/platform/access-controls/access-requests.mdx
+++ b/docs/documentation/platform/access-controls/access-requests.mdx
@@ -53,7 +53,9 @@ Approvals must be completed in order — Step 2 approvers cannot review until St
 
 ### Self-Approval Settings
 
-The **Self Approvals** toggle controls whether users who are designated as approvers can approve their own access requests. Disable this option to require approval from a different approver.
+The **Self Approvals** toggle controls whether designated approvers can approve their own access requests. Disable it to require a different approver.
+
+When disabled, approvers can only grant themselves access through the **Bypass Approvals** break-glass flow, and only if they are explicitly listed as bypass users or groups.
 
 ### Break-Glass (Bypass) Settings
 
@@ -66,7 +68,9 @@ The **Bypass Approvals** option enables emergency access in break-glass situatio
 ![User Bypassers](/images/platform/access-controls/access-request/user-bypassers.png)
 
 <Warning>
-  Not selecting specific users or groups for bypass will allow anyone to bypass the policy.
+  When **Bypass Approvals** is enabled and no users or groups are selected, anyone in the project can bypass the policy on their own requests.
+
+  When **Self Approvals** is disabled, approvers cannot approve their own requests through the normal workflow. They can only grant themselves access via break-glass bypass if **Bypass Approvals** is enabled and they are explicitly listed as a bypass user or group member. If no bypass users or groups are configured, self-approval is blocked entirely.
 </Warning>
 
 ## Submitting Access Requests

--- a/docs/documentation/platform/access-controls/access-requests.mdx
+++ b/docs/documentation/platform/access-controls/access-requests.mdx
@@ -68,7 +68,8 @@ The **Bypass Approvals** option enables emergency access in break-glass situatio
 ![User Bypassers](/images/platform/access-controls/access-request/user-bypassers.png)
 
 <Warning>
-  When **Bypass Approvals** is enabled and no users or groups are selected, anyone in the project can bypass the policy on their own requests.
+  When Bypass Approvals is enabled with no users or groups selected, any project member can bypass the policy on their own requests. This ensures the permission remains available without being applied automatically; it's only used when explicitly requested and bypassed. 
+  Admins are notified whenever access is bypassed.
 
   When **Self Approvals** is disabled, approvers cannot approve their own requests through the normal workflow. They can only grant themselves access via break-glass bypass if **Bypass Approvals** is enabled and they are explicitly listed as a bypass user or group member. If no bypass users or groups are configured, self-approval is blocked entirely.
 </Warning>


### PR DESCRIPTION
## Context
This fix a behavior where a user with no access role can create and approve their own request. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

### Scenario 1: no access user
- log in as an admin 
- Create an access policy and set their break glass as empty and define self approvals as true, which means that anyone can request and approve their requests. 
- log in with an account that has a no access role into the project 
- request access into an environment 
- try to accept the request 
- make sure this is not possible

### Scenario 2: member user but it was not mentioned on the breakglass  
- log in as an admin 
- Create an access policy and set their break glass as empty and define self approvals as false, which means that anyone can request access approvals, but cannot approve it by themselves. 
- log in with an account with member access 
- request access into an environment 
- try to accept it 
- make sure this is not possible

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)