### PR TITLE
feat(license-client): send org identity (name, slug, region) to entitlements call

### DIFF
--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -9,6 +9,7 @@ import { TLicenseClientFactory } from "@app/services/license-client";
 import {
   TCatalogProduct,
   TCheckoutLineItem,
+  TEntitlementOrg,
   TSubscriptionResponse
 } from "@app/services/license-client/license-client-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
@@ -261,7 +262,7 @@ export const licenseV2ServiceFactory = ({
 
   // Fold the subscription items and the entitlement features sourced from a product into a single
   // per-product entitlement map, keyed by the server's product ids.
-  const buildEntitlements = async (orgId: string, subscription: TSubscriptionResponse | null) => {
+  const buildEntitlements = async (org: TEntitlementOrg, subscription: TSubscriptionResponse | null) => {
     const entitlements: Record<string, BillingV2Entitlement> = {};
 
     if (subscription) {
@@ -284,10 +285,10 @@ export const licenseV2ServiceFactory = ({
 
     let features = null;
     try {
-      const result = await licenseClient.getEntitlements(orgId);
+      const result = await licenseClient.getEntitlements(org);
       features = result?.features ?? null;
     } catch (error) {
-      logger.error(error, `billing-v2: failed to read entitlements [orgId=${orgId}]`);
+      logger.error(error, `billing-v2: failed to read entitlements [orgId=${org.id}]`);
     }
 
     if (features) {
@@ -404,7 +405,10 @@ export const licenseV2ServiceFactory = ({
       payment,
       billingDetails,
       invoices,
-      entitlements: await buildEntitlements(orgId, subscription)
+      entitlements: await buildEntitlements(
+        { id: orgId, name: organization.name, slug: organization.slug },
+        subscription
+      )
     };
 
     return { overview };

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -229,7 +229,7 @@ export const licenseServiceFactory = ({
           if (!licenseClient) {
             throw new BadRequestError({ message: "License Server v2 client is not configured" });
           }
-          const entitlements = await licenseClient.getEntitlements(rootOrgId);
+          const entitlements = await licenseClient.getEntitlements({ id: rootOrgId, name: org.name, slug: org.slug });
           if (!entitlements) {
             throw new BadRequestError({ message: "License Server v2 entitlements are unavailable" });
           }

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -131,6 +131,7 @@ export const KeyStorePrefixes = {
   AuditLogMigrationAlert: "audit-log-migration-alert-last-row-count",
   LicenseCloudPlan: (orgId: string) => `infisical-cloud-plan-${orgId}` as const,
   LicenseEntitlements: (orgId: string) => `license-entitlements-${orgId}` as const,
+  LicenseEntitlementsIdentitySynced: (orgId: string) => `license-entitlements-identity-synced-${orgId}` as const,
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
   IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>

--- a/backend/src/services/license-client/dual-read/dual-read-service.ts
+++ b/backend/src/services/license-client/dual-read/dual-read-service.ts
@@ -25,7 +25,7 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
     }
 
     void (async () => {
-      const entitlements = await licenseClient.getEntitlements(orgId);
+      const entitlements = await licenseClient.getEntitlements({ id: orgId });
       if (!entitlements) {
         recordLicenseDualReadError({ error: new Error("v2 entitlements unavailable") });
         logger.warn(`license-dual-read: v2 entitlements unavailable [orgId=${orgId}]`);

--- a/backend/src/services/license-client/feature-reader.ts
+++ b/backend/src/services/license-client/feature-reader.ts
@@ -8,10 +8,10 @@ import {
   TLimitFeatureDescriptor
 } from "./feature";
 import { isLimitFeature, resolveFeatureValue } from "./license-client-fns";
-import { TEntitlementsResponse } from "./license-client-types";
+import { TEntitlementOrg, TEntitlementsResponse } from "./license-client-types";
 
 type TFeatureReaderDep = {
-  getEntitlements: (orgId: string) => Promise<TEntitlementsResponse | null>;
+  getEntitlements: (org: TEntitlementOrg) => Promise<TEntitlementsResponse | null>;
 };
 
 export type TFeatureReader = ReturnType<typeof featureReaderFactory>;
@@ -38,7 +38,7 @@ export const featureReaderFactory = ({ getEntitlements }: TFeatureReaderDep) => 
   });
 
   const getFeature = async <D extends TFeatureDescriptor>(orgId: string, feature: D): Promise<TFeatureResult<D>> => {
-    const entitlements = await getEntitlements(orgId);
+    const entitlements = await getEntitlements({ id: orgId });
     const value = resolveFeatureValue(feature, entitlements);
 
     if (isLimitFeature(feature)) {

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -14,6 +14,7 @@ import {
   TCloudPlanResponse,
   TCreateCheckoutPayload,
   TCreatePortalPayload,
+  TEntitlementOrg,
   TEntitlementsResponse,
   TLicenseClientBackend,
   TSessionResponse,
@@ -45,10 +46,23 @@ const mintServiceToken = (signingKey: string): string =>
     expiresIn: "2m"
   });
 
-export const licenseServerBackend = (serverUrl: string, signingKey: string): TLicenseClientBackend => ({
-  fetchEntitlements: async (orgId: string): Promise<TEntitlementsResponse> => {
+export const licenseServerBackend = (
+  serverUrl: string,
+  signingKey: string,
+  region?: string
+): TLicenseClientBackend => ({
+  fetchEntitlements: async (org: TEntitlementOrg): Promise<TEntitlementsResponse> => {
     const url = new URL(ENTITLEMENTS_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    url.searchParams.set("org_id", org.id);
+    if (org.name) {
+      url.searchParams.set("org_name", org.name);
+    }
+    if (org.slug) {
+      url.searchParams.set("org_slug", org.slug);
+    }
+    if (region) {
+      url.searchParams.set("region", region);
+    }
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },

--- a/backend/src/services/license-client/license-client-cache.ts
+++ b/backend/src/services/license-client/license-client-cache.ts
@@ -2,7 +2,7 @@ import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/
 import { withCache } from "@app/lib/cache/with-cache";
 import { logger } from "@app/lib/logger";
 
-import { TEntitlementsResponse, TLicenseClientBackend } from "./license-client-types";
+import { TEntitlementOrg, TEntitlementsResponse, TLicenseClientBackend } from "./license-client-types";
 
 type TEntitlementResolverDep = {
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
@@ -12,17 +12,47 @@ type TEntitlementResolverDep = {
 export type TEntitlementResolver = ReturnType<typeof entitlementResolverFactory>;
 
 export const entitlementResolverFactory = ({ keyStore, backend }: TEntitlementResolverDep) => {
+  const ttlSeconds = KeyStoreTtls.LicenseEntitlementsInSeconds;
+  const entitlementsCacheKey = (orgId: string) => KeyStorePrefixes.LicenseEntitlements(orgId);
+  const identitySyncedKey = (orgId: string) => KeyStorePrefixes.LicenseEntitlementsIdentitySynced(orgId);
+
+  // The license server learns an org's name/slug from whatever identity a request carries. Entitlement
+  // reads are cached per org and most callers (feature checks) send no identity, so a cached read would
+  // usually answer without reaching the server and the name/slug would never get there. So the first
+  // identity-carrying read in a cache window is sent uncached (delivering the identity); this marker then
+  // records that the window's identity has been delivered so later reads can serve from the cache again.
+  const identityNeedsSync = async (org: TEntitlementOrg): Promise<boolean> => {
+    if (!org.name && !org.slug) {
+      return false;
+    }
+    const alreadySynced = await keyStore.getItem(identitySyncedKey(org.id));
+    return !alreadySynced;
+  };
+
+  // One uncached read that carries the org's identity to the server, then primes the entitlement cache
+  // with the response and marks this window's identity as delivered.
+  const fetchForwardingIdentity = async (org: TEntitlementOrg): Promise<TEntitlementsResponse> => {
+    const entitlements = await backend.fetchEntitlements(org);
+    await keyStore.setItemWithExpiry(entitlementsCacheKey(org.id), ttlSeconds, JSON.stringify(entitlements));
+    await keyStore.setItemWithExpiry(identitySyncedKey(org.id), ttlSeconds, "1");
+    return entitlements;
+  };
+
   // Returns null on total failure so the caller falls back to the feature's declared fallback.
-  const getEntitlements = async (orgId: string): Promise<TEntitlementsResponse | null> => {
+  const getEntitlements = async (org: TEntitlementOrg): Promise<TEntitlementsResponse | null> => {
     try {
+      if (await identityNeedsSync(org)) {
+        return await fetchForwardingIdentity(org);
+      }
+
       return await withCache({
         keyStore,
-        key: KeyStorePrefixes.LicenseEntitlements(orgId),
-        ttlSeconds: KeyStoreTtls.LicenseEntitlementsInSeconds,
-        fetcher: () => backend.fetchEntitlements(orgId)
+        key: entitlementsCacheKey(org.id),
+        ttlSeconds,
+        fetcher: () => backend.fetchEntitlements(org)
       });
     } catch (error) {
-      logger.error(error, `license-client: failed to resolve entitlements [orgId=${orgId}]`);
+      logger.error(error, `license-client: failed to resolve entitlements [orgId=${org.id}]`);
       return null;
     }
   };

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -172,6 +172,8 @@ export const billingProfileResponseSchema = z
 
 export type TEntitlementFeature = z.infer<typeof entitlementFeatureSchema>;
 export type TEntitlementsResponse = z.infer<typeof entitlementsResponseSchema>;
+
+export type TEntitlementOrg = { id: string; name?: string | null; slug?: string | null };
 export type TCatalogProduct = z.infer<typeof catalogProductSchema>;
 export type TCatalogResponse = z.infer<typeof catalogResponseSchema>;
 export type TSubscriptionItem = z.infer<typeof subscriptionItemSchema>;
@@ -199,7 +201,7 @@ export type TCreatePortalPayload = {
 };
 
 export type TLicenseClientBackend = {
-  fetchEntitlements: (orgId: string) => Promise<TEntitlementsResponse>;
+  fetchEntitlements: (org: TEntitlementOrg) => Promise<TEntitlementsResponse>;
   fetchCatalog: () => Promise<TCatalogResponse>;
   fetchSubscription: (orgId: string) => Promise<TSubscriptionResponse | null>;
   fetchCloudPlan: (orgId: string) => Promise<TCloudPlanResponse | null>;

--- a/backend/src/services/license-client/license-client.test.ts
+++ b/backend/src/services/license-client/license-client.test.ts
@@ -40,17 +40,20 @@ const createFakeKeyStore = () => {
 
 const createStubBackend = (response: TEntitlementsResponse, opts: { fail?: boolean } = {}) => {
   let calls = 0;
+  const orgs: { id: string; name?: string | null; slug?: string | null }[] = [];
   return {
     backend: {
-      fetchEntitlements: async () => {
+      fetchEntitlements: async (org: { id: string; name?: string | null; slug?: string | null }) => {
         calls += 1;
+        orgs.push(org);
         if (opts.fail) {
           throw new Error("license server unreachable");
         }
         return response;
       }
     },
-    getCalls: () => calls
+    getCalls: () => calls,
+    getOrgs: () => orgs
   };
 };
 
@@ -62,11 +65,11 @@ describe("entitlementResolverFactory", () => {
     );
     const resolver = entitlementResolverFactory({ keyStore, backend });
 
-    const first = await resolver.getEntitlements(ORG_ID);
+    const first = await resolver.getEntitlements({ id: ORG_ID });
     expect(first?.features.max_identities.value).toBe(100);
     expect(getCalls()).toBe(1);
 
-    await resolver.getEntitlements(ORG_ID);
+    await resolver.getEntitlements({ id: ORG_ID });
     expect(getCalls()).toBe(1); // served from the cache
   });
 
@@ -75,7 +78,37 @@ describe("entitlementResolverFactory", () => {
     const { backend } = createStubBackend(makeEntitlements({}), { fail: true });
     const resolver = entitlementResolverFactory({ keyStore, backend });
 
-    expect(await resolver.getEntitlements(ORG_ID)).toBeNull();
+    expect(await resolver.getEntitlements({ id: ORG_ID })).toBeNull();
+  });
+
+  test("forwards org identity to the backend even after an identity-less call seeded the cache", async () => {
+    const keyStore = createFakeKeyStore();
+    const { backend, getCalls, getOrgs } = createStubBackend(
+      makeEntitlements({ max_identities: { value: 100, source: "plan" } })
+    );
+    const resolver = entitlementResolverFactory({ keyStore, backend });
+
+    await resolver.getEntitlements({ id: ORG_ID }); // feature-check style, identity-less
+    expect(getCalls()).toBe(1);
+    expect(getOrgs()[0]).toEqual({ id: ORG_ID });
+
+    await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
+    expect(getCalls()).toBe(2); // bypassed the identity-less cache entry
+    expect(getOrgs()[1]).toEqual({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
+  });
+
+  test("syncs org identity once per ttl window then serves from the cache", async () => {
+    const keyStore = createFakeKeyStore();
+    const { backend, getCalls } = createStubBackend(
+      makeEntitlements({ max_identities: { value: 100, source: "plan" } })
+    );
+    const resolver = entitlementResolverFactory({ keyStore, backend });
+
+    await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
+    expect(getCalls()).toBe(1);
+
+    await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
+    expect(getCalls()).toBe(1); // identity already synced, served from the cache
   });
 });
 
@@ -125,7 +158,8 @@ describe("licenseClientFactory (usage example)", () => {
     envConfig: {
       LICENSE_SERVER_V2_MODE: "off",
       LICENSE_SERVER_V2_URL: undefined,
-      LICENSE_SERVER_V2_SERVICE_KEY: undefined
+      LICENSE_SERVER_V2_SERVICE_KEY: undefined,
+      INTERNAL_REGION: undefined
     },
     keyStore: createFakeKeyStore()
   });

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -5,10 +5,18 @@ import { logger } from "@app/lib/logger";
 import { featureReaderFactory } from "./feature-reader";
 import { licenseServerBackend } from "./license-client-backends";
 import { entitlementResolverFactory } from "./license-client-cache";
-import { TCreateCheckoutPayload, TCreatePortalPayload, TLicenseClientBackend } from "./license-client-types";
+import {
+  TCreateCheckoutPayload,
+  TCreatePortalPayload,
+  TEntitlementOrg,
+  TLicenseClientBackend
+} from "./license-client-types";
 
 type TLicenseClientFactoryDep = {
-  envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY">;
+  envConfig: Pick<
+    TEnvConfig,
+    "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY" | "INTERNAL_REGION"
+  >;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
 };
 
@@ -44,18 +52,18 @@ const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicens
   }
 
   // The signing key is a PEM private key; env vars often carry it with escaped newlines.
-  return licenseServerBackend(serverUrl, signingKey.replace(/\\n/g, "\n"));
+  return licenseServerBackend(serverUrl, signingKey.replace(/\\n/g, "\n"), envConfig.INTERNAL_REGION);
 };
 
 export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFactoryDep) => {
   const backend = buildBackend(envConfig);
   const resolver = backend ? entitlementResolverFactory({ keyStore, backend }) : null;
 
-  const getEntitlements = async (orgId: string) => {
+  const getEntitlements = async (org: TEntitlementOrg) => {
     if (!resolver) {
       return null;
     }
-    return resolver.getEntitlements(orgId);
+    return resolver.getEntitlements(org);
   };
 
   const getCatalog = async () => {


### PR DESCRIPTION
## Context

The License Server populates an org directory from the entitlements call; this sends the org identity it needs. Also refactors the v2 entitlements client to take a single org-like object so future fields are additive instead of new positional params.

- `getEntitlements`/`fetchEntitlements` now take `{ id; name?; slug? }` (only `id` required)
- Send `org_name`, `org_slug` (per-org) and `region` (from `INTERNAL_REGION`, baked into the backend at construction) on `GET /v1/entitlements`
- v1/legacy path untouched; entire path only active when `LICENSE_SERVER_V2_MODE != off`

## Steps to verify the change

- Differential `tsc --noEmit` over the backend: identical error count with and without this change, none in the changed files (this change introduces no new type errors).
- With `LICENSE_SERVER_V2_MODE != off`, an org reading entitlements produces a `GET /v1/entitlements?org_id=&org_name=&org_slug=&region=` request to the License Server.

## Type

- [x] Feature

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (typecheck; see steps above)
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)