### PR TITLE
fix(gcp): resolve AWS workload identity federation on Fargate/Lambda/EKS

### DIFF
--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -4,6 +4,7 @@ import { GetAccessTokenResponse } from "google-auth-library/build/src/auth/oauth
 import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
+import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { buildGcpSourceCredential } from "@app/services/app-connection/gcp/gcp-connection-fns";
 
@@ -37,13 +38,13 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
     try {
       tokenResponse = await impersonatedCredentials.getAccessToken();
     } catch (error) {
-      let message = "Unable to validate connection";
-      if (error instanceof gaxios.GaxiosError) {
-        message = error.message;
-      }
+      logger.error(
+        { err: error },
+        `Failed to obtain GCP impersonated access token [serviceAccountEmail=${serviceAccountEmail}]`
+      );
 
       throw new BadRequestError({
-        message
+        message: error instanceof gaxios.GaxiosError ? error.message : "Unable to validate connection"
       });
     }
 

--- a/backend/src/services/app-connection/gcp/gcp-connection-fns.test.ts
+++ b/backend/src/services/app-connection/gcp/gcp-connection-fns.test.ts
@@ -1,0 +1,73 @@
+import { AwsClient, JWT } from "google-auth-library";
+
+import { buildGcpSourceCredential } from "./gcp-connection-fns";
+
+// A workload-identity-federation config as downloaded from GCP for an AWS provider. Note the
+// `credential_source` pointing at the EC2 metadata endpoint (169.254.169.254) - the address that is
+// unreachable on ECS Fargate / Lambda / EKS and produced the original "unable to impersonate" error.
+const awsExternalAccountJson = JSON.stringify({
+  type: "external_account",
+  audience:
+    "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/test-pool/providers/aws-provider",
+  subject_token_type: "urn:ietf:params:aws:token-type:aws4_request",
+  token_url: "https://sts.googleapis.com/v1/token",
+  service_account_impersonation_url:
+    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/broker@proj.iam.gserviceaccount.com:generateAccessToken",
+  credential_source: {
+    environment_id: "aws1",
+    region_url: "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+    url: "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+    regional_cred_verification_url: "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+    imdsv2_session_token_url: "http://169.254.169.254/latest/api/token"
+  }
+});
+
+const serviceAccountKeyJson = JSON.stringify({
+  type: "service_account",
+  client_email: "sa@proj.iam.gserviceaccount.com",
+  // Test-only RSA key (not a real credential).
+  private_key:
+    "-----BEGIN PRIVATE KEY-----\nMIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAuKKMfyqM\n-----END PRIVATE KEY-----\n"
+});
+
+describe("buildGcpSourceCredential", () => {
+  const AWS_ENV_KEYS = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_REGION"];
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    AWS_ENV_KEYS.forEach((key) => {
+      savedEnv[key] = process.env[key];
+    });
+  });
+
+  afterEach(() => {
+    AWS_ENV_KEYS.forEach((key) => {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    });
+  });
+
+  it("sources AWS credentials via the AWS SDK chain (never the EC2 metadata endpoint) for AWS external_account configs", async () => {
+    // Simulate the instance's AWS identity being resolvable without metadata (as on Fargate, where the
+    // container provider resolves credentials). If the client fell back to the EC2 metadata default, this
+    // call would instead try to connect to 169.254.169.254 and fail.
+    process.env.AWS_ACCESS_KEY_ID = "AKIATESTEXAMPLE";
+    process.env.AWS_SECRET_ACCESS_KEY = "secretexample";
+    process.env.AWS_SESSION_TOKEN = "sessiontoken";
+    process.env.AWS_REGION = "us-east-1";
+
+    const client = buildGcpSourceCredential(awsExternalAccountJson);
+    expect(client).toBeInstanceOf(AwsClient);
+
+    // retrieveSubjectToken() resolves credentials through the supplier and signs the STS request locally.
+    // It completes offline here precisely because credentials come from the SDK chain, not metadata.
+    const subjectToken = await (client as AwsClient).retrieveSubjectToken();
+    expect(typeof subjectToken).toBe("string");
+    expect(subjectToken.length).toBeGreaterThan(0);
+  });
+
+  it("builds a JWT client for service-account-key credentials", () => {
+    const client = buildGcpSourceCredential(serviceAccountKeyJson);
+    expect(client).toBeInstanceOf(JWT);
+  });
+});

--- a/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
+++ b/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
@@ -1,9 +1,12 @@
-import { ExternalAccountClient, gaxios, Impersonated, JWT } from "google-auth-library";
+import { STSClient } from "@aws-sdk/client-sts";
+import { AwsClient, ExternalAccountClient, gaxios, Impersonated, JWT } from "google-auth-library";
 import { GetAccessTokenResponse } from "google-auth-library/build/src/auth/oauth2client";
+import RE2 from "re2";
 
 import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
+import { logger } from "@app/lib/logger";
 import { getAppConnectionMethodName } from "@app/services/app-connection/app-connection-fns";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 
@@ -27,16 +30,61 @@ export const getGcpConnectionListItem = () => {
   };
 };
 
+type TGcpCredentialJson = {
+  type?: string;
+  client_email?: string;
+  private_key?: string;
+  subject_token_type?: string;
+  credential_source?: { environment_id?: string };
+};
+
+const AWS_ENV_ID_REGEX = new RE2(/^aws\d+$/i);
+
+// AWS federation configs default `credential_source` to the EC2 metadata endpoint, which
+// is absent on Fargate/Lambda/EKS. Detect them so we can source creds via the AWS SDK chain instead.
+const isAwsExternalAccount = (credJson: TGcpCredentialJson) =>
+  credJson.subject_token_type === "urn:ietf:params:aws:token-type:aws4_request" ||
+  AWS_ENV_ID_REGEX.test(credJson.credential_source?.environment_id ?? "");
+
+const buildGcpAwsExternalAccountClient = (credJson: TGcpCredentialJson, scopes: string[]) => {
+  // Resolve AWS creds via the SDK default chain.
+  const stsClient = new STSClient({});
+
+  const awsSecurityCredentialsSupplier = {
+    getAwsRegion: async () => {
+      try {
+        return await stsClient.config.region();
+      } catch {
+        return "us-east-1";
+      }
+    },
+    getAwsSecurityCredentials: async () => {
+      const credentials = await stsClient.config.credentials();
+      return {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        token: credentials.sessionToken
+      };
+    }
+  };
+
+  // credential_source and aws_security_credentials_supplier are mutually exclusive; drop the metadata source.
+  const awsClientOptions = { ...credJson, scopes, aws_security_credentials_supplier: awsSecurityCredentialsSupplier };
+  delete awsClientOptions.credential_source;
+
+  return new AwsClient(awsClientOptions as unknown as ConstructorParameters<typeof AwsClient>[0]);
+};
+
 export const buildGcpSourceCredential = (credentialJson: string) => {
   const scopes = ["https://www.googleapis.com/auth/cloud-platform"];
 
-  const credJson = JSON.parse(credentialJson) as {
-    type?: string;
-    client_email?: string;
-    private_key?: string;
-  };
+  const credJson = JSON.parse(credentialJson) as TGcpCredentialJson;
 
   if (credJson.type === "external_account") {
+    if (isAwsExternalAccount(credJson)) {
+      return buildGcpAwsExternalAccountClient(credJson, scopes);
+    }
+
     const externalClient = ExternalAccountClient.fromJSON({
       ...credJson,
       scopes
@@ -83,13 +131,13 @@ export const getGcpConnectionAuthToken = async (appConnection: TGcpConnectionCon
   try {
     tokenResponse = await impersonatedCredentials.getAccessToken();
   } catch (error) {
-    let message = "Unable to validate connection";
-    if (error instanceof gaxios.GaxiosError) {
-      message = error.message;
-    }
+    logger.error(
+      { err: error },
+      `Failed to obtain GCP impersonated access token [serviceAccountEmail=${appConnection.credentials.serviceAccountEmail}]`
+    );
 
     throw new BadRequestError({
-      message
+      message: error instanceof gaxios.GaxiosError ? error.message : "Unable to validate connection"
     });
   }
 

--- a/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
+++ b/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
@@ -59,7 +59,16 @@ const buildGcpAwsExternalAccountClient = (credJson: TGcpCredentialJson, scopes: 
       }
     },
     getAwsSecurityCredentials: async () => {
-      const credentials = await stsClient.config.credentials();
+      let credentials;
+      try {
+        credentials = await stsClient.config.credentials();
+      } catch (error) {
+        logger.error({ err: error }, "Failed to resolve AWS credentials for GCP workload identity federation");
+        throw new InternalServerError({
+          message:
+            "Failed to resolve AWS credentials for GCP workload identity federation. Verify the instance has valid AWS credentials available (task role, instance profile, or environment variables)."
+        });
+      }
       return {
         accessKeyId: credentials.accessKeyId,
         secretAccessKey: credentials.secretAccessKey,

--- a/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
+++ b/backend/src/services/app-connection/gcp/gcp-connection-fns.ts
@@ -40,6 +40,16 @@ type TGcpCredentialJson = {
 
 const AWS_ENV_ID_REGEX = new RE2(/^aws\d+$/i);
 
+// Lazily initialized so the SDK doesn't probe for AWS metadata on non-AWS instances at startup.
+// Shared across calls so the SDK's internal credential cache persists.
+let sharedStsClient: STSClient | undefined;
+const getStsClient = () => {
+  if (!sharedStsClient) {
+    sharedStsClient = new STSClient({});
+  }
+  return sharedStsClient;
+};
+
 // AWS federation configs default `credential_source` to the EC2 metadata endpoint, which
 // is absent on Fargate/Lambda/EKS. Detect them so we can source creds via the AWS SDK chain instead.
 const isAwsExternalAccount = (credJson: TGcpCredentialJson) =>
@@ -47,8 +57,7 @@ const isAwsExternalAccount = (credJson: TGcpCredentialJson) =>
   AWS_ENV_ID_REGEX.test(credJson.credential_source?.environment_id ?? "");
 
 const buildGcpAwsExternalAccountClient = (credJson: TGcpCredentialJson, scopes: string[]) => {
-  // Resolve AWS creds via the SDK default chain.
-  const stsClient = new STSClient({});
+  const stsClient = getStsClient();
 
   const awsSecurityCredentialsSupplier = {
     getAwsRegion: async () => {

--- a/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
@@ -50,12 +50,16 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
                 Workload identity federation is also supported. Instead of a service account key, you may
                 set `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` to an `external_account` credential
                 configuration JSON (the file produced by `gcloud iam workload-identity-pools create-cred-config`).
-                Infisical detects the credential type from the `type` field automatically.
+                Infisical detects the credential type from the `type` field automatically. The federated identity
+                needs the `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
 
-                Because an `external_account` config does not contain a secret but instead references a
-                credential source (a mounted file, a URL, or a metadata endpoint), that source must be
-                reachable from the Infisical instance at runtime. The federated identity also needs the
-                `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
+                For **AWS** providers, Infisical resolves the instance's AWS credentials through the standard AWS
+                SDK credential chain, so federation works on EC2, ECS/Fargate, EKS (IRSA), and Lambda, or from
+                `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables. The region defaults to
+                `us-east-1`; set `AWS_REGION` (or `AWS_DEFAULT_REGION`) to use a specific regional STS endpoint.
+
+                For other providers, the referenced credential source (a mounted file or URL) must be reachable
+                from the Infisical instance at runtime.
             </Note>
         </Step>
     </Steps>

--- a/docs/integrations/app-connections/gcp.mdx
+++ b/docs/integrations/app-connections/gcp.mdx
@@ -48,12 +48,16 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
                 Workload identity federation is also supported. Instead of a service account key, you may
                 set `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` to an `external_account` credential
                 configuration JSON (the file produced by `gcloud iam workload-identity-pools create-cred-config`).
-                Infisical detects the credential type from the `type` field automatically.
+                Infisical detects the credential type from the `type` field automatically. The federated identity
+                needs the `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
 
-                Because an `external_account` config does not contain a secret but instead references a
-                credential source (a mounted file, a URL, or a metadata endpoint), that source must be
-                reachable from the Infisical instance at runtime. The federated identity also needs the
-                `roles/iam.serviceAccountTokenCreator` role on the service accounts it impersonates.
+                For **AWS** providers, Infisical resolves the instance's AWS credentials through the standard AWS
+                SDK credential chain, so federation works on EC2, ECS/Fargate, EKS (IRSA), and Lambda, or from
+                `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables. The region defaults to
+                `us-east-1`; set `AWS_REGION` (or `AWS_DEFAULT_REGION`) to use a specific regional STS endpoint.
+
+                For other providers, the referenced credential source (a mounted file or URL) must be reachable
+                from the Infisical instance at runtime.
             </Note>
         </Step>
     </Steps>


### PR DESCRIPTION
## Context

AWS `external_account` GCP configs default to the EC2 metadata endpoint (`169.254.169.254`), which is unreachable on Fargate, Lambda, and EKS. That caused GCP app connections and GCP IAM dynamic secrets to fail during impersonation.

This PR detects AWS federation configs and uses `AwsClient` with the AWS SDK credential chain (task role, IRSA, instance profile, or env vars) instead of metadata. Adds error logging for impersonation failures and updates GCP docs.

## Steps to verify the change

1. On AWS (Fargate/EKS/Lambda), set `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL` to an AWS `external_account` JSON and validate a GCP app connection.
2. Confirm service account keys and non-AWS federation configs still work.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)