### PR TITLE
fix: address certificate profile defaults behavior

### DIFF
--- a/backend/src/server/routes/v1/certificate-router.ts
+++ b/backend/src/server/routes/v1/certificate-router.ts
@@ -348,8 +348,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
       };
 
       // Only include subject fields when explicitly provided (null or string).
-      // Omitting the key lets applyProfileDefaults use the profile default.
-      // Sending null (converted to undefined here) signals "clear the default".
+      // applyProfileDefaults uses profile defaults when request values are empty/undefined.
       const subjectFields = [
         "commonName",
         "organization",

--- a/backend/src/server/routes/v1/certificate-router.ts
+++ b/backend/src/server/routes/v1/certificate-router.ts
@@ -348,7 +348,8 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
       };
 
       // Only include subject fields when explicitly provided (null or string).
-      // applyProfileDefaults uses profile defaults when request values are empty/undefined.
+      // Omitting the key lets applyProfileDefaults use the profile default.
+      // Sending null (converted to undefined here) signals "clear the default".
       const subjectFields = [
         "commonName",
         "organization",

--- a/backend/src/services/certificate-common/certificate-csr-utils.ts
+++ b/backend/src/services/certificate-common/certificate-csr-utils.ts
@@ -20,19 +20,24 @@ import { mapLegacyExtendedKeyUsageToStandard, mapLegacyKeyUsageToStandard } from
  * Extracts certificate request data from a CSR string
  * @param csr - The CSR in PEM format
  * @returns TCertificateRequest object with parsed CSR data
+ *
+ * Note: Only includes keys for fields that are actually present in the CSR.
+ * This allows applyProfileDefaults to correctly apply defaults for missing fields
+ * (e.g., ACME clients like CertBot often omit CN, putting domain only in SAN).
  */
 export const extractCertificateRequestFromCSR = (csr: string): TCertificateRequest => {
   const csrObj = new x509.Pkcs10CertificateRequest(csr);
   const subject = extractDnParts(csrObj.subjectName);
 
-  const certificateRequest: TCertificateRequest = {
-    commonName: subject.commonName,
-    organization: subject.organization,
-    organizationalUnit: subject.ou,
-    locality: subject.locality,
-    state: subject.province,
-    country: subject.country
-  };
+  // Only include keys for fields that have values, so applyProfileDefaults
+  // can distinguish "absent" (use default) from "explicitly set".
+  const certificateRequest: TCertificateRequest = {};
+  if (subject.commonName) certificateRequest.commonName = subject.commonName;
+  if (subject.organization) certificateRequest.organization = subject.organization;
+  if (subject.ou) certificateRequest.organizationalUnit = subject.ou;
+  if (subject.locality) certificateRequest.locality = subject.locality;
+  if (subject.province) certificateRequest.state = subject.province;
+  if (subject.country) certificateRequest.country = subject.country;
 
   const csrKeyUsageExtension = csrObj.getExtension("2.5.29.15") as x509.KeyUsagesExtension;
   if (csrKeyUsageExtension) {

--- a/backend/src/services/certificate-v3/certificate-v3-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-fns.ts
@@ -105,7 +105,7 @@ export const resolveEffectiveTtl = ({
 /**
  * Applies profile defaults to certificate request
  * Request values always take precedence over defaults.
- * For string fields (subject DN components), use default if request value is empty/undefined.
+ * For scalar fields, key-presence distinguishes "omitted" (use default) from "explicitly set/cleared".
  * For keyUsages/extendedKeyUsages/basicConstraints, replace strategy: request array wins entirely if present.
  */
 export const applyProfileDefaults = <
@@ -128,17 +128,17 @@ export const applyProfileDefaults = <
 ): T => {
   if (!defaults) return request;
 
-  // For string fields (subject DN components), use default if request value is empty/undefined.
-  // This allows profile defaults to be injected when CSR doesn't contain these fields
-  // (e.g., ACME clients like CertBot often omit CN, putting domain only in SAN).
+  // For scalar fields, key-presence distinguishes "omitted" (use default) from "explicitly set/cleared".
+  // CSR extraction (extractCertificateRequestFromCSR) omits keys for absent fields,
+  // while API routes include keys with undefined values for explicitly cleared fields.
   return {
     ...request,
-    commonName: request.commonName || defaults.commonName,
-    organization: request.organization || defaults.organization,
-    organizationalUnit: request.organizationalUnit || defaults.organizationalUnit,
-    country: request.country || defaults.country,
-    state: request.state || defaults.state,
-    locality: request.locality || defaults.locality,
+    commonName: "commonName" in request ? request.commonName : defaults.commonName,
+    organization: "organization" in request ? request.organization : defaults.organization,
+    organizationalUnit: "organizationalUnit" in request ? request.organizationalUnit : defaults.organizationalUnit,
+    country: "country" in request ? request.country : defaults.country,
+    state: "state" in request ? request.state : defaults.state,
+    locality: "locality" in request ? request.locality : defaults.locality,
     keyAlgorithm: "keyAlgorithm" in request ? request.keyAlgorithm : defaults.keyAlgorithm,
     signatureAlgorithm: "signatureAlgorithm" in request ? request.signatureAlgorithm : defaults.signatureAlgorithm,
     keyUsages: request.keyUsages !== undefined ? request.keyUsages : defaults.keyUsages,

--- a/backend/src/services/certificate-v3/certificate-v3-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-fns.ts
@@ -105,6 +105,7 @@ export const resolveEffectiveTtl = ({
 /**
  * Applies profile defaults to certificate request
  * Request values always take precedence over defaults.
+ * For string fields (subject DN components), use default if request value is empty/undefined.
  * For keyUsages/extendedKeyUsages/basicConstraints, replace strategy: request array wins entirely if present.
  */
 export const applyProfileDefaults = <
@@ -127,17 +128,19 @@ export const applyProfileDefaults = <
 ): T => {
   if (!defaults) return request;
 
-  // For scalar fields, key-presence distinguishes "omitted" (use default) from "explicitly set/cleared".
+  // For string fields (subject DN components), use default if request value is empty/undefined.
+  // This allows profile defaults to be injected when CSR doesn't contain these fields
+  // (e.g., ACME clients like CertBot often omit CN, putting domain only in SAN).
   return {
     ...request,
-    commonName: "commonName" in request ? request.commonName : defaults.commonName,
-    organization: "organization" in request ? request.organization : defaults.organization,
-    organizationalUnit: "organizationalUnit" in request ? request.organizationalUnit : defaults.organizationalUnit,
-    country: "country" in request ? request.country : defaults.country,
-    state: "state" in request ? request.state : defaults.state,
-    locality: "locality" in request ? request.locality : defaults.locality,
-    keyAlgorithm: "keyAlgorithm" in request ? request.keyAlgorithm : defaults.keyAlgorithm,
-    signatureAlgorithm: "signatureAlgorithm" in request ? request.signatureAlgorithm : defaults.signatureAlgorithm,
+    commonName: request.commonName || defaults.commonName,
+    organization: request.organization || defaults.organization,
+    organizationalUnit: request.organizationalUnit || defaults.organizationalUnit,
+    country: request.country || defaults.country,
+    state: request.state || defaults.state,
+    locality: request.locality || defaults.locality,
+    keyAlgorithm: request.keyAlgorithm || defaults.keyAlgorithm,
+    signatureAlgorithm: request.signatureAlgorithm || defaults.signatureAlgorithm,
     keyUsages: request.keyUsages !== undefined ? request.keyUsages : defaults.keyUsages,
     extendedKeyUsages: request.extendedKeyUsages !== undefined ? request.extendedKeyUsages : defaults.extendedKeyUsages,
     basicConstraints: request.basicConstraints !== undefined ? request.basicConstraints : defaults.basicConstraints

--- a/backend/src/services/certificate-v3/certificate-v3-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-fns.ts
@@ -139,8 +139,8 @@ export const applyProfileDefaults = <
     country: request.country || defaults.country,
     state: request.state || defaults.state,
     locality: request.locality || defaults.locality,
-    keyAlgorithm: request.keyAlgorithm || defaults.keyAlgorithm,
-    signatureAlgorithm: request.signatureAlgorithm || defaults.signatureAlgorithm,
+    keyAlgorithm: "keyAlgorithm" in request ? request.keyAlgorithm : defaults.keyAlgorithm,
+    signatureAlgorithm: "signatureAlgorithm" in request ? request.signatureAlgorithm : defaults.signatureAlgorithm,
     keyUsages: request.keyUsages !== undefined ? request.keyUsages : defaults.keyUsages,
     extendedKeyUsages: request.extendedKeyUsages !== undefined ? request.extendedKeyUsages : defaults.extendedKeyUsages,
     basicConstraints: request.basicConstraints !== undefined ? request.basicConstraints : defaults.basicConstraints


### PR DESCRIPTION
## Context
This PR ensures that certificate profile defaults are applied correctly when values aren't explicitly passed in 

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)