### PR TITLE
feat(pam): implement MFA access flow for accounts

### DIFF
--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -297,7 +297,7 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
           .trim()
           .optional()
           .describe("Session duration (e.g. '1h', '30m'). Capped at the account's max session duration."),
-        mfaSessionId: z.string().optional().describe("MFA session ID from a completed MFA verification")
+        mfaSessionId: z.string().max(64).optional().describe("MFA session ID from a completed MFA verification")
       }),
       response: {
         200: z.object({
@@ -394,7 +394,7 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
       }),
       body: z.object({
         reason: z.string().trim().max(1000).optional().describe("Optional reason for the session"),
-        mfaSessionId: z.string().optional().describe("MFA session ID from a completed MFA verification")
+        mfaSessionId: z.string().max(64).optional().describe("MFA session ID from a completed MFA verification")
       }),
       response: {
         200: z.object({ ticket: z.string() })

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -296,7 +296,8 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
           .string()
           .trim()
           .optional()
-          .describe("Session duration (e.g. '1h', '30m'). Capped at the account's max session duration.")
+          .describe("Session duration (e.g. '1h', '30m'). Capped at the account's max session duration."),
+        mfaSessionId: z.string().optional().describe("MFA session ID from a completed MFA verification")
       }),
       response: {
         200: z.object({
@@ -333,7 +334,8 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
         actorIp: req.realIp ?? "",
         actorUserAgent: req.headers["user-agent"] ?? "",
         reason: req.body.reason,
-        duration: req.body.duration
+        duration: req.body.duration,
+        mfaSessionId: req.body.mfaSessionId
       });
 
       await server.services.auditLog.createAuditLog({
@@ -391,7 +393,8 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
         accountId: z.string().uuid().describe("The ID of the account")
       }),
       body: z.object({
-        reason: z.string().trim().max(1000).optional().describe("Optional reason for the session")
+        reason: z.string().trim().max(1000).optional().describe("Optional reason for the session"),
+        mfaSessionId: z.string().optional().describe("MFA session ID from a completed MFA verification")
       }),
       response: {
         200: z.object({ ticket: z.string() })
@@ -411,7 +414,8 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
         actorEmail: req.auth.user.email ?? "",
         actorName: `${req.auth.user.firstName ?? ""} ${req.auth.user.lastName ?? ""}`.trim(),
         auditLogInfo: req.auditLogInfo,
-        reason: req.body.reason
+        reason: req.body.reason,
+        mfaSessionId: req.body.mfaSessionId
       });
 
       return { ticket };

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -11,17 +11,17 @@ import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
-import { ActorType, MfaMethod } from "@app/services/auth/auth-type";
+import { ActorType } from "@app/services/auth/auth-type";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TMfaSessionServiceFactory } from "@app/services/mfa-session/mfa-session-service";
-import { MfaSessionStatus } from "@app/services/mfa-session/mfa-session-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { PamAccessMethod, PamAccountType, PamSessionStatus } from "../pam/pam-enums";
+import { enforceMfa } from "../pam/pam-mfa";
 import {
   checkAccountAccess,
   getResourceIdsWithActions,
@@ -322,42 +322,11 @@ export const pamSessionServiceFactory = ({
       });
     }
 
-    if (policy.requireMfa && !mfaSessionId) {
-      const org = await orgDAL.findOrgById(actor.actorOrgId);
-      const user = await userDAL.findById(actor.actorId);
-
-      const orgMfaMethod = org?.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
-      const userMfaMethod = user?.isMfaEnabled ? (user.selectedMfaMethod as MfaMethod | null) : undefined;
-      const mfaMethod = (orgMfaMethod ?? userMfaMethod ?? MfaMethod.EMAIL) as MfaMethod;
-
-      const newMfaSessionId = await mfaSessionService.createMfaSession(actor.actorId, account.id, mfaMethod);
-
-      if (mfaMethod === MfaMethod.EMAIL && actorEmail) {
-        await mfaSessionService.sendMfaCode(actor.actorId, actorEmail);
-      }
-
-      throw new BadRequestError({
-        name: "SESSION_MFA_REQUIRED",
-        message: "MFA verification required to access this account",
-        details: { mfaSessionId: newMfaSessionId, mfaMethod }
-      });
-    }
-
-    if (policy.requireMfa && mfaSessionId) {
-      const mfaSession = await mfaSessionService.getMfaSession(mfaSessionId);
-      if (!mfaSession) {
-        throw new BadRequestError({ message: "MFA session not found or expired" });
-      }
-      if (mfaSession.userId !== actor.actorId) {
-        throw new BadRequestError({ message: "MFA session does not belong to current user" });
-      }
-      if (mfaSession.resourceId !== account.id) {
-        throw new BadRequestError({ message: "MFA session is for a different account" });
-      }
-      if (mfaSession.status !== MfaSessionStatus.ACTIVE) {
-        throw new BadRequestError({ message: "MFA session is not verified. Please complete MFA verification first." });
-      }
-      await mfaSessionService.deleteMfaSession(mfaSessionId);
+    if (policy.requireMfa) {
+      await enforceMfa(
+        { mfaSessionService, orgDAL, userDAL },
+        { userId: actor.actorId, orgId: actor.actorOrgId, actorEmail, accountId: account.id, mfaSessionId }
+      );
     }
 
     const maxDurationMs = policy.maxSessionDurationSeconds

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -11,11 +11,14 @@ import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
-import { ActorType } from "@app/services/auth/auth-type";
+import { ActorType, MfaMethod } from "@app/services/auth/auth-type";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
+import { TMfaSessionServiceFactory } from "@app/services/mfa-session/mfa-session-service";
+import { MfaSessionStatus } from "@app/services/mfa-session/mfa-session-types";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { PamAccessMethod, PamAccountType, PamSessionStatus } from "../pam/pam-enums";
@@ -57,6 +60,11 @@ type TPamSessionServiceFactoryDep = {
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
   userDAL: Pick<TUserDALFactory, "findById">;
   pamSessionExpirationService: Pick<TPamSessionExpirationServiceFactory, "scheduleSessionExpiration">;
+  mfaSessionService: Pick<
+    TMfaSessionServiceFactory,
+    "createMfaSession" | "getMfaSession" | "deleteMfaSession" | "sendMfaCode"
+  >;
+  orgDAL: Pick<TOrgDALFactory, "findOrgById">;
 };
 
 export type TPamSessionServiceFactory = ReturnType<typeof pamSessionServiceFactory>;
@@ -72,7 +80,9 @@ export const pamSessionServiceFactory = ({
   gatewayV2Service,
   gatewayPoolService,
   userDAL,
-  pamSessionExpirationService
+  pamSessionExpirationService,
+  mfaSessionService,
+  orgDAL
 }: TPamSessionServiceFactoryDep) => {
   const decrypt = async (projectId: string, blob: Buffer): Promise<Record<string, unknown>> => {
     const { decryptor } = await kmsService.createCipherPairWithDataKey({ type: KmsDataKey.SecretManager, projectId });
@@ -277,7 +287,8 @@ export const pamSessionServiceFactory = ({
     actorIp,
     actorUserAgent,
     reason,
-    duration
+    duration,
+    mfaSessionId
   }: {
     path: string;
     projectId: string;
@@ -288,19 +299,65 @@ export const pamSessionServiceFactory = ({
     actorUserAgent: string;
     reason?: string;
     duration?: string;
+    mfaSessionId?: string;
   }) => {
     const account = await resolveAccountByPath(projectId, path);
+
+    await checkAccount(
+      account.id,
+      account.folderId,
+      projectId,
+      ResourcePermissionPamResourceActions.LaunchSessions,
+      actor
+    );
 
     const trimmedReason = reason?.trim() || null;
 
     const policy = resolveAccessControls(account.templatePolicies);
 
     if (policy.requireReason && !trimmedReason) {
-      throw new BadRequestError({ message: "A reason is required to access this account" });
+      throw new BadRequestError({
+        name: "PAM_REASON_REQUIRED",
+        message: "A reason is required to access this account"
+      });
     }
 
-    if (policy.requireMfa) {
-      throw new BadRequestError({ message: "MFA verification is required to access this account" });
+    if (policy.requireMfa && !mfaSessionId) {
+      const org = await orgDAL.findOrgById(actor.actorOrgId);
+      const user = await userDAL.findById(actor.actorId);
+
+      const orgMfaMethod = org?.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
+      const userMfaMethod = user?.isMfaEnabled ? (user.selectedMfaMethod as MfaMethod | null) : undefined;
+      const mfaMethod = (orgMfaMethod ?? userMfaMethod ?? MfaMethod.EMAIL) as MfaMethod;
+
+      const newMfaSessionId = await mfaSessionService.createMfaSession(actor.actorId, account.id, mfaMethod);
+
+      if (mfaMethod === MfaMethod.EMAIL && actorEmail) {
+        await mfaSessionService.sendMfaCode(actor.actorId, actorEmail);
+      }
+
+      throw new BadRequestError({
+        name: "SESSION_MFA_REQUIRED",
+        message: "MFA verification required to access this account",
+        details: { mfaSessionId: newMfaSessionId, mfaMethod }
+      });
+    }
+
+    if (policy.requireMfa && mfaSessionId) {
+      const mfaSession = await mfaSessionService.getMfaSession(mfaSessionId);
+      if (!mfaSession) {
+        throw new BadRequestError({ message: "MFA session not found or expired" });
+      }
+      if (mfaSession.userId !== actor.actorId) {
+        throw new BadRequestError({ message: "MFA session does not belong to current user" });
+      }
+      if (mfaSession.resourceId !== account.id) {
+        throw new BadRequestError({ message: "MFA session is for a different account" });
+      }
+      if (mfaSession.status !== MfaSessionStatus.ACTIVE) {
+        throw new BadRequestError({ message: "MFA session is not verified. Please complete MFA verification first." });
+      }
+      await mfaSessionService.deleteMfaSession(mfaSessionId);
     }
 
     const maxDurationMs = policy.maxSessionDurationSeconds
@@ -315,14 +372,6 @@ export const pamSessionServiceFactory = ({
       }
       sessionDurationMs = Math.min(parsed, maxDurationMs);
     }
-
-    await checkAccount(
-      account.id,
-      account.folderId,
-      projectId,
-      ResourcePermissionPamResourceActions.LaunchSessions,
-      actor
-    );
 
     const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({
       gatewayId: account.gatewayId ?? account.templateGatewayId,

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -6,6 +6,7 @@ import { AuditLogInfo, EventType, TAuditLogServiceFactory } from "@app/ee/servic
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { PamAccountType } from "@app/ee/services/pam/pam-enums";
+import { enforceMfa } from "@app/ee/services/pam/pam-mfa";
 import { resolveAccessControls } from "@app/ee/services/pam/pam-policies";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ResourcePermissionPamResourceActions } from "@app/ee/services/permission/resource-permission";
@@ -13,13 +14,12 @@ import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection, setupRelayServer } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
-import { ActorType, MfaMethod } from "@app/services/auth/auth-type";
+import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TMfaSessionServiceFactory } from "@app/services/mfa-session/mfa-session-service";
-import { MfaSessionStatus } from "@app/services/mfa-session/mfa-session-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
@@ -173,42 +173,11 @@ export const pamWebAccessServiceFactory = ({
       });
     }
 
-    if (policy.requireMfa && !mfaSessionId) {
-      const org = await orgDAL.findOrgById(actor.orgId);
-      const user = await userDAL.findById(actor.id);
-
-      const orgMfaMethod = org?.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
-      const userMfaMethod = user?.isMfaEnabled ? (user.selectedMfaMethod as MfaMethod | null) : undefined;
-      const mfaMethod = (orgMfaMethod ?? userMfaMethod ?? MfaMethod.EMAIL) as MfaMethod;
-
-      const newMfaSessionId = await mfaSessionService.createMfaSession(actor.id, account.id, mfaMethod);
-
-      if (mfaMethod === MfaMethod.EMAIL && actorEmail) {
-        await mfaSessionService.sendMfaCode(actor.id, actorEmail);
-      }
-
-      throw new BadRequestError({
-        name: "SESSION_MFA_REQUIRED",
-        message: "MFA verification required to access this account",
-        details: { mfaSessionId: newMfaSessionId, mfaMethod }
-      });
-    }
-
-    if (policy.requireMfa && mfaSessionId) {
-      const mfaSession = await mfaSessionService.getMfaSession(mfaSessionId);
-      if (!mfaSession) {
-        throw new BadRequestError({ message: "MFA session not found or expired" });
-      }
-      if (mfaSession.userId !== actor.id) {
-        throw new BadRequestError({ message: "MFA session does not belong to current user" });
-      }
-      if (mfaSession.resourceId !== account.id) {
-        throw new BadRequestError({ message: "MFA session is for a different account" });
-      }
-      if (mfaSession.status !== MfaSessionStatus.ACTIVE) {
-        throw new BadRequestError({ message: "MFA session is not verified. Please complete MFA verification first." });
-      }
-      await mfaSessionService.deleteMfaSession(mfaSessionId);
+    if (policy.requireMfa) {
+      await enforceMfa(
+        { mfaSessionService, orgDAL, userDAL },
+        { userId: actor.id, orgId: actor.orgId, actorEmail, accountId: account.id, mfaSessionId }
+      );
     }
 
     const maxSessionDurationMs = policy.maxSessionDurationSeconds

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -13,11 +13,14 @@ import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
 import { createGatewayConnection, createRelayConnection, setupRelayServer } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
-import { ActorType } from "@app/services/auth/auth-type";
+import { ActorType, MfaMethod } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
+import { TMfaSessionServiceFactory } from "@app/services/mfa-session/mfa-session-service";
+import { MfaSessionStatus } from "@app/services/mfa-session/mfa-session-types";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { PamAccessMethod, PamSessionStatus } from "../pam/pam-enums";
@@ -54,6 +57,11 @@ type TPamWebAccessServiceFactoryDep = {
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   userDAL: Pick<TUserDALFactory, "findById">;
+  mfaSessionService: Pick<
+    TMfaSessionServiceFactory,
+    "createMfaSession" | "getMfaSession" | "deleteMfaSession" | "sendMfaCode"
+  >;
+  orgDAL: Pick<TOrgDALFactory, "findOrgById">;
 };
 
 export type TPamWebAccessServiceFactory = ReturnType<typeof pamWebAccessServiceFactory>;
@@ -85,7 +93,9 @@ export const pamWebAccessServiceFactory = ({
   gatewayV2Service,
   gatewayPoolService,
   kmsService,
-  userDAL
+  userDAL,
+  mfaSessionService,
+  orgDAL
 }: TPamWebAccessServiceFactoryDep) => {
   const decrypt = async (projectId: string, blob: Buffer): Promise<Record<string, unknown>> => {
     const { decryptor } = await kmsService.createCipherPairWithDataKey({ type: KmsDataKey.SecretManager, projectId });
@@ -126,7 +136,8 @@ export const pamWebAccessServiceFactory = ({
     actorEmail,
     actorName,
     auditLogInfo,
-    reason
+    reason,
+    mfaSessionId
   }: TIssueWebSocketTicketDTO) => {
     const account = await pamAccountDAL.findByIdWithDetails(accountId);
     if (!account || account.projectId !== projectId) {
@@ -136,22 +147,6 @@ export const pamWebAccessServiceFactory = ({
     if (!SESSION_HANDLERS[account.accountType as PamAccountType]) {
       throw new BadRequestError({ message: "Web access is not supported for this account type" });
     }
-
-    const trimmedReason = reason?.trim() || null;
-
-    const policy = resolveAccessControls(account.templatePolicies);
-
-    if (policy.requireReason && !trimmedReason) {
-      throw new BadRequestError({ message: "A reason is required to access this account" });
-    }
-
-    if (policy.requireMfa) {
-      throw new BadRequestError({ message: "MFA verification is required to access this account" });
-    }
-
-    const maxSessionDurationMs = policy.maxSessionDurationSeconds
-      ? policy.maxSessionDurationSeconds * 1000
-      : DEFAULT_WEB_SESSION_DURATION_MS;
 
     await checkAccountAccess(
       permissionService,
@@ -166,6 +161,59 @@ export const pamWebAccessServiceFactory = ({
         actorAuthMethod: actor.authMethod
       }
     );
+
+    const trimmedReason = reason?.trim() || null;
+
+    const policy = resolveAccessControls(account.templatePolicies);
+
+    if (policy.requireReason && !trimmedReason) {
+      throw new BadRequestError({
+        name: "PAM_REASON_REQUIRED",
+        message: "A reason is required to access this account"
+      });
+    }
+
+    if (policy.requireMfa && !mfaSessionId) {
+      const org = await orgDAL.findOrgById(actor.orgId);
+      const user = await userDAL.findById(actor.id);
+
+      const orgMfaMethod = org?.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
+      const userMfaMethod = user?.isMfaEnabled ? (user.selectedMfaMethod as MfaMethod | null) : undefined;
+      const mfaMethod = (orgMfaMethod ?? userMfaMethod ?? MfaMethod.EMAIL) as MfaMethod;
+
+      const newMfaSessionId = await mfaSessionService.createMfaSession(actor.id, account.id, mfaMethod);
+
+      if (mfaMethod === MfaMethod.EMAIL && actorEmail) {
+        await mfaSessionService.sendMfaCode(actor.id, actorEmail);
+      }
+
+      throw new BadRequestError({
+        name: "SESSION_MFA_REQUIRED",
+        message: "MFA verification required to access this account",
+        details: { mfaSessionId: newMfaSessionId, mfaMethod }
+      });
+    }
+
+    if (policy.requireMfa && mfaSessionId) {
+      const mfaSession = await mfaSessionService.getMfaSession(mfaSessionId);
+      if (!mfaSession) {
+        throw new BadRequestError({ message: "MFA session not found or expired" });
+      }
+      if (mfaSession.userId !== actor.id) {
+        throw new BadRequestError({ message: "MFA session does not belong to current user" });
+      }
+      if (mfaSession.resourceId !== account.id) {
+        throw new BadRequestError({ message: "MFA session is for a different account" });
+      }
+      if (mfaSession.status !== MfaSessionStatus.ACTIVE) {
+        throw new BadRequestError({ message: "MFA session is not verified. Please complete MFA verification first." });
+      }
+      await mfaSessionService.deleteMfaSession(mfaSessionId);
+    }
+
+    const maxSessionDurationMs = policy.maxSessionDurationSeconds
+      ? policy.maxSessionDurationSeconds * 1000
+      : DEFAULT_WEB_SESSION_DURATION_MS;
 
     await pamSessionDAL.endExpiredWebSessions(actor.id, projectId);
     const activeCount = await pamSessionDAL.countActiveWebSessions(actor.id, projectId);

--- a/backend/src/ee/services/pam-web-access/pam-web-access-types.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-types.ts
@@ -66,4 +66,5 @@ export type TIssueWebSocketTicketDTO = {
   actorName: string;
   auditLogInfo: AuditLogInfo;
   reason?: string;
+  mfaSessionId?: string;
 };

--- a/backend/src/ee/services/pam/pam-mfa.ts
+++ b/backend/src/ee/services/pam/pam-mfa.ts
@@ -1,0 +1,69 @@
+import { MfaMethod } from "@app/services/auth/auth-type";
+import { TMfaSessionServiceFactory } from "@app/services/mfa-session/mfa-session-service";
+import { MfaSessionStatus } from "@app/services/mfa-session/mfa-session-types";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
+import { TUserDALFactory } from "@app/services/user/user-dal";
+
+import { BadRequestError } from "../../../lib/errors";
+
+type TMfaDeps = {
+  mfaSessionService: Pick<
+    TMfaSessionServiceFactory,
+    "createMfaSession" | "getMfaSession" | "deleteMfaSession" | "sendMfaCode"
+  >;
+  orgDAL: Pick<TOrgDALFactory, "findOrgById">;
+  userDAL: Pick<TUserDALFactory, "findById">;
+};
+
+export const enforceMfa = async (
+  { mfaSessionService, orgDAL, userDAL }: TMfaDeps,
+  {
+    userId,
+    orgId,
+    actorEmail,
+    accountId,
+    mfaSessionId
+  }: {
+    userId: string;
+    orgId: string;
+    actorEmail: string;
+    accountId: string;
+    mfaSessionId?: string;
+  }
+) => {
+  if (!mfaSessionId) {
+    const org = await orgDAL.findOrgById(orgId);
+    const user = await userDAL.findById(userId);
+
+    const orgMfaMethod = org?.enforceMfa ? (org.selectedMfaMethod as MfaMethod | null) : undefined;
+    const userMfaMethod = user?.isMfaEnabled ? (user.selectedMfaMethod as MfaMethod | null) : undefined;
+    const mfaMethod = (orgMfaMethod ?? userMfaMethod ?? MfaMethod.EMAIL) as MfaMethod;
+
+    const newMfaSessionId = await mfaSessionService.createMfaSession(userId, accountId, mfaMethod);
+
+    if (mfaMethod === MfaMethod.EMAIL && actorEmail) {
+      await mfaSessionService.sendMfaCode(userId, actorEmail);
+    }
+
+    throw new BadRequestError({
+      name: "SESSION_MFA_REQUIRED",
+      message: "MFA verification required to access this account",
+      details: { mfaSessionId: newMfaSessionId, mfaMethod }
+    });
+  }
+
+  const mfaSession = await mfaSessionService.getMfaSession(mfaSessionId);
+  if (!mfaSession) {
+    throw new BadRequestError({ message: "MFA session not found or expired" });
+  }
+  if (mfaSession.userId !== userId) {
+    throw new BadRequestError({ message: "MFA session does not belong to current user" });
+  }
+  if (mfaSession.resourceId !== accountId) {
+    throw new BadRequestError({ message: "MFA session is for a different account" });
+  }
+  if (mfaSession.status !== MfaSessionStatus.ACTIVE) {
+    throw new BadRequestError({ message: "MFA session is not verified. Please complete MFA verification first." });
+  }
+  await mfaSessionService.deleteMfaSession(mfaSessionId);
+};

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1138,6 +1138,13 @@ export const registerRoutes = async (
     keyStore
   });
 
+  const mfaSessionService = mfaSessionServiceFactory({
+    keyStore,
+    tokenService,
+    smtpService,
+    totpService
+  });
+
   const loginService = authLoginServiceFactory({
     userDAL,
     userAliasDAL,
@@ -1793,7 +1800,9 @@ export const registerRoutes = async (
     gatewayV2Service,
     gatewayPoolService,
     userDAL,
-    pamSessionExpirationService
+    pamSessionExpirationService,
+    mfaSessionService,
+    orgDAL
   });
 
   const pamSessionChunkService = pamSessionChunkServiceFactory({
@@ -1813,7 +1822,9 @@ export const registerRoutes = async (
     gatewayV2Service,
     gatewayPoolService,
     kmsService,
-    userDAL
+    userDAL,
+    mfaSessionService,
+    orgDAL
   });
 
   const gitHubAppService = gitHubAppServiceFactory({
@@ -3436,13 +3447,6 @@ export const registerRoutes = async (
   const aiMcpEndpointDAL = aiMcpEndpointDALFactory(db);
   const aiMcpEndpointServerDAL = aiMcpEndpointServerDALFactory(db);
   const aiMcpEndpointServerToolDAL = aiMcpEndpointServerToolDALFactory(db);
-
-  const mfaSessionService = mfaSessionServiceFactory({
-    keyStore,
-    tokenService,
-    smtpService,
-    totpService
-  });
 
   const aiMcpServerService = aiMcpServerServiceFactory({
     aiMcpServerDAL,

--- a/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
@@ -115,9 +115,7 @@ const PageContent = () => {
         if (account.accountType === PamAccountType.Postgres) {
           return <PamDataExplorerPage reason={reason} mfaSessionId={mfaSessionId} />;
         }
-        return (
-          <TerminalContent account={account} reason={reason} mfaSessionId={mfaSessionId} />
-        );
+        return <TerminalContent account={account} reason={reason} mfaSessionId={mfaSessionId} />;
       }}
     </SessionAccessGate>
   );

--- a/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
@@ -13,12 +13,10 @@ import { WebAccessStatusCard } from "./WebAccessStatusCard";
 
 const TerminalContent = ({
   account,
-  orgId,
   reason,
   mfaSessionId
 }: {
   account: TPamAccount;
-  orgId: string;
   reason?: string;
   mfaSessionId?: string;
 }) => {
@@ -26,8 +24,6 @@ const TerminalContent = ({
 
   const { containerRef, isConnected, disconnect, reconnect } = useWebAccessSession({
     accountId: account.id,
-    orgId,
-    accountName: account.name,
     accountType: account.accountType,
     reason,
     mfaSessionId,
@@ -88,11 +84,10 @@ const PageContent = () => {
     strict: false
   }) as {
     accountId?: string;
-    orgId?: string;
     accountType?: string;
   };
 
-  const { accountId, orgId } = params;
+  const { accountId } = params;
   const { data: account, isPending } = useGetPamAccountById(accountId);
 
   if (isPending) {
@@ -121,12 +116,7 @@ const PageContent = () => {
           return <PamDataExplorerPage reason={reason} mfaSessionId={mfaSessionId} />;
         }
         return (
-          <TerminalContent
-            account={account}
-            orgId={orgId!}
-            reason={reason}
-            mfaSessionId={mfaSessionId}
-          />
+          <TerminalContent account={account} reason={reason} mfaSessionId={mfaSessionId} />
         );
       }}
     </SessionAccessGate>

--- a/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
@@ -14,11 +14,13 @@ import { WebAccessStatusCard } from "./WebAccessStatusCard";
 const TerminalContent = ({
   account,
   orgId,
-  reason
+  reason,
+  mfaSessionId
 }: {
   account: TPamAccount;
   orgId: string;
   reason?: string;
+  mfaSessionId?: string;
 }) => {
   const [sessionEnded, setSessionEnded] = useState(false);
 
@@ -28,6 +30,7 @@ const TerminalContent = ({
     accountName: account.name,
     accountType: account.accountType,
     reason,
+    mfaSessionId,
     onSessionEnd: () => setSessionEnded(true)
   });
 
@@ -111,17 +114,20 @@ const PageContent = () => {
     );
   }
 
-  if (account.accountType === PamAccountType.SSH) {
-    return <TerminalContent account={account} orgId={orgId!} />;
-  }
-
   return (
     <SessionAccessGate account={account}>
-      {({ reason }) => {
+      {({ reason, mfaSessionId }) => {
         if (account.accountType === PamAccountType.Postgres) {
-          return <PamDataExplorerPage reason={reason} />;
+          return <PamDataExplorerPage reason={reason} mfaSessionId={mfaSessionId} />;
         }
-        return <TerminalContent account={account} orgId={orgId!} reason={reason} />;
+        return (
+          <TerminalContent
+            account={account}
+            orgId={orgId!}
+            reason={reason}
+            mfaSessionId={mfaSessionId}
+          />
+        );
       }}
     </SessionAccessGate>
   );

--- a/frontend/src/pages/pam/PamAccountAccessPage/ReasonGate.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/ReasonGate.tsx
@@ -1,5 +1,7 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useCallback, useRef, useState } from "react";
+import { ShieldCheck } from "lucide-react";
 
+import { Spinner } from "@app/components/v2";
 import {
   Button,
   Card,
@@ -9,6 +11,8 @@ import {
   CardTitle,
   TextArea
 } from "@app/components/v3";
+import { apiRequest } from "@app/config/request";
+import { MfaSessionStatus, TMfaSessionStatusResponse } from "@app/hooks/api/mfaSession/types";
 import { PamPolicyType, TPamAccount } from "@app/hooks/api/pam";
 
 type TAccessPolicy = {
@@ -29,6 +33,7 @@ export const resolveAccessPolicy = (account: TPamAccount): TAccessPolicy => {
 
 type TSessionAccessGateResult = {
   reason?: string;
+  mfaSessionId?: string;
 };
 
 type Props = {
@@ -36,23 +41,172 @@ type Props = {
   children: (result: TSessionAccessGateResult) => ReactNode;
 };
 
+const MFA_POLL_INTERVAL = 2000;
+const MFA_TIMEOUT = 5 * 60 * 1000;
+
 export const SessionAccessGate = ({ account, children }: Props) => {
   const policy = resolveAccessPolicy(account);
 
-  const [submitted, setSubmitted] = useState(false);
+  const [step, setStep] = useState<"reason" | "mfa" | "done" | "error">("reason");
   const [reason, setReason] = useState("");
+  const [mfaSessionId, setMfaSessionId] = useState<string>();
+  const [mfaVerifying, setMfaVerifying] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const popupRef = useRef<Window | null>(null);
 
-  if (submitted) {
+  const handleReasonSubmit = useCallback(async () => {
     const trimmed = reason.trim();
-    return <>{children({ reason: trimmed || undefined })}</>;
+
+    if (!policy.requireMfa) {
+      setStep("done");
+      return;
+    }
+
+    setStep("mfa");
+
+    try {
+      const { data } = await apiRequest.post<{ ticket: string }>(
+        `/api/v1/pam/accounts/${account.id}/web-access-ticket`,
+        { reason: trimmed || undefined }
+      );
+      // MFA wasn't actually required by backend (template changed). Ticket was created; proceed.
+      // The children will create another ticket, so this one goes unused (expires harmlessly).
+      void data;
+      setStep("done");
+    } catch (err: unknown) {
+      const axiosErr = err as {
+        response?: {
+          data?: {
+            error?: string;
+            message?: string;
+            details?: { mfaSessionId?: string; mfaMethod?: string };
+          };
+        };
+      };
+
+      if (axiosErr?.response?.data?.error === "SESSION_MFA_REQUIRED") {
+        const sessionId = axiosErr.response!.data!.details?.mfaSessionId;
+        if (sessionId) {
+          setMfaSessionId(sessionId);
+          return;
+        }
+      }
+
+      setErrorMessage(
+        axiosErr?.response?.data?.message ?? "Failed to access account. Please try again."
+      );
+      setStep("error");
+    }
+  }, [reason, policy.requireMfa, account.id]);
+
+  const handleMfaVerify = useCallback(async () => {
+    if (!mfaSessionId) return;
+
+    setMfaVerifying(true);
+
+    const mfaUrl = `${window.location.origin}/mfa-session/${mfaSessionId}`;
+    popupRef.current = window.open(mfaUrl, "_blank");
+
+    const startTime = Date.now();
+
+    const verified = await new Promise<boolean>((resolve) => {
+      const interval = setInterval(async () => {
+        if (Date.now() - startTime > MFA_TIMEOUT) {
+          clearInterval(interval);
+          resolve(false);
+          return;
+        }
+        try {
+          const resp = await apiRequest.get<TMfaSessionStatusResponse>(
+            `/api/v2/mfa-sessions/${mfaSessionId}/status`
+          );
+          if (resp.data.status === MfaSessionStatus.ACTIVE) {
+            clearInterval(interval);
+            resolve(true);
+          }
+        } catch {
+          clearInterval(interval);
+          resolve(false);
+        }
+      }, MFA_POLL_INTERVAL);
+    });
+
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close();
+    }
+
+    if (verified) {
+      setStep("done");
+    } else {
+      setMfaVerifying(false);
+      setErrorMessage("MFA verification timed out or failed. Please try again.");
+      setStep("error");
+    }
+  }, [mfaSessionId]);
+
+  const handleRetry = () => {
+    setErrorMessage("");
+    setMfaSessionId(undefined);
+    setMfaVerifying(false);
+    setStep("reason");
+  };
+
+  if (step === "done") {
+    const trimmed = reason.trim();
+    return <>{children({ reason: trimmed || undefined, mfaSessionId })}</>;
   }
 
+  if (step === "error") {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-base">Access Failed</CardTitle>
+            <CardDescription>{errorMessage}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button variant="pam" isFullWidth onClick={handleRetry}>
+              Try Again
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (step === "mfa") {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-background p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="flex items-center gap-3">
+            <ShieldCheck className="size-6 shrink-0 text-product-pam" />
+            <div className="flex min-w-0 flex-col gap-1">
+              <CardTitle className="text-base">MFA Verification Required</CardTitle>
+              <CardDescription>
+                Multi-factor authentication is required to access this account.
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {mfaVerifying ? (
+              <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted">
+                <Spinner className="h-4 w-4" />
+                Waiting for verification...
+              </div>
+            ) : (
+              <Button variant="pam" isFullWidth onClick={handleMfaVerify}>
+                Verify MFA
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // step === "reason"
   const trimmed = reason.trim();
   const canSubmit = !policy.requireReason || trimmed.length > 0;
-
-  const handleSubmit = () => {
-    if (canSubmit) setSubmitted(true);
-  };
 
   return (
     <div className="flex h-screen w-screen items-center justify-center bg-background p-4">
@@ -74,11 +228,11 @@ export const SessionAccessGate = ({ account, children }: Props) => {
             onChange={(e) => setReason(e.target.value)}
             onKeyDown={(e) => {
               if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                handleSubmit();
+                if (canSubmit) handleReasonSubmit();
               }
             }}
           />
-          <Button variant="pam" isFullWidth onClick={handleSubmit} isDisabled={!canSubmit}>
+          <Button variant="pam" isFullWidth onClick={handleReasonSubmit} isDisabled={!canSubmit}>
             {!policy.requireReason && trimmed.length === 0 ? "Skip & Continue" : "Continue"}
           </Button>
         </CardContent>

--- a/frontend/src/pages/pam/PamAccountAccessPage/ReasonGate.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/ReasonGate.tsx
@@ -65,13 +65,10 @@ export const SessionAccessGate = ({ account, children }: Props) => {
     setStep("mfa");
 
     try {
-      const { data } = await apiRequest.post<{ ticket: string }>(
+      await apiRequest.post<{ ticket: string }>(
         `/api/v1/pam/accounts/${account.id}/web-access-ticket`,
         { reason: trimmed || undefined }
       );
-      // MFA wasn't actually required by backend (template changed). Ticket was created; proceed.
-      // The children will create another ticket, so this one goes unused (expires harmlessly).
-      void data;
       setStep("done");
     } catch (err: unknown) {
       const axiosErr = err as {

--- a/frontend/src/pages/pam/PamAccountAccessPage/useWebAccessSession.ts
+++ b/frontend/src/pages/pam/PamAccountAccessPage/useWebAccessSession.ts
@@ -14,8 +14,6 @@ import "@xterm/xterm/css/xterm.css";
 
 type UseWebAccessSessionOptions = {
   accountId: string;
-  orgId: string;
-  accountName: string;
   accountType: string;
   reason?: string;
   mfaSessionId?: string;
@@ -24,8 +22,6 @@ type UseWebAccessSessionOptions = {
 
 export const useWebAccessSession = ({
   accountId,
-  orgId,
-  accountName,
   accountType,
   reason,
   mfaSessionId,
@@ -266,14 +262,14 @@ export const useWebAccessSession = ({
       };
 
       if (axiosErr?.response?.data?.error === "SESSION_MFA_REQUIRED") {
-        const mfaSessionId = axiosErr.response!.data!.details?.mfaSessionId;
+        const newMfaSessionId = axiosErr.response!.data!.details?.mfaSessionId;
 
-        if (!mfaSessionId) {
+        if (!newMfaSessionId) {
           terminal.write("\r\nMFA session could not be created. Please try again.\r\n");
           return;
         }
 
-        const mfaUrl = `${window.location.origin}/mfa-session/${mfaSessionId}`;
+        const mfaUrl = `${window.location.origin}/mfa-session/${newMfaSessionId}`;
 
         // Try to open MFA verification in a new window.
         const popup = window.open(mfaUrl, "_blank");
@@ -299,7 +295,7 @@ export const useWebAccessSession = ({
 
             try {
               const resp = await apiRequest.get<TMfaSessionStatusResponse>(
-                `/api/v2/mfa-sessions/${mfaSessionId}/status`
+                `/api/v2/mfa-sessions/${newMfaSessionId}/status`
               );
               if (resp.data.status === MfaSessionStatus.ACTIVE) {
                 clearInterval(interval);
@@ -332,7 +328,7 @@ export const useWebAccessSession = ({
           terminal.reset();
           const { data: retryData } = await apiRequest.post<{ ticket: string }>(
             `/api/v1/pam/accounts/${accountId}/web-access-ticket`,
-            { mfaSessionId, reason: submittedReasonRef.current }
+            { mfaSessionId: newMfaSessionId, reason: submittedReasonRef.current }
           );
           openWebSocket(terminal, retryData.ticket);
         } catch {
@@ -362,7 +358,7 @@ export const useWebAccessSession = ({
 
       terminal.write("\r\nFailed to connect. Please close and try again.\r\n");
     }
-  }, [accountId, orgId, accountName, containerEl, openWebSocket]);
+  }, [accountId, containerEl, openWebSocket]);
 
   const disconnect = useCallback(() => {
     const ws = wsRef.current;

--- a/frontend/src/pages/pam/PamAccountAccessPage/useWebAccessSession.ts
+++ b/frontend/src/pages/pam/PamAccountAccessPage/useWebAccessSession.ts
@@ -2,14 +2,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Terminal } from "@xterm/xterm";
-import ms from "ms";
 import { Readline } from "xterm-readline";
 
 import { apiRequest } from "@app/config/request";
 import { MfaSessionStatus, TMfaSessionStatusResponse } from "@app/hooks/api/mfaSession/types";
 import { PamAccountType } from "@app/hooks/api/pam";
 
-import { DEFAULT_ACCESS_DURATION } from "../constants";
 import { WebSocketServerMessageSchema, WsMessageType } from "./web-access-types";
 
 import "@xterm/xterm/css/xterm.css";
@@ -20,6 +18,7 @@ type UseWebAccessSessionOptions = {
   accountName: string;
   accountType: string;
   reason?: string;
+  mfaSessionId?: string;
   onSessionEnd?: () => void;
 };
 
@@ -29,6 +28,7 @@ export const useWebAccessSession = ({
   accountName,
   accountType,
   reason,
+  mfaSessionId,
   onSessionEnd
 }: UseWebAccessSessionOptions) => {
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
@@ -46,10 +46,8 @@ export const useWebAccessSession = ({
   const nextPromptRejecterRef = useRef<((reason: Error) => void) | null>(null);
 
   const onSessionEndRef = useRef(onSessionEnd);
-  // Seed with the prop so non-SSH flows (which collect reason via the upfront ReasonGate)
-  // pass it on the first connect; SSH leaves it undefined and uses the inline terminal prompt.
   const submittedReasonRef = useRef<string | undefined>(reason);
-  const askedOptionalReasonRef = useRef(false);
+  const mfaSessionIdRef = useRef<string | undefined>(mfaSessionId);
 
   useEffect(() => {
     onSessionEndRef.current = onSessionEnd;
@@ -243,26 +241,14 @@ export const useWebAccessSession = ({
     try {
       const { data } = await apiRequest.post<{ ticket: string }>(
         `/api/v1/pam/accounts/${accountId}/web-access-ticket`,
-        { reason: submittedReasonRef.current }
+        { reason: submittedReasonRef.current, mfaSessionId: mfaSessionIdRef.current }
       );
+      mfaSessionIdRef.current = undefined;
       if (containerEl) {
         containerEl.style.width = "";
         isWidenedRef.current = false;
       }
       if (fitAddonRef.current) fitAddonRef.current.fit();
-
-      if (isSSH && submittedReasonRef.current === undefined && !askedOptionalReasonRef.current) {
-        askedOptionalReasonRef.current = true;
-        const optional = await prompt(
-          "\r\nOptionally provide a reason for this session (press Enter to skip): "
-        );
-        if (optional.trim()) {
-          submittedReasonRef.current = optional.trim();
-          terminal.reset();
-          connect();
-          return;
-        }
-      }
 
       terminal.reset();
       openWebSocket(terminal, data.ticket);
@@ -274,10 +260,6 @@ export const useWebAccessSession = ({
             details?: {
               mfaSessionId?: string;
               mfaMethod?: string;
-              policyId?: string;
-              policyName?: string;
-              policyType?: string;
-              constraints?: { accessDuration: { max: string } };
             };
           };
         };
@@ -355,70 +337,6 @@ export const useWebAccessSession = ({
           openWebSocket(terminal, retryData.ticket);
         } catch {
           terminal.write("\r\nFailed to connect after MFA verification. Please try again.\r\n");
-        }
-        return;
-      }
-
-      // Check for PolicyViolationError
-      if (axiosErr?.response?.data?.error === "PolicyViolationError") {
-        const policyName = axiosErr.response!.data!.details?.policyName ?? "Unknown Policy";
-        const accessDurationMax =
-          axiosErr.response!.data!.details?.constraints?.accessDuration.max ??
-          DEFAULT_ACCESS_DURATION;
-
-        terminal.write(`\r\nThis account is protected by approval policy: "${policyName}"\r\n`);
-
-        const answer = await prompt(
-          "\r\nThis action requires approval. Would you like to create an approval request? [Y/n]: "
-        );
-
-        if (answer.trim().toLowerCase() === "n") {
-          terminal.write("\r\nApproval request was not created.\r\n");
-          await prompt("\r\nPress Enter to try again.");
-          terminal.reset();
-          connect();
-          return;
-        }
-
-        const justification = await prompt(
-          "\r\nEnter justification (optional, press Enter to skip): "
-        );
-
-        terminal.write("\r\nCreating approval request...\r\n");
-
-        try {
-          const { data: approvalData } = await apiRequest.post<{ request: { id: string } }>(
-            "/api/v1/approval-policies/pam-access/requests",
-            {
-              requestData: {
-                accessDuration:
-                  ms(accessDurationMax) < ms(DEFAULT_ACCESS_DURATION)
-                    ? accessDurationMax
-                    : DEFAULT_ACCESS_DURATION,
-                accountName
-              },
-              justification: justification.trim() || undefined
-            }
-          );
-
-          terminal.write("\r\nApproval request created successfully!\r\n");
-
-          const approvalUrl = `${window.location.origin}/organizations/${orgId}/approvals/${approvalData.request.id}`;
-          terminal.write(`View details at: ${approvalUrl}\r\n`);
-
-          await prompt("\r\nOnce approved, press Enter to reconnect.");
-          terminal.reset();
-          connect();
-        } catch (approvalErr: unknown) {
-          const approvalAxiosErr = approvalErr as {
-            response?: { data?: { message?: string } };
-          };
-          const errorMsg =
-            approvalAxiosErr?.response?.data?.message ?? "Failed to create approval request.";
-          terminal.write(`\r\n${errorMsg}\r\n`);
-          await prompt("\r\nPress Enter to try again.");
-          terminal.reset();
-          connect();
         }
         return;
       }

--- a/frontend/src/pages/pam/PamDataExplorerPage/PamDataExplorerPage.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/PamDataExplorerPage.tsx
@@ -30,11 +30,10 @@ type Props = {
 };
 
 export const PamDataExplorerPage = ({ reason, mfaSessionId }: Props = {}) => {
-  const { accountId, orgId } = useParams({
+  const { accountId } = useParams({
     strict: false
   }) as {
     accountId: string;
-    orgId: string;
     accountType: string;
   };
 
@@ -79,8 +78,6 @@ export const PamDataExplorerPage = ({ reason, mfaSessionId }: Props = {}) => {
     cancelQuery
   } = useDataExplorerSession({
     accountId,
-    orgId,
-    accountName: account?.name ?? "",
     reason,
     onSessionEnd: (endReason?: string) => {
       setHasDisconnected(true);

--- a/frontend/src/pages/pam/PamDataExplorerPage/PamDataExplorerPage.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/PamDataExplorerPage.tsx
@@ -26,9 +26,10 @@ import { useQueryTabs } from "./use-query-tabs";
 
 type Props = {
   reason?: string;
+  mfaSessionId?: string;
 };
 
-export const PamDataExplorerPage = ({ reason }: Props = {}) => {
+export const PamDataExplorerPage = ({ reason, mfaSessionId }: Props = {}) => {
   const { accountId, orgId } = useParams({
     strict: false
   }) as {
@@ -51,8 +52,6 @@ export const PamDataExplorerPage = ({ reason }: Props = {}) => {
   const latestSchemaRequestRef = useRef(0);
   const tabElRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
 
-  const [approvalJustification, setApprovalJustification] = useState("");
-
   // Forward refs for tab-state handlers that useDataExplorerSession calls
   // before useQueryTabs has been called. Assigned after useQueryTabs below.
   const markConnectionDeadRef = useRef<((connId: string) => void) | null>(null);
@@ -67,13 +66,10 @@ export const PamDataExplorerPage = ({ reason }: Props = {}) => {
     isConnecting,
     errorMessage,
     mfaState,
-    approvalState,
     connect,
     disconnect,
     reconnect,
     handleMfaVerification,
-    submitApprovalRequest,
-    approvalRequestUrl,
     openConnection,
     closeConnection,
     fetchSchemas,
@@ -137,10 +133,10 @@ export const PamDataExplorerPage = ({ reason }: Props = {}) => {
     (node: HTMLDivElement | null) => {
       if (node && !connectedOnceRef.current) {
         connectedOnceRef.current = true;
-        connect();
+        connect(mfaSessionId);
       }
     },
-    [connect]
+    [connect, mfaSessionId]
   );
 
   // Cleanup on real unmount
@@ -302,56 +298,6 @@ export const PamDataExplorerPage = ({ reason }: Props = {}) => {
           <Button variant="pam" isFullWidth onClick={handleMfaVerification}>
             Verify MFA
           </Button>
-        )}
-      </WebAccessStatusCard>
-    );
-  }
-
-  if (approvalState?.required) {
-    return (
-      <WebAccessStatusCard
-        icon={AlertTriangleIcon}
-        title="Approval Required"
-        description={`This account is protected by policy: ${approvalState.policyName ?? "Unknown"}`}
-      >
-        {approvalState.submitted ? (
-          <>
-            <p className="text-xs text-muted">Approval request created successfully.</p>
-            {approvalRequestUrl && (
-              <a
-                href={approvalRequestUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-primary-500 underline hover:text-primary-400"
-              >
-                View approval request
-              </a>
-            )}
-            <Button variant="pam" isFullWidth onClick={handleReconnect}>
-              Reconnect
-            </Button>
-          </>
-        ) : (
-          <>
-            <textarea
-              className="w-full rounded border border-border bg-container px-3 py-2 text-xs text-foreground placeholder:text-muted focus:border-border focus:outline-none"
-              placeholder="Justification (optional)"
-              rows={2}
-              value={approvalJustification}
-              onChange={(e) => setApprovalJustification(e.target.value)}
-            />
-            {approvalState.errorMessage && (
-              <p className="text-xs text-danger">{approvalState.errorMessage}</p>
-            )}
-            <Button
-              variant="pam"
-              isFullWidth
-              isPending={approvalState.creating}
-              onClick={() => submitApprovalRequest(approvalJustification)}
-            >
-              Create Approval Request
-            </Button>
-          </>
         )}
       </WebAccessStatusCard>
     );

--- a/frontend/src/pages/pam/PamDataExplorerPage/use-data-explorer-session.ts
+++ b/frontend/src/pages/pam/PamDataExplorerPage/use-data-explorer-session.ts
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import ms from "ms";
 
 import { apiRequest } from "@app/config/request";
 import { MfaSessionStatus, TMfaSessionStatusResponse } from "@app/hooks/api/mfaSession/types";
 
-import { DEFAULT_ACCESS_DURATION } from "../constants";
 import type {
   DataExplorerClientMessage,
   DataExplorerServerMessage,
@@ -27,17 +25,6 @@ type MfaState = {
   sessionId?: string;
   method?: string;
   verifying: boolean;
-};
-
-type ApprovalState = {
-  required: boolean;
-  policyName?: string;
-  policyId?: string;
-  accessDurationMax?: string;
-  creating: boolean;
-  submitted: boolean;
-  approvalRequestId?: string;
-  errorMessage?: string;
 };
 
 type UseDataExplorerSessionOptions = {
@@ -81,7 +68,6 @@ export const useDataExplorerSession = ({
   const [isConnecting, setIsConnecting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [mfaState, setMfaState] = useState<MfaState | null>(null);
-  const [approvalState, setApprovalState] = useState<ApprovalState | null>(null);
 
   const wsRef = useRef<WebSocket | null>(null);
   const pendingRequestsRef = useRef<Map<string, PendingRequest>>(new Map());
@@ -211,7 +197,6 @@ export const useDataExplorerSession = ({
       setIsConnecting(true);
       setErrorMessage(null);
       setMfaState(null);
-      setApprovalState(null);
 
       readyPromiseRef.current = new Promise<void>((resolve, reject) => {
         readyResolveRef.current = resolve;
@@ -236,9 +221,6 @@ export const useDataExplorerSession = ({
               details?: {
                 mfaSessionId?: string;
                 mfaMethod?: string;
-                policyId?: string;
-                policyName?: string;
-                constraints?: { accessDuration: { max: string } };
               };
             };
           };
@@ -251,20 +233,6 @@ export const useDataExplorerSession = ({
             sessionId: details?.mfaSessionId,
             method: details?.mfaMethod,
             verifying: false
-          });
-          setIsConnecting(false);
-          return;
-        }
-
-        if (axiosErr?.response?.data?.error === "PolicyViolationError") {
-          const { details } = axiosErr.response!.data!;
-          setApprovalState({
-            required: true,
-            policyName: details?.policyName,
-            policyId: details?.policyId,
-            accessDurationMax: details?.constraints?.accessDuration.max,
-            creating: false,
-            submitted: false
           });
           setIsConnecting(false);
           return;
@@ -333,54 +301,6 @@ export const useDataExplorerSession = ({
       setErrorMessage("MFA verification timed out or failed");
     }
   }, [mfaState, connect]);
-
-  // Approval request flow
-  const submitApprovalRequest = useCallback(
-    async (justification?: string) => {
-      if (!approvalState?.required) return;
-      setApprovalState((prev) =>
-        prev ? { ...prev, creating: true, errorMessage: undefined } : null
-      );
-
-      try {
-        const { data: approvalData } = await apiRequest.post<{ request: { id: string } }>(
-          "/api/v1/approval-policies/pam-access/requests",
-          {
-            requestData: {
-              accessDuration:
-                approvalState.accessDurationMax &&
-                ms(approvalState.accessDurationMax) < ms(DEFAULT_ACCESS_DURATION)
-                  ? approvalState.accessDurationMax
-                  : DEFAULT_ACCESS_DURATION,
-              accountName
-            },
-            justification: justification?.trim() || undefined
-          }
-        );
-        setApprovalState((prev) =>
-          prev
-            ? {
-                ...prev,
-                creating: false,
-                submitted: true,
-                approvalRequestId: approvalData.request.id
-              }
-            : null
-        );
-      } catch {
-        setApprovalState((prev) =>
-          prev
-            ? { ...prev, creating: false, errorMessage: "Failed to create approval request" }
-            : null
-        );
-      }
-    },
-    [approvalState, accountName]
-  );
-
-  const approvalRequestUrl = approvalState?.approvalRequestId
-    ? `${window.location.origin}/organizations/${orgId}/approvals/${approvalState.approvalRequestId}`
-    : undefined;
 
   // --- Request helpers ---
 
@@ -558,13 +478,10 @@ export const useDataExplorerSession = ({
     isConnecting,
     errorMessage,
     mfaState,
-    approvalState,
     connect,
     disconnect,
     reconnect,
     handleMfaVerification,
-    submitApprovalRequest,
-    approvalRequestUrl,
     openConnection,
     closeConnection,
     fetchSchemas,

--- a/frontend/src/pages/pam/PamDataExplorerPage/use-data-explorer-session.ts
+++ b/frontend/src/pages/pam/PamDataExplorerPage/use-data-explorer-session.ts
@@ -29,8 +29,6 @@ type MfaState = {
 
 type UseDataExplorerSessionOptions = {
   accountId: string;
-  orgId: string;
-  accountName: string;
   reason?: string;
   onSessionEnd?: (reason?: string) => void;
   // Server pushes connection-closed when a BE controller dies unexpectedly.
@@ -57,8 +55,6 @@ type QueryResult = {
 
 export const useDataExplorerSession = ({
   accountId,
-  orgId,
-  accountName,
   reason: accessReason,
   onSessionEnd,
   onConnectionClosed,


### PR DESCRIPTION
## Context

Wires MFA enforcement into PAM account access. When a template has `require-mfa` enabled, users must complete multi-factor authentication before launching a session (web or CLI).

**Backend:** replaces the placeholder `BadRequestError` throws in both `pam-session-service` (CLI path) and `pam-web-access-service` (web ticket path) with the real MFA session flow -- create session, determine method (org-enforced > user TOTP/WebAuthn > email fallback), send email code if needed, throw `SESSION_MFA_REQUIRED` with session details. On retry with a verified `mfaSessionId`, validates ownership/account binding/status, deletes the session, and proceeds.

Permission check (`checkAccountAccess`) moved before reason/MFA checks in both services so unauthorized users can't trigger MFA sessions or email sends. Reason error name fixed to `PAM_REASON_REQUIRED` so the CLI's interactive prompt actually catches it.

**Frontend:** `SessionAccessGate` (formerly just a reason dialog) now handles MFA as a second step -- after reason collection, if `requireMfa` is true, it calls the ticket endpoint to trigger MFA session creation, shows an MFA verification card, opens the popup, polls for completion, and passes `{ reason, mfaSessionId }` to children. SSH is now wrapped in the gate (previously bypassed it for inline terminal prompts). MFA handlers kept in both hooks for reconnect resilience. Approval policy dead code removed from both access hooks and the data explorer page.

Companion CLI PR: Infisical/cli#276

## Screenshots

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)