### PR TITLE
feat(endpoint): add new endpoint to get project environment by environment slug

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1238,6 +1238,10 @@ export const ENVIRONMENTS = {
   GET: {
     projectId: "The ID of the project the environment belongs to.",
     id: "The ID of the environment to fetch."
+  },
+  GET_BY_SLUG: {
+    projectId: "The ID of the project the environment belongs to.",
+    slug: "The slug of the environment to fetch."
   }
 } as const;
 

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -82,7 +82,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
       ],
       params: z.object({
         projectId: z.string().trim().uuid().describe(ENVIRONMENTS.GET_BY_SLUG.projectId),
-        envSlug: z.string().trim().describe(ENVIRONMENTS.GET_BY_SLUG.slug)
+        envSlug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.GET_BY_SLUG.slug)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -65,6 +65,58 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
   });
 
   server.route({
+    method: "GET",
+    url: "/:projectId/environments/slug/:envSlug",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      hide: false,
+      operationId: "getEnvironmentBySlug",
+      tags: [ApiDocsTags.Environments],
+      description: "Get Environment by slug",
+      security: [
+        {
+          bearerAuth: []
+        }
+      ],
+      params: z.object({
+        projectId: z.string().trim().uuid().describe(ENVIRONMENTS.GET_BY_SLUG.projectId),
+        envSlug: z.string().trim().describe(ENVIRONMENTS.GET_BY_SLUG.slug)
+      }),
+      response: {
+        200: z.object({
+          environment: ProjectEnvironmentsSchema
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const environment = await server.services.projectEnv.getEnvironmentBySlug({
+        actorId: req.permission.id,
+        actor: req.permission.type,
+        actorOrgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod,
+        projectId: req.params.projectId,
+        slug: req.params.envSlug
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        projectId: environment.projectId,
+        event: {
+          type: EventType.GET_ENVIRONMENT,
+          metadata: {
+            id: environment.id
+          }
+        }
+      });
+
+      return { environment };
+    }
+  });
+
+  server.route({
     method: "POST",
     url: "/:projectId/environments",
     config: {

--- a/backend/src/services/project-env/project-env-service.ts
+++ b/backend/src/services/project-env/project-env-service.ts
@@ -14,7 +14,14 @@ import { ActorType } from "../auth/auth-type";
 import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TProjectEnvDALFactory } from "./project-env-dal";
 import { SOFT_DELETE_GRACE_MS } from "./project-env-queue";
-import { TCreateEnvDTO, TDeleteEnvDTO, TGetEnvDTO, TRestoreEnvDTO, TUpdateEnvDTO } from "./project-env-types";
+import {
+  TCreateEnvDTO,
+  TDeleteEnvDTO,
+  TGetEnvBySlugDTO,
+  TGetEnvDTO,
+  TRestoreEnvDTO,
+  TUpdateEnvDTO
+} from "./project-env-types";
 
 type TProjectEnvServiceFactoryDep = {
   projectEnvDAL: TProjectEnvDALFactory;
@@ -438,11 +445,42 @@ export const projectEnvServiceFactory = ({
     return environment;
   };
 
+  const getEnvironmentBySlug = async ({
+    actor,
+    actorId,
+    actorOrgId,
+    actorAuthMethod,
+    projectId,
+    slug
+  }: TGetEnvBySlugDTO) => {
+    const { permission } = await permissionService.getProjectPermission({
+      actor,
+      actorId,
+      projectId,
+      actorAuthMethod,
+      actorOrgId,
+      actionProjectType: ActionProjectType.SecretManager
+    });
+
+    ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionActions.Read, ProjectPermissionSub.Environments);
+
+    const environment = await projectEnvDAL.findOne({ projectId, slug });
+
+    if (!environment) {
+      throw new NotFoundError({
+        message: `Environment with slug '${slug}' in project with ID '${projectId}' not found`
+      });
+    }
+
+    return environment;
+  };
+
   return {
     createEnvironment,
     updateEnvironment,
     deleteEnvironment,
     restoreEnvironment,
-    getEnvironmentById
+    getEnvironmentById,
+    getEnvironmentBySlug
   };
 };

--- a/backend/src/services/project-env/project-env-types.ts
+++ b/backend/src/services/project-env/project-env-types.ts
@@ -30,3 +30,7 @@ export type TReorderEnvDTO = {
 export type TGetEnvDTO = {
   id: string;
 } & Omit<TProjectPermission, "projectId">;
+
+export type TGetEnvBySlugDTO = {
+  slug: string;
+} & TProjectPermission;

--- a/docs/api-reference/endpoints/environments/get.mdx
+++ b/docs/api-reference/endpoints/environments/get.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get by Slug"
+openapi: "GET /api/v1/projects/{projectId}/environments/slug/{envSlug}"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2199,6 +2199,7 @@
                 "group": "Environments",
                 "pages": [
                   "api-reference/endpoints/environments/create",
+                  "api-reference/endpoints/environments/get",
                   "api-reference/endpoints/environments/update",
                   "api-reference/endpoints/environments/delete",
                   "api-reference/endpoints/environments/restore",


### PR DESCRIPTION
## Context
New endpoint to get project environment to be used by the terraform provider. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Use the terraform provider data source to check the endpoint

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)