### PR TITLE
fix(db): index two more nullable FK columns missing covering indexes

### DIFF
--- a/backend/src/db/migrations/20260624075011_add-fk-indexes-gateway-pool-and-pam-session.ts
+++ b/backend/src/db/migrations/20260624075011_add-fk-indexes-gateway-pool-and-pam-session.ts
@@ -1,0 +1,53 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// Two nullable FK columns from gateway-related migrations shipped without covering indexes,
+// so the per-row referential-integrity trigger seq-scans the child table on every parent delete.
+//
+// - dynamic_secrets.gatewayPoolId  (RESTRICT to gateway_pools, nullable)
+//   Set only when a dynamic secret is pinned to a pool. Most rows are NULL → partial index.
+//
+// - pam_sessions.gatewayId  (SET NULL to gateways_v2, nullable)
+//   Set when a pool-backed PAM session resolves to a specific gateway. Most rows are NULL → partial index.
+const FK_INDEXES = [
+  {
+    table: TableName.DynamicSecret,
+    column: "gatewayPoolId",
+    name: "dynamic_secrets_gateway_pool_id_idx"
+  },
+  {
+    table: TableName.PamSession,
+    column: "gatewayId",
+    name: "pam_sessions_gateway_id_idx"
+  }
+];
+
+const indexExists = async (knex: Knex, indexName: string): Promise<boolean> => {
+  const result = await knex.raw(`SELECT 1 FROM pg_indexes WHERE indexname = ?`, [indexName]);
+  return result.rows.length > 0;
+};
+
+export async function up(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if (
+      (await knex.schema.hasTable(idx.table)) &&
+      (await knex.schema.hasColumn(idx.table, idx.column)) &&
+      !(await indexExists(knex, idx.name))
+    ) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        t.index([idx.column], idx.name, { predicate: knex.whereNotNull(idx.column) });
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if ((await knex.schema.hasTable(idx.table)) && (await indexExists(knex, idx.name))) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        t.dropIndex([idx.column], idx.name);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## What

Two more nullable FK columns shipped without covering indexes — sister fix to #6965 and #6966. The per-row RI trigger on each parent delete falls back to a seq-scan of the child table on every gateway / gateway-pool delete:

- `dynamic_secrets.gatewayPoolId` (RESTRICT to `gateway_pools`, nullable). Set only when a dynamic secret is pinned to a pool, so most rows are NULL.
- `pam_sessions.gatewayId` (SET NULL to `gateways_v2`, nullable). Set when a pool-backed PAM session resolves to a specific gateway, so most rows are NULL.

Both get partial indexes filtered to the non-NULL rows (same shape as the previous two migrations). The partial form keeps the index tiny and imposes near-zero write overhead on the live insert path.

## Why partial

For pool-pinned dynamic secrets and resolved PAM sessions, `gatewayPoolId` / `gatewayId` are NULL on the live insert path and only get set as a side effect of pinning / resolution. The cascade lookup only ever walks specific non-null values, so a partial index over the non-NULL rows fully serves the cascade while staying small.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DDL-only migration)
- [x] The change is limited to the affected code path
