### PR TITLE
fix(api): add missing operationId to delete PKI Subscriber route

### DIFF
--- a/backend/src/server/routes/v1/pki-subscriber-router.ts
+++ b/backend/src/server/routes/v1/pki-subscriber-router.ts
@@ -412,6 +412,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiSubscribers],
+      operationId: "deletePkiSubscriber",
       description: "Delete PKI Subscriber",
       params: z.object({
         subscriberName: z.string().describe(PKI_SUBSCRIBERS.DELETE.subscriberName)


### PR DESCRIPTION
## What

DELETE /:subscriberName in pki-subscriber-router.ts is the only route in that router without an `operationId` in its schema block. Every other route in the file (`getPkiSubscriber`, `createPkiSubscriber`, `updatePkiSubscriber`, `orderPkiSubscriberCertificate`, `issuePkiSubscriberCertificate`, `signPkiSubscriberCertificate`, `getPkiSubscriberLatestCertificateBundle`, `listPkiSubscriberCertificates`) has one.

Without an explicit `operationId`, the OpenAPI spec ends up with an auto-generated name for the delete operation. Generated client SDKs and OpenAPI consumers will see a churn-prone name instead of a stable, predictable `deletePkiSubscriber`.

One-line fix.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (schema-only addition)
- [x] The change is limited to the affected code path