### PR TITLE
fix(secret-rotation-v2): skip soft-deleted projects in remaining DAL queries

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-dal.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-dal.ts
@@ -194,7 +194,9 @@ export const secretRotationV2DALFactory = (
     const query = (tx || db.replicaNode())(TableName.SecretRotationV2)
       .join(TableName.SecretFolder, `${TableName.SecretRotationV2}.folderId`, `${TableName.SecretFolder}.id`)
       .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .join(
         TableName.SecretRotationV2SecretMapping,
         `${TableName.SecretRotationV2SecretMapping}.rotationId`,
@@ -495,7 +497,9 @@ export const secretRotationV2DALFactory = (
       const query = (tx || db.replicaNode())(TableName.SecretRotationV2)
         .join(TableName.SecretFolder, `${TableName.SecretRotationV2}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .join(TableName.AppConnection, `${TableName.SecretRotationV2}.connectionId`, `${TableName.AppConnection}.id`)
         .join(
           TableName.SecretRotationV2SecretMapping,
@@ -586,6 +590,8 @@ export const secretRotationV2DALFactory = (
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .join(TableName.AppConnection, `${TableName.SecretRotationV2}.connectionId`, `${TableName.AppConnection}.id`)
         .join(
           TableName.SecretRotationV2SecretMapping,
@@ -670,6 +676,8 @@ export const secretRotationV2DALFactory = (
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where(`${TableName.Environment}.projectId`, projectId)
         .countDistinct(`${TableName.SecretRotationV2}.id`)
         .first();


### PR DESCRIPTION
## What

The cron-driven `findSecretRotationsToQueue` in `secret-rotation-v2-dal.ts` already filters both `Environment.deleteAfter` and `Project.deleteAfter`, but the four API / insights-driven queries in the same DAL only filtered `Environment.deleteAfter`:

- `findWithMappedSecretsCount` (rotations list page count)
- `findByProjectAndDateRange` (insights timeline)
- `findByProject` (insights list)
- `countByProject` (insights / org stats)

Soft-deleting a project does not soft-delete its environments, so these queries kept returning rotation rows for projects sitting in the delete grace window. The list and insights pages would still surface a soft-deleted project's rotations.

## Defense in depth

The API layer is gated upstream by `projectDAL.findById`, which already returns nothing for a soft-deleted project, so this isn't an external-side-effect bug like #6970 / #6983 were. It's a consistency fix: every cross-project enumeration in the codebase should match the cron path and the `org-product-stats-dal.ts` pattern.

## Fix

Adds the `Project` join + `whereNull(Project.deleteAfter)` filter to all four helpers. Mirrors the pattern already used by `findSecretRotationsToQueue` in the same file.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same shape as the matching cron-side query in this file)
- [x] The change is limited to the affected code path
