### PR TITLE
fix(api): resolve inherited sub-org groups by name when adding to project

### DIFF
--- a/backend/src/ee/services/group/group-dal.ts
+++ b/backend/src/ee/services/group/group-dal.ts
@@ -2,7 +2,7 @@ import { Knex } from "knex";
 
 import { TDbClient } from "@app/db";
 import { AccessScope, TableName, TGroups } from "@app/db/schemas";
-import { DatabaseError } from "@app/lib/errors";
+import { BadRequestError, DatabaseError } from "@app/lib/errors";
 import { buildFindFilter, ormify, selectAllTableCols, TFindFilter, TFindOpt } from "@app/lib/knex";
 import { OrderByDirection } from "@app/lib/types";
 
@@ -597,15 +597,23 @@ export const groupDALFactory = (db: TDbClient) => {
 
   const findOneByNameAndOrgScope = async (name: string, orgId: string, tx?: Knex): Promise<TGroups | undefined> => {
     try {
-      const doc = await (tx || db.replicaNode())(TableName.Groups)
+      const docs = await (tx || db.replicaNode())(TableName.Groups)
         .join(TableName.Membership, `${TableName.Membership}.actorGroupId`, `${TableName.Groups}.id`)
         .where(`${TableName.Membership}.scopeOrgId`, orgId)
         .where(`${TableName.Membership}.scope`, AccessScope.Organization)
         .where(`${TableName.Groups}.name`, name)
-        .select(selectAllTableCols(TableName.Groups))
-        .first();
-      return doc;
+        .distinctOn(`${TableName.Groups}.id`)
+        .select(selectAllTableCols(TableName.Groups));
+
+      if (docs.length > 1) {
+        throw new BadRequestError({
+          message: `Multiple groups with name '${name}' are visible in this organization. Use the group ID instead.`
+        });
+      }
+
+      return docs[0];
     } catch (error) {
+      if (error instanceof BadRequestError) throw error;
       throw new DatabaseError({ error, name: "FindOneByNameAndOrgScope" });
     }
   };

--- a/backend/src/ee/services/group/group-dal.ts
+++ b/backend/src/ee/services/group/group-dal.ts
@@ -595,6 +595,21 @@ export const groupDALFactory = (db: TDbClient) => {
     }
   };
 
+  const findOneByNameAndOrgScope = async (name: string, orgId: string, tx?: Knex): Promise<TGroups | undefined> => {
+    try {
+      const doc = await (tx || db.replicaNode())(TableName.Groups)
+        .join(TableName.Membership, `${TableName.Membership}.actorGroupId`, `${TableName.Groups}.id`)
+        .where(`${TableName.Membership}.scopeOrgId`, orgId)
+        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Groups}.name`, name)
+        .select(selectAllTableCols(TableName.Groups))
+        .first();
+      return doc;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "FindOneByNameAndOrgScope" });
+    }
+  };
+
   // Check if a group is linked by any sub-orgs (used to prevent deletion of groups still in use)
   const getGroupsReferencingGroup = async (groupId: string, tx?: Knex) => {
     try {
@@ -626,6 +641,7 @@ export const groupDALFactory = (db: TDbClient) => {
     findGroupsByProjectId,
     findById,
     findOne,
+    findOneByNameAndOrgScope,
     getGroupsReferencingGroup
   };
 };

--- a/backend/src/services/convertor/convertor-service.ts
+++ b/backend/src/services/convertor/convertor-service.ts
@@ -9,7 +9,7 @@ import { TProjectDALFactory } from "../project/project-dal";
 type TConvertorServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findOne">;
   membershipDAL: Pick<TMembershipDALFactory, "findOne">;
-  groupDAL: Pick<TGroupDALFactory, "findOne">;
+  groupDAL: Pick<TGroupDALFactory, "findOneByNameAndOrgScope">;
   additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "findOne">;
 };
 
@@ -110,7 +110,7 @@ export const convertorServiceFactory = ({
   };
 
   const getGroupIdFromName = async (name: string, orgId: string) => {
-    const group = await groupDAL.findOne({ orgId, name });
+    const group = await groupDAL.findOneByNameAndOrgScope(name, orgId);
     if (!group) throw new NotFoundError({ message: `Failed to find group with name ${name}` });
     return { groupId: group.id, group };
   };


### PR DESCRIPTION
## Context

Adding a group to a project by **name** failed in sub-orgs when the group was created in the root org and linked into the sub-org. `getGroupIdFromName` looked up groups with `Groups.orgId = orgId`, but inherited groups still have `Groups.orgId` set to the root org; visibility in the sub-org comes from an org-scoped `Membership` row.

This change resolves groups by name via org-scoped membership (`Membership.scopeOrgId = orgId`, `scope = Organization`), so both native and inherited groups work on:

- `POST /api/v2/workspace/:projectId/groups/:groupIdOrName`
- `POST /api/v1/workspace/:projectId/groups/:groupIdOrName`

## Steps to verify the change

1. In a root org, create a group.
2. Link that group to a sub-org (`POST /api/v1/organizations/memberships/groups/:groupId`).
3. From the sub-org context, add the group to a project **by name** via the v2 endpoint above.
4. Confirm the request succeeds (previously returned `Failed to find group with name <name>`).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)