### PR TITLE
fix(external-kms): use sanitized AWS provider schema in read responses

### DIFF
--- a/backend/src/ee/routes/v1/external-kms-router.ts
+++ b/backend/src/ee/routes/v1/external-kms-router.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 import { ExternalKmsSchema, KmsKeysSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import {
-  ExternalKmsAwsSchema,
   ExternalKmsGcpSchema,
   ExternalKmsInputSchema,
-  ExternalKmsInputUpdateSchema
+  ExternalKmsInputUpdateSchema,
+  SanitizedExternalKmsAwsSchema
 } from "@app/ee/services/external-kms/providers/model";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
@@ -45,8 +45,11 @@ const sanitizedExternalSchemaForGetById = KmsKeysSchema.extend({
     statusDetails: true,
     provider: true
   }).extend({
-    // for GCP, we don't return the credential object as it is sensitive data that should not be exposed
-    providerInput: z.union([ExternalKmsAwsSchema, ExternalKmsGcpSchema.pick({ gcpRegion: true, keyName: true })])
+    // neither provider returns sensitive credential material in read responses: AWS via the sanitized schema (access key only, no secret key), GCP via the picked fields only
+    providerInput: z.union([
+      SanitizedExternalKmsAwsSchema,
+      ExternalKmsGcpSchema.pick({ gcpRegion: true, keyName: true })
+    ])
   })
 });
 

--- a/backend/src/ee/services/external-kms/providers/model.test.ts
+++ b/backend/src/ee/services/external-kms/providers/model.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { ExternalKmsAwsSchema, KmsAwsCredentialType, SanitizedExternalKmsAwsSchema } from "./model";
+
+describe("SanitizedExternalKmsAwsSchema (external-KMS read response)", () => {
+  const awsAccessKeyInput = {
+    credential: {
+      type: KmsAwsCredentialType.AccessKey,
+      data: {
+        accessKey: "AKIAEXAMPLE",
+        secretKey: "super-secret-value"
+      }
+    },
+    awsRegion: "us-east-1",
+    kmsKeyId: "key-123"
+  };
+
+  test("strips secretKey from an access-key credential on read", () => {
+    const parsed = SanitizedExternalKmsAwsSchema.parse(awsAccessKeyInput);
+
+    expect(parsed.credential.type).toBe(KmsAwsCredentialType.AccessKey);
+    expect(parsed.credential.data).toHaveProperty("accessKey", "AKIAEXAMPLE");
+    expect(parsed.credential.data).not.toHaveProperty("secretKey");
+    // the secret value must not survive serialization anywhere in the response
+    expect(JSON.stringify(parsed)).not.toContain("super-secret-value");
+  });
+
+  test("negative control: the pre-fix unsanitized schema would have returned secretKey", () => {
+    const parsed = ExternalKmsAwsSchema.parse(awsAccessKeyInput);
+
+    expect(parsed.credential.data).toHaveProperty("secretKey", "super-secret-value");
+  });
+
+  test("retains assume-role identifiers (that branch carries no secret material)", () => {
+    const parsed = SanitizedExternalKmsAwsSchema.parse({
+      credential: {
+        type: KmsAwsCredentialType.AssumeRole,
+        data: {
+          assumeRoleArn: "arn:aws:iam::123456789012:role/infisical",
+          externalId: "ext-1"
+        }
+      },
+      awsRegion: "us-east-1"
+    });
+
+    expect(parsed.credential.data).toMatchObject({
+      assumeRoleArn: "arn:aws:iam::123456789012:role/infisical",
+      externalId: "ext-1"
+    });
+  });
+});


### PR DESCRIPTION
## Context

The external-KMS get-by-id and get-by-name read endpoints (`GET /external-kms/:id`,
`GET /external-kms/name/:name`) serialize the AWS provider config through the full
`ExternalKmsAwsSchema`. The provider-specific endpoints (for example `GET /external-kms/aws/:id`)
already serialize through `SanitizedExternalKmsAwsSchema`.

This brings the legacy read endpoints in line with that existing schema, so the AWS read response
shape is consistent across the external-KMS API (access key and assume-role identifiers only),
matching how the GCP branch is already handled in the same response. It is not a new control; it
applies the one already used by the provider-specific endpoints to the legacy read endpoints, which
were never migrated to it.

- Before: legacy AWS reads returned the full `ExternalKmsAwsSchema`.
- After: legacy AWS reads return `SanitizedExternalKmsAwsSchema`, the same shape the provider-specific
  endpoints already return.

Changed files:

- `backend/src/ee/routes/v1/external-kms-router.ts`: use `SanitizedExternalKmsAwsSchema` in the
  `providerInput` union of the get-by-id / get-by-name response schema (covers both endpoints);
  update the import and the adjacent comment.
- `backend/src/ee/services/external-kms/providers/model.test.ts`: unit test for the sanitized schema.

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Unit test (included in this PR): `npm run test:unit -- src/ee/services/external-kms/providers/model.test.ts`.
  It asserts the sanitized schema returns the access key and assume-role identifiers only, with a
  negative control over the prior schema.
- Manual: GET an AWS external-KMS key by id and by name and confirm the response matches the shape
  already returned by the provider-specific endpoint (`GET /external-kms/aws/:id`).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
