### PR TITLE
docs(gcp): enhance service account impersonation instructions and add troubleshooting guidance

### DIFF
--- a/docs/integrations/app-connections/gcp.mdx
+++ b/docs/integrations/app-connections/gcp.mdx
@@ -115,14 +115,16 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
 
             1. In the Google Cloud Console, navigate to **IAM & Admin > Organization Policies**.
             2. Search for and open the **Domain restricted sharing** (`iam.allowedPolicyMemberDomains`) policy.
-            3. Add a custom value containing Infisical's Google Cloud Customer ID, using the `is:` prefix:
+            3. Under **Custom values**, add a new allowed value containing Infisical's Google Cloud Customer ID:
 
                 ```
-                is:C03rsjmyl
+                C03rsjmyl
                 ```
 
                 This is **Infisical's Google Cloud Customer ID**, not your own. Infisical uses a single Google Cloud organization, so this one Customer ID covers both the US and EU service accounts.
-            4. Save the policy, then retry adding the Infisical service account as a principal (Step 4 above).
+
+                Enter the bare Customer ID (`C03rsjmyl`) in the Console UI. If you manage this policy with `gcloud`, a policy YAML file, or Terraform instead, use the prefixed form `is:C03rsjmyl`.
+            4. Save the policy, then return to **Step 4 (Grant Access)** in the main instructions above and complete steps 4–7 to add the Infisical service account as a principal.
         </Note>
     </Step>
 

--- a/docs/integrations/app-connections/gcp.mdx
+++ b/docs/integrations/app-connections/gcp.mdx
@@ -92,16 +92,38 @@ Infisical supports [service account impersonation](https://cloud.google.com/iam/
     </Step>
     <Step title="Enable Service Account Impersonation">
         To enable service account impersonation, you'll need to grant the **Service Account Token Creator** role to the Infisical instance's service account. This configuration allows Infisical to securely impersonate the new service account.
-        - Navigate to the IAM & Admin > Service Accounts section in your Google Cloud Console
-        - Select the newly created service account
-        - Click on the "PERMISSIONS" tab
-        - Click "Grant Access" to add a new principal
 
-        If you're using Infisical Cloud US, use the following service account: infisical-us@infisical-us.iam.gserviceaccount.com
-
-        If you're using Infisical Cloud EU, use the following service account: infisical-eu@infisical-eu.iam.gserviceaccount.com
+        1. Navigate to the **IAM & Admin > Service Accounts** section in your Google Cloud Console.
+        2. Select the newly created service account.
+        3. Click on the **PERMISSIONS** tab.
+        4. Click **Grant Access** to add a new principal.
+        5. In the **New principals** field, enter the Infisical service account email for your environment:
+            - **Infisical Cloud US:** `infisical-us@infisical-us.iam.gserviceaccount.com`
+            - **Infisical Cloud EU:** `infisical-eu@infisical-eu.iam.gserviceaccount.com`
+            - **Self-hosted:** use the service account you created for your instance (the one whose credentials are set in `INF_APP_CONNECTION_GCP_SERVICE_ACCOUNT_CREDENTIAL`).
+        6. In the **Role** field, select **Service Account Token Creator**.
+        7. Click **Save**.
 
         ![Service Account Page](/images/app-connections/gcp/service-account-grant-access.png)
+
+        <Note>
+            **Troubleshooting: "One or more users named in the policy do not belong to a permitted customer."**
+
+            If granting access fails with the error *"One or more users named in the policy do not belong to a permitted customer."*, your Google Cloud organization has the Domain Restricted Sharing organization policy (`iam.allowedPolicyMemberDomains`) enabled. This policy only permits identities that belong to allowlisted Google organizations, so the Infisical service account is rejected until it is explicitly allowed.
+
+            To resolve this, add Infisical's Google Cloud Customer ID to the policy's allowed values **before** granting the service account a role:
+
+            1. In the Google Cloud Console, navigate to **IAM & Admin > Organization Policies**.
+            2. Search for and open the **Domain restricted sharing** (`iam.allowedPolicyMemberDomains`) policy.
+            3. Add a custom value containing Infisical's Google Cloud Customer ID, using the `is:` prefix:
+
+                ```
+                is:C03rsjmyl
+                ```
+
+                This is **Infisical's Google Cloud Customer ID**, not your own. Infisical uses a single Google Cloud organization, so this one Customer ID covers both the US and EU service accounts.
+            4. Save the policy, then retry adding the Infisical service account as a principal (Step 4 above).
+        </Note>
     </Step>
 
 </Steps>


### PR DESCRIPTION
## Context

Customers with GCP **Domain Restricted Sharing** (`iam.allowedPolicyMemberDomains`) cannot grant Infisical Cloud service accounts the **Service Account Token Creator** role and see *"One or more users named in the policy do not belong to a permitted customer."*

This PR improves the GCP app connection impersonation docs: numbered setup steps, self-hosted principal guidance, and a troubleshooting note to allowlist Infisical’s Google Cloud Customer ID (`is:C03rsjmyl`) before granting access.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)