### PR TITLE
fix: show full shared secret error message

### DIFF
--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretErrorContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretErrorContainer.tsx
@@ -1,6 +1,6 @@
 import { TriangleAlertIcon } from "lucide-react";
 
-import { Alert, AlertTitle } from "@app/components/v3";
+import { Alert, AlertDescription, AlertTitle } from "@app/components/v3";
 
 import { BrandingTheme } from "../ViewSharedSecretByIDPage";
 
@@ -24,8 +24,14 @@ export const SecretErrorContainer = ({ error, brandingTheme }: Props) => {
         style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
       />
       <AlertTitle style={brandingTheme ? { color: brandingTheme.textColor } : undefined}>
-        {error || "The secret you are looking for is missing or has expired"}
+        Unable to view shared secret
       </AlertTitle>
+      <AlertDescription
+        className="break-words"
+        style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
+      >
+        {error || "The secret you are looking for is missing or has expired"}
+      </AlertDescription>
     </Alert>
   );
 };


### PR DESCRIPTION
## Context

Fixes #7003. Missing shared secret errors were rendered in `AlertTitle`, which is one-line clamped. This moves dynamic error text to `AlertDescription` so long IDs wrap.

## Screenshots

See #7003. Verified locally with Playwright desktop and mobile.
<img width="959" height="750" alt="image" src="https://github.com/user-attachments/assets/4c42881e-f1d4-4bd3-8dd3-c768c8a163d6" />


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)