### PR TITLE
fix(aws-syncs): remove region validation

### DIFF
--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -1,6 +1,5 @@
 import { AssumeRoleCommand, GetCallerIdentityCommand, STSClient, STSServiceException } from "@aws-sdk/client-sts";
 import { AxiosError } from "axios";
-import { z } from "zod";
 
 import { ProjectType } from "@app/db/schemas";
 import { CustomAWSHasher } from "@app/lib/aws/hashing";
@@ -9,12 +8,9 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, InternalServerError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { AppConnection, AWSRegion } from "@app/services/app-connection/app-connection-enums";
-import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { TAppConnectionRaw } from "@app/services/app-connection/app-connection-types";
-import { TPreSaveTransformDestinationConfigFn } from "@app/services/secret-sync/secret-sync-types";
 
 import { AwsConnectionMethod } from "./aws-connection-enums";
-import { AwsConnectionAssumeRoleCredentialsSchema } from "./aws-connection-schemas";
 import { TAwsConnectionConfig } from "./aws-connection-types";
 
 // Regional and VPC PrivateLink STS endpoints reject requests whose SigV4 credential scope region
@@ -230,56 +226,4 @@ export const validateAwsConnectionCredentials = async (appConnection: TAwsConnec
   }
 
   return appConnection.credentials;
-};
-
-// For AWS secret syncs: if the linked connection pins a custom STS endpoint to a specific region,
-// the sync's destination region must match that endpoint's region. A custom STS endpoint is typically
-// used in isolated/VPC networks where other regions' data-plane endpoints aren't reachable, so a
-// mismatched region is a misconfiguration we reject up front. Region-less endpoints (the global
-// sts.amazonaws.com or non-AWS hosts) pin no region and impose no constraint.
-export const awsSyncPreSaveTransformDestinationConfig: TPreSaveTransformDestinationConfigFn = async (
-  { destinationConfig, connectionId },
-  { appConnectionDAL, kmsService }
-) => {
-  if (!destinationConfig) return destinationConfig;
-
-  const appConnection = await appConnectionDAL.findById(connectionId);
-
-  if (
-    !appConnection ||
-    appConnection.app !== AppConnection.AWS ||
-    appConnection.method !== AwsConnectionMethod.AssumeRole
-  ) {
-    return destinationConfig;
-  }
-
-  const { stsEndpoint } = (await decryptAppConnectionCredentials({
-    orgId: appConnection.orgId,
-    projectId: appConnection.projectId,
-    encryptedCredentials: appConnection.encryptedCredentials,
-    kmsService
-  })) as z.infer<typeof AwsConnectionAssumeRoleCredentialsSchema>;
-
-  if (!stsEndpoint) return destinationConfig;
-
-  const stsRegion = getStsSigningRegion(stsEndpoint);
-
-  // global / non-AWS endpoint pins no region, so any sync region is allowed
-  if (!stsRegion) return destinationConfig;
-
-  const region = destinationConfig.region as string | undefined;
-
-  if (!region) {
-    throw new BadRequestError({
-      message: `Secret sync region is required when the AWS connection uses a regional STS endpoint. Set the region in the sync destination config to match the connection's STS endpoint.`
-    });
-  }
-
-  if (region !== stsRegion.region) {
-    throw new BadRequestError({
-      message: `Secret sync region "${region}" must match the AWS connection's STS endpoint region from the app connection. Update the sync region or the connection's STS endpoint.`
-    });
-  }
-
-  return destinationConfig;
 };

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -8,7 +8,6 @@ import { TLicenseServiceFactory } from "@app/ee/services/license/license-service
 import { CHEF_SYNC_LIST_OPTION, ChefSyncFns } from "@app/ee/services/secret-sync/chef";
 import { OCI_VAULT_SYNC_LIST_OPTION, OCIVaultSyncFns } from "@app/ee/services/secret-sync/oci-vault";
 import { BadRequestError } from "@app/lib/errors";
-import { awsSyncPreSaveTransformDestinationConfig } from "@app/services/app-connection/aws/aws-connection-fns";
 import {
   AWS_PARAMETER_STORE_SYNC_LIST_OPTION,
   AwsParameterStoreSyncFns
@@ -144,9 +143,7 @@ const PRE_SAVE_TRANSFORM_SYNC_OPTIONS_MAP: Partial<Record<SecretSync, TPreSaveTr
 };
 
 const PRE_SAVE_TRANSFORM_DESTINATION_CONFIG_MAP: Partial<Record<SecretSync, TPreSaveTransformDestinationConfigFn>> = {
-  [SecretSync.AzureEntraIdScim]: azureEntraIdScimPreSaveTransformDestinationConfig,
-  [SecretSync.AWSSecretsManager]: awsSyncPreSaveTransformDestinationConfig,
-  [SecretSync.AWSParameterStore]: awsSyncPreSaveTransformDestinationConfig
+  [SecretSync.AzureEntraIdScim]: azureEntraIdScimPreSaveTransformDestinationConfig
 };
 
 export const preSaveTransformSyncOptions = async (


### PR DESCRIPTION
## Context
Removed a validation where it forced the user to use the same region as the sts endpoint (in case this sts was provided)


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- create an app connection that has an sts endpoint 
- create a secret sync for parameter store or secrets management 
- Use a region different from the sts endpoint
- check that the sync works   

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview) 