### PR TITLE
feat(billing): surface usage units and billing address/tax IDs

### DIFF
--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -92,12 +92,13 @@ const BillingV2OverviewSchema = z.object({
       email: z.string(),
       address: z
         .object({
-          line1: z.string(),
-          line2: z.string(),
-          city: z.string(),
-          state: z.string(),
-          postalCode: z.string(),
-          country: z.string()
+          // Each sub-field is nullish: Stripe/older license servers omit or null any unfilled line.
+          line1: z.string().nullish(),
+          line2: z.string().nullish(),
+          city: z.string().nullish(),
+          state: z.string().nullish(),
+          postalCode: z.string().nullish(),
+          country: z.string().nullish()
         })
         .nullable(),
       taxIds: z.object({ type: z.string(), value: z.string() }).array()

--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -67,7 +67,8 @@ const BillingV2InvoiceSchema = z.object({
 const BillingV2EntitlementSchema = z.object({
   entitled: z.boolean(),
   limit: z.number().nullable().optional(),
-  used: z.number().optional()
+  used: z.number().optional(),
+  unit: z.string().nullable().optional()
 });
 
 const BillingV2OverviewSchema = z.object({
@@ -85,7 +86,23 @@ const BillingV2OverviewSchema = z.object({
     identityLimit: z.number().nullable()
   }),
   payment: z.object({ brand: z.string(), last4: z.string(), expMonth: z.number(), expYear: z.number() }).nullable(),
-  billingDetails: z.object({ name: z.string(), email: z.string() }).nullable(),
+  billingDetails: z
+    .object({
+      name: z.string(),
+      email: z.string(),
+      address: z
+        .object({
+          line1: z.string(),
+          line2: z.string(),
+          city: z.string(),
+          state: z.string(),
+          postalCode: z.string(),
+          country: z.string()
+        })
+        .nullable(),
+      taxIds: z.object({ type: z.string(), value: z.string() }).array()
+    })
+    .nullable(),
   invoices: BillingV2InvoiceSchema.array(),
   entitlements: z.record(BillingV2EntitlementSchema)
 });

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -284,22 +284,28 @@ export const licenseV2ServiceFactory = ({
 
     if (subscription) {
       subscription.items.forEach((item) => {
-        const quantityValues = Object.values(item.quantities);
+        // Surface one dimension's used count, limit, and noun together so the rendered
+        // "{used} / {limit} {unit}" always describes the same thing. "Most constraining" = the
+        // highest utilization (closest to, or furthest past, its cap), i.e. the limit the customer
+        // is likeliest to hit. Each limit is paired with its OWN quantity; taking Math.max across all
+        // quantities could otherwise report a different dimension's count than the resolved unit.
         let used = 0;
-        if (quantityValues.length > 0) {
-          used = Math.max(...quantityValues);
-        }
-
-        // Surface the most constraining dimension and resolve that same dimension's noun, so the
-        // count and its unit always describe the same thing.
         let limit: number | null = null;
         let limitKey: string | null = null;
+        let highestUtilization = -1;
         // Plain for-of (not forEach): assignments inside a closure don't refine the outer
         // variable's type, so after a forEach TS still sees limitKey as null and the `limitKey ?`
         // branch below collapses to `never`. A same-scope loop lets control-flow keep it string|null.
-        for (const [key, value] of Object.entries(item.limits)) {
-          if (limit === null || value > limit) {
-            limit = value;
+        for (const [key, dimensionLimit] of Object.entries(item.limits)) {
+          const dimensionUsed = item.quantities[key] ?? 0;
+          // An unlimited (<= 0) cap can't be "hit"; only a positive cap yields a real ratio.
+          const utilization =
+            // eslint-disable-next-line no-nested-ternary
+            dimensionLimit > 0 ? dimensionUsed / dimensionLimit : dimensionUsed > 0 ? Infinity : 0;
+          if (limitKey === null || utilization > highestUtilization) {
+            highestUtilization = utilization;
+            used = dimensionUsed;
+            limit = dimensionLimit;
             limitKey = key;
           }
         }
@@ -401,25 +407,11 @@ export const licenseV2ServiceFactory = ({
       const profile = await licenseClient.getBillingProfile(orgId);
       if (profile) {
         payment = profile.payment;
+        // name/email/address/taxIds pass straight through (address keeps its nullable sub-fields;
+        // the UI drops blank lines). The ?? null just normalizes an absent address to null, and any
+        // extra license-server keys the spread carries are stripped by the response schema.
         billingDetails = profile.billingDetails
-          ? {
-              name: profile.billingDetails.name,
-              email: profile.billingDetails.email,
-              address: profile.billingDetails.address
-                ? {
-                    line1: profile.billingDetails.address.line1,
-                    line2: profile.billingDetails.address.line2,
-                    city: profile.billingDetails.address.city,
-                    state: profile.billingDetails.address.state,
-                    postalCode: profile.billingDetails.address.postalCode,
-                    country: profile.billingDetails.address.country
-                  }
-                : null,
-              taxIds: profile.billingDetails.taxIds.map((taxId) => ({
-                type: taxId.type,
-                value: taxId.value
-              }))
-            }
+          ? { ...profile.billingDetails, address: profile.billingDetails.address ?? null }
           : null;
         invoices = profile.invoices.map((invoice) => ({
           id: invoice.id,

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -265,6 +265,23 @@ export const licenseV2ServiceFactory = ({
   const buildEntitlements = async (org: TEntitlementOrg, subscription: TSubscriptionResponse | null) => {
     const entitlements: Record<string, BillingV2Entitlement> = {};
 
+    // Dimension nouns (the unit a limit counts, e.g. "certificate") live on the catalog, keyed by
+    // dimension. Only fetch it when a subscription item actually carries a limit to name.
+    const nounByDimension = new Map<string, string>();
+    const hasLimits = Boolean(subscription?.items.some((item) => Object.keys(item.limits).length > 0));
+    if (hasLimits) {
+      try {
+        const catalog = await licenseClient.getCatalog();
+        catalog?.products.forEach((product) => {
+          product.dimensions.forEach((dimension) => {
+            nounByDimension.set(`${product.id}:${dimension.key}`, dimension.noun);
+          });
+        });
+      } catch (error) {
+        logger.error(error, `billing-v2: failed to read catalog for entitlement units [orgId=${org.id}]`);
+      }
+    }
+
     if (subscription) {
       subscription.items.forEach((item) => {
         const quantityValues = Object.values(item.quantities);
@@ -273,13 +290,23 @@ export const licenseV2ServiceFactory = ({
           used = Math.max(...quantityValues);
         }
 
-        const limitValues = Object.values(item.limits);
+        // Surface the most constraining dimension and resolve that same dimension's noun, so the
+        // count and its unit always describe the same thing.
         let limit: number | null = null;
-        if (limitValues.length > 0) {
-          limit = Math.max(...limitValues);
+        let limitKey: string | null = null;
+        // Plain for-of (not forEach): assignments inside a closure don't refine the outer
+        // variable's type, so after a forEach TS still sees limitKey as null and the `limitKey ?`
+        // branch below collapses to `never`. A same-scope loop lets control-flow keep it string|null.
+        for (const [key, value] of Object.entries(item.limits)) {
+          if (limit === null || value > limit) {
+            limit = value;
+            limitKey = key;
+          }
         }
 
-        entitlements[item.productId] = { entitled: true, used, limit };
+        const unit = limitKey ? (nounByDimension.get(`${item.productId}:${limitKey}`) ?? null) : null;
+
+        entitlements[item.productId] = { entitled: true, used, limit, unit };
       });
     }
 
@@ -374,7 +401,26 @@ export const licenseV2ServiceFactory = ({
       const profile = await licenseClient.getBillingProfile(orgId);
       if (profile) {
         payment = profile.payment;
-        billingDetails = profile.billingDetails;
+        billingDetails = profile.billingDetails
+          ? {
+              name: profile.billingDetails.name,
+              email: profile.billingDetails.email,
+              address: profile.billingDetails.address
+                ? {
+                    line1: profile.billingDetails.address.line1,
+                    line2: profile.billingDetails.address.line2,
+                    city: profile.billingDetails.address.city,
+                    state: profile.billingDetails.address.state,
+                    postalCode: profile.billingDetails.address.postalCode,
+                    country: profile.billingDetails.address.country
+                  }
+                : null,
+              taxIds: profile.billingDetails.taxIds.map((taxId) => ({
+                type: taxId.type,
+                value: taxId.value
+              }))
+            }
+          : null;
         invoices = profile.invoices.map((invoice) => ({
           id: invoice.id,
           number: invoice.number,

--- a/backend/src/ee/services/license-v2/license-v2-types.ts
+++ b/backend/src/ee/services/license-v2/license-v2-types.ts
@@ -63,6 +63,9 @@ export type BillingV2Entitlement = {
   entitled: boolean;
   limit?: number | null;
   used?: number;
+  // Singular noun for the limited dimension (e.g. "certificate"), resolved from the catalog so the
+  // UI can render the unit beside the count ("0 / 100 certificates").
+  unit?: string | null;
 };
 
 export type BillingV2Usage = {
@@ -82,7 +85,19 @@ export type BillingV2Overview = {
   interval: "month" | "year" | null;
   usage: BillingV2Usage;
   payment: BillingV2PaymentMethod;
-  billingDetails: { name: string; email: string } | null;
+  billingDetails: {
+    name: string;
+    email: string;
+    address: {
+      line1: string;
+      line2: string;
+      city: string;
+      state: string;
+      postalCode: string;
+      country: string;
+    } | null;
+    taxIds: { type: string; value: string }[];
+  } | null;
   invoices: BillingV2Invoice[];
   entitlements: Record<string, BillingV2Entitlement>;
 };

--- a/backend/src/ee/services/license-v2/license-v2-types.ts
+++ b/backend/src/ee/services/license-v2/license-v2-types.ts
@@ -89,12 +89,12 @@ export type BillingV2Overview = {
     name: string;
     email: string;
     address: {
-      line1: string;
-      line2: string;
-      city: string;
-      state: string;
-      postalCode: string;
-      country: string;
+      line1?: string | null;
+      line2?: string | null;
+      city?: string | null;
+      state?: string | null;
+      postalCode?: string | null;
+      country?: string | null;
     } | null;
     taxIds: { type: string; value: string }[];
   } | null;

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -144,14 +144,18 @@ const billingProfilePaymentSchema = z
   })
   .passthrough();
 
+// Stripe leaves any unfilled field null (line2/state are absent for most customers) and older
+// license servers may omit them, so every sub-field is nullish. A strict z.string() would throw on
+// a partial address; because the whole profile is parsed in one shot, that failure silently drops
+// the customer's payment method and invoices too, not just the address.
 const billingProfileAddressSchema = z
   .object({
-    line1: z.string(),
-    line2: z.string(),
-    city: z.string(),
-    state: z.string(),
-    postalCode: z.string(),
-    country: z.string()
+    line1: z.string().nullish(),
+    line2: z.string().nullish(),
+    city: z.string().nullish(),
+    state: z.string().nullish(),
+    postalCode: z.string().nullish(),
+    country: z.string().nullish()
   })
   .passthrough();
 

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -144,10 +144,27 @@ const billingProfilePaymentSchema = z
   })
   .passthrough();
 
+const billingProfileAddressSchema = z
+  .object({
+    line1: z.string(),
+    line2: z.string(),
+    city: z.string(),
+    state: z.string(),
+    postalCode: z.string(),
+    country: z.string()
+  })
+  .passthrough();
+
+const billingProfileTaxIdSchema = z.object({ type: z.string(), value: z.string() }).passthrough();
+
 const billingProfileDetailsSchema = z
   .object({
     name: z.string(),
-    email: z.string()
+    email: z.string(),
+    // Absent on older license servers that predate these fields; address is null when the customer
+    // has none, taxIds defaults to [] so callers can map it without a null check.
+    address: billingProfileAddressSchema.nullish(),
+    taxIds: z.array(billingProfileTaxIdSchema).default([])
   })
   .passthrough();
 

--- a/frontend/src/components/v3/generic/Table/Table.tsx
+++ b/frontend/src/components/v3/generic/Table/Table.tsx
@@ -109,7 +109,7 @@ function TableCell({
     <td
       data-slot="table-cell"
       className={cn(
-        "h-[40px] border-b border-border px-3 align-middle whitespace-nowrap text-mineshaft-200 [&:has([role=checkbox])]:pr-0 [&>svg]:size-4",
+        "h-[40px] border-b border-border px-3 align-middle whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>svg]:size-4",
         isTruncatable && "max-w-0 truncate",
         className
       )}

--- a/frontend/src/helpers/project.ts
+++ b/frontend/src/helpers/project.ts
@@ -1,11 +1,11 @@
 import {
   FileKeyIcon,
+  KeyIcon,
   LockIcon,
   LucideIcon,
-  ScanSearchIcon,
+  RadarIcon,
   TerminalIcon,
-  UsersIcon,
-  VaultIcon
+  UsersIcon
 } from "lucide-react";
 
 import { apiRequest } from "@app/config/request";
@@ -199,14 +199,14 @@ export const getProjectLottieIcon = (type: ProjectType) => {
 
 export const getProjectLucideIcon = (type: ProjectType): LucideIcon => {
   const iconConvert: Partial<Record<ProjectType, LucideIcon>> = {
-    [ProjectType.SecretManager]: VaultIcon,
+    [ProjectType.SecretManager]: KeyIcon,
     [ProjectType.KMS]: LockIcon,
     [ProjectType.CertificateManager]: FileKeyIcon,
     [ProjectType.SSH]: TerminalIcon,
-    [ProjectType.SecretScanning]: ScanSearchIcon,
+    [ProjectType.SecretScanning]: RadarIcon,
     [ProjectType.PAM]: UsersIcon
   };
-  return iconConvert[type] || VaultIcon;
+  return iconConvert[type] || KeyIcon;
 };
 
 export type ProjectTileStyle = {

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -65,6 +65,8 @@ export type BillingV2Entitlement = {
   entitled: boolean;
   limit?: number | null;
   used?: number;
+  // Singular noun for the limited dimension (e.g. "certificate"); rendered, pluralized, beside the count.
+  unit?: string | null;
 };
 
 export type BillingV2Overview = {
@@ -82,7 +84,19 @@ export type BillingV2Overview = {
     identityLimit: number | null;
   };
   payment: BillingV2PaymentMethod;
-  billingDetails: { name: string; email: string } | null;
+  billingDetails: {
+    name: string;
+    email: string;
+    address: {
+      line1: string;
+      line2: string;
+      city: string;
+      state: string;
+      postalCode: string;
+      country: string;
+    } | null;
+    taxIds: { type: string; value: string }[];
+  } | null;
   invoices: BillingV2Invoice[];
   entitlements: Record<string, BillingV2Entitlement>;
 };

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -88,12 +88,12 @@ export type BillingV2Overview = {
     name: string;
     email: string;
     address: {
-      line1: string;
-      line2: string;
-      city: string;
-      state: string;
-      postalCode: string;
-      country: string;
+      line1?: string | null;
+      line2?: string | null;
+      city?: string | null;
+      state?: string | null;
+      postalCode?: string | null;
+      country?: string | null;
     } | null;
     taxIds: { type: string; value: string }[];
   } | null;

--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -93,35 +93,31 @@ export const BillingV2Page = () => {
   };
 
   const redirectToCheckout = async (productId: string) => {
-    try {
-      const result = await createCheckoutSession.mutateAsync({
-        orgId,
-        productId,
-        cadence,
-        email: billingEmail,
-        returnPath: window.location.pathname
+    const result = await createCheckoutSession.mutateAsync({
+      orgId,
+      productId,
+      cadence,
+      email: billingEmail,
+      returnPath: window.location.pathname
+    });
+
+    // The product was added straight to the existing subscription; no Stripe redirect needed.
+    if (result.outcome === "subscription_updated") {
+      close();
+      createNotification({
+        type: "success",
+        text: "Product added to your subscription. It may take a moment to appear here."
       });
-
-      // The product was added straight to the existing subscription; no Stripe redirect needed.
-      if (result.outcome === "subscription_updated") {
-        close();
-        createNotification({
-          type: "success",
-          text: "Product added to your subscription. It may take a moment to appear here."
-        });
-        refetch();
-        return;
-      }
-
-      if (result.checkoutUrl) {
-        window.location.href = result.checkoutUrl;
-        return;
-      }
-
-      createNotification({ type: "error", text: "Failed to start checkout." });
-    } catch {
-      createNotification({ type: "error", text: "Failed to start checkout." });
+      refetch();
+      return;
     }
+
+    if (result.checkoutUrl) {
+      window.location.href = result.checkoutUrl;
+      return;
+    }
+
+    createNotification({ type: "error", text: "Failed to start checkout." });
   };
 
   const onManageSubscription = () => {
@@ -178,7 +174,7 @@ export const BillingV2Page = () => {
         <meta property="og:image" content="/images/message.png" />
       </Helmet>
       <div className="flex h-full w-full justify-center bg-bunker-800 text-white">
-        <div className="w-full max-w-5xl">
+        <div className="w-full max-w-8xl">
           <PageHeader
             scope="org"
             title={t("billing.title")}

--- a/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
+++ b/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
@@ -10,6 +10,22 @@ export const catalogById = (
 export const fmtMoney = (n: number, maximumFractionDigits = 0): string =>
   `$${Number(n).toLocaleString("en-US", { maximumFractionDigits })}`;
 
+// Pluralize a singular dimension noun (the catalog's "noun" field) for display beside a count, since
+// a limit meter always reads as a plural quantity ("0 / 100 certificates"). Conservative: a noun that
+// already ends in "s" is left alone so a value the server sends plural isn't doubled.
+export const pluralizeUnit = (noun: string): string => {
+  if (/s$/i.test(noun)) {
+    return noun;
+  }
+  if (/[^aeiou]y$/i.test(noun)) {
+    return `${noun.slice(0, -1)}ies`;
+  }
+  if (/(x|z|ch|sh)$/i.test(noun)) {
+    return `${noun}es`;
+  }
+  return `${noun}s`;
+};
+
 export const cadenceWord = (cad: BillingV2Cadence): string => {
   if (cad === "annual") {
     return "year";

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import {
-  faCalendar,
   faCircleExclamation,
   faCircleInfo,
   faCreditCard,
@@ -10,6 +9,17 @@ import {
   IconDefinition
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  ArrowBigUpDashIcon,
+  Building2,
+  Calendar,
+  CreditCard,
+  GaugeIcon,
+  Package,
+  ReceiptText,
+  ShieldAlert,
+  ShieldCheck
+} from "lucide-react";
 
 import {
   Alert,
@@ -23,6 +33,10 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
   Skeleton,
   Table,
   TableBody,
@@ -31,6 +45,7 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
 import {
   BillingV2CatalogProduct,
   BillingV2Entitlement,
@@ -38,7 +53,7 @@ import {
   BillingV2Overview
 } from "@app/hooks/api";
 
-import { fmtMoney, intervalWord } from "../billing-v2-data";
+import { fmtMoney, intervalWord, pluralizeUnit } from "../billing-v2-data";
 import { ActiveBadge, LimitMeter, ProductIcon } from "./shared";
 
 export type BillingV2Mode = "self-serve" | "managed";
@@ -128,22 +143,40 @@ const Banner = ({
   );
 };
 
-const CardEmpty = ({ children }: { children: ReactNode }) => (
-  <div className="py-7 text-center text-sm text-mineshaft-400">{children}</div>
+type CardEmptyProps = {
+  title: string;
+  description?: ReactNode;
+};
+
+const CardEmpty = ({ title, description }: CardEmptyProps) => (
+  <Empty className="border">
+    <EmptyHeader>
+      <EmptyTitle>{title}</EmptyTitle>
+      {description ? <EmptyDescription>{description}</EmptyDescription> : null}
+    </EmptyHeader>
+  </Empty>
 );
 
 const OverviewSkeleton = () => (
   <div className="flex flex-col gap-4">
-    <Card className="p-0">
-      <div className="flex gap-10 p-6">
-        {[0, 1, 2].map((i) => (
-          <div key={i} className="flex flex-1 flex-col gap-2.5">
-            <Skeleton className="h-2.5 w-1/2" />
+    <div className="flex flex-col gap-4 lg:flex-row">
+      {[0, 1, 2].map((i) => (
+        <Card key={i} className="flex-1 gap-2 p-4 shadow-none">
+          <CardHeader>
+            <CardTitle>
+              <Skeleton className="h-3 w-16" />
+            </CardTitle>
+            <CardAction>
+              <Skeleton className="size-7 rounded-md" />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-1.5">
             <Skeleton className="h-5 w-2/3" />
-          </div>
-        ))}
-      </div>
-    </Card>
+            <Skeleton className="h-4 w-20" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
     <Card>
       <CardHeader>
         <CardTitle>
@@ -180,7 +213,7 @@ const ErrorPanel = ({ onRetry }: ErrorPanelProps) => (
       <div className="text-base font-semibold text-foreground">
         Couldn&apos;t load your subscription
       </div>
-      <div className="max-w-[40ch] text-sm text-mineshaft-300">
+      <div className="max-w-[40ch] text-sm text-accent">
         There was a problem reaching the billing service. Your products are unaffected.
       </div>
       <Button variant="outline" size="sm" onClick={onRetry}>
@@ -215,37 +248,88 @@ const recurringLabel = (overview: BillingV2Overview): string => {
   return `${fmtMoney(overview.recurringAmount)} / ${intervalWord(overview.interval)}`;
 };
 
-const SummaryCard = ({ overview }: SummaryCardProps) => (
-  <Card className="overflow-hidden p-0">
-    <div className="flex flex-wrap items-stretch">
-      <div className="flex min-w-[180px] flex-1 flex-col gap-2 border-r border-border p-6">
-        <span className="text-xs font-medium tracking-wide text-mineshaft-400 uppercase">
-          Status
-        </span>
-        <span className="flex items-center text-2xl font-semibold text-foreground">
-          <StatusBadge subState={overview.subState} />
-        </span>
-        <span className="text-xs text-mineshaft-400">{overview.planName}</span>
-      </div>
-      <div className="flex min-w-[180px] flex-1 flex-col gap-2 border-r border-border p-6">
-        <span className="text-xs font-medium tracking-wide text-mineshaft-400 uppercase">
-          Next billing date
-        </span>
-        <span className="flex items-center gap-2 text-2xl font-semibold text-foreground">
-          <FontAwesomeIcon icon={faCalendar} className="text-lg text-org" />
-          {overview.nextBillingDate || "—"}
-        </span>
-        <span className="text-xs text-mineshaft-400">All products renew together</span>
-      </div>
-      <div className="flex min-w-[180px] flex-1 flex-col gap-2 p-6">
-        <span className="text-xs font-medium tracking-wide text-mineshaft-400 uppercase">
-          Recurring total
-        </span>
-        <span className="text-2xl font-semibold text-foreground">{recurringLabel(overview)}</span>
-      </div>
-    </div>
+type StatTone = "success" | "info" | "warning" | "danger" | "org";
+
+const STAT_TONE: Record<StatTone, string> = {
+  success: "border-success/15 bg-success/10 text-success",
+  info: "border-info/15 bg-info/10 text-info",
+  org: "border-org/15 bg-org/10 text-org",
+  warning: "border-warning/15 bg-warning/10 text-warning",
+  danger: "border-danger/15 bg-danger/10 text-danger"
+};
+
+const STATUS_VISUAL: Record<BillingV2RenderState, { tone: StatTone; icon: ReactNode }> = {
+  active: { tone: "success", icon: <ShieldCheck /> },
+  trialing: { tone: "info", icon: <ShieldCheck /> },
+  "past-due": { tone: "warning", icon: <ShieldAlert /> },
+  suspended: { tone: "danger", icon: <ShieldAlert /> },
+  "no-subscription": { tone: "info", icon: <ShieldCheck /> },
+  loading: { tone: "info", icon: <ShieldCheck /> },
+  error: { tone: "danger", icon: <ShieldAlert /> }
+};
+
+type StatTileProps = {
+  title: string;
+  tone: StatTone;
+  icon: ReactNode;
+  value: ReactNode;
+  footer: ReactNode;
+};
+
+const StatTile = ({ title, tone, icon, value, footer }: StatTileProps) => (
+  <Card className="flex-1 gap-2 p-4 shadow-none">
+    <CardHeader>
+      <CardTitle className="text-xs font-medium text-muted capitalize">{title}</CardTitle>
+      <CardAction>
+        <div
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md border [&>svg]:size-4",
+            STAT_TONE[tone]
+          )}
+        >
+          {icon}
+        </div>
+      </CardAction>
+    </CardHeader>
+    <CardContent className="flex flex-col gap-1.5">
+      <div className="text-lg font-semibold text-foreground">{value}</div>
+      <div className="flex min-h-5 items-center">{footer}</div>
+    </CardContent>
   </Card>
 );
+
+const SummaryCard = ({ overview }: SummaryCardProps) => {
+  const status = STATUS_VISUAL[overview.subState];
+  const recurringNote = overview.recurringAmount
+    ? `Billed ${intervalWord(overview.interval)}ly`
+    : "No recurring charges";
+
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row">
+      <StatTile
+        title="Status"
+        tone={status.tone}
+        icon={status.icon}
+        value={overview.planName || "—"}
+        footer={<StatusBadge subState={overview.subState} />}
+      />
+      <StatTile
+        title="Next billing date"
+        tone="org"
+        icon={<Calendar />}
+        value={overview.nextBillingDate || "—"}
+        footer={<span className="text-xs text-muted">All products renew together</span>}
+      />
+      <StatTile
+        title="Recurring total"
+        tone="org"
+        icon={<CreditCard />}
+        value={recurringLabel(overview)}
+        footer={<span className="text-xs text-muted">{recurringNote}</span>}
+      />
+    </div>
+  );
+};
 
 type UsageCardProps = {
   overview: BillingV2Overview;
@@ -254,7 +338,10 @@ type UsageCardProps = {
 const UsageCard = ({ overview }: UsageCardProps) => (
   <Card>
     <CardHeader>
-      <CardTitle>Usage</CardTitle>
+      <CardTitle>
+        <GaugeIcon className="size-4 text-accent" />
+        Usage
+      </CardTitle>
     </CardHeader>
     <CardContent className="flex flex-col gap-2.5">
       <LimitMeter
@@ -284,7 +371,8 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
   let limitNote: string | null = null;
   if (entitled && entitlement && entitlement.limit !== null && entitlement.limit !== undefined) {
     const used = entitlement.used ?? 0;
-    limitNote = `${used.toLocaleString()} / ${entitlement.limit.toLocaleString()}`;
+    const unit = entitlement.unit ? ` ${pluralizeUnit(entitlement.unit)}` : "";
+    limitNote = `${used.toLocaleString()} / ${entitlement.limit.toLocaleString()}${unit}`;
   }
 
   const selfServe = Boolean(prod.pro?.planKey);
@@ -300,12 +388,13 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
     } else if (selfServe) {
       action = (
         <Button variant="org" size="sm" onClick={() => onManage(prod.id)}>
+          <ArrowBigUpDashIcon />
           Upgrade
         </Button>
       );
     } else if (prod.enterprise) {
       action = (
-        <Button variant="info" size="sm" onClick={() => onContact(prod)}>
+        <Button variant="org" size="sm" onClick={() => onContact(prod)}>
           Contact sales
         </Button>
       );
@@ -321,12 +410,12 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
           {prod.addon && <Badge variant="neutral">Add-on</Badge>}
           {entitled ? <ActiveBadge /> : <Badge variant="neutral">Inactive</Badge>}
         </div>
-        <div className="text-xs text-mineshaft-400">{prod.tagline || prod.desc}</div>
+        <div className="text-xs text-muted">{prod.tagline || prod.desc}</div>
       </div>
       {limitNote && (
         <div className="flex shrink-0 flex-col items-end gap-0.5">
-          <span className="text-sm font-semibold text-foreground">{limitNote}</span>
-          <span className="text-xs text-mineshaft-400">in use</span>
+          <span className="text-xs font-semibold text-foreground">{limitNote}</span>
+          <span className="text-xs text-muted">in use</span>
         </div>
       )}
       {action && <div className="flex shrink-0 items-center gap-1.5">{action}</div>}
@@ -345,12 +434,18 @@ type ProductsCardProps = {
 const ProductsCard = ({ overview, catalog, readOnly, onManage, onContact }: ProductsCardProps) => (
   <Card>
     <CardHeader>
-      <CardTitle>Products</CardTitle>
+      <CardTitle>
+        <Package className="size-4 text-accent" />
+        Products
+      </CardTitle>
       <CardDescription>Everything you can run on your subscription.</CardDescription>
     </CardHeader>
     <CardContent>
       {catalog.length === 0 ? (
-        <CardEmpty>No products are available yet.</CardEmpty>
+        <CardEmpty
+          title="No products available"
+          description="Products will appear here once they're available."
+        />
       ) : (
         <div className="flex flex-col">
           {catalog.map((prod) => (
@@ -378,7 +473,10 @@ type PaymentCardProps = {
 const PaymentCard = ({ overview, canManage, onUpdate }: PaymentCardProps) => (
   <Card>
     <CardHeader>
-      <CardTitle>Payment method</CardTitle>
+      <CardTitle>
+        <CreditCard className="size-4 text-accent" />
+        Payment Method
+      </CardTitle>
       {canManage && (
         <CardAction>
           <Button variant="outline" size="sm" onClick={onUpdate}>
@@ -390,21 +488,24 @@ const PaymentCard = ({ overview, canManage, onUpdate }: PaymentCardProps) => (
     <CardContent>
       {overview.payment ? (
         <div className="flex items-center gap-3.5">
-          <div className="flex h-[30px] w-[46px] shrink-0 items-center justify-center rounded-sm border border-border bg-mineshaft-700 text-[10px] font-bold tracking-wide text-foreground">
+          <div className="flex h-[30px] w-[46px] shrink-0 items-center justify-center rounded-sm border border-border bg-container text-[10px] font-bold tracking-wide text-foreground">
             {overview.payment.brand.toUpperCase()}
           </div>
           <div>
             <div className="text-sm font-medium text-foreground">
               {overview.payment.brand.toUpperCase()} ending in {overview.payment.last4}
             </div>
-            <div className="mt-0.5 text-xs text-mineshaft-400">
+            <div className="mt-0.5 text-xs text-muted">
               Expires {String(overview.payment.expMonth).padStart(2, "0")} /{" "}
               {String(overview.payment.expYear).slice(-2)}
             </div>
           </div>
         </div>
       ) : (
-        <CardEmpty>No payment method on file yet.</CardEmpty>
+        <CardEmpty
+          title="No payment method"
+          description="You haven't added a payment method yet."
+        />
       )}
     </CardContent>
   </Card>
@@ -416,40 +517,135 @@ type DetailsCardProps = {
   onEdit: () => void;
 };
 
-const DetailsCard = ({ overview, canManage, onEdit }: DetailsCardProps) => (
-  <Card>
-    <CardHeader>
-      <CardTitle>Billing details</CardTitle>
-      {canManage && (
-        <CardAction>
-          <Button variant="outline" size="sm" onClick={onEdit}>
-            Edit
-          </Button>
-        </CardAction>
-      )}
-    </CardHeader>
-    <CardContent>
-      {overview.billingDetails ? (
-        <div className="grid grid-cols-3 gap-4">
-          <div>
-            <div className="mb-1 text-xs tracking-wide text-mineshaft-400 uppercase">
-              Billing name
-            </div>
-            <div className="text-sm text-foreground">{overview.billingDetails.name || "—"}</div>
-          </div>
-          <div>
-            <div className="mb-1 text-xs tracking-wide text-mineshaft-400 uppercase">
-              Billing email
-            </div>
-            <div className="text-sm text-foreground">{overview.billingDetails.email || "—"}</div>
-          </div>
-        </div>
-      ) : (
-        <CardEmpty>No billing details on file yet.</CardEmpty>
-      )}
-    </CardContent>
-  </Card>
+type BillingAddress = NonNullable<BillingV2Overview["billingDetails"]>["address"];
+
+// Resolve a 2-letter ISO country code to its English name, falling back to the raw value.
+const countryName = (code: string): string => {
+  if (code.length !== 2) {
+    return code;
+  }
+  try {
+    return new Intl.DisplayNames(["en"], { type: "region" }).of(code.toUpperCase()) ?? code;
+  } catch {
+    return code;
+  }
+};
+
+// Collapse a Stripe address into display lines, dropping any empty field.
+const formatAddressLines = (address: BillingAddress): string[] => {
+  if (!address) {
+    return [];
+  }
+  const regionLine = [address.city, [address.state, address.postalCode].filter(Boolean).join(" ")]
+    .filter(Boolean)
+    .join(", ");
+  return [
+    address.line1,
+    address.line2,
+    regionLine,
+    address.country ? countryName(address.country) : ""
+  ].filter(Boolean);
+};
+
+// Friendly labels for common Stripe tax-id types; falls back to the upper-cased raw type.
+const TAX_TYPE_LABELS: Record<string, string> = {
+  eu_vat: "EU VAT",
+  gb_vat: "UK VAT",
+  ch_vat: "CH VAT",
+  no_vat: "NO VAT",
+  in_gst: "GSTIN",
+  au_abn: "ABN",
+  nz_gst: "NZ GST",
+  ca_gst_hst: "GST/HST",
+  us_ein: "US EIN"
+};
+const taxTypeLabel = (type: string): string =>
+  TAX_TYPE_LABELS[type] ?? type.replace(/_/g, " ").toUpperCase();
+
+const DetailField = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div>
+    <div className="mb-1 text-xs text-label">{label}</div>
+    <div className="text-sm text-foreground">{children}</div>
+  </div>
 );
+
+const DetailsCard = ({ overview, canManage, onEdit }: DetailsCardProps) => {
+  const addressLines = formatAddressLines(overview.billingDetails?.address ?? null);
+  const taxIds = overview.billingDetails?.taxIds ?? [];
+  const hasAddress = addressLines.length > 0;
+  const hasTaxIds = taxIds.length > 0;
+  const emptyDash = <span className="text-muted">—</span>;
+  const name = overview.billingDetails?.name || emptyDash;
+  const email = overview.billingDetails?.email || emptyDash;
+  // Responsive (keyed off the card's own width via @container, not the viewport, since the sidebar
+  // changes how much room the card has): stack to one column when narrow, then two, then three.
+  // The third column is the tax ID, so it only appears when one is present.
+  const gridCols = hasTaxIds
+    ? "grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3"
+    : "grid-cols-1 @lg:grid-cols-2";
+
+  const nameEmailFields = (
+    <>
+      <DetailField label="Billing Name">{name}</DetailField>
+      <DetailField label="Billing Email">{email}</DetailField>
+    </>
+  );
+
+  const taxIdField = hasTaxIds ? (
+    <DetailField label="Tax ID">
+      {taxIds.map((taxId) => (
+        <div key={`${taxId.type}-${taxId.value}`}>
+          {taxId.value} <span className="text-muted">({taxTypeLabel(taxId.type)})</span>
+        </div>
+      ))}
+    </DetailField>
+  ) : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Building2 className="size-4 text-accent" />
+          Billing Details
+        </CardTitle>
+        {canManage && (
+          <CardAction>
+            <Button variant="outline" size="sm" onClick={onEdit}>
+              Edit
+            </Button>
+          </CardAction>
+        )}
+      </CardHeader>
+      <CardContent className="@container">
+        {overview.billingDetails ? (
+          <div className={cn("grid gap-x-8 gap-y-5", gridCols)}>
+            {hasAddress ? (
+              <>
+                <div className="flex flex-col gap-4">{nameEmailFields}</div>
+                <DetailField label="Billing Address">
+                  {addressLines.map((line) => (
+                    <div key={line}>{line}</div>
+                  ))}
+                </DetailField>
+                {taxIdField}
+              </>
+            ) : (
+              <>
+                {nameEmailFields}
+                {taxIdField}
+              </>
+            )}
+          </div>
+        ) : (
+          <CardEmpty
+            title="No billing details"
+            description="Your billing name, email, and address will appear here once added."
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+};
 
 type InvoicesCardProps = {
   invoices: BillingV2Invoice[];
@@ -458,13 +654,17 @@ type InvoicesCardProps = {
 const InvoicesCard = ({ invoices }: InvoicesCardProps) => (
   <Card>
     <CardHeader>
-      <CardTitle>Invoices</CardTitle>
+      <CardTitle>
+        <ReceiptText className="size-4 text-accent" />
+        Invoices
+      </CardTitle>
     </CardHeader>
     <CardContent>
       {invoices.length === 0 ? (
-        <CardEmpty>
-          No invoices yet. Your first invoice appears after your next billing date.
-        </CardEmpty>
+        <CardEmpty
+          title="No invoices yet"
+          description="Your first invoice appears after your next billing date."
+        />
       ) : (
         <Table>
           <TableHeader>
@@ -472,16 +672,14 @@ const InvoicesCard = ({ invoices }: InvoicesCardProps) => (
               <TableHead>Date</TableHead>
               <TableHead>Amount</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead className="text-right">Invoice</TableHead>
+              <TableHead />
             </TableRow>
           </TableHeader>
           <TableBody>
             {invoices.map((inv) => (
               <TableRow key={inv.id}>
                 <TableCell>{inv.date}</TableCell>
-                <TableCell className="text-mineshaft-300 tabular-nums">
-                  {fmtMoney(inv.amount, 2)}
-                </TableCell>
+                <TableCell className="tabular-nums">{fmtMoney(inv.amount, 2)}</TableCell>
                 <TableCell>
                   {inv.paid ? (
                     <Badge variant="success">Paid</Badge>
@@ -492,7 +690,7 @@ const InvoicesCard = ({ invoices }: InvoicesCardProps) => (
                 <TableCell className="text-right">
                   {inv.pdfUrl ? (
                     <a
-                      className="inline-flex items-center gap-1.5 text-xs text-org hover:underline"
+                      className="inline-flex items-center gap-1.5 text-xs text-muted hover:underline"
                       href={inv.pdfUrl}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -501,7 +699,7 @@ const InvoicesCard = ({ invoices }: InvoicesCardProps) => (
                       PDF
                     </a>
                   ) : (
-                    <span className="text-mineshaft-400">—</span>
+                    <span className="text-muted">—</span>
                   )}
                 </TableCell>
               </TableRow>

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -1,24 +1,20 @@
 import { ReactNode } from "react";
 import {
-  faCircleExclamation,
-  faCircleInfo,
-  faCreditCard,
-  faRotate,
-  faTriangleExclamation,
-  faUpRightFromSquare,
-  IconDefinition
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
   ArrowBigUpDashIcon,
   Building2,
   Calendar,
+  CircleAlert,
   CreditCard,
+  ExternalLink,
   GaugeIcon,
+  Info,
+  type LucideIcon,
   Package,
   ReceiptText,
+  RefreshCw,
   ShieldAlert,
-  ShieldCheck
+  ShieldCheck,
+  TriangleAlert
 } from "lucide-react";
 
 import {
@@ -76,7 +72,7 @@ type BannerProps = {
 
 type Dunning = {
   variant: "warning" | "danger";
-  icon: IconDefinition;
+  icon: LucideIcon;
   title: string;
   body: string;
 };
@@ -84,13 +80,13 @@ type Dunning = {
 const DUNNING: Partial<Record<BillingV2RenderState, Dunning>> = {
   "past-due": {
     variant: "warning",
-    icon: faTriangleExclamation,
+    icon: TriangleAlert,
     title: "We couldn't process your last payment",
     body: "Update your payment method to avoid losing access. Your products are still active while we retry."
   },
   suspended: {
     variant: "danger",
-    icon: faCircleExclamation,
+    icon: CircleAlert,
     title: "Your subscription is suspended",
     body: "A payment kept failing and access is paused. Complete payment to restore access to your products."
   }
@@ -106,7 +102,7 @@ const Banner = ({
   if (mode === "managed") {
     return (
       <Alert variant="info">
-        <FontAwesomeIcon icon={faCircleInfo} />
+        <Info />
         <AlertTitle>Your plan is managed by your account team</AlertTitle>
         <AlertDescription>
           Products and limits on this organization are set by contract. Contact your account manager
@@ -121,16 +117,17 @@ const Banner = ({
     return null;
   }
 
+  const DunningIcon = dunning.icon;
   return (
     <Alert variant={dunning.variant}>
-      <FontAwesomeIcon icon={dunning.icon} />
+      <DunningIcon />
       <AlertTitle>{dunning.title}</AlertTitle>
       <AlertDescription>
         {dunning.body}
         {canManage && (
           <div className="mt-3 flex flex-wrap gap-2">
             <Button variant={dunning.variant} size="sm" onClick={onUpdatePayment}>
-              <FontAwesomeIcon icon={faCreditCard} />
+              <CreditCard />
               Update payment method
             </Button>
             <Button variant="outline" size="sm" onClick={onManageSubscription}>
@@ -209,7 +206,7 @@ type ErrorPanelProps = {
 const ErrorPanel = ({ onRetry }: ErrorPanelProps) => (
   <Card>
     <div className="flex flex-col items-center gap-3 px-7 py-10 text-center">
-      <FontAwesomeIcon icon={faCircleExclamation} className="text-3xl text-danger" />
+      <CircleAlert className="size-8 text-danger" />
       <div className="text-base font-semibold text-foreground">
         Couldn&apos;t load your subscription
       </div>
@@ -217,7 +214,7 @@ const ErrorPanel = ({ onRetry }: ErrorPanelProps) => (
         There was a problem reaching the billing service. Your products are unaffected.
       </div>
       <Button variant="outline" size="sm" onClick={onRetry}>
-        <FontAwesomeIcon icon={faRotate} />
+        <RefreshCw />
         Try again
       </Button>
     </div>
@@ -544,7 +541,8 @@ const formatAddressLines = (address: BillingAddress): string[] => {
     address.line2,
     regionLine,
     address.country ? countryName(address.country) : ""
-  ].filter(Boolean);
+    // type-guard predicate (not bare Boolean) so the nullable sub-fields narrow to string[].
+  ].filter((line): line is string => Boolean(line));
 };
 
 // Friendly labels for common Stripe tax-id types; falls back to the upper-cased raw type.
@@ -695,7 +693,7 @@ const InvoicesCard = ({ invoices }: InvoicesCardProps) => (
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <FontAwesomeIcon icon={faUpRightFromSquare} />
+                      <ExternalLink className="size-3.5" />
                       PDF
                     </a>
                   ) : (

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -1,5 +1,4 @@
-import { faArrowRight, faCheck, faUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ArrowRight, Check, ExternalLink, ShoppingCart } from "lucide-react";
 
 import {
   Badge,
@@ -45,10 +44,10 @@ const proPriceParts = (prod: BillingV2CatalogProduct, cadence: BillingV2Cadence)
 
 const renderCompareCell = (value: string | boolean) => {
   if (value === true) {
-    return <FontAwesomeIcon icon={faCheck} className="text-success" />;
+    return <Check className="mx-auto size-3.5 text-success" />;
   }
   if (value === false) {
-    return <span className="text-mineshaft-500">—</span>;
+    return <span className="text-muted">—</span>;
   }
   return value;
 };
@@ -70,10 +69,10 @@ const EntitlementSummary = ({ entitlement }: EntitlementSummaryProps) => {
   return (
     <div className="rounded-lg border border-border bg-card p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <span className="text-xs font-medium text-mineshaft-300">Your plan</span>
+        <span className="text-xs font-medium text-foreground">Your Plan</span>
         {entitled ? <ActiveBadge /> : <Badge variant="neutral">Inactive</Badge>}
       </div>
-      <div className="text-xs text-mineshaft-300">{detail}</div>
+      <div className="text-xs text-accent">{detail}</div>
     </div>
   );
 };
@@ -98,50 +97,48 @@ const PlansView = ({ prod, entitlement, cadence, onContact }: PlansViewProps) =>
       <div className={`grid gap-3.5 ${hasEnterprise ? "sm:grid-cols-2" : "grid-cols-1"}`}>
         <div
           className={`flex flex-col gap-3.5 rounded-xl border p-[18px] ${
-            entitled ? "border-mineshaft-500 bg-mineshaft-700/40" : "border-org/40 bg-org/5"
+            entitled ? "border-success/40 bg-success/5" : "border-org/40 bg-org/5"
           }`}
         >
           <div className="flex items-center justify-between gap-2">
             <span className="text-[15px] font-semibold text-foreground">Pro</span>
             {entitled ? (
-              <Badge variant="outline">
-                <FontAwesomeIcon icon={faCheck} className="text-success" />
-                Current plan
+              <Badge variant="success">
+                <Check className="text-success" />
+                Current Plan
               </Badge>
             ) : (
-              <Badge variant="org">Self-serve</Badge>
+              <Badge variant="neutral">Self-Checkout</Badge>
             )}
           </div>
           {priceParts && (
             <div className="flex flex-wrap items-baseline gap-1.5">
               <span className="text-2xl font-semibold text-foreground">{priceParts.amount}</span>
-              <span className="text-xs text-mineshaft-400">{priceParts.unit}</span>
+              <span className="text-xs text-muted">{priceParts.unit}</span>
             </div>
           )}
-          {prod.pro?.proFeature && (
-            <div className="text-xs text-mineshaft-300">{prod.pro.proFeature}</div>
-          )}
+          {prod.pro?.proFeature && <div className="text-xs text-accent">{prod.pro.proFeature}</div>}
         </div>
 
         {hasEnterprise && prod.enterprise && (
           <div className="flex flex-col gap-3.5 rounded-xl border border-border bg-card p-[18px]">
             <div className="flex items-center justify-between gap-2">
               <span className="text-[15px] font-semibold text-foreground">Enterprise</span>
-              <Badge variant="info">Sales-led</Badge>
+              <Badge variant="neutral">Talk to Us</Badge>
             </div>
             <div className="flex items-baseline">
               <span className="text-2xl font-semibold text-foreground">Custom</span>
             </div>
-            <div className="text-xs text-mineshaft-300">{prod.enterprise.feature}</div>
+            <div className="text-xs text-accent">{prod.enterprise.feature}</div>
             {selfServe && (
               <Button
-                variant="info"
+                variant="org"
                 size="sm"
                 className="mt-auto self-start"
                 onClick={() => onContact(prod)}
               >
                 Contact sales
-                <FontAwesomeIcon icon={faArrowRight} />
+                <ArrowRight />
               </Button>
             )}
           </div>
@@ -150,21 +147,19 @@ const PlansView = ({ prod, entitlement, cadence, onContact }: PlansViewProps) =>
 
       {hasEnterprise && prod.compare && (
         <div>
-          <div className="mb-3 text-xs font-semibold tracking-wide text-mineshaft-400 uppercase">
-            Compare plans
-          </div>
+          <div className="mb-3 text-xs font-semibold text-muted">Compare Plans</div>
           <Table>
             <TableHeader>
               <TableRow>
                 <TableHead aria-label="Feature" />
-                <TableHead className="text-center text-org">Pro</TableHead>
-                <TableHead className="text-center text-info">Enterprise</TableHead>
+                <TableHead className="text-center">Pro</TableHead>
+                <TableHead className="text-center">Enterprise</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {prod.compare.map((row) => (
                 <TableRow key={row.label}>
-                  <TableCell className="text-mineshaft-200">{row.label}</TableCell>
+                  <TableCell className="text-accent">{row.label}</TableCell>
                   <TableCell className="text-center">{renderCompareCell(row.pro)}</TableCell>
                   <TableCell className="text-center">{renderCompareCell(row.ent)}</TableCell>
                 </TableRow>
@@ -176,13 +171,13 @@ const PlansView = ({ prod, entitlement, cadence, onContact }: PlansViewProps) =>
 
       {!(hasEnterprise && prod.compare) && prod.includes && (
         <div>
-          <div className="mb-3 text-xs font-semibold tracking-wide text-mineshaft-400 uppercase">
+          <div className="mb-3 text-xs font-semibold tracking-wide text-muted uppercase">
             What&apos;s included
           </div>
           <div className="grid gap-x-5 gap-y-2.5 sm:grid-cols-2">
             {prod.includes.map((f) => (
-              <div className="flex items-start gap-2 text-xs text-mineshaft-200" key={f}>
-                <FontAwesomeIcon icon={faCheck} className="mt-0.5 shrink-0 text-success" />
+              <div className="flex items-start gap-2 text-xs text-accent" key={f}>
+                <Check className="mt-0.5 size-3 shrink-0 text-success" />
                 {f}
               </div>
             ))}
@@ -226,20 +221,21 @@ export const ProductSheet = ({
     primaryCta = (
       <Button variant="org" onClick={() => onManage(prodId)} isPending={redirecting}>
         Manage in Stripe
-        <FontAwesomeIcon icon={faUpRightFromSquare} />
+        <ExternalLink />
       </Button>
     );
   } else if (selfServe) {
     primaryCta = (
       <Button variant="org" onClick={() => onManage(prodId)} isPending={redirecting}>
+        <ShoppingCart />
         Continue to Checkout
       </Button>
     );
   } else if (prod.enterprise) {
     primaryCta = (
-      <Button variant="info" onClick={() => onContact(prod)}>
+      <Button variant="org" onClick={() => onContact(prod)}>
         Contact sales
-        <FontAwesomeIcon icon={faArrowRight} />
+        <ArrowRight />
       </Button>
     );
   }
@@ -267,12 +263,11 @@ export const ProductSheet = ({
           }
         }}
       >
-        <SheetHeader className="flex-row items-start gap-3.5 border-b pr-12">
+        <SheetHeader className="flex-row items-center gap-3.5 border-b pr-12">
           <ProductIcon product={prod} size={40} />
           <div className="min-w-0 flex-1">
             <SheetTitle className="flex flex-wrap items-center gap-2 text-base">
               {prod.name}
-              {entitled && <ActiveBadge />}
               {prod.addon && <Badge variant="neutral">Add-on</Badge>}
             </SheetTitle>
             <SheetDescription className="mt-1">{prod.tagline || prod.desc}</SheetDescription>
@@ -288,11 +283,11 @@ export const ProductSheet = ({
           />
         </div>
 
-        <SheetFooter className="flex-row justify-end border-t">
+        <SheetFooter className="flex-row justify-start border-t">
+          {primaryCta}
           <Button variant="outline" onClick={onClose} isDisabled={redirecting}>
             Close
           </Button>
-          {primaryCta}
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/frontend/src/pages/organization/BillingV2Page/components/shared.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/shared.tsx
@@ -1,28 +1,38 @@
-import {
-  faAward,
-  faBolt,
-  faBox,
-  faKey,
-  faLock,
-  faMagnifyingGlass,
-  faShieldHalved,
-  IconDefinition
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Award, Box, LucideIcon, ScanLine, Shield, Zap } from "lucide-react";
 
-import { Badge } from "@app/components/v3";
+import { Badge, Label } from "@app/components/v3";
+import { getProjectLucideIcon } from "@app/helpers/project";
 import { BillingV2CatalogProduct } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
 
-// Maps the catalog icon token (license-server presentation metadata) to a FontAwesome glyph.
-// Tokens mirror the license server's icon vocabulary; unknown tokens fall back to faBox.
-const ICON_BY_NAME: Record<string, IconDefinition> = {
-  lock: faLock,
-  shield: faShieldHalved,
-  award: faAward,
-  scan_line: faMagnifyingGlass,
-  zap: faBolt,
-  key: faKey,
-  box: faBox
+// Catalog products carry a free-form icon token (license-server presentation metadata), not a
+// project type. Tokens that name one of our products resolve through the shared project icon helper
+// so billing stays in sync with the rest of the app; add-on / generic tokens keep a direct glyph,
+// and anything unrecognized falls back to Box.
+const TOKEN_PROJECT_TYPE: Record<string, ProjectType> = {
+  vault: ProjectType.SecretManager,
+  key: ProjectType.SecretManager,
+  file_key: ProjectType.CertificateManager,
+  lock: ProjectType.KMS,
+  scan_search: ProjectType.SecretScanning,
+  radar: ProjectType.SecretScanning,
+  users: ProjectType.PAM,
+  terminal: ProjectType.SSH
+};
+
+const ADDON_ICON_BY_TOKEN: Record<string, LucideIcon> = {
+  shield: Shield,
+  award: Award,
+  scan_line: ScanLine,
+  zap: Zap
+};
+
+const iconForToken = (token: string): LucideIcon => {
+  const projectType = TOKEN_PROJECT_TYPE[token];
+  if (projectType) {
+    return getProjectLucideIcon(projectType);
+  }
+  return ADDON_ICON_BY_TOKEN[token] ?? Box;
 };
 
 type MeterTone = "ok" | "near" | "full";
@@ -33,31 +43,26 @@ type ProductIconProps = {
 };
 
 // Tinted product icon tile. The tint is per-product brand metadata from the API, so it stays inline.
-export const ProductIcon = ({ product, size = 38 }: ProductIconProps) => {
-  const glyph = ICON_BY_NAME[product.icon] ?? faBox;
+export const ProductIcon = ({ product, size = 36 }: ProductIconProps) => {
+  const Glyph = iconForToken(product.icon);
   const { color } = product;
   return (
     <div
-      className="flex shrink-0 items-center justify-center rounded-lg border"
+      className="flex shrink-0 items-center justify-center rounded-sm border transition-colors duration-200"
       style={{
         width: size,
         height: size,
-        background: `color-mix(in srgb, ${color} 14%, transparent)`,
+        background: `linear-gradient(to bottom right, color-mix(in srgb, ${color} 20%, transparent), color-mix(in srgb, ${color} 5%, transparent))`,
         borderColor: `color-mix(in srgb, ${color} 30%, transparent)`,
         color
       }}
     >
-      <FontAwesomeIcon icon={glyph} style={{ fontSize: Math.round(size * 0.45) }} />
+      <Glyph size={Math.round(size * 0.5)} />
     </div>
   );
 };
 
-export const ActiveBadge = () => (
-  <Badge variant="success">
-    <span className="size-1.5 rounded-full bg-current" />
-    Active
-  </Badge>
-);
+export const ActiveBadge = () => <Badge variant="success">Active</Badge>;
 
 // A null limit is unlimited (no bar, no alarm).
 const meterTone = (used: number, limit: number | null): MeterTone => {
@@ -101,18 +106,18 @@ export const LimitMeter = ({ label, used, limit }: LimitMeterProps) => {
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2.5">
-        <span className="text-xs text-mineshaft-300">{label}</span>
-        <span className={`text-xs tabular-nums ${COUNT_TONE[tone]}`}>
+        <Label>{label}</Label>
+        <span className={`text-sm tabular-nums ${COUNT_TONE[tone]}`}>
           {used.toLocaleString()}
           {limit === null ? (
-            <span className="text-mineshaft-400"> / Unlimited</span>
+            <span className="text-muted"> / Unlimited</span>
           ) : (
-            <span className="text-mineshaft-400"> / {limit.toLocaleString()}</span>
+            <span className="text-muted"> / {limit.toLocaleString()}</span>
           )}
         </span>
       </div>
       {limit !== null && limit > 0 && (
-        <div className="h-1.5 overflow-hidden rounded-full bg-mineshaft-600">
+        <div className="h-1.5 overflow-hidden rounded-full bg-border">
           <div
             className={`h-full rounded-full transition-all ${FILL_TONE[tone]}`}
             style={{ width: `${pct}%` }}

--- a/frontend/src/pages/organization/BillingV2Page/components/shared.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/shared.tsx
@@ -1,39 +1,8 @@
-import { Award, Box, LucideIcon, ScanLine, Shield, Zap } from "lucide-react";
+import { Box } from "lucide-react";
+import { DynamicIcon, type IconName } from "lucide-react/dynamic";
 
 import { Badge, Label } from "@app/components/v3";
-import { getProjectLucideIcon } from "@app/helpers/project";
 import { BillingV2CatalogProduct } from "@app/hooks/api";
-import { ProjectType } from "@app/hooks/api/projects/types";
-
-// Catalog products carry a free-form icon token (license-server presentation metadata), not a
-// project type. Tokens that name one of our products resolve through the shared project icon helper
-// so billing stays in sync with the rest of the app; add-on / generic tokens keep a direct glyph,
-// and anything unrecognized falls back to Box.
-const TOKEN_PROJECT_TYPE: Record<string, ProjectType> = {
-  vault: ProjectType.SecretManager,
-  key: ProjectType.SecretManager,
-  file_key: ProjectType.CertificateManager,
-  lock: ProjectType.KMS,
-  scan_search: ProjectType.SecretScanning,
-  radar: ProjectType.SecretScanning,
-  users: ProjectType.PAM,
-  terminal: ProjectType.SSH
-};
-
-const ADDON_ICON_BY_TOKEN: Record<string, LucideIcon> = {
-  shield: Shield,
-  award: Award,
-  scan_line: ScanLine,
-  zap: Zap
-};
-
-const iconForToken = (token: string): LucideIcon => {
-  const projectType = TOKEN_PROJECT_TYPE[token];
-  if (projectType) {
-    return getProjectLucideIcon(projectType);
-  }
-  return ADDON_ICON_BY_TOKEN[token] ?? Box;
-};
 
 type MeterTone = "ok" | "near" | "full";
 
@@ -42,13 +11,23 @@ type ProductIconProps = {
   size?: number;
 };
 
-// Tinted product icon tile. The tint is per-product brand metadata from the API, so it stays inline.
+// Shown while a product's icon chunk loads and for any token lucide doesn't recognize. Sized to half
+// the tile via CSS so it matches the resolved glyph at any tile size.
+const ProductIconFallback = () => <Box className="h-1/2 w-1/2" />;
+
+// Tinted product icon tile. Both the icon token and the tint are per-product presentation metadata
+// from the license-server catalog (the source of truth), so we render the glyph straight from the
+// token rather than mapping it to an app concept. Catalog tokens are snake_case while lucide icon
+// names are kebab-case, so we only normalize the separator before handing the name to lucide's
+// dynamic icon. Unknown or still-loading tokens fall back to a generic box glyph (the catalog's own
+// default is "box").
 export const ProductIcon = ({ product, size = 36 }: ProductIconProps) => {
-  const Glyph = iconForToken(product.icon);
   const { color } = product;
+  const glyphSize = Math.round(size * 0.5);
+  const iconName = product.icon.replace(/_/g, "-") as IconName;
   return (
     <div
-      className="flex shrink-0 items-center justify-center rounded-sm border transition-colors duration-200"
+      className="flex shrink-0 items-center justify-center rounded-md border transition-colors duration-200"
       style={{
         width: size,
         height: size,
@@ -57,7 +36,7 @@ export const ProductIcon = ({ product, size = 36 }: ProductIconProps) => {
         color
       }}
     >
-      <Glyph size={Math.round(size * 0.5)} />
+      <DynamicIcon name={iconName} size={glyphSize} fallback={ProductIconFallback} />
     </div>
   );
 };


### PR DESCRIPTION
## Context

This PR polishes and expands the new billing page:

Backend
- license-client: parse address and taxIds from the billing profile; both are nullish/defaulted so older license servers that omit them still validate.
- entitlements: resolve each limits dimension noun from the catalog and return it as `unit`, choosing the most constraining dimension so the count and its unit always describe the same thing.
- overview API/types: expand billingDetails with address + taxIds and add `unit` to each entitlement.

Frontend (BillingV2Page)
- Overview: replace the summary band with Status / Next billing / Recurring stat tiles; render billing address and tax IDs (ISO country names and friendly tax-type labels) in a container-responsive grid; show units beside limits (e.g. "0 / 100 certificates") via a new pluralizeUnit helper.
- Migrate icons from FontAwesome to lucide and resolve product icons through the shared project icon helper so billing stays in sync with the app.
- Adopt v3 Empty states for empty cards and migrate mineshaft color tokens to semantic ones (foreground / muted / accent).
- ProductSheet: lucide icons, copy and CTA-order tweaks.
- Widen the page to max-w-8xl and drop the redundant local try/catch in checkout (the global mutation error toast already reports failures).

Shared
- getProjectLucideIcon: Secret Manager now uses Key, Secret Scanning uses Radar (affects project icons app-wide).
- v3 Table cell text color: mineshaft-200 -> foreground.

## Screenshots

<img width="3434" height="1924" alt="CleanShot 2026-06-24 at 18 59 17@2x" src="https://github.com/user-attachments/assets/616d77e4-68c1-4db0-a4b5-a6eea4b1995d" />

<img width="3434" height="1924" alt="CleanShot 2026-06-24 at 18 59 20@2x" src="https://github.com/user-attachments/assets/d5a4447e-886e-4279-b364-79322439dfbb" />

## Steps to verify the change

- test various billing scenarios across each UI element

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)