### PR TITLE
feat(pam): add MongoDB and MS SQL Server account types

### DIFF
--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -237,7 +237,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message:
-                "Credentials should not be included in the connection string. They are managed separately per account"
+                "Credentials should not be included in the connection string. Use the Username and Password fields instead"
             });
             return z.NEVER;
           }

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -285,6 +285,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
           secret?: boolean;
           defaultValue?: string | number | boolean;
           showWhen?: { field: string; equals: string | boolean };
+          tooltip?: string;
         }
       >;
       internalMetadata?: z.ZodTypeAny;

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -176,6 +176,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
     }),
     ui: {
       port: { defaultValue: 1433 },
+      database: { defaultValue: "master" },
       authMethod: {
         label: "Auth Method",
         defaultValue: "sql-login",

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -98,6 +98,95 @@ export const ACCOUNT_TYPE_CONFIGS = {
     }
   },
 
+  [PamAccountType.MsSQL]: {
+    name: "Microsoft SQL Server",
+    icon: "MsSql.png",
+    connectionDetails: z.object({
+      host: z.string().trim().min(1).max(255),
+      port: z.coerce.number(),
+      database: z.string().trim().min(1).max(128),
+      sslEnabled: z.boolean(),
+      sslRejectUnauthorized: z.boolean(),
+      sslCertificate: z
+        .string()
+        .trim()
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    credentials: z.object({
+      username: z.string().trim().min(1).max(128),
+      password: z
+        .string()
+        .trim()
+        .max(256)
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    sanitizedCredentials: z.object({ username: z.string().optional() }),
+    ui: {
+      port: { defaultValue: 1433 },
+      sslEnabled: { label: "SSL Enabled" },
+      sslRejectUnauthorized: {
+        label: "Reject Unauthorized",
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      sslCertificate: {
+        label: "SSL Certificate",
+        widget: PamFieldWidget.Textarea,
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      password: { widget: PamFieldWidget.Password, secret: true }
+    }
+  },
+
+  [PamAccountType.MongoDB]: {
+    name: "MongoDB",
+    icon: "MongoDB.png",
+    connectionDetails: z.object({
+      host: z.string().trim().min(1).max(255),
+      port: z.coerce.number(),
+      database: z.string().trim().min(1).max(255),
+      authSource: z
+        .string()
+        .trim()
+        .max(255)
+        .transform((v) => v || undefined)
+        .optional(),
+      sslEnabled: z.boolean(),
+      sslRejectUnauthorized: z.boolean(),
+      sslCertificate: z
+        .string()
+        .trim()
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    credentials: z.object({
+      username: z.string().trim().min(1).max(255),
+      password: z
+        .string()
+        .trim()
+        .max(256)
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    sanitizedCredentials: z.object({ username: z.string().optional() }),
+    ui: {
+      port: { defaultValue: 27017 },
+      authSource: { label: "Auth Source" },
+      sslEnabled: { label: "SSL Enabled" },
+      sslRejectUnauthorized: {
+        label: "Reject Unauthorized",
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      sslCertificate: {
+        label: "SSL Certificate",
+        widget: PamFieldWidget.Textarea,
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      password: { widget: PamFieldWidget.Password, secret: true }
+    }
+  },
+
   [PamAccountType.SSH]: {
     name: "SSH",
     icon: "SSH.png",
@@ -246,6 +335,8 @@ export const extractGatewayTarget = (
     case PamAccountType.SSH:
     case PamAccountType.Postgres:
     case PamAccountType.MySQL:
+    case PamAccountType.MongoDB:
+    case PamAccountType.MsSQL:
       return {
         host: (validated as { host: string; port: number }).host,
         port: (validated as { host: string; port: number }).port

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -143,15 +143,8 @@ export const ACCOUNT_TYPE_CONFIGS = {
     name: "MongoDB",
     icon: "MongoDB.png",
     connectionDetails: z.object({
-      host: z.string().trim().min(1).max(255),
-      port: z.coerce.number(),
+      connectionString: z.string().trim().min(1).max(2048),
       database: z.string().trim().min(1).max(255),
-      authSource: z
-        .string()
-        .trim()
-        .max(255)
-        .transform((v) => v || undefined)
-        .optional(),
       sslEnabled: z.boolean(),
       sslRejectUnauthorized: z.boolean(),
       sslCertificate: z
@@ -171,8 +164,12 @@ export const ACCOUNT_TYPE_CONFIGS = {
     }),
     sanitizedCredentials: z.object({ username: z.string().optional() }),
     ui: {
-      port: { defaultValue: 27017 },
-      authSource: { label: "Auth Source" },
+      connectionString: {
+        label: "Connection String",
+        widget: PamFieldWidget.Textarea,
+        tooltip: "Supports mongodb:// and mongodb+srv:// URIs. Do not include credentials or database in the URI."
+      },
+      database: { defaultValue: "admin" },
       sslEnabled: { label: "SSL Enabled" },
       sslRejectUnauthorized: {
         label: "Reject Unauthorized",
@@ -335,7 +332,6 @@ export const extractGatewayTarget = (
     case PamAccountType.SSH:
     case PamAccountType.Postgres:
     case PamAccountType.MySQL:
-    case PamAccountType.MongoDB:
     case PamAccountType.MsSQL:
       return {
         host: (validated as { host: string; port: number }).host,
@@ -345,6 +341,18 @@ export const extractGatewayTarget = (
       const { url } = validated as { url: string };
       const parsed = new URL(url);
       return { host: parsed.hostname };
+    }
+    case PamAccountType.MongoDB: {
+      const { connectionString } = validated as { connectionString: string };
+      try {
+        const url = new URL(connectionString);
+        return {
+          host: url.hostname,
+          port: url.port ? Number(url.port) : undefined
+        };
+      } catch {
+        return { host: connectionString };
+      }
     }
     default:
       throw new Error(`No gateway target extraction defined for account type '${accountType}'`);
@@ -406,7 +414,10 @@ export const PamFieldDescriptorSchema = z.object({
   defaultValue: z.union([z.string(), z.number(), z.boolean()]).optional(),
 
   // Only render when the referenced field equals this value
-  showWhen: z.object({ field: z.string(), equals: z.union([z.string(), z.boolean()]) }).optional()
+  showWhen: z.object({ field: z.string(), equals: z.union([z.string(), z.boolean()]) }).optional(),
+
+  // Info tooltip shown next to the label
+  tooltip: z.string().optional()
 });
 
 type PamFieldDescriptor = z.infer<typeof PamFieldDescriptorSchema>;
@@ -429,6 +440,7 @@ type TFieldUiHint = {
   secret?: boolean;
   defaultValue?: string | number | boolean;
   showWhen?: PamFieldDescriptor["showWhen"];
+  tooltip?: string;
 };
 
 const humanizeKey = (key: string) => {
@@ -491,7 +503,8 @@ const describeField = (
       ? { options: enumValues.map((v) => ({ label: humanizeKey(v), value: v })) }
       : {}),
     ...(hint.defaultValue !== undefined ? { defaultValue: hint.defaultValue } : {}),
-    ...(resolvedShowWhen ? { showWhen: resolvedShowWhen } : {})
+    ...(resolvedShowWhen ? { showWhen: resolvedShowWhen } : {}),
+    ...(hint.tooltip ? { tooltip: hint.tooltip } : {})
   };
 };
 

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -610,8 +610,7 @@ const fieldsFromSchema = (schema: z.ZodTypeAny, ui: Record<string, TFieldUiHint>
         widget: PamFieldWidget.Select,
         required: true,
         secret: false,
-        options:
-          ui[discriminator]?.options ?? discriminatorValues.map((v) => ({ label: humanizeKey(v), value: v }))
+        options: ui[discriminator]?.options ?? discriminatorValues.map((v) => ({ label: humanizeKey(v), value: v }))
       }
     ];
 

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+import ConnectionString from "mongodb-connection-string-url";
 import RE2 from "re2";
 import { z } from "zod";
 
@@ -208,8 +209,50 @@ export const ACCOUNT_TYPE_CONFIGS = {
     name: "MongoDB",
     icon: "MongoDB.png",
     connectionDetails: z.object({
-      connectionString: z.string().trim().min(1).max(2048),
-      database: z.string().trim().min(1).max(255),
+      connectionString: z
+        .string()
+        .trim()
+        .min(1)
+        .max(1024)
+        .transform((val, ctx) => {
+          let cs: ConnectionString;
+          try {
+            cs = new ConnectionString(val);
+          } catch {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Invalid MongoDB connection string. Must start with mongodb:// or mongodb+srv://"
+            });
+            return z.NEVER;
+          }
+
+          if (cs.username || cs.password) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message:
+                "Credentials should not be included in the connection string. They are managed separately per account"
+            });
+            return z.NEVER;
+          }
+
+          if (cs.pathname && cs.pathname !== "/") {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Database should not be included in the connection string. Use the Database field instead"
+            });
+            return z.NEVER;
+          }
+
+          return cs.toString();
+        }),
+      database: z
+        .string()
+        .trim()
+        .min(1)
+        .max(64)
+        .refine((val) => new RE2("^[a-zA-Z0-9_-]+$").test(val), {
+          message: "Database name can only contain letters, numbers, underscores, and hyphens"
+        }),
       sslEnabled: z.boolean(),
       sslRejectUnauthorized: z.boolean(),
       sslCertificate: z

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -104,7 +104,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
     connectionDetails: z.object({
       host: z.string().trim().min(1).max(255),
       port: z.coerce.number(),
-      database: z.string().trim().min(1).max(128),
+      database: z.string().trim().min(1).max(255),
       sslEnabled: z.boolean(),
       sslRejectUnauthorized: z.boolean(),
       sslCertificate: z
@@ -113,18 +113,82 @@ export const ACCOUNT_TYPE_CONFIGS = {
         .transform((v) => v || undefined)
         .optional()
     }),
-    credentials: z.object({
-      username: z.string().trim().min(1).max(128),
-      password: z
-        .string()
-        .trim()
-        .max(256)
-        .transform((v) => v || undefined)
-        .optional()
+    credentials: z.discriminatedUnion("authMethod", [
+      z.object({
+        authMethod: z.literal("sql-login"),
+        username: z.string().trim().min(1).max(63),
+        password: z
+          .string()
+          .trim()
+          .max(256)
+          .transform((v) => v || undefined)
+          .optional()
+      }),
+      z.object({
+        authMethod: z.literal("ntlm"),
+        username: z.string().trim().min(1).max(63),
+        password: z
+          .string()
+          .trim()
+          .max(256)
+          .transform((v) => v || undefined)
+          .optional(),
+        domain: z.string().trim().min(1).max(255)
+      }),
+      z.object({
+        authMethod: z.literal("kerberos"),
+        username: z.string().trim().min(1).max(63),
+        password: z
+          .string()
+          .trim()
+          .max(256)
+          .transform((v) => v || undefined)
+          .optional(),
+        realm: z
+          .string()
+          .trim()
+          .min(1)
+          .max(255)
+          .regex(new RE2(/^[A-Za-z0-9._-]+$/))
+          .transform((v) => v.toUpperCase()),
+        kdcAddress: z
+          .string()
+          .trim()
+          .max(255)
+          .regex(new RE2(/^[A-Za-z0-9._:-]*$/))
+          .transform((v) => v || undefined)
+          .optional(),
+        spn: z
+          .string()
+          .trim()
+          .min(1)
+          .max(500)
+          .regex(new RE2(/^[A-Za-z0-9._:/-]+$/))
+      })
+    ]),
+    sanitizedCredentials: z.object({
+      authMethod: z.string().optional(),
+      username: z.string().optional(),
+      domain: z.string().optional(),
+      realm: z.string().optional(),
+      kdcAddress: z.string().optional(),
+      spn: z.string().optional()
     }),
-    sanitizedCredentials: z.object({ username: z.string().optional() }),
     ui: {
       port: { defaultValue: 1433 },
+      authMethod: {
+        label: "Auth Method",
+        defaultValue: "sql-login",
+        options: [
+          { label: "SQL Server Authentication", value: "sql-login" },
+          { label: "Windows Authentication (NTLM)", value: "ntlm" },
+          { label: "Windows Authentication (Kerberos)", value: "kerberos" }
+        ]
+      },
+      domain: { label: "Domain" },
+      realm: { label: "Realm" },
+      kdcAddress: { label: "KDC Address" },
+      spn: { label: "SPN" },
       sslEnabled: { label: "SSL Enabled" },
       sslRejectUnauthorized: {
         label: "Reject Unauthorized",
@@ -286,6 +350,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
           defaultValue?: string | number | boolean;
           showWhen?: { field: string; equals: string | boolean };
           tooltip?: string;
+          options?: { label: string; value: string }[];
         }
       >;
       internalMetadata?: z.ZodTypeAny;
@@ -442,6 +507,7 @@ type TFieldUiHint = {
   defaultValue?: string | number | boolean;
   showWhen?: PamFieldDescriptor["showWhen"];
   tooltip?: string;
+  options?: { label: string; value: string }[];
 };
 
 const humanizeKey = (key: string) => {
@@ -543,7 +609,8 @@ const fieldsFromSchema = (schema: z.ZodTypeAny, ui: Record<string, TFieldUiHint>
         widget: PamFieldWidget.Select,
         required: true,
         secret: false,
-        options: discriminatorValues.map((v) => ({ label: humanizeKey(v), value: v }))
+        options:
+          ui[discriminator]?.options ?? discriminatorValues.map((v) => ({ label: humanizeKey(v), value: v }))
       }
     ];
 

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import dns from "dns";
-import { promisify } from "util";
-
 import ConnectionString from "mongodb-connection-string-url";
 import RE2 from "re2";
+import { promisify } from "util";
 import { z } from "zod";
 
 import { BadRequestError } from "@app/lib/errors";

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -1,10 +1,17 @@
 /* eslint-disable no-underscore-dangle */
+import dns from "dns";
+import { promisify } from "util";
+
 import ConnectionString from "mongodb-connection-string-url";
 import RE2 from "re2";
 import { z } from "zod";
 
+import { BadRequestError } from "@app/lib/errors";
+
 import { PamAccountType } from "../pam/pam-enums";
 import { getApplicablePolicies, PamPolicyDescriptorSchema } from "../pam/pam-policies";
+
+const resolveSrv = promisify(dns.resolveSrv);
 
 enum PamFieldWidget {
   Text = "text",
@@ -432,10 +439,10 @@ export const sanitizeCredentials = (accountType: PamAccountType, data: unknown) 
 
 export type TGatewayTarget = { host: string; port?: number };
 
-export const extractGatewayTarget = (
+export const extractGatewayTarget = async (
   accountType: PamAccountType,
   rawConnectionDetails: Record<string, unknown>
-): TGatewayTarget => {
+): Promise<TGatewayTarget> => {
   const validated = validateConnectionDetails(accountType, rawConnectionDetails);
 
   switch (accountType) {
@@ -454,15 +461,28 @@ export const extractGatewayTarget = (
     }
     case PamAccountType.MongoDB: {
       const { connectionString } = validated as { connectionString: string };
-      try {
-        const url = new URL(connectionString);
-        return {
-          host: url.hostname,
-          port: url.port ? Number(url.port) : undefined
-        };
-      } catch {
-        return { host: connectionString };
+      const cs = new ConnectionString(connectionString);
+      const [firstHost] = cs.hosts;
+
+      if (cs.isSRV) {
+        const records = await resolveSrv(`_mongodb._tcp.${firstHost}`);
+        if (records.length === 0) {
+          throw new BadRequestError({
+            message: `Unable to resolve SRV record for MongoDB host "${firstHost}". Ensure the host is a valid SRV domain.`
+          });
+        }
+        const record = records[Math.floor(Math.random() * records.length)];
+        return { host: record.name, port: record.port };
       }
+
+      const colonIdx = firstHost.lastIndexOf(":");
+      if (colonIdx !== -1) {
+        return {
+          host: firstHost.slice(0, colonIdx),
+          port: parseInt(firstHost.slice(colonIdx + 1), 10)
+        };
+      }
+      return { host: firstHost, port: 27017 };
     }
     default:
       throw new Error(`No gateway target extraction defined for account type '${accountType}'`);

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -215,18 +215,8 @@ export const pamSessionServiceFactory = ({
       };
     }
 
-    const mergedCredentials: Record<string, unknown> = { ...connectionDetails, ...credentials };
-
-    if (account.accountType === PamAccountType.MongoDB) {
-      const host = connectionDetails.host as string;
-      const port = connectionDetails.port as number;
-      const authSource = (connectionDetails.authSource as string) || undefined;
-      const qs = authSource ? `?authSource=${encodeURIComponent(authSource)}` : "";
-      mergedCredentials.connectionString = `mongodb://${host}:${port}${qs}`;
-    }
-
     return {
-      credentials: mergedCredentials,
+      credentials: { ...connectionDetails, ...credentials },
       recording,
       projectId: session.projectId,
       accountId: session.accountId,

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -186,6 +186,10 @@ export const pamSessionServiceFactory = ({
 
     const sessionStarted = session.status === PamSessionStatus.Starting;
 
+    if (sessionStarted) {
+      await pamSessionDAL.activateSession(sessionId);
+    }
+
     let recording: {
       sessionKey: string;
       uploadToken: string;

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -357,7 +357,7 @@ export const pamSessionServiceFactory = ({
 
     const rawConnectionDetails = await decrypt(projectId, account.encryptedConnectionDetails);
     const rawCredentials = await decrypt(projectId, account.encryptedCredentials);
-    const gatewayTarget = extractGatewayTarget(account.accountType as PamAccountType, rawConnectionDetails);
+    const gatewayTarget = await extractGatewayTarget(account.accountType as PamAccountType, rawConnectionDetails);
 
     const user = await userDAL.findById(actor.actorId);
     const expiresAt = new Date(Date.now() + sessionDurationMs);

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -49,6 +49,7 @@ type TPamSessionServiceFactoryDep = {
     | "endSessionById"
     | "terminateSessionById"
     | "updateById"
+    | "activateSession"
   >;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails" | "findOne">;
   pamFolderDAL: Pick<TPamFolderDALFactory, "findOne">;

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -215,8 +215,18 @@ export const pamSessionServiceFactory = ({
       };
     }
 
+    const mergedCredentials: Record<string, unknown> = { ...connectionDetails, ...credentials };
+
+    if (account.accountType === PamAccountType.MongoDB) {
+      const host = connectionDetails.host as string;
+      const port = connectionDetails.port as number;
+      const authSource = (connectionDetails.authSource as string) || undefined;
+      const qs = authSource ? `?authSource=${encodeURIComponent(authSource)}` : "";
+      mergedCredentials.connectionString = `mongodb://${host}:${port}${qs}`;
+    }
+
     return {
-      credentials: { ...connectionDetails, ...credentials },
+      credentials: mergedCredentials,
       recording,
       projectId: session.projectId,
       accountId: session.accountId,
@@ -409,7 +419,10 @@ export const pamSessionServiceFactory = ({
     } else {
       metadata.username = rawCredentials.username as string;
       if (
-        (account.accountType === PamAccountType.Postgres || account.accountType === PamAccountType.MySQL) &&
+        (account.accountType === PamAccountType.Postgres ||
+          account.accountType === PamAccountType.MySQL ||
+          account.accountType === PamAccountType.MongoDB ||
+          account.accountType === PamAccountType.MsSQL) &&
         rawConnectionDetails.database
       ) {
         metadata.database = rawConnectionDetails.database as string;

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -377,7 +377,7 @@ export const pamWebAccessServiceFactory = ({
       }
 
       const rawConnectionDetails = await decrypt(projectId, account.encryptedConnectionDetails);
-      const gatewayTarget = extractGatewayTarget(account.accountType as PamAccountType, rawConnectionDetails);
+      const gatewayTarget = await extractGatewayTarget(account.accountType as PamAccountType, rawConnectionDetails);
       const credentials = await decrypt(projectId, account.encryptedCredentials);
 
       const user = await userDAL.findById(userId);

--- a/frontend/src/hooks/api/pam/types/index.ts
+++ b/frontend/src/hooks/api/pam/types/index.ts
@@ -33,6 +33,7 @@ export type TPamFieldDescriptor = {
   options?: { label: string; value: string }[];
   defaultValue?: string | number | boolean;
   showWhen?: { field: string; equals: string | boolean };
+  tooltip?: string;
 };
 
 export type TPamPolicyDescriptor = {

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamSchemaFields.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamSchemaFields.tsx
@@ -1,4 +1,5 @@
 import { Control, Controller, ControllerRenderProps, useWatch } from "react-hook-form";
+import { Info } from "lucide-react";
 
 import { Field, FieldContent, FieldError, FieldLabel } from "@app/components/v3/generic/Field";
 import { Input } from "@app/components/v3/generic/Input";
@@ -11,6 +12,11 @@ import {
 } from "@app/components/v3/generic/Select";
 import { Switch } from "@app/components/v3/generic/Switch";
 import { TextArea } from "@app/components/v3/generic/TextArea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3/generic/Tooltip";
 import { PamFieldWidget, TPamFieldDescriptor } from "@app/hooks/api/pam";
 
 import { TAccountFormValues } from "./accountFormSchema";
@@ -108,6 +114,14 @@ export const PamSchemaFields = ({ control, namePrefix, fields }: Props) => {
                 <FieldLabel>
                   {descriptor.label}
                   {(descriptor.required || descriptor.secret) && <RequiredMark />}
+                  {descriptor.tooltip && (
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Info className="ml-1 inline h-3.5 w-3.5 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent>{descriptor.tooltip}</TooltipContent>
+                    </Tooltip>
+                  )}
                 </FieldLabel>
                 <Switch
                   variant="pam"
@@ -120,6 +134,14 @@ export const PamSchemaFields = ({ control, namePrefix, fields }: Props) => {
                 <FieldLabel>
                   {descriptor.label}
                   {(descriptor.required || descriptor.secret) && <RequiredMark />}
+                  {descriptor.tooltip && (
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Info className="ml-1 inline h-3.5 w-3.5 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent>{descriptor.tooltip}</TooltipContent>
+                    </Tooltip>
+                  )}
                 </FieldLabel>
                 <FieldContent>
                   <FieldWidget field={field} descriptor={descriptor} isError={!!fieldState.error} />

--- a/frontend/src/pages/pam/PamAccountsPage/components/PamSchemaFields.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/PamSchemaFields.tsx
@@ -12,11 +12,7 @@ import {
 } from "@app/components/v3/generic/Select";
 import { Switch } from "@app/components/v3/generic/Switch";
 import { TextArea } from "@app/components/v3/generic/TextArea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from "@app/components/v3/generic/Tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3/generic/Tooltip";
 import { PamFieldWidget, TPamFieldDescriptor } from "@app/hooks/api/pam";
 
 import { TAccountFormValues } from "./accountFormSchema";
@@ -117,7 +113,7 @@ export const PamSchemaFields = ({ control, namePrefix, fields }: Props) => {
                   {descriptor.tooltip && (
                     <Tooltip>
                       <TooltipTrigger>
-                        <Info className="ml-1 inline h-3.5 w-3.5 text-muted-foreground" />
+                        <Info className="text-muted-foreground ml-1 inline h-3.5 w-3.5" />
                       </TooltipTrigger>
                       <TooltipContent>{descriptor.tooltip}</TooltipContent>
                     </Tooltip>
@@ -137,7 +133,7 @@ export const PamSchemaFields = ({ control, namePrefix, fields }: Props) => {
                   {descriptor.tooltip && (
                     <Tooltip>
                       <TooltipTrigger>
-                        <Info className="ml-1 inline h-3.5 w-3.5 text-muted-foreground" />
+                        <Info className="text-muted-foreground ml-1 inline h-3.5 w-3.5" />
                       </TooltipTrigger>
                       <TooltipContent>{descriptor.tooltip}</TooltipContent>
                     </Tooltip>


### PR DESCRIPTION
## Summary
- Adds MongoDB and MS SQL Server account type schemas, connection details, and credential handling
- Adds NTLM and Kerberos auth methods for MsSQL
- Adds gateway target extraction for both account types
- Adds CLI access support (session activation on first credentials fetch)

Originally merged into `pam-revamp-c5-andrey` (#6956) instead of `pam-revamp`. This PR lands the same changes on the correct base branch.