### PR TITLE
fix(admin-signup): fix Continue button cutoff on desktop viewports (fixes #1411)

### DIFF
--- a/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/admin/SignUpPage/SignUpPage.tsx
@@ -71,7 +71,7 @@ export const SignUpPage = () => {
   }
 
   return (
-    <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
+    <div className="flex min-h-screen flex-col overflow-y-auto bg-linear-to-tr from-mineshaft-600 via-mineshaft-800 to-bunker-700 px-6">
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>
         <link rel="icon" href="/infisical.ico" />
@@ -79,7 +79,7 @@ export const SignUpPage = () => {
         <meta property="og:title" content={t("signup.og-title") ?? ""} />
         <meta name="og:description" content={t("signup.og-description") ?? ""} />
       </Helmet>
-      <div className="flex items-center justify-center">
+      <div className="my-auto flex items-center justify-center py-8">
         <AnimatePresence mode="wait">
           <motion.div
             className="text-mineshaft-200"


### PR DESCRIPTION
## Problem

The admin signup form's **Continue** button is cut off and unreachable on desktop screens because the page uses `justify-center` on a flex container that also has `max-h-screen` + `overflow-y-auto`.

This is a well-known CSS behaviour: when `justify-content: center` is applied to a flex/grid container with `overflow: auto`, the overflow is distributed equally above **and** below the content. The portion clipped above the scroll origin cannot be scrolled to — the browser won't scroll past position 0. The user can see half the form is missing but cannot reach the button by scrolling.

Reference: https://stackoverflow.com/questions/33454533/cant-scroll-to-top-of-flex-item-that-is-overflowing-container

## Fix

```diff
- <div className="flex max-h-screen min-h-screen flex-col justify-center overflow-y-auto ...">
+ <div className="flex min-h-screen flex-col overflow-y-auto ...">

-   <div className="flex items-center justify-center">
+   <div className="my-auto flex items-center justify-center py-8">
```

**Why this works:**
- `my-auto` on a flex child centres the content vertically when the parent has spare height (normal desktop)
- When the form is taller than the viewport, `my-auto` collapses to `0` and `overflow-y-auto` allows the user to scroll down to the Continue button
- Removing `max-h-screen` from the outer div lets the container grow naturally; `min-h-screen` still ensures the gradient covers the full viewport

## Before / After

| Before | After |
|---|---|
| Button unreachable — clipped at bottom | Button reachable — page scrolls correctly |

Fixes #1411