### PR TITLE
fix(auth): reject oauth on project key route

### DIFF
--- a/backend/e2e-test/routes/v1/oauth-scope.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-scope.spec.ts
@@ -50,6 +50,13 @@ const createFolder = async (token: string, name: string) =>
     }
   });
 
+const getEncryptedProjectKey = async (token: string) =>
+  testServer.inject({
+    method: "GET",
+    url: `/api/v2/workspace/${seedData1.project.id}/encrypted-key`,
+    headers: { authorization: `Bearer ${token}` }
+  });
+
 describe("OAuth delegated token scope enforcement", async () => {
   // Control: a first-party session JWT (no oauthClientId) is never scope-narrowed, so the org admin
   // can read secrets. This is the baseline the scoped cases are compared against.
@@ -85,6 +92,17 @@ describe("OAuth delegated token scope enforcement", async () => {
     const token = signOauthToken(["secrets:read"]);
     const res = await createFolder(token, "oauth-scope-write-denied");
     expect(res.statusCode).toBe(403);
+  });
+
+  test("a delegated token cannot reach the deprecated project-key route", async () => {
+    const token = signOauthToken(["secrets:read"]);
+    const res = await getEncryptedProjectKey(token);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("a first-party session JWT can reach the deprecated project-key route", async () => {
+    const res = await getEncryptedProjectKey(jwtAuthToken);
+    expect(res.statusCode).toBe(200);
   });
 
   // Security regression: account-management routes (TOTP, MFA, sessions, password) authenticate on

--- a/backend/e2e-test/routes/v1/oauth-scope.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-scope.spec.ts
@@ -50,13 +50,6 @@ const createFolder = async (token: string, name: string) =>
     }
   });
 
-const getEncryptedProjectKey = async (token: string) =>
-  testServer.inject({
-    method: "GET",
-    url: `/api/v2/workspace/${seedData1.project.id}/encrypted-key`,
-    headers: { authorization: `Bearer ${token}` }
-  });
-
 describe("OAuth delegated token scope enforcement", async () => {
   // Control: a first-party session JWT (no oauthClientId) is never scope-narrowed, so the org admin
   // can read secrets. This is the baseline the scoped cases are compared against.
@@ -92,17 +85,6 @@ describe("OAuth delegated token scope enforcement", async () => {
     const token = signOauthToken(["secrets:read"]);
     const res = await createFolder(token, "oauth-scope-write-denied");
     expect(res.statusCode).toBe(403);
-  });
-
-  test("a delegated token cannot reach the deprecated project-key route", async () => {
-    const token = signOauthToken(["secrets:read"]);
-    const res = await getEncryptedProjectKey(token);
-    expect(res.statusCode).toBe(403);
-  });
-
-  test("a first-party session JWT can reach the deprecated project-key route", async () => {
-    const res = await getEncryptedProjectKey(jwtAuthToken);
-    expect(res.statusCode).toBe(200);
   });
 
   // Security regression: account-management routes (TOTP, MFA, sessions, password) authenticate on

--- a/backend/e2e-test/routes/v2/project-key.spec.ts
+++ b/backend/e2e-test/routes/v2/project-key.spec.ts
@@ -1,0 +1,40 @@
+import jwt from "jsonwebtoken";
+
+import { seedData1 } from "@app/db/seed-data";
+import { AuthMethod, AuthTokenType } from "@app/services/auth/auth-type";
+
+const signOauthToken = (scopes: string[]) =>
+  jwt.sign(
+    {
+      authTokenType: AuthTokenType.ACCESS_TOKEN,
+      userId: seedData1.id,
+      tokenVersionId: seedData1.token.id,
+      authMethod: AuthMethod.EMAIL,
+      organizationId: seedData1.organization.id,
+      accessVersion: 1,
+      oauthClientId: "oauth_client_e2e_test",
+      scopes
+    },
+    process.env.AUTH_SECRET ?? "something-random",
+    { expiresIn: "1h" }
+  );
+
+const getEncryptedProjectKey = async (token: string) =>
+  testServer.inject({
+    method: "GET",
+    url: `/api/v2/workspace/${seedData1.project.id}/encrypted-key`,
+    headers: { authorization: `Bearer ${token}` }
+  });
+
+describe("Project key route V2", async () => {
+  test("a delegated token cannot reach the deprecated project-key route", async () => {
+    const token = signOauthToken(["secrets:read"]);
+    const res = await getEncryptedProjectKey(token);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("a first-party session JWT can reach the deprecated project-key route", async () => {
+    const res = await getEncryptedProjectKey(jwtAuthToken);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -59,7 +59,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         )
       }
     },
-    onResponse: verifyAuth([AuthMode.JWT, AuthMode.API_KEY]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY]),
     handler: async (req) => {
       const key = await server.services.projectKey.getLatestProjectKey({
         actor: req.permission.type,


### PR DESCRIPTION
## Context

This fixes a broken-access-control bug on the deprecated v2 project-key endpoint.

`GET /api/v2/workspace/:workspaceId/encrypted-key` intended to allow only first-party JWT and API key auth, but it registered `verifyAuth([AuthMode.JWT, AuthMode.API_KEY])` as an `onResponse` hook. Fastify runs `onResponse` after the handler has executed, so delegated OAuth tokens could reach the handler before the auth-mode rejection ran.

This PR moves that guard to `onRequest`, matching sibling route patterns and ensuring delegated OAuth tokens are rejected before the encrypted project key handler executes. The accepted auth modes remain unchanged.

## Screenshots

N/A

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
