### PR TITLE
fix(secret-sync): render not re-triggering deployment for env groups

### DIFF
--- a/backend/src/services/secret-sync/render/render-sync-fns.ts
+++ b/backend/src/services/secret-sync/render/render-sync-fns.ts
@@ -258,6 +258,7 @@ const redeployService = async (secretSync: TRenderSyncWithCredentials) => {
         await makeRequestWithRetry(() =>
           request.request({
             ...req,
+            method: "POST",
             url: `/services/${link.id}/deploys`,
             data: {}
           })


### PR DESCRIPTION
## Context

Fixed Render sync not redeploying env groups correctly when a sync happens. We were passing the incorrect request method.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)