### PR TITLE
feat: improve response types from "any" to typed lease data responses

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { DynamicSecretLeasesSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
+import { DynamicSecretLeaseResultSchema } from "@app/ee/services/dynamic-secret/providers/models";
 import { ApiDocsTags, DYNAMIC_SECRET_LEASES } from "@app/lib/api-docs";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { ms } from "@app/lib/ms";
@@ -42,24 +43,25 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         config: z.any().optional()
       }),
       response: {
-        200: z.object({
-          lease: DynamicSecretLeasesSchema,
-          dynamicSecret: SanitizedDynamicSecretSchema,
-          data: z.unknown()
-        })
+        200: DynamicSecretLeaseResultSchema.and(
+          z.object({
+            lease: DynamicSecretLeasesSchema,
+            dynamicSecret: SanitizedDynamicSecretSchema
+          })
+        )
       }
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const { data, lease, dynamicSecret, projectId, environment, secretPath } =
-        await server.services.dynamicSecretLease.create({
-          actor: req.permission.type,
-          actorId: req.permission.id,
-          actorAuthMethod: req.permission.authMethod,
-          actorOrgId: req.permission.orgId,
-          name: req.body.dynamicSecretName,
-          ...req.body
-        });
+      const leaseResult = await server.services.dynamicSecretLease.create({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        name: req.body.dynamicSecretName,
+        ...req.body
+      });
+      const { lease, dynamicSecret, projectId, environment, secretPath } = leaseResult;
 
       await server.services.telemetry
         .sendPostHogEvents({
@@ -96,7 +98,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         }
       });
 
-      return { lease, data, dynamicSecret };
+      return leaseResult;
     }
   });
 

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-config-types.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-config-types.ts
@@ -1,0 +1,13 @@
+export type ActorIdentityAttributes = {
+  name: string;
+};
+
+export type TDynamicSecretKubernetesLeaseConfig = {
+  namespace?: string;
+};
+
+export type TDynamicSecretSshLeaseConfig = {
+  principals?: string[];
+};
+
+export type TDynamicSecretLeaseConfig = TDynamicSecretKubernetesLeaseConfig & TDynamicSecretSshLeaseConfig;

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-service.ts
@@ -26,7 +26,11 @@ import { SecretValidationRuleType } from "@app/services/secret-validation-rule/s
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { TDynamicSecretDALFactory } from "../dynamic-secret/dynamic-secret-dal";
-import { DynamicSecretProviders, TDynamicProviderFns } from "../dynamic-secret/providers/models";
+import {
+  DynamicSecretLeaseResultSchema,
+  DynamicSecretProviders,
+  TDynamicProviderFns
+} from "../dynamic-secret/providers/models";
 import { toSafeUsername } from "../dynamic-secret/providers/templateUtils";
 import { TDynamicSecretLeaseDALFactory } from "./dynamic-secret-lease-dal";
 import { TDynamicSecretLeaseQueueServiceFactory } from "./dynamic-secret-lease-queue";
@@ -208,10 +212,13 @@ export const dynamicSecretLeaseServiceFactory = ({
     });
 
     await dynamicSecretQueueService.setLeaseRevocation(dynamicSecretLease.id, dynamicSecretCfg.id, expireAt);
+
+    const leaseResult = DynamicSecretLeaseResultSchema.parse({ type: dynamicSecretCfg.type, data });
+
     return {
+      ...leaseResult,
       lease: dynamicSecretLease,
       dynamicSecret: dynamicSecretCfg,
-      data,
       projectId,
       environment: environmentSlug,
       secretPath: path

--- a/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-types.ts
+++ b/backend/src/ee/services/dynamic-secret-lease/dynamic-secret-lease-types.ts
@@ -1,13 +1,24 @@
 import { TDynamicSecretLeases } from "@app/db/schemas";
 import { TDynamicSecretWithMetadata, TProjectPermission } from "@app/lib/types";
 
+import { TDynamicSecretLeaseResult } from "../dynamic-secret/providers/models";
+import {
+  ActorIdentityAttributes,
+  TDynamicSecretKubernetesLeaseConfig,
+  TDynamicSecretLeaseConfig,
+  TDynamicSecretSshLeaseConfig
+} from "./dynamic-secret-lease-config-types";
+
+export type {
+  ActorIdentityAttributes,
+  TDynamicSecretKubernetesLeaseConfig,
+  TDynamicSecretLeaseConfig,
+  TDynamicSecretSshLeaseConfig
+};
+
 export enum DynamicSecretLeaseStatus {
   FailedDeletion = "Failed to delete"
 }
-
-export type ActorIdentityAttributes = {
-  name: string;
-};
 
 export type TCreateDynamicSecretLeaseDTO = {
   name: string;
@@ -48,25 +59,16 @@ export type TRenewDynamicSecretLeaseDTO = {
   projectSlug: string;
 } & Omit<TProjectPermission, "projectId">;
 
-export type TDynamicSecretKubernetesLeaseConfig = {
-  namespace?: string;
-};
-
-export type TDynamicSecretSshLeaseConfig = {
-  principals?: string[];
-};
-
-export type TDynamicSecretLeaseConfig = TDynamicSecretKubernetesLeaseConfig & TDynamicSecretSshLeaseConfig;
-
 export type TDynamicSecretLeaseServiceFactory = {
-  create: (arg: TCreateDynamicSecretLeaseDTO) => Promise<{
-    lease: TDynamicSecretLeases;
-    dynamicSecret: TDynamicSecretWithMetadata;
-    data: unknown;
-    projectId: string;
-    environment: string;
-    secretPath: string;
-  }>;
+  create: (arg: TCreateDynamicSecretLeaseDTO) => Promise<
+    TDynamicSecretLeaseResult & {
+      lease: TDynamicSecretLeases;
+      dynamicSecret: TDynamicSecretWithMetadata;
+      projectId: string;
+      environment: string;
+      secretPath: string;
+    }
+  >;
   listLeases: (arg: TListDynamicSecretLeasesDTO) => Promise<{
     leases: TDynamicSecretLeases[];
     dynamicSecret: TDynamicSecretWithMetadata;

--- a/backend/src/ee/services/dynamic-secret/providers/aws-elasticache.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/aws-elasticache.ts
@@ -20,7 +20,7 @@ import { sanitizeString } from "@app/lib/fn";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { DynamicSecretAwsElastiCacheSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretAwsElastiCacheSchema, TAwsElastiCacheLeaseData, TDynamicProviderFns } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const CreateElastiCacheUserSchema = z.object({
@@ -141,7 +141,7 @@ const generatePassword = () => {
   return customAlphabet(charset, 64)();
 };
 
-export const AwsElastiCacheDatabaseProvider = (): TDynamicProviderFns => {
+export const AwsElastiCacheDatabaseProvider = (): TDynamicProviderFns<TAwsElastiCacheLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = DynamicSecretAwsElastiCacheSchema.parse(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/aws-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/aws-iam.ts
@@ -28,13 +28,19 @@ import { sanitizeString } from "@app/lib/fn";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { AwsIamAuthType, AwsIamCredentialType, DynamicSecretAwsIamSchema, TDynamicProviderFns } from "./models";
+import {
+  AwsIamAuthType,
+  AwsIamCredentialType,
+  DynamicSecretAwsIamSchema,
+  TAwsIamLeaseData,
+  TDynamicProviderFns
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 // AWS STS duration constants (in seconds)
 const AWS_STS_MIN_DURATION = 900;
 
-export const AwsIamProvider = (): TDynamicProviderFns => {
+export const AwsIamProvider = (): TDynamicProviderFns<TAwsIamLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretAwsIamSchema.parseAsync(inputs);
     return providerInputs;
@@ -436,8 +442,13 @@ export const AwsIamProvider = (): TDynamicProviderFns => {
             UserName: createUserRes.User.UserName
           })
         );
-        if (!createAccessKeyRes.AccessKey)
+        if (
+          !createAccessKeyRes.AccessKey ||
+          !createAccessKeyRes.AccessKey.AccessKeyId ||
+          !createAccessKeyRes.AccessKey.SecretAccessKey
+        ) {
           throw new BadRequestError({ message: "Failed to create AWS IAM User access key" });
+        }
 
         return {
           entityId: username,

--- a/backend/src/ee/services/dynamic-secret/providers/aws-memorydb.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/aws-memorydb.ts
@@ -17,7 +17,12 @@ import { sanitizeString } from "@app/lib/fn";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { AwsMemoryDbAuthType, DynamicSecretAwsMemoryDbSchema, TDynamicProviderFns } from "./models";
+import {
+  AwsMemoryDbAuthType,
+  DynamicSecretAwsMemoryDbSchema,
+  TAwsMemoryDbLeaseData,
+  TDynamicProviderFns
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 const CreateMemoryDbUserSchema = z.object({
@@ -124,7 +129,7 @@ const $getAwsCredentials = (providerInputs: z.infer<typeof DynamicSecretAwsMemor
   throw new BadRequestError({ message: "Unsupported MemoryDB auth type" });
 };
 
-export const AwsMemoryDbDatabaseProvider = (): TDynamicProviderFns => {
+export const AwsMemoryDbDatabaseProvider = (): TDynamicProviderFns<TAwsMemoryDbLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = DynamicSecretAwsMemoryDbSchema.parse(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/azure-entra-id.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-entra-id.ts
@@ -4,7 +4,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 
-import { AzureEntraIDSchema, TDynamicProviderFns } from "./models";
+import { AzureEntraIDSchema, TAzureEntraIDLeaseData, TDynamicProviderFns } from "./models";
 
 const MSFT_GRAPH_API_URL = "https://graph.microsoft.com/v1.0/";
 const MSFT_LOGIN_URL = "https://login.microsoftonline.com";
@@ -16,7 +16,7 @@ const generatePassword = () => {
 
 type User = { name: string; id: string; email: string };
 
-export const AzureEntraIDProvider = (): TDynamicProviderFns & {
+export const AzureEntraIDProvider = (): TDynamicProviderFns<TAzureEntraIDLeaseData> & {
   fetchAzureEntraIdUsers: (tenantId: string, applicationId: string, clientSecret: string) => Promise<User[]>;
 } => {
   const validateProviderInputs = async (inputs: unknown) => {

--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -16,7 +16,13 @@ import { TGatewayServiceFactory } from "../../gateway/gateway-service";
 import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "../../gateway-v2/gateway-v2-service";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretAzureSqlDBSchema, PasswordRequirements, SqlProviders, TDynamicProviderFns } from "./models";
+import {
+  DynamicSecretAzureSqlDBSchema,
+  PasswordRequirements,
+  SqlProviders,
+  TAzureSqlDatabaseLeaseData,
+  TDynamicProviderFns
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 const EXTERNAL_REQUEST_TIMEOUT = 10 * 1000;
@@ -116,7 +122,7 @@ export const AzureSqlDatabaseProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TAzureSqlDatabaseProviderDTO): TDynamicProviderFns => {
+}: TAzureSqlDatabaseProviderDTO): TDynamicProviderFns<TAzureSqlDatabaseLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretAzureSqlDBSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/cassandra.ts
@@ -10,7 +10,7 @@ import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretCassandraSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretCassandraSchema, TCassandraLeaseData, TDynamicProviderFns } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = (size = 48) => {
@@ -18,7 +18,7 @@ const generatePassword = (size = 48) => {
   return customAlphabet(charset, 48)(size);
 };
 
-export const CassandraProvider = (): TDynamicProviderFns => {
+export const CassandraProvider = (): TDynamicProviderFns<TCassandraLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretCassandraSchema.parseAsync(inputs);
     await Promise.all(

--- a/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
@@ -15,7 +15,12 @@ import { TGatewayServiceFactory } from "../../gateway/gateway-service";
 import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "../../gateway-v2/gateway-v2-service";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretClickhouseSchema, PasswordRequirements, TDynamicProviderFns } from "./models";
+import {
+  DynamicSecretClickhouseSchema,
+  PasswordRequirements,
+  TClickhouseLeaseData,
+  TDynamicProviderFns
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 const EXTERNAL_REQUEST_TIMEOUT = 10 * 1000;
@@ -108,7 +113,7 @@ export const ClickhouseProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TClickhouseProviderDTO): TDynamicProviderFns => {
+}: TClickhouseProviderDTO): TDynamicProviderFns<TClickhouseLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretClickhouseSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/couchbase.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/couchbase.ts
@@ -10,7 +10,7 @@ import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator/validate-url";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { DynamicSecretCouchbaseSchema, PasswordRequirements, TDynamicProviderFns } from "./models";
+import { DynamicSecretCouchbaseSchema, PasswordRequirements, TCouchbaseLeaseData, TDynamicProviderFns } from "./models";
 import { generateUsername } from "./templateUtils";
 
 type TCreateCouchbaseUser = {
@@ -183,7 +183,7 @@ const couchbaseApiRequest = async (
   }
 };
 
-export const CouchbaseProvider = (): TDynamicProviderFns => {
+export const CouchbaseProvider = (): TDynamicProviderFns<TCouchbaseLeaseData> => {
   const validateProviderInputs = async (inputs: object) => {
     const providerInputs = DynamicSecretCouchbaseSchema.parse(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/elastic-search.ts
@@ -8,7 +8,12 @@ import { sanitizeString } from "@app/lib/fn";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretElasticSearchSchema, ElasticSearchAuthTypes, TDynamicProviderFns } from "./models";
+import {
+  DynamicSecretElasticSearchSchema,
+  ElasticSearchAuthTypes,
+  TDynamicProviderFns,
+  TElasticSearchLeaseData
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = () => {
@@ -16,7 +21,7 @@ const generatePassword = () => {
   return customAlphabet(charset, 64)();
 };
 
-export const ElasticSearchProvider = (): TDynamicProviderFns => {
+export const ElasticSearchProvider = (): TDynamicProviderFns<TElasticSearchLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretElasticSearchSchema.parseAsync(inputs);
     await verifyHostInputValidity({ host: providerInputs.host, isDynamicSecret: true });

--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -8,9 +8,9 @@ import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { buildGcpSourceCredential } from "@app/services/app-connection/gcp/gcp-connection-fns";
 
-import { DynamicSecretGcpIamSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretGcpIamSchema, TDynamicProviderFns, TGcpIamLeaseData } from "./models";
 
-export const GcpIamProvider = (): TDynamicProviderFns => {
+export const GcpIamProvider = (): TDynamicProviderFns<TGcpIamLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretGcpIamSchema.parseAsync(inputs);
     return providerInputs;

--- a/backend/src/ee/services/dynamic-secret/providers/github.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/github.ts
@@ -8,7 +8,7 @@ import { sanitizeString } from "@app/lib/fn";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 
-import { DynamicSecretGithubSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretGithubSchema, TDynamicProviderFns, TGithubLeaseData } from "./models";
 
 interface GitHubInstallationTokenResponse {
   token: string;
@@ -23,7 +23,7 @@ interface TGithubProviderInputs {
   privateKey: string;
 }
 
-export const GithubProvider = (): TDynamicProviderFns => {
+export const GithubProvider = (): TDynamicProviderFns<TGithubLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretGithubSchema.parseAsync(inputs);
     return providerInputs;

--- a/backend/src/ee/services/dynamic-secret/providers/ibm-api-connect.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ibm-api-connect.ts
@@ -3,7 +3,7 @@ import { BadRequestError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator/validate-url";
 
-import { DynamicSecretIbmApiConnectSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretIbmApiConnectSchema, TDynamicProviderFns, TIbmApiConnectLeaseData } from "./models";
 
 export type TIbmApiConnectBaseCredentials = {
   clientId: string;
@@ -248,7 +248,7 @@ const $revokeApplicationCredential = async (
   }
 };
 
-export const IbmApiConnectProvider = (): TDynamicProviderFns & {
+export const IbmApiConnectProvider = (): TDynamicProviderFns<TIbmApiConnectLeaseData> & {
   fetchOrganizations: (inputs: TIbmApiConnectBaseCredentials) => Promise<TApiConnectResource[]>;
   fetchOrganizationCatalogs: (inputs: TIbmApiConnectBaseCredentials, orgId: string) => Promise<TApiConnectResource[]>;
   fetchOrganizationApps: (

--- a/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
@@ -22,7 +22,8 @@ import {
   KubernetesAuthMethod,
   KubernetesCredentialType,
   KubernetesRoleType,
-  TDynamicProviderFns
+  TDynamicProviderFns,
+  TKubernetesLeaseData
 } from "./models";
 import { generateUsername } from "./templateUtils";
 
@@ -41,7 +42,7 @@ export const KubernetesProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TKubernetesProviderDTO): TDynamicProviderFns => {
+}: TKubernetesProviderDTO): TDynamicProviderFns<TKubernetesLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretKubernetesSchema.parseAsync(inputs);
     if (!providerInputs.gatewayId && !providerInputs.gatewayPoolId && providerInputs.url) {

--- a/backend/src/ee/services/dynamic-secret/providers/ldap.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ldap.ts
@@ -12,7 +12,7 @@ import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { LdapCredentialType, LdapSchema, TDynamicProviderFns } from "./models";
+import { LdapCredentialType, LdapSchema, TDynamicProviderFns, TLdapLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = () => {
@@ -48,7 +48,7 @@ const generateLDIF = ({
   return renderedLdif;
 };
 
-export const LdapProvider = (): TDynamicProviderFns => {
+export const LdapProvider = (): TDynamicProviderFns<TLdapLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await LdapSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/milvus.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/milvus.ts
@@ -18,7 +18,12 @@ import { TGatewayServiceFactory } from "../../gateway/gateway-service";
 import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "../../gateway-v2/gateway-v2-service";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretMilvusSchema, TDynamicProviderCreateMetadata, TDynamicProviderFns } from "./models";
+import {
+  DynamicSecretMilvusSchema,
+  TDynamicProviderCreateMetadata,
+  TDynamicProviderFns,
+  TMilvusLeaseData
+} from "./models";
 import { generateUsername } from "./templateUtils";
 
 type TMilvusProviderInputs = z.infer<typeof DynamicSecretMilvusSchema>;
@@ -89,7 +94,7 @@ export const MilvusProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TMilvusProviderDTO): TDynamicProviderFns => {
+}: TMilvusProviderDTO): TDynamicProviderFns<TMilvusLeaseData> => {
   const validateProviderInputs = async (inputs: object) => {
     const providerInputs = await DynamicSecretMilvusSchema.parseAsync(inputs);
     const { hostname, origin } = parseMilvusHost(providerInputs, providerInputs.host, providerInputs.port);

--- a/backend/src/ee/services/dynamic-secret/providers/models.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/models.ts
@@ -10,7 +10,7 @@ import { TConstraint } from "@app/services/secret-validation-rule/secret-validat
 import {
   ActorIdentityAttributes,
   TDynamicSecretLeaseConfig
-} from "../../dynamic-secret-lease/dynamic-secret-lease-types";
+} from "../../dynamic-secret-lease/dynamic-secret-lease-config-types";
 
 export type PasswordRequirements = {
   length: number;
@@ -850,6 +850,154 @@ export const DynamicSecretProviderSchema = z.discriminatedUnion("type", [
   })
 ]);
 
+// Per-provider lease data schemas. These describe the credentials returned to
+// the caller after a successful lease creation. Adding a new provider requires
+// declaring its schema here and adding it to TDynamicSecretLeaseDataMap +
+// DynamicSecretLeaseResultSchema below.
+const DbUsernamePasswordLeaseDataSchema = z.object({
+  DB_USERNAME: z.string(),
+  DB_PASSWORD: z.string()
+});
+
+export const SqlDatabaseLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const ClickhouseLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const CassandraLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const SapAseLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const SapHanaLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const SnowflakeLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const RedisLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const AwsElastiCacheLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const AwsMemoryDbLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const MongoAtlasLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const MongoDBLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const ElasticSearchLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const RabbitMqLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const AzureSqlDatabaseLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const VerticaLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+export const MilvusLeaseDataSchema = DbUsernamePasswordLeaseDataSchema;
+
+export const AwsIamLeaseDataSchema = z.union([
+  z.object({
+    ACCESS_KEY: z.string(),
+    SECRET_ACCESS_KEY: z.string(),
+    SESSION_TOKEN: z.string()
+  }),
+  z.object({
+    ACCESS_KEY: z.string(),
+    SECRET_ACCESS_KEY: z.string(),
+    USERNAME: z.string()
+  })
+]);
+
+export const AzureEntraIDLeaseDataSchema = z.object({
+  email: z.string(),
+  password: z.string()
+});
+
+export const LdapLeaseDataSchema = z.object({
+  DN_ARRAY: z.array(z.string()),
+  USERNAME: z.string(),
+  PASSWORD: z.string()
+});
+
+export const TotpLeaseDataSchema = z.object({
+  TOTP: z.string(),
+  TIME_REMAINING: z.number()
+});
+
+export const KubernetesLeaseDataSchema = z.object({
+  TOKEN: z.string()
+});
+
+export const GcpIamLeaseDataSchema = z.object({
+  SERVICE_ACCOUNT_EMAIL: z.string(),
+  TOKEN: z.string()
+});
+
+export const GithubLeaseDataSchema = z.object({
+  TOKEN: z.string(),
+  EXPIRES_AT: z.string(),
+  PERMISSIONS: z.record(z.string()).optional(),
+  REPOSITORY_SELECTION: z.string().optional()
+});
+
+export const CouchbaseLeaseDataSchema = z.object({
+  username: z.string(),
+  password: z.string()
+});
+
+export const SshLeaseDataSchema = z.object({
+  PRIVATE_KEY: z.string(),
+  SIGNED_KEY: z.string()
+});
+
+export const IbmApiConnectLeaseDataSchema = z.object({
+  CLIENT_ID: z.string(),
+  CLIENT_SECRET: z.string()
+});
+
+export type TSqlDatabaseLeaseData = z.infer<typeof SqlDatabaseLeaseDataSchema>;
+export type TClickhouseLeaseData = z.infer<typeof ClickhouseLeaseDataSchema>;
+export type TCassandraLeaseData = z.infer<typeof CassandraLeaseDataSchema>;
+export type TSapAseLeaseData = z.infer<typeof SapAseLeaseDataSchema>;
+export type TSapHanaLeaseData = z.infer<typeof SapHanaLeaseDataSchema>;
+export type TSnowflakeLeaseData = z.infer<typeof SnowflakeLeaseDataSchema>;
+export type TRedisLeaseData = z.infer<typeof RedisLeaseDataSchema>;
+export type TAwsElastiCacheLeaseData = z.infer<typeof AwsElastiCacheLeaseDataSchema>;
+export type TAwsMemoryDbLeaseData = z.infer<typeof AwsMemoryDbLeaseDataSchema>;
+export type TMongoAtlasLeaseData = z.infer<typeof MongoAtlasLeaseDataSchema>;
+export type TMongoDBLeaseData = z.infer<typeof MongoDBLeaseDataSchema>;
+export type TElasticSearchLeaseData = z.infer<typeof ElasticSearchLeaseDataSchema>;
+export type TRabbitMqLeaseData = z.infer<typeof RabbitMqLeaseDataSchema>;
+export type TAzureSqlDatabaseLeaseData = z.infer<typeof AzureSqlDatabaseLeaseDataSchema>;
+export type TVerticaLeaseData = z.infer<typeof VerticaLeaseDataSchema>;
+export type TMilvusLeaseData = z.infer<typeof MilvusLeaseDataSchema>;
+export type TAwsIamLeaseData = z.infer<typeof AwsIamLeaseDataSchema>;
+export type TAzureEntraIDLeaseData = z.infer<typeof AzureEntraIDLeaseDataSchema>;
+export type TLdapLeaseData = z.infer<typeof LdapLeaseDataSchema>;
+export type TTotpLeaseData = z.infer<typeof TotpLeaseDataSchema>;
+export type TKubernetesLeaseData = z.infer<typeof KubernetesLeaseDataSchema>;
+export type TGcpIamLeaseData = z.infer<typeof GcpIamLeaseDataSchema>;
+export type TGithubLeaseData = z.infer<typeof GithubLeaseDataSchema>;
+export type TCouchbaseLeaseData = z.infer<typeof CouchbaseLeaseDataSchema>;
+export type TSshLeaseData = z.infer<typeof SshLeaseDataSchema>;
+export type TIbmApiConnectLeaseData = z.infer<typeof IbmApiConnectLeaseDataSchema>;
+
+// Discriminated union of every possible lease result, used to type both the
+// API response (so the OpenAPI spec documents the per-provider data shape) and
+// the service-layer return value.
+export const DynamicSecretLeaseResultSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal(DynamicSecretProviders.SqlDatabase), data: SqlDatabaseLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Clickhouse), data: ClickhouseLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Cassandra), data: CassandraLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.SapAse), data: SapAseLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.AwsIam), data: AwsIamLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Redis), data: RedisLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.SapHana), data: SapHanaLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.AwsElastiCache), data: AwsElastiCacheLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.AwsMemoryDb), data: AwsMemoryDbLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.MongoAtlas), data: MongoAtlasLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.ElasticSearch), data: ElasticSearchLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.MongoDB), data: MongoDBLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.RabbitMq), data: RabbitMqLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.AzureEntraID), data: AzureEntraIDLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.AzureSqlDatabase), data: AzureSqlDatabaseLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Ldap), data: LdapLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Snowflake), data: SnowflakeLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Totp), data: TotpLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Kubernetes), data: KubernetesLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Vertica), data: VerticaLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.GcpIam), data: GcpIamLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Github), data: GithubLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Couchbase), data: CouchbaseLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Milvus), data: MilvusLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.Ssh), data: SshLeaseDataSchema }),
+  z.object({ type: z.literal(DynamicSecretProviders.IbmApiConnect), data: IbmApiConnectLeaseDataSchema })
+]);
+
+export type TDynamicSecretLeaseResult = z.infer<typeof DynamicSecretLeaseResultSchema>;
+export type TDynamicSecretLeaseData = TDynamicSecretLeaseResult["data"];
+
 // Extended metadata passed to a provider's create() call. When the project
 // has a matching secret validation rule, `passwordValidation` carries the
 // constraints that any generated password must satisfy; providers that
@@ -863,7 +1011,7 @@ export type TDynamicProviderCreateMetadata = {
   };
 };
 
-export type TDynamicProviderFns = {
+export type TDynamicProviderFns<TLeaseData = TDynamicSecretLeaseData> = {
   create: (arg: {
     inputs: unknown;
     expireAt: number;
@@ -872,7 +1020,7 @@ export type TDynamicProviderFns = {
     dynamicSecret: TDynamicSecrets;
     metadata: TDynamicProviderCreateMetadata;
     config?: TDynamicSecretLeaseConfig;
-  }) => Promise<{ entityId: string; data: unknown }>;
+  }) => Promise<{ entityId: string; data: TLeaseData }>;
   validateConnection: (inputs: unknown, metadata: { projectId: string }) => Promise<boolean>;
   validateProviderInputs: (inputs: object, metadata: { projectId: string }) => Promise<unknown>;
   revoke: (

--- a/backend/src/ee/services/dynamic-secret/providers/mongo-atlas.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/mongo-atlas.ts
@@ -8,7 +8,7 @@ import { BadRequestError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { DynamicSecretMongoAtlasSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretMongoAtlasSchema, TDynamicProviderFns, TMongoAtlasLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = (size = 48) => {
@@ -16,7 +16,7 @@ const generatePassword = (size = 48) => {
   return customAlphabet(charset, 48)(size);
 };
 
-export const MongoAtlasProvider = (): TDynamicProviderFns => {
+export const MongoAtlasProvider = (): TDynamicProviderFns<TMongoAtlasLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretMongoAtlasSchema.parseAsync(inputs);
     return providerInputs;

--- a/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/mongo-db.ts
@@ -8,7 +8,7 @@ import { sanitizeString } from "@app/lib/fn";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretMongoDBSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretMongoDBSchema, TDynamicProviderFns, TMongoDBLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = (size = 48) => {
@@ -16,7 +16,7 @@ const generatePassword = (size = 48) => {
   return customAlphabet(charset, 48)(size);
 };
 
-export const MongoDBProvider = (): TDynamicProviderFns => {
+export const MongoDBProvider = (): TDynamicProviderFns<TMongoDBLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretMongoDBSchema.parseAsync(inputs);
     await verifyHostInputValidity({ host: providerInputs.host, isDynamicSecret: true });

--- a/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/rabbit-mq.ts
@@ -10,7 +10,7 @@ import { logger } from "@app/lib/logger";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretRabbitMqSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretRabbitMqSchema, TDynamicProviderFns, TRabbitMqLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = () => {
@@ -75,7 +75,7 @@ async function deleteRabbitMqUser({ axiosInstance, usernameToDelete }: TDeleteRa
   return { username: usernameToDelete };
 }
 
-export const RabbitMqProvider = (): TDynamicProviderFns => {
+export const RabbitMqProvider = (): TDynamicProviderFns<TRabbitMqLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretRabbitMqSchema.parseAsync(inputs);
     await verifyHostInputValidity({ host: providerInputs.host, isDynamicSecret: true });

--- a/backend/src/ee/services/dynamic-secret/providers/redis.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/redis.ts
@@ -10,7 +10,7 @@ import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretRedisDBSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretRedisDBSchema, TDynamicProviderFns, TRedisLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = () => {
@@ -48,7 +48,7 @@ const executeTransactions = async (connection: Redis, commands: string[]): Promi
   return results.map(([_, result]) => result as string | null);
 };
 
-export const RedisDatabaseProvider = (): TDynamicProviderFns => {
+export const RedisDatabaseProvider = (): TDynamicProviderFns<TRedisLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretRedisDBSchema.parseAsync(inputs);
     const [hostIp] = await verifyHostInputValidity({ host: providerInputs.host, isDynamicSecret: true });

--- a/backend/src/ee/services/dynamic-secret/providers/sap-ase.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sap-ase.ts
@@ -10,7 +10,7 @@ import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretSapAseSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretSapAseSchema, TDynamicProviderFns, TSapAseLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = (size = 48) => {
@@ -23,7 +23,7 @@ enum SapCommands {
   DropLogin = "sp_droplogin"
 }
 
-export const SapAseProvider = (): TDynamicProviderFns => {
+export const SapAseProvider = (): TDynamicProviderFns<TSapAseLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretSapAseSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sap-hana.ts
@@ -16,7 +16,7 @@ import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretSapHanaSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretSapHanaSchema, TDynamicProviderFns, TSapHanaLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 const generatePassword = (size = 48) => {
@@ -24,7 +24,7 @@ const generatePassword = (size = 48) => {
   return customAlphabet(charset, 48)(size);
 };
 
-export const SapHanaProvider = (): TDynamicProviderFns => {
+export const SapHanaProvider = (): TDynamicProviderFns<TSapHanaLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretSapHanaSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/snowflake.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/snowflake.ts
@@ -9,7 +9,7 @@ import { sanitizeString } from "@app/lib/fn";
 import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 
 import { ActorIdentityAttributes } from "../../dynamic-secret-lease/dynamic-secret-lease-types";
-import { DynamicSecretSnowflakeSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretSnowflakeSchema, TDynamicProviderFns, TSnowflakeLeaseData } from "./models";
 import { generateUsername } from "./templateUtils";
 
 // destroy client requires callback...
@@ -28,7 +28,7 @@ const getDaysToExpiry = (expiryDate: Date) => {
   return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 };
 
-export const SnowflakeProvider = (): TDynamicProviderFns => {
+export const SnowflakeProvider = (): TDynamicProviderFns<TSnowflakeLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretSnowflakeSchema.parseAsync(inputs);
     validateHandlebarTemplate("Snowflake creation", providerInputs.creationStatement, {

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -22,7 +22,8 @@ import {
   PasswordRequirements,
   SqlProviders,
   TDynamicProviderCreateMetadata,
-  TDynamicProviderFns
+  TDynamicProviderFns,
+  TSqlDatabaseLeaseData
 } from "./models";
 import { generateUsername } from "./templateUtils";
 
@@ -129,7 +130,7 @@ export const SqlDatabaseProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TSqlDatabaseProviderDTO): TDynamicProviderFns => {
+}: TSqlDatabaseProviderDTO): TDynamicProviderFns<TSqlDatabaseLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretSqlDBSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/ssh.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/ssh.ts
@@ -7,9 +7,9 @@ import { TDynamicSecretLeaseConfig } from "../../dynamic-secret-lease/dynamic-se
 import { createSshCert, createSshKeyPair, getSshPublicKey } from "../../ssh/ssh-certificate-authority-fns";
 import { SshCertType } from "../../ssh/ssh-certificate-authority-types";
 import { SshCertKeyAlgorithm } from "../../ssh-certificate/ssh-certificate-types";
-import { DynamicSecretSshSchema, SshStoredSchema, TDynamicProviderFns } from "./models";
+import { DynamicSecretSshSchema, SshStoredSchema, TDynamicProviderFns, TSshLeaseData } from "./models";
 
-export const SshProvider = (): TDynamicProviderFns => {
+export const SshProvider = (): TDynamicProviderFns<TSshLeaseData> => {
   const validateProviderInputs = async (inputs: object) => {
     const parsed = DynamicSecretSshSchema.parse(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/totp.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/totp.ts
@@ -5,9 +5,9 @@ import { BadRequestError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 
-import { DynamicSecretTotpSchema, TDynamicProviderFns, TotpConfigType } from "./models";
+import { DynamicSecretTotpSchema, TDynamicProviderFns, TotpConfigType, TTotpLeaseData } from "./models";
 
-export const TotpProvider = (): TDynamicProviderFns => {
+export const TotpProvider = (): TDynamicProviderFns<TTotpLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretTotpSchema.parseAsync(inputs);
 

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -15,7 +15,7 @@ import { TGatewayServiceFactory } from "../../gateway/gateway-service";
 import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "../../gateway-v2/gateway-v2-service";
 import { verifyHostInputValidity } from "../dynamic-secret-fns";
-import { DynamicSecretVerticaSchema, PasswordRequirements, TDynamicProviderFns } from "./models";
+import { DynamicSecretVerticaSchema, PasswordRequirements, TDynamicProviderFns, TVerticaLeaseData } from "./models";
 
 const EXTERNAL_REQUEST_TIMEOUT = 10 * 1000;
 
@@ -143,7 +143,7 @@ export const VerticaProvider = ({
   gatewayService,
   gatewayV2Service,
   gatewayPoolService
-}: TVerticaProviderDTO): TDynamicProviderFns => {
+}: TVerticaProviderDTO): TDynamicProviderFns<TVerticaLeaseData> => {
   const validateProviderInputs = async (inputs: unknown) => {
     const providerInputs = await DynamicSecretVerticaSchema.parseAsync(inputs);
 


### PR DESCRIPTION
## Context

DRAFT:

This PR aims to add better type safety for the leased data that we return. Historically, we've just been returning unknown, which in the documentation has been reflected as return type any. The user had no way to tell what data structure was going to be returned when they go and generate a lease, because it differs slightly between most of our dynamic secret lease types. This PR addresses that gap. 

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)