### PR TITLE
fix(secret-approval): navigation error

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
@@ -120,7 +120,7 @@ export const SecretApprovalRequest = () => {
   const isSecretApprovalScreen = Boolean(requestId);
 
   const handleGoBackSecretRequestDetail = () => {
-    navigate({ search: { requestId: "" } });
+    navigate({ search: (prev) => ({ ...prev, requestId: "" }) });
     refetch();
   };
 
@@ -287,9 +287,12 @@ export const SecretApprovalRequest = () => {
               className="flex border-b border-mineshaft-600 px-8 py-3 last:border-b-0 hover:bg-mineshaft-700"
               role="button"
               tabIndex={0}
-              onClick={() => navigate({ search: { requestId: secretApproval.id } })}
+              onClick={() =>
+                navigate({ search: (prev) => ({ ...prev, requestId: secretApproval.id }) })
+              }
               onKeyDown={(evt) => {
-                if (evt.key === "Enter") navigate({ search: { requestId: secretApproval.id } });
+                if (evt.key === "Enter")
+                  navigate({ search: (prev) => ({ ...prev, requestId: secretApproval.id }) });
               }}
             >
               <div className="flex flex-col">


### PR DESCRIPTION
## Context
When clicking to open a secret approval, this was redirecting to the access requests tab

## Screenshots

previously 


https://github.com/user-attachments/assets/b2112cbb-e7e5-4cc0-829c-8266993157f1





<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- try to approve a secret request change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)