### PR TITLE
fix(eng-1580): debounce universal auth client secret usage writes

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -67,6 +67,8 @@ export const KeyStorePrefixes = {
     `identity-access-token-status:${identityAccessTokenId}`,
   IdentityTokenUsesRemaining: (identityId: string, jti: string) =>
     `identity-token-uses-remaining:${identityId}:${jti}` as const,
+  IdentityUaClientSecretUsageDebounce: (clientSecretId: string) =>
+    `identity-ua-client-secret-usage-debounce:${clientSecretId}` as const,
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
   GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`,
   ActiveSSEConnectionsSet: (projectId: string, identityId: string) =>

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -68,7 +68,13 @@ type TIdentityUaServiceFactoryDep = {
   >;
   keyStore: Pick<
     TKeyStoreFactory,
-    "setItemWithExpiry" | "getItem" | "deleteItem" | "getKeysByPattern" | "deleteItems" | "acquireLock"
+    | "setItemWithExpiry"
+    | "setItemWithExpiryNX"
+    | "getItem"
+    | "deleteItem"
+    | "getKeysByPattern"
+    | "deleteItems"
+    | "acquireLock"
   >;
 };
 
@@ -78,6 +84,9 @@ type LockoutObject = {
   lockedOut: boolean;
   failedAttempts: number;
 };
+
+// debounce per-secret usage writes so login bursts on one unlimited secret don't pile up on its row lock
+const UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS = 10;
 
 export const identityUaServiceFactory = ({
   identityUaDAL,
@@ -305,7 +314,20 @@ export const identityUaServiceFactory = ({
       }
 
       await identityUaDAL.transaction(async (tx) => {
-        await identityUaClientSecretDAL.incrementUsage(validClientSecretInfo!.id, tx);
+        if (clientSecretNumUsesLimit > 0) {
+          // finite usage limit: count must stay exact, so increment synchronously (low-frequency, no contention)
+          await identityUaClientSecretDAL.incrementUsage(validClientSecretInfo!.id, tx);
+        } else {
+          // unlimited secret: numUses is informational, so collapse a login storm to one row write per window
+          const isFirstUseInWindow = await keyStore.setItemWithExpiryNX(
+            KeyStorePrefixes.IdentityUaClientSecretUsageDebounce(validClientSecretInfo!.id),
+            UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS,
+            "1"
+          );
+          if (isFirstUseInWindow) {
+            await identityUaClientSecretDAL.incrementUsage(validClientSecretInfo!.id, tx);
+          }
+        }
         await membershipIdentityDAL.update(
           identity.projectId
             ? {


### PR DESCRIPTION
## Context

Every Universal Auth login ran a synchronous `UPDATE identity_ua_client_secrets SET clientSecretNumUses + 1, clientSecretLastUsedAt WHERE id = X` inside the login transaction. When many logins use the **same** client secret, those updates serialize on that one row lock and pile up.

This is the root cause behind ENG-1580 and the EU prod incident on 2026-06-26 (02:18 to 02:20 UTC):

- ~220 active DB sessions blocked on `Lock:transactionid` (baseline ~1.5), at only ~48% CPU and sub-ms read/write latency, so they were waiting on the row lock, not working.
- p95 target latency spiked to 40 to 45s; the ALB timed out requests and emitted 128 HTTP 504s.
- Self-resolved in ~2 min once the login burst drained. Performance Insights, sliced by SQL, attributed 220 of 222 AAS to this exact `UPDATE`.

**Fix:** for unlimited secrets (`clientSecretNumUsesLimit = 0`, where `numUses` is purely informational), gate the usage write behind a per-secret Redis NX key with a 10s window. The first login in the window persists the increment; the rest skip it. A same-secret login storm goes from N serialized row writes to at most one write per 10s, so the pile-up cannot form.

Finite-limit secrets (`numUsesLimit > 0`) keep the exact synchronous increment: they must stay exact for enforcement, are low-frequency, and were never the contended path.

Reuses the existing `keyStore` + `KeyStorePrefixes` pattern (mirrors the access-token `IdentityTokenUsesRemaining` counter). No schema change, no migration, no new cron or queue.

Tradeoff accepted: `numUses` on unlimited secrets becomes approximate, and `lastUsedAt` is accurate to within the 10s window. Both are non-load-bearing for those secrets.

Closes ENG-1580.

## Steps to verify the change

- **Repro (pre-fix):** drive concurrent UA logins against a single client secret with `numUsesLimit = 0`; observe serialized `Lock:transactionid` waits on `identity_ua_client_secrets` in RDS Performance Insights (this is what the EU incident showed).
- **Post-fix:** the same burst produces at most one `incrementUsage` write per secret per 10s window; the remaining logins skip the DB write, so no row-lock contention accumulates.
- **Finite-limit path unchanged:** a secret with `numUsesLimit > 0` still increments on every login and still revokes on hitting the limit.
- `npm run lint:fix` clean on both changed files. Type-check is clean for the changed files; unrelated errors in a local run were a stale `node_modules` on the source checkout missing `randexp`, not present in CI.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [ ] Tested locally (lint clean; behavior verified by reasoning, no automated test added; see note below)
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)

> No unit test added: this service has no existing unit-test harness and the change lives inside the large `login` flow, so a test would need new scaffolding. Happy to add e2e coverage as a follow-up if wanted.
