### PR TITLE
feat: add kubernetes cert-issuer docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -776,7 +776,8 @@
                         "group": "Applications",
                         "pages": [
                           "documentation/platform/pki/guides/applications/infisical-agent",
-                          "documentation/platform/pki/guides/applications/k8s-cert-manager",
+                          "documentation/platform/pki/guides/applications/k8s-cert-manager-acme",
+                          "documentation/platform/pki/guides/applications/k8s-cert-manager-issuer",
                           "documentation/platform/pki/guides/applications/nginx-certbot",
                           "documentation/platform/pki/guides/applications/apache-certbot",
                           "documentation/platform/pki/guides/applications/tomcat-certbot",
@@ -3931,6 +3932,10 @@
     }
   },
   "redirects": [
+    {
+      "source": "/documentation/platform/pki/guides/applications/k8s-cert-manager",
+      "destination": "/documentation/platform/pki/guides/applications/k8s-cert-manager-acme"
+    },
     {
       "source": "/sdks/languages/csharp",
       "destination": "/sdks/languages/dotnet"

--- a/docs/documentation/platform/pki/applications/enrollment-methods/acme.mdx
+++ b/docs/documentation/platform/pki/applications/enrollment-methods/acme.mdx
@@ -146,7 +146,7 @@ Configure your ACME client with the credentials from the previous step.
       --from-literal=secret="<EAB Secret>"
     ```
     
-    For full setup, see [Kubernetes cert-manager guide](/documentation/platform/pki/guides/applications/k8s-cert-manager).
+    For full setup, see [Kubernetes cert-manager guide](/documentation/platform/pki/guides/applications/k8s-cert-manager-acme).
   </Tab>
   <Tab title="Other Clients">
     Any [RFC 8555-compliant ACME client](https://letsencrypt.org/docs/client-options/) works with Infisical. Configure your client with:
@@ -179,7 +179,7 @@ For Kubernetes, cert-manager monitors Certificate resources and renews them auto
   <Card title="Nginx Guide" icon="n" href="/documentation/platform/pki/guides/applications/nginx-certbot">
     Set up HTTPS on Nginx with Certbot.
   </Card>
-  <Card title="Kubernetes Guide" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager">
+  <Card title="Kubernetes Guide" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-acme">
     Issue certificates for Kubernetes workloads.
   </Card>
   <Card title="Certificate Syncs" icon="arrows-rotate" href="/documentation/platform/pki/applications/certificate-syncs/overview">

--- a/docs/documentation/platform/pki/guides/applications/gloo-mesh.mdx
+++ b/docs/documentation/platform/pki/guides/applications/gloo-mesh.mdx
@@ -30,7 +30,7 @@ When you deploy a `Certificate` CRD in your workload cluster, `cert-manager` use
 Infisical verifies the request against your certificate policies and returns the signed certificate.
 From there, Istio's control plane will automatically use this intermediate CA to sign leaf certificates for workloads in the service mesh, enabling secure mTLS communication across your entire Gloo Mesh infrastructure.
 
-Follow the [Kubernetes cert-manager guide](/documentation/platform/pki/guides/applications/k8s-cert-manager) for detailed instructions on how to set up the Infisical and cert-manager for your Istio intermediate CA certificates in Gloo Mesh clusters.
+Follow the [Kubernetes cert-manager guide](/documentation/platform/pki/guides/applications/k8s-cert-manager-acme) for detailed instructions on how to set up the Infisical and cert-manager for your Istio intermediate CA certificates in Gloo Mesh clusters.
 
 For Gloo Mesh-specific configuration, ensure that:
 

--- a/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-acme.mdx
+++ b/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-acme.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Kubernetes cert-manager (ACME)"
-sidebarTitle: "cert-manager (ACME)"
+title: "Kubernetes with cert-manager (ACME)"
+sidebarTitle: "Issue TLS Certificates in Kubernetes (ACME)"
 description: "Automatically provision and manage TLS certificates in Kubernetes using cert-manager's ACME issuer and Infisical."
 ---
 

--- a/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-acme.mdx
+++ b/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-acme.mdx
@@ -1,12 +1,14 @@
 ---
-title: "Kubernetes cert-manager"
-sidebarTitle: "Issue Certificates in Kubernetes"
-description: "Automatically provision and manage TLS certificates in Kubernetes using Infisical."
+title: "Kubernetes cert-manager (ACME)"
+sidebarTitle: "cert-manager (ACME)"
+description: "Automatically provision and manage TLS certificates in Kubernetes using cert-manager's ACME issuer and Infisical."
 ---
 
-Issue TLS certificates to your Kubernetes workloads using [cert-manager](https://cert-manager.io/) and Infisical. Certificates are requested via ACME, stored in Kubernetes Secrets, and renewed automatically before expiration.
+Issue TLS certificates to your Kubernetes workloads using [cert-manager](https://cert-manager.io/) and Infisical over **ACME**. Certificates are requested via ACME with External Account Binding (EAB), stored in Kubernetes Secrets, and renewed automatically before expiration.
 
 <Info>
+  This is the **ACME** approach. If you would rather authenticate with an Infisical [machine identity](/documentation/platform/identities/machine-identities) (Universal Auth or Kubernetes Auth) instead of ACME/EAB, and want the CA chain populated in the Secret automatically, use the [Infisical Issuer guide](/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer) instead.
+
   This guide assumes you have an Application with [ACME enrollment](/documentation/platform/pki/applications/enrollment-methods/acme) configured.
 </Info>
 

--- a/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer.mdx
+++ b/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer.mdx
@@ -1,0 +1,353 @@
+---
+title: "Kubernetes cert-manager (Infisical Issuer)"
+sidebarTitle: "cert-manager (Infisical Issuer)"
+description: "Issue and renew Kubernetes TLS certificates with the Infisical cert-manager external issuer, authenticating with a machine identity."
+---
+
+Issue TLS certificates to your Kubernetes workloads using [cert-manager](https://cert-manager.io/) and the **Infisical Issuer**, an [external issuer](https://cert-manager.io/docs/configuration/external/) for cert-manager. Certificates are signed by Infisical through a PKI Application and Certificate Profile, stored in Kubernetes Secrets (including the CA chain), and renewed automatically before expiration.
+
+<Info>
+  This is the **Infisical Issuer** approach. If you would rather use the standard cert-manager ACME issuer with EAB credentials, see the [cert-manager (ACME) guide](/documentation/platform/pki/guides/applications/k8s-cert-manager-acme) instead.
+
+  This guide assumes you have a PKI Application with [API enrollment](/documentation/platform/pki/applications/enrollment-methods/api) configured.
+</Info>
+
+## When to use the Infisical Issuer instead of ACME
+
+- You want to authenticate with a **machine identity** (Universal Auth or Kubernetes Auth) rather than ACME/EAB credentials.
+- You want the **CA chain populated** in the Secret's `ca.crt` automatically (the ACME issuer does not populate `ca.crt`).
+- You do not want ACME domain-ownership challenges (HTTP-01/DNS-01).
+- You are issuing workload identity certificates (for example `spiffe://` URIs for service meshes).
+
+## How It Works
+
+1. Install cert-manager and the Infisical Issuer controller in your Kubernetes cluster.
+2. Create an `Issuer` (or `ClusterIssuer`) that authenticates to Infisical with a machine identity and points at your PKI Application and Profile.
+3. Create `Certificate` resources that define the certificates you need.
+4. cert-manager approves each request and the Infisical Issuer signs it through Infisical, storing the certificate, private key, and CA chain in a Secret.
+5. Certificates are automatically renewed before expiration.
+
+## Guide
+
+Throughout this guide, replace `<namespace>` with the namespace where your workloads and certificates live. The credentials `Secret`, the `Issuer`, and the `Certificate` all go in this same namespace (an `Issuer` is namespace-scoped). If you instead use a `ClusterIssuer`, see the note in the "Create the Infisical Issuer" step.
+
+<Steps>
+  <Step title="Set up your Infisical PKI Application and machine identity">
+    Before installing anything in Kubernetes, make sure you have the following in Infisical:
+
+    - A **PKI Application** with a **Certificate Profile** that uses **API enrollment**. See [Applications](/documentation/platform/pki/applications/overview) and [Certificate Profiles](/documentation/platform/pki/settings/profiles). Note the **Application name** (for example `web-services`) and the **Profile slug** (for example `web-server`). You reference the Application by its name and the Profile by its slug from the `Issuer` in a later step, so copy the slug exactly as shown in Infisical.
+    - A **machine identity** that is allowed to issue certificates on that Application. Add the identity to the Application with a role that grants the **issue-cert** permission (for example the **operator** role).
+
+    <Note>
+      The identity must have permission to issue on the **Application** (not only read it). If it is missing, issuance fails with `You are not allowed to issue-cert on certificate-profiles`.
+    </Note>
+
+    Pick one authentication method for the identity:
+
+    - **Universal Auth**: use the identity's **Client ID** and **Client Secret**. See [Universal Auth](/documentation/platform/identities/universal-auth).
+    - **Kubernetes Auth**: the controller mints a short-lived token for a Kubernetes service account and presents it to Infisical. Configure [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth) on the identity first, and note its **Identity ID**.
+  </Step>
+
+  <Step title="Install cert-manager">
+    Install cert-manager by following the official guide [here](https://cert-manager.io/docs/installation/) or by applying the manifest directly:
+
+    ```bash
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.yaml
+    ```
+  </Step>
+
+  <Step title="Install the Infisical Issuer">
+    Install the Infisical Issuer controller with Helm:
+
+    ```bash
+    helm repo add infisical-helm-charts 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/'
+    helm repo update
+    helm install infisical-pki-issuer infisical-helm-charts/infisical-pki-issuer \
+      --namespace infisical-pki-issuer --create-namespace
+    ```
+
+    This installs the controller and registers the `Issuer` and `ClusterIssuer` custom resources in the `infisical-issuer.infisical.com` API group. Confirm the controller is running:
+
+    ```bash
+    kubectl get pods -n infisical-pki-issuer
+    ```
+  </Step>
+
+  <Step title="Allow cert-manager to approve Infisical Issuer requests">
+    cert-manager only signs a `CertificateRequest` once it has been **approved**. Its built-in approver approves requests for the standard cert-manager issuer types, but for an external issuer you must explicitly grant it permission to approve requests for the Infisical Issuer's signers. Apply the following once:
+
+    ```yaml infisical-issuer-approver.yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: infisical-issuer-approver
+    rules:
+      - apiGroups: ["cert-manager.io"]
+        resources: ["signers"]
+        verbs: ["approve"]
+        resourceNames:
+          - "issuers.infisical-issuer.infisical.com/*"
+          - "clusterissuers.infisical-issuer.infisical.com/*"
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: infisical-issuer-approver
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: infisical-issuer-approver
+    subjects:
+      - kind: ServiceAccount
+        name: cert-manager
+        namespace: cert-manager
+    ```
+
+    ```bash
+    kubectl apply -f infisical-issuer-approver.yaml
+    ```
+
+    <Note>
+      If you skip this step, `Certificate` resources stay pending because their `CertificateRequest` is never approved, so the Infisical Issuer never signs it. Adjust the `ServiceAccount` name and namespace if your cert-manager runs under different ones.
+    </Note>
+  </Step>
+
+  <Step title="Store your machine identity credentials in a Secret">
+    Create a Kubernetes `Secret` holding your machine identity credentials, in the namespace where you will issue certificates.
+
+    <Tabs>
+      <Tab title="Universal Auth">
+        ```bash
+        kubectl create secret generic infisical-credentials \
+          --namespace <namespace> \
+          --from-literal=clientId=<machine_identity_client_id> \
+          --from-literal=clientSecret=<machine_identity_client_secret>
+        ```
+      </Tab>
+      <Tab title="Kubernetes Auth">
+        Store the machine identity's **Identity ID** (Kubernetes Auth does not use a client secret):
+
+        ```bash
+        kubectl create secret generic infisical-identity \
+          --namespace <namespace> \
+          --from-literal=identityId=<machine_identity_id>
+        ```
+
+        The controller mints a short-lived token (via the Kubernetes `TokenRequest` API) for a service account you reference in the next step, then presents it to Infisical. Create that service account if it does not exist:
+
+        ```bash
+        kubectl create serviceaccount infisical-issuer-auth --namespace <namespace>
+        ```
+
+        The service account's name and namespace must be allowed by the identity's [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth) configuration in Infisical (and the audience there must match), otherwise issuance fails authentication.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Create the Infisical Issuer">
+    Create an `Issuer` (or `ClusterIssuer`) referencing your Application and Profile by name, and the credentials Secret from the previous step.
+
+    <Tabs>
+      <Tab title="Universal Auth">
+        ```yaml issuer-infisical.yaml
+        apiVersion: infisical-issuer.infisical.com/v1alpha1
+        kind: Issuer
+        metadata:
+          name: infisical-issuer
+          namespace: <namespace>
+        spec:
+          # Base URL of your Infisical instance
+          # (https://app.infisical.com, https://eu.infisical.com, or your self-hosted URL)
+          url: https://app.infisical.com
+          # Name of the PKI Application to issue through
+          application: <application_name>
+          # Slug of the Certificate Profile to issue with
+          profile: <profile_slug>
+          authentication:
+            method: universal
+            universal:
+              clientIdRef:
+                name: infisical-credentials
+                namespace: <namespace>
+                key: clientId
+              clientSecretRef:
+                name: infisical-credentials
+                namespace: <namespace>
+                key: clientSecret
+        ```
+      </Tab>
+      <Tab title="Kubernetes Auth">
+        ```yaml issuer-infisical.yaml
+        apiVersion: infisical-issuer.infisical.com/v1alpha1
+        kind: Issuer
+        metadata:
+          name: infisical-issuer
+          namespace: <namespace>
+        spec:
+          url: https://app.infisical.com
+          application: <application_name>
+          profile: <profile_slug>
+          authentication:
+            method: kubernetes
+            kubernetes:
+              # Secret holding the machine identity ID
+              identityIdRef:
+                name: infisical-identity
+                namespace: <namespace>
+                key: identityId
+              # Service account whose token is presented to Infisical
+              # (the one created in the previous step)
+              serviceAccountRef:
+                name: infisical-issuer-auth
+                namespace: <namespace>
+        ```
+      </Tab>
+    </Tabs>
+
+    ```bash
+    kubectl apply -f issuer-infisical.yaml
+    ```
+
+    Confirm the issuer is ready. The controller authenticates with Infisical and checks that the Application and Profile exist, then records the result on the issuer's `Ready` condition:
+
+    ```bash
+    kubectl get issuers.infisical-issuer.infisical.com infisical-issuer \
+      -n <namespace> \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
+    ```
+
+    ```bash
+    True
+    ```
+
+    If this is not `True`, run `kubectl describe issuers.infisical-issuer.infisical.com infisical-issuer -n <namespace>` and read the `Ready` condition message for the reason (for example a missing secret, or an unknown Application or Profile).
+
+    <Note>
+      - An `Issuer` is namespace-scoped: certificates can only be issued from an `Issuer` in the same namespace as the `Certificate`. Its referenced Secrets (and service account) must live in that same namespace; cross-namespace references are rejected.
+      - To issue across namespaces with one resource, create a `ClusterIssuer` instead. The spec is identical except `kind: ClusterIssuer` and no `metadata.namespace`. Because a `ClusterIssuer` has no namespace of its own, its referenced Secrets and service account must live in the controller's namespace (the one the issuer is installed into, configurable with the controller's `--cluster-resource-namespace` flag), and each reference's `namespace` must match it.
+      - For a self-hosted Infisical that uses a private CA, add a `tls` block so the controller trusts it:
+        ```yaml
+        spec:
+          tls:
+            caCertificate:
+              name: <secret_with_ca_cert>
+              namespace: <namespace>
+              key: ca.crt
+        ```
+    </Note>
+  </Step>
+
+  <Step title="Create the Certificate">
+    Request a certificate by creating a cert-manager `Certificate` that references the Infisical Issuer. The `issuerRef.group` must be `infisical-issuer.infisical.com`.
+
+    ```yaml certificate.yaml
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: example-com
+      namespace: <namespace>
+    spec:
+      secretName: example-com-tls
+      commonName: example.com
+      dnsNames:
+        - example.com
+      # Optional. If omitted, the Certificate Profile's default TTL is used.
+      duration: 720h
+      # cert-manager renews before expiry
+      renewBefore: 240h
+      privateKey:
+        algorithm: RSA
+        size: 2048
+      issuerRef:
+        name: infisical-issuer
+        kind: Issuer
+        group: infisical-issuer.infisical.com
+    ```
+
+    ```bash
+    kubectl apply -f certificate.yaml
+    ```
+
+    Check that it was issued:
+
+    ```bash
+    kubectl get certificate -n <namespace>
+    ```
+
+    ```bash
+    NAME          READY   SECRET            AGE
+    example-com   True    example-com-tls   15s
+    ```
+
+    <Note>
+      Workload identity certificates work too. For a SPIFFE identity (for example with istio-csr), set a `uris` SAN and make sure the Certificate Profile policy allows URI SANs:
+      ```yaml
+      spec:
+        uris:
+          - spiffe://cluster.local/ns/default/sa/my-workload
+      ```
+    </Note>
+  </Step>
+
+  <Step title="Use the certificate">
+    The certificate and key are stored in the Secret named by `secretName`:
+
+    ```bash
+    kubectl get secret example-com-tls -n <namespace>
+    ```
+
+    ```bash
+    NAME              TYPE                DATA   AGE
+    example-com-tls   kubernetes.io/tls   3      1m
+    ```
+
+    The Secret contains three keys: `tls.crt` (the issued certificate plus any intermediates), `tls.key` (the private key), and `ca.crt` (the root CA). You can decode the certificate with `openssl`:
+
+    ```bash
+    kubectl get secret example-com-tls -n <namespace> \
+      -o jsonpath='{.data.tls\.crt}' | base64 --decode | openssl x509 -text -noout
+    ```
+
+    The Secret is now ready to be mounted by your workloads (Ingresses, Deployments, service meshes, and so on).
+  </Step>
+</Steps>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Which authentication method should I use?">
+    Both authenticate as an Infisical machine identity:
+
+    - **Universal Auth** is the simplest: store a Client ID and Client Secret in a Secret. Good for any cluster.
+    - **Kubernetes Auth** avoids storing a long-lived secret: the controller mints a short-lived token for a Kubernetes service account, and Infisical validates it against your cluster. Prefer this when you want to bind issuance to a service account rather than a static secret. It requires configuring [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth) on the identity first.
+  </Accordion>
+
+  <Accordion title="Why is my certificate duration different from what I requested?">
+    Infisical issues certificates in whole-hour granularity, so the requested `duration` is rounded down to whole hours (with a one-hour minimum). The effective lifetime is also clamped to the maximum validity allowed by the Certificate Profile's policy. If you omit `duration` entirely, the Profile's default TTL is used.
+  </Accordion>
+
+  <Accordion title="My CertificateRequest is stuck waiting for approval.">
+    cert-manager must be allowed to approve requests for the Infisical Issuer's signers. Make sure you applied the approver `ClusterRole` and `ClusterRoleBinding` from Step 4, and that the `ServiceAccount` subject matches your cert-manager installation (name and namespace).
+  </Accordion>
+
+  <Accordion title="Can certificates be renewed automatically?">
+    Yes. cert-manager renews certificates according to the `renewBefore` threshold on the `Certificate`. A renewal is just a new request that the Infisical Issuer signs, so no extra configuration is needed.
+  </Accordion>
+</AccordionGroup>
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="cert-manager (ACME)" icon="lock" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-acme">
+    Use the standard cert-manager ACME issuer with EAB instead.
+  </Card>
+  <Card title="Certificate Profiles" icon="sliders" href="/documentation/platform/pki/settings/profiles">
+    Configure the policy and defaults for issued certificates.
+  </Card>
+  <Card title="Certificate Syncs" icon="arrows-rotate" href="/documentation/platform/pki/applications/certificate-syncs/overview">
+    Push certificates to AWS, Azure, and more.
+  </Card>
+  <Card title="Alerting" icon="bell" href="/documentation/platform/pki/applications/alerting/overview">
+    Get notified when certificates are about to expire.
+  </Card>
+</CardGroup>

--- a/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer.mdx
+++ b/docs/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Kubernetes cert-manager (Infisical Issuer)"
-sidebarTitle: "cert-manager (Infisical Issuer)"
+title: "Kubernetes with cert-manager (Infisical Issuer)"
+sidebarTitle: "Issue TLS Certificates in Kubernetes (Infisical Issuer)"
 description: "Issue and renew Kubernetes TLS certificates with the Infisical cert-manager external issuer, authenticating with a machine identity."
 ---
 
-Issue TLS certificates to your Kubernetes workloads using [cert-manager](https://cert-manager.io/) and the **Infisical Issuer**, an [external issuer](https://cert-manager.io/docs/configuration/external/) for cert-manager. Certificates are signed by Infisical through a PKI Application and Certificate Profile, stored in Kubernetes Secrets (including the CA chain), and renewed automatically before expiration.
+Issue TLS certificates to your Kubernetes workloads using [cert-manager](https://cert-manager.io/) and the [Infisical Issuer](https://github.com/Infisical/infisical-issuer), an [external issuer](https://cert-manager.io/docs/configuration/external/) for cert-manager. Certificates are signed by Infisical through a [PKI Application](/documentation/platform/pki/applications/overview) and [Certificate Profile](/documentation/platform/pki/settings/profiles), stored in Kubernetes Secrets (including the CA chain), and renewed automatically before expiration.
 
 <Info>
   This is the **Infisical Issuer** approach. If you would rather use the standard cert-manager ACME issuer with EAB credentials, see the [cert-manager (ACME) guide](/documentation/platform/pki/guides/applications/k8s-cert-manager-acme) instead.
@@ -14,8 +14,8 @@ Issue TLS certificates to your Kubernetes workloads using [cert-manager](https:/
 
 ## When to use the Infisical Issuer instead of ACME
 
-- You want to authenticate with a **machine identity** (Universal Auth or Kubernetes Auth) rather than ACME/EAB credentials.
-- You want the **CA chain populated** in the Secret's `ca.crt` automatically (the ACME issuer does not populate `ca.crt`).
+- You want to authenticate with a [machine identity](/documentation/platform/identities/machine-identities) ([Universal Auth](/documentation/platform/identities/universal-auth) or [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth)) rather than ACME/EAB credentials.
+- You want the **CA chain populated** in the Secret's `ca.crt` automatically (with the ACME issuer this is not automatic and needs extra setup such as [trust-manager](https://cert-manager.io/docs/trust/trust-manager/)).
 - You do not want ACME domain-ownership challenges (HTTP-01/DNS-01).
 - You are issuing workload identity certificates (for example `spiffe://` URIs for service meshes).
 
@@ -29,23 +29,19 @@ Issue TLS certificates to your Kubernetes workloads using [cert-manager](https:/
 
 ## Guide
 
-Throughout this guide, replace `<namespace>` with the namespace where your workloads and certificates live. The credentials `Secret`, the `Issuer`, and the `Certificate` all go in this same namespace (an `Issuer` is namespace-scoped). If you instead use a `ClusterIssuer`, see the note in the "Create the Infisical Issuer" step.
+Throughout this guide, replace `<namespace>` with the namespace where your workloads and certificates live. With a namespaced `Issuer`, its credentials `Secret`, the `Issuer`, and the `Certificate` all live in this namespace. To issue across namespaces from a single resource, use a [`ClusterIssuer`](#create-the-infisical-issuer) instead, whose `Secret` and service account live in the controller's namespace rather than alongside each workload.
 
 <Steps>
   <Step title="Set up your Infisical PKI Application and machine identity">
     Before installing anything in Kubernetes, make sure you have the following in Infisical:
 
-    - A **PKI Application** with a **Certificate Profile** that uses **API enrollment**. See [Applications](/documentation/platform/pki/applications/overview) and [Certificate Profiles](/documentation/platform/pki/settings/profiles). Note the **Application name** (for example `web-services`) and the **Profile slug** (for example `web-server`). You reference the Application by its name and the Profile by its slug from the `Issuer` in a later step, so copy the slug exactly as shown in Infisical.
-    - A **machine identity** that is allowed to issue certificates on that Application. Add the identity to the Application with a role that grants the **issue-cert** permission (for example the **operator** role).
-
-    <Note>
-      The identity must have permission to issue on the **Application** (not only read it). If it is missing, issuance fails with `You are not allowed to issue-cert on certificate-profiles`.
-    </Note>
+    - A **PKI Application** with a **Certificate Profile** that uses **API enrollment**. Note the **Application name** (for example `web-services`) and the **Profile name** (for example `web-server`); you reference both by name when you create the `Issuer`.
+    - A **machine identity** added to the Application with the **operator** role, which lets it issue certificates.
 
     Pick one authentication method for the identity:
 
-    - **Universal Auth**: use the identity's **Client ID** and **Client Secret**. See [Universal Auth](/documentation/platform/identities/universal-auth).
-    - **Kubernetes Auth**: the controller mints a short-lived token for a Kubernetes service account and presents it to Infisical. Configure [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth) on the identity first, and note its **Identity ID**.
+    - **Universal Auth**: use the identity's **Client ID** and **Client Secret**.
+    - **Kubernetes Auth**: the controller mints a short-lived token for a Kubernetes service account and presents it to Infisical. Configure it on the identity first, and note its **Identity ID**.
   </Step>
 
   <Step title="Install cert-manager">
@@ -161,8 +157,8 @@ Throughout this guide, replace `<namespace>` with the namespace where your workl
           url: https://app.infisical.com
           # Name of the PKI Application to issue through
           application: <application_name>
-          # Slug of the Certificate Profile to issue with
-          profile: <profile_slug>
+          # Name of the Certificate Profile to issue with
+          profile: <profile_name>
           authentication:
             method: universal
             universal:
@@ -186,7 +182,7 @@ Throughout this guide, replace `<namespace>` with the namespace where your workl
         spec:
           url: https://app.infisical.com
           application: <application_name>
-          profile: <profile_slug>
+          profile: <profile_name>
           authentication:
             method: kubernetes
             kubernetes:

--- a/docs/documentation/platform/pki/guides/overview.mdx
+++ b/docs/documentation/platform/pki/guides/overview.mdx
@@ -12,10 +12,10 @@ Guides walk you through complete workflows, from start to finish.
   <Card title="Automate Certificate Renewal" icon="robot" href="/documentation/platform/pki/guides/applications/infisical-agent">
     Set up the Infisical Agent for automatic certificate management.
   </Card>
-  <Card title="Kubernetes cert-manager (ACME)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-acme">
+  <Card title="Issue TLS Certificates in Kubernetes (ACME)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-acme">
     Issue certificates in Kubernetes with cert-manager's ACME issuer.
   </Card>
-  <Card title="Kubernetes cert-manager (Infisical Issuer)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer">
+  <Card title="Issue TLS Certificates in Kubernetes (Infisical Issuer)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer">
     Issue certificates in Kubernetes with a machine identity via the Infisical Issuer.
   </Card>
   <Card title="Set Up HTTPS for Nginx" icon="server" href="/documentation/platform/pki/guides/applications/nginx-certbot">

--- a/docs/documentation/platform/pki/guides/overview.mdx
+++ b/docs/documentation/platform/pki/guides/overview.mdx
@@ -12,8 +12,11 @@ Guides walk you through complete workflows, from start to finish.
   <Card title="Automate Certificate Renewal" icon="robot" href="/documentation/platform/pki/guides/applications/infisical-agent">
     Set up the Infisical Agent for automatic certificate management.
   </Card>
-  <Card title="Issue Certificates in Kubernetes" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager">
-    Use cert-manager for Kubernetes workloads.
+  <Card title="Kubernetes cert-manager (ACME)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-acme">
+    Issue certificates in Kubernetes with cert-manager's ACME issuer.
+  </Card>
+  <Card title="Kubernetes cert-manager (Infisical Issuer)" icon="dharmachakra" href="/documentation/platform/pki/guides/applications/k8s-cert-manager-issuer">
+    Issue certificates in Kubernetes with a machine identity via the Infisical Issuer.
   </Card>
   <Card title="Set Up HTTPS for Nginx" icon="server" href="/documentation/platform/pki/guides/applications/nginx-certbot">
     ACME certificates with Certbot for Nginx.

--- a/docs/documentation/platform/pki/migration.mdx
+++ b/docs/documentation/platform/pki/migration.mdx
@@ -152,7 +152,7 @@ Once you've consolidated your projects (or if you only have one), go to your **a
   <Step title="Update your issuance clients">
     Enrollment URLs now include both Application and Profile. Update your:
 
-    - **ACME clients** (Certbot, [cert-manager](/documentation/platform/pki/guides/applications/k8s-cert-manager), etc.)
+    - **ACME clients** (Certbot, [cert-manager](/documentation/platform/pki/guides/applications/k8s-cert-manager-acme), etc.)
     - **[Infisical Agent](/documentation/platform/pki/guides/applications/infisical-agent)** — Update to reference `application-name` and `profile-name`
     - **EST/SCEP clients**
     - **Terraform** — Update `infisical_pki_*` resources


### PR DESCRIPTION
## Context

Kubernetes Issuer guide: This adds a friendly, step-by-step guide that walks customers through issuing Kubernetes certificates with the Infisical Issuer, from installing it to connecting it to their PKI Application and getting their first certificate. It also renames the existing cert-manager guide so it's clear that one covers the ACME approach, making it easy for readers to pick the path that fits their setup without mixing the two up.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)