### PR TITLE
fix(secret-scanning): avoid leaking git clone credentials

### DIFF
--- a/backend/src/ee/services/secret-scanning-v2/bitbucket/bitbucket-secret-scanning-factory.ts
+++ b/backend/src/ee/services/secret-scanning-v2/bitbucket/bitbucket-secret-scanning-factory.ts
@@ -181,8 +181,12 @@ export const BitbucketSecretScanningFactory = () => {
     const { username } = await getBitbucketUser({ email, apiToken });
 
     await cloneRepository({
-      cloneUrl: `https://${encodeURIComponent(username)}:${apiToken}@bitbucket.org/${resourceName}.git`,
-      repoPath
+      remoteUrl: `https://bitbucket.org/${resourceName}.git`,
+      repoPath,
+      auth: {
+        username,
+        password: apiToken
+      }
     });
 
     return repoPath;

--- a/backend/src/ee/services/secret-scanning-v2/github/github-secret-scanning-factory.ts
+++ b/backend/src/ee/services/secret-scanning-v2/github/github-secret-scanning-factory.ts
@@ -132,8 +132,12 @@ export const GitHubSecretScanningFactory = () => {
     }
 
     await cloneRepository({
-      cloneUrl: `https://x-access-token:${token}@github.com/${resourceName}.git`,
-      repoPath
+      remoteUrl: `https://github.com/${resourceName}.git`,
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: token
+      }
     });
 
     return repoPath;

--- a/backend/src/ee/services/secret-scanning-v2/gitlab/gitlab-secret-scanning-factory.ts
+++ b/backend/src/ee/services/secret-scanning-v2/gitlab/gitlab-secret-scanning-factory.ts
@@ -263,8 +263,12 @@ export const GitLabSecretScanningFactory = ({ appConnectionDAL, kmsService }: TS
     const validatedHostname = new URL(instanceUrl).host;
 
     await cloneRepository({
-      cloneUrl: `https://${user.username}:${connection.credentials.accessToken}@${validatedHostname}/${resourceName}.git`,
-      repoPath
+      remoteUrl: `https://${validatedHostname}/${resourceName}.git`,
+      repoPath,
+      auth: {
+        username: user.username,
+        password: connection.credentials.accessToken
+      }
     });
 
     return repoPath;

--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.test.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.test.ts
@@ -5,13 +5,25 @@ import { cloneRepository, parseScanErrorMessage } from "./secret-scanning-v2-fns
 type ExecFileCallback = (err: Error | null) => void;
 type ExecFileCall = [string, string[], { env?: NodeJS.ProcessEnv }, ExecFileCallback];
 
-const { execFileMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn<(...args: ExecFileCall) => void>()
+const { execFileMock, rmMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn<(...args: ExecFileCall) => void>(),
+  rmMock: vi.fn()
 }));
 
 vi.mock("child_process", () => ({
   execFile: execFileMock
 }));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+
+  rmMock.mockImplementation(actual.rm);
+
+  return {
+    ...actual,
+    rm: rmMock
+  };
+});
 
 const repoPath = "/tmp/infisical-secret-scanning-test-repo.git";
 const fakeToken = "ghs_fake_secret_token";
@@ -148,6 +160,48 @@ describe("secret scanning v2 git clone auth", () => {
 
     resolveLastExecFileCall();
     await expect(clonePromise).resolves.toBeUndefined();
+  });
+
+  it("does not fail a successful clone when askpass cleanup fails", async () => {
+    rmMock.mockRejectedValueOnce(new Error("EPERM cleanup failed"));
+
+    const clonePromise = cloneRepository({
+      remoteUrl: "https://github.com/infisical/infisical.git",
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: fakeToken
+      }
+    });
+    void clonePromise.catch(() => undefined);
+
+    await waitForLastExecFileCall();
+
+    resolveLastExecFileCall();
+
+    await expect(clonePromise).resolves.toBeUndefined();
+  });
+
+  it("does not replace sanitized clone failures with askpass cleanup errors", async () => {
+    rmMock.mockRejectedValueOnce(new Error(`EPERM cleanup failed: ${fakeToken}`));
+
+    const clonePromise = cloneRepository({
+      remoteUrl: "https://github.com/infisical/infisical.git",
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: fakeToken
+      }
+    });
+    void clonePromise.catch(() => undefined);
+
+    await waitForLastExecFileCall();
+
+    resolveLastExecFileCall(new Error(`Command failed: git clone ${credentialedGitHubUrl}`));
+
+    await expect(clonePromise).rejects.toThrow("https://[redacted]@github.com/infisical/infisical.git");
+    await expect(clonePromise).rejects.not.toThrow("EPERM cleanup failed");
+    await expect(clonePromise).rejects.not.toThrow(fakeToken);
   });
 
   it("rejects clone failures with a sanitized error", async () => {

--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.test.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { cloneRepository, parseScanErrorMessage } from "./secret-scanning-v2-fns";
+
+type ExecFileCallback = (err: Error | null) => void;
+type ExecFileCall = [string, string[], { env?: NodeJS.ProcessEnv }, ExecFileCallback];
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn<(...args: ExecFileCall) => void>()
+}));
+
+vi.mock("child_process", () => ({
+  execFile: execFileMock
+}));
+
+const repoPath = "/tmp/infisical-secret-scanning-test-repo.git";
+const fakeToken = "ghs_fake_secret_token";
+const gitUrlAuthSeparator = String.fromCharCode(64);
+const makeCredentialedGitHubUrl = (repository: string) =>
+  [`https://x-access-token:${fakeToken}`, `github.com/${repository}.git`].join(gitUrlAuthSeparator);
+const credentialedGitHubUrl = makeCredentialedGitHubUrl("infisical/infisical");
+
+const getLastExecFileCall = (): ExecFileCall => {
+  const call = execFileMock.mock.calls.at(-1);
+  if (!call) throw new Error("Expected execFile to be called");
+  return call;
+};
+
+const waitForLastExecFileCall = async () => {
+  await vi.waitFor(() => expect(execFileMock).toHaveBeenCalled());
+  return getLastExecFileCall();
+};
+
+const resolveLastExecFileCall = (error: Error | null = null) => {
+  getLastExecFileCall()[3](error);
+};
+
+const getLastExecFileOptions = () => getLastExecFileCall()[2];
+
+describe("secret scanning v2 git clone auth", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.GIT_TRACE;
+    delete process.env.GIT_TRACE_PACKET;
+    delete process.env.GIT_TRACE_CURL;
+    delete process.env.GIT_CURL_VERBOSE;
+    delete process.env.GIT_TRACE2;
+    delete process.env.GIT_TRACE2_EVENT;
+  });
+
+  it("redacts credentials embedded in URLs before exposing scan errors", () => {
+    const result = parseScanErrorMessage(new Error(`Command failed: git clone ${credentialedGitHubUrl}`));
+
+    expect(result).not.toContain(fakeToken);
+    expect(result).toContain("https://[redacted]@github.com/infisical/infisical.git");
+  });
+
+  it("redacts authorization header values before exposing scan errors", () => {
+    const result = parseScanErrorMessage(
+      new Error(`fatal: request failed with Authorization: Bearer ${fakeToken} and Authorization: Basic abc123`)
+    );
+
+    expect(result).not.toContain(fakeToken);
+    expect(result).not.toContain("abc123");
+    expect(result).toContain("Authorization: Bearer [redacted]");
+    expect(result).toContain("Authorization: Basic [redacted]");
+  });
+
+  it("truncates scan errors after redacting secrets", () => {
+    const result = parseScanErrorMessage(new Error(`${makeCredentialedGitHubUrl("a/b")} ${"x".repeat(1200)}`));
+
+    expect(result).toHaveLength(1024);
+    expect(result).not.toContain(fakeToken);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("rejects clone URLs that contain embedded credentials", async () => {
+    await expect(
+      cloneRepository({
+        remoteUrl: credentialedGitHubUrl,
+        repoPath
+      })
+    ).rejects.toThrow(/credentials/i);
+
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a credential-free remote URL to git clone while providing auth through askpass", async () => {
+    const clonePromise = cloneRepository({
+      remoteUrl: "https://github.com/infisical/infisical.git",
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: fakeToken
+      }
+    });
+    void clonePromise.catch(() => undefined);
+
+    const [command, args] = await waitForLastExecFileCall();
+    const options = getLastExecFileOptions();
+
+    expect(command).toBe("git");
+    expect(args).toEqual([
+      "-c",
+      "credential.helper=",
+      "clone",
+      "https://github.com/infisical/infisical.git",
+      repoPath,
+      "--bare"
+    ]);
+    expect(JSON.stringify(args)).not.toContain(fakeToken);
+    expect(options?.env?.GIT_ASKPASS).toContain("git-askpass");
+    expect(options?.env?.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(options?.env?.INFISICAL_GIT_USERNAME).toBe("x-access-token");
+    expect(options?.env?.INFISICAL_GIT_PASSWORD).toBe(fakeToken);
+
+    resolveLastExecFileCall();
+    await expect(clonePromise).resolves.toBeUndefined();
+  });
+
+  it("removes inherited git trace environment variables before cloning", async () => {
+    process.env.GIT_TRACE = "1";
+    process.env.GIT_TRACE_PACKET = "1";
+    process.env.GIT_TRACE_CURL = "1";
+    process.env.GIT_CURL_VERBOSE = "1";
+    process.env.GIT_TRACE2 = "1";
+    process.env.GIT_TRACE2_EVENT = "/tmp/git-trace";
+
+    const clonePromise = cloneRepository({
+      remoteUrl: "https://github.com/infisical/infisical.git",
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: fakeToken
+      }
+    });
+    void clonePromise.catch(() => undefined);
+
+    await waitForLastExecFileCall();
+
+    const env = getLastExecFileOptions()?.env;
+    expect(env?.GIT_TRACE).toBeUndefined();
+    expect(env?.GIT_TRACE_PACKET).toBeUndefined();
+    expect(env?.GIT_TRACE_CURL).toBeUndefined();
+    expect(env?.GIT_CURL_VERBOSE).toBeUndefined();
+    expect(env?.GIT_TRACE2).toBeUndefined();
+    expect(env?.GIT_TRACE2_EVENT).toBeUndefined();
+
+    resolveLastExecFileCall();
+    await expect(clonePromise).resolves.toBeUndefined();
+  });
+
+  it("rejects clone failures with a sanitized error", async () => {
+    const clonePromise = cloneRepository({
+      remoteUrl: "https://github.com/infisical/infisical.git",
+      repoPath,
+      auth: {
+        username: "x-access-token",
+        password: fakeToken
+      }
+    });
+    void clonePromise.catch(() => undefined);
+
+    await waitForLastExecFileCall();
+
+    resolveLastExecFileCall(new Error(`Command failed: git clone ${credentialedGitHubUrl}`));
+
+    await expect(clonePromise).rejects.toThrow("https://[redacted]@github.com/infisical/infisical.git");
+    await expect(clonePromise).rejects.not.toThrow(fakeToken);
+  });
+});

--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
@@ -83,6 +83,7 @@ const writeGitAskPassScript = async (askPassPath: string) => {
     ].join("\n"),
     { mode: 0o700 }
   );
+  // writeFile's mode can be masked by process umask; chmod enforces the executable bit for Git.
   await chmod(askPassPath, 0o700);
 };
 
@@ -113,13 +114,17 @@ export const cloneRepository = async ({ remoteUrl, repoPath, auth }: TCloneRepos
       ["-c", "credential.helper=", "clone", remoteUrl, repoPath, "--bare"],
       { env: getGitCloneEnv(auth, askPassPath) },
       (error) => {
-        void cleanupAskPass().then(() => {
-          if (error) {
-            reject(new Error(sanitizeErrorMessage(error.message || "An unknown error occurred.")));
-          } else {
-            resolve();
-          }
-        }, reject);
+        void cleanupAskPass()
+          .catch(() => {
+            // Cleanup must not replace the git clone result with a filesystem error.
+          })
+          .then(() => {
+            if (error) {
+              reject(new Error(sanitizeErrorMessage(error.message || "An unknown error occurred.")));
+            } else {
+              resolve();
+            }
+          });
       }
     );
   });

--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from "axios";
 import { execFile } from "child_process";
-import { join } from "path";
+import { chmod, rm, writeFile } from "fs/promises";
+import { dirname, join } from "path";
 import picomatch from "picomatch";
 import RE2 from "re2";
 
@@ -32,20 +33,95 @@ export const listSecretScanningDataSourceOptions = () => {
   return Object.values(SECRET_SCANNING_SOURCE_LIST_OPTIONS).sort((a, b) => a.name.localeCompare(b.name));
 };
 
-export const cloneRepository = async ({ cloneUrl, repoPath }: TCloneRepository): Promise<void> => {
+const GIT_TRACE_ENV_KEYS = ["GIT_TRACE", "GIT_TRACE_PACKET", "GIT_TRACE_CURL", "GIT_CURL_VERBOSE"];
+const GIT_ASKPASS_FILE_NAME = "git-askpass.sh";
+const MAX_MESSAGE_LENGTH = 1024;
+
+const redactSensitiveErrorData = (message: string) =>
+  message
+    .replace(/\b(https?:\/\/)([^/\s:@]+):([^@\s/]+)@/gi, "$1[redacted]@")
+    .replace(/\b((?:Proxy-)?Authorization:\s*(?:Bearer|Basic)\s+)[^\s,;]+/gi, "$1[redacted]");
+
+const sanitizeErrorMessage = (message: string) => {
+  const redactedErrorMessage = redactSensitiveErrorData(message);
+
+  return redactedErrorMessage.length <= MAX_MESSAGE_LENGTH
+    ? redactedErrorMessage
+    : `${redactedErrorMessage.substring(0, MAX_MESSAGE_LENGTH - 3)}...`;
+};
+
+const getGitCloneEnv = (auth: TCloneRepository["auth"], askPassPath?: string): NodeJS.ProcessEnv => {
+  const env = { ...process.env };
+
+  for (const key of Object.keys(env)) {
+    if (GIT_TRACE_ENV_KEYS.includes(key) || key.startsWith("GIT_TRACE2")) {
+      delete env[key];
+    }
+  }
+
+  if (auth && askPassPath) {
+    env.GIT_ASKPASS = askPassPath;
+    env.GIT_TERMINAL_PROMPT = "0";
+    env.INFISICAL_GIT_USERNAME = auth.username;
+    env.INFISICAL_GIT_PASSWORD = auth.password;
+  }
+
+  return env;
+};
+
+const writeGitAskPassScript = async (askPassPath: string) => {
+  await writeFile(
+    askPassPath,
+    [
+      "#!/bin/sh",
+      'case "$1" in',
+      '  *Username*) printf "%s\\n" "$INFISICAL_GIT_USERNAME" ;;',
+      '  *Password*) printf "%s\\n" "$INFISICAL_GIT_PASSWORD" ;;',
+      '  *) printf "\\n" ;;',
+      "esac",
+      ""
+    ].join("\n"),
+    { mode: 0o700 }
+  );
+  await chmod(askPassPath, 0o700);
+};
+
+export const cloneRepository = async ({ remoteUrl, repoPath, auth }: TCloneRepository): Promise<void> => {
   // Validate that the constructed URL is structurally valid.
   // This prevents malformed or tampered components from producing unexpected git behavior.
-  // eslint-disable-next-line no-new
-  new URL(cloneUrl);
+  const parsedRemoteUrl = new URL(remoteUrl);
+
+  if (parsedRemoteUrl.username || parsedRemoteUrl.password) {
+    throw new Error("Git remote URL must not contain credentials");
+  }
+
+  const askPassPath = auth ? join(dirname(repoPath), GIT_ASKPASS_FILE_NAME) : undefined;
+
+  if (askPassPath) {
+    await writeGitAskPassScript(askPassPath);
+  }
 
   return new Promise((resolve, reject) => {
-    execFile("git", ["clone", cloneUrl, repoPath, "--bare"], (error) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
+    const cleanupAskPass = async () => {
+      if (askPassPath) {
+        await rm(askPassPath, { force: true });
       }
-    });
+    };
+
+    execFile(
+      "git",
+      ["-c", "credential.helper=", "clone", remoteUrl, repoPath, "--bare"],
+      { env: getGitCloneEnv(auth, askPassPath) },
+      (error) => {
+        void cleanupAskPass().then(() => {
+          if (error) {
+            reject(new Error(sanitizeErrorMessage(error.message || "An unknown error occurred.")));
+          } else {
+            resolve();
+          }
+        }, reject);
+      }
+    );
   });
 };
 
@@ -158,8 +234,6 @@ export const convertPatchLineToFileLineNumber = (patch: string, patchLineNumber:
   return currentNewLine;
 };
 
-const MAX_MESSAGE_LENGTH = 1024;
-
 export const parseScanErrorMessage = (err: unknown): string => {
   let errorMessage: string;
 
@@ -171,9 +245,7 @@ export const parseScanErrorMessage = (err: unknown): string => {
     errorMessage = (err as Error)?.message || "An unknown error occurred.";
   }
 
-  return errorMessage.length <= MAX_MESSAGE_LENGTH
-    ? errorMessage
-    : `${errorMessage.substring(0, MAX_MESSAGE_LENGTH - 3)}...`;
+  return sanitizeErrorMessage(errorMessage);
 };
 
 const generateSecretValuePolicyConfiguration = (entropy: number): string => `

--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-types.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-types.ts
@@ -154,8 +154,12 @@ export type TQueueSecretScanningSendNotification = {
 );
 
 export type TCloneRepository = {
-  cloneUrl: string;
+  remoteUrl: string;
   repoPath: string;
+  auth?: {
+    username: string;
+    password: string;
+  };
 };
 
 export type TSecretScanningFactoryListRawResources<T extends TSecretScanningDataSourceWithConnection> = (


### PR DESCRIPTION
## Context

Secret Scanning V2 cloned GitHub, GitLab, and Bitbucket repositories by embedding provider credentials directly in HTTPS clone URLs. When `git clone` failed, Node's child-process error message could include the full command line, and the raw scan error could then be stored as scan status or sent in failure notifications.

This PR changes the V2 clone path to pass credential-free remote URLs to git, provide credentials through a temporary `GIT_ASKPASS` helper, strip inherited Git trace env vars from the child process, and redact sensitive auth data from scan error messages before they are stored or sent.

## Screenshots

N/A

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
