### PR TITLE
fix: parse JSON fields in certificate policy/profile delete responses

### DIFF
--- a/backend/src/services/certificate-policy/certificate-policy-dal.ts
+++ b/backend/src/services/certificate-policy/certificate-policy-dal.ts
@@ -120,7 +120,11 @@ export const certificatePolicyDALFactory = (db: TDbClient) => {
         .del()
         .returning("*")) as Record<string, unknown>[];
 
-      return certificatePolicy;
+      if (!certificatePolicy) {
+        return null;
+      }
+
+      return parseJsonFields(certificatePolicy);
     } catch (error) {
       throw new DatabaseError({ error, name: "Delete certificate policy" });
     }

--- a/backend/src/services/certificate-policy/certificate-policy-service.ts
+++ b/backend/src/services/certificate-policy/certificate-policy-service.ts
@@ -1007,7 +1007,7 @@ export const certificatePolicyServiceFactory = ({
       throw new NotFoundError({ message: "Failed to delete certificate policy" });
     }
 
-    return deletedTemplate as TCertificatePolicy;
+    return deletedTemplate;
   };
 
   const validateCertificateRequest = async (

--- a/backend/src/services/certificate-profile/certificate-profile-dal.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-dal.ts
@@ -80,10 +80,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
 
   const deleteById = async (id: string, tx?: Knex): Promise<TCertificateProfile | undefined> => {
     try {
-      const [certificateProfile] = await (tx || db)(TableName.PkiCertificateProfile)
-        .where({ id })
-        .del()
-        .returning("*");
+      const [certificateProfile] = await (tx || db)(TableName.PkiCertificateProfile).where({ id }).del().returning("*");
 
       if (!certificateProfile) return undefined;
 

--- a/backend/src/services/certificate-profile/certificate-profile-dal.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-dal.ts
@@ -78,13 +78,22 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
     }
   };
 
-  const deleteById = async (id: string, tx?: Knex): Promise<TCertificateProfile> => {
+  const deleteById = async (id: string, tx?: Knex): Promise<TCertificateProfile | undefined> => {
     try {
-      const [certificateProfile] = (await (tx || db)(TableName.PkiCertificateProfile)
+      const [certificateProfile] = await (tx || db)(TableName.PkiCertificateProfile)
         .where({ id })
         .del()
-        .returning("*")) as [TCertificateProfile];
-      return certificateProfile;
+        .returning("*");
+
+      if (!certificateProfile) return undefined;
+
+      return {
+        ...certificateProfile,
+        externalConfigs: certificateProfile.externalConfigs
+          ? (JSON.parse(certificateProfile.externalConfigs) as Record<string, unknown>)
+          : null,
+        defaults: (certificateProfile.defaults as TCertificateProfileDefaults) ?? null
+      } as TCertificateProfile;
     } catch (error) {
       throw new DatabaseError({ error, name: "Delete certificate profile" });
     }


### PR DESCRIPTION
## Summary
- The `deleteById` methods in both `certificate-policy-dal` and `certificate-profile-dal` returned raw database rows without parsing JSON fields (`subject`, `sans`, `keyUsages`, `externalConfigs`, etc.)
- Fastify's response schema validation rejected the unparsed strings (expecting objects/arrays), returning a 500 `ResponseValidationError` to the caller
- The delete itself succeeded, so the resource was removed, but the API returned `500 "Something went wrong"` -- reported by a customer using Terraform, where `terraform apply` after removing a cert policy from `.tf` files would error, requiring a second apply to reconcile state

## Test plan
- [x] Reproduced locally: created a certificate policy with JSON fields, deleted it, confirmed 500
- [x] Applied fix, retested: delete now returns 200 with properly serialized response