### PR TITLE
improvement(billing): render metered pricing in the catalog

### DIFF
--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -24,7 +24,9 @@ const BillingV2DimSchema = z.object({
   noun: z.string(),
   monthly: z.number(),
   annual: z.number(),
-  included: z.number()
+  included: z.number(),
+  meteredMonthly: z.boolean().optional(),
+  meteredAnnual: z.boolean().optional()
 });
 
 const BillingV2CompareRowSchema = z.object({

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -82,6 +82,12 @@ const toModel = (model: string): BillingV2Model => {
   return "usage";
 };
 
+// Price kinds we understand; an unknown kind is treated as non-purchasable, never sold as per_unit.
+const PER_UNIT_KIND = "per_unit";
+const METERED_KIND = "metered";
+const KNOWN_PRICE_KINDS: readonly string[] = [PER_UNIT_KIND, METERED_KIND];
+const isKnownPriceKind = (kind: string): boolean => KNOWN_PRICE_KINDS.includes(kind);
+
 const centsToDollars = (cents: number | null | undefined): number => {
   if (!cents) {
     return 0;
@@ -134,15 +140,15 @@ const normalizeCadence = (cadence: string | undefined): "monthly" | "annual" => 
   return "monthly";
 };
 
-// A plan carries pricing either as a flat base fee, as per-dimension prices, or both. Checking the
-// per-dimension prices alone wrongly treats a base-only plan (e.g. the NHI add-on, which has a base
-// fee but no metered dimensions) as unpriced.
+// A plan carries pricing as a known-kind price, a flat base fee, or both. An unknown price kind is
+// treated as non-purchasable (never sold as per_unit); a base-only plan (e.g. the NHI add-on, a base
+// fee with no priced dimensions) must still count as priced.
 const planHasPricing = (plan: TCatalogProduct["plans"][number]): boolean =>
-  plan.prices.length > 0 ||
+  plan.prices.some((price) => isKnownPriceKind(price.kind)) ||
   (plan.basePriceMonthlyCents !== null && plan.basePriceMonthlyCents !== undefined) ||
   (plan.basePriceAnnualCents !== null && plan.basePriceAnnualCents !== undefined);
 
-// The paid self-serve plan (e.g. "pro"); the free tier is self-serve too but carries no prices.
+// The paid self-serve plan (e.g. "pro"); the free tier is self-serve too but carries no pricing.
 const findPaidSelfServePlan = (product: TCatalogProduct) =>
   product.plans.find((plan) => plan.selfServe === true && plan.tier !== "free" && planHasPricing(plan));
 
@@ -150,14 +156,30 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
   const paidSelfServePlan = findPaidSelfServePlan(product);
   const salesLedPlan = product.plans.find((plan) => plan.salesLed === true);
 
-  // Fold the plan's per-dimension/per-cadence prices into the dim view the UI renders.
-  const priceByDim = new Map<string, { monthly: number; annual: number; included: number }>();
+  // Fold the plan's per-dimension/per-cadence prices into the dim view the UI renders. metered is
+  // tracked per cadence so a dimension priced per_unit on one cadence and metered on the other
+  // doesn't mislabel both.
+  const priceByDim = new Map<
+    string,
+    { monthly: number; annual: number; included: number; meteredMonthly: boolean; meteredAnnual: boolean }
+  >();
   (paidSelfServePlan?.prices ?? []).forEach((price) => {
-    const entry = priceByDim.get(price.dimensionKey) ?? { monthly: 0, annual: 0, included: 0 };
+    if (!isKnownPriceKind(price.kind)) {
+      return;
+    }
+    const entry = priceByDim.get(price.dimensionKey) ?? {
+      monthly: 0,
+      annual: 0,
+      included: 0,
+      meteredMonthly: false,
+      meteredAnnual: false
+    };
     if (price.cadence === "annual") {
       entry.annual = centsToDollars(price.unitAmountCents);
+      entry.meteredAnnual = price.kind === METERED_KIND;
     } else {
       entry.monthly = centsToDollars(price.unitAmountCents);
+      entry.meteredMonthly = price.kind === METERED_KIND;
     }
     if (price.includedQuantity !== null && price.includedQuantity !== undefined) {
       entry.included = price.includedQuantity;
@@ -177,7 +199,9 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
       noun: dimension.noun,
       monthly: priced.monthly,
       annual: priced.annual,
-      included: priced.included
+      included: priced.included,
+      meteredMonthly: priced.meteredMonthly,
+      meteredAnnual: priced.meteredAnnual
     });
   });
 
@@ -230,25 +254,29 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
   };
 };
 
-// Translates a catalog product into the line items the checkout endpoint expects: its paid
-// self-serve plan plus the primary priced dimension for the chosen cadence at quantity 1. A base-only
-// product (a base fee with no metered dimensions, e.g. the NHI add-on) checks out with no quantities.
+// Builds the checkout line items: only per_unit dimensions carry a quantity (metered and base lines
+// are added server-side), so a metered-only or base-only plan checks out with no quantities.
 const buildCheckoutItems = (product: TCatalogProduct, cadence: "monthly" | "annual"): TCheckoutLineItem[] | null => {
   const paidSelfServePlan = findPaidSelfServePlan(product);
   if (!paidSelfServePlan) {
     return null;
   }
 
-  const price = paidSelfServePlan.prices.find(
-    (candidate) => candidate.cadence === cadence && candidate.unitAmountCents > 0
+  const quantities: Record<string, number> = {};
+  const perUnitPrice = paidSelfServePlan.prices.find(
+    (candidate) => candidate.cadence === cadence && candidate.kind === PER_UNIT_KIND && candidate.unitAmountCents > 0
   );
+  if (perUnitPrice) {
+    quantities[perUnitPrice.dimensionKey] = 1;
+  }
 
-  const baseCents =
+  const hasMetered = paidSelfServePlan.prices.some(
+    (candidate) => candidate.cadence === cadence && candidate.kind === METERED_KIND
+  );
+  const baseForCadence =
     cadence === "annual" ? paidSelfServePlan.basePriceAnnualCents : paidSelfServePlan.basePriceMonthlyCents;
-  const hasBasePrice = baseCents !== null && baseCents !== undefined;
-
-  // Neither a metered price nor a base fee for this cadence means there's nothing to charge.
-  if (!price && !hasBasePrice) {
+  const hasBase = baseForCadence !== null && baseForCadence !== undefined;
+  if (!perUnitPrice && !hasMetered && !hasBase) {
     return null;
   }
 
@@ -257,7 +285,7 @@ const buildCheckoutItems = (product: TCatalogProduct, cadence: "monthly" | "annu
       productId: product.id,
       plan: paidSelfServePlan.tier,
       cadence,
-      quantities: price ? { [price.dimensionKey]: 1 } : {}
+      quantities
     }
   ];
 };

--- a/backend/src/ee/services/license-v2/license-v2-types.ts
+++ b/backend/src/ee/services/license-v2/license-v2-types.ts
@@ -13,6 +13,9 @@ export type BillingV2Dim = {
   monthly: number;
   annual: number;
   included: number;
+  // When true, the matching cadence's price is a usage overage rate, not a buyer-selected quantity.
+  meteredMonthly?: boolean;
+  meteredAnnual?: boolean;
 };
 
 export type BillingV2CompareRow = {

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -28,6 +28,8 @@ const catalogPlanPriceSchema = z
   .object({
     dimensionKey: z.string(),
     cadence: z.string(),
+    // Permissive (like model/tier/cadence) so a new License Server kind can't break parsing; normalized in code.
+    kind: z.string().default("per_unit"),
     unitAmountCents: z.number(),
     includedQuantity: z.number().nullish()
   })

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -9,6 +9,9 @@ export type BillingV2Dim = {
   monthly: number;
   annual: number;
   included: number;
+  // When true, the matching cadence's price is a usage overage rate, not a buyer-selected quantity.
+  meteredMonthly?: boolean;
+  meteredAnnual?: boolean;
 };
 
 export type BillingV2CompareRow = {

--- a/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
+++ b/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
@@ -63,3 +63,11 @@ export const unitPrice = (dim: BillingV2Dim | BillingV2ProBase, cad: BillingV2Ca
   }
   return dim.monthly;
 };
+
+// Whether the active cadence's price is a usage-based (metered) rate rather than a per-unit charge.
+export const isMeteredCadence = (dim: BillingV2Dim, cad: BillingV2Cadence): boolean => {
+  if (cad === "annual") {
+    return dim.meteredAnnual ?? false;
+  }
+  return dim.meteredMonthly ?? false;
+};

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -16,12 +16,25 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
-import { BillingV2Cadence, BillingV2CatalogProduct, BillingV2Entitlement } from "@app/hooks/api";
+import {
+  BillingV2Cadence,
+  BillingV2CatalogProduct,
+  BillingV2Dim,
+  BillingV2Entitlement
+} from "@app/hooks/api";
 
-import { cadenceWord, cadenceWordShort, fmtMoney, unitPrice } from "../billing-v2-data";
+import {
+  cadenceWord,
+  cadenceWordShort,
+  fmtMoney,
+  isMeteredCadence,
+  pluralizeUnit,
+  unitPrice
+} from "../billing-v2-data";
 import { ActiveBadge, ProductIcon } from "./shared";
 
-type PriceLine = { amount: string; unit: string };
+// prefix/metered carry the usage-based framing for metered dims; absent for per_unit and base prices.
+type PriceLine = { amount: string; unit: string; prefix?: string; metered?: boolean };
 
 // The plan's flat/base fee for the active cadence, when it has one (e.g. "$20 / month").
 const proBaseLine = (
@@ -35,7 +48,31 @@ const proBaseLine = (
   return { amount: fmtMoney(unitPrice(base, cadence)), unit: `/ ${cadenceWord(cadence)}` };
 };
 
-// A plan's price is a base fee plus any number of metered dimensions, and any combination is valid:
+// A priced dimension as a display line. A metered dimension reads as usage-based: an optional "First
+// N included, then" prefix and a flag to badge the line, instead of a fixed per-unit charge.
+const dimPriceLine = (dim: BillingV2Dim, cadence: BillingV2Cadence, unit: string): PriceLine => {
+  const metered = isMeteredCadence(dim, cadence);
+  const line: PriceLine = { amount: fmtMoney(unitPrice(dim, cadence), 2), unit, metered };
+  if (metered && dim.included > 0) {
+    line.prefix = `First ${dim.included.toLocaleString()} ${pluralizeUnit(dim.noun)} included, then`;
+  }
+  return line;
+};
+
+const PriceLineView = ({ line, headline }: { line: PriceLine; headline?: boolean }) => (
+  <div className="flex flex-col gap-0.5">
+    {line.prefix && <span className="text-xs text-muted">{line.prefix}</span>}
+    <div className="flex flex-wrap items-baseline gap-1.5">
+      <span className={`font-medium text-foreground ${headline ? "text-2xl" : "text-sm"}`}>
+        {line.amount}
+      </span>
+      <span className="text-xs text-muted">{line.unit}</span>
+      {line.metered && <Badge variant="neutral">Usage-based</Badge>}
+    </div>
+  </div>
+);
+
+// A plan's price is a base fee plus any number of priced dimensions, and any combination is valid:
 // base only, meter only, or both. The base fee leads as the headline; every priced dimension is then
 // listed below (e.g. "$5 per MCP / mo", "$3 per Agent / mo"). When there's no base fee the first
 // dimension is promoted to the headline so the card always opens with a price.
@@ -47,42 +84,33 @@ const ProPricing = ({
   cadence: BillingV2Cadence;
 }) => {
   const dims = prod.pro?.dims ?? [];
-  const dimLines = dims.map((dim) => ({
-    key: dim.key,
-    amount: fmtMoney(unitPrice(dim, cadence), 2),
-    unit: `per ${dim.noun} / ${cadenceWordShort(cadence)}`
-  }));
 
   let headline = proBaseLine(prod, cadence);
-  let usageLines = dimLines;
+  let usageDims = dims;
   if (!headline && dims.length > 0) {
-    headline = {
-      amount: fmtMoney(unitPrice(dims[0], cadence), 2),
-      unit: `/ ${dims[0].noun} / ${cadenceWord(cadence)}`
-    };
-    usageLines = dimLines.slice(1);
+    headline = dimPriceLine(dims[0], cadence, `/ ${dims[0].noun} / ${cadenceWord(cadence)}`);
+    usageDims = dims.slice(1);
   }
 
   if (!headline) {
     return null;
   }
 
+  const usageLines = usageDims.map((dim) => ({
+    key: dim.key,
+    line: dimPriceLine(dim, cadence, `per ${dim.noun} / ${cadenceWordShort(cadence)}`)
+  }));
+
   return (
     <div className="flex flex-col gap-3.5">
-      <div className="flex flex-wrap items-baseline gap-1.5">
-        <span className="text-2xl font-medium text-foreground">{headline.amount}</span>
-        <span className="text-xs text-muted">{headline.unit}</span>
-      </div>
+      <PriceLineView line={headline} headline />
       {usageLines.length > 0 && (
         <div className="flex flex-col gap-2 border-t border-border pt-3.5">
           <span className="text-[10px] font-medium tracking-wide text-muted uppercase">
             Plus per-unit usage
           </span>
-          {usageLines.map((line) => (
-            <div key={line.key} className="flex items-baseline gap-1.5">
-              <span className="text-sm font-medium text-foreground">{line.amount}</span>
-              <span className="text-xs text-muted">{line.unit}</span>
-            </div>
+          {usageLines.map(({ key, line }) => (
+            <PriceLineView key={key} line={line} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Context

Renders usage-based (metered) pricing in the billing v2 catalog and hardens catalog parsing against new License Server price kinds.

- Honor the License Server price `kind`: a metered dimension renders as usage-based ("First N included, then $X / noun / period" plus a "Usage-based" badge) instead of a fixed per-unit price. The metered flag is tracked per cadence, so a dimension that is `per_unit` on one cadence and `metered` on the other only badges the metered cadence.
- Defensive `kind` parsing: the catalog schema accepts any string (like `model`/`tier`/`cadence`) so a new License Server kind can't break parsing for an un-upgraded consumer. Unknown kinds normalize in code via a single `KNOWN_PRICE_KINDS` allow-list and degrade to non-purchasable, never mis-sold as `per_unit`.
- `buildCheckoutItems`: only `per_unit` dimensions carry a quantity; metered and base lines are added server-side, so a metered-only plan now checks out (previously returned "not available for self-serve checkout").
- Built on main's redesigned `ProPricing` (base-fee headline plus per-dimension usage list). Base-only self-serve checkout already landed on main via `planHasPricing`, so this folds `kind`-awareness into that helper rather than re-adding the base-only path.
- Pairs with Infisical/license-server-go#31, which surfaces metered prices on `/v1/products`.

## Steps to verify the change

- `make reviewable-api` and `make reviewable-ui`: `tsc --noEmit` and ESLint clean for all changed files.
- A plan priced only on a metered dimension shows the usage-based framing and reaches checkout, instead of a fixed per-unit price or "Contact sales".

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
