### PR TITLE
fix(scim): scope group role sync to the group's organization

### DIFF
--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -994,11 +994,13 @@ export const scimServiceFactory = ({
     // no mapping, user will have default org membership
     if (!externalGroupMapping) return;
 
-    // only get org memberships that are new (invites)
+    // only get org memberships that are new (invites), scoped to the group's organization
+    // (consistent with the other membership lookups in this service)
     const newOrgMemberships = await membershipUserDAL.find(
       {
         status: "invited",
         scope: AccessScope.Organization,
+        scopeOrgId: group.orgId,
         $in: {
           id: members.map((member) => member.value)
         }


### PR DESCRIPTION
## Context

When a SCIM group is created, replaced, or patched and an external group-to-role mapping exists for
that group, `$syncNewMembersRoles` in the SCIM service updates the organization role of the newly
provisioned (invited) members. The lookup that resolves those memberships filtered on
`status: "invited"`, `scope: AccessScope.Organization`, and the member IDs from the request body, but
it did not include `scopeOrgId`, so it was not constrained to the group's organization.

The other membership lookups in this same service (for example in `createScimGroup` and the group
update paths) already pass `scopeOrgId`. This change brings the role-sync lookup in line with that
existing pattern so the role sync only ever considers invited memberships within the group's own
organization.

- Before: the invited-membership lookup in `$syncNewMembersRoles` was not scoped to the group's
  organization.
- After: the lookup is scoped with `scopeOrgId: group.orgId`. Normal SCIM provisioning is unchanged,
  since provisioning only references members of its own organization.

Changed files:

- `backend/src/ee/services/scim/scim-service.ts`: add `scopeOrgId: group.orgId` to the invited
  `membershipUserDAL.find` lookup inside `$syncNewMembersRoles`, matching the org-scoped membership
  lookups already used elsewhere in the service.

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

1. In an org with SCIM enabled, configure an external group-to-role mapping for a group.
2. Invite a user so there is a membership with status `invited`, and note its membership ID.
3. Create or PATCH the mapped group with that membership ID in `members[].value`.

Expected: the invited member's role is updated by the mapping. Confirm that only invited memberships
belonging to the group's own organization are updated, and that normal provisioning of the org's own
members is unaffected. A regression test that provisions a mapped group while referencing an invited
membership outside the group's organization, and asserts that membership is left unchanged, covers
this.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
