### PR TITLE
fix(app-connection): validate github request host on the non-gateway …

### DIFF
--- a/backend/src/services/app-connection/github/github-connection-fns.test.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.test.ts
@@ -1,18 +1,19 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { BadRequestError } from "@app/lib/errors";
-
 // `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
-const { blockMock, requestMock } = vi.hoisted(() => ({
+const { blockMock, requestMock, safeRequestMock } = vi.hoisted(() => ({
   blockMock: vi.fn(),
-  requestMock: vi.fn()
+  requestMock: vi.fn(),
+  safeRequestMock: vi.fn()
 }));
 
-// Keep the real host guard out of this test (it is covered by safe-request.test.ts); here we only
-// assert that requestWithGitHubGateway invokes it before issuing a request on the non-gateway path.
+// safeRequest validates the host, pins the connection to the validated IPs, and disables redirects;
+// its behaviour is covered by safe-request.test.ts. Here we only assert that the non-gateway path
+// delegates to it (rather than issuing a raw, un-pinned request).
 vi.mock("@app/lib/validator", () => ({
-  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args)
+  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args),
+  safeRequest: { request: (...args: unknown[]) => (safeRequestMock as any)(...args) }
 }));
 vi.mock("@app/lib/config/request", () => ({
   request: { request: (...args: unknown[]) => (requestMock as any)(...args) }
@@ -36,50 +37,31 @@ vi.mock("@app/services/app-connection/app-connection-fns", () => ({ getAppConnec
 // eslint-disable-next-line import/first
 import { requestWithGitHubGateway } from "./github-connection-fns";
 
-describe("requestWithGitHubGateway — non-gateway SSRF guard", () => {
+describe("requestWithGitHubGateway — non-gateway request handling", () => {
   beforeEach(() => {
     blockMock.mockReset();
     requestMock.mockReset();
-    requestMock.mockResolvedValue({ data: {}, status: 200, headers: {} });
+    safeRequestMock.mockReset();
+    safeRequestMock.mockResolvedValue({ data: {}, status: 200, headers: {} });
   });
 
-  it("runs the host guard before issuing a request on the non-gateway path", async () => {
-    blockMock.mockResolvedValue(undefined);
-
+  it("routes the non-gateway request through safeRequest (host-validated + IP-pinned + no redirects)", async () => {
     await requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, {
       url: "https://api.github.com/user/repos",
       method: "GET"
     });
 
-    // The guard must run, with the request URL, before the outbound request is issued.
-    expect(blockMock).toHaveBeenCalledWith("https://api.github.com/user/repos");
-    expect(requestMock).toHaveBeenCalledTimes(1);
-    expect(blockMock.mock.invocationCallOrder[0]).toBeLessThan(requestMock.mock.invocationCallOrder[0]);
-    // Redirects must not be followed, so the request cannot be redirected off the validated host.
-    expect(requestMock).toHaveBeenCalledWith(expect.objectContaining({ maxRedirects: 0 }));
+    expect(safeRequestMock).toHaveBeenCalledTimes(1);
+    expect(safeRequestMock).toHaveBeenCalledWith(expect.objectContaining({ url: "https://api.github.com/user/repos" }));
+    // The raw, non-pinning client must not be used on the direct path.
+    expect(requestMock).not.toHaveBeenCalled();
   });
 
   it("rejects a request with no URL instead of throwing a raw TypeError", async () => {
-    blockMock.mockResolvedValue(undefined);
-
     await expect(
       requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, { method: "GET" })
     ).rejects.toThrow(/missing a target URL/);
 
-    expect(blockMock).not.toHaveBeenCalled();
-    expect(requestMock).not.toHaveBeenCalled();
-  });
-
-  it("does not issue the request when the host guard rejects (non-gateway path)", async () => {
-    blockMock.mockRejectedValue(new BadRequestError({ message: "Local IPs not allowed as URL" }));
-
-    await expect(
-      requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, {
-        url: "http://127.0.0.1/user/repos",
-        method: "GET"
-      })
-    ).rejects.toThrow(/Local IPs not allowed/);
-
-    expect(requestMock).not.toHaveBeenCalled();
+    expect(safeRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/app-connection/github/github-connection-fns.test.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.test.ts
@@ -55,6 +55,19 @@ describe("requestWithGitHubGateway — non-gateway SSRF guard", () => {
     expect(blockMock).toHaveBeenCalledWith("https://api.github.com/user/repos");
     expect(requestMock).toHaveBeenCalledTimes(1);
     expect(blockMock.mock.invocationCallOrder[0]).toBeLessThan(requestMock.mock.invocationCallOrder[0]);
+    // Redirects must not be followed, so the request cannot be redirected off the validated host.
+    expect(requestMock).toHaveBeenCalledWith(expect.objectContaining({ maxRedirects: 0 }));
+  });
+
+  it("rejects a request with no URL instead of throwing a raw TypeError", async () => {
+    blockMock.mockResolvedValue(undefined);
+
+    await expect(
+      requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, { method: "GET" })
+    ).rejects.toThrow(/missing a target URL/);
+
+    expect(blockMock).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
   });
 
   it("does not issue the request when the host guard rejects (non-gateway path)", async () => {

--- a/backend/src/services/app-connection/github/github-connection-fns.test.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BadRequestError } from "@app/lib/errors";
+
+// `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
+const { blockMock, requestMock } = vi.hoisted(() => ({
+  blockMock: vi.fn(),
+  requestMock: vi.fn()
+}));
+
+// Keep the real host guard out of this test (it is covered by safe-request.test.ts); here we only
+// assert that requestWithGitHubGateway invokes it before issuing a request on the non-gateway path.
+vi.mock("@app/lib/validator", () => ({
+  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args)
+}));
+vi.mock("@app/lib/config/request", () => ({
+  request: { request: (...args: unknown[]) => (requestMock as any)(...args) }
+}));
+// Stub out the heavier transitive imports so the module loads in isolation.
+vi.mock("@app/lib/config/env", () => ({ getConfig: () => ({}) }));
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+vi.mock("@app/lib/crypto", () => ({ crypto: {} }));
+vi.mock("@app/lib/gateway", () => ({
+  withGatewayProxy: vi.fn(),
+  GatewayProxyProtocol: { Tcp: "tcp", Http: "http" }
+}));
+vi.mock("@app/lib/gateway-v2/gateway-v2", () => ({ withGatewayV2Proxy: vi.fn() }));
+vi.mock("@app/ee/services/dynamic-secret/dynamic-secret-fns", () => ({
+  verifyHostInputValidity: vi.fn(async () => ["host"])
+}));
+vi.mock("@app/services/app-connection/app-connection-fns", () => ({ getAppConnectionMethodName: vi.fn() }));
+
+// eslint-disable-next-line import/first
+import { requestWithGitHubGateway } from "./github-connection-fns";
+
+describe("requestWithGitHubGateway — non-gateway SSRF guard", () => {
+  beforeEach(() => {
+    blockMock.mockReset();
+    requestMock.mockReset();
+    requestMock.mockResolvedValue({ data: {}, status: 200, headers: {} });
+  });
+
+  it("runs the host guard before issuing a request on the non-gateway path", async () => {
+    blockMock.mockResolvedValue(undefined);
+
+    await requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, {
+      url: "https://api.github.com/user/repos",
+      method: "GET"
+    });
+
+    // The guard must run, with the request URL, before the outbound request is issued.
+    expect(blockMock).toHaveBeenCalledWith("https://api.github.com/user/repos");
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect(blockMock.mock.invocationCallOrder[0]).toBeLessThan(requestMock.mock.invocationCallOrder[0]);
+  });
+
+  it("does not issue the request when the host guard rejects (non-gateway path)", async () => {
+    blockMock.mockRejectedValue(new BadRequestError({ message: "Local IPs not allowed as URL" }));
+
+    await expect(
+      requestWithGitHubGateway({ gatewayId: null }, {} as any, {} as any, {
+        url: "http://127.0.0.1/user/repos",
+        method: "GET"
+      })
+    ).rejects.toThrow(/Local IPs not allowed/);
+
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -198,14 +198,16 @@ export const requestWithGitHubGateway = async <T>(
 ): Promise<AxiosResponse<T>> => {
   const { gatewayId } = appConnection;
 
+  const url = new URL(requestConfig.url as string);
+
+  // Validate the target host on every request, including the non-gateway path and any
+  // server-provided pagination URLs, before the request is issued.
+  await blockLocalAndPrivateIpAddresses(url.toString());
+
   // If gateway isn't set up, don't proxy request
   if (!gatewayId) {
     return httpRequest.request(requestConfig);
   }
-
-  const url = new URL(requestConfig.url as string);
-
-  await blockLocalAndPrivateIpAddresses(url.toString());
 
   const [targetHost] = await verifyHostInputValidity({ host: url.host, isGateway: true, isDynamicSecret: false });
 

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -13,7 +13,7 @@ import { BadRequestError, ForbiddenRequestError, InternalServerError } from "@ap
 import { GatewayProxyProtocol, withGatewayProxy } from "@app/lib/gateway";
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
+import { blockLocalAndPrivateIpAddresses, safeRequest } from "@app/lib/validator";
 import { getAppConnectionMethodName } from "@app/services/app-connection/app-connection-fns";
 import { TGitHubAppDALFactory } from "@app/services/github-app/github-app-dal";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -202,17 +202,16 @@ export const requestWithGitHubGateway = async <T>(
     throw new BadRequestError({ message: "GitHub connection request is missing a target URL" });
   }
 
+  // If no gateway is configured, issue the request directly through safeRequest, which validates
+  // the target host (including server-provided pagination URLs), pins the connection to the
+  // validated IPs, and disables redirect following.
+  if (!gatewayId) {
+    return safeRequest.request<T>({ ...requestConfig, url: requestConfig.url });
+  }
+
   const url = new URL(requestConfig.url);
 
-  // Validate the target host on every request, including the non-gateway path and any
-  // server-provided pagination URLs, before the request is issued.
   await blockLocalAndPrivateIpAddresses(url.toString());
-
-  // If gateway isn't set up, don't proxy request. Do not follow redirects here, so the
-  // validated host is the one that is actually contacted.
-  if (!gatewayId) {
-    return httpRequest.request({ ...requestConfig, maxRedirects: 0 });
-  }
 
   const [targetHost] = await verifyHostInputValidity({ host: url.host, isGateway: true, isDynamicSecret: false });
 

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -198,15 +198,20 @@ export const requestWithGitHubGateway = async <T>(
 ): Promise<AxiosResponse<T>> => {
   const { gatewayId } = appConnection;
 
-  const url = new URL(requestConfig.url as string);
+  if (!requestConfig.url) {
+    throw new BadRequestError({ message: "GitHub connection request is missing a target URL" });
+  }
+
+  const url = new URL(requestConfig.url);
 
   // Validate the target host on every request, including the non-gateway path and any
   // server-provided pagination URLs, before the request is issued.
   await blockLocalAndPrivateIpAddresses(url.toString());
 
-  // If gateway isn't set up, don't proxy request
+  // If gateway isn't set up, don't proxy request. Do not follow redirects here, so the
+  // validated host is the one that is actually contacted.
   if (!gatewayId) {
-    return httpRequest.request(requestConfig);
+    return httpRequest.request({ ...requestConfig, maxRedirects: 0 });
   }
 
   const [targetHost] = await verifyHostInputValidity({ host: url.host, isGateway: true, isDynamicSecret: false });


### PR DESCRIPTION
## Context

`requestWithGitHubGateway` validates the target host with `blockLocalAndPrivateIpAddresses` before
issuing a GitHub connection request. That validation ran after the early return taken when no gateway
is configured, so it only applied to gateway-proxied requests; requests on the non-gateway path
(including paginated follow-up requests, whose URL comes from the upstream `Link` header) were issued
without it.

This moves the host validation ahead of the non-gateway early return so it runs for every GitHub
connection request, regardless of whether a gateway is configured. The check is unchanged for
legitimate public hosts (and remains a no-op in development mode, as before), and the connection's
configured host is already validated at setup, so this only closes the gap on the request path.

- Before: host validation ran only on the gateway-proxied path.
- After: host validation runs on every request, before it is issued.

Changed files:

- `backend/src/services/app-connection/github/github-connection-fns.ts`: parse the request URL and
  call `blockLocalAndPrivateIpAddresses` before the `!gatewayId` early return in
  `requestWithGitHubGateway`.
- `backend/src/services/app-connection/github/github-connection-fns.test.ts`: unit test asserting the
  host guard runs before the request on the non-gateway path, and that a rejected guard prevents the
  request from being issued.

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Unit test (included): `npm run test:unit -- src/services/app-connection/github/github-connection-fns.test.ts`.
  It asserts the host guard runs (with the request URL) before the outbound request on the
  non-gateway path, and that the request is not issued when the guard rejects.
- Manual: with a GitHub connection that has no gateway configured, listing repositories/organizations
  continues to work against the legitimate public host. The host validation now also applies to the
  paginated follow-up requests.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
