### PR TITLE
improvement: move remove product button to management sheet

### DIFF
--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -207,7 +207,6 @@ export const BillingV2Page = () => {
               subState={subState}
               onManageSubscription={onManageSubscription}
               onUpgrade={onUpgrade}
-              onRemove={setRemoveProdId}
               onUpdatePayment={onUpdatePayment}
               onEditDetails={onEditDetails}
               onContact={onContact}
@@ -227,6 +226,7 @@ export const BillingV2Page = () => {
           redirecting={sheetRedirecting}
           onClose={close}
           onManage={onSheetManage}
+          onRemove={setRemoveProdId}
           onContact={() => {
             close();
             onContact();
@@ -239,6 +239,10 @@ export const BillingV2Page = () => {
           orgId={orgId}
           product={removeProd}
           onClose={() => setRemoveProdId(null)}
+          onRemoved={() => {
+            setRemoveProdId(null);
+            close();
+          }}
         />
       )}
 

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -360,18 +360,10 @@ type ProductRowProps = {
   entitlement?: BillingV2Entitlement;
   readOnly?: boolean;
   onManage: (id: string) => void;
-  onRemove: (id: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const ProductRow = ({
-  prod,
-  entitlement,
-  readOnly,
-  onManage,
-  onRemove,
-  onContact
-}: ProductRowProps) => {
+const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: ProductRowProps) => {
   const entitled = Boolean(entitlement?.entitled);
   let limitNote: string | null = null;
   if (entitled && entitlement && entitlement.limit !== null && entitlement.limit !== undefined) {
@@ -386,16 +378,9 @@ const ProductRow = ({
   if (!readOnly) {
     if (entitled) {
       action = (
-        <>
-          {selfServe && (
-            <Button variant="outline" size="sm" onClick={() => onRemove(prod.id)}>
-              Remove
-            </Button>
-          )}
-          <Button variant="outline" size="sm" onClick={() => onManage(prod.id)}>
-            Manage
-          </Button>
-        </>
+        <Button variant="outline" size="sm" onClick={() => onManage(prod.id)}>
+          Manage
+        </Button>
       );
     } else if (selfServe) {
       action = (
@@ -440,18 +425,10 @@ type ProductsCardProps = {
   catalog: BillingV2CatalogProduct[];
   readOnly?: boolean;
   onManage: (id: string) => void;
-  onRemove: (id: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const ProductsCard = ({
-  overview,
-  catalog,
-  readOnly,
-  onManage,
-  onRemove,
-  onContact
-}: ProductsCardProps) => (
+const ProductsCard = ({ overview, catalog, readOnly, onManage, onContact }: ProductsCardProps) => (
   <Card>
     <CardHeader>
       <CardTitle>
@@ -475,7 +452,6 @@ const ProductsCard = ({
               entitlement={overview.entitlements[prod.id]}
               readOnly={readOnly}
               onManage={onManage}
-              onRemove={onRemove}
               onContact={onContact}
             />
           ))}
@@ -739,7 +715,6 @@ export type OverviewProps = {
   subState: BillingV2RenderState;
   onManageSubscription: () => void;
   onUpgrade: (productId: string) => void;
-  onRemove: (productId: string) => void;
   onUpdatePayment: () => void;
   onEditDetails: () => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
@@ -753,7 +728,6 @@ export const Overview = ({
   subState,
   onManageSubscription,
   onUpgrade,
-  onRemove,
   onUpdatePayment,
   onEditDetails,
   onContact,
@@ -793,7 +767,6 @@ export const Overview = ({
           catalog={catalog}
           readOnly={productsReadOnly}
           onManage={onUpgrade}
-          onRemove={onRemove}
           onContact={onContact}
         />
       </div>
@@ -818,7 +791,6 @@ export const Overview = ({
         catalog={catalog}
         readOnly={productsReadOnly}
         onManage={onUpgrade}
-        onRemove={onRemove}
         onContact={onContact}
       />
       {showPayment && (

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -196,6 +196,7 @@ type ProductSheetProps = {
   redirecting?: boolean;
   onClose: () => void;
   onManage: (prodId: string) => void;
+  onRemove: (prodId: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
@@ -207,6 +208,7 @@ export const ProductSheet = ({
   redirecting,
   onClose,
   onManage,
+  onRemove,
   onContact
 }: ProductSheetProps) => {
   if (!prod) {
@@ -288,6 +290,16 @@ export const ProductSheet = ({
           <Button variant="outline" onClick={onClose} isDisabled={redirecting}>
             Close
           </Button>
+          {entitled && selfServe && (
+            <Button
+              variant="danger"
+              className="ml-auto"
+              onClick={() => onRemove(prodId)}
+              isDisabled={redirecting}
+            >
+              Remove
+            </Button>
+          )}
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
@@ -24,10 +24,13 @@ import { fmtMoney } from "../billing-v2-data";
 type Props = {
   orgId: string;
   product: BillingV2CatalogProduct;
+  // Dismissed without removing (cancel / escape / overlay) — keep the management sheet open behind it.
   onClose: () => void;
+  // Removal succeeded — close the confirm and the management sheet it was opened from.
+  onRemoved: () => void;
 };
 
-export const RemoveProductModal = ({ orgId, product, onClose }: Props) => {
+export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props) => {
   const preview = usePreviewBillingV2Change();
   const removeProduct = useRemoveBillingV2Product();
 
@@ -44,7 +47,7 @@ export const RemoveProductModal = ({ orgId, product, onClose }: Props) => {
         type: "success",
         text: `${product.name} will be removed. It may take a moment to update here.`
       });
-      onClose();
+      onRemoved();
     } catch {
       createNotification({ type: "error", text: `Failed to remove ${product.name}.` });
     }


### PR DESCRIPTION
## Context

This PR moves the remove product button/modal into the product management sheet

## Screenshots

<img width="3456" height="2086" alt="CleanShot 2026-06-26 at 13 49 46@2x" src="https://github.com/user-attachments/assets/557e0494-7b91-45ac-8da9-c186ee1571fd" />

## Steps to verify the change

- open sheet, remove

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)